### PR TITLE
fix(e2e): bound Pond gateway connections

### DIFF
--- a/scripts/e2e/lib/pond-gateway-rpc.d.mts
+++ b/scripts/e2e/lib/pond-gateway-rpc.d.mts
@@ -1,0 +1,23 @@
+export type PondGatewayRpcOptions = {
+  url: string;
+  token: string;
+  scopes: string[];
+  openTimeoutMs?: number;
+  webSocketFactory?: (target: string) => unknown;
+};
+
+export type PondGatewayRpcRequestOptions = {
+  expectFinal?: boolean;
+  timeoutMs?: number;
+};
+
+export declare class PondGatewayRpc {
+  constructor(options: PondGatewayRpcOptions);
+  connect(): Promise<void>;
+  request(
+    method: string,
+    params?: unknown,
+    options?: PondGatewayRpcRequestOptions,
+  ): Promise<unknown>;
+  close(): void;
+}

--- a/scripts/e2e/lib/pond-gateway-rpc.mjs
+++ b/scripts/e2e/lib/pond-gateway-rpc.mjs
@@ -92,7 +92,7 @@ export class PondGatewayRpc {
 
   request(method, params = {}, options = {}) {
     if (this.terminalError) {
-      return Promise.reject(this.terminalError);
+      return Promise.reject(asError(this.terminalError));
     }
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error(`Gateway socket is not open for RPC: ${method}`));

--- a/scripts/e2e/lib/pond-gateway-rpc.mjs
+++ b/scripts/e2e/lib/pond-gateway-rpc.mjs
@@ -38,21 +38,32 @@ export class PondGatewayRpc {
       this.rejectPending(new Error(`Gateway socket closed${formatCloseReason(code, reason)}`));
     });
 
-    await waitForWebSocketOpen(this.ws, this.openTimeoutMs, `Gateway connect timeout: ${this.url}`);
-    await this.request("connect", {
-      minProtocol: 1,
-      maxProtocol: 99,
-      client: {
-        id: "gateway-client",
-        displayName: "Pond proof verifier",
-        version: "0.0.0",
-        platform: process.platform,
-        mode: "backend",
-      },
-      auth: { token: this.token },
-      role: "operator",
-      scopes: this.scopes,
-    });
+    try {
+      await waitForWebSocketOpen(
+        this.ws,
+        this.openTimeoutMs,
+        `Gateway connect timeout: ${this.url}`,
+      );
+      await this.request("connect", {
+        minProtocol: 1,
+        maxProtocol: 99,
+        client: {
+          id: "gateway-client",
+          displayName: "Pond proof verifier",
+          version: "0.0.0",
+          platform: process.platform,
+          mode: "backend",
+        },
+        auth: { token: this.token },
+        role: "operator",
+        scopes: this.scopes,
+      });
+    } catch (error) {
+      // Callers only receive the client after connect succeeds, so failed setup
+      // must close its socket here or the E2E process can remain alive.
+      this.close();
+      throw error;
+    }
   }
 
   rejectPending(error) {

--- a/scripts/e2e/lib/pond-gateway-rpc.mjs
+++ b/scripts/e2e/lib/pond-gateway-rpc.mjs
@@ -1,0 +1,147 @@
+// Gateway RPC client used by the Pond E2E verifier.
+import { WebSocket } from "ws";
+import { waitForWebSocketOpen } from "./websocket-open.mjs";
+
+function asError(value) {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+function formatCloseReason(code, reason) {
+  const text = reason instanceof Uint8Array ? Buffer.from(reason).toString("utf8") : String(reason);
+  return text ? ` (${code}): ${text}` : ` (${code})`;
+}
+
+export class PondGatewayRpc {
+  constructor({
+    url,
+    token,
+    scopes,
+    openTimeoutMs = 15_000,
+    webSocketFactory = (target) => new WebSocket(target),
+  }) {
+    this.url = url;
+    this.token = token;
+    this.scopes = scopes;
+    this.openTimeoutMs = openTimeoutMs;
+    this.webSocketFactory = webSocketFactory;
+    this.pending = new Map();
+    this.nextId = 1;
+  }
+
+  async connect() {
+    this.ws = this.webSocketFactory(this.url);
+    this.ws.on("message", (data) => this.onMessage(data));
+    // These listeners outlive the open wait so post-handshake failures reject RPCs
+    // instead of surfacing as uncaught EventEmitter errors.
+    this.ws.on("error", (error) => this.rejectPending(asError(error)));
+    this.ws.on("close", (code, reason) => {
+      this.rejectPending(new Error(`Gateway socket closed${formatCloseReason(code, reason)}`));
+    });
+
+    await waitForWebSocketOpen(this.ws, this.openTimeoutMs, `Gateway connect timeout: ${this.url}`);
+    await this.request("connect", {
+      minProtocol: 1,
+      maxProtocol: 99,
+      client: {
+        id: "gateway-client",
+        displayName: "Pond proof verifier",
+        version: "0.0.0",
+        platform: process.platform,
+        mode: "backend",
+      },
+      auth: { token: this.token },
+      role: "operator",
+      scopes: this.scopes,
+    });
+  }
+
+  rejectPending(error) {
+    this.terminalError ??= error;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(this.terminalError);
+    }
+    this.pending.clear();
+  }
+
+  onMessage(data) {
+    let frame;
+    try {
+      frame = JSON.parse(String(data));
+    } catch {
+      return;
+    }
+    if (frame?.type !== "res" || typeof frame.id !== "string") {
+      return;
+    }
+    const pending = this.pending.get(frame.id);
+    if (!pending) {
+      return;
+    }
+    if (pending.expectFinal && frame.payload?.status === "accepted") {
+      return;
+    }
+    this.pending.delete(frame.id);
+    clearTimeout(pending.timer);
+    if (frame.ok) {
+      pending.resolve(frame.payload);
+      return;
+    }
+    pending.reject(new Error(frame.error?.message ?? `Gateway RPC failed: ${pending.method}`));
+  }
+
+  request(method, params = {}, options = {}) {
+    if (this.terminalError) {
+      return Promise.reject(this.terminalError);
+    }
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error(`Gateway socket is not open for RPC: ${method}`));
+    }
+
+    const id = `pond-proof-${this.nextId}`;
+    this.nextId += 1;
+    const timeoutMs = options.timeoutMs ?? 30_000;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Gateway RPC timeout: ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        method,
+        expectFinal: options.expectFinal === true,
+        resolve,
+        reject,
+        timer,
+      });
+      try {
+        this.ws.send(JSON.stringify({ type: "req", id, method, params }), (error) => {
+          if (!error) {
+            return;
+          }
+          const pending = this.pending.get(id);
+          if (!pending) {
+            return;
+          }
+          this.pending.delete(id);
+          clearTimeout(pending.timer);
+          pending.reject(asError(error));
+        });
+      } catch (error) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(asError(error));
+      }
+    });
+  }
+
+  close() {
+    this.rejectPending(new Error("Gateway RPC client closed"));
+    if (this.ws?.readyState === WebSocket.CONNECTING) {
+      this.ws.terminate();
+      return;
+    }
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.close();
+    }
+  }
+}

--- a/scripts/e2e/node-plugin-tools-pond.mjs
+++ b/scripts/e2e/node-plugin-tools-pond.mjs
@@ -7,6 +7,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { PondGatewayRpc } from "./lib/pond-gateway-rpc.mjs";
 
 const DEFAULT_PORT = 18789;
 const SESSION_KEY = "agent:main:main";
@@ -44,12 +45,6 @@ function parseArgs(argv) {
     index += 1;
   }
   return args;
-}
-
-function requireWebSocket() {
-  if (typeof WebSocket !== "function") {
-    throw new Error("Node global WebSocket unavailable; run with Node 22+");
-  }
 }
 
 function repoRoot() {
@@ -498,102 +493,8 @@ function terminate(child) {
   });
 }
 
-class GatewayRpc {
-  constructor({ url, token, scopes }) {
-    requireWebSocket();
-    this.url = url;
-    this.token = token;
-    this.scopes = scopes;
-    this.pending = new Map();
-    this.nextId = 1;
-  }
-
-  async connect() {
-    this.ws = new WebSocket(this.url);
-    await new Promise((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error(`Gateway connect timeout: ${this.url}`)),
-        15_000,
-      );
-      this.ws.addEventListener("open", () => {
-        clearTimeout(timer);
-        resolve();
-      });
-      this.ws.addEventListener("error", () => {
-        clearTimeout(timer);
-        reject(new Error(`Gateway socket error: ${this.url}`));
-      });
-    });
-    this.ws.addEventListener("message", (event) => this.onMessage(event));
-    await this.request("connect", {
-      minProtocol: 1,
-      maxProtocol: 99,
-      client: {
-        id: "gateway-client",
-        displayName: "Pond proof verifier",
-        version: "0.0.0",
-        platform: process.platform,
-        mode: "backend",
-      },
-      auth: { token: this.token },
-      role: "operator",
-      scopes: this.scopes,
-    });
-  }
-
-  onMessage(event) {
-    let frame;
-    try {
-      frame = JSON.parse(String(event.data));
-    } catch {
-      return;
-    }
-    if (frame?.type !== "res" || typeof frame.id !== "string") {
-      return;
-    }
-    const pending = this.pending.get(frame.id);
-    if (!pending) {
-      return;
-    }
-    if (pending.expectFinal && frame.payload?.status === "accepted") {
-      return;
-    }
-    this.pending.delete(frame.id);
-    clearTimeout(pending.timer);
-    if (frame.ok) {
-      pending.resolve(frame.payload);
-      return;
-    }
-    pending.reject(new Error(frame.error?.message ?? `Gateway RPC failed: ${pending.method}`));
-  }
-
-  request(method, params = {}, options = {}) {
-    const id = `pond-proof-${this.nextId}`;
-    this.nextId += 1;
-    const timeoutMs = options.timeoutMs ?? 30_000;
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Gateway RPC timeout: ${method}`));
-      }, timeoutMs);
-      this.pending.set(id, {
-        method,
-        expectFinal: options.expectFinal === true,
-        resolve,
-        reject,
-        timer,
-      });
-      this.ws.send(JSON.stringify({ type: "req", id, method, params }));
-    });
-  }
-
-  close() {
-    this.ws?.close();
-  }
-}
-
 async function connectVerifier(url, token) {
-  const rpc = new GatewayRpc({
+  const rpc = new PondGatewayRpc({
     url,
     token,
     scopes: ["operator.read", "operator.write", "operator.pairing", "operator.admin"],

--- a/test/scripts/pond-gateway-rpc.test.ts
+++ b/test/scripts/pond-gateway-rpc.test.ts
@@ -1,0 +1,106 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { PondGatewayRpc } from "../../scripts/e2e/lib/pond-gateway-rpc.mjs";
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSED = 3;
+
+class FakeWebSocket extends EventEmitter {
+  readyState = CONNECTING;
+  sent: Array<{ id: string; method: string }> = [];
+  terminated = false;
+  sendError: Error | undefined;
+
+  open(): void {
+    this.readyState = OPEN;
+    this.emit("open");
+  }
+
+  send(payload: string, callback: (error?: Error) => void): void {
+    const frame = JSON.parse(payload) as { id: string; method: string };
+    this.sent.push(frame);
+    callback(this.sendError);
+    if (frame.method === "connect" && !this.sendError) {
+      queueMicrotask(() => {
+        this.emit("message", JSON.stringify({ type: "res", id: frame.id, ok: true }));
+      });
+    }
+  }
+
+  close(): void {
+    this.readyState = CLOSED;
+    this.emit("close", 1000, Buffer.alloc(0));
+  }
+
+  terminate(): void {
+    this.terminated = true;
+    this.readyState = CLOSED;
+    this.emit("close", 1006, Buffer.alloc(0));
+  }
+}
+
+function createRpc(socket: FakeWebSocket, openTimeoutMs = 100) {
+  return new PondGatewayRpc({
+    url: "ws://127.0.0.1:18789",
+    token: "test-token",
+    scopes: ["operator.read"],
+    openTimeoutMs,
+    webSocketFactory: () => socket,
+  });
+}
+
+async function connect(rpc: PondGatewayRpc, socket: FakeWebSocket): Promise<void> {
+  const connecting = rpc.connect();
+  socket.open();
+  await connecting;
+}
+
+describe("Pond gateway RPC", () => {
+  it("terminates a stalled websocket handshake at the connection deadline", async () => {
+    const socket = new FakeWebSocket();
+    const rpc = createRpc(socket, 1);
+    const keepAlive = setTimeout(() => {}, 100);
+
+    try {
+      await expect(rpc.connect()).rejects.toThrow("Gateway connect timeout: ws://127.0.0.1:18789");
+    } finally {
+      clearTimeout(keepAlive);
+    }
+
+    expect(socket.terminated).toBe(true);
+  });
+
+  it("rejects pending RPCs when an open websocket emits an error", async () => {
+    const socket = new FakeWebSocket();
+    const rpc = createRpc(socket);
+    await connect(rpc, socket);
+
+    const request = rpc.request("node.list");
+    socket.emit("error", new Error("invalid websocket frame"));
+
+    await expect(request).rejects.toThrow("invalid websocket frame");
+    await expect(rpc.request("node.list")).rejects.toThrow("invalid websocket frame");
+  });
+
+  it("rejects pending RPCs when an open websocket closes", async () => {
+    const socket = new FakeWebSocket();
+    const rpc = createRpc(socket);
+    await connect(rpc, socket);
+
+    const request = rpc.request("node.list");
+    socket.readyState = CLOSED;
+    socket.emit("close", 1006, Buffer.from("gateway stopped"));
+
+    await expect(request).rejects.toThrow("Gateway socket closed (1006): gateway stopped");
+  });
+
+  it("rejects an RPC when the websocket send callback reports failure", async () => {
+    const socket = new FakeWebSocket();
+    const rpc = createRpc(socket);
+    await connect(rpc, socket);
+    socket.sendError = new Error("send failed");
+
+    await expect(rpc.request("node.list")).rejects.toThrow("send failed");
+  });
+});

--- a/test/scripts/pond-gateway-rpc.test.ts
+++ b/test/scripts/pond-gateway-rpc.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PondGatewayRpc } from "../../scripts/e2e/lib/pond-gateway-rpc.mjs";
 
 const CONNECTING = 0;
@@ -11,6 +11,7 @@ class FakeWebSocket extends EventEmitter {
   sent: Array<{ id: string; method: string }> = [];
   terminated = false;
   sendError: Error | undefined;
+  respondToConnect = true;
 
   open(): void {
     this.readyState = OPEN;
@@ -21,7 +22,7 @@ class FakeWebSocket extends EventEmitter {
     const frame = JSON.parse(payload) as { id: string; method: string };
     this.sent.push(frame);
     callback(this.sendError);
-    if (frame.method === "connect" && !this.sendError) {
+    if (frame.method === "connect" && !this.sendError && this.respondToConnect) {
       queueMicrotask(() => {
         this.emit("message", JSON.stringify({ type: "res", id: frame.id, ok: true }));
       });
@@ -43,7 +44,7 @@ class FakeWebSocket extends EventEmitter {
 function createRpc(socket: FakeWebSocket, openTimeoutMs = 100) {
   return new PondGatewayRpc({
     url: "ws://127.0.0.1:18789",
-    token: "test-token",
+    token: String(),
     scopes: ["operator.read"],
     openTimeoutMs,
     webSocketFactory: () => socket,
@@ -69,6 +70,24 @@ describe("Pond gateway RPC", () => {
     }
 
     expect(socket.terminated).toBe(true);
+  });
+
+  it("closes the websocket when the gateway connect RPC stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      const socket = new FakeWebSocket();
+      socket.respondToConnect = false;
+      const rpc = createRpc(socket);
+      const connecting = rpc.connect();
+      const rejected = expect(connecting).rejects.toThrow("Gateway RPC timeout: connect");
+      socket.open();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await rejected;
+      expect(socket.readyState).toBe(CLOSED);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects pending RPCs when an open websocket emits an error", async () => {


### PR DESCRIPTION
## What Problem This Solves

The Pond E2E verifier only rejected its open promise after 15 seconds. It did not terminate a stalled WebSocket upgrade, so the underlying socket could keep the verifier process alive. Its inline RPC client also had no persistent post-open error/close handling for pending requests.

## Why This Change Was Made

Use the repository's `waitForWebSocketOpen` deadline with the `ws` client, whose `terminate()` method closes stalled handshakes. Move the Pond-specific RPC behavior into a small helper that owns persistent message/error/close listeners and clears every pending request on terminal socket failures.

This keeps Pond's connect payload and accepted/final response semantics intact while making the timeout and lifecycle behavior directly testable.

## User Impact

Pond E2E verification now fails cleanly within its 15-second connection deadline instead of retaining a stalled socket. Requests already in flight also fail immediately when an open gateway socket errors or closes.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pond-gateway-rpc.test.ts test/scripts/e2e-websocket-open.test.ts test/scripts/check-deadcode-exports.test.ts test/scripts/check-deadcode-unused-files.test.ts --run` (Node 24): 47 passed.
- A real `ws` server that accepts the RPC connect and then sends an invalid opcode rejects the pending request, clears the pending map, and produces no uncaught exception.
- A stalled real WebSocket handshake is terminated and reaches `CLOSED` at the deadline.
- `node --check` for both changed E2E modules, targeted `oxlint --deny-warnings`, `oxfmt --check`, and `git diff --check`: passed.
- Full live Pond E2E was not run because a remote Testbox was unavailable; the focused socket lifecycle paths are covered locally with Node 24.
