### PR TITLE
refactor(message): keep read fallback policy at call site

### DIFF
--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -276,40 +276,6 @@ describe("resolveMessageChannelSelection", () => {
     });
   });
 
-  it("rejects an explicit unknown channel instead of using the tool context", async () => {
-    await expect(
-      expectResolvedSelection({
-        cfg: {} as never,
-        channel: "channel:C123",
-        fallbackChannel: "beta",
-        requireExplicitChannelAvailable: true,
-      }),
-    ).rejects.toThrow("Unknown channel: channel:c123");
-  });
-
-  it("rejects an explicit unavailable channel instead of using the tool context", async () => {
-    const cfg = {} as never;
-    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) =>
-      channel === "beta" ? { id: "beta" } : undefined,
-    );
-
-    await expect(
-      expectResolvedSelection({
-        cfg,
-        channel: "alpha",
-        fallbackChannel: "beta",
-        requireExplicitChannelAvailable: true,
-      }),
-    ).rejects.toThrow("Channel is unavailable: alpha");
-
-    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledTimes(1);
-    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledWith({
-      channel: "alpha",
-      cfg,
-      allowBootstrap: true,
-    });
-  });
-
   it.each([
     {
       params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "not-a-channel" },

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -219,7 +219,6 @@ export async function resolveMessageChannelSelection(params: {
   cfg: OpenClawConfig;
   channel?: string | null;
   fallbackChannel?: string | null;
-  requireExplicitChannelAvailable?: boolean;
 }): Promise<{
   channel: MessageChannelId;
   configured: MessageChannelId[];
@@ -227,26 +226,21 @@ export async function resolveMessageChannelSelection(params: {
 }> {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
-    if (params.requireExplicitChannelAvailable && !isKnownChannel(normalized)) {
-      throw new Error(`Unknown channel: ${normalized}`);
-    }
     const availableExplicit = resolveAvailableKnownChannel({
       cfg: params.cfg,
       value: normalized,
     });
     if (!availableExplicit) {
-      if (!params.requireExplicitChannelAvailable) {
-        const fallback = resolveAvailableKnownChannel({
-          cfg: params.cfg,
-          value: params.fallbackChannel,
-        });
-        if (fallback) {
-          return {
-            channel: fallback,
-            configured: [],
-            source: "tool-context-fallback",
-          };
-        }
+      const fallback = resolveAvailableKnownChannel({
+        cfg: params.cfg,
+        value: params.fallbackChannel,
+      });
+      if (fallback) {
+        return {
+          channel: fallback,
+          configured: [],
+          source: "tool-context-fallback",
+        };
       }
       if (!isKnownChannel(normalized)) {
         throw new Error(`Unknown channel: ${normalized}`);

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -403,11 +403,15 @@ async function resolveChannel(
   toolContext?: { currentChannelProvider?: string },
   action?: ChannelMessageActionName,
 ) {
+  const channel = readStringParam(params, "channel");
+  // Explicit reads must never switch to the source conversation when their
+  // requested provider is unknown or unavailable.
+  const fallbackChannel =
+    action === "read" && channel ? undefined : toolContext?.currentChannelProvider;
   const selection = await resolveMessageChannelSelection({
     cfg,
-    channel: readStringParam(params, "channel"),
-    fallbackChannel: toolContext?.currentChannelProvider,
-    requireExplicitChannelAvailable: action === "read",
+    channel,
+    fallbackChannel,
   });
   if (selection.source === "tool-context-fallback") {
     params.channel = selection.channel;


### PR DESCRIPTION
Related: #108637

AI-assisted: Codex implemented and reviewed this maintainer-requested follow-up.

## What Problem This Solves

The explicit-read fallback rule introduced while fixing #108637 lived behind a read-specific boolean in the shared channel selector. That made a generic selection helper own message-action policy and required toggle-specific selector tests.

## Why This Change Was Made

Keep the policy at the message-action call site: explicit reads omit the current-conversation fallback, while implicit reads and non-read actions continue to pass it. Remove the single-caller selector option and its duplicate tests. The focused behavior suite remains the boundary proof.

## User Impact

No user-visible behavior change. Explicit malformed, unknown, and unavailable read targets still fail closed; implicit reads and non-read fallback behavior remain unchanged.

## Evidence

- Blacksmith Testbox focused proof: `pnpm test src/infra/outbound/channel-selection.test.ts src/infra/outbound/message-action-runner.context.test.ts` — 2 files, 49 tests passed. [Run](https://github.com/openclaw/openclaw/actions/runs/29492741979)
- Blacksmith Testbox changed gate: `CI=1 pnpm check:changed` — passed all selected format, typecheck, lint, boundary, and repository policy lanes on lease `tbx_01kxn98ca5rzyrhq2tarbs3td7`.
- `git diff --check` — passed.
- Fresh autoreview — no actionable findings, correctness confidence 0.94.
- Net result: 36 fewer lines across the bounded selector/caller surface.
