### PR TITLE
fix(vault): SecretRef resolution no longer hangs on stalled response bodies

### DIFF
--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -371,7 +371,7 @@ describe("vault SecretRef resolver", () => {
       },
       env: {
         VAULT_ADDR: fixture.vaultAddr,
-        VAULT_TOKEN: "not-a-real-auth-header",
+        VAULT_TOKEN: "test-token",
         VAULT_NAMESPACE: "team-a",
       },
     });

--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -145,7 +145,7 @@ async function startVaultErrorFixture() {
 async function startVaultStalledBodyFixture() {
   const server = createServer((_request, response) => {
     response.setHeader("content-type", "application/json");
-    response.write('{"data":{"data":{"apiKey":"partial');
+    response.write('{"data":{"data":{"value":"partial');
   });
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);

--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -15,7 +15,8 @@ const packagePath = fileURLToPath(new URL("../package.json", import.meta.url));
 function runResolver(params: {
   request: unknown;
   env?: Record<string, string>;
-}): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  timeoutMs?: number;
+}): Promise<{ stdout: string; stderr: string; code: number | null; timedOut: boolean }> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [resolverPath], {
       stdio: ["pipe", "pipe", "pipe"],
@@ -36,6 +37,14 @@ function runResolver(params: {
     });
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
+    const timeout =
+      params.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            timedOut = true;
+            child.kill();
+          }, params.timeoutMs);
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => {
@@ -46,7 +55,10 @@ function runResolver(params: {
     });
     child.on("error", reject);
     child.on("exit", (code) => {
-      resolve({ stdout, stderr, code });
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      resolve({ stdout, stderr, code, timedOut });
     });
     child.stdin.end(`${JSON.stringify(params.request)}\n`);
   });
@@ -119,6 +131,30 @@ async function startVaultErrorFixture() {
     close: () =>
       new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server did not bind to a TCP port");
+  }
+  return {
+    vaultAddr: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function startVaultStalledBodyFixture() {
+  const server = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.write('{"data":{"data":{"apiKey":"partial');
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
       }),
   });
   const address = server.address();
@@ -621,5 +657,32 @@ describe("vault SecretRef resolver", () => {
       },
     });
     expect(result.stdout).not.toContain("not-a-real-sensitive-jwt");
+  });
+
+  it("times out while reading a stalled Vault JSON response body", async () => {
+    const fixture = await startVaultStalledBodyFixture();
+    const result = await runResolver({
+      request: {
+        protocolVersion: 1,
+        provider: "vault",
+        ids: ["providers/openai/apiKey"],
+      },
+      env: {
+        VAULT_ADDR: fixture.vaultAddr,
+        VAULT_TOKEN: "not-a-real-auth-header",
+      },
+      timeoutMs: 6_500,
+    });
+
+    expect(result).toMatchObject({ code: 0, stderr: "", timedOut: false });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      protocolVersion: 1,
+      values: {},
+      errors: {
+        "providers/openai/apiKey": {
+          message: expect.stringMatching(/abort/iu),
+        },
+      },
+    });
   });
 });

--- a/extensions/vault/vault-secret-ref-resolver.js
+++ b/extensions/vault/vault-secret-ref-resolver.js
@@ -135,11 +135,15 @@ async function fetchVault(baseUrl, url, init) {
   const abortController = new AbortController();
   const timeout = setTimeout(() => abortController.abort(), VAULT_FETCH_TIMEOUT_MS);
   try {
-    return await fetch(url, {
+    const response = await fetch(url, {
       ...init,
       redirect: "manual",
       signal: abortController.signal,
     });
+    return {
+      response,
+      payload: response.ok ? await response.json() : undefined,
+    };
   } finally {
     clearTimeout(timeout);
   }
@@ -192,7 +196,7 @@ async function resolveVaultTokenFromJwt(baseUrl, method) {
     "Content-Type": "application/json",
   };
   addVaultNamespaceHeader(headers);
-  const response = await fetchVault(baseUrl, `${baseUrl}/v1/auth/${mount}/login`, {
+  const { response, payload } = await fetchVault(baseUrl, `${baseUrl}/v1/auth/${mount}/login`, {
     method: "POST",
     headers,
     body: JSON.stringify({
@@ -203,7 +207,7 @@ async function resolveVaultTokenFromJwt(baseUrl, method) {
   if (!response.ok) {
     throw new Error(`Vault ${method} login failed (${response.status}).`);
   }
-  return readVaultLoginToken(await response.json(), method);
+  return readVaultLoginToken(payload, method);
 }
 
 async function resolveVaultClientToken(baseUrl) {
@@ -238,11 +242,13 @@ async function readVaultSecret(baseUrl, vaultToken, id) {
     "X-Vault-Token": vaultToken,
   };
   addVaultNamespaceHeader(headers);
-  const response = await fetchVault(baseUrl, buildVaultUrl(baseUrl, parsedId), { headers });
+  const { response, payload } = await fetchVault(baseUrl, buildVaultUrl(baseUrl, parsedId), {
+    headers,
+  });
   if (!response.ok) {
     throw new Error(`Vault read failed for "${id}" (${response.status}).`);
   }
-  return readStringField(await response.json(), parsedId);
+  return readStringField(payload, parsedId);
 }
 
 async function resolveFromVault(ids) {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Vault-backed SecretRef resolution could remain pending after the Vault server sent response headers but stalled while sending the JSON body. This affected both KV reads and JWT/Kubernetes login responses.

## Why This Change Was Made

The existing five-second Vault AbortController now remains active until a successful JSON body has been consumed. Error-status responses keep their existing status-only handling, and the configured timeout value and SecretRef protocol are unchanged.

## User Impact

Operators receive a finite per-secret failure when Vault stalls mid-response instead of waiting for the outer exec-provider timeout or an indefinitely open body. Normal token, token-file, JWT, Kubernetes, KV v1/v2, namespace, and error-response behavior is unchanged.

## Evidence

Before the fix, the production resolver child was still pending when a 6.5-second external test guard terminated it after the server had flushed headers and a partial JSON body.

After the fix:

```text
extensions/vault/src/secret-ref-resolver.test.ts
Test Files  1 passed (1)
Tests       14 passed (14)
stalled JSON response regression: passed in 5.1s
```

Local live proof used a real OpenClaw gateway, `openclaw secrets audit --allow-exec --check --json`, the production Vault resolver, and a real loopback HTTP server. Three resolver requests reached the fixture; the first partial-body connection was closed by the resolver after approximately 4.9 seconds. OpenClaw returned a finite unresolved-ref result, and a gateway health call succeeded afterward.

Additional checks passed:

```text
oxfmt --check: passed
targeted oxlint: passed
git diff --check: passed
```

Immediately before review, the latest fetched `main` still cleared the Vault timer when `fetch()` returned headers and performed both successful `response.json()` calls afterward, so the reported stalled-body behavior remained unfixed upstream.
