### PR TITLE
fix(onepassword): preserve oversized token diagnostics

### DIFF
--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -127,7 +127,7 @@ describe("OpClient", () => {
       client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
     ).rejects.toMatchObject({
       code: "TOKEN_MISSING",
-      message: "1Password service account token file is too large",
+      message: `1Password service account token file at ${tokenFile} exceeds 16384 bytes.`,
     });
     expect(runner).not.toHaveBeenCalled();
   });

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -2,9 +2,9 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
-import { FsSafeError } from "openclaw/plugin-sdk/security-runtime";
 import { OnePasswordError } from "./errors.js";
 
 const MAX_STDOUT_BYTES = 1024 * 1024;
@@ -208,8 +208,8 @@ export class OpClient {
       }
     } catch (error) {
       const message =
-        error instanceof FsSafeError && error.code === "too-large"
-          ? "1Password service account token file is too large"
+        error instanceof Error && extractErrorCode(error) === "too-large"
+          ? error.message
           : "1Password service account token file is missing";
       throw new OnePasswordError("TOKEN_MISSING", message, { cause: error });
     }


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #108596. The oversized 1Password service-account token path was correctly capped before CLI spawn, but its owner error replaced the shared secret-file reader's actionable diagnosis with a generic "file is too large" message. Operators lost the exact file path and the 16,384-byte boundary, and the repair imported the deprecated broad security runtime solely to identify one error code.

## Why This Change Was Made

The 1Password client now detects the stable `too-large` code through the narrow error runtime and preserves the bounded reader's original message. This names the rejected file and exact cap while retaining the stable `TOKEN_MISSING` broker code. The deprecated broad security-runtime import is removed.

This is the smallest owner-boundary fix: it does not alter the pinned read, link policy, child-process boundary, configuration, or other error mappings.

## User Impact

Oversized 1Password service-account token files still fail closed before the CLI starts. The error now identifies the file and says it exceeds 16,384 bytes, making recovery actionable. Normal, missing, empty, symlinked, and hardlinked token behavior is unchanged.

## Evidence

Focused tests:

```text
node scripts/run-vitest.mjs extensions/onepassword
Test Files  6 passed (6)
Tests       61 passed (61)
```

Fresh autoreview against current main reported no accepted or actionable findings and rated the patch correct at 0.96 confidence.

Hosted changed gate passed formatting, Plugin SDK baseline, plugin boundaries, extension and extension-test typechecks, targeted lint, database-first guard, runtime sidecar checks, and import-cycle checks:

https://github.com/openclaw/openclaw/actions/runs/29495155165

`git diff --check origin/main...HEAD` passed.

AI-assisted: Codex identified the follow-up during the required sibling/refactor sweep, implemented it, and ran the focused and hosted proof above.
