### PR TITLE
fix(feishu): messages with 4+ markdown tables fail to send as cards

### DIFF
--- a/extensions/feishu/src/markdown.test.ts
+++ b/extensions/feishu/src/markdown.test.ts
@@ -4,7 +4,81 @@ import {
   chunkFeishuMarkdown,
   chunkFeishuPostMarkdown,
   materializeFeishuPostMarkdownSoftBreaks,
+  sanitizeFeishuCardMarkdownTables,
 } from "./markdown.js";
+
+function markdownTable(header: string, value: string): string {
+  return `| ${header} | col |\n| --- | --- |\n| ${value} | x |`;
+}
+
+describe("sanitizeFeishuCardMarkdownTables", () => {
+  it("keeps text with up to three tables byte-identical", () => {
+    const input = [
+      "Intro",
+      markdownTable("a", "1"),
+      markdownTable("b", "2"),
+      markdownTable("c", "3"),
+      "Outro",
+    ].join("\n\n");
+    expect(sanitizeFeishuCardMarkdownTables(input)).toBe(input);
+  });
+
+  it("fences the fourth and later tables so the card stays under the Feishu table limit", () => {
+    const input = [
+      markdownTable("a", "1"),
+      markdownTable("b", "2"),
+      markdownTable("c", "3"),
+      markdownTable("d", "4"),
+      "between",
+      markdownTable("e", "5"),
+    ].join("\n\n");
+    expect(sanitizeFeishuCardMarkdownTables(input)).toBe(
+      [
+        markdownTable("a", "1"),
+        markdownTable("b", "2"),
+        markdownTable("c", "3"),
+        `\`\`\`\n${markdownTable("d", "4")}\n\`\`\``,
+        "between",
+        `\`\`\`\n${markdownTable("e", "5")}\n\`\`\``,
+      ].join("\n\n"),
+    );
+  });
+
+  it("does not count tables already inside code fences toward the limit", () => {
+    const fenced = `\`\`\`\n${markdownTable("z", "0")}\n\`\`\``;
+    const input = [
+      fenced,
+      markdownTable("a", "1"),
+      markdownTable("b", "2"),
+      markdownTable("c", "3"),
+    ].join("\n\n");
+    expect(sanitizeFeishuCardMarkdownTables(input)).toBe(input);
+  });
+
+  it("counts nested tables toward the limit and lets top-level tables absorb the overflow", () => {
+    const nestedTable = (value: string) =>
+      `- item\n\n  | ${value} | col |\n  | --- | --- |\n  | ${value} | x |`;
+    const input = [
+      nestedTable("n1"),
+      nestedTable("n2"),
+      markdownTable("a", "1"),
+      markdownTable("b", "2"),
+    ].join("\n\n");
+    expect(sanitizeFeishuCardMarkdownTables(input)).toBe(
+      [
+        nestedTable("n1"),
+        nestedTable("n2"),
+        markdownTable("a", "1"),
+        `\`\`\`\n${markdownTable("b", "2")}\n\`\`\``,
+      ].join("\n\n"),
+    );
+  });
+
+  it("ignores plain pipes and table-free text", () => {
+    expect(sanitizeFeishuCardMarkdownTables("a | b | c")).toBe("a | b | c");
+    expect(sanitizeFeishuCardMarkdownTables("no tables here")).toBe("no tables here");
+  });
+});
 
 describe("materializeFeishuPostMarkdownSoftBreaks", () => {
   it.each([

--- a/extensions/feishu/src/markdown.ts
+++ b/extensions/feishu/src/markdown.ts
@@ -31,6 +31,77 @@ export function parseFeishuMarkdown(text: string): FeishuMarkdownNode {
   }) as FeishuMarkdownNode;
 }
 
+// Feishu's OAPI rejects cards rendering more than 3 markdown tables with
+// 230099 / sub-error 11310 "card table number over limit"; the retired
+// official @larksuite plugin shipped the same measured cap. Exceeding it
+// fails the whole send, so extra tables degrade to code blocks instead.
+const FEISHU_CARD_TABLE_LIMIT = 3;
+
+// Every GFM table has exactly one delimiter row built only from `|:- ` plus
+// optional indent/blockquote prefixes, with at least one dash and one pipe,
+// so this cheap line scan never undercounts real tables. It may overcount
+// (fenced examples, ASCII art), which only means the precise parse below
+// runs; card writes are throttled, so most streaming snapshots skip the
+// full markdown parse here.
+function countTableDelimiterLines(text: string): number {
+  let count = 0;
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.includes("|") && trimmed.includes("-") && /^[|:>\s-]+$/.test(trimmed)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Keep card markdown under Feishu's table limit by fencing the 4th+ table
+ * as a code block. Fenced content no longer counts as a card table element,
+ * so the send succeeds and the overflow tables stay readable as text.
+ */
+export function sanitizeFeishuCardMarkdownTables(text: string): string {
+  if (countTableDelimiterLines(text) <= FEISHU_CARD_TABLE_LIMIT) {
+    return text;
+  }
+  // Nested tables (inside lists/quotes) count toward the server-side limit
+  // but cannot be fenced in place, so top-level tables absorb the overflow.
+  // If nested tables alone exceed the limit the remainder stays unfenced.
+  const topLevelTables: FeishuMarkdownNode[] = [];
+  let nestedTableCount = 0;
+  for (const child of parseFeishuMarkdown(text).children ?? []) {
+    if (child.type === "table") {
+      topLevelTables.push(child);
+      continue;
+    }
+    const pending = [...(child.children ?? [])];
+    while (pending.length > 0) {
+      const node = pending.pop();
+      if (node?.type === "table") {
+        nestedTableCount += 1;
+      } else if (node?.children) {
+        pending.push(...node.children);
+      }
+    }
+  }
+  const overflow = topLevelTables.length + nestedTableCount - FEISHU_CARD_TABLE_LIMIT;
+  if (overflow <= 0) {
+    return text;
+  }
+  const fenceCount = Math.min(overflow, topLevelTables.length);
+  let sanitized = text;
+  // Fence the last tables first so earlier offsets stay valid and the
+  // leading tables keep their native card rendering.
+  for (const table of topLevelTables.slice(topLevelTables.length - fenceCount).toReversed()) {
+    const start = table.position?.start.offset;
+    const end = table.position?.end.offset;
+    if (start === undefined || end === undefined) {
+      continue;
+    }
+    sanitized = `${sanitized.slice(0, start)}\`\`\`\n${sanitized.slice(start, end)}\n\`\`\`${sanitized.slice(end)}`;
+  }
+  return sanitized;
+}
+
 function buildFeishuPostMentionElements(mentions?: MentionTarget[]): FeishuPostMessageElement[] {
   if (!mentions?.length) {
     return [];

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -325,6 +325,44 @@ describe("getMessageFeishu", () => {
     });
   });
 
+  it.each([
+    {
+      name: "markdown",
+      send: (text: string) =>
+        sendMarkdownCardFeishu({ cfg: {} as ClawdbotConfig, to: "oc_card", text }),
+    },
+    {
+      name: "structured",
+      send: (text: string) =>
+        sendStructuredCardFeishu({ cfg: {} as ClawdbotConfig, to: "oc_card", text }),
+    },
+  ])("fences card tables over the Feishu limit in $name cards", async ({ send }) => {
+    const table = (value: string) => `| ${value} | col |\n| --- | --- |\n| ${value} | x |`;
+    const text = [table("a"), table("b"), table("c"), table("d")].join("\n\n");
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_card" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    await send(text);
+
+    const request = create.mock.calls[0]?.[0] as { data?: { content?: string } } | undefined;
+    const card = JSON.parse(request?.data?.content ?? "null") as {
+      body?: { elements?: Array<{ content?: string }> };
+    };
+    expect(card.body?.elements?.[0]?.content).toBe(
+      [table("a"), table("b"), table("c"), `\`\`\`\n${table("d")}\n\`\`\``].join("\n\n"),
+    );
+  });
+
   it("extracts text content from interactive card elements", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -14,6 +14,7 @@ import {
   assertFeishuPostWithinEnvelope,
   buildFeishuPostMessageContent,
   materializeFeishuPostMarkdownSoftBreaks,
+  sanitizeFeishuCardMarkdownTables,
 } from "./markdown.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
@@ -677,7 +678,7 @@ function buildMarkdownCard(text: string): Record<string, unknown> {
       elements: [
         {
           tag: "markdown",
-          content: text,
+          content: sanitizeFeishuCardMarkdownTables(text),
         },
       ],
     },
@@ -703,7 +704,9 @@ function buildStructuredCard(
     note?: string;
   },
 ): Record<string, unknown> {
-  const elements: Record<string, unknown>[] = [{ tag: "markdown", content: text }];
+  const elements: Record<string, unknown>[] = [
+    { tag: "markdown", content: sanitizeFeishuCardMarkdownTables(text) },
+  ];
   if (options?.note) {
     elements.push({ tag: "hr" });
     elements.push({ tag: "markdown", content: `<font color='grey'>${options.note}</font>` });

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -467,6 +467,44 @@ describe("FeishuStreamingSession", () => {
     });
   });
 
+  it("sanitizes card tables over the Feishu limit at the CardKit write boundary", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const updateBodies: string[] = [];
+    const deps = mockFetches(updateBodies);
+
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_table_limit",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_1",
+        messageId: "om_1",
+        sequence: 1,
+        currentText: "",
+        sentText: "",
+        hasNote: false,
+      },
+      lastUpdateTime: 1_000,
+    });
+
+    const table = (value: string) => `| ${value} | col |\n| --- | --- |\n| ${value} | x |`;
+    const text = [table("a"), table("b"), table("c"), table("d")].join("\n\n");
+    await session.update(text);
+    await vi.advanceTimersByTimeAsync(160);
+
+    expect(updateBodies).toHaveLength(1);
+    expect(JSON.parse(updateBodies[0] ?? "{}")).toMatchObject({
+      content: [table("a"), table("b"), table("c"), `\`\`\`\n${table("d")}\n\`\`\``].join("\n\n"),
+    });
+  });
+
   it("retries the same throttled snapshot after a CardKit body error", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_500);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -14,6 +14,7 @@ import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { readFeishuJsonResponse } from "./json-response.js";
+import { sanitizeFeishuCardMarkdownTables } from "./markdown.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import { resolveStreamingCardSendMode } from "./streaming-card-send-mode.js";
 import type { FeishuDomain } from "./types.js";
@@ -424,7 +425,9 @@ export class FeishuStreamingSession {
             "User-Agent": getFeishuUserAgent(),
           },
           body: JSON.stringify({
-            content: text,
+            // Sanitize at the write boundary only; sentText/currentText keep
+            // raw text so update-vs-replace prefix checks stay consistent.
+            content: sanitizeFeishuCardMarkdownTables(text),
             sequence: this.state.sequence,
             uuid: `s_${this.state.cardId}_${this.state.sequence}`,
           }),
@@ -474,7 +477,11 @@ export class FeishuStreamingSession {
             "User-Agent": getFeishuUserAgent(),
           },
           body: JSON.stringify({
-            element: JSON.stringify({ tag: "markdown", content: text, element_id: "content" }),
+            element: JSON.stringify({
+              tag: "markdown",
+              content: sanitizeFeishuCardMarkdownTables(text),
+              element_id: "content",
+            }),
             sequence: this.state.sequence,
             uuid: `r_${this.state.cardId}_${this.state.sequence}`,
           }),


### PR DESCRIPTION
Closes #108819

## What Problem This Solves

Fixes an issue where Feishu users sending or receiving replies containing 4 or more markdown tables would get no message at all: the Feishu OAPI rejects the card with `230099` / sub-error `11310` ("card table number over limit"), the send fails, and the user only sees a typing indicator with no reply. The retired official `@larksuite/openclaw-lark` plugin shipped table-limit sanitization for exactly this case; the migration to the community `@openclaw/feishu` plugin in 2026.7.1 silently dropped it (regression reported in #108819).

## Why This Change Was Made

Prevention at the card-content boundary beats reacting to the API error: `sanitizeFeishuCardMarkdownTables` counts tables with the plugin's existing mdast/GFM parser contract (`parseFeishuMarkdown`) and fences the 4th+ table as a code block, so the card stays deliverable and the overflow tables remain readable as text. It is applied at all four card-content construction points: `buildMarkdownCard` / `buildStructuredCard` (plain and structured card sends) and both CardKit streaming write boundaries (incremental update and full replace), while streaming-session internal state keeps raw text so update-vs-replace prefix checks stay consistent. A cheap delimiter-row line scan gates the full markdown parse so throttled streaming writes without table-dense content skip parsing. Nested tables (inside lists/quotes) count toward the limit and top-level tables absorb the overflow; a native `channelData.feishu.card` payload remains user-owned and untouched.

The table cap of 3 is a dependency contract, not a guess: the official cardkit docs cap table components per card, the reporter reproduced 4 markdown tables failing with `11310`, and the retired official plugin shipped the same measured cap (see `FEISHU_CARD_TABLE_LIMIT` comment).

## User Impact

Feishu messages with many markdown tables (e.g. multi-table comparisons) now deliver reliably in both regular and streaming card modes. The first 3 tables render natively in the card; additional tables appear as fenced code blocks instead of the whole message failing.

## Evidence

- Focused tests (all passing, 72 tests across the three touched suites):
  - `extensions/feishu/src/markdown.test.ts` — sanitizer unit tests: ≤3 tables byte-identical, 4th+ fenced, fenced examples not counted, nested tables absorb overflow via top-level fencing, pipe-only text untouched.
  - `extensions/feishu/src/send.test.ts` — markdown and structured card sends fence the 4th table in the card element content.
  - `extensions/feishu/src/streaming-card.test.ts` — CardKit write body is sanitized at the write boundary.
  - `node scripts/run-vitest.mjs extensions/feishu/src/markdown.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/streaming-card.test.ts` → `Test Files 3 passed (3), Tests 72 passed (72)`.
- `oxfmt` and `oxlint` clean on all touched files; `git diff --check` clean.
- Dependency contract: Feishu cardkit table component limit (official docs), reproduction and error codes from #108819, and the retired official plugin's identical cap.
- Known proof gap: no live Feishu tenant available for an end-to-end send; validation is unit-level against the documented/reproduced OAPI contract.
