### PR TITLE
fix(xai): ignore blank audio env api key

### DIFF
--- a/extensions/xai/realtime-transcription-provider.test.ts
+++ b/extensions/xai/realtime-transcription-provider.test.ts
@@ -6,8 +6,6 @@ import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
 import { buildXaiRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
 
-const TEST_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
-
 const { isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } = vi.hoisted(() => ({
   isProviderAuthProfileConfiguredMock: vi.fn(() => false),
   resolveApiKeyForProviderMock: vi.fn(
@@ -42,7 +40,7 @@ async function createRealtimeSttServer(params?: {
   initialEvent?: unknown;
 }) {
   const server = createServer();
-  const wss = new WebSocketServer({ maxPayload: TEST_WS_MAX_PAYLOAD_BYTES, noServer: true });
+  const wss = new WebSocketServer({ noServer: true });
   const clients = new Set<WebSocket>();
   const done = vi.fn();
   let resolveDone: (() => void) | undefined;

--- a/extensions/xai/realtime-transcription-provider.test.ts
+++ b/extensions/xai/realtime-transcription-provider.test.ts
@@ -6,6 +6,8 @@ import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
 import { buildXaiRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
 
+const TEST_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
+
 const { isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } = vi.hoisted(() => ({
   isProviderAuthProfileConfiguredMock: vi.fn(() => false),
   resolveApiKeyForProviderMock: vi.fn(
@@ -40,7 +42,7 @@ async function createRealtimeSttServer(params?: {
   initialEvent?: unknown;
 }) {
   const server = createServer();
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ maxPayload: TEST_WS_MAX_PAYLOAD_BYTES, noServer: true });
   const clients = new Set<WebSocket>();
   const done = vi.fn();
   let resolveDone: (() => void) | undefined;
@@ -249,6 +251,14 @@ describe("xai realtime transcription provider", () => {
       provider: "xai",
       cfg: {},
     });
+  });
+
+  it("does not treat a blank environment api key as configured", () => {
+    vi.stubEnv("XAI_API_KEY", "   ");
+    isProviderAuthProfileConfiguredMock.mockReturnValue(false);
+    const provider = buildXaiRealtimeTranscriptionProvider();
+
+    expect(provider.isConfigured({ cfg: {}, providerConfig: {} })).toBe(false);
   });
 
   it("threads cfg into the lazy WebSocket bearer resolver", async () => {

--- a/extensions/xai/realtime-transcription-provider.ts
+++ b/extensions/xai/realtime-transcription-provider.ts
@@ -237,8 +237,10 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
     autoSelectOrder: 25,
     resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
     isConfigured: ({ providerConfig, cfg }) =>
-      Boolean(normalizeProviderConfig(providerConfig).apiKey || process.env.XAI_API_KEY) ||
-      isProviderAuthProfileConfigured({ provider: "xai", cfg }),
+      Boolean(
+        normalizeProviderConfig(providerConfig).apiKey ??
+        normalizeOptionalString(process.env.XAI_API_KEY),
+      ) || isProviderAuthProfileConfigured({ provider: "xai", cfg }),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
       // createSession must stay sync per RealtimeTranscriptionProviderPlugin; bearer is resolved lazily in headers().

--- a/extensions/xai/speech-provider.test.ts
+++ b/extensions/xai/speech-provider.test.ts
@@ -303,20 +303,6 @@ describe("xai speech provider", () => {
     ).toBe(false);
   });
 
-  it("does not treat a blank environment api key as configured", () => {
-    process.env.XAI_API_KEY = "   ";
-    isProviderAuthProfileConfiguredMock.mockReturnValue(false);
-    const provider = buildXaiSpeechProvider();
-
-    expect(
-      provider.isConfigured({
-        cfg: {},
-        providerConfig: {},
-        timeoutMs: 5_000,
-      }),
-    ).toBe(false);
-  });
-
   it("uses direct voice-list auth and URL overrides before configured sources", async () => {
     process.env.XAI_API_KEY = "env-key";
     resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "oauth-bearer" });

--- a/extensions/xai/speech-provider.test.ts
+++ b/extensions/xai/speech-provider.test.ts
@@ -303,6 +303,20 @@ describe("xai speech provider", () => {
     ).toBe(false);
   });
 
+  it("does not treat a blank environment api key as configured", () => {
+    process.env.XAI_API_KEY = "   ";
+    isProviderAuthProfileConfiguredMock.mockReturnValue(false);
+    const provider = buildXaiSpeechProvider();
+
+    expect(
+      provider.isConfigured({
+        cfg: {},
+        providerConfig: {},
+        timeoutMs: 5_000,
+      }),
+    ).toBe(false);
+  });
+
   it("uses direct voice-list auth and URL overrides before configured sources", async () => {
     process.env.XAI_API_KEY = "env-key";
     resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "oauth-bearer" });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a whitespace-only `XAI_API_KEY` could make xAI speech and realtime transcription appear configured even though the runtime credential resolver would treat the value as missing.

## Why This Change Was Made

The xAI `isConfigured` checks now normalize the environment API key the same way the runtime auth paths do. This keeps provider availability status aligned with the credentials that synthesis and realtime transcription can actually use.

## User Impact

Users no longer see xAI audio providers advertised as configured when the only environment value is blank whitespace.

## Evidence

- Real provider-inventory boundary: `proof-xai-provider-status.ts` loads the xAI plugin entrypoint, registers its real speech and realtime-transcription providers through OpenClaw's plugin registration API, reads them back through the production provider registries, and checks blank versus nonblank `XAI_API_KEY` behavior.

```text
$ HOME="$(mktemp -d)" XDG_STATE_HOME="$HOME/.local/state" node --import tsx proof-xai-provider-status.ts
case=blank XAI_API_KEY env=blank registered.speech=true registered.realtimeTranscription=true configured.speech=false configured.realtimeTranscription=false
case=nonblank XAI_API_KEY env=nonblank registered.speech=true registered.realtimeTranscription=true configured.speech=true configured.realtimeTranscription=true
```

<details>
<summary>proof-xai-provider-status.ts</summary>

```ts
import xaiPlugin from "./extensions/xai/index.js";
import { createCapturedPluginRegistration } from "./src/plugins/captured-registration.js";
import { createEmptyPluginRegistry } from "./src/plugins/registry-empty.js";
import { setActivePluginRegistry } from "./src/plugins/runtime.js";
import { listRealtimeTranscriptionProviders } from "./src/realtime-transcription/provider-registry.js";
import { listSpeechProviders } from "./src/tts/provider-registry.js";

type Status = {
  label: string;
  env: "blank" | "nonblank";
  registered: {
    speech: string[];
    realtimeTranscription: string[];
  };
  configured: {
    speech: boolean | undefined;
    realtimeTranscription: boolean | undefined;
  };
};

function loadXaiRegistry() {
  const captured = createCapturedPluginRegistration({
    id: "xai",
    name: "xAI",
    source: "extensions/xai/index.ts",
  });
  xaiPlugin.register(captured.api);
  const registry = createEmptyPluginRegistry();
  registry.plugins.push({
    id: "xai",
    name: "xAI",
    source: "extensions/xai/index.ts",
    origin: "bundled",
    enabled: true,
    status: "loaded",
    speechProviderIds: captured.speechProviders.map((provider) => provider.id),
    realtimeTranscriptionProviderIds: captured.realtimeTranscriptionProviders.map(
      (provider) => provider.id,
    ),
  } as never);
  registry.speechProviders.push(
    ...captured.speechProviders.map((provider) => ({
      pluginId: "xai",
      pluginName: "xAI",
      provider,
      source: "extensions/xai/index.ts",
    })),
  );
  registry.realtimeTranscriptionProviders.push(
    ...captured.realtimeTranscriptionProviders.map((provider) => ({
      pluginId: "xai",
      pluginName: "xAI",
      provider,
      source: "extensions/xai/index.ts",
    })),
  );
  setActivePluginRegistry(registry, "proof-xai-provider-status", "default", process.cwd());
}

function readStatus(label: string, apiKey: string): Status {
  process.env.XAI_API_KEY = apiKey;
  loadXaiRegistry();
  const cfg = {};
  const speechProviders = listSpeechProviders(cfg);
  const realtimeTranscriptionProviders = listRealtimeTranscriptionProviders(cfg);
  const speech = speechProviders.find((provider) => provider.id === "xai");
  const realtimeTranscription = realtimeTranscriptionProviders.find((provider) => provider.id === "xai");
  return {
    label,
    env: apiKey.trim() ? "nonblank" : "blank",
    registered: {
      speech: speechProviders.map((provider) => provider.id),
      realtimeTranscription: realtimeTranscriptionProviders.map((provider) => provider.id),
    },
    configured: {
      speech: speech?.isConfigured?.({ cfg, providerConfig: {}, timeoutMs: 5_000 }),
      realtimeTranscription: realtimeTranscription?.isConfigured({
        cfg,
        providerConfig: {},
      }),
    },
  };
}

const blank = readStatus("blank XAI_API_KEY", "   ");
const nonblank = readStatus("nonblank XAI_API_KEY", "redacted-test-key");
delete process.env.XAI_API_KEY;

for (const result of [blank, nonblank]) {
  console.log(
    [
      `case=${result.label}`,
      `env=${result.env}`,
      `registered.speech=${result.registered.speech.includes("xai")}`,
      `registered.realtimeTranscription=${result.registered.realtimeTranscription.includes("xai")}`,
      `configured.speech=${String(result.configured.speech)}`,
      `configured.realtimeTranscription=${String(result.configured.realtimeTranscription)}`,
    ].join(" "),
  );
}
```

</details>

- Focused regression tests:

```text
$ pnpm vitest run extensions/xai/speech-provider.test.ts extensions/xai/realtime-transcription-provider.test.ts
Test Files  2 passed (2)
Tests  28 passed (28)
```

AI-assisted: built with Codex
