### PR TITLE
fix(gateway): CLI probes fail with gateway.bind≠loopback

### DIFF
--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -3,7 +3,11 @@ import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensit
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveConfigPath, resolveGatewayPort } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { isSecureWebSocketUrl } from "./net.js";
+import {
+  inspectBestEffortPrimaryTailnetIPv4,
+  pickBestEffortPrimaryLanIPv4,
+} from "../infra/network-discovery-display.js";
+import { isSecureWebSocketUrl, isValidIPv4 } from "./net.js";
 
 /** Resolved gateway target plus redacted display text for diagnostics. */
 export type GatewayConnectionDetails = {
@@ -45,8 +49,26 @@ export function buildGatewayConnectionDetailsWithResolvers(
     resolvers.resolveGatewayPort?.(config, process.env) ??
     resolveGatewayPort(config);
   const bindMode = config.gateway?.bind ?? "loopback";
+  const customBindHost = config.gateway?.customBindHost?.trim();
+  const { tailnetIPv4 } = inspectBestEffortPrimaryTailnetIPv4();
+  // Resolve the bind address the same way resolveControlUiLinks does so
+  // CLI probes (health, cron list, doctor, gateway probe) reach a gateway
+  // bound to tailnet, lan, or a custom address instead of failing with 1006
+  // because the target hardcoded 127.0.0.1. (#108406)
+  const bindHost = (() => {
+    if (bindMode === "custom" && customBindHost && isValidIPv4(customBindHost)) {
+      return customBindHost;
+    }
+    if (bindMode === "tailnet" && tailnetIPv4) {
+      return tailnetIPv4;
+    }
+    if (bindMode === "lan") {
+      return pickBestEffortPrimaryLanIPv4() ?? "127.0.0.1";
+    }
+    return "127.0.0.1";
+  })();
   const scheme = tlsEnabled ? "wss" : "ws";
-  const localUrl = `${scheme}://127.0.0.1:${localPort}`;
+  const localUrl = `${scheme}://${bindHost}:${localPort}`;
   const cliUrlOverride = normalizeOptionalString(options.url);
   const envUrlOverride =
     cliUrlOverride || options.ignoreEnvUrlOverride || options.localPortOverride !== undefined
@@ -67,7 +89,9 @@ export function buildGatewayConnectionDetailsWithResolvers(
       ? "config gateway.remote.url"
       : remoteMisconfigured
         ? "missing gateway.remote.url (fallback local)"
-        : "local loopback";
+        : bindMode === "loopback"
+          ? "local loopback"
+          : `local ${bindMode}`;
   const bindDetail = !urlOverride && !remoteUrl ? `Bind: ${bindMode}` : undefined;
   const remoteFallbackNote = remoteMisconfigured
     ? "Warn: gateway.mode=remote but gateway.remote.url is missing; set gateway.remote.url or switch gateway.mode=local."


### PR DESCRIPTION
Closes #108406

## What Problem This Solves

Fixes an issue where `openclaw health`, `openclaw cron list`, `openclaw doctor`, and `openclaw gateway probe` always target `ws://127.0.0.1:18789` regardless of the configured `gateway.bind` mode. When the gateway is bound to `tailnet`, `lan`, or a `custom` address, the gateway does not listen on loopback at all, and every CLI probe deterministically fails with a 1006 abnormal close — even though the gateway is perfectly healthy and reachable at its real bound address.

## Why This Change Was Made

`buildGatewayConnectionDetailsWithResolvers` (the shared resolver backing all CLI probes that reach for the gateway) hardcoded `127.0.0.1` unconditionally. This change resolves the bind host the same way `resolveControlUiLinks` already does: the primary tailnet IPv4 for `bind=tailnet`, the primary LAN IPv4 for `bind=lan`, the configured `customBindHost` for `bind=custom`, and `127.0.0.1` otherwise. The `urlSource` diagnostic label now reflects the bind mode (e.g. `"local tailnet"`) instead of always saying `"local loopback"`.

The security check (`isSecureWebSocketUrl`) already treats CGNAT (100.64/10), private RFC 1918, and mDNS/.local/.ts.net hostnames as trusted plaintext WS endpoints, so tailnet and LAN IPs pass the existing security gate without any permissive flag.

## User Impact

Operators with `gateway.bind=tailnet`, `gateway.bind=lan`, or `gateway.bind=custom` can now run `openclaw health`, `openclaw cron list`, and `openclaw doctor` without manually exporting `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_TOKEN`. The `openclaw gateway probe` command also resolves correctly.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/client-bootstrap.test.ts src/commands/health.test.ts` → `Test Files 1 passed (1), Tests 23 passed (23)`.
- `oxfmt`, `oxlint`, and `git diff --check` clean.
- Host-resolution logic mirrors `resolveControlUiLinks` (`src/gateway/control-ui-links.ts:31-43`), an existing reviewed path used by the Control UI URL builder.
- Security boundary verified: `isSecureWebSocketUrl` → `isTrustedPlaintextWebSocketHost` already covers CGNAT (`isPrivateOrLoopbackHost` includes 100.64/10 in `@openclaw/net-policy`), so a resolved tailnet IPv4 like `ws://100.x.x.x:18789` passes the existing plaintext-WS security gate.
- Known proof gap: no tailnet/LAN environment available for end-to-end connectivity validation; fix is unit-level regression-safe (default loopback path produces identical output) and the resolved host uses network discovery primitives exercised by the Control UI link builder.
