### PR TITLE
fix(skills): canonical frontmatter parser + per-file diagnostics

### DIFF
--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -2,7 +2,11 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
-import { parseFrontmatterBlock, stripFrontmatterBlock } from "./frontmatter.js";
+import {
+  parseFrontmatterBlock,
+  parseFrontmatterBlockResult,
+  stripFrontmatterBlock,
+} from "./frontmatter.js";
 
 describe("parseFrontmatterBlock", () => {
   it("parses YAML block scalars", () => {
@@ -77,6 +81,99 @@ description: Use anime style IMPORTANT: Must be kawaii
 ---`;
     const result = parseFrontmatterBlock(content);
     expect(result.description).toBe("Use anime style IMPORTANT: Must be kawaii");
+  });
+
+  it("normalizes free-form descriptions before YAML parsing", () => {
+    const content = `---
+name: sample-skill
+description: Use anime style IMPORTANT: Must be kawaii
+---`;
+    const result = parseFrontmatterBlockResult(content);
+
+    expect(result.frontmatter.description).toBe("Use anime style IMPORTANT: Must be kawaii");
+    expect(result.issues).toEqual([]);
+  });
+
+  it("leaves valid YAML description semantics untouched", () => {
+    expect(
+      parseFrontmatterBlock(`---
+name: comment
+description: text # note
+---`).description,
+    ).toBe("text");
+    expect(
+      parseFrontmatterBlock(`---
+name: escape
+description: "line\\nbreak"
+---`).description,
+    ).toBe("line\nbreak");
+    expect(
+      parseFrontmatterBlock(`---
+name: block
+description: | # note
+  line one
+  line two
+---`).description,
+    ).toBe("line one\nline two");
+  });
+
+  it("retains structured-value parser errors for owning loaders", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: [broken
+description: Broken skill
+---`);
+
+    expect(result.frontmatter.name).toBe("[broken");
+    expect(result.issues[0]).toMatchObject({ code: "BAD_INDENT" });
+  });
+
+  it("attributes errors positioned on a key to that key", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: first
+description: Working skill
+name: second
+---`);
+
+    expect(result.issues[0]).toMatchObject({ code: "DUPLICATE_KEY" });
+  });
+
+  it("attributes unresolved alias conversion errors to their owning field", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: sample-skill
+metadata: *missing
+---`);
+
+    expect(result.issues[0]).toMatchObject({ code: "YAML_EXCEPTION" });
+  });
+
+  it("decodes quoted keys when attributing conversion errors", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: sample-skill
+description: Working skill
+"metadata": *missing
+---`);
+
+    expect(result.issues[0]).toMatchObject({ code: "YAML_EXCEPTION" });
+  });
+
+  it("normalizes description aliases without masking structured aliases", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: sample-skill
+description: *legacy
+metadata: *missing
+---`);
+
+    expect(result.issues).toEqual([expect.objectContaining({ code: "YAML_EXCEPTION" })]);
+  });
+
+  it("normalizes colon-rich descriptions without masking structured aliases", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: sample-skill
+description: Use anime style IMPORTANT: Must be kawaii
+metadata: *missing
+---`);
+
+    expect(result.issues).toEqual([expect.objectContaining({ code: "YAML_EXCEPTION" })]);
   });
 
   it("does not replace YAML block scalars with block indicators", () => {

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -1,7 +1,17 @@
 // Markdown Core module implements frontmatter behavior.
-import { isMap, isNode, parseDocument } from "yaml";
+import { isMap, isNode, isScalar, parseDocument } from "yaml";
 
 type ParsedFrontmatter = Record<string, string>;
+
+export type ParsedFrontmatterBlockResult = {
+  frontmatter: ParsedFrontmatter;
+  issues: FrontmatterParseIssue[];
+};
+
+export type FrontmatterParseIssue = {
+  code: string;
+  message: string;
+};
 
 type ParsedYamlValue = {
   value: string;
@@ -69,17 +79,56 @@ function parseLineFrontmatter(block: string): ParsedFrontmatter {
   return result;
 }
 
-function parseYamlFrontmatter(block: string): ParsedFrontmatter {
-  const fallback = parseLineFrontmatter(block);
+function normalizeFreeformDescription(block: string): string {
+  const doc = parseDocument(block, { schema: "core", prettyErrors: false });
+  if (!isMap(doc.contents)) {
+    return block;
+  }
+  const descriptionPair = doc.contents.items.find(
+    (pair) => isScalar(pair.key) && pair.key.value === "description",
+  );
+  const keyStart = isNode(descriptionPair?.key) ? descriptionPair.key.range?.[0] : undefined;
+  if (keyStart === undefined) {
+    return block;
+  }
+  const lineStart = block.lastIndexOf("\n", keyStart - 1) + 1;
+  const lineEnd = block.indexOf("\n", keyStart);
+  const end = lineEnd === -1 ? block.length : lineEnd;
+  const line = block.slice(lineStart, end);
+  const match = line.match(/^(?:description|"description"|'description'):\s*(.*)$/);
+  const rawValue = match?.[1]?.trim();
+  if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue)) {
+    return block;
+  }
+  const replacement = `description: ${JSON.stringify(stripQuotes(rawValue))}`;
+  return `${block.slice(0, lineStart)}${replacement}${block.slice(end)}`;
+}
+
+function parseYamlFrontmatterOnce(
+  block: string,
+  fallback: ParsedFrontmatter,
+): ParsedFrontmatterBlockResult {
   try {
     const doc = parseDocument(block, { schema: "core", prettyErrors: false });
     if (doc.errors.length > 0 || !isMap(doc.contents)) {
-      return fallback;
+      return {
+        frontmatter: fallback,
+        issues:
+          doc.errors.length > 0
+            ? doc.errors.map((error) => ({
+                code: error.code ?? error.name,
+                message: error.message,
+              }))
+            : [{ code: "INVALID_ROOT", message: "frontmatter must be a YAML mapping" }],
+      };
     }
 
     const parsed = doc.toJS() as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return fallback;
+      return {
+        frontmatter: fallback,
+        issues: [{ code: "INVALID_ROOT", message: "frontmatter must be a YAML mapping" }],
+      };
     }
 
     const inlineColonKeys = new Set<string>();
@@ -118,10 +167,24 @@ function parseYamlFrontmatter(block: string): ParsedFrontmatter {
         result[key] = value;
       }
     }
-    return result;
-  } catch {
-    return fallback;
+    return { frontmatter: result, issues: [] };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      frontmatter: fallback,
+      issues: [{ code: "YAML_EXCEPTION", message }],
+    };
   }
+}
+
+function parseYamlFrontmatter(block: string): ParsedFrontmatterBlockResult {
+  const fallback = parseLineFrontmatter(block);
+  const parsed = parseYamlFrontmatterOnce(block, fallback);
+  if (parsed.issues.length === 0) {
+    return parsed;
+  }
+  const recoveredBlock = normalizeFreeformDescription(block);
+  return recoveredBlock === block ? parsed : parseYamlFrontmatterOnce(recoveredBlock, fallback);
 }
 
 export type ExtractedFrontmatterBlock = {
@@ -171,6 +234,11 @@ export function stripFrontmatterBlock(content: string): string {
 
 /** Parses leading YAML frontmatter into string values used by skill and metadata loaders. */
 export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
+  return parseFrontmatterBlockResult(content).frontmatter;
+}
+
+/** Parses frontmatter once while retaining recoverable YAML parser issues for owning loaders. */
+export function parseFrontmatterBlockResult(content: string): ParsedFrontmatterBlockResult {
   const block = extractFrontmatterBlock(content)?.block;
-  return block ? parseYamlFrontmatter(block) : {};
+  return block ? parseYamlFrontmatter(block) : { frontmatter: {}, issues: [] };
 }

--- a/src/node-host/skills.test.ts
+++ b/src/node-host/skills.test.ts
@@ -77,12 +77,45 @@ describe("scanNodeHostedSkills", () => {
     ]);
   });
 
+  it("loads JSON5-style metadata frontmatter", () => {
+    const root = createRoot();
+    const skillDir = path.join(root, "json5-metadata");
+    fs.mkdirSync(skillDir);
+    const content = `---
+name: json5-metadata
+description: JSON5-style metadata
+metadata:
+  {
+    "openclaw":
+      {
+        "requires":
+          {
+            "env": ["EXAMPLE_VAR"],
+          },
+      },
+  }
+---
+`;
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), content);
+
+    expect(scanNodeHostedSkills({ skillsDir: root })).toEqual([
+      { name: "json5-metadata", description: "JSON5-style metadata", content },
+    ]);
+  });
+
   it("skips invalid and oversized skills with warnings", () => {
     const root = createRoot();
     writeSkill(root, "valid-skill", "Valid");
     const invalidDir = path.join(root, "invalid");
     fs.mkdirSync(invalidDir);
     fs.writeFileSync(path.join(invalidDir, "SKILL.md"), "# Missing frontmatter");
+    const malformedDir = path.join(root, "malformed");
+    fs.mkdirSync(malformedDir);
+    const malformedFile = path.join(malformedDir, "SKILL.md");
+    fs.writeFileSync(
+      malformedFile,
+      "---\nname: [malformed\ndescription: Malformed frontmatter\n---\n",
+    );
     writeSkill(root, "oversized", "Oversized", "x".repeat(64 * 1024));
     const mismatchedDir = path.join(root, "folder-name");
     fs.mkdirSync(mismatchedDir);
@@ -96,8 +129,27 @@ describe("scanNodeHostedSkills", () => {
 
     expect(skills.map((skill) => skill.name)).toEqual(["valid-skill"]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("invalid or missing frontmatter"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(malformedFile));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("BAD_INDENT"));
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("exceeds 65536 bytes"));
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("directory, name, and frontmatter"));
+  });
+
+  it("keeps nested diagnostics separate from the current candidate", () => {
+    const root = createRoot();
+    const candidateDir = path.join(root, "candidate");
+    fs.mkdirSync(path.join(candidateDir, "nested"), { recursive: true });
+    const candidateFile = path.join(candidateDir, "SKILL.md");
+    fs.writeFileSync(candidateFile, "# Missing frontmatter\n");
+    const nestedFile = path.join(candidateDir, "nested", "SKILL.md");
+    fs.writeFileSync(nestedFile, "---\nname: [nested\ndescription: Malformed nested skill\n---\n");
+    const warn = vi.fn();
+
+    expect(scanNodeHostedSkills({ skillsDir: root, warn })).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(nestedFile));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`${candidateFile}): has invalid or missing frontmatter`),
+    );
   });
 
   it("rejects a root-level skill because its node locator is not representable", () => {

--- a/src/node-host/skills.ts
+++ b/src/node-host/skills.ts
@@ -88,14 +88,20 @@ export function scanNodeHostedSkills(
   const loadedSkills: ReturnType<typeof loadSkillsFromDirSafe>["skills"] = [];
   const frontmatterByFilePath = new Map<string, Record<string, string>>();
   for (const candidate of candidates) {
+    let invalidFrontmatter = false;
+    const candidatePath = path.resolve(candidate);
     const loaded = loadSkillsFromDirSafe({
       dir: path.dirname(candidate),
       source: "openclaw-node",
       maxBytes: NODE_SKILL_MAX_CONTENT_BYTES,
+      onDiagnostic: (diagnostic) => {
+        if (path.resolve(diagnostic.path) === candidatePath) {
+          invalidFrontmatter = true;
+        }
+        warn(`node host skill skipped (${diagnostic.path}): ${diagnostic.message}`);
+      },
     });
-    const skill = loaded.skills.find(
-      (entry) => path.resolve(entry.filePath) === path.resolve(candidate),
-    );
+    const skill = loaded.skills.find((entry) => path.resolve(entry.filePath) === candidatePath);
     if (skill) {
       loadedSkills.push(skill);
       const frontmatter = loaded.frontmatterByFilePath.get(skill.filePath);
@@ -111,11 +117,14 @@ export function scanNodeHostedSkills(
       warn(`node host skill skipped (${candidate}): ${String(error)}`);
       continue;
     }
-    const reason =
-      typeof size === "number" && size > NODE_SKILL_MAX_CONTENT_BYTES
+    const reason = invalidFrontmatter
+      ? null
+      : typeof size === "number" && size > NODE_SKILL_MAX_CONTENT_BYTES
         ? `exceeds ${NODE_SKILL_MAX_CONTENT_BYTES} bytes`
         : "has invalid or missing frontmatter";
-    warn(`node host skill skipped (${candidate}): ${reason}`);
+    if (reason) {
+      warn(`node host skill skipped (${candidate}): ${reason}`);
+    }
   }
 
   const descriptors: NodeSkillDescriptor[] = [];

--- a/src/skills/loading/bundled-context.ts
+++ b/src/skills/loading/bundled-context.ts
@@ -32,7 +32,14 @@ export function resolveBundledSkillsContext(
     return { dir, names: new Set(cachedBundledContext.names) };
   }
   // Bundled skill metadata is process-stable; cache names until restart.
-  const result = loadSkillsFromDirSafe({ dir, source: "openclaw-bundled" });
+  const result = loadSkillsFromDirSafe({
+    dir,
+    source: "openclaw-bundled",
+    onDiagnostic: (diagnostic) =>
+      skillsLogger.warn(
+        `Skipping bundled skill with invalid frontmatter (${diagnostic.path}): ${diagnostic.message}`,
+      ),
+  });
   for (const skill of result.skills) {
     if (skill.name.trim()) {
       names.add(skill.name);

--- a/src/skills/loading/frontmatter.test.ts
+++ b/src/skills/loading/frontmatter.test.ts
@@ -23,6 +23,136 @@ describe("resolveSkillInvocationPolicy", () => {
   });
 });
 
+describe("parseFrontmatter", () => {
+  it("keeps recoverable colon-rich scalar values", () => {
+    const frontmatter = parseFrontmatter(`---
+name: sample-skill
+description: Use anime style IMPORTANT: Must be kawaii
+---`);
+
+    expect(frontmatter.description).toBe("Use anime style IMPORTANT: Must be kawaii");
+  });
+
+  it("keeps recoverable description values beginning with punctuation", () => {
+    const frontmatter = parseFrontmatter(`---
+name: sample-skill
+description: [Beta] Builds prereleases
+---`);
+
+    expect(frontmatter.description).toBe("[Beta] Builds prereleases");
+  });
+
+  it("keeps recoverable description values beginning with YAML-reserved characters", () => {
+    const frontmatter = parseFrontmatter(`---
+name: sample-skill
+description: @scope/package helper
+---`);
+
+    expect(frontmatter.description).toBe("@scope/package helper");
+  });
+
+  it("keeps recoverable description values that resemble YAML aliases", () => {
+    const frontmatter = parseFrontmatter(`---
+name: sample-skill
+description: *Experimental
+---`);
+
+    expect(frontmatter.description).toBe("*Experimental");
+  });
+
+  it("rejects malformed structured fallback values with the YAML parse error", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: [broken
+description: Broken skill
+---`),
+    ).toThrow("invalid frontmatter: BAD_INDENT");
+  });
+
+  it("rejects unresolved YAML aliases", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: sample-skill
+description: Broken skill
+metadata: *missing
+---`),
+    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
+  });
+
+  it("rejects duplicate keys after a recoverable description", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: first
+description: Working skill
+name: second
+---`),
+    ).toThrow("invalid frontmatter: DUPLICATE_KEY");
+  });
+
+  it("rejects invalid structured values under quoted keys", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: sample-skill
+description: Working skill
+"metadata": *missing
+---`),
+    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
+  });
+
+  it("does not let a description alias mask a later structured alias", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: sample-skill
+description: *legacy
+metadata: *missing
+---`),
+    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
+  });
+
+  it("does not let a colon-rich description mask a structured alias", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: sample-skill
+description: Use anime style IMPORTANT: Must be kawaii
+metadata: *missing
+---`),
+    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
+  });
+
+  it("rejects indentation errors following a description", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: sample-skill
+description: Working skill
+\tmetadata: {}
+---`),
+    ).toThrow(/invalid frontmatter.*(?:TAB_AS_INDENT|BAD_INDENT)/);
+  });
+
+  it("rejects unresolved aliases under explicit YAML keys", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: sample-skill
+description: Working skill
+? metadata
+: *missing
+---`),
+    ).toThrow(/invalid frontmatter.*YAML_EXCEPTION: Unresolved alias/);
+  });
+
+  it("does not recover nested description keys inside malformed metadata", () => {
+    expect(() =>
+      parseFrontmatter(`---
+name: sample-skill
+description: Working skill
+metadata: {
+description: *missing
+}
+---`),
+    ).toThrow(/invalid frontmatter/);
+  });
+});
+
 describe("resolveOpenClawMetadata install validation", () => {
   function resolveInstall(frontmatter: Record<string, string>) {
     return resolveOpenClawMetadata(frontmatter)?.install;

--- a/src/skills/loading/frontmatter.ts
+++ b/src/skills/loading/frontmatter.ts
@@ -1,6 +1,6 @@
 // Frontmatter helpers parse skill metadata from SKILL.md files.
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import { parseFrontmatterBlock } from "../../../packages/markdown-core/src/frontmatter.js";
+import { parseFrontmatterBlockResult } from "../../../packages/markdown-core/src/frontmatter.js";
 import { validateRegistryNpmSpec } from "../../infra/npm-registry-spec.js";
 import {
   applyOpenClawManifestInstallCommonFields,
@@ -23,7 +23,12 @@ import type {
 import type { Skill } from "./skill-contract.js";
 
 export function parseFrontmatter(content: string): ParsedSkillFrontmatter {
-  return parseFrontmatterBlock(content);
+  const parsed = parseFrontmatterBlockResult(content);
+  const issue = parsed.issues[0];
+  if (issue) {
+    throw new Error(`invalid frontmatter: ${issue.code}: ${issue.message}`);
+  }
+  return parsed.frontmatter;
 }
 
 const BREW_FORMULA_PATTERN = /^[A-Za-z0-9][A-Za-z0-9@+._/-]*$/;

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -12,6 +12,11 @@ type LoadedLocalSkill = {
   frontmatter: ParsedSkillFrontmatter;
 };
 
+export type LocalSkillLoadDiagnostic = {
+  path: string;
+  message: string;
+};
+
 // Read SKILL.md through the root boundary helper so symlinks cannot escape the skill root.
 function readSkillFileSync(params: {
   rootRealPath: string;
@@ -40,6 +45,7 @@ function loadSingleSkillDirectory(params: {
   source: string;
   rootRealPath: string;
   maxBytes?: number;
+  onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
 }): LoadedLocalSkill | null {
   const skillFilePath = path.join(params.skillDir, "SKILL.md");
   const raw = readSkillFileSync({
@@ -54,7 +60,9 @@ function loadSingleSkillDirectory(params: {
   let frontmatter: Record<string, string>;
   try {
     frontmatter = parseFrontmatter(raw);
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "failed to parse skill frontmatter";
+    params.onDiagnostic?.({ path: skillFilePath, message });
     return null;
   }
 
@@ -104,7 +112,12 @@ function listCandidateSkillDirs(dir: string): string[] {
 }
 
 /** Loads skills from a local directory while turning read/parse failures into diagnostics. */
-export function loadSkillsFromDirSafe(params: { dir: string; source: string; maxBytes?: number }): {
+export function loadSkillsFromDirSafe(params: {
+  dir: string;
+  source: string;
+  maxBytes?: number;
+  onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
+}): {
   skills: Skill[];
   frontmatterByFilePath: ReadonlyMap<string, ParsedSkillFrontmatter>;
 } {
@@ -121,6 +134,7 @@ export function loadSkillsFromDirSafe(params: { dir: string; source: string; max
     source: params.source,
     rootRealPath,
     maxBytes: params.maxBytes,
+    onDiagnostic: params.onDiagnostic,
   });
   if (rootSkill) {
     return {
@@ -136,6 +150,7 @@ export function loadSkillsFromDirSafe(params: { dir: string; source: string; max
         source: params.source,
         rootRealPath,
         maxBytes: params.maxBytes,
+        onDiagnostic: params.onDiagnostic,
       }),
     )
     .filter((skill): skill is LoadedLocalSkill => skill !== null);

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -114,7 +114,7 @@ description: Valid sibling
       "utf-8",
     );
 
-    const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+    const result = loadSkillsFromPath(tempDir);
 
     expect(result.skills.map((skill) => skill.name)).toEqual(["valid"]);
     expect(result.diagnostics).toEqual([

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { parseFrontmatter, resolveOpenClawMetadata } from "./frontmatter.js";
+import { loadSkills } from "./session.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function loadSkillsFromPath(dir: string) {
+  return loadSkills({ cwd: dir, agentDir: dir, skillPaths: [dir], includeDefaults: false });
+}
+
+describe("loadSkills", () => {
+  it("reports directory scan failures as diagnostics", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-scan-");
+    const regularFile = path.join(tempDir, "not-a-directory");
+    await fs.writeFile(regularFile, "not a skill directory");
+
+    const result = loadSkillsFromPath(regularFile);
+
+    expect(result.skills).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ type: "warning", path: regularFile }),
+    ]);
+  });
+
+  it("does not load dash-prefixed Markdown as frontmatter", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-scan-");
+    const skillDir = path.join(tempDir, "dash-prefix");
+    await fs.mkdir(skillDir);
+    const skillFile = path.join(skillDir, "SKILL.md");
+    await fs.writeFile(
+      skillFile,
+      "----\nname: bogus\ndescription: must remain Markdown\n---\n# Body\n",
+      "utf-8",
+    );
+
+    const result = loadSkillsFromPath(tempDir);
+
+    expect(result.skills).toEqual([]);
+    expect(result.diagnostics).toContainEqual({
+      type: "warning",
+      message: "description is required",
+      path: skillFile,
+    });
+  });
+
+  it("loads skills with JSON5-style trailing commas in metadata frontmatter", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-scan-");
+    const skillDir = path.join(tempDir, "json5-metadata");
+    await fs.mkdir(skillDir);
+    const skillFile = path.join(skillDir, "SKILL.md");
+    await fs.writeFile(
+      skillFile,
+      `---
+name: json5-metadata
+description: Skill with JSON5-style metadata.
+metadata:
+  {
+    "openclaw":
+      {
+        "requires":
+          {
+            "env": ["EXAMPLE_VAR"],
+          },
+      },
+  }
+disable-model-invocation: true
+---
+# JSON5 Metadata
+`,
+      "utf-8",
+    );
+
+    const result = loadSkillsFromPath(tempDir);
+    const frontmatter = parseFrontmatter(await fs.readFile(skillFile, "utf-8"));
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.skills).toEqual([
+      expect.objectContaining({
+        name: "json5-metadata",
+        description: "Skill with JSON5-style metadata.",
+        disableModelInvocation: true,
+        filePath: skillFile,
+      }),
+    ]);
+    expect(resolveOpenClawMetadata(frontmatter)?.requires?.env).toEqual(["EXAMPLE_VAR"]);
+  });
+});

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -87,4 +87,42 @@ disable-model-invocation: true
     ]);
     expect(resolveOpenClawMetadata(frontmatter)?.requires?.env).toEqual(["EXAMPLE_VAR"]);
   });
+
+  it("reports malformed frontmatter by file and keeps loading sibling skills", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-scan-");
+    const brokenDir = path.join(tempDir, "broken");
+    const validDir = path.join(tempDir, "valid");
+    await fs.mkdir(brokenDir);
+    await fs.mkdir(validDir);
+    const brokenFile = path.join(brokenDir, "SKILL.md");
+    await fs.writeFile(
+      brokenFile,
+      `---
+name: [broken
+description: Broken skill
+---
+`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(validDir, "SKILL.md"),
+      `---
+name: valid
+description: Valid sibling
+---
+`,
+      "utf-8",
+    );
+
+    const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(["valid"]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "warning",
+        path: brokenFile,
+        message: expect.stringContaining("invalid frontmatter: BAD_INDENT"),
+      }),
+    ]);
+  });
 });

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -3,12 +3,12 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "nod
 import { CONFIG_DIR_NAME, getAgentDir } from "../../agents/config.js";
 import type { ResourceDiagnostic } from "../../agents/sessions/diagnostics.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "../../agents/sessions/source-info.js";
-import { parseFrontmatter } from "../../agents/utils/frontmatter.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import { addIgnoreRules, toPosixPath, type IgnoreMatcher } from "../../shared/ignore-rules.js";
 // Session skill helpers resolve skills attached to a session and its transcript state.
 import { expandTildePath } from "../../shared/tilde-path.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
+import { parseFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
 import { formatSkillsForPrompt as formatSkillContractForPrompt } from "./skill-contract.js";
 import { computeSkillPromptVersion } from "./skill-version.js";
 
@@ -17,13 +17,6 @@ const MAX_NAME_LENGTH = 64;
 
 /** Max description length per spec */
 const MAX_DESCRIPTION_LENGTH = 1024;
-
-interface SkillFrontmatter {
-  name?: string;
-  description?: string;
-  "disable-model-invocation"?: boolean;
-  [key: string]: unknown;
-}
 
 export interface Skill {
   name: string;
@@ -220,7 +213,8 @@ function loadSkillFromFile(
 
   try {
     const rawContent = readFileSync(filePath, "utf-8");
-    const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
+    const frontmatter = parseFrontmatter(rawContent);
+    const invocation = resolveSkillInvocationPolicy(frontmatter);
     const skillDir = dirname(filePath);
     const parentDirName = basename(skillDir);
 
@@ -253,7 +247,7 @@ function loadSkillFromFile(
         promptVersion: computeSkillPromptVersion(rawContent),
         source,
         sourceInfo: createSkillSourceInfo(filePath, skillDir, source),
-        disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+        disableModelInvocation: invocation.disableModelInvocation,
       },
       diagnostics,
     };

--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -392,6 +392,67 @@ describe("loadWorkspaceSkillEntries", () => {
     expect(hiddenEntry?.exposure?.includeInAvailableSkillsPrompt).toBe(false);
   });
 
+  it("loads workspace metadata with JSON5-style trailing commas", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "json5-metadata");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---
+name: json5-metadata
+description: JSON5-style metadata
+metadata:
+  {
+    "openclaw":
+      {
+        "requires":
+          {
+            "env": ["EXAMPLE_VAR"],
+          },
+      },
+  }
+---
+`,
+      "utf8",
+    );
+
+    const entry = loadTestWorkspaceSkillEntries(workspaceDir).find(
+      (candidate) => candidate.skill.name === "json5-metadata",
+    );
+
+    expect(entry?.metadata?.requires?.env).toEqual(["EXAMPLE_VAR"]);
+  });
+
+  it("warns with the malformed file and keeps loading sibling workspace skills", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const brokenDir = path.join(workspaceDir, "skills", "broken");
+    const brokenFile = path.join(brokenDir, "SKILL.md");
+    await fs.mkdir(brokenDir, { recursive: true });
+    await fs.writeFile(
+      brokenFile,
+      `---
+name: [broken
+description: Broken skill
+---
+`,
+      "utf8",
+    );
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "valid"),
+      name: "valid",
+      description: "Valid sibling",
+    });
+    const warn = captureWarningLogger();
+
+    const entries = loadTestWorkspaceSkillEntries(workspaceDir);
+    const warningText = warn.mock.calls.flat().map(String).join("\n");
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("valid");
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("broken");
+    expect(warningText).toContain(brokenFile);
+    expect(warningText).toContain("invalid frontmatter: BAD_INDENT");
+  });
+
   it("applies agent skill filters and replacement semantics", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     await writeWorkspaceSkills(workspaceDir, [

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -36,7 +36,11 @@ import { getArchivedSkillFiles } from "../workshop/curator.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
 import { resolveBundledAllowlist, shouldIncludeSkill } from "./config.js";
 import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontmatter.js";
-import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "./local-loader.js";
+import {
+  loadSkillsFromDirSafe,
+  readSkillFrontmatterSafe,
+  type LocalSkillLoadDiagnostic,
+} from "./local-loader.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
@@ -170,6 +174,17 @@ function normalizeCompactedSkillPath(filePath: string, matchedHomePrefix: string
 
 function compactPathForConsoleMessage(filePath: string): string {
   return compactHomePath(filePath, resolveCompactHomePrefixes());
+}
+
+function warnInvalidSkillFrontmatter(source: string, diagnostic: LocalSkillLoadDiagnostic): void {
+  skillsLogger.warn("Skipping skill with invalid frontmatter.", {
+    source,
+    filePath: diagnostic.path,
+    error: diagnostic.message,
+    consoleMessage:
+      `Skipping skill with invalid frontmatter: ` +
+      `file=${compactPathForConsoleMessage(diagnostic.path)} error=${diagnostic.message}`,
+  });
 }
 
 function filterSkillEntries(
@@ -622,6 +637,7 @@ function loadContainedSkillRecords(params: {
     dir: params.skillDir,
     source: params.source,
     maxBytes: params.maxSkillFileBytes,
+    onDiagnostic: (diagnostic) => warnInvalidSkillFrontmatter(params.source, diagnostic),
   });
   const records = unwrapLoadedSkillRecords(loaded).filter(
     (record) => path.resolve(record.skill.baseDir) === expectedBaseDir,

--- a/src/skills/runtime/remote-skills.test.ts
+++ b/src/skills/runtime/remote-skills.test.ts
@@ -1,5 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSyntheticSourceInfo } from "../../agents/sessions/source-info.js";
+import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
+import { loggingState } from "../../logging/state.js";
 import { buildWorkspaceSkillCommandSpecs } from "../discovery/command-specs.js";
 import { buildWorkspaceSkillStatus } from "../discovery/status.js";
 import { buildWorkspaceSkillSnapshot, loadWorkspaceSkillEntries } from "../loading/workspace.js";
@@ -36,6 +38,24 @@ function localEntry(name: string): SkillEntry {
 beforeEach(() => {
   resetRemoteNodeSkillsForTests();
 });
+
+afterEach(() => {
+  setLoggerOverride(null);
+  loggingState.rawConsole = null;
+  resetLogger();
+});
+
+function captureWarningLogger() {
+  setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+  const warn = vi.fn();
+  loggingState.rawConsole = {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn,
+    error: vi.fn(),
+  };
+  return warn;
+}
 
 describe("node-hosted skill snapshots", () => {
   it("appears while connected, includes the locator note, and disappears on disconnect", () => {
@@ -222,7 +242,44 @@ describe("node-hosted skill snapshots", () => {
     expect(command?.dispatch).toBeUndefined();
   });
 
+  it("accepts JSON5-style metadata from node skills", () => {
+    recordRemoteSkillNodeInfo({
+      nodeId: "node-1",
+      connId: "conn-1",
+      commands: ["system.run"],
+    });
+    replaceRemoteNodeSkills({
+      nodeId: "node-1",
+      skills: [
+        {
+          name: "json5-metadata",
+          description: "JSON5-style metadata",
+          content: `---
+name: json5-metadata
+description: JSON5-style metadata
+metadata:
+  {
+    "openclaw":
+      {
+        "requires":
+          {
+            "env": ["EXAMPLE_VAR"],
+          },
+      },
+  }
+---
+`,
+        },
+      ],
+    });
+
+    const [entry] = mergeRemoteNodeSkillEntries([], { canExec: true });
+    expect(entry?.skill.name).toBe("json5-metadata");
+    expect(entry?.frontmatter?.metadata).toContain("EXAMPLE_VAR");
+  });
+
   it("drops content that fails existing frontmatter parsing", () => {
+    const warn = captureWarningLogger();
     recordRemoteSkillNodeInfo({
       nodeId: "node-1",
       connId: "conn-1",
@@ -240,6 +297,9 @@ describe("node-hosted skill snapshots", () => {
     });
 
     expect(mergeRemoteNodeSkillEntries([], { canExec: true })).toEqual([]);
+    const warningText = warn.mock.calls.flat().map(String).join("\n");
+    expect(warningText).toContain("node://node-1/skills/broken-skill/SKILL.md");
+    expect(warningText).toContain("BAD_INDENT");
   });
 
   it("replaces a node catalog and invalidates the snapshot", () => {

--- a/src/skills/runtime/remote-skills.ts
+++ b/src/skills/runtime/remote-skills.ts
@@ -40,9 +40,8 @@ function prepareNodeSkills(
       }
       prepared.push({ ...skill, frontmatter });
     } catch (error) {
-      log.warn(
-        `dropped node skill with invalid frontmatter: ${nodeId}/${skill.name}: ${String(error)}`,
-      );
+      const filePath = `node://${encodeURIComponent(nodeId)}/skills/${skill.name}/SKILL.md`;
+      log.warn(`dropped node skill with invalid frontmatter (${filePath}): ${String(error)}`);
     }
   }
   return prepared;


### PR DESCRIPTION
## What Problem This Solves

Workspace skills silently vanish when SKILL.md frontmatter uses JSON5-style syntax (e.g. trailing commas): one parser tolerated it, another rejected it, and the skill disappeared with no diagnostic (#108432).

## Why This Change Was Made

Supersedes #108486 (contributor closed it during a maintainer rebase collision; base commit and authorship preserved — thanks @jincheng-xydt). Consolidates every skill-loading entry point onto the canonical markdown-core frontmatter parser and adds per-file diagnostics:

- Two-pass parse in the single skills-side wrapper: valid YAML untouched; JSON5-style metadata accepted; legacy free-form root descriptions recover only after parse failure; genuine YAML failures reject the skill with the actual parse error.
- Entry points proven on the canonical parser: workspace/managed/personal/project/plugin, bundled, `openclaw skills` CLI + gateway status, agent/session loading, snapshots/watchers, node-host, remote nodes, install/workshop readers. Remaining duplicate parser imports deleted.
- Malformed files now warn with file path + parser code/message via existing loggers; sibling skills keep loading.

## User Impact

The issue's repro (trailing-comma metadata) now loads. Genuinely malformed frontmatter is reported with the file name and parse error instead of silently hiding the skill.

## Evidence

- Focused tests: 12 files, 183 tests green (trailing commas, malformed structures, aliases, duplicate keys, indentation, nested-flow metadata, sibling survival, per-entry-point coverage).
- `pnpm plugin-sdk:surface:check` — pass (7945 public exports, 0 forbidden subpaths); generated surface report has zero branch diff after rebase.
- Exact-head CI on the predecessor PR head (identical tree): green (65 success, rest skips/neutral). Autoreview clean.

Fixes #108432
