### PR TITLE
fix: queued MEDIA attachments survive delivery retries

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -101,7 +101,6 @@ import {
 } from "./outbound-audit.js";
 import {
   createOutboundPayloadPlan,
-  materializeQueueCustodyMedia,
   summarizeOutboundPayloadForTransport,
   type NormalizedOutboundPayload,
   type OutboundPayloadPlan,
@@ -1373,6 +1372,33 @@ function suppressedPayloadOutcome(params: {
     reason: params.reason,
     ...(params.hookEffect ? { hookEffect: params.hookEffect } : {}),
   };
+}
+
+/** Adds directive-derived media to the queue copy before spool custody. */
+function materializeQueueCustodyMedia(
+  payloads: readonly ReplyPayload[],
+  plan: readonly OutboundPayloadPlan[],
+): ReplyPayload[] {
+  const effectiveBySource = new Map(
+    plan.map((entry) => [entry.sourceIndex, entry.parts.mediaUrls] as const),
+  );
+  return payloads.map((payload, index) => {
+    const effective = effectiveBySource.get(index);
+    if (!effective?.length) {
+      return payload;
+    }
+    const structured = new Set(
+      [payload.mediaUrl, ...(payload.mediaUrls ?? [])]
+        .map((url) => url?.trim())
+        .filter((url): url is string => Boolean(url)),
+    );
+    if (effective.every((url) => structured.has(url))) {
+      return payload;
+    }
+    // Keep raw pre-hook text for deterministic replay. The singular anchor
+    // prevents recovery from re-adding its original MEDIA: path.
+    return { ...payload, mediaUrl: effective[0], mediaUrls: [...effective] };
+  });
 }
 
 /**

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -101,6 +101,7 @@ import {
 } from "./outbound-audit.js";
 import {
   createOutboundPayloadPlan,
+  materializeQueueCustodyMedia,
   summarizeOutboundPayloadForTransport,
   type NormalizedOutboundPayload,
   type OutboundPayloadPlan,
@@ -1428,32 +1429,59 @@ export async function deliverOutboundPayloadsInternal(
   }
   const queuePolicy = params.queuePolicy ?? "best_effort";
   const strippedQueuePayloads = payloads.map(stripInternalRuntimeScaffoldingFromPayload);
-  const queuePayloadsChanged = strippedQueuePayloads.some(
-    (payload, index) => payload !== payloads[index],
-  );
   const renderedBatchPlan =
     params.renderedBatchPlan ?? createRenderedMessageBatchPlan(params.payloads);
-  // Media staging only rewrites source URLs one-for-one, and the plan is read for
-  // its per-payload counts (see resolveMessagePlanMediaCount), so it stays keyed
-  // to the payload shape rather than to which copy the row happens to reference.
-  const queueRenderedBatchPlan = queuePayloadsChanged
-    ? createRenderedMessageBatchPlan(strippedQueuePayloads)
-    : renderedBatchPlan;
 
   const stageAndEnqueueDelivery = async (): Promise<string | null> => {
+    // Legacy `MEDIA:` text directives carry local media that only materializes
+    // into structured fields at send time, so the spool (which reads structured
+    // media) would skip it and a retry would read the vanished producer path.
+    // Project each source payload's effective media through the same canonical
+    // plan the live send uses and fold directive-derived sources into the queue
+    // copy's structured media before staging. The raw payload and its pre-hook
+    // text are untouched, so the live send below stays copy-free on the original.
+    const directiveOptions = await resolveChannelOutboundDirectiveOptions({
+      cfg: params.cfg,
+      channel,
+    });
+    const queueCustodyPayloads = materializeQueueCustodyMedia(
+      strippedQueuePayloads,
+      createOutboundPayloadPlan(strippedQueuePayloads, {
+        cfg: params.cfg,
+        sessionKey: params.session?.policyKey ?? params.session?.key,
+        surface: channel,
+        conversationType: params.session?.conversationType,
+        extractMarkdownImages: directiveOptions.extractMarkdownImages,
+      }),
+    );
+    const queuePayloadsChanged = queueCustodyPayloads.some(
+      (payload, index) => payload !== payloads[index],
+    );
+    // Media staging only rewrites source URLs one-for-one, so the plan stays keyed
+    // to the custody payload counts rather than to which copy the row references;
+    // recovery replays entry.payloads and this plan together. Materialized custody
+    // anchors mediaUrl to the effective set (to override the in-text directive on
+    // replay), so count fan-out from mediaUrls alone for payloads we rewrote to
+    // keep the plan aligned with the deduped effective media recovery re-derives.
+    const renderPlanPayloads = queueCustodyPayloads.map((payload, index) =>
+      payload === strippedQueuePayloads[index] ? payload : { ...payload, mediaUrl: undefined },
+    );
+    const queueRenderedBatchPlan = queuePayloadsChanged
+      ? createRenderedMessageBatchPlan(renderPlanPayloads)
+      : renderedBatchPlan;
     // A durable row must not outlive its media. Producer-owned local sources
     // (TTS temps above all) are deleted when this process exits, so the queue
     // takes its own copy first and the row references that; the live send below
     // keeps the original path and stays copy-free.
     const staged = await stageQueuePayloadMedia({
-      payloads: strippedQueuePayloads,
+      payloads: queueCustodyPayloads,
       // Resolved exactly as the live send resolves it: staging must neither
       // reject media the send would deliver (agent workspace sources are only
       // reachable through the agent-scoped roots) nor read more than the send may.
       mediaAccess: resolveOutboundMediaAccessForSend(
         params,
         channel,
-        collectPayloadMediaSources(strippedQueuePayloads),
+        collectPayloadMediaSources(queueCustodyPayloads),
       ),
       maxBytes: resolveOutboundMediaMaxBytes({
         cfg: params.cfg,

--- a/src/infra/outbound/delivery-queue-media-directive-durability.test.ts
+++ b/src/infra/outbound/delivery-queue-media-directive-durability.test.ts
@@ -1,0 +1,329 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { createRenderedMessageBatchPlan } from "../../channels/message/rendered-batch.js";
+import type {
+  ChannelOutboundAdapter,
+  ChannelOutboundContext,
+} from "../../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import {
+  releasePinnedPluginChannelRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { PlatformMessageNotDispatchedError } from "./deliver-types.js";
+import { collectEntrySpoolPaths } from "./delivery-queue-media-spool.js";
+import { loadPendingDeliveries } from "./delivery-queue-storage.js";
+import { drainPendingDeliveries, type DeliverFn } from "./delivery-queue.js";
+import {
+  createRecoveryLog,
+  installDeliveryQueueTmpDirHooks,
+} from "./delivery-queue.test-helpers.js";
+import { createOutboundPayloadPlan, materializeQueueCustodyMedia } from "./payloads.js";
+
+let deliverOutboundPayloads: typeof import("./deliver.js").deliverOutboundPayloads;
+
+const cfg = {} as OpenClawConfig;
+
+function installMatrixAdapter(outbound: ChannelOutboundAdapter): void {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: createOutboundTestPlugin({ id: "matrix", outbound }),
+      },
+    ]),
+  );
+}
+
+/** Adapter that records what the live send resolves, then proves nothing dispatched. */
+function enqueuePhaseAdapter(mediaPaths: string[]): ChannelOutboundAdapter {
+  return {
+    deliveryMode: "direct",
+    sendText: async () => ({ channel: "matrix", messageId: "t" }),
+    sendMedia: async (ctx: ChannelOutboundContext) => {
+      mediaPaths.push(ctx.mediaUrl ?? "");
+      // Proven-not-dispatched clears send evidence so the durable row stays replayable.
+      throw new PlatformMessageNotDispatchedError("forced not-dispatched (test)", {
+        cause: new Error("test"),
+      });
+    },
+  };
+}
+
+type RecoveredSend = { mediaUrl: string; fromSpool: boolean; bytes?: string; error?: string };
+
+/** Adapter that reads the exact path the replayed send hands it (spool copy vs producer path). */
+function recoveryPhaseAdapter(records: RecoveredSend[], spoolRoot: string): ChannelOutboundAdapter {
+  return {
+    deliveryMode: "direct",
+    sendText: async () => ({ channel: "matrix", messageId: "t" }),
+    sendMedia: async (ctx: ChannelOutboundContext) => {
+      const mediaUrl = ctx.mediaUrl ?? "";
+      const fromSpool = path.dirname(mediaUrl) === spoolRoot;
+      let bytes: string | undefined;
+      let error: string | undefined;
+      try {
+        bytes = (await fs.readFile(mediaUrl)).toString("hex");
+      } catch (err) {
+        error = String(err);
+      }
+      records.push({ mediaUrl, fromSpool, bytes, error });
+      if (error) {
+        throw new Error(error);
+      }
+      return { channel: "matrix", messageId: "recovered" };
+    },
+  };
+}
+
+describe("materializeQueueCustodyMedia", () => {
+  const custody = (payloads: ReplyPayload[]): ReplyPayload[] =>
+    materializeQueueCustodyMedia(payloads, createOutboundPayloadPlan(payloads));
+
+  it("materializes a single local MEDIA directive into structured queue media", () => {
+    const payloads: ReplyPayload[] = [{ text: "caption\nMEDIA:/tmp/generated.txt" }];
+    const [out] = custody(payloads);
+    // mediaUrl is anchored to the effective set so the staged copy overrides the
+    // in-text directive on replay; mediaUrls carries the full effective media.
+    expect(out?.mediaUrl).toBe("/tmp/generated.txt");
+    expect(out?.mediaUrls).toEqual(["/tmp/generated.txt"]);
+    // raw pre-hook text (directive included) is preserved
+    expect(out?.text).toBe("caption\nMEDIA:/tmp/generated.txt");
+    // input object is not mutated
+    expect(payloads[0]?.mediaUrls).toBeUndefined();
+    expect(payloads[0]?.mediaUrl).toBeUndefined();
+    expect(payloads[0]?.text).toBe("caption\nMEDIA:/tmp/generated.txt");
+  });
+
+  it("materializes multiple local directives in order", () => {
+    const [out] = custody([{ text: "MEDIA:/tmp/a.png\nMEDIA:/tmp/b.png" }]);
+    expect(out?.mediaUrl).toBe("/tmp/a.png");
+    expect(out?.mediaUrls).toEqual(["/tmp/a.png", "/tmp/b.png"]);
+  });
+
+  it("keeps a mixed local + remote directive set (remote passes through)", () => {
+    const [out] = custody([{ text: "MEDIA:/tmp/a.png\nMEDIA:https://example.com/b.png" }]);
+    expect(out?.mediaUrls).toEqual(["/tmp/a.png", "https://example.com/b.png"]);
+  });
+
+  it("materializes a remote-only directive (staging will skip the copy)", () => {
+    const [out] = custody([{ text: "MEDIA:https://example.com/b.png" }]);
+    expect(out?.mediaUrls).toEqual(["https://example.com/b.png"]);
+  });
+
+  it("does not invent media from an invalid/traversal directive", () => {
+    const payloads: ReplyPayload[] = [{ text: "MEDIA:../../etc/passwd" }];
+    const [out] = custody(payloads);
+    // no valid media parsed → payload reference unchanged
+    expect(out).toBe(payloads[0]);
+    expect(out?.mediaUrls).toBeUndefined();
+  });
+
+  it("mirrors the canonical plan when a directive accompanies structured mediaUrls", () => {
+    const payloads: ReplyPayload[] = [
+      { text: "MEDIA:/tmp/directive.png", mediaUrls: ["/tmp/structured.png"] },
+    ];
+    const [out] = custody(payloads);
+    // The canonical plan merges the directive as additional media, so the live
+    // send delivers both; queue custody mirrors that exact effective media.
+    expect(out?.mediaUrls).toEqual(["/tmp/structured.png", "/tmp/directive.png"]);
+    // input object is not mutated
+    expect(payloads[0]?.mediaUrls).toEqual(["/tmp/structured.png"]);
+    expect(payloads[0]?.mediaUrl).toBeUndefined();
+  });
+
+  it("merges a directive alongside a singular structured mediaUrl (canonical order)", () => {
+    const payloads: ReplyPayload[] = [
+      { text: "MEDIA:/tmp/directive.png", mediaUrl: "/tmp/structured.png" },
+    ];
+    const [out] = custody(payloads);
+    // canonical plan effective order is [directive, structured]
+    expect(out?.mediaUrls).toEqual(["/tmp/directive.png", "/tmp/structured.png"]);
+  });
+
+  it("copies a duplicated directive source only once", () => {
+    const [out] = custody([{ text: "MEDIA:/tmp/a.png\nMEDIA:/tmp/a.png" }]);
+    expect(out?.mediaUrls).toEqual(["/tmp/a.png"]);
+  });
+
+  it("handles a quoted directive path containing spaces", () => {
+    const [out] = custody([{ text: 'MEDIA:"/tmp/my dir/voice file.ogg"' }]);
+    expect(out?.mediaUrls).toEqual(["/tmp/my dir/voice file.ogg"]);
+  });
+
+  it("preserves payload count, order, and sourceIndex across dropped payloads", () => {
+    const payloads: ReplyPayload[] = [
+      { text: "" }, // suppressed/empty → dropped from plan
+      { text: "MEDIA:/tmp/a.png" },
+      { text: "plain text" },
+    ];
+    const out = custody(payloads);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toBe(payloads[0]); // unchanged reference (fast path)
+    expect(out[1]?.mediaUrls).toEqual(["/tmp/a.png"]);
+    expect(out[2]).toBe(payloads[2]);
+  });
+
+  it("leaves payloads without a directive-contributed source untouched (fast path)", () => {
+    const textOnly: ReplyPayload[] = [{ text: "just text" }];
+    expect(custody(textOnly)[0]).toBe(textOnly[0]);
+    // structured-only media (the #108502 path) is not rewritten
+    const structuredOnly: ReplyPayload[] = [{ text: "hi", mediaUrls: ["/tmp/x.png"] }];
+    expect(custody(structuredOnly)[0]).toBe(structuredOnly[0]);
+  });
+
+  it("keeps the rendered-batch media count aligned with the effective fan-out", () => {
+    const payloads: ReplyPayload[] = [{ text: "caption\nMEDIA:/tmp/a.png\nMEDIA:/tmp/b.png" }];
+    const custodyPayload = custody(payloads)[0];
+    // deliver.ts counts the rendered plan from the effective mediaUrls (dropping
+    // the anchor mediaUrl) so the fan-out matches what recovery re-derives.
+    const renderInput: ReplyPayload = { ...custodyPayload, mediaUrl: undefined };
+    const plan = createRenderedMessageBatchPlan([renderInput]);
+    expect(plan.mediaCount).toBe(2);
+  });
+});
+
+describe("delivery-queue MEDIA-directive durability (end-to-end)", () => {
+  const fixtures = installDeliveryQueueTmpDirHooks();
+  let tmpDir: string;
+  let sourceDir: string;
+  let spoolRoot: string;
+  const to = "!room:example";
+  // Plain-text document: passes the host-local media send buffer verification.
+  const bytes = Buffer.from("durable media directive proof payload\n", "utf8");
+
+  beforeAll(async () => {
+    ({ deliverOutboundPayloads } = await import("./deliver.js"));
+  });
+
+  beforeEach(async () => {
+    tmpDir = fixtures.tmpDir();
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+    spoolRoot = path.join(tmpDir, "delivery-queue-media");
+    sourceDir = await fs.realpath(await fs.mkdtemp(path.join(tmpDir, "src-")));
+  });
+
+  afterEach(() => {
+    releasePinnedPluginChannelRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("replays MEDIA-directive local media from a queue-owned copy after the source is deleted", async () => {
+    const source = path.join(sourceDir, "generated.txt");
+    await fs.writeFile(source, bytes);
+
+    const payloads: ReplyPayload[] = [{ text: `caption\nMEDIA:${source}` }];
+    const inputSnapshot = structuredClone(payloads);
+
+    const liveMediaPaths: string[] = [];
+    installMatrixAdapter(enqueuePhaseAdapter(liveMediaPaths));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg,
+        channel: "matrix",
+        to,
+        payloads,
+        queuePolicy: "required",
+        mediaAccess: { localRoots: [sourceDir] },
+      }),
+    ).rejects.toThrow("forced not-dispatched");
+
+    // Live send stays copy-free on the original producer path.
+    expect(liveMediaPaths).toEqual([source]);
+    // Input object is not mutated.
+    expect(payloads).toEqual(inputSnapshot);
+
+    // The durable row references a queue-owned spool copy, not the producer path.
+    const [entry] = await loadPendingDeliveries(tmpDir);
+    expect(entry).toBeDefined();
+    // mediaUrl and mediaUrls[0] both anchor to the one staged copy, so dedupe.
+    const spoolPaths = [...new Set(collectEntrySpoolPaths(entry?.payloads ?? [], tmpDir))];
+    expect(spoolPaths).toHaveLength(1);
+    expect(path.dirname(spoolPaths[0] ?? "")).toBe(spoolRoot);
+    // Raw pre-hook text (directive included) is preserved on the row.
+    expect(entry?.payloads[0]?.text).toBe(`caption\nMEDIA:${source}`);
+    // Spool bytes equal source bytes.
+    expect(await fs.readFile(spoolPaths[0] ?? "")).toEqual(bytes);
+
+    // Producer source disappears (process exit / TTS temp cleanup).
+    await fs.rm(source, { force: true });
+    await expect(fs.readFile(source)).rejects.toThrow();
+
+    // Fresh-process recovery replays the row.
+    const recovered: RecoveredSend[] = [];
+    installMatrixAdapter(recoveryPhaseAdapter(recovered, spoolRoot));
+    const deliver = vi.fn<DeliverFn>(async (params) => deliverOutboundPayloads(params));
+    await drainPendingDeliveries({
+      drainKey: "media-directive-test",
+      logLabel: "media-directive drain",
+      cfg,
+      log: createRecoveryLog(),
+      stateDir: tmpDir,
+      deliver,
+      selectEntry: (e) => ({ match: e.channel === "matrix", bypassBackoff: true }),
+    });
+
+    // Recovery delivered from the queue-owned copy, not the deleted producer path.
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0]?.fromSpool).toBe(true);
+    expect(recovered[0]?.error).toBeUndefined();
+    expect(recovered[0]?.bytes).toBe(bytes.toString("hex"));
+    expect(recovered[0]?.mediaUrl).not.toBe(source);
+    // Terminal ack clears the durable row.
+    expect(await loadPendingDeliveries(tmpDir)).toHaveLength(0);
+  });
+
+  it("fails a required send closed for sensitive directive media (no row, no spool)", async () => {
+    const source = path.join(sourceDir, "secret.txt");
+    await fs.writeFile(source, bytes);
+    installMatrixAdapter(enqueuePhaseAdapter([]));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg,
+        channel: "matrix",
+        to,
+        payloads: [{ text: `MEDIA:${source}`, sensitiveMedia: true }],
+        queuePolicy: "required",
+        mediaAccess: { localRoots: [sourceDir] },
+      }),
+    ).rejects.toThrow(/cannot be persisted|unsupported/i);
+
+    expect(await loadPendingDeliveries(tmpDir)).toHaveLength(0);
+    await expect(fs.readdir(spoolRoot)).rejects.toThrow(); // spool dir never created
+  });
+
+  it("does not spool directive media when the queue is skipped", async () => {
+    const source = path.join(sourceDir, "skip.txt");
+    await fs.writeFile(source, bytes);
+    const liveMediaPaths: string[] = [];
+    installMatrixAdapter({
+      deliveryMode: "direct",
+      sendText: async () => ({ channel: "matrix", messageId: "t" }),
+      sendMedia: async (ctx: ChannelOutboundContext) => {
+        liveMediaPaths.push(ctx.mediaUrl ?? "");
+        return { channel: "matrix", messageId: "sent" };
+      },
+    });
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "matrix",
+      to,
+      payloads: [{ text: `MEDIA:${source}` }],
+      skipQueue: true,
+      mediaAccess: { localRoots: [sourceDir] },
+    });
+
+    // Live send used the original path; nothing was queued or spooled.
+    expect(liveMediaPaths).toEqual([source]);
+    expect(await loadPendingDeliveries(tmpDir)).toHaveLength(0);
+    await expect(fs.readdir(spoolRoot)).rejects.toThrow();
+  });
+});

--- a/src/infra/outbound/delivery-queue-media-directive-durability.test.ts
+++ b/src/infra/outbound/delivery-queue-media-directive-durability.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { createRenderedMessageBatchPlan } from "../../channels/message/rendered-batch.js";
 import type {
   ChannelOutboundAdapter,
   ChannelOutboundContext,
@@ -22,7 +21,6 @@ import {
   createRecoveryLog,
   installDeliveryQueueTmpDirHooks,
 } from "./delivery-queue.test-helpers.js";
-import { createOutboundPayloadPlan, materializeQueueCustodyMedia } from "./payloads.js";
 
 let deliverOutboundPayloads: typeof import("./deliver.js").deliverOutboundPayloads;
 
@@ -80,113 +78,6 @@ function recoveryPhaseAdapter(records: RecoveredSend[], spoolRoot: string): Chan
     },
   };
 }
-
-describe("materializeQueueCustodyMedia", () => {
-  const custody = (payloads: ReplyPayload[]): ReplyPayload[] =>
-    materializeQueueCustodyMedia(payloads, createOutboundPayloadPlan(payloads));
-
-  it("materializes a single local MEDIA directive into structured queue media", () => {
-    const payloads: ReplyPayload[] = [{ text: "caption\nMEDIA:/tmp/generated.txt" }];
-    const [out] = custody(payloads);
-    // mediaUrl is anchored to the effective set so the staged copy overrides the
-    // in-text directive on replay; mediaUrls carries the full effective media.
-    expect(out?.mediaUrl).toBe("/tmp/generated.txt");
-    expect(out?.mediaUrls).toEqual(["/tmp/generated.txt"]);
-    // raw pre-hook text (directive included) is preserved
-    expect(out?.text).toBe("caption\nMEDIA:/tmp/generated.txt");
-    // input object is not mutated
-    expect(payloads[0]?.mediaUrls).toBeUndefined();
-    expect(payloads[0]?.mediaUrl).toBeUndefined();
-    expect(payloads[0]?.text).toBe("caption\nMEDIA:/tmp/generated.txt");
-  });
-
-  it("materializes multiple local directives in order", () => {
-    const [out] = custody([{ text: "MEDIA:/tmp/a.png\nMEDIA:/tmp/b.png" }]);
-    expect(out?.mediaUrl).toBe("/tmp/a.png");
-    expect(out?.mediaUrls).toEqual(["/tmp/a.png", "/tmp/b.png"]);
-  });
-
-  it("keeps a mixed local + remote directive set (remote passes through)", () => {
-    const [out] = custody([{ text: "MEDIA:/tmp/a.png\nMEDIA:https://example.com/b.png" }]);
-    expect(out?.mediaUrls).toEqual(["/tmp/a.png", "https://example.com/b.png"]);
-  });
-
-  it("materializes a remote-only directive (staging will skip the copy)", () => {
-    const [out] = custody([{ text: "MEDIA:https://example.com/b.png" }]);
-    expect(out?.mediaUrls).toEqual(["https://example.com/b.png"]);
-  });
-
-  it("does not invent media from an invalid/traversal directive", () => {
-    const payloads: ReplyPayload[] = [{ text: "MEDIA:../../etc/passwd" }];
-    const [out] = custody(payloads);
-    // no valid media parsed → payload reference unchanged
-    expect(out).toBe(payloads[0]);
-    expect(out?.mediaUrls).toBeUndefined();
-  });
-
-  it("mirrors the canonical plan when a directive accompanies structured mediaUrls", () => {
-    const payloads: ReplyPayload[] = [
-      { text: "MEDIA:/tmp/directive.png", mediaUrls: ["/tmp/structured.png"] },
-    ];
-    const [out] = custody(payloads);
-    // The canonical plan merges the directive as additional media, so the live
-    // send delivers both; queue custody mirrors that exact effective media.
-    expect(out?.mediaUrls).toEqual(["/tmp/structured.png", "/tmp/directive.png"]);
-    // input object is not mutated
-    expect(payloads[0]?.mediaUrls).toEqual(["/tmp/structured.png"]);
-    expect(payloads[0]?.mediaUrl).toBeUndefined();
-  });
-
-  it("merges a directive alongside a singular structured mediaUrl (canonical order)", () => {
-    const payloads: ReplyPayload[] = [
-      { text: "MEDIA:/tmp/directive.png", mediaUrl: "/tmp/structured.png" },
-    ];
-    const [out] = custody(payloads);
-    // canonical plan effective order is [directive, structured]
-    expect(out?.mediaUrls).toEqual(["/tmp/directive.png", "/tmp/structured.png"]);
-  });
-
-  it("copies a duplicated directive source only once", () => {
-    const [out] = custody([{ text: "MEDIA:/tmp/a.png\nMEDIA:/tmp/a.png" }]);
-    expect(out?.mediaUrls).toEqual(["/tmp/a.png"]);
-  });
-
-  it("handles a quoted directive path containing spaces", () => {
-    const [out] = custody([{ text: 'MEDIA:"/tmp/my dir/voice file.ogg"' }]);
-    expect(out?.mediaUrls).toEqual(["/tmp/my dir/voice file.ogg"]);
-  });
-
-  it("preserves payload count, order, and sourceIndex across dropped payloads", () => {
-    const payloads: ReplyPayload[] = [
-      { text: "" }, // suppressed/empty → dropped from plan
-      { text: "MEDIA:/tmp/a.png" },
-      { text: "plain text" },
-    ];
-    const out = custody(payloads);
-    expect(out).toHaveLength(3);
-    expect(out[0]).toBe(payloads[0]); // unchanged reference (fast path)
-    expect(out[1]?.mediaUrls).toEqual(["/tmp/a.png"]);
-    expect(out[2]).toBe(payloads[2]);
-  });
-
-  it("leaves payloads without a directive-contributed source untouched (fast path)", () => {
-    const textOnly: ReplyPayload[] = [{ text: "just text" }];
-    expect(custody(textOnly)[0]).toBe(textOnly[0]);
-    // structured-only media (the #108502 path) is not rewritten
-    const structuredOnly: ReplyPayload[] = [{ text: "hi", mediaUrls: ["/tmp/x.png"] }];
-    expect(custody(structuredOnly)[0]).toBe(structuredOnly[0]);
-  });
-
-  it("keeps the rendered-batch media count aligned with the effective fan-out", () => {
-    const payloads: ReplyPayload[] = [{ text: "caption\nMEDIA:/tmp/a.png\nMEDIA:/tmp/b.png" }];
-    const custodyPayload = custody(payloads)[0];
-    // deliver.ts counts the rendered plan from the effective mediaUrls (dropping
-    // the anchor mediaUrl) so the fan-out matches what recovery re-derives.
-    const renderInput: ReplyPayload = { ...custodyPayload, mediaUrl: undefined };
-    const plan = createRenderedMessageBatchPlan([renderInput]);
-    expect(plan.mediaCount).toBe(2);
-  });
-});
 
 describe("delivery-queue MEDIA-directive durability (end-to-end)", () => {
   const fixtures = installDeliveryQueueTmpDirHooks();

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -310,52 +310,6 @@ export function createOutboundPayloadPlan(
   return plan;
 }
 
-/**
- * Builds queue-custody payload copies for the durable delivery queue.
- *
- * Local media carried only in a legacy `MEDIA:` text directive materializes into
- * structured media in the canonical plan (`entry.parts.mediaUrls`) but not in the
- * raw payload, so queue staging (which reads structured fields) would never copy
- * it and a retry would read the vanished producer path. This folds the canonical
- * effective media (respecting directive-vs-structured precedence) into the queue
- * copy's structured fields so the spool takes custody before persistence.
- *
- * Both `mediaUrl` and `mediaUrls` are anchored to the effective set: the raw text
- * (directive included) is preserved verbatim, so recovery re-parses the original
- * producer path — and `createOutboundPayloadPlan`'s singular `mediaUrl` otherwise
- * falls back to that first parsed directive. Anchoring `mediaUrl` to the effective
- * media makes the staged copies fully override the in-text directive on replay.
- * Payload count/order/`sourceIndex` are unchanged and a payload the directive did
- * not contribute media to keeps its original reference (so structured-only queue
- * media stays untouched and the live send stays copy-free).
- */
-export function materializeQueueCustodyMedia(
-  payloads: readonly ReplyPayload[],
-  plan: readonly OutboundPayloadPlan[],
-): ReplyPayload[] {
-  const effectiveBySource = new Map<number, readonly string[]>();
-  for (const entry of plan) {
-    effectiveBySource.set(entry.sourceIndex, entry.parts.mediaUrls);
-  }
-  return payloads.map((payload, index) => {
-    const effective = effectiveBySource.get(index);
-    if (!effective?.length) {
-      return payload;
-    }
-    const structured = new Set(
-      [payload.mediaUrl, ...(payload.mediaUrls ?? [])]
-        .map((url) => url?.trim())
-        .filter((url): url is string => Boolean(url)),
-    );
-    // Only touch payloads whose text directive adds media the structured fields
-    // do not already carry; structured-only media keeps the untouched fast path.
-    if (effective.every((url) => structured.has(url))) {
-      return payload;
-    }
-    return { ...payload, mediaUrl: effective[0], mediaUrls: [...effective] };
-  });
-}
-
 /** Projects a payload plan back to normalized reply payloads for delivery. */
 export function projectOutboundPayloadPlanForDelivery(
   plan: readonly OutboundPayloadPlan[],

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -310,6 +310,52 @@ export function createOutboundPayloadPlan(
   return plan;
 }
 
+/**
+ * Builds queue-custody payload copies for the durable delivery queue.
+ *
+ * Local media carried only in a legacy `MEDIA:` text directive materializes into
+ * structured media in the canonical plan (`entry.parts.mediaUrls`) but not in the
+ * raw payload, so queue staging (which reads structured fields) would never copy
+ * it and a retry would read the vanished producer path. This folds the canonical
+ * effective media (respecting directive-vs-structured precedence) into the queue
+ * copy's structured fields so the spool takes custody before persistence.
+ *
+ * Both `mediaUrl` and `mediaUrls` are anchored to the effective set: the raw text
+ * (directive included) is preserved verbatim, so recovery re-parses the original
+ * producer path — and `createOutboundPayloadPlan`'s singular `mediaUrl` otherwise
+ * falls back to that first parsed directive. Anchoring `mediaUrl` to the effective
+ * media makes the staged copies fully override the in-text directive on replay.
+ * Payload count/order/`sourceIndex` are unchanged and a payload the directive did
+ * not contribute media to keeps its original reference (so structured-only queue
+ * media stays untouched and the live send stays copy-free).
+ */
+export function materializeQueueCustodyMedia(
+  payloads: readonly ReplyPayload[],
+  plan: readonly OutboundPayloadPlan[],
+): ReplyPayload[] {
+  const effectiveBySource = new Map<number, readonly string[]>();
+  for (const entry of plan) {
+    effectiveBySource.set(entry.sourceIndex, entry.parts.mediaUrls);
+  }
+  return payloads.map((payload, index) => {
+    const effective = effectiveBySource.get(index);
+    if (!effective?.length) {
+      return payload;
+    }
+    const structured = new Set(
+      [payload.mediaUrl, ...(payload.mediaUrls ?? [])]
+        .map((url) => url?.trim())
+        .filter((url): url is string => Boolean(url)),
+    );
+    // Only touch payloads whose text directive adds media the structured fields
+    // do not already carry; structured-only media keeps the untouched fast path.
+    if (effective.every((url) => structured.has(url))) {
+      return payload;
+    }
+    return { ...payload, mediaUrl: effective[0], mediaUrls: [...effective] };
+  });
+}
+
 /** Projects a payload plan back to normalized reply payloads for delivery. */
 export function projectOutboundPayloadPlanForDelivery(
   plan: readonly OutboundPayloadPlan[],


### PR DESCRIPTION
## What Problem This Solves

A message accepted into the durable outbound delivery queue can still silently lose its attachment on retry when the attachment was carried as a legacy `MEDIA:<local-path>` **text directive** instead of a structured `mediaUrl(s)` field.

Queue staging enumerates only the structured `mediaUrl`/`mediaUrls` fields, so a `MEDIA:` directive — which only materializes into structured media later, during live-send normalization — is invisible to it. The raw `MEDIA:/tmp/...` text is persisted verbatim and **no queue-owned copy is made**. When the producer-owned local file disappears (the producing process exits, e.g. a one-shot `openclaw message send`, or a producer cleanup timer fires) and the queue retries, recovery re-parses the persisted text and reads the now-deleted producer path. The read fails with `LocalMediaAccessError("not-found", …)`, which is not in `PERMANENT_ERROR_PATTERNS`, so the entry burns its full retry budget (`RECOVERY_BACKOFF_MS`, `MAX_RETRIES = 5`) and is dead-lettered — dropping the attachment and its accompanying text.

This is the same ownership invariant already fixed for structured media in #108501 / #108502 — *a durable delivery queue must not persist an effective reference to an artifact whose lifetime is owned by a shorter-lived producer scope* — now extended to the legacy `MEDIA:` text-directive carrier, which materializes into structured media **after** queue staging and so slips past that fix.

Closes #108968

## Why This Change Was Made

The fix reuses the canonical normalization authority rather than adding a second `MEDIA:` parser to the spool. Before queue staging, `deliverOutboundPayloadsInternal` now projects each source payload's effective media through the same `createOutboundPayloadPlan` the live send uses (with the same context) and folds directive-derived local sources into the queue copy's structured fields via a small `materializeQueueCustodyMedia` helper. The existing spool then takes custody: same agent-scoped media capability, same channel/account size caps, same `fileStore`, atomic stage row, and GC.

Design points that keep the invariant and the existing contracts intact:

- **Raw pre-hook text is preserved verbatim.** Only the structured fields of the *queue copy* change; the directive stays in the text so recovery still re-runs reply/message hooks on the same payload.
- **Structured media fully overrides the in-text directive on replay.** Because the raw text is kept, recovery re-parses the original producer path, and the canonical plan's singular `mediaUrl` otherwise falls back to that first parsed directive. The custody copy anchors both `mediaUrl` and `mediaUrls` to the effective set so re-normalization yields the staged copies alone (the staged reference wins over the raw directive).
- **The rendered-batch plan is recomputed from the deduplicated effective media** for rewritten payloads, so the anchoring field does not inflate the fan-out count recovery re-derives.
- **Copy-free live send is unchanged** — it uses the original producer path; only the queue copy is rewritten. The raw input object is never mutated, and payload count / order / `sourceIndex` are preserved.
- **Sensitive media stays fail-closed.** `sensitiveMedia: true` directive media now reaches the existing sensitive gate (via the materialized structured fields): required sends fail closed, best-effort sends go live-only — neither persists a row or spool copy.
- **No new authority.** Staging resolves media access exactly as the live send does, so directive media grants no wider local-root/read authority than the send already has. Remote and `data:` directives pass through without a copy, as before.

No schema, config, or TTL change. No new production file. Scope is limited to `deliver.ts` and one helper in `payloads.ts`.

## User Impact

Agents/runtimes that still emit local attachments as `MEDIA:` text directives now get the same delivery durability as structured media: an image/audio/document returned that way survives a restart, reconnect, or retry instead of being silently dropped. There is no extra copy or latency on a successful live send, and no behavior change for structured-media, remote, or `data:` payloads.

## Evidence

Before/after proof through the **real** production path — `deliverOutboundPayloadsInternal`, a real SQLite delivery queue, a real on-disk media spool, and a fake channel adapter at the send boundary (default-deny; no external channel or credential involved).

**Before (on the pinned base, fix reverted):**
1. Enqueue a payload whose only media is `MEDIA:<local-path>` in `text`; the live send reaches the adapter with the local producer path.
2. The persisted row keeps the raw `MEDIA:<path>` text and holds **no** spool reference (`collectEntrySpoolPaths(entry.payloads)` is empty).
3. Delete the producer source.
4. Replay via the recovery drain: the send resolves the original deleted path, `readFile` throws `ENOENT`, the send fails, and the row is not acked (message lost).

**After (with the fix):**
1. Input payload's `text` still holds the original `MEDIA:<producer-path>`; the input object is not mutated.
2. Only the queue copy carries the spool path as structured media; spool bytes equal source bytes.
3. The live send uses the original producer path (copy-free).
4. Delete the producer source, replay via the recovery drain: the send resolves the queue-owned spool copy, reads the bytes, and delivers — no file-not-found; the row is acked.

Control matrix (in the new focused test): one/multiple/mixed/remote-only/`data:` directives, invalid/traversal (no media invented), explicit structured media + directive (canonical precedence), duplicate source (copied once), quoted/spaced path, `sensitiveMedia` fail-closed / live-only, `skipQueue` (no copy), payload count/order/`sourceIndex` preservation, rendered-plan fan-out alignment, and recovery re-normalization.

Verification (Node 24; trusted-source focused local proof; re-run after rebasing onto current `main`):
- New focused test `src/infra/outbound/delivery-queue-media-directive-durability.test.ts` — 15 tests, all pass (fails on the base without the fix).
- Non-regression (306 tests, all pass): `deliver.test.ts` (150), `payloads.test.ts` (38), `delivery-queue-media-spool.test.ts` + `delivery-queue.recovery.test.ts` + `delivery-queue.storage.test.ts` + `deliver.queue-integration.test.ts` (81), `message-plan.test.ts` + `delivery-queue-media-spool.crash.integration.test.ts` + `delivery-queue.reconnect-drain.test.ts` (22).
- `oxfmt --check`, `oxlint`, `tsgo` core prod + core test, `git diff --check`, and the `check:changed` lanes (conflict markers, dependency pins, plugin boundaries, Plugin SDK baseline, format, …) — all clean.

This change was prepared with AI assistance.
