### PR TITLE
fix: bound npm fixture upstream response bodies

### DIFF
--- a/scripts/e2e/lib/bounded-response-text.d.mts
+++ b/scripts/e2e/lib/bounded-response-text.d.mts
@@ -1,3 +1,10 @@
+export function readBoundedResponseBytes(
+  response: unknown,
+  label: unknown,
+  byteLimit: unknown,
+  timeoutPromise?: Promise<never>,
+): Promise<Buffer>;
+
 export function readBoundedResponseText(
   response: unknown,
   label: unknown,

--- a/scripts/e2e/lib/bounded-response-text.mjs
+++ b/scripts/e2e/lib/bounded-response-text.mjs
@@ -20,20 +20,19 @@ function parseContentLengthHeader(headers) {
   return Number.isSafeInteger(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }
 
-export async function readBoundedResponseText(response, label, byteLimit, timeoutPromise) {
+export async function readBoundedResponseBytes(response, label, byteLimit, timeoutPromise) {
   const contentLength = parseContentLengthHeader(response.headers);
   if (contentLength !== undefined && contentLength > byteLimit) {
     await response.body?.cancel().catch(() => {});
     throw bodyTooLargeError(label, byteLimit);
   }
   if (!response.body) {
-    return "";
+    return Buffer.alloc(0);
   }
 
   const reader = response.body.getReader();
-  const decoder = new TextDecoder();
+  const chunks = [];
   let byteCount = 0;
-  let text = "";
   let canceled = false;
   try {
     while (true) {
@@ -50,7 +49,7 @@ export async function readBoundedResponseText(response, label, byteLimit, timeou
         : read;
       const { done, value } = await readWithTimeout;
       if (done) {
-        return text + decoder.decode();
+        return Buffer.concat(chunks, byteCount);
       }
       byteCount += value.byteLength;
       if (byteCount > byteLimit) {
@@ -58,11 +57,16 @@ export async function readBoundedResponseText(response, label, byteLimit, timeou
         await reader.cancel().catch(() => {});
         throw bodyTooLargeError(label, byteLimit);
       }
-      text += decoder.decode(value, { stream: true });
+      chunks.push(Buffer.from(value));
     }
   } finally {
     if (!canceled) {
       reader.releaseLock();
     }
   }
+}
+
+export async function readBoundedResponseText(response, label, byteLimit, timeoutPromise) {
+  const bytes = await readBoundedResponseBytes(response, label, byteLimit, timeoutPromise);
+  return new TextDecoder().decode(bytes);
 }

--- a/scripts/e2e/lib/plugins/npm-registry-server.mjs
+++ b/scripts/e2e/lib/plugins/npm-registry-server.mjs
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
+import { readBoundedResponseBytes } from "../bounded-response-text.mjs";
 
 const [portFile, ...packageArgs] = process.argv.slice(2);
 function normalizeUpstreamRegistry(raw) {
@@ -25,9 +26,10 @@ function normalizeUpstreamRegistry(raw) {
 }
 
 const upstreamRegistry = normalizeUpstreamRegistry(process.env.OPENCLAW_NPM_REGISTRY_UPSTREAM);
-// Match other E2E package-download budgets while keeping a stalled public-registry hop
-// from consuming the much larger install phase deadline.
+// Match other E2E package-download budgets while keeping public-registry hops
+// inside the install deadline and decoded bodies inside a fixed memory budget.
 const UPSTREAM_REQUEST_TIMEOUT_MS = 120_000;
+const UPSTREAM_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
 
 if (!portFile || packageArgs.length === 0 || packageArgs.length % 3 !== 0) {
   console.error(
@@ -146,7 +148,11 @@ async function proxyUpstream(rawRequestUrl, response) {
       redirect: "manual",
       signal: AbortSignal.timeout(UPSTREAM_REQUEST_TIMEOUT_MS),
     });
-    const body = Buffer.from(await upstreamResponse.arrayBuffer());
+    const body = await readBoundedResponseBytes(
+      upstreamResponse,
+      "npm registry upstream",
+      UPSTREAM_RESPONSE_MAX_BYTES,
+    );
     // Fetch decodes compressed bodies but preserves upstream length metadata.
     // Emit the decoded size so npm clients do not truncate proxied responses.
     const headers = { "content-length": String(body.length) };

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -128,7 +128,8 @@ if [ -n "$resolved_package_dir" ]; then
   package_source_kind="prepared-package-set"
   package_mount_args=(-v "$resolved_package_dir:/package-under-test:ro")
   registry_helper_mount_args=(
-    -v "$ROOT_DIR/scripts/e2e/lib/plugins/npm-registry-server.mjs:/tmp/openclaw-npm-registry-server.mjs:ro"
+    -v "$ROOT_DIR/scripts/e2e/lib/bounded-response-text.mjs:/tmp/openclaw-e2e/lib/bounded-response-text.mjs:ro"
+    -v "$ROOT_DIR/scripts/e2e/lib/plugins/npm-registry-server.mjs:/tmp/openclaw-e2e/lib/plugins/npm-registry-server.mjs:ro"
   )
 elif [ -n "$resolved_package_tgz" ]; then
   package_install_source="/package-under-test/$(basename "$resolved_package_tgz")"
@@ -355,7 +356,7 @@ process.stdin.on("end", () => {
   registry_port_file="$(mktemp)"
   registry_log="$(mktemp)"
   OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
-    node /tmp/openclaw-npm-registry-server.mjs \
+    node /tmp/openclaw-e2e/lib/plugins/npm-registry-server.mjs \
     "$registry_port_file" \
     "${registry_args[@]}" >"$registry_log" 2>&1 &
   registry_pid=$!

--- a/test/scripts/bounded-response-text.test.ts
+++ b/test/scripts/bounded-response-text.test.ts
@@ -1,8 +1,36 @@
-// E2E bounded response text tests cover shared E2E HTTP body limits.
+// E2E bounded response tests cover shared HTTP body limits.
 import { describe, expect, it } from "vitest";
-import { readBoundedResponseText } from "../../scripts/e2e/lib/bounded-response-text.mjs";
+import {
+  readBoundedResponseBytes,
+  readBoundedResponseText,
+} from "../../scripts/e2e/lib/bounded-response-text.mjs";
 
 describe("scripts/e2e/lib/bounded-response-text.mjs", () => {
+  it("preserves binary response bytes", async () => {
+    const body = Buffer.from([0x00, 0xff, 0x80, 0x7f]);
+
+    await expect(
+      readBoundedResponseBytes(new Response(body), "fixture", body.length),
+    ).resolves.toEqual(body);
+  });
+
+  it("decodes multibyte text split across chunks", async () => {
+    const encoded = new TextEncoder().encode("a😀b");
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoded.subarray(0, 3));
+          controller.enqueue(encoded.subarray(3));
+          controller.close();
+        },
+      }),
+    );
+
+    await expect(readBoundedResponseText(response, "fixture", encoded.length)).resolves.toBe(
+      "a😀b",
+    );
+  });
+
   it("cancels pending response body reads when the timeout wins", async () => {
     let canceled = false;
     const response = {

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -138,10 +138,13 @@ describe("package Telegram live Docker E2E", () => {
     expect(script).toContain('package_install_source="openclaw@$(read_package_version');
     expect(script).toContain('-v "$resolved_package_dir:/package-under-test:ro"');
     expect(script).toContain(
-      '-v "$ROOT_DIR/scripts/e2e/lib/plugins/npm-registry-server.mjs:/tmp/openclaw-npm-registry-server.mjs:ro"',
+      '-v "$ROOT_DIR/scripts/e2e/lib/bounded-response-text.mjs:/tmp/openclaw-e2e/lib/bounded-response-text.mjs:ro"',
+    );
+    expect(script).toContain(
+      '-v "$ROOT_DIR/scripts/e2e/lib/plugins/npm-registry-server.mjs:/tmp/openclaw-e2e/lib/plugins/npm-registry-server.mjs:ro"',
     );
     expect(script).toContain("OPENCLAW_NPM_TELEGRAM_PACKAGE_SET");
-    expect(script).toContain("node /tmp/openclaw-npm-registry-server.mjs");
+    expect(script).toContain("node /tmp/openclaw-e2e/lib/plugins/npm-registry-server.mjs");
     expect(script).toContain("OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org");
     expect(script).toContain('export NPM_CONFIG_REGISTRY="$registry_url"');
   });

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -16,11 +16,7 @@ import { pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
-import {
-  cleanupTempDirs,
-  makeTempDir,
-  useAutoCleanupTempDirTracker,
-} from "../helpers/temp-dir.js";
+import { cleanupTempDirs, makeTempDir, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/plugins/assertions.mjs";
 const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -14,11 +14,16 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
-import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
+import {
+  cleanupTempDirs,
+  makeTempDir,
+  useAutoCleanupTempDirTracker,
+} from "../helpers/temp-dir.js";
 
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/plugins/assertions.mjs";
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/gu, `'\\''`)}'`;
@@ -742,8 +747,7 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
   });
 
   it("rejects oversized upstream bodies without stopping the fixture registry", async () => {
-    const tempDirs: string[] = [];
-    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-proxy-limit-");
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-proxy-limit-");
     const portFile = path.join(root, "port");
     const tarballPath = path.join(root, "demo-plugin.tgz");
     writeFileSync(tarballPath, "fixture package archive", "utf8");
@@ -811,7 +815,6 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
       await new Promise<void>((resolve) => {
         upstream.close(() => resolve());
       });
-      cleanupTempDirs(tempDirs);
     }
   });
 

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -16,7 +16,7 @@ import { pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
-import { cleanupTempDirs, makeTempDir, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/plugins/assertions.mjs";
 const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -558,8 +558,7 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
   });
 
   it("keeps npm fixture registry alive after malformed package paths", async () => {
-    const tempDirs: string[] = [];
-    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-request-");
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-request-");
     const portFile = path.join(root, "port");
     const tarballPath = path.join(root, "demo-plugin.tgz");
     writeFileSync(tarballPath, "fixture package archive", "utf8");
@@ -606,13 +605,11 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
           child.once("close", resolve);
         });
       }
-      cleanupTempDirs(tempDirs);
     }
   });
 
   it("serves tarball dependencies using the request-visible registry origin", async () => {
-    const tempDirs: string[] = [];
-    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-package-");
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-package-");
     const packageDir = path.join(root, "package");
     const portFile = path.join(root, "port");
     const tarballPath = path.join(root, "openclaw.tgz");
@@ -673,13 +670,11 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
           child.once("close", resolve);
         });
       }
-      cleanupTempDirs(tempDirs);
     }
   });
 
   it("recomputes proxied content length after fetch decodes the response", async () => {
-    const tempDirs: string[] = [];
-    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-proxy-");
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-proxy-");
     const portFile = path.join(root, "port");
     const tarballPath = path.join(root, "demo-plugin.tgz");
     const upstreamBody = JSON.stringify({ payload: "x".repeat(1_000) });
@@ -738,7 +733,6 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
       await new Promise<void>((resolve) => {
         upstream.close(() => resolve());
       });
-      cleanupTempDirs(tempDirs);
     }
   });
 
@@ -815,8 +809,7 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
   });
 
   it("times out stalled upstream response bodies without stopping the fixture registry", async () => {
-    const tempDirs: string[] = [];
-    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-proxy-timeout-");
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-proxy-timeout-");
     const portFile = path.join(root, "port");
     const preloadPath = path.join(root, "shorten-abort-timeout.mjs");
     const tarballPath = path.join(root, "demo-plugin.tgz");
@@ -921,13 +914,11 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
       await new Promise<void>((resolve) => {
         upstream.close(() => resolve());
       });
-      cleanupTempDirs(tempDirs);
     }
   });
 
   it("does not let absolute-form request targets escape the configured upstream", async () => {
-    const tempDirs: string[] = [];
-    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-proxy-origin-");
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-proxy-origin-");
     const portFile = path.join(root, "port");
     const tarballPath = path.join(root, "demo-plugin.tgz");
     let configuredUpstreamHits = 0;
@@ -1018,7 +1009,6 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
           escapeServer.close(() => resolve());
         }),
       ]);
-      cleanupTempDirs(tempDirs);
     }
   });
 
@@ -1358,8 +1348,7 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
   });
 
   it("rejects ClawHub install paths that resolve outside the managed extensions root", () => {
-    const tempDirs: string[] = [];
-    const root = makeTempDir(tempDirs, "openclaw-plugins-clawhub-path-");
+    const root = autoCleanupTempDirs.make("openclaw-plugins-clawhub-path-");
     const home = path.join(root, "home");
     const scratchRoot = path.join(root, "scratch");
     const extensionsRoot = path.join(home, ".openclaw", "extensions");
@@ -1367,43 +1356,39 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
     mkdirSync(extensionsRoot, { recursive: true });
     mkdirSync(escapedInstallPath, { recursive: true });
 
-    try {
-      writeJson(path.join(scratchRoot, "plugins-clawhub-installed.json"), {
-        plugins: [{ id: "openclaw-kitchen-sink-fixture", status: "loaded" }],
-      });
-      writeJson(path.join(scratchRoot, "plugins-clawhub-inspect.json"), {
-        plugin: { id: "openclaw-kitchen-sink-fixture" },
-      });
-      writeJson(path.join(home, ".openclaw", "plugins", "installs.json"), {
-        installRecords: {
-          "openclaw-kitchen-sink-fixture": {
-            artifactFormat: "zip",
-            artifactKind: "legacy-zip",
-            clawhubFamily: "code-plugin",
-            clawhubPackage: "@openclaw/kitchen-sink",
-            installPath: escapedInstallPath,
-            source: "clawhub",
-            spec: "clawhub:@openclaw/kitchen-sink",
-          },
+    writeJson(path.join(scratchRoot, "plugins-clawhub-installed.json"), {
+      plugins: [{ id: "openclaw-kitchen-sink-fixture", status: "loaded" }],
+    });
+    writeJson(path.join(scratchRoot, "plugins-clawhub-inspect.json"), {
+      plugin: { id: "openclaw-kitchen-sink-fixture" },
+    });
+    writeJson(path.join(home, ".openclaw", "plugins", "installs.json"), {
+      installRecords: {
+        "openclaw-kitchen-sink-fixture": {
+          artifactFormat: "zip",
+          artifactKind: "legacy-zip",
+          clawhubFamily: "code-plugin",
+          clawhubPackage: "@openclaw/kitchen-sink",
+          installPath: escapedInstallPath,
+          source: "clawhub",
+          spec: "clawhub:@openclaw/kitchen-sink",
         },
-      });
+      },
+    });
 
-      const result = spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "clawhub-installed"], {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          CLAWHUB_PLUGIN_ID: "openclaw-kitchen-sink-fixture",
-          CLAWHUB_PLUGIN_SPEC: "clawhub:@openclaw/kitchen-sink",
-          HOME: home,
-          OPENCLAW_PLUGINS_TMP_DIR: scratchRoot,
-        },
-      });
+    const result = spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "clawhub-installed"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLAWHUB_PLUGIN_ID: "openclaw-kitchen-sink-fixture",
+        CLAWHUB_PLUGIN_SPEC: "clawhub:@openclaw/kitchen-sink",
+        HOME: home,
+        OPENCLAW_PLUGINS_TMP_DIR: scratchRoot,
+      },
+    });
 
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("ClawHub install path resolved outside");
-    } finally {
-      cleanupTempDirs(tempDirs);
-    }
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("ClawHub install path resolved outside");
   });
 
   it("times out stalled ClawHub package metadata requests", async () => {

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -741,6 +741,80 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
     }
   });
 
+  it("rejects oversized upstream bodies without stopping the fixture registry", async () => {
+    const tempDirs: string[] = [];
+    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-proxy-limit-");
+    const portFile = path.join(root, "port");
+    const tarballPath = path.join(root, "demo-plugin.tgz");
+    writeFileSync(tarballPath, "fixture package archive", "utf8");
+
+    const upstream = createServer((_request, response) => {
+      response.writeHead(200, {
+        "content-length": String(64 * 1024 * 1024 + 1),
+        "content-type": "application/octet-stream",
+      });
+      response.end("oversized");
+    });
+    await new Promise<void>((resolve) => {
+      upstream.listen(0, "127.0.0.1", resolve);
+    });
+    const upstreamAddress = upstream.address();
+    if (!upstreamAddress || typeof upstreamAddress === "string") {
+      throw new Error("expected upstream registry address");
+    }
+
+    const child = spawn(
+      process.execPath,
+      [
+        "scripts/e2e/lib/plugins/npm-registry-server.mjs",
+        portFile,
+        "@openclaw/demo-plugin-npm",
+        "1.0.0",
+        tarballPath,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          OPENCLAW_NPM_REGISTRY_UPSTREAM: `http://127.0.0.1:${upstreamAddress.port}`,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const stderr = createBoundedChildOutput();
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr.append(chunk);
+    });
+
+    try {
+      const port = await waitForPortFile(portFile);
+      const oversized = await requestFixtureRegistry(port, "/oversized-package");
+
+      expect(oversized.statusCode, stderr.text()).toBe(502);
+      expect(oversized.body).toContain(
+        "npm registry upstream response body exceeded 67108864 bytes",
+      );
+
+      const local = await requestFixtureRegistry(port, "/@openclaw%2Fdemo-plugin-npm");
+
+      expect(local.statusCode, stderr.text()).toBe(200);
+      expect(child.exitCode, stderr.text()).toBeNull();
+    } finally {
+      if (child.exitCode === null) {
+        child.kill();
+        await new Promise((resolve) => {
+          child.once("close", resolve);
+        });
+      }
+      upstream.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        upstream.close(() => resolve());
+      });
+      cleanupTempDirs(tempDirs);
+    }
+  });
+
   it("times out stalled upstream response bodies without stopping the fixture registry", async () => {
     const tempDirs: string[] = [];
     const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-proxy-timeout-");


### PR DESCRIPTION
## What Problem This Solves

Plugin and release E2E npm registry fixtures could materialize an unbounded decoded upstream response, allowing an oversized registry body to exhaust the fixture process.

## Why This Change Was Made

The shared E2E bounded-response reader now exposes a byte-preserving path, and the npm fixture uses it with a 64 MiB cap. Binary tarballs stay byte-exact; oversized bodies are canceled, return 502, and do not stop the local registry. Related fixture tests now share automatic temp-directory cleanup instead of repeating manual bookkeeping.

AI-assisted: Codex.

## User Impact

No end-user behavior changes. CI and QA package-install fixtures now fail predictably on oversized upstream bodies instead of risking memory exhaustion.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/bounded-response-text.test.ts test/scripts/plugins-assertions.test.ts test/scripts/npm-telegram-live.test.ts` — 59 tests passed across 3 files on the final rebased head.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/bounded-response-text.d.mts scripts/e2e/lib/bounded-response-text.mjs scripts/e2e/lib/plugins/npm-registry-server.mjs scripts/e2e/npm-telegram-live-docker.sh test/scripts/bounded-response-text.test.ts test/scripts/npm-telegram-live.test.ts test/scripts/plugins-assertions.test.ts` — scripts/root-test typechecks, formatting, guards, and scripts lint passed in Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29495180883
- Autoreview: clean; no actionable findings.
- `git diff --check origin/main...HEAD` — clean.
