### PR TITLE
fix(feishu): retry inbound dispatch on reply session init conflict, notify sender on exhaustion

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -66,6 +66,11 @@ import { resolveFeishuReasoningPreviewEnabled } from "./reasoning-preview.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, listFeishuThreadMessages, sendMessageFeishu } from "./send.js";
+import {
+  FEISHU_SESSION_CONFLICT_FAILURE_TEXT,
+  FeishuSessionConflictExhaustedError,
+  runFeishuDispatchWithSessionInitConflictRetry,
+} from "./session-conflict-retry.js";
 export type { FeishuBotAddedEvent, FeishuMessageEvent } from "./event-types.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import {
@@ -1346,6 +1351,28 @@ export async function handleFeishuMessage(params: {
       };
     };
 
+    // Exhausted session-init retries would otherwise drop the inbound message
+    // silently (parity gap vs Slack/Signal/Discord/WhatsApp) — tell the sender.
+    const notifySessionConflictLoss = async (noticeCfg: ClawdbotConfig, cause: unknown) => {
+      error(
+        `feishu[${account.accountId}]: dropping inbound message after reply session init conflict retries: ${String(cause)}`,
+      );
+      try {
+        await sendMessageFeishu({
+          cfg: noticeCfg,
+          to: feishuTo,
+          text: FEISHU_SESSION_CONFLICT_FAILURE_TEXT,
+          replyToMessageId: replyTargetMessageId,
+          replyInThread,
+          accountId: account.accountId,
+        });
+      } catch (noticeErr) {
+        error(
+          `feishu[${account.accountId}]: failed to send session-conflict notice: ${String(noticeErr)}`,
+        );
+      }
+    };
+
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
       // event to every bot account in the group. Only one account should handle
@@ -1543,27 +1570,43 @@ export async function handleFeishuMessage(params: {
         }
       };
 
+      // Broadcast gets the same session-init conflict retry as single-agent
+      // dispatch so a transient init race does not silently drop that agent's
+      // turn. Only the active agent owes the sender a visible loss notice.
+      const dispatchForAgentWithRetry = (agentId: string) =>
+        runFeishuDispatchWithSessionInitConflictRetry({
+          dispatch: () => dispatchForAgent(agentId),
+          onRetry: (attempt, delayMs) => {
+            log(
+              `feishu[${account.accountId}]: broadcast reply session init conflict for agent=${agentId}; retrying in ${delayMs}ms (attempt ${attempt})`,
+            );
+          },
+        });
+      const handleBroadcastDispatchFailure = async (agentId: string, err: unknown) => {
+        log(
+          `feishu[${account.accountId}]: broadcast dispatch failed for agent=${agentId}: ${String(err)}`,
+        );
+        if (err instanceof FeishuSessionConflictExhaustedError && agentId === activeAgentId) {
+          await notifySessionConflictLoss(cfg, err);
+        }
+      };
       if (strategy === "sequential") {
         for (const agentId of broadcastAgents) {
           try {
-            await dispatchForAgent(agentId);
+            await dispatchForAgentWithRetry(agentId);
           } catch (err) {
-            log(
-              `feishu[${account.accountId}]: broadcast dispatch failed for agent=${agentId}: ${String(err)}`,
-            );
+            await handleBroadcastDispatchFailure(agentId, err);
           }
         }
       } else {
-        const results = await Promise.allSettled(broadcastAgents.map(dispatchForAgent));
+        const results = await Promise.allSettled(broadcastAgents.map(dispatchForAgentWithRetry));
         for (const [i, result] of results.entries()) {
           if (result.status === "rejected") {
             const agentId = broadcastAgents.at(i);
             if (agentId === undefined) {
               continue;
             }
-            log(
-              `feishu[${account.accountId}]: broadcast dispatch failed for agent=${agentId}: ${String(result.reason)}`,
-            );
+            await handleBroadcastDispatchFailure(agentId, result.reason);
           }
         }
       }
@@ -1579,122 +1622,142 @@ export async function handleFeishuMessage(params: {
         `feishu[${account.accountId}]: broadcast dispatch complete for ${broadcastAgents.length} agents`,
       );
     } else {
-      // --- Single-agent dispatch (existing behavior) ---
-      const ctxPayload = await buildCtxPayloadForAgent(
-        route.agentId,
-        route.sessionKey,
-        route.accountId,
-        ctx.mentionedBot,
-      );
+      // --- Single-agent dispatch ---
+      // Each retry attempt rebuilds the dispatcher: a settled dispatcher
+      // must not carry queued/settled state into a retry attempt.
+      const runSingleAgentDispatch = async () => {
+        const ctxPayload = await buildCtxPayloadForAgent(
+          route.agentId,
+          route.sessionKey,
+          route.accountId,
+          ctx.mentionedBot,
+        );
 
-      const identity = resolveAgentOutboundIdentity(effectiveCfg, route.agentId);
-      const storePath = core.channel.session.resolveStorePath(effectiveCfg.session?.store, {
-        agentId: route.agentId,
-      });
-      const allowReasoningPreview = resolveFeishuReasoningPreviewEnabled({
-        cfg: effectiveCfg,
-        agentId: route.agentId,
-        storePath,
-        sessionKey: route.sessionKey,
-      });
-      const { dispatcher, replyOptions, markDispatchIdle, ensureNoVisibleReplyFallback } =
-        createFeishuReplyDispatcher({
+        const identity = resolveAgentOutboundIdentity(effectiveCfg, route.agentId);
+        const storePath = core.channel.session.resolveStorePath(effectiveCfg.session?.store, {
+          agentId: route.agentId,
+        });
+        const allowReasoningPreview = resolveFeishuReasoningPreviewEnabled({
           cfg: effectiveCfg,
           agentId: route.agentId,
-          runtime: runtime as RuntimeEnv,
-          chatId: ctx.chatId,
-          sendTarget: feishuTo,
-          allowReasoningPreview,
-          replyToMessageId: replyTargetMessageId,
-          typingTargetMessageId,
-          skipReplyToInMessages: !isGroup && !directThreadReply,
-          replyInThread,
-          rootId: ctx.rootId,
-          threadReply,
-          accountId: account.accountId,
-          identity,
-          mentionTargets: ctx.mentionTargets,
-          messageCreateTimeMs,
+          storePath,
           sessionKey: route.sessionKey,
         });
+        const { dispatcher, replyOptions, markDispatchIdle, ensureNoVisibleReplyFallback } =
+          createFeishuReplyDispatcher({
+            cfg: effectiveCfg,
+            agentId: route.agentId,
+            runtime: runtime as RuntimeEnv,
+            chatId: ctx.chatId,
+            sendTarget: feishuTo,
+            allowReasoningPreview,
+            replyToMessageId: replyTargetMessageId,
+            typingTargetMessageId,
+            skipReplyToInMessages: !isGroup && !directThreadReply,
+            replyInThread,
+            rootId: ctx.rootId,
+            threadReply,
+            accountId: account.accountId,
+            identity,
+            mentionTargets: ctx.mentionTargets,
+            messageCreateTimeMs,
+            sessionKey: route.sessionKey,
+          });
 
-      log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
-      const turnResult = await core.channel.inbound.run({
-        channel: "feishu",
-        accountId: route.accountId,
-        raw: ctx,
-        adapter: {
-          ingest: () => ({
-            id: ctx.messageId,
-            timestamp: messageCreateTimeMs,
-            rawText: ctx.content,
-            textForAgent: ctxPayload.BodyForAgent,
-            textForCommands: ctxPayload.CommandBody,
-            raw: ctx,
-          }),
-          resolveTurn: () => ({
-            channel: "feishu",
-            accountId: route.accountId,
-            routeSessionKey: route.sessionKey,
-            storePath,
-            ctxPayload,
-            recordInboundSession: core.channel.session.recordInboundSession,
-            record: {
-              updateLastRoute: buildFeishuInboundLastRouteUpdate({
-                sessionKey: route.sessionKey,
-                accountId: route.accountId,
-              }),
-              onRecordError: (err) => {
-                log(
-                  `feishu[${account.accountId}]: failed to record inbound session ${route.sessionKey}: ${String(err)}`,
-                );
-              },
-            },
-            history: {
-              isGroup,
-              historyKey,
-              historyMap: chatHistories,
-              limit: historyLimit,
-            },
-            onPreDispatchFailure: () =>
-              core.channel.reply.settleReplyDispatcher({
-                dispatcher,
-                onSettled: () => markDispatchIdle(),
-              }),
-            runDispatch: () =>
-              core.channel.reply.withReplyDispatcher({
-                dispatcher,
-                onSettled: () => {
-                  markDispatchIdle();
+        log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
+        const turnResult = await core.channel.inbound.run({
+          channel: "feishu",
+          accountId: route.accountId,
+          raw: ctx,
+          adapter: {
+            ingest: () => ({
+              id: ctx.messageId,
+              timestamp: messageCreateTimeMs,
+              rawText: ctx.content,
+              textForAgent: ctxPayload.BodyForAgent,
+              textForCommands: ctxPayload.CommandBody,
+              raw: ctx,
+            }),
+            resolveTurn: () => ({
+              channel: "feishu",
+              accountId: route.accountId,
+              routeSessionKey: route.sessionKey,
+              storePath,
+              ctxPayload,
+              recordInboundSession: core.channel.session.recordInboundSession,
+              record: {
+                updateLastRoute: buildFeishuInboundLastRouteUpdate({
+                  sessionKey: route.sessionKey,
+                  accountId: route.accountId,
+                }),
+                onRecordError: (err) => {
+                  log(
+                    `feishu[${account.accountId}]: failed to record inbound session ${route.sessionKey}: ${String(err)}`,
+                  );
                 },
-                run: () =>
-                  core.channel.reply.dispatchReplyFromConfig({
-                    ctx: ctxPayload,
-                    cfg: effectiveCfg,
-                    dispatcher,
-                    replyOptions,
-                  }),
-              }),
-          }),
-        },
-      });
-      if (!turnResult.dispatched) {
-        return;
-      }
-      const { dispatchResult } = turnResult;
-      const { queuedFinal, counts } = dispatchResult;
-      if (
-        shouldSendNoVisibleReplyFallback({
-          ...dispatchResult,
-          failedCounts: dispatcher.getFailedCounts?.() ?? { tool: 0, block: 0, final: 0 },
-        })
-      ) {
-        await ensureNoVisibleReplyFallback("dispatch-complete-no-visible-reply");
-      }
+              },
+              history: {
+                isGroup,
+                historyKey,
+                historyMap: chatHistories,
+                limit: historyLimit,
+              },
+              onPreDispatchFailure: () =>
+                core.channel.reply.settleReplyDispatcher({
+                  dispatcher,
+                  onSettled: () => markDispatchIdle(),
+                }),
+              runDispatch: () =>
+                core.channel.reply.withReplyDispatcher({
+                  dispatcher,
+                  onSettled: () => {
+                    markDispatchIdle();
+                  },
+                  run: () =>
+                    core.channel.reply.dispatchReplyFromConfig({
+                      ctx: ctxPayload,
+                      cfg: effectiveCfg,
+                      dispatcher,
+                      replyOptions,
+                    }),
+                }),
+            }),
+          },
+        });
+        if (!turnResult.dispatched) {
+          return;
+        }
+        const { dispatchResult } = turnResult;
+        const { queuedFinal, counts } = dispatchResult;
+        if (
+          shouldSendNoVisibleReplyFallback({
+            ...dispatchResult,
+            failedCounts: dispatcher.getFailedCounts?.() ?? { tool: 0, block: 0, final: 0 },
+          })
+        ) {
+          await ensureNoVisibleReplyFallback("dispatch-complete-no-visible-reply");
+        }
 
-      log(
-        `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
-      );
+        log(
+          `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
+        );
+      };
+
+      try {
+        await runFeishuDispatchWithSessionInitConflictRetry({
+          dispatch: runSingleAgentDispatch,
+          onRetry: (attempt, delayMs) => {
+            log(
+              `feishu[${account.accountId}]: reply session init conflict; retrying dispatch in ${delayMs}ms (attempt ${attempt})`,
+            );
+          },
+        });
+      } catch (err) {
+        if (!(err instanceof FeishuSessionConflictExhaustedError)) {
+          throw err;
+        }
+        await notifySessionConflictLoss(effectiveCfg, err);
+      }
     }
   } catch (err) {
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);

--- a/extensions/feishu/src/session-conflict-retry.integration.test.ts
+++ b/extensions/feishu/src/session-conflict-retry.integration.test.ts
@@ -1,0 +1,443 @@
+// Feishu integration tests prove the session-init conflict retry in the actual
+// handleFeishuMessage dispatch path — single-agent (non-broadcast group) and
+// broadcast — with mocked downstream so the test exercises the real
+// runFeishuDispatchWithSessionInitConflictRetry wiring, exhaustion notice, and
+// active-versus-observer broadcast behavior.
+import type { EnvelopeFormatOptions } from "openclaw/plugin-sdk/channel-inbound";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import { handleFeishuMessage } from "./bot.js";
+import { getFeishuRuntime, setFeishuRuntime } from "./runtime.js";
+
+const CONFLICT_ERROR_MESSAGE =
+  "reply session initialization conflicted for agent:codex:feishu:group:test-group";
+
+const {
+  mockCreateFeishuReplyDispatcher,
+  mockCreateFeishuClient,
+  mockResolveAgentRoute,
+  mockSendMessageFeishu,
+} = vi.hoisted(() => ({
+  mockCreateFeishuReplyDispatcher: vi.fn((_p?: unknown) => ({
+    dispatcher: {
+      sendToolResult: vi.fn(),
+      sendBlockReply: vi.fn(),
+      sendFinalReply: vi.fn(),
+      waitForIdle: vi.fn(),
+      getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      markComplete: vi.fn(),
+    },
+    replyOptions: {},
+    markDispatchIdle: vi.fn(),
+    ensureNoVisibleReplyFallback: vi.fn(),
+  })),
+  mockCreateFeishuClient: vi.fn(),
+  mockResolveAgentRoute: vi.fn(),
+  mockSendMessageFeishu: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./reply-dispatcher.js", () => ({
+  createFeishuReplyDispatcher: mockCreateFeishuReplyDispatcher,
+}));
+vi.mock("./client.js", () => ({
+  createFeishuClient: mockCreateFeishuClient,
+}));
+vi.mock("./send.js", () => ({
+  sendMessageFeishu: mockSendMessageFeishu,
+  getMessageFeishu: vi.fn(),
+  listFeishuThreadMessages: vi.fn(),
+}));
+
+const mockGetChatInfo = vi.fn();
+
+function createRuntimeEnv() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    }),
+  };
+}
+
+/** Factory for the shared runtime stub. `spy` is wired as inbound.run. */
+function buildRuntime(spy: ReturnType<typeof vi.fn>): PluginRuntime {
+  return {
+    system: { enqueueSystemEvent: vi.fn() },
+    channel: {
+      routing: { resolveAgentRoute: (p: unknown) => mockResolveAgentRoute(p) },
+      session: {
+        resolveStorePath: vi.fn(() => "/tmp/feishu-session-store.json"),
+        recordInboundSession: vi.fn().mockResolvedValue(undefined),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions:
+          (() => ({})) as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
+        formatAgentEnvelope: vi.fn((p: { body: string }) => p.body),
+        finalizeInboundContext: vi.fn((ctx) => ({
+          ...ctx,
+          CommandAuthorized: false,
+          CommandTurn: { kind: "normal" as const, source: "message" as const, authorized: false },
+        })),
+        dispatchReplyFromConfig: vi
+          .fn()
+          .mockResolvedValue({ queuedFinal: false, counts: { final: 1 } }),
+        withReplyDispatcher: (async ({ dispatcher, run, onSettled }: any) => {
+          try {
+            return await run();
+          } finally {
+            dispatcher.markComplete();
+            await dispatcher.waitForIdle().finally(() => onSettled?.());
+          }
+        }) as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn(() => false),
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+      },
+      media: {
+        saveMediaBuffer: vi
+          .fn()
+          .mockResolvedValue({ path: "/tmp/test.mp4", contentType: "video/mp4" }),
+      },
+      inbound: { run: spy },
+      pairing: {
+        readAllowFromStore: vi.fn().mockResolvedValue([]),
+        upsertPairingRequest: vi.fn().mockResolvedValue({ code: "TEST", created: false }),
+        buildPairingReply: vi.fn(() => "Pairing response"),
+      },
+    },
+    media: { detectMime: vi.fn(async () => "application/octet-stream") },
+  } as unknown as PluginRuntime;
+}
+
+// ─── Single-agent dispatch (non-broadcast group) ─────────────────────────
+
+describe("single-agent dispatch (group, no broadcast)", () => {
+  const inboundRunSpy = vi.fn();
+
+  afterAll(() => {
+    vi.doUnmock("./reply-dispatcher.js");
+    vi.doUnmock("./client.js");
+    vi.doUnmock("./send.js");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetChatInfo.mockReset();
+    inboundRunSpy.mockReset();
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }) } },
+      im: {
+        chat: { get: mockGetChatInfo.mockResolvedValue({ code: 0, data: { name: "Test Group" } }) },
+      },
+    });
+    mockCreateFeishuReplyDispatcher.mockReturnValue({
+      dispatcher: {
+        sendToolResult: vi.fn(),
+        sendBlockReply: vi.fn(),
+        sendFinalReply: vi.fn(),
+        waitForIdle: vi.fn(),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      },
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      ensureNoVisibleReplyFallback: vi.fn(),
+    });
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "codex",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:codex:feishu:group:test-group",
+      mainSessionKey: "agent:codex:main",
+      lastRoutePolicy: "session",
+      matchedBy: "config",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function run(msgId: string, text: string): Promise<void> {
+    setFeishuRuntime(buildRuntime(inboundRunSpy));
+    const cfg: ClawdbotConfig = {
+      agents: { list: [{ id: "codex" }] },
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "sec_test", // pragma: allowlist secret
+          groups: { "test-group": { requireMention: true } },
+        },
+      },
+    };
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou_sender" } },
+      message: {
+        message_id: msgId,
+        chat_id: "test-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text }),
+        mentions: [
+          { key: "@_user_1", id: { open_id: "bot-open-id" }, name: "Bot", tenant_key: "" },
+        ],
+      },
+    };
+    return handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: "bot-open-id",
+      runtime: createRuntimeEnv(),
+    });
+  }
+
+  it("succeeds immediately when no conflict", async () => {
+    inboundRunSpy.mockResolvedValue({
+      admission: { kind: "dispatch" },
+      dispatched: true,
+      dispatchResult: { queuedFinal: false, counts: { final: 1 } },
+    });
+
+    await run("msg-no-conflict", "hello");
+
+    expect(inboundRunSpy).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
+  it("retries on conflict and succeeds on second attempt", async () => {
+    inboundRunSpy
+      .mockImplementationOnce(async () => {
+        throw new Error(CONFLICT_ERROR_MESSAGE);
+      })
+      .mockResolvedValue({
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        dispatchResult: { queuedFinal: false, counts: { final: 1 } },
+      });
+
+    const p = run("msg-retry", "hello");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await p;
+
+    expect(inboundRunSpy).toHaveBeenCalledTimes(2);
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
+  it("sends user notice after exhausting 1s/2s/4s retries", async () => {
+    inboundRunSpy.mockRejectedValue(new Error(CONFLICT_ERROR_MESSAGE));
+
+    const p = run("msg-exhaust", "hello");
+    await vi.advanceTimersByTimeAsync(7_000);
+    await p;
+
+    // Initial + 3 retries = 4 calls, then user notice
+    expect(inboundRunSpy).toHaveBeenCalledTimes(4);
+    expect(mockSendMessageFeishu).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageFeishu.mock.calls[0][0].text).toBe(
+      "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.",
+    );
+  });
+
+  it("does NOT retry non-conflict errors", async () => {
+    inboundRunSpy.mockRejectedValue(new Error("feishu api unavailable"));
+
+    await run("msg-nonconflict", "hello");
+
+    // Error propagates to handleFeishuMessage's outer catch; logged, not retried
+    expect(inboundRunSpy).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
+  it("retries cause-nested conflict errors", async () => {
+    inboundRunSpy
+      .mockImplementationOnce(async () => {
+        const inner = new Error(CONFLICT_ERROR_MESSAGE);
+        throw new Error("wrapper", { cause: { error: inner } });
+      })
+      .mockResolvedValue({
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        dispatchResult: { queuedFinal: false, counts: { final: 1 } },
+      });
+
+    const p = run("msg-nested", "hello");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await p;
+
+    expect(inboundRunSpy).toHaveBeenCalledTimes(2);
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Broadcast dispatch ───────────────────────────────────────────────────
+
+describe("broadcast dispatch", () => {
+  const inboundRunSpy = vi.fn();
+
+  afterAll(() => {
+    vi.doUnmock("./reply-dispatcher.js");
+    vi.doUnmock("./client.js");
+    vi.doUnmock("./send.js");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetChatInfo.mockReset();
+    inboundRunSpy.mockReset();
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }) } },
+      im: {
+        chat: {
+          get: mockGetChatInfo.mockResolvedValue({ code: 0, data: { name: "Broadcast Team" } }),
+        },
+      },
+    });
+    mockCreateFeishuReplyDispatcher.mockReturnValue({
+      dispatcher: {
+        sendToolResult: vi.fn(),
+        sendBlockReply: vi.fn(),
+        sendFinalReply: vi.fn(),
+        waitForIdle: vi.fn(),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      },
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      ensureNoVisibleReplyFallback: vi.fn(),
+    });
+    mockResolveAgentRoute
+      .mockReset()
+      .mockReturnValueOnce({
+        agentId: "codex",
+        channel: "feishu",
+        accountId: "default",
+        sessionKey: "agent:codex:feishu:group:oc-broadcast-group",
+        mainSessionKey: "agent:codex:main",
+        lastRoutePolicy: "session",
+        matchedBy: "config",
+      })
+      .mockReturnValueOnce({
+        agentId: "susan",
+        channel: "feishu",
+        accountId: "default",
+        sessionKey: "agent:susan:feishu:group:oc-broadcast-group",
+        mainSessionKey: "agent:susan:main",
+        lastRoutePolicy: "session",
+        matchedBy: "config",
+      });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function run(msgId: string, text: string): Promise<void> {
+    setFeishuRuntime(buildRuntime(inboundRunSpy));
+    const cfg: ClawdbotConfig = {
+      broadcast: { "oc-broadcast-group": ["codex", "susan"] },
+      agents: { list: [{ id: "codex" }, { id: "susan" }] },
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "sec_test", // pragma: allowlist secret
+          groups: { "oc-broadcast-group": { requireMention: true } },
+        },
+      },
+    };
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: msgId,
+        chat_id: "oc-broadcast-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text }),
+        mentions: [
+          { key: "@_user_1", id: { open_id: "bot-open-id" }, name: "Bot", tenant_key: "" },
+        ],
+      },
+    };
+    return handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: "bot-open-id",
+      runtime: createRuntimeEnv(),
+    });
+  }
+
+  it("sends notice only for the active agent when its retries exhaust", async () => {
+    // In parallel broadcast both agents start concurrently. codex (active)
+    // must exhaust (4 failures) while susan (observer) succeeds immediately.
+    // Mock queue: call 1 = codex conflict, call 2 = susan success,
+    // calls 3-5 = codex retries (all conflict).
+    inboundRunSpy
+      .mockRejectedValueOnce(new Error(CONFLICT_ERROR_MESSAGE))
+      .mockResolvedValueOnce({
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        dispatchResult: { queuedFinal: false, counts: { final: 1 } },
+      })
+      .mockRejectedValueOnce(new Error(CONFLICT_ERROR_MESSAGE))
+      .mockRejectedValueOnce(new Error(CONFLICT_ERROR_MESSAGE))
+      .mockRejectedValueOnce(new Error(CONFLICT_ERROR_MESSAGE));
+
+    const p = run("bc-exhaust", "hello @bot");
+    await vi.advanceTimersByTimeAsync(7_000);
+    await p;
+
+    // codex: 4 calls (1+3 retries), susan: 1 call = 5
+    expect(inboundRunSpy).toHaveBeenCalledTimes(5);
+    // Only active agent (codex) triggers notice
+    expect(mockSendMessageFeishu).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageFeishu.mock.calls[0][0].text).toBe(
+      "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.",
+    );
+  });
+
+  it("does NOT send notice for observer agent exhaustion", async () => {
+    inboundRunSpy.mockRejectedValue(new Error(CONFLICT_ERROR_MESSAGE));
+
+    const p = run("bc-observer", "hello @bot");
+    await vi.advanceTimersByTimeAsync(7_000);
+    await p;
+
+    // Both agents exhaust: 4 + 4 = 8 calls
+    expect(inboundRunSpy).toHaveBeenCalledTimes(8);
+    // Only active agent (first = codex) triggers notice
+    expect(mockSendMessageFeishu).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers per-agent: codex retries once, susan succeeds immediately", async () => {
+    // First call (codex) throws conflict, subsequent calls succeed
+    inboundRunSpy
+      .mockImplementationOnce(async () => {
+        throw new Error(CONFLICT_ERROR_MESSAGE);
+      })
+      .mockResolvedValue({
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        dispatchResult: { queuedFinal: false, counts: { final: 1 } },
+      });
+
+    const p = run("bc-recover", "hello @bot");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await p;
+
+    // codex: 2 calls, susan: 1 call = 3
+    expect(inboundRunSpy).toHaveBeenCalledTimes(3);
+    // No notice — codex recovered on retry
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/session-conflict-retry.test.ts
+++ b/extensions/feishu/src/session-conflict-retry.test.ts
@@ -1,0 +1,116 @@
+// Feishu tests cover the session-init conflict matcher and bounded retry ladder.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FeishuSessionConflictExhaustedError,
+  isFeishuReplySessionInitConflictError,
+  runFeishuDispatchWithSessionInitConflictRetry,
+} from "./session-conflict-retry.js";
+
+const CONFLICT_ERROR = new Error(
+  "reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1",
+);
+
+describe("isFeishuReplySessionInitConflictError", () => {
+  it("matches direct conflict error message", () => {
+    expect(isFeishuReplySessionInitConflictError(CONFLICT_ERROR)).toBe(true);
+  });
+
+  it("matches cause-nested conflict errors", () => {
+    expect(
+      isFeishuReplySessionInitConflictError(new Error("wrapper", { cause: CONFLICT_ERROR })),
+    ).toBe(true);
+  });
+
+  it("matches error-property-nested conflict errors", () => {
+    expect(
+      isFeishuReplySessionInitConflictError(
+        new Error("wrapper", { cause: { error: CONFLICT_ERROR } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated errors", () => {
+    expect(isFeishuReplySessionInitConflictError(new Error("rate limited"))).toBe(false);
+  });
+
+  it("rejects null/undefined/empty input safely", () => {
+    expect(isFeishuReplySessionInitConflictError(undefined)).toBe(false);
+    expect(isFeishuReplySessionInitConflictError(null)).toBe(false);
+    expect(isFeishuReplySessionInitConflictError("")).toBe(false);
+  });
+});
+
+describe("runFeishuDispatchWithSessionInitConflictRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the result immediately when dispatch succeeds on first attempt", async () => {
+    const dispatch = vi.fn().mockResolvedValue("ok");
+    await expect(runFeishuDispatchWithSessionInitConflictRetry({ dispatch })).resolves.toBe("ok");
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries conflicts on the 1s/2s/4s ladder and returns the first success", async () => {
+    const dispatch = vi
+      .fn()
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockResolvedValue("ok");
+    const onRetry = vi.fn();
+
+    const result = runFeishuDispatchWithSessionInitConflictRetry({ dispatch, onRetry });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(result).resolves.toBe("ok");
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry.mock.calls).toEqual([
+      [1, 1_000],
+      [2, 2_000],
+    ]);
+  });
+
+  it("throws a typed exhausted error after all retry delays are spent", async () => {
+    const dispatch = vi.fn().mockRejectedValue(CONFLICT_ERROR);
+
+    const result = runFeishuDispatchWithSessionInitConflictRetry({ dispatch });
+    const rejection = result.catch((err: unknown) => err);
+    await vi.advanceTimersByTimeAsync(7_000);
+    const err = await rejection;
+    expect(err).toBeInstanceOf(FeishuSessionConflictExhaustedError);
+    expect((err as FeishuSessionConflictExhaustedError).cause).toBe(CONFLICT_ERROR);
+    expect(dispatch).toHaveBeenCalledTimes(4);
+  });
+
+  it("rethrows non-conflict failures without retrying", async () => {
+    const failure = new Error("feishu api unavailable");
+    const dispatch = vi.fn().mockRejectedValue(failure);
+
+    await expect(runFeishuDispatchWithSessionInitConflictRetry({ dispatch })).rejects.toThrow(
+      "feishu api unavailable",
+    );
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onRetry with attempt number and delay for each retry", async () => {
+    const dispatch = vi.fn().mockRejectedValue(CONFLICT_ERROR);
+    const onRetry = vi.fn();
+    const result = runFeishuDispatchWithSessionInitConflictRetry({ dispatch, onRetry });
+    const rejection = result.catch((err: unknown) => err);
+    await vi.advanceTimersByTimeAsync(7_000);
+    const err = await rejection;
+    expect(err).toBeInstanceOf(FeishuSessionConflictExhaustedError);
+    expect(onRetry).toHaveBeenCalledTimes(3);
+    expect(onRetry.mock.calls).toEqual([
+      [1, 1_000],
+      [2, 2_000],
+      [3, 4_000],
+    ]);
+  });
+});

--- a/extensions/feishu/src/session-conflict-retry.ts
+++ b/extensions/feishu/src/session-conflict-retry.ts
@@ -1,0 +1,63 @@
+// Feishu plugin module implements inbound dispatch retry for reply-session init conflicts.
+// Parity target: Signal (extensions/signal/src/monitor/event-handler.ts:686-721)
+// wraps bounded retry for the same conflict pattern with 1s/2s/4s backoff.
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+
+// The message shape is the cross-channel retry classification contract raised
+// by core reply-session initialization (see ReplySessionInitConflictError).
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
+// Bounded backoff ladder before declaring the inbound message lost.
+const FEISHU_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
+
+/** Shown to the sender after all retries are exhausted. */
+export const FEISHU_SESSION_CONFLICT_FAILURE_TEXT =
+  "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.";
+
+export function isFeishuReplySessionInitConflictError(error: unknown): boolean {
+  return collectErrorGraphCandidates(error, (current) => [current.cause, current.error]).some(
+    (candidate) => REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(formatErrorMessage(candidate)),
+  );
+}
+
+/**
+ * Raised when a session-init conflict survives every channel retry delay;
+ * callers owe the sender a visible loss notice.
+ */
+export class FeishuSessionConflictExhaustedError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "FeishuSessionConflictExhaustedError";
+  }
+}
+
+/**
+ * Retries only reply-session init conflicts with a bounded 1s/2s/4s backoff;
+ * other failures propagate immediately so the dispatch catch keeps existing
+ * logging behavior. Each retry rebuilds the dispatcher — a settled dispatcher
+ * must not carry queued/settled state into a retry, so the caller must supply
+ * a fresh dispatch function per attempt.
+ */
+export async function runFeishuDispatchWithSessionInitConflictRetry<T>(params: {
+  dispatch: () => Promise<T>;
+  onRetry?: (attempt: number, delayMs: number) => void;
+}): Promise<T> {
+  for (let retryIndex = 0; ; retryIndex += 1) {
+    try {
+      return await params.dispatch();
+    } catch (error) {
+      if (!isFeishuReplySessionInitConflictError(error)) {
+        throw error;
+      }
+      const delayMs = FEISHU_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS[retryIndex];
+      if (delayMs === undefined) {
+        throw new FeishuSessionConflictExhaustedError(
+          `reply session init conflict persisted after channel retries: ${formatErrorMessage(error)}`,
+          { cause: error },
+        );
+      }
+      params.onRetry?.(retryIndex + 1, delayMs);
+      await sleepWithAbort(delayMs);
+    }
+  }
+}


### PR DESCRIPTION
Closes #108320

## What Problem This Solves

Fixes an issue where Feishu users could have an inbound message silently dropped when reply-session initialization remained conflicted after the shared retry path finished. The sender received no reply or failure notice, so the bot appeared unresponsive and the message was permanently lost (15 incidents in 8 days on the reporter's production gateway).

This is a parity gap: Slack (#99647) and Signal (#100944, fixed in #103218) special-case this exact error with bounded retry + user notice, and Telegram spools the update for delayed replay.

## Why This Change Was Made

The Feishu inbound path now retries only reply-session initialization conflicts with a bounded 1s/2s/4s backoff ladder (matching Signal's pattern). Each retry creates a fresh reply dispatcher — a settled dispatcher must not carry queued/settled state into a session-init conflict retry. If the conflict persists through all three retries, the channel sends the sender a visible threaded notice asking them to try again.

Both single-agent and broadcast dispatch paths are covered. For broadcast, only the active agent's exhaustion triggers the user notice; observer agent failures stay logged as before.

Non-conflict dispatch failures (rate limits, network errors) propagate immediately with existing logging — no behavioral change.

## User Impact

Feishu users can expect transient reply-session conflicts to recover automatically within ~7 seconds. When the session stays busy through every retry, they receive a visible threaded notice instead of losing the message without explanation.

## Evidence

### Unit tests — 10/10 (session-conflict-retry.test.ts)
- Error classification: direct conflict, cause-nested, error-property-nested, reject unrelated, reject null/undefined
- Retry ladder: immediate success, 1s/2s/4s recovery, exhausted → typed error, non-conflict propagation, onRetry callback

### Production-path integration tests — 8/8 (session-conflict-retry.integration.test.ts)
Exercises the real `runFeishuDispatchWithSessionInitConflictRetry` wiring through `handleFeishuMessage`:

**Single-agent dispatch (group, non-broadcast):**
- No conflict → succeeds immediately
- Conflict retry → recovers on 2nd attempt (no user notice)
- All 3 retries exhausted → sends user notice with correct text
- Non-conflict error → immediate propagation (no retry)
- Cause-nested conflict → recognized and retried

**Broadcast dispatch:**
- Active agent exhausts → sends notice only for active (not observer)
- Both agents exhaust → only active triggers notice
- Per-agent independent recovery → codex retries once, susan succeeds immediately

### Broadcast tests — 9/9 (bot.broadcast.test.ts)
Existing broadcast behavior preserved unchanged.

### Runtime behavior proof — terminal captured
```
Error classification:
  direct conflict:        ✓ RECOGNIZED
  cause-nested conflict:  ✓ RECOGNIZED
  non-conflict error:     ✓ CORRECTLY REJECTED

Retry ladder:
  conflict on 1st attempt → retry → 2nd attempt succeeds (result: "dispatch-ok")

Exhaustion:
  4 total attempts (1 initial + 3 retries at 1s/2s/4s)
  → FeishuSessionConflictExhaustedError ✓
  → User notice text: "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment."

Non-conflict propagation:
  1 attempt → immediate propagation (no retry)
```

### Feishu credential configuration
Feishu bot credentials (App ID `cli_a8dc6eb797e8100e`, connection mode: websocket) are configured in `openclaw.json`. The bot is operational; the Feishu API server is reachable from external networks.

### Summary
```
 Test Files  3 passed (3)
      Tests  27 passed (27)    (10 unit + 8 integration + 9 broadcast)
```

Files changed:
- `extensions/feishu/src/session-conflict-retry.ts` — new, retry utility with error classification, bounded 1s/2s/4s backoff, and typed exhausted error
- `extensions/feishu/src/session-conflict-retry.test.ts` — new, unit tests for the retry utility
- `extensions/feishu/src/session-conflict-retry.integration.test.ts` — new, production-path integration tests
- `extensions/feishu/src/bot.ts` — modified, wraps single-agent and broadcast dispatch with retry, sends user notice on exhaustion