### PR TITLE
refactor(clickclack): deduplicate gateway event fixtures

### DIFF
--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -102,11 +102,16 @@ function createBacklogEvent(index: number, type = "channel.updated") {
   };
 }
 
-function emitMessageEvent(socket: FakeSocket, index: number) {
+function emitMessageEvent(
+  socket: FakeSocket,
+  index: number,
+  payload: Record<string, unknown> = {},
+) {
+  const event = createBacklogEvent(index, "message.created");
   socket.emit(
     "message",
     Buffer.from(
-      JSON.stringify({ ...createBacklogEvent(index, "message.created"), seq: index + 1 }),
+      JSON.stringify({ ...event, seq: index + 1, payload: { ...event.payload, ...payload } }),
     ),
   );
 }
@@ -316,21 +321,7 @@ describe("ClickClack gateway", () => {
       "[default] skipped malformed ClickClack websocket event",
     );
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          id: "evt-1",
-          cursor: "cursor-1",
-          type: "message.created",
-          workspace_id: "workspace-1",
-          channel_id: "chan-1",
-          seq: 2,
-          created_at: "2026-01-01T00:00:00.000Z",
-          payload: { message_id: "msg-1", author_id: "human-1" },
-        }),
-      ),
-    );
+    emitMessageEvent(socket, 1);
 
     await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
     expect(mocks.handleClickClackInbound.mock.calls[0]?.[0].access).toEqual({
@@ -362,21 +353,7 @@ describe("ClickClack gateway", () => {
     await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
 
     for (const index of [1, 2]) {
-      firstSocket.emit(
-        "message",
-        Buffer.from(
-          JSON.stringify({
-            id: `evt-${index}`,
-            cursor: `cursor-${index}`,
-            type: "message.created",
-            workspace_id: "workspace-1",
-            channel_id: "chan-1",
-            seq: index + 1,
-            created_at: "2026-01-01T00:00:00.000Z",
-            payload: { message_id: "msg-1", author_id: "human-1" },
-          }),
-        ),
-      );
+      emitMessageEvent(firstSocket, index);
     }
     firstSocket.emit("close");
 
@@ -481,21 +458,7 @@ describe("ClickClack gateway", () => {
 
     await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          id: "evt-1",
-          cursor: "cursor-1",
-          type: "message.created",
-          workspace_id: "workspace-1",
-          channel_id: "chan-1",
-          seq: 2,
-          created_at: "2026-01-01T00:00:00.000Z",
-          payload: { message_id: "msg-1", author_id: "human-1" },
-        }),
-      ),
-    );
+    emitMessageEvent(socket, 1);
 
     await vi.waitFor(() => expect(mocks.resolveClickClackInboundAccess).toHaveBeenCalledTimes(1));
     expect(mocks.handleClickClackInbound).not.toHaveBeenCalled();
@@ -512,25 +475,7 @@ describe("ClickClack gateway", () => {
 
     await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          id: "evt-1",
-          cursor: "cursor-1",
-          type: "message.created",
-          workspace_id: "workspace-1",
-          channel_id: "chan-1",
-          seq: 2,
-          created_at: "2026-01-01T00:00:00.000Z",
-          payload: {
-            message_id: "msg-1",
-            author_id: "human-1",
-            correlation_id: "fakeco.case_1",
-          },
-        }),
-      ),
-    );
+    emitMessageEvent(socket, 1, { correlation_id: "fakeco.case_1" });
 
     await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
     expect(mocks.createClickClackClient).toHaveBeenLastCalledWith({
@@ -556,25 +501,7 @@ describe("ClickClack gateway", () => {
 
     await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          id: "evt-1",
-          cursor: "cursor-1",
-          type: "message.created",
-          workspace_id: "workspace-1",
-          channel_id: "chan-1",
-          seq: 2,
-          created_at: "2026-01-01T00:00:00.000Z",
-          payload: {
-            message_id: "msg-1",
-            author_id: "human-1",
-            correlation_id: "bad correlation",
-          },
-        }),
-      ),
-    );
+    emitMessageEvent(socket, 1, { correlation_id: "bad correlation" });
 
     await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
     expect(mocks.createClickClackClient).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Related: #108570
Follow-up to #108577.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The ClickClack gateway regression suite repeated full websocket event envelopes across ordering, access, and correlation tests. The duplication made the cursor/reconnect scenarios harder to scan and allowed equivalent fixtures to drift.

## Why This Change Was Made

Use one canonical websocket message-event helper with optional payload overrides. This removes 73 lines while preserving each test's event type, sequence, cursor, and correlation cases. Production behavior is unchanged.

## User Impact

No user-visible impact. Maintainers get smaller, clearer ClickClack gateway regressions around the newly landed reconnect recovery behavior.

## Evidence

- `node scripts/run-vitest.mjs extensions/clickclack/src/gateway.test.ts` — 20 passed after rebase onto current `main`.
- `node scripts/check-changed.mjs -- extensions/clickclack/src/gateway.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29493759293
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — no findings; correctness confidence 0.95.
- `git diff --check` — passed.

## AI assistance

OpenAI Codex performed the maintainer-requested follow-up cleanup and review. I reviewed the result and understand the behavior.
