### PR TITLE
fix(gateway): resolve admin scope for node.invoke admin-only commands

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -474,6 +474,35 @@ describe("method scope resolution", () => {
     );
   });
 
+  describe("node.invoke command-aware scopes", () => {
+    it.each(["browser.proxy", "fs.listDir", "terminal.upload"])(
+      "resolves operator.admin for node.invoke with admin-only command %s",
+      (command) => {
+        expect(resolveLeastPrivilegeOperatorScopesForMethod("node.invoke", { command })).toEqual([
+          "operator.admin",
+        ]);
+      },
+    );
+
+    it("resolves operator.write for node.invoke with a non-admin command", () => {
+      expect(
+        resolveLeastPrivilegeOperatorScopesForMethod("node.invoke", { command: "system.run" }),
+      ).toEqual(["operator.write"]);
+    });
+
+    it("resolves operator.write for node.invoke without params", () => {
+      expect(resolveLeastPrivilegeOperatorScopesForMethod("node.invoke")).toEqual([
+        "operator.write",
+      ]);
+    });
+
+    it("resolves operator.write for node.invoke with empty params object", () => {
+      expect(resolveLeastPrivilegeOperatorScopesForMethod("node.invoke", {})).toEqual([
+        "operator.write",
+      ]);
+    });
+  });
+
   it("reads plugin-registered gateway method scopes from the active plugin registry", () => {
     const registry = createEmptyPluginRegistry();
     registry.gatewayHandlers["browser.request"] = pluginHandler;
@@ -637,6 +666,39 @@ describe("operator scope authorization", () => {
     expect(authorizeOperatorScopesForMethod("unknown.method", ["operator.read"])).toEqual({
       allowed: false,
       missingScope: "operator.admin",
+    });
+  });
+
+  describe("node.invoke command-aware authorization", () => {
+    it.each(["browser.proxy", "fs.listDir", "terminal.upload"])(
+      "rejects write scope for node.invoke with admin-only command %s",
+      (command) => {
+        expect(
+          authorizeOperatorScopesForMethod("node.invoke", ["operator.write"], { command }),
+        ).toEqual({ allowed: false, missingScope: "operator.admin" });
+      },
+    );
+
+    it("allows admin scope for node.invoke with an admin-only command", () => {
+      expect(
+        authorizeOperatorScopesForMethod("node.invoke", ["operator.admin"], {
+          command: "browser.proxy",
+        }),
+      ).toEqual({ allowed: true });
+    });
+
+    it("allows write scope for node.invoke with a standard command", () => {
+      expect(
+        authorizeOperatorScopesForMethod("node.invoke", ["operator.write"], {
+          command: "system.run",
+        }),
+      ).toEqual({ allowed: true });
+    });
+
+    it("allows write scope for node.invoke without params", () => {
+      expect(authorizeOperatorScopesForMethod("node.invoke", ["operator.write"])).toEqual({
+        allowed: true,
+      });
     });
   });
 

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -1,7 +1,10 @@
 // Gateway method authorization scope resolver.
 // Maps static and plugin-defined gateway methods to operator scopes.
 import { normalizeOptionalString as normalizeSessionActionParam } from "@openclaw/normalization-core/string-coerce";
-import { isAdminOnlyNodeInvokeCommand } from "../infra/node-commands.js";
+import {
+  NODE_ADMIN_ONLY_INVOKE_COMMANDS,
+  isAdminOnlyNodeInvokeCommand,
+} from "../infra/node-commands.js";
 import { getPluginRegistryState } from "../plugins/runtime-state.js";
 import { resolveReservedGatewayMethodScope } from "../shared/gateway-method-policy.js";
 import { isAgentSessionResetCommand } from "./agent-command-policy.js";
@@ -155,6 +158,18 @@ function resolveSessionActionLeastPrivilegeScopes(params: unknown): OperatorScop
   return [WRITE_SCOPE];
 }
 
+/** Returns true when node.invoke params carry a command that requires operator.admin. */
+function isNodeInvokeAdminCommand(params: unknown): boolean {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return false;
+  }
+  const command = (params as { command?: unknown }).command;
+  return (
+    typeof command === "string" &&
+    (NODE_ADMIN_ONLY_INVOKE_COMMANDS as readonly string[]).includes(command)
+  );
+}
+
 function resolveDynamicLeastPrivilegeOperatorScopesForMethod(
   method: string,
   params: unknown,
@@ -246,6 +261,11 @@ export function resolveLeastPrivilegeOperatorScopesForMethod(
   method: string,
   params?: unknown,
 ): OperatorScope[] {
+  // node.invoke commands that require operator.admin need admin scope,
+  // not the default operator.write for generic node.invoke.
+  if (method === "node.invoke" && isNodeInvokeAdminCommand(params)) {
+    return [ADMIN_SCOPE];
+  }
   if (isDynamicOperatorGatewayMethod(method)) {
     return resolveDynamicLeastPrivilegeOperatorScopesForMethod(method, params);
   }
@@ -265,6 +285,11 @@ export function authorizeOperatorScopesForMethod(
 ): { allowed: true } | { allowed: false; missingScope: OperatorScope } {
   if (scopes.includes(ADMIN_SCOPE)) {
     return { allowed: true };
+  }
+  // node.invoke admin-only commands need operator.admin — fail early with
+  // a clear scope error instead of reaching the handler-level admin check.
+  if (method === "node.invoke" && isNodeInvokeAdminCommand(params)) {
+    return { allowed: false, missingScope: ADMIN_SCOPE };
   }
   if (isDynamicOperatorGatewayMethod(method)) {
     if (method === "plugins.sessionAction") {


### PR DESCRIPTION
## What Problem This Solves

Closes #108951

`node.invoke` with `browser.proxy`, `fs.listDir`, or `terminal.upload` fails with `missing scope: operator.admin` when invoked through `openclaw nodes invoke` or other generic `node.invoke` CLI paths. The gateway server correctly requires `operator.admin` for these commands (enforced by `ADMIN_ONLY_NODE_INVOKE_COMMANDS` in `nodes.ts`), but the client-side scope resolver always returns `operator.write` for `node.invoke`. The client connects with insufficient scope and the gateway rejects the request before it reaches the paired node.

## Why This Change Was Made

The `resolveLeastPrivilegeOperatorScopesForMethod` and `authorizeOperatorScopesForMethod` functions in `src/gateway/method-scopes.ts` did not inspect `node.invoke` params to determine the required scope. The `NODE_ADMIN_ONLY_INVOKE_COMMANDS` list already defines which commands need admin scope; the scope resolver and authorizer now use it.

A new `isNodeInvokeAdminCommand` helper checks whether `params.command` is in the admin-only command list. The resolver returns `[operator.admin]` for admin-only commands (so the client requests the right scope), and the authorizer rejects write-scoped clients early with a clear `missing scope: operator.admin` error (before reaching the handler).

## What Changed

- `src/gateway/method-scopes.ts`: add `isNodeInvokeAdminCommand` helper, wire it into `resolveLeastPrivilegeOperatorScopesForMethod` and `authorizeOperatorScopesForMethod`
- `src/gateway/method-scopes.test.ts`: 12 new tests covering scope resolution and authorization for admin-only commands, standard commands, and missing params

## Evidence

- `node scripts/run-vitest.mjs src/gateway/method-scopes.test.ts --no-coverage`: 127 tests passed (12 new)
- New tests cover:
  - `browser.proxy`, `fs.listDir`, `terminal.upload` → resolves to `operator.admin`
  - `system.run` → resolves to `operator.write` (unchanged)
  - no params / empty params → resolves to `operator.write` (unchanged)
  - write-scoped authorization rejected for admin-only commands
  - admin-scoped authorization allowed
  - standard commands unchanged

## Merge Risk

Low. The fix only changes the scope resolver and authorizer for `node.invoke` when the command is in the existing `NODE_ADMIN_ONLY_INVOKE_COMMANDS` list. The gateway server-side `nodes.ts:1304` already enforces the same check independently; this fix aligns the client-side scope negotiation with it. Existing node.invoke callers using `operator.admin` or standard commands are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)