### PR TITLE
fix(models): honor scan timeout while reading OpenRouter catalog

### DIFF
--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -177,7 +177,7 @@ describe("scanOpenRouterModels", () => {
     });
   });
 
-  it("applies the scan timeout to the OpenRouter catalog request", async () => {
+  it("applies the scan timeout before the OpenRouter catalog responds", async () => {
     vi.useFakeTimers();
     const fetchImpl: typeof fetch = async (_input, init) =>
       await new Promise<Response>((_resolve, reject) => {
@@ -201,6 +201,68 @@ describe("scanOpenRouterModels", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await scan;
+  });
+
+  it("keeps the catalog timeout active while reading a streaming body", async () => {
+    vi.useFakeTimers();
+    const timeoutMs = 20;
+    const chunkIntervalMs = 5;
+    const encoder = new TextEncoder();
+    let chunkCount = 0;
+    let abortCount = 0;
+
+    const fetchImpl = withFetchPreconnect(async (_input, init) => {
+      const signal = typeof init === "object" && init ? init.signal : undefined;
+      if (!signal) {
+        throw new Error("Expected catalog request signal");
+      }
+      let interval: ReturnType<typeof setInterval> | undefined;
+      let completionTimer: ReturnType<typeof setTimeout> | undefined;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode('{"data":['));
+            interval = setInterval(() => {
+              chunkCount += 1;
+              controller.enqueue(encoder.encode(" "));
+            }, chunkIntervalMs);
+            completionTimer = setTimeout(() => {
+              clearInterval(interval);
+              controller.enqueue(encoder.encode("]}"));
+              controller.close();
+            }, timeoutMs + chunkIntervalMs);
+            signal.addEventListener(
+              "abort",
+              () => {
+                abortCount += 1;
+                clearInterval(interval);
+                clearTimeout(completionTimer);
+                controller.error(signal.reason);
+              },
+              { once: true },
+            );
+          },
+          cancel() {
+            clearInterval(interval);
+            clearTimeout(completionTimer);
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const scan = expect(
+      scanOpenRouterModels({ fetchImpl, probe: false, timeoutMs }),
+    ).rejects.toThrow(/aborted/i);
+
+    await vi.advanceTimersByTimeAsync(timeoutMs - 1);
+    expect(chunkCount).toBe(3);
+    expect(abortCount).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(chunkIntervalMs + 1);
+    await scan;
+    expect(abortCount).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("caps oversized scan timeouts before scheduling catalog aborts", async () => {

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -216,80 +216,79 @@ async function fetchOpenRouterModels(
   fetchImpl: typeof fetch,
   timeoutMs: number,
 ): Promise<OpenRouterModelMeta[]> {
-  const controller = new AbortController();
-  // fetch resolves after headers, so keep one deadline alive until the
-  // provider-controlled catalog body has been consumed.
-  const timer = setTimeout(controller.abort.bind(controller), timeoutMs);
   let res: Response | undefined;
   try {
-    res = await fetchImpl(OPENROUTER_MODELS_URL, {
-      headers: { Accept: "application/json" },
-      signal: controller.signal,
-    });
-    if (!res.ok) {
-      throw new Error(`OpenRouter /models failed: HTTP ${res.status}`);
-    }
-    const payload = (await readOpenRouterModelsJson(res, timeoutMs)) as { data?: unknown };
-    const entries = Array.isArray(payload.data) ? payload.data : [];
+    // fetch resolves after headers, so keep the shared timeout active until
+    // the provider-controlled catalog body has been consumed.
+    return await withTimeout(timeoutMs, async (signal) => {
+      res = await fetchImpl(OPENROUTER_MODELS_URL, {
+        headers: { Accept: "application/json" },
+        signal,
+      });
+      if (!res.ok) {
+        throw new Error(`OpenRouter /models failed: HTTP ${res.status}`);
+      }
+      const payload = (await readOpenRouterModelsJson(res, timeoutMs)) as { data?: unknown };
+      const entries = Array.isArray(payload.data) ? payload.data : [];
 
-    return entries
-      .map((entry) => {
-        if (!entry || typeof entry !== "object") {
-          return null;
-        }
-        const obj = entry as Record<string, unknown>;
-        const id = normalizeOptionalString(obj.id) ?? "";
-        if (!id) {
-          return null;
-        }
-        const name = typeof obj.name === "string" && obj.name.trim() ? obj.name.trim() : id;
+      return entries
+        .map((entry) => {
+          if (!entry || typeof entry !== "object") {
+            return null;
+          }
+          const obj = entry as Record<string, unknown>;
+          const id = normalizeOptionalString(obj.id) ?? "";
+          if (!id) {
+            return null;
+          }
+          const name = typeof obj.name === "string" && obj.name.trim() ? obj.name.trim() : id;
 
-        const contextLength =
-          typeof obj.context_length === "number" && Number.isFinite(obj.context_length)
-            ? obj.context_length
-            : null;
-
-        const maxCompletionTokens =
-          typeof obj.max_completion_tokens === "number" &&
-          Number.isFinite(obj.max_completion_tokens)
-            ? obj.max_completion_tokens
-            : typeof obj.max_output_tokens === "number" && Number.isFinite(obj.max_output_tokens)
-              ? obj.max_output_tokens
+          const contextLength =
+            typeof obj.context_length === "number" && Number.isFinite(obj.context_length)
+              ? obj.context_length
               : null;
 
-        const supportedParameters = Array.isArray(obj.supported_parameters)
-          ? normalizeStringEntries(
-              obj.supported_parameters.filter((value) => typeof value === "string"),
-            )
-          : [];
+          const maxCompletionTokens =
+            typeof obj.max_completion_tokens === "number" &&
+            Number.isFinite(obj.max_completion_tokens)
+              ? obj.max_completion_tokens
+              : typeof obj.max_output_tokens === "number" && Number.isFinite(obj.max_output_tokens)
+                ? obj.max_output_tokens
+                : null;
 
-        const supportedParametersCount = supportedParameters.length;
-        const supportsToolsMeta = supportedParameters.includes("tools");
+          const supportedParameters = Array.isArray(obj.supported_parameters)
+            ? normalizeStringEntries(
+                obj.supported_parameters.filter((value) => typeof value === "string"),
+              )
+            : [];
 
-        const modality =
-          typeof obj.modality === "string" && obj.modality.trim() ? obj.modality.trim() : null;
+          const supportedParametersCount = supportedParameters.length;
+          const supportsToolsMeta = supportedParameters.includes("tools");
 
-        const inferredParamB = inferParamBFromIdOrName(`${id} ${name}`);
-        const createdAtMs = normalizeCreatedAtMs(obj.created_at);
-        const pricing = parseOpenRouterPricing(obj.pricing);
+          const modality =
+            typeof obj.modality === "string" && obj.modality.trim() ? obj.modality.trim() : null;
 
-        return {
-          id,
-          name,
-          contextLength,
-          maxCompletionTokens,
-          supportedParameters,
-          supportedParametersCount,
-          supportsToolsMeta,
-          modality,
-          inferredParamB,
-          createdAtMs,
-          pricing,
-        } satisfies OpenRouterModelMeta;
-      })
-      .filter((entry): entry is OpenRouterModelMeta => Boolean(entry));
+          const inferredParamB = inferParamBFromIdOrName(`${id} ${name}`);
+          const createdAtMs = normalizeCreatedAtMs(obj.created_at);
+          const pricing = parseOpenRouterPricing(obj.pricing);
+
+          return {
+            id,
+            name,
+            contextLength,
+            maxCompletionTokens,
+            supportedParameters,
+            supportedParametersCount,
+            supportsToolsMeta,
+            modality,
+            inferredParamB,
+            createdAtMs,
+            pricing,
+          } satisfies OpenRouterModelMeta;
+        })
+        .filter((entry): entry is OpenRouterModelMeta => Boolean(entry));
+    });
   } finally {
-    clearTimeout(timer);
     if (res && !res.bodyUsed) {
       await res.body?.cancel().catch(() => undefined);
     }

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -216,14 +216,16 @@ async function fetchOpenRouterModels(
   fetchImpl: typeof fetch,
   timeoutMs: number,
 ): Promise<OpenRouterModelMeta[]> {
+  const controller = new AbortController();
+  // fetch resolves after headers, so keep one deadline alive until the
+  // provider-controlled catalog body has been consumed.
+  const timer = setTimeout(controller.abort.bind(controller), timeoutMs);
   let res: Response | undefined;
   try {
-    res = await withTimeout(timeoutMs, (signal) =>
-      fetchImpl(OPENROUTER_MODELS_URL, {
-        headers: { Accept: "application/json" },
-        signal,
-      }),
-    );
+    res = await fetchImpl(OPENROUTER_MODELS_URL, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
     if (!res.ok) {
       throw new Error(`OpenRouter /models failed: HTTP ${res.status}`);
     }
@@ -287,6 +289,7 @@ async function fetchOpenRouterModels(
       })
       .filter((entry): entry is OpenRouterModelMeta => Boolean(entry));
   } finally {
+    clearTimeout(timer);
     if (res && !res.bodyUsed) {
       await res.body?.cancel().catch(() => undefined);
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw models scan --timeout` could wait beyond the configured timeout when OpenRouter returned response headers but continued streaming catalog body chunks. The request deadline previously ended as soon as the headers arrived, so a slow continuous body could keep the scan running.

## Why This Change Was Made

Keep one catalog `AbortController` and deadline active from request start through the complete bounded response-body read, then clear it in `finally`. The existing response-size cap, idle-chunk guard, HTTP error cleanup, and probe timeout behavior remain unchanged.

## User Impact

OpenRouter model scans now stop within the requested timeout even when the upstream catalog sends a slow continuous response body. Successful catalog scans, filtering, and probing behavior are unchanged.

## Evidence

- Node v24.15.0: `node scripts/run-vitest.mjs src/agents/model-scan.test.ts` (10/10 passed).
- Deterministic fake-timer regression streams body chunks every 5 ms and verifies abort at the 20 ms total deadline with zero pending timers.
- Node v24.15.0 loopback probe: `globalThis.fetch` aborted an already-started response body with `AbortError`.
- `oxfmt --check src/agents/model-scan.ts src/agents/model-scan.test.ts`: passed.
- `oxlint src/agents/model-scan.ts src/agents/model-scan.test.ts`: passed.
- `git diff --check`: passed.
- Live duplicate PR/issue searches and the 100 most recently updated open PR file-overlap check found no match.
- Fresh independent Codex adversarial review reported zero actionable findings.

Blacksmith Testbox was unavailable, so focused validation used the repository local test wrapper under Node 24.

AI-assisted: yes. I reviewed and understand the change.