### PR TITLE
feat(presentation): hosted-widget launch via typed web-app actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Portable hosted-widget actions:** let typed `web-app` presentation buttons carry an OpenClaw hosted-widget ID, with Discord mapping valid IDs to native Activity launch buttons while URL-only channels skip unsupported hosted widgets safely.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Portable hosted-widget actions:** let typed `web-app` presentation buttons carry an OpenClaw hosted-widget ID, with Discord mapping valid IDs to native Activity launch buttons while URL-only channels skip unsupported hosted widgets safely.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/docs/plugins/message-presentation.md
+++ b/docs/plugins/message-presentation.md
@@ -78,7 +78,16 @@ type MessagePresentationAction =
       decision: "allow-once" | "allow-always" | "deny";
     }
   | { type: "url"; url: string }
-  | { type: "web-app"; url: string };
+  | {
+      type: "web-app";
+      url: string;
+      widgetId?: string;
+    }
+  | {
+      type: "web-app";
+      url?: string;
+      widgetId: string;
+    };
 
 type MessagePresentationButton = {
   label: string;
@@ -128,7 +137,11 @@ Button semantics:
   the approval service; they must not parse `/approve` command text or infer
   kind from the ID.
 - `action.type: "url"` opens a normal link.
-- `action.type: "web-app"` launches a channel-native web app.
+- `action.type: "web-app"` launches a channel-native web app. Set `url` for a
+  URL-backed app or `widgetId` for an OpenClaw-hosted widget whose launch
+  mechanics are owned by the channel; at least one is required. When both are
+  present, a channel can prefer its native hosted-widget launch and use the URL
+  where that mechanism is unavailable.
 - `value` is the legacy opaque callback value. New controls should use `action`
   so channel plugins can map commands and callbacks without guessing from text.
 - `url`, `webApp`, and `web_app` remain accepted as deprecated boundary inputs.
@@ -501,9 +514,10 @@ keeping opaque callback data private:
 - **`approval`-typed actions** render label-only. Approval IDs and decisions are
   transport data and are not exposed through generic scalar helpers or fallback
   text.
-- **`url` / `web-app` actions** and deprecated **`url` / `webApp` / `web_app`**
-  inputs render the URL text alongside the button label, since the URL is
-  user-facing.
+- **`url` actions**, URL-backed **`web-app` actions**, and deprecated **`url` /
+  `webApp` / `web_app`** inputs render the URL text alongside the button label,
+  since the URL is user-facing. Hosted-widget-only actions render label-only on
+  channels without a native widget launch.
 - **Select options** render as label-only. The underlying option value is not
   exposed in fallback text.
 

--- a/extensions/discord/src/activities/interaction.test.ts
+++ b/extensions/discord/src/activities/interaction.test.ts
@@ -8,6 +8,7 @@ import {
   createInternalTestClient,
 } from "../internal/test-builders.test-support.js";
 import type { AgentComponentContext } from "../monitor/agent-components.types.js";
+import { buildDiscordPresentationComponents } from "../shared-interactive.js";
 import { createDiscordActivityButton } from "./interaction.js";
 import { setDiscordActivitiesRuntime } from "./runtime.js";
 import {
@@ -73,8 +74,25 @@ describe("Discord Activity interaction", () => {
     });
     const launchActivity = vi.fn(async () => undefined);
     const interaction = { launchActivity } as unknown as ButtonInteraction;
+    const rendered = buildDiscordPresentationComponents({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Open widget",
+              action: { type: "web-app", widgetId: "AAAAAAAAAAAAAAAAAAAAAA" },
+            },
+          ],
+        },
+      ],
+    });
+    const actionBlock = rendered?.blocks?.find((block) => block.type === "actions");
+    const customId =
+      actionBlock?.type === "actions" ? actionBlock.buttons?.[0]?.internalCustomId : "";
+    const data = button?.customIdParser(customId ?? "").data ?? {};
 
-    await button?.run(interaction, { widgetId: "AAAAAAAAAAAAAAAAAAAAAA" });
+    await button?.run(interaction, data);
 
     expect(authorize).toHaveBeenCalledOnce();
     expect(launchActivity).toHaveBeenCalledOnce();

--- a/extensions/discord/src/activities/tool.test.ts
+++ b/extensions/discord/src/activities/tool.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../component-custom-id.js";
 import { buildDiscordComponentMessage } from "../components.js";
 import type { sendDiscordComponentMessage } from "../send.components.js";
+import { createDiscordSendReceipt } from "../send.receipt.js";
 import { createActivityTestRuntime } from "./test-helpers.test-support.js";
 import { createDiscordWidgetTool } from "./tool.js";
 
@@ -186,7 +187,11 @@ describe("discord_widget", () => {
       await args[2].onDeliveryResult?.({
         messageId: "delivered-message",
         channelId: "987654321",
-        receipt: {},
+        receipt: createDiscordSendReceipt({
+          platformMessageIds: ["delivered-message"],
+          channelId: "987654321",
+          kind: "text",
+        }),
       });
       throw failure;
     }) as unknown as typeof sendDiscordComponentMessage;

--- a/extensions/discord/src/activities/tool.test.ts
+++ b/extensions/discord/src/activities/tool.test.ts
@@ -1,7 +1,11 @@
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it, vi } from "vitest";
-import { buildDiscordActivityCustomId } from "../component-custom-id.js";
-import type { sendMessageDiscord } from "../send.js";
+import {
+  buildDiscordActivityCustomId,
+  parseDiscordActivityCustomIdForInteraction,
+} from "../component-custom-id.js";
+import { buildDiscordComponentMessage } from "../components.js";
+import type { sendDiscordComponentMessage } from "../send.components.js";
 import { createActivityTestRuntime } from "./test-helpers.test-support.js";
 import { createDiscordWidgetTool } from "./tool.js";
 
@@ -25,14 +29,14 @@ describe("discord_widget", () => {
 
   it("stores a wrapped widget and posts its launch button", async () => {
     const runtime = createActivityTestRuntime();
-    const send = vi.fn(async (..._args: Parameters<typeof sendMessageDiscord>) => ({
+    const send = vi.fn(async (..._args: Parameters<typeof sendDiscordComponentMessage>) => ({
       messageId: "message-1",
       channelId: "987654321",
       receipt: {},
     }));
     const tool = createDiscordWidgetTool(discordContext(), {
       runtime,
-      sendMessage: send as unknown as typeof sendMessageDiscord,
+      sendComponentMessage: send as unknown as typeof sendDiscordComponentMessage,
       now: () => 7,
     });
     if (!tool) {
@@ -56,24 +60,38 @@ describe("discord_widget", () => {
     });
     expect(stored?.html).toContain("<!doctype html>");
     expect(stored?.html).toContain("<button");
-    const options = send.mock.calls[0]?.[2] as { components?: Array<{ serialize(): unknown }> };
-    expect(send).toHaveBeenCalledWith("channel:987654321", "Status", expect.any(Object));
-    expect(options.components?.[0]?.serialize()).toEqual({
-      type: 1,
-      components: [
+    const spec = send.mock.calls[0]?.[1];
+    const customId = buildDiscordActivityCustomId(details.widgetId);
+    expect(send).toHaveBeenCalledWith("channel:987654321", expect.any(Object), expect.any(Object));
+    expect(send.mock.calls[0]?.[2]).toMatchObject({ allowedMentions: { parse: [] } });
+    if (!spec) {
+      throw new Error("expected Discord component spec");
+    }
+    expect(spec).toEqual({
+      text: "Status",
+      blocks: [
         {
-          type: 2,
-          style: 1,
-          custom_id: buildDiscordActivityCustomId(details.widgetId),
-          label: "Open widget",
+          type: "actions",
+          buttons: [
+            {
+              label: "Open widget",
+              style: "secondary",
+              internalCustomId: customId,
+            },
+          ],
         },
       ],
+    });
+    expect(JSON.stringify(buildDiscordComponentMessage({ spec }).components)).toContain(customId);
+    expect(parseDiscordActivityCustomIdForInteraction(customId)).toEqual({
+      key: "ocactivity",
+      data: { widgetId: details.widgetId },
     });
   });
 
   it("resolves a provider-prefixed forum thread target", async () => {
     const runtime = createActivityTestRuntime();
-    const send = vi.fn(async (..._args: Parameters<typeof sendMessageDiscord>) => ({
+    const send = vi.fn(async (..._args: Parameters<typeof sendDiscordComponentMessage>) => ({
       messageId: "message-1",
       channelId: "987654321",
       receipt: {},
@@ -85,7 +103,7 @@ describe("discord_widget", () => {
       }),
       {
         runtime,
-        sendMessage: send as unknown as typeof sendMessageDiscord,
+        sendComponentMessage: send as unknown as typeof sendDiscordComponentMessage,
       },
     );
     if (!tool) {
@@ -98,20 +116,24 @@ describe("discord_widget", () => {
     });
 
     expect(result.details).toMatchObject({ channelId: "987654321" });
-    expect(send).toHaveBeenCalledWith("channel:987654321", "Forum widget", expect.any(Object));
+    expect(send).toHaveBeenCalledWith(
+      "channel:987654321",
+      expect.objectContaining({ text: "Forum widget" }),
+      expect.any(Object),
+    );
   });
 
   it("keeps full documents unchanged and rejects oversized HTML", async () => {
     const document = "<!doctype html><html><body>full</body></html>";
     const runtime = createActivityTestRuntime();
-    const send = vi.fn(async (..._args: Parameters<typeof sendMessageDiscord>) => ({
+    const send = vi.fn(async (..._args: Parameters<typeof sendDiscordComponentMessage>) => ({
       messageId: "message-1",
       channelId: "987654321",
       receipt: {},
     }));
     const tool = createDiscordWidgetTool(discordContext(), {
       runtime,
-      sendMessage: send as unknown as typeof sendMessageDiscord,
+      sendComponentMessage: send as unknown as typeof sendDiscordComponentMessage,
     });
     if (!tool) {
       throw new Error("expected Discord widget tool");
@@ -143,8 +165,8 @@ describe("discord_widget", () => {
     const failure = new Error("send failed");
     const send = vi.fn(async () => {
       throw failure;
-    }) as unknown as typeof sendMessageDiscord;
-    const tool = createDiscordWidgetTool(discordContext(), { runtime, sendMessage: send });
+    }) as unknown as typeof sendDiscordComponentMessage;
+    const tool = createDiscordWidgetTool(discordContext(), { runtime, sendComponentMessage: send });
     if (!tool) {
       throw new Error("expected Discord widget tool");
     }
@@ -157,10 +179,38 @@ describe("discord_widget", () => {
     ).resolves.toMatchObject({ id: existingId, widget: { title: "Existing" } });
   });
 
+  it("keeps a widget when component bookkeeping fails after delivery", async () => {
+    const runtime = createActivityTestRuntime();
+    const failure = new Error("registry failed");
+    const send = vi.fn(async (...args: Parameters<typeof sendDiscordComponentMessage>) => {
+      await args[2].onDeliveryResult?.({
+        messageId: "delivered-message",
+        channelId: "987654321",
+        receipt: {},
+      });
+      throw failure;
+    }) as unknown as typeof sendDiscordComponentMessage;
+    const tool = createDiscordWidgetTool(discordContext(), { runtime, sendComponentMessage: send });
+    if (!tool) {
+      throw new Error("expected Discord widget tool");
+    }
+
+    const result = await tool.execute("delivered-send", {
+      html: "<p>delivered</p>",
+      title: "Delivered",
+    });
+    const details = result.details as { widgetId: string; messageId: string };
+
+    expect(details.messageId).toBe("delivered-message");
+    await expect(runtime.store.lookupWidget(details.widgetId)).resolves.toMatchObject({
+      title: "Delivered",
+    });
+  });
+
   it("requires a concrete channel target", async () => {
     const tool = createDiscordWidgetTool(discordContext({ nativeChannelId: undefined }), {
       runtime: createActivityTestRuntime(),
-      sendMessage: vi.fn() as unknown as typeof sendMessageDiscord,
+      sendComponentMessage: vi.fn() as unknown as typeof sendDiscordComponentMessage,
     });
     if (!tool) {
       throw new Error("expected Discord widget tool");
@@ -178,7 +228,7 @@ describe("discord_widget", () => {
       }),
       {
         runtime: createActivityTestRuntime(),
-        sendMessage: vi.fn() as unknown as typeof sendMessageDiscord,
+        sendComponentMessage: vi.fn() as unknown as typeof sendDiscordComponentMessage,
       },
     );
     if (!tool) {

--- a/extensions/discord/src/activities/tool.ts
+++ b/extensions/discord/src/activities/tool.ts
@@ -9,9 +9,8 @@ import {
 } from "openclaw/plugin-sdk/widget-html";
 import { Type } from "typebox";
 import { resolveDiscordAccount } from "../accounts.js";
-import { buildDiscordActivityCustomId } from "../component-custom-id.js";
-import { Button, Row } from "../internal/discord.js";
-import { sendMessageDiscord } from "../send.js";
+import { sendDiscordComponentMessage } from "../send.components.js";
+import { buildDiscordPresentationComponents } from "../shared-interactive.js";
 import { resolveDiscordChannelId as resolveDiscordTargetChannelId } from "../target-parsing.js";
 import type { DiscordActivitiesRuntime } from "./runtime.js";
 
@@ -22,15 +21,6 @@ const DiscordWidgetParameters = Type.Object({
   title: Type.String({ minLength: 1, maxLength: 80 }),
   button_label: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
 });
-
-class DiscordWidgetLaunchButton extends Button {
-  constructor(
-    readonly customId: string,
-    readonly label: string,
-  ) {
-    super();
-  }
-}
 
 function currentConfig(context: OpenClawPluginToolContext, runtime: DiscordActivitiesRuntime) {
   return (
@@ -64,7 +54,7 @@ function buildDiscordWidgetDocument(title: string, html: string): string {
 
 type DiscordWidgetToolDeps = {
   runtime: DiscordActivitiesRuntime;
-  sendMessage?: typeof sendMessageDiscord;
+  sendComponentMessage?: typeof sendDiscordComponentMessage;
   now?: () => number;
 };
 
@@ -120,24 +110,43 @@ export function createDiscordWidgetTool(
         accountId: account.accountId,
         createdAt: (deps.now ?? Date.now)(),
       });
-      let result: Awaited<ReturnType<typeof sendMessageDiscord>>;
+      let result: Awaited<ReturnType<typeof sendDiscordComponentMessage>>;
+      let deliveredResult: Awaited<ReturnType<typeof sendDiscordComponentMessage>> | undefined;
       try {
-        result = await (deps.sendMessage ?? sendMessageDiscord)(`channel:${channelId}`, title, {
-          cfg: cfg as OpenClawConfig,
-          accountId: account.accountId,
-          components: [
-            new Row([
-              new DiscordWidgetLaunchButton(
-                buildDiscordActivityCustomId(widgetId),
-                buttonLabel.trim(),
-              ),
-            ]),
+        const components = buildDiscordPresentationComponents({
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: buttonLabel.trim(),
+                  action: { type: "web-app", widgetId },
+                },
+              ],
+            },
           ],
-          allowedMentions: { parse: [] },
         });
+        if (!components) {
+          throw new Error("Discord widget launch button could not be rendered");
+        }
+        result = await (deps.sendComponentMessage ?? sendDiscordComponentMessage)(
+          `channel:${channelId}`,
+          { ...components, text: title },
+          {
+            cfg: cfg as OpenClawConfig,
+            accountId: account.accountId,
+            allowedMentions: { parse: [] },
+            onDeliveryResult: (deliveryResult) => {
+              deliveredResult = deliveryResult;
+            },
+          },
+        );
       } catch (error) {
-        await deps.runtime.store.deleteWidget(widgetId);
-        throw error;
+        if (!deliveredResult) {
+          await deps.runtime.store.deleteWidget(widgetId);
+          throw error;
+        }
+        result = deliveredResult;
       }
       return jsonResult({ widgetId, messageId: result.messageId, channelId: result.channelId });
     },

--- a/extensions/discord/src/component-custom-id.ts
+++ b/extensions/discord/src/component-custom-id.ts
@@ -11,6 +11,10 @@ export const DISCORD_MODAL_CUSTOM_ID_KEY = "ocmodal";
 const DISCORD_ACTIVITY_CUSTOM_ID_KEY = "ocactivity";
 const ENCODED_CUSTOM_ID_VERSION = "1";
 
+export function isValidDiscordActivityWidgetId(widgetId: string): boolean {
+  return /^[A-Za-z0-9_-]{22}$/.test(widgetId);
+}
+
 export function buildDiscordActivityCustomId(widgetId: string): string {
   return `${DISCORD_ACTIVITY_CUSTOM_ID_KEY}:v=${ENCODED_CUSTOM_ID_VERSION};wid=${widgetId}`;
 }
@@ -21,7 +25,7 @@ export function parseDiscordActivityCustomId(id: string): { widgetId: string } |
     parsed.key !== DISCORD_ACTIVITY_CUSTOM_ID_KEY ||
     parsed.data.v !== ENCODED_CUSTOM_ID_VERSION ||
     typeof parsed.data.wid !== "string" ||
-    !/^[A-Za-z0-9_-]{22}$/.test(parsed.data.wid)
+    !isValidDiscordActivityWidgetId(parsed.data.wid)
   ) {
     return null;
   }

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -101,6 +101,25 @@ describe("sendDiscordComponentMessage", () => {
     resetClassicMocks();
   });
 
+  it("passes allowed mentions through component sends", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText, id: "chan-1" });
+    postMock.mockResolvedValueOnce({ id: "msg1", channel_id: "chan-1" });
+
+    await sendDiscordComponentMessage(
+      "channel:chan-1",
+      { blocks: [{ type: "actions", buttons: [{ label: "Open" }] }] },
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        allowedMentions: { parse: [] },
+      },
+    );
+
+    expect(readRecordArg(postMock, 0, 1).body).toMatchObject({ allowed_mentions: { parse: [] } });
+  });
+
   it("keeps direct-channel DM session keys on component entries", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -36,6 +36,7 @@ import {
   resolveDiscordChannel,
   stripUndefinedFields,
   SUPPRESS_NOTIFICATIONS_FLAG,
+  type DiscordAllowedMentions,
 } from "./send.shared.js";
 import type { DiscordSendResult } from "./send.types.js";
 
@@ -168,6 +169,7 @@ type DiscordComponentSendOpts = {
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
   suppressEmbeds?: boolean;
+  allowedMentions?: DiscordAllowedMentions;
   /** Persist the concrete platform send before component bookkeeping can fail. */
   onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
 };
@@ -253,6 +255,7 @@ async function buildDiscordComponentPayload(params: {
 
   const payload: MessagePayloadObject = {
     components: buildResult.components,
+    allowed_mentions: params.opts.allowedMentions,
     ...(finalFlags ? { flags: finalFlags } : {}),
     ...(files ? { files } : {}),
   };

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -1,7 +1,9 @@
 // Discord tests cover shared interactive plugin behavior.
 import { buildApprovalResolutionRef } from "openclaw/plugin-sdk/approval-reference-runtime";
+import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { describe, expect, it } from "vitest";
 import { parseExecApprovalData } from "./approval-custom-id.js";
+import { buildDiscordActivityCustomId } from "./component-custom-id.js";
 import { buildDiscordComponentMessage } from "./components.js";
 import { parseCustomId } from "./internal/discord.js";
 import {
@@ -126,6 +128,88 @@ describe("buildDiscordInteractiveComponents", () => {
       });
     },
   );
+
+  it("renders hosted widget actions as Discord Activity buttons", () => {
+    const widgetId = "AAAAAAAAAAAAAAAAAAAAAA";
+    expect(
+      buildDiscordPresentationComponents({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Open widget",
+                action: { type: "web-app", widgetId },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      blocks: [
+        {
+          type: "actions",
+          buttons: [
+            {
+              label: "Open widget",
+              style: "secondary",
+              internalCustomId: buildDiscordActivityCustomId(widgetId),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("falls back to a web-app URL when the hosted widget id is invalid", () => {
+    expect(
+      buildDiscordPresentationComponents({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Open app",
+                action: {
+                  type: "web-app",
+                  widgetId: "invalid",
+                  url: "https://example.com/app",
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      blocks: [
+        {
+          type: "actions",
+          buttons: [
+            {
+              label: "Open app",
+              style: "link",
+              url: "https://example.com/app",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("skips web-app actions without a renderable Discord target", () => {
+    const presentation = {
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: [
+            { label: "Missing", action: { type: "web-app" } },
+            { label: "Invalid", action: { type: "web-app", widgetId: "invalid" } },
+          ],
+        },
+      ],
+    } as unknown as MessagePresentation;
+    expect(buildDiscordPresentationComponents(presentation)).toBeUndefined();
+  });
 
   it("renders typed approvals as actionable transport-private Discord controls", () => {
     const rendered = buildDiscordPresentationComponents({

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -1,6 +1,9 @@
 // Discord tests cover shared interactive plugin behavior.
 import { buildApprovalResolutionRef } from "openclaw/plugin-sdk/approval-reference-runtime";
-import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
+import type {
+  MessagePresentation,
+  MessagePresentationAction,
+} from "openclaw/plugin-sdk/interactive-runtime";
 import { describe, expect, it } from "vitest";
 import { parseExecApprovalData } from "./approval-custom-id.js";
 import { buildDiscordActivityCustomId } from "./component-custom-id.js";
@@ -106,7 +109,7 @@ describe("buildDiscordInteractiveComponents", () => {
               buttons: [
                 {
                   label: "Review",
-                  action: { type, url: "https://example.com/review" },
+                  action: { type, url: "https://example.com/review" } as MessagePresentationAction,
                 },
               ],
             },

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -12,6 +12,10 @@ import type {
   MessagePresentationOption,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { buildDiscordApprovalCustomId } from "./approval-custom-id.js";
+import {
+  buildDiscordActivityCustomId,
+  isValidDiscordActivityWidgetId,
+} from "./component-custom-id.js";
 import type {
   DiscordComponentButtonSpec,
   DiscordComponentButtonStyle,
@@ -77,6 +81,22 @@ function buildDiscordButtonComponent(
       internalCustomId,
       ...(button.disabled === true ? { disabled: true } : {}),
     };
+  }
+  if (
+    action.type === "web-app" &&
+    action.widgetId &&
+    isValidDiscordActivityWidgetId(action.widgetId)
+  ) {
+    return {
+      label: button.label,
+      style: resolveDiscordInteractiveButtonStyle(button.style),
+      internalCustomId: buildDiscordActivityCustomId(action.widgetId),
+      ...(button.disabled === true ? { disabled: true } : {}),
+      ...(button.reusable === true ? { reusable: true } : {}),
+    };
+  }
+  if (action.type === "web-app" && !action.url) {
+    return undefined;
   }
   const component: DiscordComponentButtonSpec = {
     label: button.label,

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -7,6 +7,7 @@ import {
   adaptMessagePresentationForChannel,
   renderMessagePresentationFallbackText,
   type MessagePresentation,
+  type MessagePresentationAction,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
@@ -1007,7 +1008,7 @@ describe("feishuOutbound.sendPayload native cards", () => {
             buttons: [
               {
                 label: "Review",
-                action: { type, url: "https://example.com/review" },
+                action: { type, url: "https://example.com/review" } as MessagePresentationAction,
               },
             ],
           },

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -1409,6 +1409,40 @@ describe("mattermostPlugin", () => {
       expect(JSON.stringify(options)).not.toContain("/approve");
     });
 
+    it("skips hosted widget actions without a Mattermost URL", async () => {
+      const renderPresentation = requireMattermostRenderPresentation();
+      const cfg = createMattermostTestConfig();
+      const presentation = {
+        blocks: [
+          {
+            type: "buttons" as const,
+            buttons: [
+              {
+                label: "Hosted widget",
+                action: {
+                  type: "web-app" as const,
+                  widgetId: "AAAAAAAAAAAAAAAAAAAAAA",
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(
+        await renderPresentation({
+          payload: { presentation },
+          presentation,
+          ctx: {
+            cfg,
+            to: "channel:CHAN1",
+            text: "",
+            payload: { presentation },
+          },
+        }),
+      ).toBeNull();
+    });
+
     it("requires upload success for local media on presentation button payloads", async () => {
       const renderPresentation = requireMattermostRenderPresentation();
       const sendPayload = requireMattermostSendPayload();

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -115,7 +115,7 @@ function hasMattermostPresentationNavigation(presentation: MessagePresentation):
       block.type === "buttons" &&
       block.buttons.some((button) => {
         const action = resolveMessagePresentationButtonAction(button);
-        return action?.type === "url" || action?.type === "web-app";
+        return action?.type === "url" || (action?.type === "web-app" && Boolean(action.url));
       }),
   );
 }

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -247,6 +247,13 @@ describe("msteamsOutbound cfg threading", () => {
               action: { type: "web-app" as const, url: "https://example.com/app" },
             },
             {
+              label: "Hosted widget",
+              action: {
+                type: "web-app" as const,
+                widgetId: "AAAAAAAAAAAAAAAAAAAAAA",
+              },
+            },
+            {
               label: "Allow",
               action: {
                 type: "approval" as const,

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -69,10 +69,14 @@ export function buildMSTeamsPresentationCard(params: {
       for (const button of block.buttons) {
         const action = resolveMessagePresentationButtonAction(button);
         if (action?.type === "url" || action?.type === "web-app") {
+          const url = normalizeOptionalString(action.url);
+          if (!url) {
+            continue;
+          }
           actions.push({
             type: "Action.OpenUrl",
             title: button.label,
-            url: action.url,
+            url,
           });
           continue;
         }

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -393,6 +393,24 @@ describe("buildTelegramPresentationButtons", () => {
     ]);
   });
 
+  it("skips hosted widget actions without a Telegram web app URL", () => {
+    expect(
+      buildTelegramPresentationButtons({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Hosted widget",
+                action: { type: "web-app", widgetId: "AAAAAAAAAAAAAAAAAAAAAA" },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
   it("lets canonical typed actions override deprecated button fields", () => {
     expect(
       buildTelegramPresentationButtons({

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -53,7 +53,7 @@ function toTelegramInlineButton(
     return { text: button.label, url: action.url, style };
   }
   if (action.type === "web-app") {
-    return { text: button.label, web_app: { url: action.url }, style };
+    return action.url ? { text: button.label, web_app: { url: action.url }, style } : undefined;
   }
   if (action.type === "approval") {
     const callbackData = buildTelegramApprovalCallbackData(action);

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -119,6 +119,12 @@ type AgentRuntimeMessagePresentationAction =
   | {
       type: "web-app";
       url: string;
+      widgetId?: string;
+    }
+  | {
+      type: "web-app";
+      url?: string;
+      widgetId: string;
     };
 
 /** Portable action control exposed to agent runtime reply payloads. */

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -2142,12 +2142,35 @@ describe("message tool schema scoping", () => {
           properties?: { blocks?: { items?: Record<string, unknown> } };
         }
       ).properties?.blocks?.items;
+      const presentationActionVariants = (
+        presentationBlockItemSchema as {
+          properties?: {
+            buttons?: {
+              items?: { properties?: { action?: { anyOf?: Array<Record<string, unknown>> } } };
+            };
+          };
+        }
+      ).properties?.buttons?.items?.properties?.action?.anyOf;
+      const webAppRequiredFields = presentationActionVariants
+        ?.filter(
+          (variant) =>
+            (variant.properties as { type?: { const?: string } } | undefined)?.type?.const ===
+            "web-app",
+        )
+        .map((variant) => variant.required);
 
       expect(properties).toHaveProperty("presentation");
       expect(presentationSchemaJson).toContain('"action"');
       expect(presentationSchemaJson).toContain('"command"');
       expect(presentationSchemaJson).toContain('"const":"url"');
       expect(presentationSchemaJson).toContain('"const":"web-app"');
+      expect(presentationSchemaJson).toContain('"widgetId"');
+      expect(webAppRequiredFields).toEqual(
+        expect.arrayContaining([
+          ["type", "url"],
+          ["type", "widgetId"],
+        ]),
+      );
       expect(presentationSchemaJson).not.toContain('"const":"approval"');
       expect(presentationSchemaJson).toContain('"chartType"');
       expect(presentationSchemaJson).toContain('"pie"');
@@ -3470,6 +3493,14 @@ describe("message tool boot-echo guard", () => {
                   action: { type: "web-app", url: echoedText },
                   url: "https://legacy.example.test",
                 },
+                {
+                  label: "Hosted app",
+                  action: {
+                    type: "web-app",
+                    url: echoedText,
+                    widgetId: "AAAAAAAAAAAAAAAAAAAAAA",
+                  },
+                },
               ],
             },
           ],
@@ -3488,6 +3519,10 @@ describe("message tool boot-echo guard", () => {
             { label: "App" },
             { label: "Typed status" },
             { label: "Typed app" },
+            {
+              label: "Hosted app",
+              action: { type: "web-app", widgetId: "AAAAAAAAAAAAAAAAAAAAAA" },
+            },
           ],
         },
       ],

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -418,6 +418,13 @@ function sanitizePresentationTextFieldsResult(
               if (sanitized.text) {
                 sanitizedAction.url = sanitized.text;
                 sanitizedButton.action = sanitizedAction;
+              } else if (
+                sanitizedAction.type === "web-app" &&
+                typeof sanitizedAction.widgetId === "string" &&
+                sanitizedAction.widgetId.trim()
+              ) {
+                delete sanitizedAction.url;
+                sanitizedButton.action = sanitizedAction;
               } else {
                 // Explicit typed actions own the control. If sanitization removes
                 // the target, legacy shadow fields must not become active fallbacks.
@@ -579,6 +586,12 @@ const presentationButtonActionSchema = Type.Union([
   Type.Object({
     type: Type.Literal("web-app"),
     url: Type.String(),
+    widgetId: Type.Optional(Type.String()),
+  }),
+  Type.Object({
+    type: Type.Literal("web-app"),
+    url: Type.Optional(Type.String()),
+    widgetId: Type.String(),
   }),
 ]);
 

--- a/src/channels/plugins/outbound/interactive.test.ts
+++ b/src/channels/plugins/outbound/interactive.test.ts
@@ -157,6 +157,10 @@ describe("presentation capability limits", () => {
           label: "Open app",
           action: { type: "web-app", url: "https://example.test/app/a-long-id" },
         },
+        {
+          label: "Open widget",
+          action: { type: "web-app", widgetId: "AAAAAAAAAAAAAAAAAAAAAA" },
+        },
       ],
       {
         limits: {
@@ -184,6 +188,10 @@ describe("presentation capability limits", () => {
       {
         label: "Open app",
         action: { type: "web-app", url: "https://example.test/app/a-long-id" },
+      },
+      {
+        label: "Open widget",
+        action: { type: "web-app", widgetId: "AAAAAAAAAAAAAAAAAAAAAA" },
       },
     ]);
   });

--- a/src/channels/plugins/outbound/presentation-limits.ts
+++ b/src/channels/plugins/outbound/presentation-limits.ts
@@ -149,7 +149,9 @@ function buttonFallbackLabel(
     return label;
   }
   const action = resolveMessagePresentationButtonAction(button);
-  return action?.type === "url" || action?.type === "web-app" ? `${label}: ${action.url}` : label;
+  return action?.type === "url" || (action?.type === "web-app" && action.url)
+    ? `${label}: ${action.url}`
+    : label;
 }
 
 function actionCapacity(limits: ActionLimits | undefined): number | undefined {

--- a/src/interactive/payload.test.ts
+++ b/src/interactive/payload.test.ts
@@ -287,6 +287,90 @@ describe("interactive payload helpers", () => {
     });
   });
 
+  it("requires a web-app target and preserves hosted widget ids", () => {
+    const normalized = normalizeMessagePresentation({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Hosted widget",
+              action: { type: "web-app", widgetId: " AAAAAAAAAAAAAAAAAAAAAA " },
+            },
+            {
+              label: "Hosted fallback",
+              action: {
+                type: "web-app",
+                widgetId: "BBBBBBBBBBBBBBBBBBBBBB",
+                url: " https://example.com/app ",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(normalized).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Hosted widget",
+              action: { type: "web-app", widgetId: "AAAAAAAAAAAAAAAAAAAAAA" },
+            },
+            {
+              label: "Hosted fallback",
+              action: {
+                type: "web-app",
+                widgetId: "BBBBBBBBBBBBBBBBBBBBBB",
+                url: "https://example.com/app",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const interactive = presentationToInteractiveReply(normalized!);
+    expect(interactive?.blocks[0]).toMatchObject({
+      type: "buttons",
+      buttons: [
+        {
+          label: "Hosted widget",
+          action: { type: "web-app", widgetId: "AAAAAAAAAAAAAAAAAAAAAA" },
+        },
+        {
+          label: "Hosted fallback",
+          action: {
+            type: "web-app",
+            widgetId: "BBBBBBBBBBBBBBBBBBBBBB",
+            url: "https://example.com/app",
+          },
+          webApp: { url: "https://example.com/app" },
+        },
+      ],
+    });
+    expect(interactive?.blocks[0]).not.toHaveProperty("buttons.0.webApp");
+    expect(renderMessagePresentationFallbackText({ presentation: normalized })).toBe(
+      "- Hosted widget\n- Hosted fallback: https://example.com/app",
+    );
+    expect(
+      resolveMessagePresentationButtonAction({
+        action: { type: "web-app" },
+      }),
+    ).toBeUndefined();
+    expect(
+      normalizeMessagePresentation({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Missing", action: { type: "web-app" } }],
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
   it("resolves deprecated button inputs without overriding a canonical action", () => {
     expect(
       resolveMessagePresentationButtonAction({

--- a/src/interactive/payload.test.ts
+++ b/src/interactive/payload.test.ts
@@ -1,5 +1,6 @@
 // Interactive payload tests cover validation of interactive response payloads.
 import { describe, expect, it } from "vitest";
+import type { MessagePresentationAction } from "./payload.js";
 import {
   hasReplyChannelData,
   hasReplyContent,
@@ -356,7 +357,8 @@ describe("interactive payload helpers", () => {
     );
     expect(
       resolveMessagePresentationButtonAction({
-        action: { type: "web-app" },
+        // Boundary input missing both url and widgetId; the union forbids this statically.
+        action: { type: "web-app" } as unknown as MessagePresentationAction,
       }),
     ).toBeUndefined();
     expect(

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -41,7 +41,18 @@ export type MessagePresentationAction =
   | {
       /** Launch a channel-native web app. */
       type: "web-app";
+      /** External web app URL for channels that launch web apps by URL. */
       url: string;
+      /** OpenClaw hosted-widget ID whose launch mechanics are owned by the channel. */
+      widgetId?: string;
+    }
+  | {
+      /** Launch a channel-native web app. */
+      type: "web-app";
+      /** External web app URL for channels that launch web apps by URL. */
+      url?: string;
+      /** OpenClaw hosted-widget ID whose launch mechanics are owned by the channel. */
+      widgetId: string;
     };
 
 /** Portable action control rendered as a button or link by channel adapters. */
@@ -350,9 +361,17 @@ function normalizePresentationAction(raw: unknown): MessagePresentationAction | 
     }
     return { type: "approval", approvalId, approvalKind, decision };
   }
-  if (type === "url" || type === "web-app") {
+  if (type === "url") {
     const url = normalizeOptionalString(record.url);
-    return url ? { type, url } : undefined;
+    return url ? { type: "url", url } : undefined;
+  }
+  if (type === "web-app") {
+    const url = normalizeOptionalString(record.url);
+    const widgetId = normalizeOptionalString(record.widgetId);
+    if (url) {
+      return { type: "web-app", url, ...(widgetId ? { widgetId } : {}) };
+    }
+    return widgetId ? { type: "web-app", widgetId } : undefined;
   }
   return undefined;
 }
@@ -703,7 +722,7 @@ export function presentationToInteractiveReply(
               interactiveButton.value = actionValue;
             } else if (button.action.type === "url") {
               interactiveButton.url = button.action.url;
-            } else if (button.action.type === "web-app") {
+            } else if (button.action.type === "web-app" && button.action.url) {
               interactiveButton.webApp = { url: button.action.url };
             }
           } else {
@@ -898,7 +917,7 @@ export function renderMessagePresentationFallbackText(params: {
             return button.label;
           }
           const action = resolveMessagePresentationButtonAction(button);
-          if (action?.type === "url" || action?.type === "web-app") {
+          if (action?.type === "url" || (action?.type === "web-app" && action.url)) {
             return `${button.label}: ${action.url}`;
           }
           if (action?.type === "command") {


### PR DESCRIPTION
## What Problem This Solves

Discord Activity launches cannot be expressed through the portable presentation-action seam: `web-app` actions only carry a URL and Discord maps them to link buttons, but Activity launch needs a transport-private custom_id button answered with a LAUNCH_ACTIVITY callback. So `discord_widget` hand-built raw `Button` components — the exact coupling the typed-action seam exists to prevent, and a dead end for any future cross-channel widget producer (canvas `show_widget` unification is next).

## Why This Change Was Made

Phase 2 of the widget/canvas unification program. Additive protocol change: the `web-app` action becomes a two-member union — URL-required or `widgetId`-required — so at-least-one is enforced at the type level, mirrored in the agent-runtime types, message-tool schema, sanitizer, and normalizer. Channel mapping stays channel-owned: Discord maps a valid `widgetId` to its Activity custom_id button through the one shared `buildDiscordButtonComponent` path (raw callback data stays transport-private); URL-capable channels keep link buttons; telegram/mattermost/msteams skip widget-only buttons gracefully. `discord_widget` now posts a portable button instead of hand-built components, and gains delivered-result recovery so post-send bookkeeping failures cannot orphan or falsely delete a widget record.

## User Impact

Release-note summary: typed `web-app` presentation buttons can carry an OpenClaw hosted-widget ID; Discord maps valid IDs to native Activity launch buttons while URL-only channels skip hosted-widget-only buttons safely. No behavior change for existing URL-based web-app buttons.

## Evidence

- Focused tests green: `node scripts/run-vitest.mjs src/interactive/payload.test.ts src/agents/tools/message-tool.test.ts extensions/discord/src/activities/tool.test.ts extensions/discord/src/shared-interactive.test.ts extensions/discord/src/activities/interaction.test.ts extensions/telegram/src/button-types.test.ts extensions/mattermost/src/channel.test.ts extensions/msteams/src/outbound.test.ts` (Discord launch round-trip covered via the interaction handler).
- Structured autoreview (codex/gpt-5.6-sol, branch vs origin/main): clean, no actionable findings.
- `docs/plugins/message-presentation.md` updated (existing page, no heading changes).
