### PR TITLE
fix(ci): bound actionlint downloads

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -186,8 +186,16 @@ jobs:
           # GitHub release downloads occasionally return transient 5xx responses.
           # Retry all curl errors here so workflow-sanity does not fail closed on
           # a one-off release edge outage.
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          curl_args=(
+            --connect-timeout 10
+            --max-time 120
+            --retry 5
+            --retry-delay 2
+            --retry-all-errors
+            -sSfL
+          )
+          curl "${curl_args[@]}" -o "${archive}" "${base_url}/${archive}"
+          curl "${curl_args[@]}" -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           grep " ${archive}\$" checksums.txt | sha256sum -c -
           tar -xzf "${archive}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1986,17 +1986,29 @@ describe("ci workflow guards", () => {
     }
   });
 
-  it("bounds the workflow sanity ShellCheck download", () => {
+  it("bounds the workflow sanity tool downloads", () => {
     const workflow = readWorkflowSanityWorkflow();
-    const installStep = expectDefined(
+    const shellcheckStep = expectDefined(
       workflow.jobs.actionlint.steps.find(
         (step: WorkflowStep) => step.name === "Install ShellCheck",
       ),
       "ShellCheck install step",
     );
+    const actionlintStep = expectDefined(
+      workflow.jobs.actionlint.steps.find(
+        (step: WorkflowStep) => step.name === "Install actionlint",
+      ),
+      "actionlint install step",
+    );
 
-    expect(installStep.run).toContain("curl --connect-timeout 10 --max-time 120");
-    expect(installStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
+    expect(shellcheckStep.run).toContain("curl --connect-timeout 10 --max-time 120");
+    expect(shellcheckStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
+    expect(actionlintStep.run).toContain("--connect-timeout 10");
+    expect(actionlintStep.run).toContain("--max-time 120");
+    expect(actionlintStep.run).toContain("--retry 5");
+    expect(actionlintStep.run).toContain("--retry-delay 2");
+    expect(actionlintStep.run).toContain("--retry-all-errors");
+    expect(actionlintStep.run.match(/curl "\$\{curl_args\[@\]\}"/gu)).toHaveLength(2);
   });
 
   it("runs generated baseline drift checks in workflow sanity", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the workflow-sanity job could remain stuck when either actionlint release download connected but stopped transferring data.

## Why This Change Was Made

Both actionlint downloads now reuse one step-local curl argument array with finite connection and transfer deadlines. The helper stays inline because workflow-sanity must not execute helper code from an untrusted pull-request checkout.

## User Impact

Maintainers get bounded workflow-sanity failures instead of indefinitely stalled actionlint setup. Retry, checksum verification, and installation behavior remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 64 passed, 1 skipped.
- `node scripts/check-changed.mjs -- .github/workflows/workflow-sanity.yml test/scripts/ci-workflow-guards.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29493357111
- `./node_modules/.bin/oxfmt --check .github/workflows/workflow-sanity.yml test/scripts/ci-workflow-guards.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh branch autoreview — clean, confidence 0.98.

AI-assisted; maintainer-reviewed and understood.
