### PR TITLE
fix(doctor): stop duplicating state schema migration labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Doctor state schema reporting:** distinguish audit, operator-approval, registry, and STRICT SQLite repairs in migration previews and report actual plugin-local repair results without duplicate labels.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Doctor state schema reporting:** distinguish audit, operator-approval, registry, and STRICT SQLite repairs in migration previews and report actual plugin-local repair results without duplicate labels.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -279,11 +279,15 @@ describe("voice-call doctor state migration", () => {
     await expect(migration.detectLegacyState(params)).resolves.toEqual({
       preview: [
         "- Voice Call SQLite schema: audit event ledger -> versioned message lifecycle schema",
+        "- Voice Call SQLite schema: tables -> SQLite STRICT typing",
       ],
     });
     await expect(migration.migrateLegacyState(params)).resolves.toEqual({
       changes: [
         "Migrated Voice Call SQLite audit event ledger -> versioned message lifecycle schema",
+        expect.stringMatching(
+          /^Migrated Voice Call SQLite tables to SQLite STRICT typing \(\d+\)$/,
+        ),
       ],
       warnings: [],
     });

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -149,6 +149,7 @@ function describeVoiceCallSchemaMigration(migration: OpenClawStateDatabaseSchema
     case "strict-tables-v3":
       return "tables -> SQLite STRICT typing";
   }
+  return migration.kind satisfies never;
 }
 
 /** Return true when a path exists and is a file. */

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -139,9 +139,16 @@ function resolveVoiceCallStateDatabaseEnv(
 }
 
 function describeVoiceCallSchemaMigration(migration: OpenClawStateDatabaseSchemaMigration): string {
-  return migration.kind === "agent-databases-composite-primary-key"
-    ? "agent database registry primary key -> agent_id,path"
-    : "audit event ledger -> versioned message lifecycle schema";
+  switch (migration.kind) {
+    case "agent-databases-composite-primary-key":
+      return "agent database registry primary key -> agent_id,path";
+    case "audit-events-v2":
+      return "audit event ledger -> versioned message lifecycle schema";
+    case "operator-approvals-system-agent":
+      return "operator approvals -> OpenClaw system changes";
+    case "strict-tables-v3":
+      return "tables -> SQLite STRICT typing";
+  }
 }
 
 /** Return true when a path exists and is a file. */
@@ -333,9 +340,10 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           return { changes, warnings };
         }
         changes.push(
-          ...schemaMigrations.map(
-            (migration) =>
-              `Migrated Voice Call SQLite ${describeVoiceCallSchemaMigration(migration)}`,
+          ...repaired.changes.map((change) =>
+            change
+              .replace(/^Migrated shared state /, "Migrated Voice Call SQLite ")
+              .replaceAll("→", "->"),
           ),
         );
       }

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -25,6 +25,7 @@ import { DEFAULT_ACCOUNT_ID, DEFAULT_MAIN_KEY, normalizeAgentId } from "../routi
 import {
   detectOpenClawStateDatabaseSchemaMigrations,
   repairOpenClawStateDatabaseSchema,
+  type OpenClawStateDatabaseSchemaMigration,
 } from "../state/openclaw-state-db.js";
 import {
   detectLegacyApnsRegistrations,
@@ -132,6 +133,19 @@ import {
   resolveLegacyUpdateCheckPath,
 } from "./state-migrations.update-check.js";
 import { detectLegacyWebPush, migrateLegacyWebPush } from "./state-migrations.web-push.js";
+
+function describeStateSchemaMigration(migration: OpenClawStateDatabaseSchemaMigration): string {
+  switch (migration.kind) {
+    case "agent-databases-composite-primary-key":
+      return "agent database registry primary key → agent_id,path";
+    case "audit-events-v2":
+      return "audit event ledger → versioned message lifecycle schema";
+    case "operator-approvals-system-agent":
+      return "operator approvals → OpenClaw system changes";
+    case "strict-tables-v3":
+      return "tables → SQLite STRICT typing";
+  }
+}
 
 let autoMigrateChecked = false;
 
@@ -537,11 +551,7 @@ export async function detectLegacyStateMigrations(params: {
   }
   if (stateSchemaMigrations.length > 0) {
     for (const migration of stateSchemaMigrations) {
-      preview.push(
-        migration.kind === "agent-databases-composite-primary-key"
-          ? "- Shared SQLite schema: agent database registry primary key → agent_id,path"
-          : "- Shared SQLite schema: audit event ledger → versioned message lifecycle schema",
-      );
+      preview.push(`- Shared SQLite schema: ${describeStateSchemaMigration(migration)}`);
     }
     preview.push(
       "- Rerun doctor after shared SQLite schema repair to detect plugin state migrations",

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -145,6 +145,7 @@ function describeStateSchemaMigration(migration: OpenClawStateDatabaseSchemaMigr
     case "strict-tables-v3":
       return "tables → SQLite STRICT typing";
   }
+  return migration.kind satisfies never;
 }
 
 let autoMigrateChecked = false;

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1808,9 +1808,10 @@ describe("state migrations", () => {
     const cfg = createConfig();
 
     const detected = await detectLegacyStateMigrations({ cfg, env, homedir: () => root });
-    expect(detected.preview).toContain(
+    expect(detected.preview.filter((line) => line.startsWith("- Shared SQLite schema:"))).toEqual([
       "- Shared SQLite schema: audit event ledger → versioned message lifecycle schema",
-    );
+      "- Shared SQLite schema: tables → SQLite STRICT typing",
+    ]);
 
     const result = await runLegacyStateMigrations({ detected, config: cfg, env });
     expect(result.warnings).toStrictEqual([]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw doctor` could show the audit-ledger migration twice when a state database also needed SQLite STRICT-table repair. The same stale two-kind formatter caused the Voice Call plugin prerelease shard to fail once `strict-tables-v3` was detected.

## Why This Change Was Made

Formats every current state-schema migration kind explicitly in both the shared doctor plan and Voice Call plugin plan. Voice Call completion messages now come from the repair result, preserving the actual number of repaired tables instead of reconstructing it from detection metadata.

## User Impact

Operators now see one accurate preview and completion line per state-schema repair. Doctor output distinguishes registry, audit-ledger, operator-approval, and STRICT-table migrations without duplicate labels.

## Evidence

- Release failure reproduced at exact target `76a236da5fa6ddd4d577e0c2732e6238caa6c0b0`: [Plugin Prerelease run 29491102535](https://github.com/openclaw/openclaw/actions/runs/29491102535), job `checks-node-extensions-shard-2`.
- Focused hosted Testbox proof: `src/infra/state-migrations.test.ts` (51 tests) and `extensions/voice-call/doctor-contract-api.test.ts` (5 tests), all passing on `tbx_01kxn8s14ttsyj6haps20x8hcq`.
- Fresh autoreview: clean, no accepted/actionable findings (0.97 for the fix; 0.99 for the exhaustiveness and changelog follow-ups).
- `git diff --check` passes.

Known unrelated blocker: the same full release validation also hit Z.AI provider billing errors in the live suite. This PR does not mask or downgrade that external failure.
