### PR TITLE
fix(twitch): strip tool traces from monitor replies

### DIFF
--- a/extensions/twitch/src/monitor.test.ts
+++ b/extensions/twitch/src/monitor.test.ts
@@ -43,14 +43,17 @@ type InboundRunInput = {
 };
 
 describe("monitorTwitchProvider", () => {
+  let replyText: string;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    replyText = "**Hello** Twitch";
     mocks.getClient.mockResolvedValue({});
     mocks.sendMessage.mockResolvedValue({ ok: true, messageId: "message-id" });
     mocks.runInbound.mockImplementation(async (input: InboundRunInput) => {
       const ingested = input.adapter.ingest(input.raw);
       const turn = await input.adapter.resolveTurn(ingested);
-      await turn.delivery.deliver({ text: "**Hello** Twitch" });
+      await turn.delivery.deliver({ text: replyText });
     });
     mocks.getRuntime.mockReturnValue({
       logging: {
@@ -90,7 +93,7 @@ describe("monitorTwitchProvider", () => {
     });
   });
 
-  it("delivers fallback replies through the monitor boundary", async () => {
+  async function deliverMonitorReply() {
     let onMessage: ((message: TwitchChatMessage) => void) | undefined;
     mocks.onMessage.mockImplementation(
       (_account: unknown, handler: (message: TwitchChatMessage) => void) => {
@@ -115,6 +118,17 @@ describe("monitorTwitchProvider", () => {
     });
 
     await vi.waitFor(() => {
+      expect(mocks.runInbound).toHaveBeenCalledOnce();
+    });
+    await mocks.runInbound.mock.results[0]?.value;
+
+    return { account, monitor };
+  }
+
+  it("delivers fallback replies through the monitor boundary", async () => {
+    const { account, monitor } = await deliverMonitorReply();
+
+    await vi.waitFor(() => {
       expect(mocks.sendMessage).toHaveBeenCalledWith(
         account,
         "testchannel",
@@ -126,5 +140,39 @@ describe("monitorTwitchProvider", () => {
 
     monitor.stop();
     expect(mocks.unregister).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "tool-trace lines",
+      input: "Done.\n🛠️ git status",
+      expected: "Done.",
+    },
+    {
+      name: "tool-call XML",
+      input: '<tool_call>{"name":"exec"}</tool_call>Stream is live.',
+      expected: "Stream is live.",
+    },
+    {
+      name: "ordinary Markdown",
+      input: "**Hello** Twitch",
+      expected: "Hello Twitch",
+    },
+  ])("sanitizes $name before monitor delivery", async ({ input, expected }) => {
+    replyText = input;
+    const { account, monitor } = await deliverMonitorReply();
+
+    expect(mocks.sendMessage).toHaveBeenCalledWith(account, "testchannel", expected, {}, "default");
+
+    monitor.stop();
+  });
+
+  it("does not send trace-only monitor replies", async () => {
+    replyText = "🛠️ git status";
+    const { monitor } = await deliverMonitorReply();
+
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+
+    monitor.stop();
   });
 });

--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -9,6 +9,7 @@ import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/conf
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { checkTwitchAccessControl } from "./access-control.js";
 import { getOrCreateClientManager } from "./client-manager-registry.js";
 import { getTwitchRuntime } from "./runtime.js";
@@ -194,7 +195,9 @@ async function deliverTwitchReply(params: {
       runtime.error?.(`No text to send in reply payload`);
       return { visibleReplySent: false };
     }
-    const textToSend = stripMarkdownForTwitch(payload.text);
+    // Monitor replies bypass the outbound adapter, so apply the same user-visible
+    // boundary here before Twitch-specific Markdown cleanup.
+    const textToSend = stripMarkdownForTwitch(sanitizeAssistantVisibleText(payload.text));
     if (!textToSend) {
       return { visibleReplySent: false };
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Twitch users could receive internal tool-trace lines or tool-call XML when an assistant reply was sent through the inbound monitor path. That path bypasses the Twitch outbound adapter's existing visible-text sanitizer.

## Why This Change Was Made

Monitor replies now apply the same canonical assistant-visible text sanitizer as regular Twitch outbound delivery before Twitch-specific Markdown cleanup. The main risk is suppressing legitimate reply text, so the regression coverage includes ordinary Markdown and verifies that only trace-only replies become no-send results.

## User Impact

Twitch chat replies no longer expose internal tool activity or tool-call scaffolding, while normal assistant replies continue to be delivered as plain Twitch text.

## Evidence

Environment: Linux x86_64, Node.js v24.18.0. The focused proof drives the real exported `monitorTwitchProvider`; only the Twitch network client and core runtime boundary are replaced so the exact text reaching `sendMessage` is observable.

Before, on current `upstream/main` (`dd58667be87`), I temporarily restored the unmodified monitor delivery line while keeping the regression harness and ran:

```text
$ node scripts/run-vitest.mjs extensions/twitch/src/monitor.test.ts
Test Files  1 failed (1)
Tests  3 failed | 2 passed (5)

mixed trace received: "Done. 🛠️ git status"
tool XML received: "<tool_call>{\"name\":\"exec\"}</tool_call>Stream is live."
trace-only sendMessage calls: 1 (text: "🛠️ git status")
```

Premise: regular Twitch outbound delivery already declares `sanitizeAssistantVisibleText` as its user-visible boundary in `extensions/twitch/src/outbound.ts:49`; the monitor callback sends directly and therefore did not pass through that adapter.

After restoring this patch, the same production-path proof passed:

```text
$ node scripts/run-vitest.mjs extensions/twitch/src/monitor.test.ts
Test Files  1 passed (1)
Tests  5 passed (5)
```

The complete Twitch extension test surface and adjacent outbound/send tests also passed:

```text
$ node scripts/run-vitest.mjs extensions/twitch
Test Files  19 passed (19)
Tests  207 passed (207)

$ node scripts/run-vitest.mjs extensions/twitch/src/outbound-tool-trace-sanitize.test.ts extensions/twitch/src/outbound.test.ts extensions/twitch/src/send.test.ts
Test Files  3 passed (3)
Tests  39 passed (39)
```

Targeted `oxfmt`, `oxlint`, `git diff --check`, and the repository `autoreview` helper also completed cleanly with no actionable findings. Live Twitch credentials were not available in this checkout; the defect and fix occur before the network boundary, and full repository gates are left to CI.

AI-assisted: implemented with Codex; the commands and before/after proof above were run manually.
