### PR TITLE
fix(qqbot): pass timeoutMs to SSRF guard for API and channel requests

### DIFF
--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -81,6 +81,7 @@ describe("ApiClient", () => {
         },
         signal: expect.any(AbortSignal),
       },
+      timeoutMs: 30_000,
       auditContext: "qqbot-api",
       policy: {
         hostnameAllowlist: ["qqbot.test"],

--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -139,6 +139,9 @@ export class ApiClient {
       const guarded = await fetchWithSsrFGuard({
         url,
         init: fetchInit,
+        // Bound redirect resolution alongside the caller's AbortController
+        // so a slow or hanging redirect cannot outlive the request deadline.
+        timeoutMs: timeout,
         auditContext: "qqbot-api",
         policy: resolveQqbotApiSsrfPolicy(url),
       });

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -78,6 +78,7 @@ describe("executeChannelApi", () => {
         },
         signal: expect.any(AbortSignal),
       },
+      timeoutMs: 30_000,
       auditContext: "qqbot-channel-api",
       policy: {
         hostnameAllowlist: ["api.sgroup.qq.com"],

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -329,6 +329,9 @@ export async function executeChannelApi(
       const guarded = await fetchWithSsrFGuard({
         url,
         init: fetchOptions,
+        // Bound redirect resolution alongside the caller's AbortController
+        // so a slow or hanging redirect cannot outlive the request deadline.
+        timeoutMs: DEFAULT_TIMEOUT_MS,
         auditContext: "qqbot-channel-api",
         policy: resolveChannelApiSsrfPolicy(url),
       });


### PR DESCRIPTION
## What Problem This Solves

Both `ApiClient.request` and `executeChannelApi` create their own `AbortController` with a timeout, but they do not pass `timeoutMs` to `fetchWithSsrFGuard`. The SSRF guard's internal redirect-following uses `buildTimeoutAbortSignal`, which returns `undefined` when `timeoutMs` is absent, leaving redirect resolution unbounded. A slow or hanging redirect can outlive the caller's deadline.

## Why This Change Was Made

Pass the same timeout value (`timeout` in ApiClient, `DEFAULT_TIMEOUT_MS` in channel-api) to `fetchWithSsrFGuard` so the guard's redirect chain is bounded by the caller's deadline. The caller's `AbortController` still governs the overall request lifecycle; this change only ensures the SSRF guard's internal redirect hops cannot exceed it.

## User Impact

A QQBot API or channel API request that encounters a slow or hanging redirect now fails within the configured timeout (30 s default) instead of potentially hanging indefinitely on redirect resolution.

## Evidence

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/api-client.test.ts extensions/qqbot/src/engine/tools/channel-api.test.ts`: 20 passed.
- Test assertions updated to verify `timeoutMs` is passed to the SSRF guard.