### PR TITLE
refactor(gateway-client): centralize challenge timeout resolution

### DIFF
--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -330,18 +330,6 @@ export type GatewayClientConnectionMetadata = {
   preauthHandshakeTimeoutMs?: number;
 };
 
-function readConnectChallengeTimeoutOverride(
-  opts: Pick<GatewayClientOptions, "connectChallengeTimeoutMs">,
-): number | undefined {
-  if (
-    typeof opts.connectChallengeTimeoutMs === "number" &&
-    Number.isFinite(opts.connectChallengeTimeoutMs)
-  ) {
-    return opts.connectChallengeTimeoutMs;
-  }
-  return undefined;
-}
-
 function isGatewayClientStoppedError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
   return message === "gateway client stopped" || message === "Error: gateway client stopped";
@@ -355,18 +343,6 @@ function formatGatewayClientErrorForLog(err: unknown): string {
       isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,
     );
   return redactedUrlLikeString;
-}
-
-function resolveGatewayClientConnectChallengeTimeoutMs(
-  opts: Pick<
-    GatewayClientOptions,
-    "connectChallengeTimeoutMs" | "env" | "preauthHandshakeTimeoutMs"
-  >,
-): number {
-  return resolveConnectChallengeTimeoutMs(readConnectChallengeTimeoutOverride(opts), {
-    env: opts.env,
-    configuredTimeoutMs: opts.preauthHandshakeTimeoutMs,
-  });
 }
 
 const FORCE_STOP_TERMINATE_GRACE_MS = 250;
@@ -413,6 +389,13 @@ export class GatewayClient {
       typeof opts.requestTimeoutMs === "number" && Number.isFinite(opts.requestTimeoutMs)
         ? resolveSafeTimeoutDelayMs(opts.requestTimeoutMs, { minMs: 0 })
         : DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
+    const connectChallengeTimeoutMs = resolveConnectChallengeTimeoutMs(
+      this.opts.connectChallengeTimeoutMs,
+      {
+        env: this.opts.env,
+        configuredTimeoutMs: this.opts.preauthHandshakeTimeoutMs,
+      },
+    );
     this.protocol = new GatewayProtocolClient<AssembledConnect>({
       createSocket: (handlers) => this.createSocket(handlers),
       createRequestId: randomUUID,
@@ -465,9 +448,9 @@ export class GatewayClient {
         ),
       handshake: {
         mode: "require-challenge",
-        timeoutMs: resolveGatewayClientConnectChallengeTimeoutMs(this.opts),
+        timeoutMs: connectChallengeTimeoutMs,
         timeoutMessage: (elapsedMs) =>
-          `gateway connect challenge timeout (waited ${elapsedMs}ms, limit ${resolveGatewayClientConnectChallengeTimeoutMs(this.opts)}ms)`,
+          `gateway connect challenge timeout (waited ${elapsedMs}ms, limit ${connectChallengeTimeoutMs}ms)`,
       },
       reconnect: { initialMs: 1_000, multiplier: 2, maxMs: 30_000 },
       requestTimeoutMs: this.requestTimeoutMs,

--- a/packages/gateway-client/src/readiness.ts
+++ b/packages/gateway-client/src/readiness.ts
@@ -33,12 +33,7 @@ function resolveGatewayClientStartReadinessTimeoutMs(
     return options.timeoutMs;
   }
   const clientOptions = options.clientOptions ?? {};
-  const timeoutOverride =
-    typeof clientOptions.connectChallengeTimeoutMs === "number" &&
-    Number.isFinite(clientOptions.connectChallengeTimeoutMs)
-      ? clientOptions.connectChallengeTimeoutMs
-      : undefined;
-  return resolveConnectChallengeTimeoutMs(timeoutOverride, {
+  return resolveConnectChallengeTimeoutMs(clientOptions.connectChallengeTimeoutMs, {
     env: clientOptions.env,
     configuredTimeoutMs: clientOptions.preauthHandshakeTimeoutMs,
   });


### PR DESCRIPTION
## What Problem This Solves

The GatewayClient challenge timeout was resolved through duplicate adapter validation, and the client resolved the same timeout separately for the protocol timer and its diagnostic message. That duplication made future timeout-policy changes easier to apply inconsistently.

## Why This Change Was Made

Use the shared timeout resolver as the single validation and fallback boundary. Resolve once per client construction, then reuse that value for both the protocol timeout and its message; readiness now delegates its raw override directly to the same resolver.

## User Impact

No user-visible behavior change. The gateway-client timeout path is smaller and keeps the armed timer and reported limit structurally consistent.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29492863324
- Focused runtime proof: `pnpm test packages/gateway-client/src/client.handshake.test.ts packages/gateway-client/src/client.watchdog.test.ts packages/gateway-client/src/readiness.test.ts packages/gateway-client/src/timeouts.test.ts` — 4 files, 31 tests passed; live loopback peer timed out at 262 ms for a 250 ms handshake deadline.
- Changed gate: `pnpm check:changed` — passed production/test typechecks, format, lint, SDK baseline, dependency/boundary, cycle, storage, sidecar, webhook, and pairing guards.
- Autoreview: clean; no accepted/actionable findings (0.98).
