### PR TITLE
fix(qa-lab-web): guard dashboard json responses

### DIFF
--- a/extensions/qa-lab/web/src/http.test.ts
+++ b/extensions/qa-lab/web/src/http.test.ts
@@ -127,4 +127,19 @@ describe("QA Lab dashboard HTTP", () => {
 
     await expect(postJson("/api/runner/start", { scenario: "baseline" })).rejects.toThrow("boom");
   });
+
+  it("allows large successful JSON responses", async () => {
+    const body = JSON.stringify({ data: "x".repeat(128 * 1024) });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        responseWithText(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(getJson("/api/snapshot")).resolves.toEqual({ data: "x".repeat(128 * 1024) });
+  });
 });

--- a/extensions/qa-lab/web/src/http.test.ts
+++ b/extensions/qa-lab/web/src/http.test.ts
@@ -113,7 +113,35 @@ describe("QA Lab dashboard HTTP", () => {
     );
   });
 
-  it("keeps API error bodies bounded and readable", async () => {
+  it("labels malformed JSON success responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        responseWithText("{", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(getJson("/api/state")).rejects.toThrow(/\/api\/state: malformed JSON response/);
+  });
+
+  it("accepts vendor JSON success responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        responseWithText(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/problem+json; charset=utf-8" },
+        }),
+      ),
+    );
+
+    await expect(getJson("/api/bootstrap")).resolves.toEqual({ ok: true });
+  });
+
+  it("keeps JSON API error messages readable", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>(async () =>

--- a/extensions/qa-lab/web/src/http.test.ts
+++ b/extensions/qa-lab/web/src/http.test.ts
@@ -6,6 +6,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function responseWithText(text: string, init?: ResponseInit): Response {
+  return new Response(text, init);
+}
+
 describe("QA Lab dashboard HTTP", () => {
   it("gives every API request a fresh 30 second deadline", async () => {
     const controllers = [new AbortController(), new AbortController(), new AbortController()];
@@ -75,5 +79,52 @@ describe("QA Lab dashboard HTTP", () => {
     timeoutController.abort(new DOMException("request deadline exceeded", "TimeoutError"));
 
     await expect(request).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("fails closed on non-JSON success responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        responseWithText("not json", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      ),
+    );
+
+    await expect(getJson("/api/bootstrap")).rejects.toThrow(
+      /\/api\/bootstrap: expected JSON response/,
+    );
+  });
+
+  it("fails closed on empty JSON success responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        responseWithText("", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(getJsonNoStore("/api/snapshot")).rejects.toThrow(
+      /\/api\/snapshot: empty JSON response/,
+    );
+  });
+
+  it("keeps API error bodies bounded and readable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        responseWithText(JSON.stringify({ error: "boom" }), {
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(postJson("/api/runner/start", { scenario: "baseline" })).rejects.toThrow("boom");
   });
 });

--- a/extensions/qa-lab/web/src/http.test.ts
+++ b/extensions/qa-lab/web/src/http.test.ts
@@ -30,7 +30,7 @@ describe("QA Lab dashboard HTTP", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await getJson("/api/bootstrap");
-    await getJsonNoStore("/api/snapshot");
+    await getJsonNoStore("/api/ui-version");
     await postJson("/api/runner/start", { scenario: "baseline" });
 
     expect(timeout).toHaveBeenCalledTimes(3);
@@ -41,7 +41,7 @@ describe("QA Lab dashboard HTTP", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "/api/snapshot",
+      "/api/ui-version",
       expect.objectContaining({ cache: "no-store", signal: expect.any(AbortSignal) }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -108,8 +108,8 @@ describe("QA Lab dashboard HTTP", () => {
       ),
     );
 
-    await expect(getJsonNoStore("/api/snapshot")).rejects.toThrow(
-      /\/api\/snapshot: empty JSON response/,
+    await expect(getJsonNoStore("/api/ui-version")).rejects.toThrow(
+      /\/api\/ui-version: empty JSON response/,
     );
   });
 
@@ -140,6 +140,6 @@ describe("QA Lab dashboard HTTP", () => {
       ),
     );
 
-    await expect(getJson("/api/snapshot")).resolves.toEqual({ data: "x".repeat(128 * 1024) });
+    await expect(getJson("/api/state")).resolves.toEqual({ data: "x".repeat(128 * 1024) });
   });
 });

--- a/extensions/qa-lab/web/src/http.ts
+++ b/extensions/qa-lab/web/src/http.ts
@@ -47,7 +47,10 @@ export async function postJson<T>(path: string, body: unknown): Promise<T> {
     signal: createRequestSignal(),
   });
   if (!response.ok) {
-    const payload = await readJsonResponse<{ error?: string }>(response, path).catch(() => ({}));
+    const payload: { error?: string } = await readJsonResponse<{ error?: string }>(
+      response,
+      path,
+    ).catch(() => ({}));
     throw new Error(payload.error || `${response.status} ${response.statusText}`);
   }
   return await readJsonResponse<T>(response, path);

--- a/extensions/qa-lab/web/src/http.ts
+++ b/extensions/qa-lab/web/src/http.ts
@@ -1,7 +1,27 @@
 const QA_LAB_API_REQUEST_TIMEOUT_MS = 30_000;
+const QA_LAB_JSON_RESPONSE_MAX_BYTES = 64 * 1024;
 
 function createRequestSignal(): AbortSignal {
   return AbortSignal.timeout(QA_LAB_API_REQUEST_TIMEOUT_MS);
+}
+
+async function readJsonResponse<T>(response: Response, label: string): Promise<T> {
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType && contentType !== "application/json" && !contentType.endsWith("+json")) {
+    throw new Error(`${label}: expected JSON response`);
+  }
+  const text = await response.text();
+  if (!text.trim()) {
+    throw new Error(`${label}: empty JSON response`);
+  }
+  if (new TextEncoder().encode(text).byteLength > QA_LAB_JSON_RESPONSE_MAX_BYTES) {
+    throw new Error(`${label}: JSON response exceeds ${QA_LAB_JSON_RESPONSE_MAX_BYTES} bytes`);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (cause) {
+    throw new Error(`${label}: malformed JSON response`, { cause });
+  }
 }
 
 export async function getJson<T>(path: string): Promise<T> {
@@ -9,7 +29,7 @@ export async function getJson<T>(path: string): Promise<T> {
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);
   }
-  return (await response.json()) as T;
+  return await readJsonResponse<T>(response, path);
 }
 
 export async function getJsonNoStore<T>(path: string): Promise<T> {
@@ -20,7 +40,7 @@ export async function getJsonNoStore<T>(path: string): Promise<T> {
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);
   }
-  return (await response.json()) as T;
+  return await readJsonResponse<T>(response, path);
 }
 
 export async function postJson<T>(path: string, body: unknown): Promise<T> {
@@ -31,8 +51,8 @@ export async function postJson<T>(path: string, body: unknown): Promise<T> {
     signal: createRequestSignal(),
   });
   if (!response.ok) {
-    const payload = (await response.json().catch(() => ({}))) as { error?: string };
+    const payload = await readJsonResponse<{ error?: string }>(response, path).catch(() => ({}));
     throw new Error(payload.error || `${response.status} ${response.statusText}`);
   }
-  return (await response.json()) as T;
+  return await readJsonResponse<T>(response, path);
 }

--- a/extensions/qa-lab/web/src/http.ts
+++ b/extensions/qa-lab/web/src/http.ts
@@ -1,5 +1,4 @@
 const QA_LAB_API_REQUEST_TIMEOUT_MS = 30_000;
-const QA_LAB_JSON_RESPONSE_MAX_BYTES = 64 * 1024;
 
 function createRequestSignal(): AbortSignal {
   return AbortSignal.timeout(QA_LAB_API_REQUEST_TIMEOUT_MS);
@@ -13,9 +12,6 @@ async function readJsonResponse<T>(response: Response, label: string): Promise<T
   const text = await response.text();
   if (!text.trim()) {
     throw new Error(`${label}: empty JSON response`);
-  }
-  if (new TextEncoder().encode(text).byteLength > QA_LAB_JSON_RESPONSE_MAX_BYTES) {
-    throw new Error(`${label}: JSON response exceeds ${QA_LAB_JSON_RESPONSE_MAX_BYTES} bytes`);
   }
   try {
     return JSON.parse(text) as T;

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -49,9 +49,9 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("qa-lab", "src/suite.ts", 330),
   bundledPluginCallsite("qa-lab", "src/suite.ts", 341),
   // The QA dashboard calls its same-origin local API from the browser, where server SSRF helpers do not run.
-  bundledPluginCallsite("qa-lab", "web/src/http.ts", 8),
-  bundledPluginCallsite("qa-lab", "web/src/http.ts", 16),
-  bundledPluginCallsite("qa-lab", "web/src/http.ts", 27),
+  bundledPluginCallsite("qa-lab", "web/src/http.ts", 24),
+  bundledPluginCallsite("qa-lab", "web/src/http.ts", 32),
+  bundledPluginCallsite("qa-lab", "web/src/http.ts", 43),
   bundledPluginCallsite("qqbot", "src/engine/api/api-client.ts", 124),
   bundledPluginCallsite("qqbot", "src/engine/api/media-chunked.ts", 554),
   bundledPluginCallsite("qqbot", "src/engine/api/token.ts", 211),


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where the QA Lab web dashboard would throw raw JSON parse errors when an API route returned a non-JSON or empty success body.

## Why This Change Was Made
The dashboard HTTP helper now treats JSON as an explicit contract: it rejects non-JSON success bodies and empty bodies with a clear route-labeled error instead of letting `response.json()` fail unpredictably. Error responses stay readable through the same helper.

The follow-up on this head removes the earlier global 64 KiB success-body cap so valid large dashboard payloads, including the production `/api/state` polling payload, are not rejected by the client helper.

## User Impact
Dashboard actions now fail with a stable, labeled error when the backend returns malformed or unexpected JSON, while valid large JSON responses can still be consumed by polling/rendering paths.

## Evidence
Malformed success response before:
```text
before: SyntaxError Unexpected token 'o', "not json" is not valid JSON
```

Malformed success response after:
```text
after: Error /api/bootstrap: expected JSON response
```

Focused validation command:
```text
PATH=/usr/local/node24150/bin:$PATH node ../../scripts/run-vitest.mjs extensions/qa-lab/web/src/http.test.ts && PATH=/usr/local/node24150/bin:$PATH pnpm tsgo:prod && PATH=/usr/local/node24150/bin:$PATH pnpm run lint:tmp:no-raw-channel-fetch && git diff --check
```

Focused validation output:
```text
[test] starting test/vitest/vitest.extension-qa.config.ts

 RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw/worktrees/qa-lab-web-json-guard


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  17:28:59
   Duration  1.27s (transform 575ms, setup 721ms, import 19ms, tests 190ms, environment 0ms)

[test] passed 1 Vitest shard in 8.44s
$ pnpm tsgo:core && pnpm tsgo:ui && pnpm tsgo:extensions
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
$ node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
$ node scripts/check-no-raw-channel-fetch.mjs
```

Result: command exited successfully with code 0; `git diff --check` produced no output.

Real browser dashboard proof command:
```text
PATH=/usr/local/node24150/bin:$PATH node /tmp/qa-lab-browser-proof.mjs
```

Real browser dashboard proof output:
```text
browser malformed response badge: /API/BOOTSTRAP: EXPECTED JSON RESPONSE
browser large /api/state bytes: 131444
browser large state marker visible: true
browser normal status: IDLE
```

Notes on the browser proof:
- It launched the real QA Lab web app through Vite and Chromium.
- The malformed case returned `text/plain` for `/api/bootstrap` and verified the visible dashboard error badge.
- The large-payload case returned a 131,444-byte valid `/api/state` JSON payload and verified the page rendered the marker instead of rejecting the response.
