### PR TITLE
fix(doctor): seed plugins.allow from installed extensions when allowlist is unset

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1617,6 +1617,46 @@ describe("doctor config flow", () => {
     );
   });
 
+  it("migrates plugins.allow when extension artifacts exist and allowlist is unset", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(path.join(configDir, "extensions", "zalo"), { recursive: true });
+      await fs.mkdir(path.join(configDir, "extensions", "matrix"), { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify({}, null, 2),
+        "utf-8",
+      );
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.shouldWriteConfig).toBe(true);
+      expect(result.cfg.plugins?.allow).toEqual(["matrix", "zalo"]);
+    });
+  });
+
+  it("does not alter explicit plugins.allow when extension artifacts exist", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(path.join(configDir, "extensions", "zalo"), { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify({ plugins: { allow: ["voice-call"] } }, null, 2),
+        "utf-8",
+      );
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.cfg.plugins?.allow).toEqual(["voice-call"]);
+    });
+  });
+
   it("collects plugin blocker previews from the pre-auto-enable config", async () => {
     await runDoctorConfigWithInput({
       config: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -2,7 +2,7 @@
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import { CONFIG_PATH } from "../config/paths.js";
+import { CONFIG_PATH, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -23,6 +23,7 @@ import {
 import { applyDoctorConfigMutation } from "./doctor/shared/config-mutation-state.js";
 import { isSingleTopLevelIncludeMigration } from "./doctor/shared/include-migration-ownership.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
+import { maybeMigratePluginsAllowForExtensions } from "./doctor/shared/migrate-plugins-allow-extensions.js";
 
 function hasLegacyInternalHookHandlers(raw: unknown): boolean {
   const handlers = (raw as { hooks?: { internal?: { handlers?: unknown } } })?.hooks?.internal
@@ -141,6 +142,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   prompter?: DoctorPrompter;
 }) {
   const shouldRepair = params.options.repair === true || params.options.yes === true;
+  const stateDir = resolveStateDir();
   const preflight = await runDoctorConfigPreflight({
     repairPrefixedConfig: shouldRepair,
     recoverCorruptTargetStore: shouldRepair,
@@ -405,6 +407,20 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
   if (unknownStep.warnings.length > 0) {
     note(unknownStep.warnings.join("\n"), "Doctor warnings");
+  }
+
+  const pluginsAllowMigration = await maybeMigratePluginsAllowForExtensions({
+    cfg: candidate,
+    stateDir,
+  });
+  if (pluginsAllowMigration.changes.length > 0) {
+    emitDoctorChangesPanel(pluginsAllowMigration.changes, shouldRepair);
+    ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
+      state: { cfg, candidate, pendingChanges, fixHints },
+      mutation: pluginsAllowMigration,
+      shouldRepair,
+      fixHint: `Run "${doctorFixCommand}" to apply these changes.`,
+    }));
   }
 
   const finalized = await finalizeDoctorConfigFlow({

--- a/src/commands/doctor/shared/migrate-plugins-allow-extensions.test.ts
+++ b/src/commands/doctor/shared/migrate-plugins-allow-extensions.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { maybeMigratePluginsAllowForExtensions } from "./migrate-plugins-allow-extensions.js";
+
+async function makeTempStateDir(pluginIds: string[]): Promise<{
+  stateDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-migrate-plugins-allow-"));
+  for (const pluginId of pluginIds) {
+    await fs.mkdir(path.join(stateDir, "extensions", pluginId, "dist"), { recursive: true });
+    await fs.writeFile(path.join(stateDir, "extensions", pluginId, "package.json"), "{}");
+  }
+  return {
+    stateDir,
+    cleanup: async () => {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("maybeMigratePluginsAllowForExtensions", () => {
+  it("does nothing when no extension directories exist", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-migrate-plugins-allow-"));
+    try {
+      const cfg = {};
+      const result = await maybeMigratePluginsAllowForExtensions({ cfg, stateDir });
+      expect(result.changes).toEqual([]);
+      expect(result.config).toEqual(cfg);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("seeds plugins.allow from discovered extensions when allowlist is unset", async () => {
+    const { stateDir, cleanup } = await makeTempStateDir(["brave", "slack"]);
+    try {
+      const cfg = {};
+      const result = await maybeMigratePluginsAllowForExtensions({ cfg, stateDir });
+      expect(result.changes).toEqual([
+        'Set plugins.allow to ["brave", "slack"] because extension artifacts exist but no allowlist was configured.',
+      ]);
+      expect(result.config.plugins?.allow).toEqual(["brave", "slack"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves an existing plugins.allow", async () => {
+    const { stateDir, cleanup } = await makeTempStateDir(["brave"]);
+    try {
+      const cfg = { plugins: { allow: ["existing"] } };
+      const result = await maybeMigratePluginsAllowForExtensions({ cfg, stateDir });
+      expect(result.changes).toEqual([]);
+      expect(result.config.plugins?.allow).toEqual(["existing"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not overwrite an explicit empty plugins.allow", async () => {
+    const { stateDir, cleanup } = await makeTempStateDir(["brave"]);
+    try {
+      const cfg = { plugins: { allow: [] } };
+      const result = await maybeMigratePluginsAllowForExtensions({ cfg, stateDir });
+      expect(result.changes).toEqual([]);
+      expect(result.config.plugins?.allow).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("excludes denied plugins and explicitly disabled entries", async () => {
+    const { stateDir, cleanup } = await makeTempStateDir(["brave", "slack", "trello"]);
+    try {
+      const cfg = {
+        plugins: {
+          deny: ["slack"],
+          entries: {
+            trello: { enabled: false },
+          },
+        },
+      };
+      const result = await maybeMigratePluginsAllowForExtensions({ cfg, stateDir });
+      expect(result.changes).toEqual([
+        'Set plugins.allow to ["brave"] because extension artifacts exist but no allowlist was configured.',
+      ]);
+      expect(result.config.plugins?.allow).toEqual(["brave"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ignores generated install debris", async () => {
+    const { stateDir, cleanup } = await makeTempStateDir(["brave"]);
+    try {
+      await fs.mkdir(path.join(stateDir, "extensions", "node_modules"), { recursive: true });
+      await fs.mkdir(path.join(stateDir, "extensions", "brave.bak"), { recursive: true });
+      const cfg = {};
+      const result = await maybeMigratePluginsAllowForExtensions({ cfg, stateDir });
+      expect(result.config.plugins?.allow).toEqual(["brave"]);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/commands/doctor/shared/migrate-plugins-allow-extensions.ts
+++ b/src/commands/doctor/shared/migrate-plugins-allow-extensions.ts
@@ -1,0 +1,70 @@
+// Doctor migration: seed plugins.allow from installed extension directories when no allowlist exists.
+import path from "node:path";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { normalizePluginsConfig } from "../../../plugins/config-state.js";
+import { listInstalledPluginDirs } from "../../../security/installed-plugin-dirs.js";
+
+function hasExplicitPluginsAllow(cfg: OpenClawConfig): boolean {
+  return cfg.plugins != null && Object.hasOwn(cfg.plugins, "allow");
+}
+
+/**
+ * When extension artifacts exist under the state directory but the operator has
+ * not pinned an explicit plugins.allow, seed the allowlist with the discovered
+ * installed plugin ids. This prevents post-upgrade hosts from immediately
+ * landing in a security-audit critical/warn state.
+ *
+ * Explicit operator-defined allowlists, denylists, and disabled entries are
+ * preserved and never overwritten by this migration.
+ */
+export async function maybeMigratePluginsAllowForExtensions(params: {
+  cfg: OpenClawConfig;
+  stateDir: string;
+}): Promise<{ config: OpenClawConfig; changes: string[] }> {
+  const cfg = params.cfg;
+  if (hasExplicitPluginsAllow(cfg)) {
+    return { config: cfg, changes: [] };
+  }
+
+  const normalizedPlugins = normalizePluginsConfig(cfg.plugins);
+  if (!normalizedPlugins.enabled) {
+    return { config: cfg, changes: [] };
+  }
+
+  const { pluginDirs } = await listInstalledPluginDirs({ stateDir: params.stateDir });
+  if (pluginDirs.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const denySet = new Set(normalizedPlugins.deny.map((id) => id.toLowerCase()));
+  const disabled = new Set<string>();
+  for (const [id, entry] of Object.entries(normalizedPlugins.entries)) {
+    if (entry?.enabled === false) {
+      disabled.add(id.toLowerCase());
+    }
+  }
+
+  const allowIds = pluginDirs
+    .map((dir) => path.basename(dir))
+    .filter((id) => !denySet.has(id.toLowerCase()) && !disabled.has(id.toLowerCase()))
+    .toSorted((a, b) => a.localeCompare(b, "en"));
+
+  if (allowIds.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next: OpenClawConfig = {
+    ...cfg,
+    plugins: {
+      ...cfg.plugins,
+      allow: allowIds,
+    },
+  };
+
+  const changeNote =
+    allowIds.length === 1
+      ? `Set plugins.allow to ["${allowIds[0]}"] because extension artifacts exist but no allowlist was configured.`
+      : `Set plugins.allow to [${allowIds.map((id) => `"${id}"`).join(", ")}] because extension artifacts exist but no allowlist was configured.`;
+
+  return { config: next, changes: [changeNote] };
+}


### PR DESCRIPTION
Closes #19995

## What Problem This Solves

When an existing OpenClaw host has extension artifacts under the state `extensions/` directory but no explicit `plugins.allow`, `openclaw security audit` emits `plugins.extensions_no_allowlist` (warn or critical) immediately after upgrade. The operator must manually edit `openclaw.json` to pin the allowlist before the host is security-compliant.

## Why This Change Was Made

`openclaw doctor --fix` is the canonical place for config compat/security migrations. Seeding `plugins.allow` from already-installed extension directories when the allowlist is unset turns a repeated manual post-upgrade hardening step into a one-time safe default that the operator can later refine.

The migration:
- only runs when `plugins.allow` is absent (an explicit empty array is left untouched);
- respects `plugins.deny` and `plugins.entries.<id>.enabled=false`;
- is ordered after the stale-plugin repair sequence so freshly seeded entries are not immediately pruned;
- uses the same `listInstalledPluginDirs` helper that the security audit uses, so the two surfaces agree on what is "installed".

## User Impact

Hosts with installed extensions that previously landed in a critical/warn audit state right after upgrade now get an explicit, conservative `plugins.allow` written by `openclaw doctor --fix`. Users who already set `plugins.allow` see no change.

## Evidence

- Added unit tests in `src/commands/doctor/shared/migrate-plugins-allow-extensions.test.ts` covering: no extensions, unset allowlist, explicit allowlist, explicit empty allowlist, deny/disabled filtering, and ignored install debris.
- Added integration tests in `src/commands/doctor-config-flow.test.ts` verifying the full `loadAndMaybeMigrateDoctorConfig` flow seeds `plugins.allow` and preserves an explicit one.
- Validation:
  - `node scripts/run-vitest.mjs src/commands/doctor/shared/migrate-plugins-allow-extensions.test.ts src/commands/doctor-config-flow.test.ts` — pass.
  - `pnpm tsgo:core` — pass.
  - `node scripts/run-oxlint.mjs <changed-files>` — pass.
  - `oxfmt --check <changed-files>` — pass.
  - `node scripts/plugin-sdk-surface-report.mjs --check` — pass.
  - `node scripts/build-all.mjs` — pass.
- Real CLI proof (built from this branch, Node 24.15.0):
  - Before fix: `openclaw security audit --json` reports `plugins.extensions_no_allowlist`.
  - After `openclaw doctor --fix --yes --non-interactive`: config gains `plugins.allow` with the discovered extension id and the audit no longer reports `plugins.extensions_no_allowlist`.
