### PR TITLE
refactor(agents): simplify provider key normalization

### DIFF
--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -242,6 +242,19 @@ describe("models-config merge helpers", () => {
     expect(merged.openai?.baseUrl).toBe("https://canonical.example/v1");
   });
 
+  it("keeps canonical providers at the canonical key's position", () => {
+    const merged = mergeProviders({
+      explicit: {
+        OpenAI: createConfigProvider({ baseUrl: "https://variant.example/v1" }),
+        anthropic: createConfigProvider({ baseUrl: "https://anthropic.example/v1" }),
+        openai: createConfigProvider({ baseUrl: "https://canonical.example/v1" }),
+      },
+    });
+
+    expect(Object.keys(merged)).toEqual(["anthropic", "openai"]);
+    expect(merged.openai?.baseUrl).toBe("https://canonical.example/v1");
+  });
+
   it("keeps the later provider when no collision key uses canonical spelling", () => {
     const merged = mergeProviders({
       explicit: {

--- a/src/agents/models-config.providers.keys.ts
+++ b/src/agents/models-config.providers.keys.ts
@@ -4,24 +4,26 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 export function normalizeProviderMapKeys<T>(
   providers: Record<string, T> | null | undefined,
 ): Record<string, T> {
-  const entries = Object.entries(providers ?? {});
-  const canonicalKeys = new Set<string>();
-  for (const [key] of entries) {
-    const providerKey = normalizeProviderId(key);
-    if (providerKey && key === providerKey) {
-      canonicalKeys.add(providerKey);
-    }
-  }
-
   const normalized: Record<string, T> = {};
-  for (const [key, value] of entries) {
+  const canonicalKeys = new Set<string>();
+  for (const [key, value] of Object.entries(providers ?? {})) {
     const providerKey = normalizeProviderId(key);
-    if (!providerKey || (canonicalKeys.has(providerKey) && key !== providerKey)) {
+    if (!providerKey) {
+      continue;
+    }
+    if (key === providerKey) {
+      canonicalKeys.add(providerKey);
+      // A prior alias inserted this key at the alias's position. Reinsert it so
+      // canonical spelling also controls deterministic provider order.
+      delete normalized[providerKey];
+      normalized[providerKey] = value;
       continue;
     }
     // Exact canonical spelling wins over aliases regardless of object order.
     // Without one, the later variant wins, matching existing trim-collision behavior.
-    normalized[providerKey] = value;
+    if (!canonicalKeys.has(providerKey)) {
+      normalized[providerKey] = value;
+    }
   }
   return normalized;
 }


### PR DESCRIPTION
Related: #95722

AI-assisted: yes. Maintainer-requested follow-up cleanup after landing #95722.

## What Problem This Solves

The provider-key collision helper traversed every provider entry twice and normalized each key twice. That made the deterministic collision rule harder to audit than necessary.

## Why This Change Was Made

Normalize each entry once in a single pass while preserving all existing precedence and enumeration-order semantics. Exact canonical spellings still win regardless of input order; without a canonical spelling, the later alias still wins. A prior alias is deleted and reinserted when the canonical entry arrives so canonical key position remains deterministic.

## User Impact

No user-visible behavior change. Model config generation keeps the collision and SecretRef-preservation behavior landed in #95722 with a smaller normalization path.

## Evidence

- Focused provider merge and runtime source snapshot suites: 33 tests passed across 2 Vitest shards.
- Added a regression assertion for alias-before-canonical provider enumeration order.
- Blacksmith Testbox changed gate passed for the implementation and test: formatting, API and ownership guards, core and core-test typechecks, lint, import cycles, and database-first guards.
- Fresh local autoreview: no accepted or actionable findings.
