### PR TITLE
fix(inworld): bound TTS API requests with fallback timeout

### DIFF
--- a/extensions/inworld/tts.test.ts
+++ b/extensions/inworld/tts.test.ts
@@ -359,6 +359,28 @@ describe("inworldTTS", () => {
     expect(buffer).toEqual(Buffer.from("audio"));
   });
 
+  it("defaults to a bounded timeout for TTS requests", async () => {
+    const chunk = Buffer.from("audio").toString("base64");
+    queueGuardedResponse(
+      new Response(JSON.stringify({ result: { audioContent: chunk } }), { status: 200 }),
+    );
+
+    await inworldTTS({ text: "test", apiKey: "test-key" });
+
+    expect(lastGuardRequest().timeoutMs).toBe(30_000);
+  });
+
+  it("preserves an explicit timeout for TTS requests", async () => {
+    const chunk = Buffer.from("audio").toString("base64");
+    queueGuardedResponse(
+      new Response(JSON.stringify({ result: { audioContent: chunk } }), { status: 200 }),
+    );
+
+    await inworldTTS({ text: "test", apiKey: "test-key", timeoutMs: 5_000 });
+
+    expect(lastGuardRequest().timeoutMs).toBe(5_000);
+  });
+
   it("releases the guarded dispatcher after failure", async () => {
     const { release } = queueGuardedResponse(new Response("fail", { status: 500 }));
 

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -140,7 +140,9 @@ export async function inworldTTS(params: {
       },
       body: requestBody,
     },
-    timeoutMs: params.timeoutMs,
+    // Cover the phase before response headers; the bounded body reader below
+    // only starts after fetch resolves.
+    timeoutMs: params.timeoutMs ?? INWORLD_UPSTREAM_IDLE_TIMEOUT_MS,
     policy: ssrfPolicyFromInworldBaseUrl(baseUrl),
     auditContext: "inworld-tts",
   });


### PR DESCRIPTION
## What Problem This Solves

`inworldTTS` passes `params.timeoutMs` directly to `fetchWithSsrFGuard`, which leaves the request unbounded when the caller does not supply `timeoutMs`. The sibling `inworldVoices` function already applies `INWORLD_UPSTREAM_IDLE_TIMEOUT_MS` (30 s) as a fallback, but `inworldTTS` does not. A stalled Inworld TTS endpoint can therefore hold the agent turn open indefinitely with no timeout.

## Why This Change Was Made

Apply `INWORLD_UPSTREAM_IDLE_TIMEOUT_MS` (30 s) as a fallback in `inworldTTS` when the caller does not supply `timeoutMs`, matching the pattern already used by `inworldVoices` at line 231. The body reader already uses `chunkTimeoutMs: INWORLD_UPSTREAM_IDLE_TIMEOUT_MS`, so this only covers the previously-unbounded phase before response headers arrive.

## User Impact

An Inworld TTS request now fails within 30 seconds when the upstream API stalls and no explicit timeout is provided, instead of hanging indefinitely. Callers that supply their own `timeoutMs` are unaffected.

## Evidence

- `node scripts/run-vitest.mjs extensions/inworld/tts.test.ts`: 32 passed (including the two new timeout-default and timeout-preserve tests).
- The new tests mirror the existing `listInworldVoices` timeout tests at lines 197–211.