### PR TITLE
fix(codex): preserve stable embedded session bindings

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -141,6 +141,13 @@ two-party event loops that do not go through the shared inbound reply runner.
 
     `runEmbeddedAgent(...)` is the neutral helper for starting a normal OpenClaw agent turn from plugin code. It uses the same provider/model resolution and agent-harness selection as channel-triggered replies.
 
+    `sessionId` identifies the physical embedded run/transcript target. `sessionKey` is optional
+    and identifies a stable logical owner that can survive physical session rotation. Use a stable
+    `sessionKey` when sequential isolated runs should keep the same Codex app-server binding while
+    each call receives a fresh `sessionId`; omit `sessionKey` when every run must be fully
+    independent. OpenClaw still fences retired generations and concurrent stale owners, so a delayed
+    old run cannot clear or replace a newer generation.
+
     `runEmbeddedPiAgent(...)` remains as a deprecated compatibility alias for existing plugins. New code should use `runEmbeddedAgent(...)`.
 
     `resolveThinkingPolicy(...)` returns the provider/model's supported thinking levels and optional default. Provider plugins own the model-specific profile through their thinking hooks, so tool plugins should call this runtime helper instead of importing or duplicating provider lists.

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -566,18 +566,26 @@ describe("Codex app-server binding store", () => {
       kind: "set",
       binding: { threadId: "thread-1", cwd: "/repo" },
     });
+    await expect(store.mutate(first, { kind: "clear", threadId: "thread-1" })).resolves.toBe(true);
     await expect(store.read(second)).resolves.toBeUndefined();
-    await store.withLease(second, async () => undefined);
+    await store.withLease(second, async () => {
+      await expect(
+        store.mutate(second, {
+          kind: "set",
+          binding: { threadId: "thread-2", cwd: "/repo" },
+          if: { kind: "absent" },
+        }),
+      ).resolves.toBe(true);
+    });
 
     expect(bindingStoreKey(first)).toBe(bindingStoreKey(second));
     expect(values.size).toBe(1);
-    expect(values.get(bindingStoreKey(second))).toMatchObject({ sessionId: "session-1" });
-    await expect(store.adoptSessionGeneration(second, first.sessionId)).resolves.toBe("adopted");
     expect(values.get(bindingStoreKey(second))).toMatchObject({
       state: "active",
       sessionId: "session-2",
-      binding: { threadId: "thread-1" },
+      binding: { threadId: "thread-2" },
     });
+    await expect(store.adoptSessionGeneration(second, first.sessionId)).resolves.toBe("current");
     await expect(
       store.mutate(first, {
         kind: "patch",
@@ -586,8 +594,37 @@ describe("Codex app-server binding store", () => {
       }),
     ).resolves.toBe(false);
     await expect(store.mutate(first, { kind: "clear" })).resolves.toBe(false);
-    await expect(store.read(second)).resolves.toMatchObject({ threadId: "thread-1" });
+    await expect(store.read(second)).resolves.toMatchObject({ threadId: "thread-2" });
     await expect(store.mutate(second, { kind: "clear" })).resolves.toBe(true);
+  });
+
+  it("does not let a delayed stable-key owner reacquire and clear its successor", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const first = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:telegram:chat-1",
+    };
+    const second = { ...first, sessionId: "session-2" };
+
+    await store.mutate(first, {
+      kind: "set",
+      binding: { threadId: "thread-1", cwd: "/repo" },
+    });
+    await expect(store.adoptSessionGeneration(second, first.sessionId)).resolves.toBe("adopted");
+    await expect(store.read(second)).resolves.toMatchObject({ threadId: "thread-1" });
+
+    await store.withLease(first, async () => undefined);
+
+    expect(values.get(bindingStoreKey(second))).toMatchObject({
+      state: "active",
+      sessionId: "session-2",
+      binding: { threadId: "thread-1" },
+    });
+    await expect(store.mutate(first, { kind: "clear", threadId: "thread-1" })).resolves.toBe(false);
+    await expect(store.read(second)).resolves.toMatchObject({ threadId: "thread-1" });
   });
 
   it("rejects a delayed adoption after a newer session generation wins", async () => {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -1000,7 +1000,7 @@ export function createCodexAppServerBindingStore(
         if (current?.state === "active") {
           return {
             result: true,
-            next: { ...current, ...preservedSessionGeneration(identity, current), lease },
+            next: { ...current, ...leasedSessionGeneration(identity, current), lease },
           };
         }
         if (current?.state === "cleared" && current.retired === true) {
@@ -1011,7 +1011,7 @@ export function createCodexAppServerBindingStore(
           next: {
             version: 1,
             state: "cleared",
-            ...preservedSessionGeneration(identity, current),
+            ...leasedSessionGeneration(identity, current),
             lease,
           },
         };
@@ -1182,6 +1182,21 @@ function preservedSessionGeneration(
     return { sessionId: current.sessionId };
   }
   return storedSessionGeneration(identity, current);
+}
+
+function leasedSessionGeneration(
+  identity: CodexAppServerBindingIdentity,
+  current: StoredCodexAppServerBinding | undefined,
+): { sessionId?: string } {
+  if (
+    identity.kind === "session" &&
+    identity.sessionKey?.trim() &&
+    current?.state === "cleared" &&
+    current.retired !== true
+  ) {
+    return { sessionId: identity.sessionId };
+  }
+  return preservedSessionGeneration(identity, current);
 }
 
 function ownsStoredSessionGeneration(


### PR DESCRIPTION
Fixes #108769

## What Problem This Solves

`runEmbeddedAgent` callers can legitimately reuse a stable logical `sessionKey` while rotating the physical `sessionId` for sequential isolated runs. The Codex app-server binding row is keyed by the stable `sessionKey`, but a follow-up physical run could fail before model execution when the prior run left only a cleared stable-key row behind.

This patch lets the serialized `withLease` path advance the stored generation only for cleared, non-retired stable-key rows. Active bindings are not generation-swapped by lease acquisition alone, so a delayed old run cannot reacquire the lease and clear or replace a newer generation. Retired generation fences and private supervision bindings also keep their existing protections.

The SDK docs now state the intended lifecycle: `sessionId` is the physical run/transcript target, while optional `sessionKey` is the stable logical owner for sequential rotated runs.

## Evidence

Head: `496879bcd6cbb6da3e4a08a3fdc60cbef4691e86`

Passed locally:

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/session-binding.test.ts -- -t "keeps one binding across physical session rotations|does not let a delayed stable-key owner|preserves a stale private supervision binding|rejects reclaim when another session generation wins|fences a retired physical generation"`
  - 1 file passed; 5 focused tests passed.
  - Covers the fixed stable-key rotation path, the reviewer-reported stale reacquisition regression, and stale-generation/supervision/retired-fence protections.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `oxfmt --check --threads=1 extensions/codex/src/app-server/session-binding.ts extensions/codex/src/app-server/session-binding.test.ts docs/plugins/sdk-runtime.md`
- `oxlint extensions/codex/src/app-server/session-binding.ts extensions/codex/src/app-server/session-binding.test.ts`
- `git diff --check upstream/main...HEAD`

Attempted but not completed locally:

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/session-binding.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
  - The non-SQLite binding/lifecycle portions ran; the run-attempt/session-store portions are blocked on this machine because bundled Node v24.14.0 embeds SQLite 3.51.2, which OpenClaw rejects for WAL safety.
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/session-binding.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/session-binding.test.ts docs/plugins/sdk-runtime.md`
  - Started successfully and passed lockfile supply-chain policy checks, but `pnpm install` repeatedly stalled on registry downloads for platform packages, so I interrupted it rather than submit weak/noisy output.
