### PR TITLE
fix(agents): pass agent/session context to OpenClaw tool result middleware (#106910)

### DIFF
--- a/src/agents/embedded-agent-runner/extensions.test.ts
+++ b/src/agents/embedded-agent-runner/extensions.test.ts
@@ -35,6 +35,8 @@ function buildSafeguardFactories(cfg: OpenClawConfig, workspaceDir?: string) {
     provider: "anthropic",
     modelId: "claude-sonnet-4-20250514",
     model,
+    agentId: "main",
+    sessionKey: "agent:main:main",
   });
 
   return { factories, sessionManager };
@@ -141,6 +143,8 @@ describe("buildEmbeddedExtensionFactories", () => {
       provider: "litellm",
       modelId: "claude-sonnet-4-6",
       model: { api: "anthropic-messages", contextWindow: 200_000 } as Model,
+      agentId: "main",
+      sessionKey: "agent:main:main",
     });
 
     expect(factories).toContain(contextPruningExtension);

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -52,9 +52,18 @@ function snapshotToolSendReceipt(details: unknown): unknown {
 
 function buildAgentToolResultMiddlewareFactory(
   sessionManager: SessionManager,
+  agentId?: string,
+  sessionId?: string,
+  sessionKey?: string,
   runId?: string,
 ): ExtensionFactory {
-  const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" });
+  const runner = createAgentToolResultMiddlewareRunner({
+    runtime: "openclaw",
+    ...(agentId ? { agentId } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(runId ? { runId } : {}),
+  });
   return (agent) => {
     agent.on("tool_result", async (rawEvent: unknown, ctx: { cwd?: string }) => {
       const event = recordFromUnknown(rawEvent) as AgentToolResultEvent;
@@ -179,6 +188,9 @@ export function buildEmbeddedExtensionFactories(params: {
   modelId: string;
   model: ProviderRuntimeModel | undefined;
   runId?: string;
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveEffectiveCompactionMode(params.cfg) === "safeguard") {
@@ -209,6 +221,14 @@ export function buildEmbeddedExtensionFactories(params: {
   if (pruningFactory) {
     factories.push(pruningFactory);
   }
-  factories.push(buildAgentToolResultMiddlewareFactory(params.sessionManager, params.runId));
+  factories.push(
+    buildAgentToolResultMiddlewareFactory(
+      params.sessionManager,
+      params.agentId,
+      params.sessionId,
+      params.sessionKey,
+      params.runId,
+    ),
+  );
   return factories;
 }

--- a/src/agents/embedded-agent-runner/run/attempt-session.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.ts
@@ -80,6 +80,9 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
     modelId: attempt.modelId,
     model: attempt.model,
     runId: attempt.runId,
+    agentId: attempt.agentId ?? input.sessionAgentId,
+    sessionKey: attempt.sessionKey,
+    sessionId: attempt.sessionId,
   });
   const resourceLoader = createEmbeddedAgentResourceLoader({
     cwd: input.effectiveCwd,


### PR DESCRIPTION
## Summary

- Pass `agentId`, `sessionId`, `sessionKey`, and `runId` to `createAgentToolResultMiddlewareRunner` on the OpenClaw runtime path.
- Previously only `{ runtime: "openclaw" }` was passed, while the Codex runtime passes the full `toolResultHookContext`.

## What Problem This Solves

The OpenClaw runtime invoked `AgentToolResultMiddleware` handlers without agent, session, or run identity, even though those fields are part of the public middleware context (`AgentToolResultMiddlewareContext`). Middleware could not attribute or scope OpenClaw events.

The Codex runtime (`dynamic-tools.ts:460-462`) already passes the full context via `toolResultHookContext`.

## User Impact

- **Why it matters:** Installed middleware that performs per-agent/per-session audit, telemetry, or policy decisions can now attribute OpenClaw events at parity with Codex.
- **What did NOT change:** The middleware API is unchanged. Only the context values passed to existing handlers are added.

## Origin / follow-up

Fixes #106910.

## Evidence

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/extensions.test.ts src/agents/embedded-agent-runner/run/attempt-session.test.ts
# 7/7 tests passed
```

Fixes #106910
