### PR TITLE
fix(hooks): do not load hooks with blank required env values

### DIFF
--- a/src/hooks/config.test.ts
+++ b/src/hooks/config.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withEnv } from "../test-utils/env.js";
 import { shouldIncludeHook } from "./config.js";
 import { buildWorkspaceHookStatus } from "./hooks-status.js";
 import type { HookEntry } from "./types.js";
@@ -42,10 +43,6 @@ function evaluate(config?: OpenClawConfig) {
 }
 
 describe("hook environment requirements", () => {
-  afterEach(() => {
-    delete process.env[ENV_NAME];
-  });
-
   it.each([
     { name: "missing values", hostEnv: undefined, configEnv: undefined, satisfied: false },
     { name: "blank host env", hostEnv: " \t ", configEnv: undefined, satisfied: false },
@@ -59,14 +56,8 @@ describe("hook environment requirements", () => {
       satisfied: true,
     },
   ])("keeps runtime and status aligned for $name", ({ hostEnv, configEnv, satisfied }) => {
-    if (hostEnv === undefined) {
-      delete process.env[ENV_NAME];
-    } else {
-      process.env[ENV_NAME] = hostEnv;
-    }
-
-    const { runtimeIncluded, status } = evaluate(
-      configEnv === undefined ? undefined : configWithEnv(configEnv),
+    const { runtimeIncluded, status } = withEnv({ [ENV_NAME]: hostEnv }, () =>
+      evaluate(configEnv === undefined ? undefined : configWithEnv(configEnv)),
     );
 
     expect(runtimeIncluded).toBe(satisfied);

--- a/src/hooks/config.test.ts
+++ b/src/hooks/config.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { shouldIncludeHook } from "./config.js";
+import { buildWorkspaceHookStatus } from "./hooks-status.js";
+import type { HookEntry } from "./types.js";
+
+const ENV_NAME = "OPENCLAW_TEST_HOOK_REQUIRED_ENV";
+const HOOK_NAME = "required-env-hook";
+
+const entry: HookEntry = {
+  hook: {
+    name: HOOK_NAME,
+    description: "Requires an environment variable",
+    source: "openclaw-bundled",
+    filePath: "/tmp/HOOK.md",
+    baseDir: "/tmp",
+    handlerPath: "/tmp/handler.js",
+  },
+  frontmatter: {},
+  metadata: {
+    events: ["command:new"],
+    requires: { env: [ENV_NAME] },
+  },
+};
+
+function configWithEnv(value: string): OpenClawConfig {
+  return {
+    hooks: {
+      internal: {
+        entries: {
+          [HOOK_NAME]: { env: { [ENV_NAME]: value } },
+        },
+      },
+    },
+  };
+}
+
+function evaluate(config?: OpenClawConfig) {
+  const runtimeIncluded = shouldIncludeHook({ entry, config });
+  const status = buildWorkspaceHookStatus("/tmp", { entries: [entry], config }).hooks[0];
+  return { runtimeIncluded, status };
+}
+
+describe("hook environment requirements", () => {
+  afterEach(() => {
+    delete process.env[ENV_NAME];
+  });
+
+  it.each([
+    { name: "missing values", hostEnv: undefined, configEnv: undefined, satisfied: false },
+    { name: "blank host env", hostEnv: " \t ", configEnv: undefined, satisfied: false },
+    { name: "blank config env", hostEnv: undefined, configEnv: " \n ", satisfied: false },
+    { name: "valid host env", hostEnv: " host-token ", configEnv: undefined, satisfied: true },
+    { name: "valid config env", hostEnv: undefined, configEnv: " config-token ", satisfied: true },
+    {
+      name: "valid config env after blank host env",
+      hostEnv: "   ",
+      configEnv: " config-token ",
+      satisfied: true,
+    },
+  ])("keeps runtime and status aligned for $name", ({ hostEnv, configEnv, satisfied }) => {
+    if (hostEnv === undefined) {
+      delete process.env[ENV_NAME];
+    } else {
+      process.env[ENV_NAME] = hostEnv;
+    }
+
+    const { runtimeIncluded, status } = evaluate(
+      configEnv === undefined ? undefined : configWithEnv(configEnv),
+    );
+
+    expect(runtimeIncluded).toBe(satisfied);
+    expect(status?.requirementsSatisfied).toBe(satisfied);
+    expect(status?.loadable).toBe(satisfied);
+    expect(status?.missing.env).toEqual(satisfied ? [] : [ENV_NAME]);
+  });
+});

--- a/src/hooks/config.ts
+++ b/src/hooks/config.ts
@@ -26,6 +26,10 @@ export function isHookConfigPathTruthy(
 
 export { resolveHookConfig };
 
+export function isHookEnvSatisfied(envName: string, hookConfig?: HookConfig): boolean {
+  return Boolean(process.env[envName]?.trim() || hookConfig?.env?.[envName]?.trim());
+}
+
 function evaluateHookRuntimeEligibility(params: {
   entry: HookEntry;
   config?: OpenClawConfig;
@@ -47,7 +51,7 @@ function evaluateHookRuntimeEligibility(params: {
   return evaluateRuntimeEligibility({
     ...base,
     hasBin: hasBinary,
-    hasEnv: (envName) => Boolean(process.env[envName] || hookConfig?.env?.[envName]),
+    hasEnv: (envName) => isHookEnvSatisfied(envName, hookConfig),
     isConfigPathTruthy: (configPath) => isHookConfigPathTruthy(config, configPath),
   });
 }

--- a/src/hooks/hooks-status.ts
+++ b/src/hooks/hooks-status.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { evaluateEntryRequirementsForCurrentPlatform } from "../shared/entry-status.js";
 import type { RequirementConfigCheck, Requirements } from "../shared/requirements.js";
 import { CONFIG_DIR } from "../utils.js";
-import { hasBinary, isHookConfigPathTruthy } from "./config.js";
+import { hasBinary, isHookConfigPathTruthy, isHookEnvSatisfied } from "./config.js";
 import { isKnownInternalHookEventKey } from "./internal-hook-types.js";
 import {
   resolveHookConfig,
@@ -100,8 +100,7 @@ function buildHookStatus(
   const always = entry.metadata?.always === true;
   const events = entry.metadata?.events ?? [];
   const unknownEvents = events.filter((event) => !isKnownInternalHookEventKey(event));
-  const isEnvSatisfied = (envName: string) =>
-    Boolean(process.env[envName] || hookConfig?.env?.[envName]);
+  const isEnvSatisfied = (envName: string) => isHookEnvSatisfied(envName, hookConfig);
   const isConfigSatisfied = (pathStr: string) => isHookConfigPathTruthy(config, pathStr);
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a hook that requires an environment variable could have that hook loaded and reported as available when the variable contained only whitespace. The hook would then run without a usable required value.

## Why This Change Was Made

Runtime eligibility and hook status now use one hook-owned predicate that accepts nonblank process or per-hook config values after trimming. The main regression risk is rejecting padded but otherwise valid values; the production-path control and focused matrix below cover that case.

## User Impact

Hooks with blank required environment values remain unavailable and are reported as missing the requirement, while padded valid values continue to satisfy it.

## Evidence

On `upstream/main` at `3550d3140e5`, I ran a real Node 24.18.0 process with `TEST_HOOK_TOKEN='   '` and directly imported the production `shouldIncludeHook` and `buildWorkspaceHookStatus` entry points. Both paths incorrectly accepted the blank value:

```text
{"env":"\"   \"","runtimeIncluded":true,"statusRequirementsSatisfied":true,"statusLoadable":true,"statusMissingEnv":[]}
```

The same command against this branch rejects the blank value consistently:

```text
{"env":"\"   \"","runtimeIncluded":false,"statusRequirementsSatisfied":false,"statusLoadable":false,"statusMissingEnv":["TEST_HOOK_TOKEN"]}
```

Negative control with `TEST_HOOK_TOKEN=' padded-valid '` against this branch:

```text
{"env":"\" padded-valid \"","runtimeIncluded":true,"statusRequirementsSatisfied":true,"statusLoadable":true,"statusMissingEnv":[]}
```

Focused regression matrix covering missing, blank, and valid process/config values:

```text
$ node scripts/run-vitest.mjs src/hooks/config.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)
```

Formatting (`oxfmt`), `git diff --check`, and local Codex autoreview passed with no actionable findings. Full build/check/test were not run locally; the broad gates are left to GitHub Actions per the contributor checkout resource policy.

AI-assisted: Codex helped implement and review the patch; the production-path proof and focused tests above were run manually.
