### PR TITLE
fix(qa-lab): bound retained child output without changing verdicts

### DIFF
--- a/extensions/qa-lab/src/child-output.test.ts
+++ b/extensions/qa-lab/src/child-output.test.ts
@@ -10,6 +10,13 @@ import {
 } from "./child-output.js";
 
 describe("qa child output", () => {
+  it("does not mark an exactly full first stderr chunk as truncated", () => {
+    const tail = createQaChildOutputTail(4);
+    appendQaChildOutputTail(tail, Buffer.from("tail"));
+    expect(tail.truncated).toBe(false);
+    expect(formatQaChildOutputTail(tail, "stderr")).toBe("tail");
+  });
+
   it("keeps capped stdout UTF-8 safe when the byte cap splits a code point", () => {
     const text = "ok \u{1f600} done";
     const capture = createQaChildOutputCapture(Buffer.byteLength("ok \u{1f600}", "utf8") - 1);

--- a/extensions/qa-lab/src/child-output.ts
+++ b/extensions/qa-lab/src/child-output.ts
@@ -74,6 +74,10 @@ export function appendQaChildOutputTail(tail: QaChildOutputTail, chunk: unknown)
   tail.truncated = true;
 }
 
+export function readQaChildOutputTail(tail: QaChildOutputTail) {
+  return tail.buffer.toString("utf8");
+}
+
 export function formatQaChildOutputTail(tail: QaChildOutputTail, label: string) {
   const text = tail.buffer.toString("utf8").trim();
   if (!text) {

--- a/extensions/qa-lab/src/child-output.ts
+++ b/extensions/qa-lab/src/child-output.ts
@@ -77,8 +77,8 @@ export function createQaChildOutputTail(maxBytes = QA_CHILD_STDERR_TAIL_BYTES) {
 export function appendQaChildOutputTail(tail: QaChildOutputTail, chunk: unknown) {
   const buffer = toBuffer(chunk);
   if (buffer.byteLength >= tail.maxBytes) {
+    tail.truncated ||= tail.buffer.byteLength > 0 || buffer.byteLength > tail.maxBytes;
     tail.buffer = Buffer.from(buffer.subarray(buffer.byteLength - tail.maxBytes));
-    tail.truncated = true;
     return;
   }
   const next = Buffer.concat([tail.buffer, buffer], tail.buffer.byteLength + buffer.byteLength);
@@ -90,8 +90,12 @@ export function appendQaChildOutputTail(tail: QaChildOutputTail, chunk: unknown)
   tail.truncated = true;
 }
 
+export function readQaChildOutputTail(tail: QaChildOutputTail) {
+  return decodeUtf8Tail(tail.buffer, tail.truncated);
+}
+
 export function formatQaChildOutputTail(tail: QaChildOutputTail, label: string) {
-  const text = decodeUtf8Tail(tail.buffer, tail.truncated).trim();
+  const text = readQaChildOutputTail(tail).trim();
   if (!text) {
     return "";
   }

--- a/extensions/qa-lab/src/gateway-process-boundary.test.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { QA_CHILD_STDOUT_MAX_BYTES } from "./child-output.js";
 import {
   assertQaGatewayCredentialLeaseQuarantine,
   createQaGatewayProcessBoundaryController,
@@ -120,6 +121,14 @@ describe("gateway process boundary", () => {
       expect(evidence.launches).toEqual([
         expect.objectContaining({ generation: prepared.generation }),
       ]);
+
+      await fs.writeFile(
+        `${prepared.identityFilePath}.runtime`,
+        Buffer.alloc(QA_CHILD_STDOUT_MAX_BYTES + 1, "x"),
+      );
+      await expect(controller.markReady(identity)).rejects.toThrow(
+        `process-boundary live verification proxy stdout exceeded ${QA_CHILD_STDOUT_MAX_BYTES} bytes`,
+      );
 
       const malformed = await controller.prepare({
         args: ["gateway", "run"],

--- a/extensions/qa-lab/src/gateway-process-boundary.test.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { QA_CHILD_STDOUT_MAX_BYTES } from "./child-output.js";
 import {
   assertQaGatewayCredentialLeaseQuarantine,
   createQaGatewayProcessBoundaryController,
@@ -120,6 +121,19 @@ describe("gateway process boundary", () => {
       expect(evidence.launches).toEqual([
         expect.objectContaining({ generation: prepared.generation }),
       ]);
+
+      // Whitespace leaves JSON valid, but oversized verification output must not
+      // authenticate a truncated proof as a complete response.
+      await fs.appendFile(
+        `${prepared.identityFilePath}.runtime`,
+        " ".repeat(QA_CHILD_STDOUT_MAX_BYTES),
+      );
+      await expect(controller.markReady(identity)).rejects.toThrow("proxy stdout exceeded");
+
+      await fs.writeFile(launcherPath, '#!/bin/sh\ncat "$3.runtime" >&2\nexit 7\n');
+      await expect(controller.markReady(identity)).rejects.toThrow(
+        "proxy exited 7 (stderr truncated)",
+      );
 
       const malformed = await controller.prepare({
         args: ["gateway", "run"],

--- a/extensions/qa-lab/src/gateway-process-boundary.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.ts
@@ -4,6 +4,14 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import {
+  appendQaChildOutput,
+  appendQaChildOutputTail,
+  createQaChildOutputCapture,
+  createQaChildOutputTail,
+  formatQaChildOutputTail,
+  readQaChildOutput,
+} from "./child-output.js";
 
 const PROCESS_BOUNDARY_VERSION = 1;
 const PROCESS_BOUNDARY_START_TIMEOUT_MS = 30_000;
@@ -319,37 +327,74 @@ async function runBoundaryLauncherCommand(params: {
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  const stdout: Buffer[] = [];
-  const stderr: Buffer[] = [];
-  child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
-  child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+  const stdout = createQaChildOutputCapture();
+  const stderr = createQaChildOutputTail();
+  let settled = false;
+  child.stderr.on("data", (chunk) => appendQaChildOutputTail(stderr, chunk));
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const clearTimer = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+    };
+    const rejectOnce = (error: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimer();
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // The launcher may have exited between the stream failure and cleanup.
+      }
+      reject(error);
+    };
+    child.stdout.on("data", (chunk) => {
+      appendQaChildOutput(stdout, chunk);
+      if (stdout.exceeded) {
+        rejectOnce(
+          new Error(
+            `process-boundary ${params.label} proxy stdout exceeded ${stdout.maxBytes} bytes`,
+          ),
+        );
+      }
+    });
+    child.stdout.once("error", (error) => {
+      rejectOnce(
+        new Error(`process-boundary ${params.label} proxy stdout stream failed: ${String(error)}`, {
+          cause: error,
+        }),
+      );
+    });
+    child.stderr.once("error", (error) => {
+      rejectOnce(
+        new Error(`process-boundary ${params.label} proxy stderr stream failed: ${String(error)}`, {
+          cause: error,
+        }),
+      );
+    });
+    child.once("error", rejectOnce);
+    child.once("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimer();
+      resolve(code ?? 1);
+    });
     timeout = setTimeout(() => {
-      child.kill("SIGKILL");
-      reject(new Error(`process-boundary ${params.label} proxy timed out`));
+      rejectOnce(new Error(`process-boundary ${params.label} proxy timed out`));
     }, params.timeoutMs);
   });
-  let exitCode: number;
-  try {
-    exitCode = await Promise.race([
-      new Promise<number>((resolve, reject) => {
-        child.once("error", reject);
-        child.once("close", (code) => resolve(code ?? 1));
-      }),
-      timeoutPromise,
-    ]);
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
   if (exitCode !== 0) {
     throw new Error(
-      `process-boundary ${params.label} proxy exited ${exitCode}: ${Buffer.concat(stderr).toString("utf8").trim()}`,
+      `process-boundary ${params.label} proxy exited ${exitCode}: ${formatQaChildOutputTail(stderr, "stderr")}`,
     );
   }
-  return Buffer.concat(stdout).toString("utf8");
+  return readQaChildOutput(stdout);
 }
 
 async function runBoundaryVerification(params: {

--- a/extensions/qa-lab/src/gateway-process-boundary.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.ts
@@ -350,7 +350,7 @@ async function runBoundaryLauncherCommand(params: {
       } catch {
         // The launcher may have exited between the stream failure and cleanup.
       }
-      reject(error);
+      reject(error instanceof Error ? error : new Error(String(error)));
     };
     child.stdout.on("data", (chunk) => {
       appendQaChildOutput(stdout, chunk);

--- a/extensions/qa-lab/src/gateway-process-boundary.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
@@ -7,6 +7,8 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
+import { QA_CHILD_STDOUT_MAX_BYTES } from "./child-output.js";
+import { runQaScenarioCommandLifecycle } from "./test-file-scenario-command-lifecycle.js";
 
 const PROCESS_BOUNDARY_VERSION = 1;
 const PROCESS_BOUNDARY_START_TIMEOUT_MS = 30_000;
@@ -300,45 +302,30 @@ async function runBoundaryLauncherCommand(params: {
   launcherPath: string;
   timeoutMs: number;
 }) {
-  const child = spawn(params.launcherPath, params.args, {
+  // The proxy gets its own process group; the verified SUT identity and its
+  // UID-quiescence checks remain owned by the launcher, never this cleanup.
+  const result = await runQaScenarioCommandLifecycle({
+    command: params.launcherPath,
+    args: [...params.args],
+    cwd: process.cwd(),
+    timeoutMs: params.timeoutMs,
     env: {
       HOME: process.env.HOME,
       LANG: process.env.LANG ?? "C.UTF-8",
       PATH: process.env.PATH,
     },
-    stdio: ["ignore", "pipe", "pipe"],
   });
-  const stdout: Buffer[] = [];
-  const stderr: Buffer[] = [];
-  child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
-  child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timeout = setTimeout(() => {
-      child.kill("SIGKILL");
-      reject(new Error(`process-boundary ${params.label} proxy timed out`));
-    }, params.timeoutMs);
-  });
-  let exitCode: number;
-  try {
-    exitCode = await Promise.race([
-      new Promise<number>((resolve, reject) => {
-        child.once("error", reject);
-        child.once("close", (code) => resolve(code ?? 1));
-      }),
-      timeoutPromise,
-    ]);
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
-  if (exitCode !== 0) {
+  if (result.exitCode !== 0) {
     throw new Error(
-      `process-boundary ${params.label} proxy exited ${exitCode}: ${Buffer.concat(stderr).toString("utf8").trim()}`,
+      `process-boundary ${params.label} proxy exited ${result.exitCode}${result.stderrTruncated ? " (stderr truncated)" : ""}: ${result.failureMessage ?? result.stderr.trim()}`,
     );
   }
-  return Buffer.concat(stdout).toString("utf8");
+  if (result.stdoutTruncated) {
+    throw new Error(
+      `process-boundary ${params.label} proxy stdout exceeded ${QA_CHILD_STDOUT_MAX_BYTES} bytes`,
+    );
+  }
+  return result.stdout;
 }
 
 async function runBoundaryVerification(params: {

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -141,29 +141,52 @@ describe.skipIf(process.platform === "win32")("qa scenario command lifecycle", (
     },
   );
 
-  it.each([
-    ["stdout", QA_CHILD_STDOUT_MAX_BYTES],
-    ["stderr", QA_CHILD_STDERR_TAIL_BYTES],
-  ] as const)(
-    "bounds %s and keeps close from replacing the overflow failure",
-    async (streamName, maxBytes) => {
-      const child = createChild();
-      const resultPromise = runCommand(5_000);
+  it("bounds stdout and keeps close from replacing the overflow failure", async () => {
+    const child = createChild();
+    const resultPromise = runCommand(5_000);
 
-      child[streamName]?.emit("data", Buffer.alloc(maxBytes + 1, "x"));
-      child.emit("close", 0, null);
+    child.stdout?.emit("data", Buffer.alloc(QA_CHILD_STDOUT_MAX_BYTES + 1, "x"));
+    child.emit("close", 0, null);
 
-      const result = await resultPromise;
-      expect(result).toMatchObject({
-        exitCode: 1,
-        failureMessage: `scenario-command ${streamName} exceeded ${maxBytes} bytes`,
-        signal: null,
-      });
-      expect(Buffer.byteLength(result[streamName])).toBe(maxBytes);
-      expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
-      expect(parentHandlers.size).toBe(0);
-    },
-  );
+    const result = await resultPromise;
+    expect(result).toMatchObject({
+      exitCode: 1,
+      failureMessage: `scenario-command stdout exceeded ${QA_CHILD_STDOUT_MAX_BYTES} bytes`,
+      signal: null,
+    });
+    expect(Buffer.byteLength(result.stdout)).toBe(QA_CHILD_STDOUT_MAX_BYTES);
+    expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
+    expect(parentHandlers.size).toBe(0);
+  });
+
+  it("retains the stderr tail after overflow", async () => {
+    const child = createChild();
+    const resultPromise = runCommand(5_000);
+    const prefix = "discarded startup output\n";
+    const suffix = "\nretained final stack trace";
+
+    child.stderr?.emit(
+      "data",
+      Buffer.concat([
+        Buffer.from(prefix),
+        Buffer.alloc(QA_CHILD_STDERR_TAIL_BYTES, "x"),
+        Buffer.from(suffix),
+      ]),
+    );
+    child.emit("close", 0, null);
+
+    const result = await resultPromise;
+    expect(result).toMatchObject({
+      exitCode: 1,
+      failureMessage: `scenario-command stderr exceeded ${QA_CHILD_STDERR_TAIL_BYTES} bytes`,
+      signal: null,
+    });
+    expect(Buffer.byteLength(result.stderr)).toBe(QA_CHILD_STDERR_TAIL_BYTES);
+    expect(result.stderr).not.toContain(prefix);
+    expect(result.stderr.endsWith(suffix)).toBe(true);
+    expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
+    expect(parentHandlers.size).toBe(0);
+  });
 
   it("escalates timed-out commands and preserves the timeout result", async () => {
     createChild();

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QA_CHILD_STDERR_TAIL_BYTES, QA_CHILD_STDOUT_MAX_BYTES } from "./child-output.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -113,6 +114,56 @@ describe.skipIf(process.platform === "win32")("qa scenario command lifecycle", (
     await expect(runCommand()).rejects.toBe(error);
     expect(parentHandlers.size).toBe(0);
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "stops the process group and reports a %s pipe failure once",
+    async (streamName) => {
+      const child = createChild();
+      const resultPromise = runCommand(5_000);
+      const message = `synthetic ${streamName} read failure`;
+
+      child[streamName]?.emit("error", new Error(message));
+      child.emit("close", 0, null);
+      child.emit("close", 0, null);
+
+      await expect(resultPromise).resolves.toEqual({
+        exitCode: 1,
+        failureMessage: `scenario-command ${streamName} stream failed: ${message}`,
+        signal: null,
+        stdout: "",
+        stderr: "",
+      });
+      expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
+      expect(parentHandlers.size).toBe(0);
+      processKill.mockClear();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(processKill).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["stdout", QA_CHILD_STDOUT_MAX_BYTES],
+    ["stderr", QA_CHILD_STDERR_TAIL_BYTES],
+  ] as const)(
+    "bounds %s and keeps close from replacing the overflow failure",
+    async (streamName, maxBytes) => {
+      const child = createChild();
+      const resultPromise = runCommand(5_000);
+
+      child[streamName]?.emit("data", Buffer.alloc(maxBytes + 1, "x"));
+      child.emit("close", 0, null);
+
+      const result = await resultPromise;
+      expect(result).toMatchObject({
+        exitCode: 1,
+        failureMessage: `scenario-command ${streamName} exceeded ${maxBytes} bytes`,
+        signal: null,
+      });
+      expect(Buffer.byteLength(result[streamName])).toBe(maxBytes);
+      expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
+      expect(parentHandlers.size).toBe(0);
+    },
+  );
 
   it("escalates timed-out commands and preserves the timeout result", async () => {
     createChild();

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
@@ -1,5 +1,12 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import path from "node:path";
+import {
+  appendQaChildOutput,
+  createQaChildOutputCapture,
+  QA_CHILD_STDERR_TAIL_BYTES,
+  QA_CHILD_STDOUT_MAX_BYTES,
+  readQaChildOutput,
+} from "./child-output.js";
 import { resolveQaWindowsSystem32ExePath } from "./windows-system-tools.js";
 
 export type QaScenarioCommandExecution = {
@@ -58,10 +65,11 @@ export function killQaScenarioWindowsProcessTree(
 // One owner keeps timers, parent handlers, child signals, and final result
 // settlement symmetric across every command exit path.
 class QaScenarioCommandLifecycle {
-  private readonly stderr: Buffer[] = [];
-  private readonly stdout: Buffer[] = [];
+  private readonly stderr = createQaChildOutputCapture(QA_CHILD_STDERR_TAIL_BYTES);
+  private readonly stdout = createQaChildOutputCapture(QA_CHILD_STDOUT_MAX_BYTES);
   private resolve: ((result: QaScenarioCommandResult) => void) | undefined;
   private settled = false;
+  private terminalFailure: string | undefined;
   private timers: QaScenarioCommandTimers = {};
   private timedOut = false;
 
@@ -74,16 +82,19 @@ class QaScenarioCommandLifecycle {
   start(resolve: (result: QaScenarioCommandResult) => void, reject: (reason?: unknown) => void) {
     this.resolve = resolve;
     this.armTimeout();
-    this.child.stdout?.on("data", (chunk: Buffer) => this.stdout.push(chunk));
-    this.child.stderr?.on("data", (chunk: Buffer) => this.stderr.push(chunk));
+    this.child.stdout?.on("data", (chunk: Buffer) => this.handleOutput("stdout", chunk));
+    this.child.stderr?.on("data", (chunk: Buffer) => this.handleOutput("stderr", chunk));
+    this.child.stdout?.once("error", (error) => this.handleStreamError("stdout", error));
+    this.child.stderr?.once("error", (error) => this.handleStreamError("stderr", error));
     process.once("exit", this.handleParentExit);
     for (const signal of QA_SCENARIO_COMMAND_PARENT_SIGNALS) {
       process.once(signal, this.handleParentSignal);
     }
     this.child.on("error", (error) => {
-      if (this.settled) {
+      if (this.settled || this.timedOut || this.terminalFailure) {
         return;
       }
+      this.settled = true;
       this.clearTimers();
       this.cleanupParentHandlers();
       reject(error);
@@ -113,24 +124,23 @@ class QaScenarioCommandLifecycle {
     if (!this.timedOut) {
       this.clearTimeoutTimer();
     }
+    const failureMessage = this.timedOut
+      ? `${this.commandLabel()} timed out after ${this.execution.timeoutMs}ms`
+      : this.terminalFailure;
     const result = {
-      exitCode: this.timedOut ? 1 : (exitCode ?? (signal ? 1 : 0)),
+      exitCode: failureMessage ? 1 : (exitCode ?? (signal ? 1 : 0)),
       signal,
-      ...(this.timedOut
-        ? {
-            failureMessage: `${this.commandLabel()} timed out after ${this.execution.timeoutMs}ms`,
-          }
-        : {}),
+      ...(failureMessage ? { failureMessage } : {}),
     };
     if (
-      this.timedOut &&
+      (this.timedOut || this.terminalFailure) &&
       !this.useProcessGroup &&
       (this.timers.forceKill || this.timers.forceSettle)
     ) {
       return;
     }
     if (this.isProcessGroupRunning()) {
-      if (!this.timedOut) {
+      if (!this.timedOut && !this.terminalFailure) {
         this.signalChild("SIGTERM");
       }
       this.scheduleForcedCleanup(result);
@@ -138,6 +148,34 @@ class QaScenarioCommandLifecycle {
     }
     this.finish(result);
   };
+
+  private handleOutput(source: "stderr" | "stdout", chunk: Buffer) {
+    const capture = source === "stdout" ? this.stdout : this.stderr;
+    appendQaChildOutput(capture, chunk);
+    if (capture.exceeded) {
+      this.handleTerminalFailure(
+        `${this.commandLabel()} ${source} exceeded ${capture.maxBytes} bytes`,
+      );
+    }
+  }
+
+  private handleStreamError(source: "stderr" | "stdout", error: Error) {
+    this.handleTerminalFailure(
+      `${this.commandLabel()} ${source} stream failed: ${error.message || String(error)}`,
+    );
+  }
+
+  private handleTerminalFailure(failureMessage: string) {
+    if (this.settled || this.timedOut || this.terminalFailure) {
+      return;
+    }
+    this.terminalFailure = failureMessage;
+    this.clearTimeoutTimer();
+    // Pipe loss or truncated evidence makes the result unusable. Keep failure on
+    // the normal process-tree cleanup path before reporting it to the scenario.
+    this.signalChild("SIGTERM");
+    this.scheduleForcedCleanup({ exitCode: 1, failureMessage, signal: null });
+  }
 
   private armTimeout() {
     const timeoutMs = this.execution.timeoutMs;
@@ -216,8 +254,8 @@ class QaScenarioCommandLifecycle {
     this.cleanupParentHandlers();
     this.resolve?.({
       ...result,
-      stdout: Buffer.concat(this.stdout).toString("utf8"),
-      stderr: Buffer.concat(this.stderr).toString("utf8"),
+      stdout: readQaChildOutput(this.stdout),
+      stderr: readQaChildOutput(this.stderr),
     });
   }
 

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
@@ -2,10 +2,13 @@ import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import {
   appendQaChildOutput,
+  appendQaChildOutputTail,
   createQaChildOutputCapture,
+  createQaChildOutputTail,
   QA_CHILD_STDERR_TAIL_BYTES,
   QA_CHILD_STDOUT_MAX_BYTES,
   readQaChildOutput,
+  readQaChildOutputTail,
 } from "./child-output.js";
 import { resolveQaWindowsSystem32ExePath } from "./windows-system-tools.js";
 
@@ -65,7 +68,8 @@ export function killQaScenarioWindowsProcessTree(
 // One owner keeps timers, parent handlers, child signals, and final result
 // settlement symmetric across every command exit path.
 class QaScenarioCommandLifecycle {
-  private readonly stderr = createQaChildOutputCapture(QA_CHILD_STDERR_TAIL_BYTES);
+  private readonly stderr = createQaChildOutputTail();
+  private stderrBytes = 0;
   private readonly stdout = createQaChildOutputCapture(QA_CHILD_STDOUT_MAX_BYTES);
   private resolve: ((result: QaScenarioCommandResult) => void) | undefined;
   private settled = false;
@@ -150,11 +154,23 @@ class QaScenarioCommandLifecycle {
   };
 
   private handleOutput(source: "stderr" | "stdout", chunk: Buffer) {
-    const capture = source === "stdout" ? this.stdout : this.stderr;
-    appendQaChildOutput(capture, chunk);
-    if (capture.exceeded) {
+    if (source === "stderr") {
+      this.stderrBytes = Math.min(
+        this.stderrBytes + chunk.byteLength,
+        QA_CHILD_STDERR_TAIL_BYTES + 1,
+      );
+      appendQaChildOutputTail(this.stderr, chunk);
+      if (this.stderrBytes > QA_CHILD_STDERR_TAIL_BYTES) {
+        this.handleTerminalFailure(
+          `${this.commandLabel()} stderr exceeded ${QA_CHILD_STDERR_TAIL_BYTES} bytes`,
+        );
+      }
+      return;
+    }
+    appendQaChildOutput(this.stdout, chunk);
+    if (this.stdout.exceeded) {
       this.handleTerminalFailure(
-        `${this.commandLabel()} ${source} exceeded ${capture.maxBytes} bytes`,
+        `${this.commandLabel()} stdout exceeded ${this.stdout.maxBytes} bytes`,
       );
     }
   }
@@ -255,7 +271,7 @@ class QaScenarioCommandLifecycle {
     this.resolve?.({
       ...result,
       stdout: readQaChildOutput(this.stdout),
-      stderr: readQaChildOutput(this.stderr),
+      stderr: readQaChildOutputTail(this.stderr),
     });
   }
 

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
@@ -1,5 +1,15 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
+import {
+  appendQaChildOutput,
+  appendQaChildOutputTail,
+  createQaChildOutputCapture,
+  createQaChildOutputTail,
+  QA_CHILD_STDERR_TAIL_BYTES,
+  QA_CHILD_STDOUT_MAX_BYTES,
+  readQaChildOutput,
+  readQaChildOutputTail,
+} from "./child-output.js";
 import { createQaPosixCommandSettlement } from "./posix-command-settlement.js";
 import { runQaWindowsTaskkill } from "./windows-system-tools.js";
 
@@ -18,6 +28,8 @@ export type QaScenarioCommandResult = {
   signal?: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
+  stdoutTruncated?: true;
+  stderrTruncated?: true;
 };
 
 type QaScenarioCommandTerminalResult = Pick<
@@ -41,8 +53,10 @@ export function runQaScenarioCommandLifecycle(
       env: execution.env,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
+    // Logs are diagnostics, not native test verdicts: bound retention without
+    // failing noisy commands or truncating their live onOutput stream.
+    const stdout = createQaChildOutputCapture();
+    const stderr = createQaChildOutputTail();
     const commandLabel = path.basename(execution.command);
     createQaPosixCommandSettlement({
       child,
@@ -104,8 +118,10 @@ export function runQaScenarioCommandLifecycle(
         resolve({
           ...result,
           ...(settlementFailure && result.exitCode === 0 ? { exitCode: 1 } : {}),
-          stdout: Buffer.concat(stdout).toString("utf8"),
-          stderr: Buffer.concat(stderr).toString("utf8"),
+          stdout: readQaChildOutput(stdout),
+          stderr: readQaChildOutputTail(stderr),
+          ...(stdout.exceeded ? { stdoutTruncated: true } : {}),
+          ...(stderr.truncated ? { stderrTruncated: true } : {}),
           ...(settlementFailure
             ? result.failureMessage
               ? { failureMessage: `${result.failureMessage}; settlement: ${settlementFailure}` }
@@ -115,18 +131,31 @@ export function runQaScenarioCommandLifecycle(
       },
       onStderrData: (chunk) => {
         const buffered = Buffer.from(chunk);
-        stderr.push(buffered);
+        appendQaChildOutputTail(stderr, buffered);
         execution.onOutput?.("stderr", buffered);
       },
       onStdoutData: (chunk) => {
         const buffered = Buffer.from(chunk);
-        stdout.push(buffered);
+        appendQaChildOutput(stdout, buffered);
         execution.onOutput?.("stdout", buffered);
       },
       processGroupId: isWindows ? undefined : child.pid,
       verifyAfterMs: timeoutForceSettleMs,
     });
   });
+}
+
+export function formatQaScenarioCommandOutput(result: QaScenarioCommandResult): string {
+  return [
+    result.stdoutTruncated
+      ? `[stdout truncated to first ${QA_CHILD_STDOUT_MAX_BYTES} bytes]\n`
+      : "",
+    result.stdout,
+    result.stderrTruncated
+      ? `\n[stderr truncated to last ${QA_CHILD_STDERR_TAIL_BYTES} bytes]\n`
+      : "",
+    result.stderr,
+  ].join("");
 }
 
 export function resetQaScenarioCommandCleanupTimings() {

--- a/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
+++ b/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import { shellQuote } from "./shell-quote.js";
 import {
+  formatQaScenarioCommandOutput,
   runQaScenarioCommandLifecycle,
   type QaScenarioCommandExecution,
 } from "./test-file-scenario-command-lifecycle.js";
@@ -201,7 +202,7 @@ export async function runDockerE2eBatch(params: {
   }
   await fs.writeFile(
     logPath,
-    `$ ${shellQuote(process.execPath)} scripts/test-docker-all.mjs\n${commandResult.stdout}${commandResult.stderr}`,
+    `$ ${shellQuote(process.execPath)} scripts/test-docker-all.mjs\n${formatQaScenarioCommandOutput(commandResult)}`,
     "utf8",
   );
 

--- a/extensions/qa-lab/src/test-file-scenario-runner.process.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.process.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { runQaScenarioCommandLifecycle } from "./test-file-scenario-command-lifecycle.js";
+import { QA_CHILD_STDERR_TAIL_BYTES, QA_CHILD_STDOUT_MAX_BYTES } from "./child-output.js";
+import {
+  formatQaScenarioCommandOutput,
+  runQaScenarioCommandLifecycle,
+} from "./test-file-scenario-command-lifecycle.js";
 import {
   runQaTestFileScenarios,
   type QaScenarioCommandExecution,
@@ -22,6 +26,46 @@ afterEach(async () => {
 });
 
 describe("qa test file scenario runner", () => {
+  it.each([0, 7])(
+    "bounds retained child logs without changing exit %i or live output",
+    async (exitCode) => {
+      const streamed = { stdout: 0, stderr: 0 };
+      const result = await runQaScenarioCommandLifecycle({
+        command: process.execPath,
+        args: [
+          "-e",
+          [
+            `process.stdout.write('x'.repeat(${QA_CHILD_STDOUT_MAX_BYTES * 2}));`,
+            `process.stderr.write('🦞'.repeat(${QA_CHILD_STDERR_TAIL_BYTES / 2 + 1}) + '\\nfinal diagnostic\\n');`,
+            `process.exitCode = ${exitCode};`,
+          ].join("\n"),
+        ],
+        cwd: process.cwd(),
+        env: process.env,
+        onOutput: (stream, chunk) => {
+          streamed[stream] += chunk.byteLength;
+        },
+        timeoutMs: 5_000,
+      });
+
+      expect(Buffer.byteLength(result.stdout)).toBe(QA_CHILD_STDOUT_MAX_BYTES);
+      expect(Buffer.byteLength(result.stderr)).toBeLessThanOrEqual(QA_CHILD_STDERR_TAIL_BYTES);
+      expect(result.exitCode).toBe(exitCode);
+      expect(result.failureMessage).toBeUndefined();
+      expect(result.stdoutTruncated).toBe(true);
+      expect(result.stderrTruncated).toBe(true);
+      const log = formatQaScenarioCommandOutput(result);
+      expect(log.startsWith("[stdout truncated to first")).toBe(true);
+      expect(log.includes("[stderr truncated to last")).toBe(true);
+      expect(result.stderr).toContain("final diagnostic");
+      expect(result.stderr).not.toContain("�");
+      expect(streamed).toEqual({
+        stdout: QA_CHILD_STDOUT_MAX_BYTES * 2,
+        stderr: QA_CHILD_STDERR_TAIL_BYTES * 2 + 4 + Buffer.byteLength("\nfinal diagnostic\n"),
+      });
+    },
+  );
+
   it("streams real native subprocess output before command settlement", async () => {
     const observed: Array<{ stream: "stderr" | "stdout"; value: string }> = [];
     let settled = false;

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -22,6 +22,7 @@ import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
 import { shellQuote } from "./shell-quote.js";
 import {
+  formatQaScenarioCommandOutput,
   runQaScenarioCommandLifecycle,
   type QaScenarioCommandExecution,
   type QaScenarioCommandResult,
@@ -293,12 +294,7 @@ async function runScenarioCommandSteps(params: {
           : {}),
         timeoutMs,
       });
-      if (result.stdout) {
-        logChunks.push(result.stdout);
-      }
-      if (result.stderr) {
-        logChunks.push(result.stderr);
-      }
+      logChunks.push(formatQaScenarioCommandOutput(result));
       if (result.failureMessage || result.exitCode !== 0 || result.signal) {
         failureMessage =
           result.failureMessage ??


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where QA Lab could retain unlimited child stdout and stderr while running noisy test/build commands or gateway verification helpers. This rewrites the contributor's useful bounded-output repair on current main rather than restoring the retired caller-local lifecycle.

## Why This Change Was Made

Reuse the existing 1 MiB stdout capture and 64 KiB UTF-8-safe stderr tail. Keep raw small output unchanged and record truncation only when bytes were discarded. Native and Docker scenario logs label truncation, and live output callbacks still receive every byte. The exact-cap stderr case is also corrected: filling an empty buffer is not truncation.

Scenario logs are diagnostic; native reports and Docker summary artifacts own the verdict. Consequently a successful noisy command stays successful. Gateway helper stdout is different: it is verification JSON, so a truncated response is rejected before parsing. Failed launcher diagnostics identify truncated stderr.

The gateway helper now uses the current scenario command lifecycle, deleting its duplicate timeout/listener path. `createQaPosixCommandSettlement` remains unchanged and owns stream errors, exit-before-close, pipe draining, parent signals, and process-group cleanup. The proxy runs in its own POSIX group. Verified SUT identity, UID-quiescence checks, termination retries, credential-lease retention, path containment, and atomic writes remain with their existing owners and are unchanged.

Best-fix verdict: repair the bounded-output policy at the capture owner and reuse the canonical settlement path. Restoring the old lifecycle would regress cleanup; killing ordinary commands at the diagnostic retention limit would change valid test outcomes.

Production LOC: +63/-46 (net +17), versus the incoming net +103. Tests: +66/-1. Remaining production growth supplies bounded retention, explicit truncation facts, and honest diagnostic formatting; the duplicate gateway lifecycle has been removed.

## User Impact

Internal QA reliability only. No new public configuration, schema, migration, dependency, or runtime-provider behavior. QA commands retain bounded diagnostic output without losing their exit status or live output stream. Gateway verification refuses incomplete output instead of treating a prefix as complete proof.

Thanks @wahaha1223 for the original report and repair. Contributor credit is preserved in the rewritten commit.

## Evidence

Baseline: `0b60846fa42109b337f829d04ea2aa77090846ba`.

- Before the production rewrite, real Node children exiting 0 and 7 retained 2 MiB stdout instead of the 1 MiB limit; both new regressions failed. The Linux controller also accepted otherwise valid verification JSON with more than 1 MiB of trailing whitespace. The exact-cap stderr regression failed separately.
- After the rewrite, 83 tests passed on macOS and 87 tests across eight files passed on Linux. Real subprocess assertions cover bounded stdout/stderr, Unicode-safe tails, unchanged exit codes, complete live callback byte counts, and truncation labels. Existing coverage exercises exit-before-close, inherited pipes, escaped descendants, timeout, parent SIGTERM, stream errors after exit, mocked Windows taskkill, and native/Docker/script result consumers.
- The Linux gateway acceptance fixture rejects oversized verification JSON and labels truncated stderr on an actual failing helper process. The diagnostic assertion was observed failing before the final correction, then passing.
- An additional real Linux `sudo -n` probe ran successfully as UID 0 from an unprivileged parent. A self-expiring privileged child ignoring SIGTERM produced a visible timeout **and settlement failure**, not a false successful cleanup claim. After its bounded lifetime, `/proc/<pid>` was absent. This is process-boundary proof, not a live Telegram or full release run.
- Linux proof used the task-owned Testbox associated with [this run](https://github.com/openclaw/openclaw/actions/runs/33027145428); the wrapper completed successfully and the lease was stopped. Its workflow may show cancellation during explicit lease cleanup. No raw credential-bearing captures are published.
- Independent source review found no blocker. Fresh Codex autoreview found no actionable P0 defects; that automated pass used the default P0-only threshold.
- Full local changed-file checks passed on the final SHA `92341a4373b25f32fc48b7dd5013f2dc0ab4e4bc`. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33028470389) completed successfully, including the changed-extension Node test lane and all six QA Smoke profiles.

Focused Linux command:

```sh
node scripts/run-vitest.mjs \
  extensions/qa-lab/src/gateway-process-boundary.test.ts \
  extensions/qa-lab/src/child-output.test.ts \
  extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts \
  extensions/qa-lab/src/test-file-scenario-runner.process.test.ts \
  extensions/qa-lab/src/posix-command-settlement.test.ts \
  extensions/qa-lab/src/test-file-scenario-runner.native.test.ts \
  extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts \
  extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
```

Dependency contract checked: Node documents that [POSIX detached children get their own process group](https://nodejs.org/api/child_process.html#optionsdetached), and [close follows exit after stdio closes](https://nodejs.org/api/child_process.html#event-close). The actual release QA launcher uses `exec sudo -n` and checks that the verified SUT group differs from its own proxy group.

Provenance: unbounded scenario capture was carried forward by #120010, commit `bf0aadbc40c25a2d5231f7736633f5fa68ebca5b` (2026-08-08; code/PR author @vincentkoc, merger @RomneyDa). Its parent already contained the unbounded arrays, so this is not attributed as a new defect introduced by that cleanup repair. Gateway history reaches the local shallow boundary; original introduction is not established.

## Previous Review / Rank-up Follow-through

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/108981#issuecomment-4993010037) requested a current-main rewrite, shared settlement ownership, preservation of newer boundary safeguards, and new real-child/exit-before-close proof. All are addressed above. The specific suggestion to make diagnostic overflow a scenario failure is deliberately not adopted: scenario reports, not console output, own pass/fail. Only truncated gateway verification JSON fails closed. The earlier data-model warning was a test-file heuristic; this patch changes no stored schema or persistence semantics.
