### PR TITLE
fix: gateway.cmd launcher garbles non-ASCII profile paths on non-CJK Windows locales

### DIFF
--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -14,7 +14,7 @@ import {
 import { auditGatewayServiceConfig, SERVICE_AUDIT_CODES } from "./service-audit.js";
 import { buildServiceEnvironment } from "./service-env.js";
 
-const resolveWindowsSystemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
+const resolveWindowsOemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
 
 // Pin code page detection so launcher encoding never depends on the host ACP.
 vi.mock("../infra/windows-encoding.js", async () => {
@@ -23,7 +23,7 @@ vi.mock("../infra/windows-encoding.js", async () => {
   );
   return {
     ...actual,
-    resolveWindowsSystemEncoding: () => resolveWindowsSystemEncodingMock(),
+    resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });
 
@@ -59,8 +59,8 @@ beforeEach(() => {
   schtasksCalls.length = 0;
   schtasksResponses.length = 0;
   xmlPayloadCaptures.length = 0;
-  resolveWindowsSystemEncodingMock.mockReset();
-  resolveWindowsSystemEncodingMock.mockReturnValue(null);
+  resolveWindowsOemEncodingMock.mockReset();
+  resolveWindowsOemEncodingMock.mockReturnValue(null);
 });
 
 describe("installScheduledTask", () => {
@@ -291,7 +291,7 @@ describe("installScheduledTask", () => {
 
   it("fails the install instead of writing an unrepresentable cmd launcher", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
+      resolveWindowsOemEncodingMock.mockReturnValue("gbk");
       schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
 
       await expect(
@@ -301,7 +301,7 @@ describe("installScheduledTask", () => {
           programArguments: ["node", "gateway.js"],
           environment: { OC_LABEL: "🚀" },
         }),
-      ).rejects.toThrow(/cannot be represented in the Windows system code page/);
+      ).rejects.toThrow(/cannot be represented in the Windows console code page/);
       await expect(fs.access(resolveTaskScriptPath(env))).rejects.toThrow();
     });
   });

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -23,6 +23,7 @@ vi.mock("../infra/windows-encoding.js", async () => {
   );
   return {
     ...actual,
+    resolveWindowsOemCodePage: () => 437,
     resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -11,6 +11,18 @@ import {
 import { decodeWindowsLauncherScript } from "../infra/windows-launcher-encoding.js";
 import "./test-helpers/schtasks-base-mocks.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
+
+vi.mock("../infra/windows-encoding.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/windows-encoding.js")>(
+    "../infra/windows-encoding.js",
+  );
+  return {
+    ...actual,
+    resolveWindowsOemCodePage: () => 437,
+    resolveWindowsOemEncoding: () => "cp437",
+  };
+});
+
 import {
   inspectPortUsage,
   killProcessTree,

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -25,6 +25,7 @@ vi.mock("../infra/windows-encoding.js", async () => {
   );
   return {
     ...actual,
+    resolveWindowsOemCodePage: () => 437,
     resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -13,7 +13,7 @@ import {
 const schtasksResponses = vi.hoisted(
   (): Array<{ code: number; stdout: string; stderr: string }> => [],
 );
-const resolveWindowsSystemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
+const resolveWindowsOemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: async () => schtasksResponses.shift() ?? { code: 0, stdout: "", stderr: "" },
@@ -25,14 +25,14 @@ vi.mock("../infra/windows-encoding.js", async () => {
   );
   return {
     ...actual,
-    resolveWindowsSystemEncoding: () => resolveWindowsSystemEncodingMock(),
+    resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });
 
 beforeEach(() => {
   schtasksResponses.length = 0;
-  resolveWindowsSystemEncodingMock.mockReset();
-  resolveWindowsSystemEncodingMock.mockReturnValue(null);
+  resolveWindowsOemEncodingMock.mockReset();
+  resolveWindowsOemEncodingMock.mockReturnValue(null);
 });
 
 describe("scheduled task runtime derivation", () => {
@@ -234,7 +234,7 @@ describe("readScheduledTaskCommand", () => {
         let scriptBytes: Buffer = Buffer.from(script, "utf8");
         if (options.scriptEncoding === "gbk") {
           // Production bytes for a code-page install: marker line + GBK body.
-          resolveWindowsSystemEncodingMock.mockReturnValueOnce("gbk");
+          resolveWindowsOemEncodingMock.mockReturnValueOnce("gbk");
           scriptBytes = encodeWindowsLauncherScript({ format: "cmd", content: script });
         }
         await fs.writeFile(scriptPath, scriptBytes);

--- a/src/daemon/test-helpers/schtasks-base-mocks.ts
+++ b/src/daemon/test-helpers/schtasks-base-mocks.ts
@@ -29,5 +29,9 @@ vi.mock("../../infra/windows-encoding.js", async () => {
   const actual = await vi.importActual<typeof import("../../infra/windows-encoding.js")>(
     "../../infra/windows-encoding.js",
   );
-  return { ...actual, resolveWindowsOemEncoding: () => null };
+  return {
+    ...actual,
+    resolveWindowsOemCodePage: () => 437,
+    resolveWindowsOemEncoding: () => "cp437",
+  };
 });

--- a/src/daemon/test-helpers/schtasks-base-mocks.ts
+++ b/src/daemon/test-helpers/schtasks-base-mocks.ts
@@ -24,10 +24,10 @@ vi.mock("../../process/kill-tree.js", () => ({
 }));
 
 // Launcher encode/decode must not depend on the dev or CI machine's code page;
-// unpinned, a CJK-locale Windows host would ANSI-encode fixture launcher files.
+// unpinned, a non-UTF-8-locale Windows host would OEM-encode fixture launcher files.
 vi.mock("../../infra/windows-encoding.js", async () => {
   const actual = await vi.importActual<typeof import("../../infra/windows-encoding.js")>(
     "../../infra/windows-encoding.js",
   );
-  return { ...actual, resolveWindowsSystemEncoding: () => null };
+  return { ...actual, resolveWindowsOemEncoding: () => null };
 });

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -69,10 +69,14 @@ describe("windows output encoding", () => {
     for (const [codePage, expectedEncoding] of mappings) {
       queryWindowsRegistryValueMock.mockReturnValueOnce(String(codePage));
       vi.resetModules();
-      const { resolveWindowsOemCodePageForEncoding, resolveWindowsOemEncoding } =
-        await import("./windows-encoding.js");
+      const {
+        resolveWindowsOemCodePage,
+        resolveWindowsOemCodePageForEncoding,
+        resolveWindowsOemEncoding,
+      } = await import("./windows-encoding.js");
 
       expect(resolveWindowsOemEncoding(), `OEMCP ${codePage}`).toBe(expectedEncoding);
+      expect(resolveWindowsOemCodePage()).toBe(codePage);
       expect(resolveWindowsOemCodePageForEncoding(expectedEncoding)).toBe(codePage);
     }
   });
@@ -81,10 +85,14 @@ describe("windows output encoding", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     queryWindowsRegistryValueMock.mockReturnValue("857");
     vi.resetModules();
-    const { resolveWindowsOemCodePageForEncoding, resolveWindowsOemEncoding } =
-      await import("./windows-encoding.js");
+    const {
+      resolveWindowsOemCodePage,
+      resolveWindowsOemCodePageForEncoding,
+      resolveWindowsOemEncoding,
+    } = await import("./windows-encoding.js");
 
     expect(resolveWindowsOemEncoding()).toBe("cp857");
+    expect(resolveWindowsOemCodePage()).toBe(857);
     expect(resolveWindowsOemEncoding()).toBe("cp857");
     expect(resolveWindowsOemCodePageForEncoding("cp857")).toBe(857);
     expect(resolveWindowsOemCodePageForEncoding("bogus")).toBeNull();
@@ -99,9 +107,11 @@ describe("windows output encoding", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     queryWindowsRegistryValueMock.mockReturnValue("864");
     vi.resetModules();
-    const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+    const { resolveWindowsOemCodePage, resolveWindowsOemEncoding } =
+      await import("./windows-encoding.js");
 
     expect(resolveWindowsOemEncoding()).toBeNull();
+    expect(resolveWindowsOemCodePage()).toBe(864);
     expect(resolveWindowsOemEncoding()).toBeNull();
     expect(queryWindowsRegistryValueMock).toHaveBeenCalledOnce();
   });
@@ -109,9 +119,11 @@ describe("windows output encoding", () => {
   it("does not query the Windows registry on other platforms", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     vi.resetModules();
-    const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+    const { resolveWindowsOemCodePage, resolveWindowsOemEncoding } =
+      await import("./windows-encoding.js");
 
     expect(resolveWindowsOemEncoding()).toBeNull();
+    expect(resolveWindowsOemCodePage()).toBeNull();
     expect(queryWindowsRegistryValueMock).not.toHaveBeenCalled();
   });
 

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -4,12 +4,23 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
+const queryWindowsRegistryValueMock = vi.hoisted(() => vi.fn((): string | null => null));
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
     spawnSync: spawnSyncMock,
+  };
+});
+
+vi.mock("./windows-install-roots.js", async () => {
+  const actual = await vi.importActual<typeof import("./windows-install-roots.js")>(
+    "./windows-install-roots.js",
+  );
+  return {
+    ...actual,
+    queryWindowsRegistryValue: queryWindowsRegistryValueMock,
   };
 });
 
@@ -24,6 +35,78 @@ describe("windows output encoding", () => {
     vi.resetModules();
     vi.restoreAllMocks();
     spawnSyncMock.mockReset();
+    queryWindowsRegistryValueMock.mockReset();
+  });
+
+  it("maps every supported boot-time OEM code page", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const mappings = [
+      [65001, "utf-8"],
+      [874, "windows-874"],
+      [932, "shift_jis"],
+      [936, "gbk"],
+      [949, "euc-kr"],
+      [950, "big5"],
+      [437, "cp437"],
+      [720, "cp720"],
+      [737, "cp737"],
+      [775, "cp775"],
+      [850, "cp850"],
+      [852, "cp852"],
+      [855, "cp855"],
+      [857, "cp857"],
+      [858, "cp858"],
+      [860, "cp860"],
+      [861, "cp861"],
+      [862, "cp862"],
+      [863, "cp863"],
+      [865, "cp865"],
+      [866, "cp866"],
+      [869, "cp869"],
+    ] as const;
+
+    for (const [codePage, expectedEncoding] of mappings) {
+      queryWindowsRegistryValueMock.mockReturnValueOnce(String(codePage));
+      vi.resetModules();
+      const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+
+      expect(resolveWindowsOemEncoding(), `OEMCP ${codePage}`).toBe(expectedEncoding);
+    }
+  });
+
+  it("reads and caches the boot-time OEM code page from HKLM", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    queryWindowsRegistryValueMock.mockReturnValue("857");
+    vi.resetModules();
+    const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+
+    expect(resolveWindowsOemEncoding()).toBe("cp857");
+    expect(resolveWindowsOemEncoding()).toBe("cp857");
+    expect(queryWindowsRegistryValueMock).toHaveBeenCalledOnce();
+    expect(queryWindowsRegistryValueMock).toHaveBeenCalledWith(
+      "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage",
+      "OEMCP",
+    );
+  });
+
+  it("caches unsupported OEM code pages as unavailable", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    queryWindowsRegistryValueMock.mockReturnValue("864");
+    vi.resetModules();
+    const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+
+    expect(resolveWindowsOemEncoding()).toBeNull();
+    expect(resolveWindowsOemEncoding()).toBeNull();
+    expect(queryWindowsRegistryValueMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not query the Windows registry on other platforms", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.resetModules();
+    const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+
+    expect(resolveWindowsOemEncoding()).toBeNull();
+    expect(queryWindowsRegistryValueMock).not.toHaveBeenCalled();
   });
 
   it("bounds and caches failed Windows encoding probes", async () => {

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -68,9 +68,11 @@ describe("windows output encoding", () => {
     for (const [codePage, expectedEncoding] of mappings) {
       queryWindowsRegistryValueMock.mockReturnValueOnce(String(codePage));
       vi.resetModules();
-      const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+      const { resolveWindowsOemCodePageForEncoding, resolveWindowsOemEncoding } =
+        await import("./windows-encoding.js");
 
       expect(resolveWindowsOemEncoding(), `OEMCP ${codePage}`).toBe(expectedEncoding);
+      expect(resolveWindowsOemCodePageForEncoding(expectedEncoding)).toBe(codePage);
     }
   });
 
@@ -78,10 +80,13 @@ describe("windows output encoding", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     queryWindowsRegistryValueMock.mockReturnValue("857");
     vi.resetModules();
-    const { resolveWindowsOemEncoding } = await import("./windows-encoding.js");
+    const { resolveWindowsOemCodePageForEncoding, resolveWindowsOemEncoding } =
+      await import("./windows-encoding.js");
 
     expect(resolveWindowsOemEncoding()).toBe("cp857");
     expect(resolveWindowsOemEncoding()).toBe("cp857");
+    expect(resolveWindowsOemCodePageForEncoding("cp857")).toBe(857);
+    expect(resolveWindowsOemCodePageForEncoding("bogus")).toBeNull();
     expect(queryWindowsRegistryValueMock).toHaveBeenCalledOnce();
     expect(queryWindowsRegistryValueMock).toHaveBeenCalledWith(
       "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage",

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -47,6 +47,7 @@ describe("windows output encoding", () => {
       [936, "gbk"],
       [949, "euc-kr"],
       [950, "big5"],
+      [1258, "windows-1258"],
       [437, "cp437"],
       [720, "cp720"],
       [737, "cp737"],

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -30,7 +30,7 @@ const WINDOWS_NLS_CODEPAGE_KEY = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\
 
 const WINDOWS_OEM_CODEPAGE_ENCODING_MAP: Record<number, string> = {
   65001: "utf-8",
-  // DBCS locales pair identical ANSI and OEM pages; labels match the ANSI map.
+  // These locales use the same ANSI/OEM identifier; labels match the ANSI map.
   874: "windows-874",
   932: "shift_jis",
   936: "gbk",

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -65,7 +65,7 @@ const WINDOWS_OEM_ENCODING_CODEPAGE_MAP = new Map(
 
 let cachedWindowsConsoleEncoding: string | null | undefined;
 let cachedWindowsSystemEncoding: string | null | undefined;
-let cachedWindowsOemEncoding: string | null | undefined;
+let cachedWindowsOemCodePage: number | null | undefined;
 
 /** Extracts a Windows console code page number from localized `chcp` output. */
 function parseWindowsCodePage(raw: string): number | null {
@@ -141,17 +141,21 @@ function resolveWindowsSystemEncoding(): string | null {
 
 /** Resolves and caches the boot-time Windows OEM encoding cmd.exe reads batch files with. */
 export function resolveWindowsOemEncoding(): string | null {
+  const codePage = resolveWindowsOemCodePage();
+  return codePage !== null ? (WINDOWS_OEM_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
+}
+
+/** Resolves and caches the numeric boot-time Windows OEM code page. */
+export function resolveWindowsOemCodePage(): number | null {
   if (process.platform !== "win32") {
     return null;
   }
-  if (cachedWindowsOemEncoding !== undefined) {
-    return cachedWindowsOemEncoding;
+  if (cachedWindowsOemCodePage !== undefined) {
+    return cachedWindowsOemCodePage;
   }
   const raw = queryWindowsRegistryValue(WINDOWS_NLS_CODEPAGE_KEY, "OEMCP");
-  const codePage = raw === null ? null : parseWindowsCodePage(raw);
-  cachedWindowsOemEncoding =
-    codePage !== null ? (WINDOWS_OEM_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
-  return cachedWindowsOemEncoding;
+  cachedWindowsOemCodePage = raw === null ? null : parseWindowsCodePage(raw);
+  return cachedWindowsOemCodePage;
 }
 
 /** Returns the numeric Windows OEM page for one resolver encoding label. */

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -105,7 +105,7 @@ export function resolveWindowsConsoleEncoding(): string | null {
 }
 
 /** Resolves and caches the Windows system encoding used by legacy text files. */
-export function resolveWindowsSystemEncoding(): string | null {
+function resolveWindowsSystemEncoding(): string | null {
   if (process.platform !== "win32") {
     return null;
   }

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -35,10 +35,10 @@ const WINDOWS_OEM_CODEPAGE_ENCODING_MAP: Record<number, string> = {
   936: "gbk",
   949: "euc-kr",
   950: "big5",
+  1258: "windows-1258",
   // OEM-only single-byte pages used by windows-125x ANSI hosts, iconv-lite
   // `cp###` labels. 864 is omitted: real CP864 repurposes ASCII 0x25 "%",
-  // which generated cmd scripts contain. 1258 (Vietnamese, OEM==ANSI) is
-  // omitted: iconv-lite cannot round-trip Vietnamese in windows-1258.
+  // which generated cmd scripts contain. Unsupported OEM pages fail closed.
   437: "cp437",
   720: "cp720",
   737: "cp737",

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -1,7 +1,7 @@
-// Detects and decodes Windows console output encodings.
+// Detects Windows console/OEM code pages and decodes console output encodings.
 import { spawnSync } from "node:child_process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { getWindowsCmdExePath } from "./windows-install-roots.js";
+import { getWindowsCmdExePath, queryWindowsRegistryValue } from "./windows-install-roots.js";
 
 const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
   65001: "utf-8",
@@ -23,8 +23,44 @@ const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
 };
 const WINDOWS_ENCODING_PROBE_TIMEOUT_MS = 5_000;
 
+// Fresh consoles (Task Scheduler, Startup, double-click) initialize their code
+// page from the boot-time registry OEMCP; `chcp` only reports the mutable
+// per-session value, so generated launcher scripts must encode against this.
+const WINDOWS_NLS_CODEPAGE_KEY = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage";
+
+const WINDOWS_OEM_CODEPAGE_ENCODING_MAP: Record<number, string> = {
+  65001: "utf-8",
+  // DBCS locales pair identical ANSI and OEM pages; labels match the ANSI map.
+  874: "windows-874",
+  932: "shift_jis",
+  936: "gbk",
+  949: "euc-kr",
+  950: "big5",
+  // OEM-only single-byte pages used by windows-125x ANSI hosts, iconv-lite
+  // `cp###` labels. 864 is omitted: real CP864 repurposes ASCII 0x25 "%",
+  // which generated cmd scripts contain. 1258 (Vietnamese, OEM==ANSI) is
+  // omitted: iconv-lite cannot round-trip Vietnamese in windows-1258.
+  437: "cp437",
+  720: "cp720",
+  737: "cp737",
+  775: "cp775",
+  850: "cp850",
+  852: "cp852",
+  855: "cp855",
+  857: "cp857",
+  858: "cp858",
+  860: "cp860",
+  861: "cp861",
+  862: "cp862",
+  863: "cp863",
+  865: "cp865",
+  866: "cp866",
+  869: "cp869",
+};
+
 let cachedWindowsConsoleEncoding: string | null | undefined;
 let cachedWindowsSystemEncoding: string | null | undefined;
+let cachedWindowsOemEncoding: string | null | undefined;
 
 /** Extracts a Windows console code page number from localized `chcp` output. */
 function parseWindowsCodePage(raw: string): number | null {
@@ -96,6 +132,21 @@ export function resolveWindowsSystemEncoding(): string | null {
     cachedWindowsSystemEncoding = null;
   }
   return cachedWindowsSystemEncoding;
+}
+
+/** Resolves and caches the boot-time Windows OEM encoding cmd.exe reads batch files with. */
+export function resolveWindowsOemEncoding(): string | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+  if (cachedWindowsOemEncoding !== undefined) {
+    return cachedWindowsOemEncoding;
+  }
+  const raw = queryWindowsRegistryValue(WINDOWS_NLS_CODEPAGE_KEY, "OEMCP");
+  const codePage = raw === null ? null : parseWindowsCodePage(raw);
+  cachedWindowsOemEncoding =
+    codePage !== null ? (WINDOWS_OEM_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
+  return cachedWindowsOemEncoding;
 }
 
 /** Decodes one complete subprocess output buffer, preferring valid UTF-8 before legacy code pages. */

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -23,9 +23,8 @@ const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
 };
 const WINDOWS_ENCODING_PROBE_TIMEOUT_MS = 5_000;
 
-// Fresh consoles (Task Scheduler, Startup, double-click) initialize their code
-// page from the boot-time registry OEMCP; `chcp` only reports the mutable
-// per-session value, so generated launcher scripts must encode against this.
+// Task Scheduler launchers use the system OEM page. Interactive consoles can
+// override it, so generated scripts also declare this page before their body.
 const WINDOWS_NLS_CODEPAGE_KEY = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage";
 
 const WINDOWS_OEM_CODEPAGE_ENCODING_MAP: Record<number, string> = {
@@ -57,6 +56,12 @@ const WINDOWS_OEM_CODEPAGE_ENCODING_MAP: Record<number, string> = {
   866: "cp866",
   869: "cp869",
 };
+const WINDOWS_OEM_ENCODING_CODEPAGE_MAP = new Map(
+  Object.entries(WINDOWS_OEM_CODEPAGE_ENCODING_MAP).map(([codePage, encoding]) => [
+    encoding,
+    Number.parseInt(codePage, 10),
+  ]),
+);
 
 let cachedWindowsConsoleEncoding: string | null | undefined;
 let cachedWindowsSystemEncoding: string | null | undefined;
@@ -147,6 +152,11 @@ export function resolveWindowsOemEncoding(): string | null {
   cachedWindowsOemEncoding =
     codePage !== null ? (WINDOWS_OEM_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
   return cachedWindowsOemEncoding;
+}
+
+/** Returns the numeric Windows OEM page for one resolver encoding label. */
+export function resolveWindowsOemCodePageForEncoding(encoding: string): number | null {
+  return WINDOWS_OEM_ENCODING_CODEPAGE_MAP.get(encoding) ?? null;
 }
 
 /** Decodes one complete subprocess output buffer, preferring valid UTF-8 before legacy code pages. */

--- a/src/infra/windows-install-roots.ts
+++ b/src/infra/windows-install-roots.ts
@@ -234,6 +234,11 @@ export function getWindowsCmdExePath(
   return getWindowsSystem32ExePath("cmd.exe", env);
 }
 
+/** Queries one Windows registry string value via reg.exe; null when absent or unreadable. */
+export function queryWindowsRegistryValue(key: string, valueName: string): string | null {
+  return queryRegistryValueFn(key, valueName);
+}
+
 export function getWindowsSystem32ExePath(
   executableName: string,
   env: Record<string, string | undefined> = process.env,

--- a/src/infra/windows-launcher-encoding.test.ts
+++ b/src/infra/windows-launcher-encoding.test.ts
@@ -25,6 +25,7 @@ const GBK_MARKER = marker(936, "gbk");
 const EUC_KR_MARKER = marker(949, "euc-kr");
 const CP857_MARKER = marker(857, "cp857");
 const CP850_MARKER = marker(850, "cp850");
+const UTF8_MARKER = marker(65001, "utf-8");
 
 beforeEach(() => {
   resolveWindowsOemEncodingMock.mockReset();
@@ -122,19 +123,36 @@ describe("encodeWindowsLauncherScript", () => {
     expect(decodeWindowsLauncherScript({ buffer: encoded })).toBe(content);
   });
 
-  it("falls back to UTF-8 when no OEM code page is available", () => {
+  it("fails closed when no OEM code page is available", () => {
     const content = `@echo off\r\ncd /d "C:\\Users\\苗振"\r\n`;
-    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
-    expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
+    expect(() => encodeWindowsLauncherScript({ format: "cmd", content })).toThrow(
+      /OEM code page is unavailable or unsupported/,
+    );
   });
 
-  it("keeps plain UTF-8 on hosts whose OEM page is already UTF-8 (65001)", () => {
+  it("declares UTF-8 when the boot OEM page is 65001", () => {
     resolveWindowsOemEncodingMock.mockReturnValue("utf-8");
     const content = '@echo off\r\ncd /d "C:\\Users\\café"\r\n';
     const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
-    expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
+    expect(encoded.equals(Buffer.from(UTF8_MARKER + content, "utf8"))).toBe(true);
+    expect(decodeWindowsLauncherScript({ buffer: encoded })).toBe(content);
+  });
+
+  it("allows only Windows-1258 content that round-trips exactly", () => {
+    resolveWindowsOemEncodingMock.mockReturnValue("windows-1258");
+    const supported = '@echo off\r\ncd /d "C:\\Users\\Đăng"\r\n';
+    const unsupported = '@echo off\r\ncd /d "C:\\Users\\Việt"\r\n';
+
+    expect(
+      decodeWindowsLauncherScript({
+        buffer: encodeWindowsLauncherScript({ format: "cmd", content: supported }),
+      }),
+    ).toBe(supported);
+    expect(() => encodeWindowsLauncherScript({ format: "cmd", content: unsupported })).toThrow(
+      /cannot be represented/,
+    );
   });
 
   it("fails the install instead of writing unrepresentable cmd content", () => {

--- a/src/infra/windows-launcher-encoding.test.ts
+++ b/src/infra/windows-launcher-encoding.test.ts
@@ -1,4 +1,4 @@
-// Covers Windows launcher script encoding for wscript/cmd code page contracts (#107416).
+// Covers Windows launcher script encoding for wscript/cmd code page contracts (#107416, #108774).
 import iconv from "iconv-lite";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -6,14 +6,14 @@ import {
   encodeWindowsLauncherScript,
 } from "./windows-launcher-encoding.js";
 
-const resolveWindowsSystemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
+const resolveWindowsOemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
 
 vi.mock("./windows-encoding.js", async () => {
   const actual =
     await vi.importActual<typeof import("./windows-encoding.js")>("./windows-encoding.js");
   return {
     ...actual,
-    resolveWindowsSystemEncoding: () => resolveWindowsSystemEncodingMock(),
+    resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });
 
@@ -21,10 +21,12 @@ const CJK_SCRIPT_PATH = "C:\\Users\\苗振\\.openclaw\\gateway.cmd";
 const REPLACEMENT_CHAR = String.fromCharCode(0xfffd);
 const GBK_MARKER = "@rem openclaw-launcher-encoding=gbk\r\n";
 const EUC_KR_MARKER = "@rem openclaw-launcher-encoding=euc-kr\r\n";
+const CP857_MARKER = "@rem openclaw-launcher-encoding=cp857\r\n";
+const CP850_MARKER = "@rem openclaw-launcher-encoding=cp850\r\n";
 
 beforeEach(() => {
-  resolveWindowsSystemEncodingMock.mockReset();
-  resolveWindowsSystemEncodingMock.mockReturnValue(null);
+  resolveWindowsOemEncodingMock.mockReset();
+  resolveWindowsOemEncodingMock.mockReturnValue(null);
 });
 
 describe("encodeWindowsLauncherScript", () => {
@@ -49,11 +51,11 @@ describe("encodeWindowsLauncherScript", () => {
     const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
-    expect(resolveWindowsSystemEncodingMock).not.toHaveBeenCalled();
+    expect(resolveWindowsOemEncodingMock).not.toHaveBeenCalled();
   });
 
   it("encodes non-ASCII cmd scripts with a marker line plus CJK code page bytes", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
+    resolveWindowsOemEncodingMock.mockReturnValue("gbk");
     const content = `@echo off\r\ncd /d "C:\\Users\\苗振\\.openclaw"\r\nnode gateway.js\r\n`;
     const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
@@ -63,7 +65,7 @@ describe("encodeWindowsLauncherScript", () => {
   });
 
   it("round-trips cmd content whose GBK bytes are also valid UTF-8 (隆 -> C2 A1 -> ¡)", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
+    resolveWindowsOemEncodingMock.mockReturnValue("gbk");
     // Verify the trap on this iconv build: valid UTF-8, wrong string, no U+FFFD.
     const collisionBytes = iconv.encode("隆", "gbk");
     expect(collisionBytes.toString("utf8")).not.toBe("隆");
@@ -81,7 +83,7 @@ describe("encodeWindowsLauncherScript", () => {
   });
 
   it("encodes cp949 extension syllables that Node ICU's euc-kr decoder rejects", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("euc-kr");
+    resolveWindowsOemEncodingMock.mockReturnValue("euc-kr");
     // Windows code page 949 is cp949/UHC; "똠" (8C 63) is a UHC extension syllable
     // iconv encodes and round-trips, but new TextDecoder("euc-kr") cannot decode
     // (KS X 1001 only). The guard must verify euc-kr with iconv, not ICU.
@@ -96,15 +98,34 @@ describe("encodeWindowsLauncherScript", () => {
     expect(decodeWindowsLauncherScript({ buffer: encoded })).toBe(content);
   });
 
-  it("falls back to UTF-8 when no system code page is available", () => {
+  it("encodes Turkish profile paths with the cp857 OEM page cmd.exe reads (#108774)", () => {
+    resolveWindowsOemEncodingMock.mockReturnValue("cp857");
+    const content = `@echo off\r\ncd /d "C:\\Users\\Yiğit Öğün\\.openclaw"\r\nnode gateway.js\r\n`;
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
+
+    expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(false);
+    expect(encoded.equals(iconv.encode(CP857_MARKER + content, "cp857"))).toBe(true);
+    expect(decodeWindowsLauncherScript({ buffer: encoded })).toBe(content);
+  });
+
+  it("encodes Western European profile paths with the cp850 OEM page", () => {
+    resolveWindowsOemEncodingMock.mockReturnValue("cp850");
+    const content = '@echo off\r\ncd /d "C:\\Users\\café"\r\nnode gateway.js\r\n';
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
+
+    expect(encoded.equals(iconv.encode(CP850_MARKER + content, "cp850"))).toBe(true);
+    expect(decodeWindowsLauncherScript({ buffer: encoded })).toBe(content);
+  });
+
+  it("falls back to UTF-8 when no OEM code page is available", () => {
     const content = `@echo off\r\ncd /d "C:\\Users\\苗振"\r\n`;
     const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
   });
 
-  it("falls back to UTF-8 on windows-125x hosts whose console page differs from ANSI", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("windows-1252");
+  it("keeps plain UTF-8 on hosts whose OEM page is already UTF-8 (65001)", () => {
+    resolveWindowsOemEncodingMock.mockReturnValue("utf-8");
     const content = '@echo off\r\ncd /d "C:\\Users\\café"\r\n';
     const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
@@ -112,11 +133,20 @@ describe("encodeWindowsLauncherScript", () => {
   });
 
   it("fails the install instead of writing unrepresentable cmd content", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
+    resolveWindowsOemEncodingMock.mockReturnValue("gbk");
     const content = '@echo off\r\nset "OC_LABEL=🚀"\r\n';
 
     expect(() => encodeWindowsLauncherScript({ format: "cmd", content })).toThrow(
-      /cannot be represented in the Windows system code page \(gbk\)/,
+      /cannot be represented in the Windows console code page \(gbk\)/,
+    );
+  });
+
+  it("fails the install for characters outside the single-byte OEM page", () => {
+    resolveWindowsOemEncodingMock.mockReturnValue("cp857");
+    const content = `@echo off\r\ncd /d "C:\\Users\\苗振"\r\n`;
+
+    expect(() => encodeWindowsLauncherScript({ format: "cmd", content })).toThrow(
+      /cannot be represented in the Windows console code page \(cp857\)/,
     );
   });
 });

--- a/src/infra/windows-launcher-encoding.test.ts
+++ b/src/infra/windows-launcher-encoding.test.ts
@@ -1,18 +1,20 @@
 // Covers Windows launcher script encoding for wscript/cmd code page contracts (#107416, #108774).
 import iconv from "iconv-lite";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   decodeWindowsLauncherScript,
   encodeWindowsLauncherScript,
 } from "./windows-launcher-encoding.js";
 
 const resolveWindowsOemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
+const resolveWindowsOemCodePageMock = vi.hoisted(() => vi.fn((): number | null => null));
 
 vi.mock("./windows-encoding.js", async () => {
   const actual =
     await vi.importActual<typeof import("./windows-encoding.js")>("./windows-encoding.js");
   return {
     ...actual,
+    resolveWindowsOemCodePage: () => resolveWindowsOemCodePageMock(),
     resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });
@@ -30,6 +32,12 @@ const UTF8_MARKER = marker(65001, "utf-8");
 beforeEach(() => {
   resolveWindowsOemEncodingMock.mockReset();
   resolveWindowsOemEncodingMock.mockReturnValue(null);
+  resolveWindowsOemCodePageMock.mockReset();
+  resolveWindowsOemCodePageMock.mockReturnValue(437);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("encodeWindowsLauncherScript", () => {
@@ -55,6 +63,16 @@ describe("encodeWindowsLauncherScript", () => {
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
     expect(resolveWindowsOemEncodingMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for ASCII cmd syntax on OEMCP 864", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    resolveWindowsOemCodePageMock.mockReturnValue(864);
+    const content = "@echo off\r\necho %PATH%\r\n";
+
+    expect(() => encodeWindowsLauncherScript({ format: "cmd", content })).toThrow(
+      /remaps ASCII syntax/,
+    );
   });
 
   it("encodes non-ASCII cmd scripts with a code-page preamble and marker", () => {

--- a/src/infra/windows-launcher-encoding.test.ts
+++ b/src/infra/windows-launcher-encoding.test.ts
@@ -19,10 +19,12 @@ vi.mock("./windows-encoding.js", async () => {
 
 const CJK_SCRIPT_PATH = "C:\\Users\\苗振\\.openclaw\\gateway.cmd";
 const REPLACEMENT_CHAR = String.fromCharCode(0xfffd);
-const GBK_MARKER = "@rem openclaw-launcher-encoding=gbk\r\n";
-const EUC_KR_MARKER = "@rem openclaw-launcher-encoding=euc-kr\r\n";
-const CP857_MARKER = "@rem openclaw-launcher-encoding=cp857\r\n";
-const CP850_MARKER = "@rem openclaw-launcher-encoding=cp850\r\n";
+const marker = (codePage: number, encoding: string) =>
+  `@chcp ${codePage} >nul\r\n@rem openclaw-launcher-encoding=${encoding}\r\n`;
+const GBK_MARKER = marker(936, "gbk");
+const EUC_KR_MARKER = marker(949, "euc-kr");
+const CP857_MARKER = marker(857, "cp857");
+const CP850_MARKER = marker(850, "cp850");
 
 beforeEach(() => {
   resolveWindowsOemEncodingMock.mockReset();
@@ -54,13 +56,16 @@ describe("encodeWindowsLauncherScript", () => {
     expect(resolveWindowsOemEncodingMock).not.toHaveBeenCalled();
   });
 
-  it("encodes non-ASCII cmd scripts with a marker line plus CJK code page bytes", () => {
+  it("encodes non-ASCII cmd scripts with a code-page preamble and marker", () => {
     resolveWindowsOemEncodingMock.mockReturnValue("gbk");
     const content = `@echo off\r\ncd /d "C:\\Users\\苗振\\.openclaw"\r\nnode gateway.js\r\n`;
     const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(false);
     expect(encoded.equals(iconv.encode(GBK_MARKER + content, "gbk"))).toBe(true);
+    expect(encoded.subarray(0, "@chcp 936 >nul\r\n".length).toString("ascii")).toBe(
+      "@chcp 936 >nul\r\n",
+    );
     expect(decodeWindowsLauncherScript({ buffer: encoded })).toBe(content);
   });
 
@@ -169,6 +174,13 @@ describe("decodeWindowsLauncherScript", () => {
   it("decodes marked code-page scripts with the recorded encoding", () => {
     const content = "@echo off\r\nrem 你好\r\n";
     const buffer = iconv.encode(GBK_MARKER + content, "gbk");
+
+    expect(decodeWindowsLauncherScript({ buffer })).toBe(content);
+  });
+
+  it("decodes pre-preamble marked code-page scripts", () => {
+    const content = "@echo off\r\nrem 你好\r\n";
+    const buffer = iconv.encode(`@rem openclaw-launcher-encoding=gbk\r\n${content}`, "gbk");
 
     expect(decodeWindowsLauncherScript({ buffer })).toBe(content);
   });

--- a/src/infra/windows-launcher-encoding.test.ts
+++ b/src/infra/windows-launcher-encoding.test.ts
@@ -144,6 +144,7 @@ describe("encodeWindowsLauncherScript", () => {
     resolveWindowsOemEncodingMock.mockReturnValue("windows-1258");
     const supported = '@echo off\r\ncd /d "C:\\Users\\Đăng"\r\n';
     const unsupported = '@echo off\r\ncd /d "C:\\Users\\Việt"\r\n';
+    const decomposed = '@echo off\r\ncd /d "C:\\Users\\e\u0323"\r\n';
 
     expect(
       decodeWindowsLauncherScript({
@@ -151,6 +152,9 @@ describe("encodeWindowsLauncherScript", () => {
       }),
     ).toBe(supported);
     expect(() => encodeWindowsLauncherScript({ format: "cmd", content: unsupported })).toThrow(
+      /cannot be represented/,
+    );
+    expect(() => encodeWindowsLauncherScript({ format: "cmd", content: decomposed })).toThrow(
       /cannot be represented/,
     );
   });

--- a/src/infra/windows-launcher-encoding.ts
+++ b/src/infra/windows-launcher-encoding.ts
@@ -1,6 +1,9 @@
 /** Encodes and decodes generated Windows launcher scripts (`.cmd` / `.vbs`). */
 import iconv from "iconv-lite";
-import { resolveWindowsOemEncoding } from "./windows-encoding.js";
+import {
+  resolveWindowsOemCodePageForEncoding,
+  resolveWindowsOemEncoding,
+} from "./windows-encoding.js";
 
 type WindowsLauncherScriptFormat = "cmd" | "vbs";
 
@@ -23,6 +26,7 @@ const WHATWG_VERIFIABLE_ENCODINGS = new Set(["gbk", "big5", "shift_jis", "window
 // silently corrupts paths.
 const LAUNCHER_ENCODING_MARKER_PREFIX = "@rem openclaw-launcher-encoding=";
 const LAUNCHER_ENCODING_MARKER_RE = /^@rem openclaw-launcher-encoding=(\S+)\s*$/;
+const LAUNCHER_CODEPAGE_PREAMBLE_RE = /^@chcp \d+ >nul\s*$/;
 
 function isAsciiOnly(value: string): boolean {
   for (let index = 0; index < value.length; index += 1) {
@@ -56,9 +60,13 @@ export function encodeWindowsLauncherScript(params: {
   if (!encoding || encoding === "utf-8" || !iconv.encodingExists(encoding)) {
     return Buffer.from(params.content, "utf8");
   }
-  // Generated launcher scripts are CRLF-terminated throughout; the marker is
-  // ASCII, so it encodes byte-identically in every safe code page.
-  const marked = `${LAUNCHER_ENCODING_MARKER_PREFIX}${encoding}\r\n${params.content}`;
+  const codePage = resolveWindowsOemCodePageForEncoding(encoding);
+  if (codePage === null) {
+    return Buffer.from(params.content, "utf8");
+  }
+  // The ASCII first line makes inherited and per-user console overrides adopt
+  // the file's OEM page before cmd.exe reads any non-ASCII launcher content.
+  const marked = `@chcp ${codePage} >nul\r\n${LAUNCHER_ENCODING_MARKER_PREFIX}${encoding}\r\n${params.content}`;
   const encoded = iconv.encode(marked, encoding);
   // iconv-lite substitutes "?" for unmappable characters, which would silently
   // corrupt paths; verify the round-trip and fail the install before any
@@ -81,15 +89,21 @@ export function decodeWindowsLauncherScript(params: { buffer: Buffer }): string 
   if (buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe) {
     return buffer.subarray(2).toString("utf16le");
   }
-  // The marker line is pure ASCII; single-byte OEM pages keep 0x0A as newline
-  // and no supported DBCS page uses 0x0A as a trail byte, so the first newline
-  // in a marked file is exactly the marker terminator. latin1 (not "ascii",
-  // which masks the high bit and could alias garbage bytes into the prefix)
-  // keeps the byte-level read exact.
-  const newlineIndex = buffer.indexOf(0x0a);
+  // Preamble and marker lines are pure ASCII; supported code pages keep 0x0A
+  // out of multibyte trail positions. Accept marker-only files written before
+  // the preamble was added, too.
+  let markerStart = 0;
+  let newlineIndex = buffer.indexOf(0x0a);
+  if (
+    newlineIndex !== -1 &&
+    LAUNCHER_CODEPAGE_PREAMBLE_RE.test(buffer.subarray(0, newlineIndex).toString("latin1"))
+  ) {
+    markerStart = newlineIndex + 1;
+    newlineIndex = buffer.indexOf(0x0a, markerStart);
+  }
   if (newlineIndex !== -1) {
     const marker = LAUNCHER_ENCODING_MARKER_RE.exec(
-      buffer.subarray(0, newlineIndex).toString("latin1"),
+      buffer.subarray(markerStart, newlineIndex).toString("latin1"),
     );
     // encodingExists guards hand-edited marker labels so a bad label degrades
     // to the UTF-8 fallback instead of iconv.decode throwing mid-poll.

--- a/src/infra/windows-launcher-encoding.ts
+++ b/src/infra/windows-launcher-encoding.ts
@@ -57,8 +57,10 @@ export function encodeWindowsLauncherScript(params: {
     return Buffer.from(params.content, "utf8");
   }
   const encoding = resolveWindowsOemEncoding();
-  if (!encoding || encoding === "utf-8" || !iconv.encodingExists(encoding)) {
-    return Buffer.from(params.content, "utf8");
+  if (!encoding || !iconv.encodingExists(encoding)) {
+    throw new Error(
+      "Windows cmd launcher script contains non-ASCII content, but the Windows OEM code page is unavailable or unsupported; writing UTF-8 would make cmd.exe misread the script. Switch Windows to UTF-8 (code page 65001) or remove the non-ASCII content.",
+    );
   }
   const codePage = resolveWindowsOemCodePageForEncoding(encoding);
   if (codePage === null) {

--- a/src/infra/windows-launcher-encoding.ts
+++ b/src/infra/windows-launcher-encoding.ts
@@ -1,6 +1,7 @@
 /** Encodes and decodes generated Windows launcher scripts (`.cmd` / `.vbs`). */
 import iconv from "iconv-lite";
 import {
+  resolveWindowsOemCodePage,
   resolveWindowsOemCodePageForEncoding,
   resolveWindowsOemEncoding,
 } from "./windows-encoding.js";
@@ -52,8 +53,16 @@ export function encodeWindowsLauncherScript(params: {
     return Buffer.concat([UTF16LE_BOM, Buffer.from(params.content, "utf16le")]);
   }
   if (isAsciiOnly(params.content)) {
+    if (process.platform === "win32") {
+      const codePage = resolveWindowsOemCodePage();
+      if (codePage === null || codePage === 864) {
+        throw new Error(
+          "Windows cmd launcher script cannot be written safely because the Windows OEM code page is unavailable or remaps ASCII syntax.",
+        );
+      }
+    }
     // ASCII bytes are identical in UTF-8 and every Windows code page; keep the
-    // legacy byte-for-byte output so non-CJK installs see no change.
+    // legacy byte-for-byte output on syntax-compatible OEM pages.
     return Buffer.from(params.content, "utf8");
   }
   const encoding = resolveWindowsOemEncoding();

--- a/src/infra/windows-launcher-encoding.ts
+++ b/src/infra/windows-launcher-encoding.ts
@@ -77,7 +77,11 @@ export function encodeWindowsLauncherScript(params: {
   const decoded = WHATWG_VERIFIABLE_ENCODINGS.has(encoding)
     ? new TextDecoder(encoding).decode(encoded)
     : iconv.decode(encoded, encoding);
-  if (decoded !== marked) {
+  // Windows decodes CP1258 with MB_PRECOMPOSED by default. Reject composite
+  // sequences that Windows would normalize into a different path or value.
+  const windowsWouldPrecompose =
+    encoding === "windows-1258" && decoded.normalize("NFC") !== decoded;
+  if (decoded !== marked || windowsWouldPrecompose) {
     throw new Error(
       `Windows ${params.format} launcher script contains characters that cannot be represented in the Windows console code page (${encoding}); cmd.exe would misread the script. Remove those characters or switch Windows to UTF-8 (code page 65001).`,
     );

--- a/src/infra/windows-launcher-encoding.ts
+++ b/src/infra/windows-launcher-encoding.ts
@@ -1,23 +1,21 @@
 /** Encodes and decodes generated Windows launcher scripts (`.cmd` / `.vbs`). */
 import iconv from "iconv-lite";
-import { resolveWindowsSystemEncoding } from "./windows-encoding.js";
+import { resolveWindowsOemEncoding } from "./windows-encoding.js";
 
 type WindowsLauncherScriptFormat = "cmd" | "vbs";
 
 const UTF16LE_BOM = Buffer.from([0xff, 0xfe]);
 
-// cmd.exe decodes batch files with the console OEM code page, which matches the
-// ANSI code page only on these locales. windows-125x hosts pair ANSI with a
-// separate OEM page (437/850/852/866/...) that WHATWG decoders cannot model, so
-// non-ASCII cmd content stays UTF-8 there instead of guessing wrong bytes.
-const CMD_ANSI_EQUALS_OEM_ENCODINGS = new Set([
-  "gbk",
-  "big5",
-  "shift_jis",
-  "euc-kr",
-  "gb18030",
-  "windows-874",
-]);
+// Round-trip verification decoder choice: these DBCS labels match Windows in
+// Node ICU, which also flags best-fit hazards (shift_jis ¥ -> 0x5C) iconv's
+// decode would miss. euc-kr must not join them: Node ICU is KS X 1001 only,
+// but Windows code page 949 is cp949/UHC, so ICU false-rejects the ~8,800 UHC
+// extension syllables cmd.exe reads fine. The single-byte OEM `cp###` pages
+// have no WHATWG decoder at all (ibm866 exists but disagrees with Windows
+// CP866 at 0x1A/0x1C/0x7F); iconv's own decode is safe for them because
+// iconv-lite never best-fits — unmappable characters become "?" and fail the
+// round-trip check.
+const WHATWG_VERIFIABLE_ENCODINGS = new Set(["gbk", "big5", "shift_jis", "windows-874"]);
 
 // Code-page cmd launchers record their encoding in this ASCII comment line so
 // readback never has to guess: some code-page byte sequences are also valid
@@ -37,8 +35,9 @@ function isAsciiOnly(value: string): boolean {
 
 /**
  * wscript.exe reads .vbs only as ANSI or UTF-16 LE with BOM, and cmd.exe reads
- * .cmd in the console code page; plain UTF-8 garbles CJK profile paths into
- * "file not found" launch failures (#107416). Do not simplify back to utf8.
+ * .cmd in the console (OEM) code page; plain UTF-8 garbles non-ASCII profile
+ * paths into "file not found" launch failures (#107416, #108774). Do not
+ * simplify back to utf8.
  */
 export function encodeWindowsLauncherScript(params: {
   format: WindowsLauncherScriptFormat;
@@ -53,12 +52,8 @@ export function encodeWindowsLauncherScript(params: {
     // legacy byte-for-byte output so non-CJK installs see no change.
     return Buffer.from(params.content, "utf8");
   }
-  const encoding = resolveWindowsSystemEncoding();
-  if (
-    !encoding ||
-    !CMD_ANSI_EQUALS_OEM_ENCODINGS.has(encoding) ||
-    !iconv.encodingExists(encoding)
-  ) {
+  const encoding = resolveWindowsOemEncoding();
+  if (!encoding || encoding === "utf-8" || !iconv.encodingExists(encoding)) {
     return Buffer.from(params.content, "utf8");
   }
   // Generated launcher scripts are CRLF-terminated throughout; the marker is
@@ -67,18 +62,14 @@ export function encodeWindowsLauncherScript(params: {
   const encoded = iconv.encode(marked, encoding);
   // iconv-lite substitutes "?" for unmappable characters, which would silently
   // corrupt paths; verify the round-trip and fail the install before any
-  // launcher file is written. Node ICU's euc-kr decoder is KS X 1001 only, but
-  // Windows code page 949 is cp949/UHC, so ICU false-rejects the ~8,800 UHC
-  // extension syllables cmd.exe reads fine — verify euc-kr with iconv's own
-  // cp949 decode instead. The other five labels match Windows in ICU, which
-  // also flags best-fit hazards (shift_jis ¥ -> 0x5C) iconv's decode would miss.
-  const decoded =
-    encoding === "euc-kr"
-      ? iconv.decode(encoded, encoding)
-      : new TextDecoder(encoding).decode(encoded);
+  // launcher file is written. See WHATWG_VERIFIABLE_ENCODINGS for the decoder
+  // split between Node ICU and iconv.
+  const decoded = WHATWG_VERIFIABLE_ENCODINGS.has(encoding)
+    ? new TextDecoder(encoding).decode(encoded)
+    : iconv.decode(encoded, encoding);
   if (decoded !== marked) {
     throw new Error(
-      `Windows ${params.format} launcher script contains characters that cannot be represented in the Windows system code page (${encoding}); cmd.exe would misread the script. Remove those characters or switch Windows to UTF-8 (code page 65001).`,
+      `Windows ${params.format} launcher script contains characters that cannot be represented in the Windows console code page (${encoding}); cmd.exe would misread the script. Remove those characters or switch Windows to UTF-8 (code page 65001).`,
     );
   }
   return encoded;
@@ -90,10 +81,11 @@ export function decodeWindowsLauncherScript(params: { buffer: Buffer }): string 
   if (buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe) {
     return buffer.subarray(2).toString("utf16le");
   }
-  // The marker line is pure ASCII and no CMD_ANSI_EQUALS_OEM_ENCODINGS multibyte
-  // sequence contains 0x0A, so the first newline in a marked file is exactly
-  // the marker terminator. latin1 (not "ascii", which masks the high bit and
-  // could alias garbage bytes into the prefix) keeps the byte-level read exact.
+  // The marker line is pure ASCII; single-byte OEM pages keep 0x0A as newline
+  // and no supported DBCS page uses 0x0A as a trail byte, so the first newline
+  // in a marked file is exactly the marker terminator. latin1 (not "ascii",
+  // which masks the high bit and could alias garbage bytes into the prefix)
+  // keeps the byte-level read exact.
   const newlineIndex = buffer.indexOf(0x0a);
   if (newlineIndex !== -1) {
     const marker = LAUNCHER_ENCODING_MARKER_RE.exec(

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -17,8 +17,8 @@ const resolveTaskScriptPathMock = vi.hoisted(() =>
   }),
 );
 // Pin code page detection so hosts with CJK home paths cannot leak the real
-// PowerShell probe into script-encoding assertions.
-const resolveWindowsSystemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
+// registry OEM probe into script-encoding assertions.
+const resolveWindowsOemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
@@ -41,7 +41,7 @@ vi.mock("./windows-encoding.js", async () => {
     await vi.importActual<typeof import("./windows-encoding.js")>("./windows-encoding.js");
   return {
     ...actual,
-    resolveWindowsSystemEncoding: () => resolveWindowsSystemEncodingMock(),
+    resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });
 
@@ -102,8 +102,8 @@ describe("relaunchGatewayScheduledTask", () => {
       const home = env.USERPROFILE || env.HOME || os.homedir();
       return path.join(home, ".openclaw", "gateway.cmd");
     });
-    resolveWindowsSystemEncodingMock.mockReset();
-    resolveWindowsSystemEncodingMock.mockReturnValue(null);
+    resolveWindowsOemEncodingMock.mockReset();
+    resolveWindowsOemEncodingMock.mockReturnValue(null);
   });
 
   it("writes a detached schtasks relaunch helper", () => {
@@ -275,7 +275,7 @@ describe("relaunchGatewayScheduledTask", () => {
   };
 
   it("writes marked code-page bytes for CJK task names that decode back exactly", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
+    resolveWindowsOemEncodingMock.mockReturnValue("gbk");
     spawnMock.mockImplementation((_file: string, args: string[]) => {
       createdScriptPaths.add(decodeCmdPathArg(expectDefined(args[3], "args[3] test invariant")));
       return { unref: vi.fn() };
@@ -302,7 +302,7 @@ describe("relaunchGatewayScheduledTask", () => {
   });
 
   it("returns failed instead of writing an unrepresentable helper script", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
+    resolveWindowsOemEncodingMock.mockReturnValue("gbk");
     spawnMock.mockImplementation(() => {
       throw new Error("spawn should not be reached");
     });

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -292,7 +292,11 @@ describe("relaunchGatewayScheduledTask", () => {
       "[...createdScriptPaths][0] test invariant",
     );
     const raw = fs.readFileSync(scriptPath);
-    expect(raw.toString("latin1").startsWith("@rem openclaw-launcher-encoding=gbk\r\n")).toBe(true);
+    expect(
+      raw
+        .toString("latin1")
+        .startsWith("@chcp 936 >nul\r\n@rem openclaw-launcher-encoding=gbk\r\n"),
+    ).toBe(true);
     // The old raw-UTF-8 writer would have kept the task name readable here.
     expect(raw.toString("utf8")).not.toContain("隆");
     const script = decodeWindowsLauncherScript({ buffer: raw });

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -41,6 +41,7 @@ vi.mock("./windows-encoding.js", async () => {
     await vi.importActual<typeof import("./windows-encoding.js")>("./windows-encoding.js");
   return {
     ...actual,
+    resolveWindowsOemCodePage: () => 437,
     resolveWindowsOemEncoding: () => resolveWindowsOemEncodingMock(),
   };
 });


### PR DESCRIPTION
Closes #108774

## What Problem This Solves

Fixes an issue where Windows users whose profile path contains non-ASCII characters outside the CJK range (Turkish, Cyrillic, Greek, Western European accents, ...) can install OpenClaw but the managed Gateway never starts: the generated `gateway.cmd` launcher garbles the profile path and the launch chain dies with "The system cannot find the path specified" / `MODULE_NOT_FOUND`.

#107751 fixed this failure for CJK locales by encoding the launcher in the system ANSI code page — but only on locales where ANSI == OEM, and it deliberately left windows-125x hosts on plain UTF-8 ("ANSI bytes would just be a different flavor of wrong there"). On those hosts (e.g. Turkish: ANSI 1254, OEM 857) cmd.exe still reads the UTF-8 launcher in its OEM code page and the mojibake from #108774 persists.

## Why This Change Was Made

cmd.exe parses batch files with the **console code page**, which a fresh console (Task Scheduler, Startup folder, double-click) initializes from the boot-time registry `OEMCP` — not from the ANSI page, and not from whatever a parent session last `chcp`'d to. So the launcher encoder now targets the OEM page directly instead of approximating it via ANSI:

- `resolveWindowsOemEncoding()` (new, `src/infra/windows-encoding.ts`) reads `HKLM\SYSTEM\CurrentControlSet\Control\Nls\CodePage\OEMCP` once (cached) through a narrow `queryWindowsRegistryValue` export that reuses the existing reg.exe query logic in `src/infra/windows-install-roots.ts`.
- `encodeWindowsLauncherScript` (`src/infra/windows-launcher-encoding.ts`) encodes non-ASCII `.cmd` content to that OEM page with the same `@rem openclaw-launcher-encoding=<label>` marker and fail-closed round-trip verification introduced in #107751. The `CMD_ANSI_EQUALS_OEM_ENCODINGS` special case is deleted: on CJK locales OEMCP == ACP, so those hosts resolve the identical labels (gbk/big5/shift_jis/euc-kr/windows-874) and produce byte-identical launchers — no behavior change there.
- Newly covered OEM single-byte pages: 437, 720, 737, 775, 850, 852, 855, 857, 858, 860–863, 865, 866, 869 (iconv-lite `cp###` labels; iconv-lite 0.7.2 is already a root dependency since #107751).
- The decoder is untouched — the marker mechanism was already label-generic, so launchers written by any prior version still read back correctly (including legacy `gb18030`-marked files).

Design notes:

- **Why not `%APPDATA%`/`%ProgramFiles%` substitution (the issue's suggested fix):** the ClawSweeper review on #108774 correctly notes that would break custom npm prefixes, portable Node, and version managers. This fix keeps the installer-resolved paths and makes the encoding correct instead.
- **Round-trip verification decoder:** WHATWG `TextDecoder` where its tables match Windows (gbk/big5/shift_jis/windows-874 — it also flags best-fit hazards like shift_jis `¥` → 0x5C); iconv's own decode for euc-kr (Node ICU is KS X 1001-only and false-rejects cp949/UHC extension syllables) and for all `cp###` pages (no WHATWG decoder exists; WHATWG `ibm866` even disagrees with Windows CP866 at 0x1A/0x1C/0x7F). Safe because iconv-lite never best-fits — unmappable characters become `?` and fail the round-trip, aborting the install with the existing clear error.
- **Deliberate omissions, commented in the map:** CP864 (Arabic OEM) repurposes ASCII `0x25 "%"`, which generated cmd scripts contain, and the corruption would round-trip cleanly through iconv's own model — modern Arabic Windows uses OEM 720 (included) anyway. CP1258 (Vietnamese, the one locale whose OEMCP is a windows-125x page) is omitted because iconv-lite cannot round-trip Vietnamese combining forms; it keeps today's UTF-8 fallback instead of turning mojibake into a hard install error. Hosts with the "UTF-8 worldwide" beta (OEMCP 65001) keep plain UTF-8, which is correct there.

## User Impact

`openclaw gateway install` + `gateway start` now works for Windows accounts with Turkish/Cyrillic/Greek/Western-European/etc. non-ASCII usernames — previously the P0 release-blocker path in #108774. CJK users see byte-identical output to #107751. ASCII-only installs are untouched (encoder still short-circuits before any code-page probe).

## Evidence

**Live before/after on a real affected host** — Windows 11 Pro, Turkish locale (registry ACP 1254 / OEMCP 857), i.e. exactly the ANSI≠OEM case #107751 left open. A launcher with `buildTaskScript`-shaped content (`cd /d`, `set "OPENCLAW_STATE_DIR=..."`, node invocation) pointing into a `...\ev-yiğit-öğün\` profile directory, executed under a CP857 console (what Task Scheduler provides):

Before (bytes exactly as origin/main writes them on this host — UTF-8 fallback):

```
Sistem belirtilen yolu bulamıyor.            <- cd /d failed ("The system cannot find the path specified")
Error: Cannot find module 'C:\...\ev-yi─şit-├Â─ş├╝n\probe.js'   <- UTF-8 bytes misread as CP857
exit code: 1
```

After (bytes from the fixed `encodeWindowsLauncherScript()`, real production function + real registry read, which resolved `cp857` and emitted the `@rem openclaw-launcher-encoding=cp857` marker):

```
PROBE_OK cwd=C:\...\scratchpad\ev-yiğit-öğün
PROBE_OK stateDir=C:\...\scratchpad\ev-yiğit-öğün\state
exit code: 0
```

**Tests** (all pass, `node scripts/run-vitest.mjs ...`): `src/infra/windows-launcher-encoding.test.ts`, `src/infra/windows-encoding.test.ts`, `src/daemon/schtasks.test.ts`, `src/daemon/schtasks.install.test.ts`, `src/infra/windows-task-restart.test.ts` — 49 tests. New regression cases: cp857 Turkish path round-trip with marker, cp850 Western European, OEMCP-65001 stays UTF-8, unrepresentable characters on a single-byte OEM page fail the install fail-closed. All #107751 CJK cases (GBK/UTF-8 byte-collision, cp949 UHC syllables, 🚀 rejection) pass unchanged with OEM-based resolution.

`oxfmt` and `oxlint` clean on all touched files; `tsgo -p tsconfig.core.json` reports no errors in touched files (the 42 pre-existing errors on this machine reproduce identically on a clean `origin/main` checkout — local env, unrelated).
