### PR TITLE
perf(ci): skip global declaration emission in the CI artifacts build

### DIFF
--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -178,8 +178,15 @@ export const BUILD_ALL_PROFILE_STEP_ENV = {
   },
   ciArtifacts: {
     tsdown: {
-      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+      // Global declaration emission is ~95% of the tsdown wall clock and PR
+      // CI's dist consumers are runtime JS only; the plugin-sdk gate below
+      // self-builds its scoped declarations instead. Release/package builds
+      // (full profile, docker packaging) keep canonical dts.
+      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
       OPENCLAW_PRESERVE_CLI_STARTUP_METADATA: "1",
+    },
+    "write-plugin-sdk-entry-dts": {
+      OPENCLAW_PLUGIN_SDK_CANONICAL_DTS: "0",
     },
   },
   gatewayWatch: {
@@ -267,7 +274,17 @@ export function resolveBuildAllSteps(profile = "full") {
       return step;
     }
     const mergedEnv = Object.assign({}, step.env, env);
-    return Object.assign({}, step, { env: mergedEnv });
+    const merged = Object.assign({}, step, { env: mergedEnv });
+    // Self-built plugin-sdk declarations depend on the whole SDK source
+    // graph, which the canonical-mode cache inputs do not cover; a cache hit
+    // here would restore stale declarations after source changes.
+    if (
+      step.label === "write-plugin-sdk-entry-dts" &&
+      mergedEnv.OPENCLAW_PLUGIN_SDK_CANONICAL_DTS !== "1"
+    ) {
+      delete merged.cache;
+    }
+    return merged;
   });
 }
 

--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -138,7 +138,7 @@ function isExclusiveCompactGroup(group) {
 // scales with the runner class. infra-process spawns child processes per test
 // and hit worker-startup timeouts under contention before serialization.
 const PINNED_WORKER_COMPACT_GROUP_RE =
-  /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-media-ui$/u;
+  /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-media-ui$|^agentic-gateway-(?:core|methods)$/u;
 const PINNED_COMPACT_GROUP_ENV = { OPENCLAW_VITEST_MAX_WORKERS: "2" };
 
 function applyCompactGroupWorkerPins(group) {

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -352,18 +352,35 @@ describe("resolveBuildAllSteps", () => {
     }
   });
 
-  it("keeps canonical declarations enabled for package artifact builds", () => {
-    const tsdown = resolveBuildAllSteps("ciArtifacts").find((step) => step.label === "tsdown");
+  it("skips global declarations on CI artifacts and self-builds the plugin-sdk gate", () => {
+    // Global dts emission is ~95% of the tsdown wall clock; PR CI dist
+    // consumers are runtime JS, and the plugin-sdk export gate validates
+    // self-built scoped declarations instead. Release/package builds keep
+    // canonical declarations (full profile, docker packaging).
+    const steps = resolveBuildAllSteps("ciArtifacts");
+    const tsdown = steps.find((step) => step.label === "tsdown");
     if (!tsdown) {
       throw new Error("Missing ciArtifacts tsdown step");
     }
-
-    expect(
-      resolveBuildAllStep(tsdown, { env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" } }).options.env,
-    ).toMatchObject({
-      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+    expect(resolveBuildAllStep(tsdown, { env: {} }).options.env).toMatchObject({
+      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
       OPENCLAW_PRESERVE_CLI_STARTUP_METADATA: "1",
     });
+
+    const entryDts = steps.find((step) => step.label === "write-plugin-sdk-entry-dts");
+    if (!entryDts) {
+      throw new Error("Missing ciArtifacts write-plugin-sdk-entry-dts step");
+    }
+    expect(entryDts.env).toMatchObject({ OPENCLAW_PLUGIN_SDK_CANONICAL_DTS: "0" });
+    // Self-build outputs depend on the SDK source graph the canonical cache
+    // inputs do not cover; the profile must drop the step cache.
+    expect(entryDts.cache).toBeUndefined();
+
+    const fullEntryDts = resolveBuildAllSteps("full").find(
+      (step) => step.label === "write-plugin-sdk-entry-dts",
+    );
+    expect(fullEntryDts?.env).toMatchObject({ OPENCLAW_PLUGIN_SDK_CANONICAL_DTS: "1" });
+    expect(fullEntryDts?.cache).toBeDefined();
   });
 
   it("preserves startup metadata only for profiles that regenerate it", () => {


### PR DESCRIPTION
## What Problem This Solves

`build-artifacts` is now the PR CI wall-clock pole (376s in run 29492619358). Its cost is one tsdown invocation at 224.7s — and measurement shows declaration emission is ~95% of that: the same main-graph invocation takes 132.5s with dts and 6.0s without (local, M-series; CI instrumentation via `[tsdown-build] invocation N` timings).

## Why This Change Was Made

PR CI's dist consumers (dist-requiring node test bins, QA packaging, boundary checks) execute runtime JS only. The single declaration consumer on the PR path is `check-plugin-sdk-exports`, and `write-plugin-sdk-entry-dts` already has a self-build mode that produces the scoped plugin-sdk declarations with its own bounded tsdown pass (45s local). So the `ciArtifacts` profile now:

- runs tsdown with `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1` (precedent: `qaRuntime`, `gatewayWatch`, `cliStartup`, `sourcePerformance` already skip dts),
- runs `write-plugin-sdk-entry-dts` in non-canonical (self-build) mode,
- drops that step's build cache in self-build mode — its outputs depend on the whole SDK source graph, which the canonical-mode cache inputs do not cover, so a hit could restore stale declarations.

Release and package builds (`full` profile, docker packaging with `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=0`) keep canonical declaration emission and canonical-mode gate verification. Trade-off note: PR CI validates the SDK surface against self-built scoped declarations rather than the full-graph canonical chunks; full-graph dts breakage would surface at release-build validation rather than PR CI. tsgo prod/test typechecks still run on every PR.

## User Impact

None at runtime — CI-only. PR feedback gets faster: local end-to-end `pnpm build:ci-artifacts` drops to 92s (was ~4min equivalent); the CI job should drop from ~376s toward ~200s, removing the current PR wall-clock pole.

## Evidence

- Measurement: `node scripts/tsdown-build.mjs` 147s total with dts, 14.9s without (same tree, back-to-back).
- Self-build gate: `node --import tsx scripts/write-plugin-sdk-entry-dts.ts` (non-canonical) 49s, then `node scripts/check-plugin-sdk-exports.mjs` → "OK: All 4 required plugin-sdk exports verified" (declaration graph 3.83MB within budget).
- Full pipeline: `pnpm build:ci-artifacts` 92s, all steps green, phase timings in the build log.
- `node scripts/run-vitest.mjs test/scripts/build-all.test.ts` green (profile expectations updated with the contract note).
- This PR touches `scripts/build-all.mjs`, so its own CI run exercises the changed build lane end-to-end — compare `build-artifacts` duration against 376s baseline before merge.
