### PR TITLE
fix(ci): bound release validation dispatch curl POST with --max-time

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1905,7 +1905,7 @@ jobs:
               }'
           )"
 
-          if ! curl --fail-with-body \
+          if ! curl --fail-with-body --connect-timeout 10 --max-time 30 \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${RELEASES_DISPATCH_TOKEN}" \

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3881,4 +3881,22 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       'call.getFile().getRelativePath() = "extensions/codex/src/app-server/transport-websocket.ts"',
     );
   });
+
+  it("bounds full release validation dispatch curl POST with connection and transfer deadlines", () => {
+    const workflow = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
+    // Workflow curl is backslash-continued across several physical lines. Match
+    // the full command block (not a single physical line) before asserting the
+    // connect/transfer deadlines and the warning fallback path.
+    const dispatchBlock =
+      workflow.match(
+        /curl --fail-with-body[\s\S]*?repos\/openclaw\/releases\/dispatches[\s\S]*?-d "\$payload"/u,
+      )?.[0] ?? "";
+
+    expect(dispatchBlock).toContain("--connect-timeout 10");
+    expect(dispatchBlock).toContain("--max-time 30");
+    expect(dispatchBlock).toContain("repos/openclaw/releases/dispatches");
+    expect(workflow).toContain(
+      "::warning::Automatic release evidence dispatch failed; child workflow validation remains authoritative.",
+    );
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

The `curl --fail-with-body` POST in `full-release-validation.yml` that dispatches a `workflow_run` event to `openclaw/releases` had no network deadline. A stalled GitHub API connection could hold the release validation summary job until the surrounding job timeout. The existing warning fallback only handles HTTP failures, not connection-level stalls.

## Why This Change Was Made

Add `--connect-timeout 10 --max-time 30` to bound the dispatch POST. Keep the warning-and-continue fallback unchanged. Guard the full multiline curl command block (not a single physical line) so backslash continuations cannot hide a missing deadline later.

## User Impact

**Before:** A hung GitHub API dispatch could consume the full job deadline without writing the validation manifest.

**After:** The dispatch fails within 30 seconds, the existing warning path runs, and the job continues to manifest writing within a bounded interval. GitHub API latency above 30s can skip automatic evidence dispatch (same tradeoff as sibling bounded-curl CI fixes).

## Evidence

- Changed: `.github/workflows/full-release-validation.yml`, `test/scripts/ci-workflow-guards.test.ts`
- Guard matches the complete `curl --fail-with-body … releases/dispatches … -d "$payload"` block and requires `--connect-timeout 10` / `--max-time 30`
- Controlled stall: local `node:http` server accepts POST and never finishes the body; exact curl flags with `--max-time 2` exit 28 and hit the warning fallback

## Real behavior proof

### Caller path

`.github/workflows/full-release-validation.yml` release-evidence dispatch step → `curl --fail-with-body --connect-timeout 10 --max-time 30` → warning fallback on failure.

### Commands

```bash
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "bounds full release validation dispatch" --reporter=verbose
```

Controlled stall (scaled `--max-time 2`; production uses 30):

```bash
# node:http server accepts connection, writes headers, never ends body
curl --fail-with-body --connect-timeout 10 --max-time 2 \
  -X POST -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer REDACTED" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  "http://127.0.0.1:${PORT}/repos/openclaw/releases/dispatches" \
  -d '{"event_type":"full-validation","client_payload":{}}'
```

### Evidence after fix

```text
✓ ci workflow guards > bounds full release validation dispatch curl POST with connection and transfer deadlines 5ms
 Test Files  1 passed (1)
      Tests  1 passed | 65 skipped (66)

stall server port=51366
curl_exit=28 elapsed_s=2.119
curl: (28) Operation timed out after 2007 milliseconds with 0 bytes received
::warning::Automatic release evidence dispatch failed; child workflow validation remains authoritative.
STALL_PROOF_OK
```

### What was not tested

Live `api.github.com/repos/openclaw/releases/dispatches` with a real token and a production 30s stall (would mutate release evidence). Bounded local stall uses the same curl flags and fallback text as the workflow.

## AI Assistance

AI-assisted. Author reviewed the multiline guard, stall transcript, and warning fallback path.
