### PR TITLE
fix(ci): bound remaining installer runner downloads

### DIFF
--- a/scripts/docker/install-sh-nonroot/run.sh
+++ b/scripts/docker/install-sh-nonroot/run.sh
@@ -62,7 +62,10 @@ node -e '
 command -v npm >/dev/null
 
 echo "==> Run installer (non-root user)"
-curl -fsSL "$INSTALL_URL" | bash
+installer_tmp="$(mktemp)"
+curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer_tmp" "$INSTALL_URL"
+bash "$installer_tmp"
+rm -f "$installer_tmp"
 
 # Ensure PATH picks up user npm prefix
 export PATH="$HOME/.npm-global/bin:$PATH"

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -255,10 +255,13 @@ resolve_update_baseline_version() {
 run_installer_for_package_spec() {
   local install_url="$1"
   local package_spec="$2"
+  local installer_tmp
 
+  installer_tmp="$(mktemp)"
+  curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer_tmp" "$install_url"
   timeout --kill-after=30s "${INSTALL_COMMAND_TIMEOUT}s" \
-    bash -c "curl -fsSL \"\$1\" | bash -s -- --install-method npm --version \"\$2\" --no-prompt --no-onboard" \
-    _ "$install_url" "$package_spec"
+    bash "$installer_tmp" --install-method npm --version "$package_spec" --no-prompt --no-onboard
+  rm -f "$installer_tmp"
 }
 
 run_install_smoke() {
@@ -594,13 +597,15 @@ run_freshness_smoke() {
   fi
 
   echo "==> Run installer with same npm freshness policy"
+  installer_tmp="$(mktemp)"
+  curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer_tmp" "$INSTALL_URL"
   env \
     HOME="$policy_home" \
     NPM_CONFIG_USERCONFIG="${policy_home}/.npmrc" \
     OPENCLAW_NO_ONBOARD=1 \
     OPENCLAW_NO_PROMPT=1 \
-    bash -c 'curl -fsSL "$1" | bash -s -- --install-method npm --version "$2" --no-prompt --no-onboard' \
-    _ "$INSTALL_URL" "$FRESHNESS_VERSION"
+    bash "$installer_tmp" --install-method npm --version "$FRESHNESS_VERSION" --no-prompt --no-onboard
+  rm -f "$installer_tmp"
 
   echo "==> Verify installed version"
   print_install_audit "freshness install"

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -470,6 +470,17 @@ describe("test-install-sh-docker", () => {
     expect(nonrootDockerfile).toContain('bash "$installer"');
     expect(nonrootDockerfile).toContain('rm -f "$installer"');
     expect(nonrootDockerfile).not.toMatch(/curl[^\n]+\|\s*bash/u);
+
+    const nonrootRunner = readFileSync(NONROOT_RUNNER_PATH, "utf8");
+    const smokeRunner = readFileSync(SMOKE_RUNNER_PATH, "utf8");
+    expect(nonrootRunner).toContain("--connect-timeout 10 --max-time 120");
+    expect(nonrootRunner).toContain('"$(mktemp)"');
+    expect(nonrootRunner).toContain("rm -f");
+    expect(nonrootRunner).not.toMatch(/curl[^\n]+\|\s*bash/u);
+    expect(smokeRunner).toContain("--connect-timeout 10 --max-time 120");
+    expect(smokeRunner).toContain('"$(mktemp)"');
+    expect(smokeRunner).toContain("rm -f");
+    expect(smokeRunner).not.toMatch(/curl[^\n]+\|\s*bash/u);
   });
 
   it("keeps shared install helpers parsing and verifying installed CLI versions", () => {


### PR DESCRIPTION
## What Problem This Solves

The install-sh-nonroot runner piped `curl` output directly into `bash` with no connection or transfer deadline. The install-sh-smoke runner had two additional `curl | bash` calls behind a 900-second outer timeout that lacked curl-level timeout flags. A stalled installer response could hold these Docker runners open for up to 15 minutes.

## Why This Change Was Made

Download each installer to a temporary file with a 10-second connection timeout and a 120-second per-transfer deadline, then execute it only after the download succeeds. A stalled stream cannot reach `bash` partially.

## User Impact

Install-sh Docker runners now fail within a bounded interval when the installer endpoint stalls, rather than consuming the full outer command timeout. Healthy installer downloads keep their existing behavior.

## Evidence

- `npx vitest run test/scripts/test-install-sh-docker.test.ts --reporter=dot` — 73 tests passed at the rebased head.
- The added structured guard verifies all three runner scripts contain the bounded curl flags, download-to-temp-file pattern, and cleanup.
- Each runner script also asserts it no longer pipes `curl` directly to `bash`.
- Controlled stall proof: `curl -fsSL --connect-timeout 1 --max-time 1` against a local no-response server exits with curl(28) within ~1 second using the scaled mechanism.
- All three runner scripts pass `bash -n`.