### PR TITLE
fix(googlechat): skip blank service account env during setup

### DIFF
--- a/extensions/googlechat/src/setup-surface.ts
+++ b/extensions/googlechat/src/setup-surface.ts
@@ -145,7 +145,10 @@ export const googlechatSetupWizard: ChannelSetupWizard = {
   prepare: async ({ cfg, accountId, credentialValues, prompter }) => {
     const envReady =
       accountId === DEFAULT_ACCOUNT_ID &&
-      (Boolean(process.env[ENV_SERVICE_ACCOUNT]) || Boolean(process.env[ENV_SERVICE_ACCOUNT_FILE]));
+      Boolean(
+        normalizeOptionalString(process.env[ENV_SERVICE_ACCOUNT]) ||
+        normalizeOptionalString(process.env[ENV_SERVICE_ACCOUNT_FILE]),
+      );
     if (envReady) {
       const useEnv = await prompter.confirm({
         message: t("wizard.googlechat.useEnvPrompt"),

--- a/extensions/googlechat/src/setup.test.ts
+++ b/extensions/googlechat/src/setup.test.ts
@@ -110,6 +110,60 @@ describe("googlechat setup", () => {
     ).toBe("Google Chat requires --token (service account JSON) or --token-file.");
   });
 
+  it("ignores blank service-account env values during setup", async () => {
+    vi.stubEnv("GOOGLE_CHAT_SERVICE_ACCOUNT", "   ");
+    vi.stubEnv("GOOGLE_CHAT_SERVICE_ACCOUNT_FILE", "  ");
+    const confirm = vi.fn(async () => true);
+    const select = vi.fn(async () => "file" as const) as unknown as WizardPrompter["select"];
+
+    const result = await googlechatSetupWizard.prepare?.({
+      cfg: {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      credentialValues: {},
+      prompter: createTestWizardPrompter({ confirm, select }),
+    } as never);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledOnce();
+    expect(result?.credentialValues?.["__googlechatUseEnv"]).toBe("0");
+  });
+
+  it("offers valid service-account env credentials for the default account", async () => {
+    vi.stubEnv("GOOGLE_CHAT_SERVICE_ACCOUNT", '  {"client_email":"bot@example.com"}  ');
+    vi.stubEnv("GOOGLE_CHAT_SERVICE_ACCOUNT_FILE", "  ");
+    const confirm = vi.fn(async () => true);
+    const select = vi.fn(async () => "file" as const) as unknown as WizardPrompter["select"];
+
+    const result = await googlechatSetupWizard.prepare?.({
+      cfg: {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      credentialValues: {},
+      prompter: createTestWizardPrompter({ confirm, select }),
+    } as never);
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(select).not.toHaveBeenCalled();
+    expect(result?.credentialValues?.["__googlechatUseEnv"]).toBe("1");
+  });
+
+  it("does not offer default-account env credentials to named accounts", async () => {
+    vi.stubEnv("GOOGLE_CHAT_SERVICE_ACCOUNT", '{"client_email":"bot@example.com"}');
+    vi.stubEnv("GOOGLE_CHAT_SERVICE_ACCOUNT_FILE", "/tmp/googlechat.json");
+    const confirm = vi.fn(async () => true);
+    const select = vi.fn(async () => "file" as const) as unknown as WizardPrompter["select"];
+
+    const result = await googlechatSetupWizard.prepare?.({
+      cfg: {},
+      accountId: "alerts",
+      credentialValues: {},
+      prompter: createTestWizardPrompter({ confirm, select }),
+    } as never);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledOnce();
+    expect(result?.credentialValues?.["__googlechatUseEnv"]).toBe("0");
+  });
+
   it("builds a patch from token-file and trims optional webhook fields", () => {
     if (!googlechatSetupAdapter.applyAccountConfig) {
       throw new Error("Expected googlechatSetupAdapter.applyAccountConfig to be defined");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring Google Chat would be prompted to use service-account environment credentials when `GOOGLE_CHAT_SERVICE_ACCOUNT` or `GOOGLE_CHAT_SERVICE_ACCOUNT_FILE` contained only whitespace. Accepting that prompt left setup using credentials that the runtime correctly treated as missing.

## Why This Change Was Made

The Google Chat setup wizard now applies the same non-blank string normalization used by the runtime before offering environment credentials. The change is limited to the setup-time availability predicate: valid default-account inline/file env credentials and named-account isolation are unchanged.

## User Impact

Google Chat setup now falls back to manual service-account selection when the relevant environment variables are blank, instead of offering an unusable env-auth path.

## Evidence

Real production-path proof was run on Linux 6.8.0-134-generic x86_64 with Node v24.18.0. The harness directly imported and called the shipped `googlechatSetupWizard.prepare` and `resolveGoogleChatAccount` functions; it did not copy their decision logic.

Exact command used for both revisions (run once in the detached main worktree and once in the branch worktree):

```bash
GOOGLE_CHAT_SERVICE_ACCOUNT='   ' GOOGLE_CHAT_SERVICE_ACCOUNT_FILE='  ' \
  node --import tsx --input-type=module -e 'import { googlechatSetupWizard } from "./extensions/googlechat/src/setup-surface.ts"; import { resolveGoogleChatAccount } from "./extensions/googlechat/src/accounts.ts"; const calls=[]; const result=await googlechatSetupWizard.prepare({cfg:{},accountId:"default",credentialValues:{},prompter:{confirm:async()=>{calls.push("confirm-use-env");return true},select:async()=>{calls.push("select-manual");return "file"}}}); const runtime=resolveGoogleChatAccount({cfg:{},accountId:"default"}); console.log(JSON.stringify({calls,useEnv:result.credentialValues?.__googlechatUseEnv,runtimeCredentialSource:runtime.credentialSource}));'
```

Negative control / before, detached latest `upstream/main` at `a719a851bbcb`:

```json
{"calls":["confirm-use-env"],"useEnv":"1","runtimeCredentialSource":"none"}
```

The wizard offered and selected env auth even though the runtime resolved no credential.

After, branch commit `afb1e33f0dd6` with the same command and environment:

```json
{"calls":["select-manual"],"useEnv":"0","runtimeCredentialSource":"none"}
```

Production-function control matrix on the fixed branch:

```json
{"case":"missing","calls":["select-manual"],"useEnv":"0","runtimeCredentialSource":"none"}
{"case":"blank","calls":["select-manual"],"useEnv":"0","runtimeCredentialSource":"none"}
{"case":"valid-inline","calls":["confirm-use-env"],"useEnv":"1","runtimeCredentialSource":"env"}
{"case":"valid-file","calls":["confirm-use-env"],"useEnv":"1","runtimeCredentialSource":"env"}
{"case":"named-account","calls":["select-manual"],"useEnv":"0","runtimeCredentialSource":"none"}
```

Focused validation:

```text
node scripts/run-vitest.mjs extensions/googlechat/src/setup.test.ts
Test Files  1 passed (1)
Tests       27 passed (27)

pnpm test:extension googlechat
Test Files  22 passed (22)
Tests       206 passed (206)

./node_modules/.bin/oxfmt --check --threads=1 extensions/googlechat/src/setup-surface.ts extensions/googlechat/src/setup.test.ts
All matched files use the correct format.

node scripts/run-oxlint.mjs extensions/googlechat/src/setup-surface.ts extensions/googlechat/src/setup.test.ts
exit 0

git diff --check upstream/main...HEAD
exit 0
```

The contributor `pnpm check:changed` wrapper could not complete because it attempted unavailable Blacksmith delegation before running its checks; no remote task started. Full repository-wide checks and live Google Chat API delivery were not run locally. This change is confined to the network-free setup decision, and fork CI will cover repository gates.

AI-assisted: Codex implemented and reviewed this change; the final structured autoreview reported no accepted/actionable findings.
