### PR TITLE
fix(ollama): update bundled static MiniMax Cloud default from m2.7 to m3

### DIFF
--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -95,8 +95,8 @@
             }
           },
           {
-            "id": "minimax-m2.7:cloud",
-            "name": "minimax-m2.7:cloud",
+            "id": "minimax-m3:cloud",
+            "name": "minimax-m3:cloud",
             "reasoning": true,
             "input": ["text"],
             "cost": {

--- a/extensions/ollama/src/defaults.ts
+++ b/extensions/ollama/src/defaults.ts
@@ -7,7 +7,7 @@ export const OLLAMA_GLM52_CLOUD_MODEL_ID = "glm-5.2:cloud";
 export const OLLAMA_GLM52_CONTEXT_WINDOW = 1_000_000;
 export const OLLAMA_CLOUD_DEFAULT_MODELS = [
   "kimi-k2.5:cloud",
-  "minimax-m2.7:cloud",
+  "minimax-m3:cloud",
   "glm-5.1:cloud",
   OLLAMA_GLM52_CLOUD_MODEL_ID,
 ] as const;

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -231,7 +231,7 @@ describe("ollama setup", () => {
     expect(modelIds).toEqual([
       "gemma4",
       "kimi-k2.5:cloud",
-      "minimax-m2.7:cloud",
+      "minimax-m3:cloud",
       "glm-5.1:cloud",
       "glm-5.2:cloud",
       "llama3:8b",
@@ -417,7 +417,7 @@ describe("ollama setup", () => {
 
     expect(modelIds).toEqual([
       "kimi-k2.5:cloud",
-      "minimax-m2.7:cloud",
+      "minimax-m3:cloud",
       "glm-5.1:cloud",
       "glm-5.2:cloud",
     ]);
@@ -446,7 +446,7 @@ describe("ollama setup", () => {
 
     expect(modelIds).toEqual([
       "kimi-k2.5:cloud",
-      "minimax-m2.7:cloud",
+      "minimax-m3:cloud",
       "glm-5.1:cloud",
       "glm-5.2:cloud",
       "qwen3-coder:480b-cloud",

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1054,7 +1054,7 @@ describe("buildAssistantMessage", () => {
 
   it("drops provider-returned thinking for non-reasoning models", () => {
     const response = {
-      model: "minimax-m2.7:cloud",
+      model: "minimax-m3:cloud",
       created_at: "2026-01-01T00:00:00Z",
       message: {
         role: "assistant" as const,
@@ -1067,7 +1067,7 @@ describe("buildAssistantMessage", () => {
     };
     const result = buildAssistantMessage(response, {
       ...modelInfo,
-      id: "minimax-m2.7:cloud",
+      id: "minimax-m3:cloud",
       reasoning: false,
     });
     expect(result.stopReason).toBe("stop");


### PR DESCRIPTION
Closes #108644

## What Problem This Solves

The bundled static Ollama Cloud catalog and default-model list still reference `minimax-m2.7:cloud` while runtime Ollama Cloud discovery already surfaces `minimax-m3:cloud`. Installations or workflows that rely on the bundled static catalog (without live discovery) get a stale model reference.

## Why This Change Was Made

The upstream Ollama Cloud discovery behavior and test coverage already use `minimax-m3:cloud`; the bundled static catalog had simply drifted. This updates the static defaults and plugin manifest to match the live discovery behavior — one search-and-replace across four files covering the default list, the plugin catalog entry, and the test fixtures that assert the default list.

## User Impact

Ollama Cloud users relying on the bundled static catalog (no live discovery) now see `minimax-m3:cloud` as the MiniMax Cloud default model instead of the stale `minimax-m2.7:cloud`.

## Evidence

- `node scripts/run-vitest.mjs extensions/ollama/src/setup.test.ts extensions/ollama/src/stream-runtime.test.ts` → `Test Files 2 passed (2), Tests 133 passed (133)`.
- `oxfmt` and `oxlint` clean on all touched files.
- Validated against the existing test coverage in `discovery-shared.test.ts` which already uses `minimax-m3:cloud`.
