### PR TITLE
fix(openai): bound stalled generated video download body reads with idle timeout

### DIFF
--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -104,6 +104,18 @@ function streamedVideoResponse(bytes: string): Response {
   );
 }
 
+/** Accepts headers then never sends body chunks — exercises download idle timeout. */
+function stalledVideoResponse(): Response {
+  return new Response(
+    new ReadableStream({
+      start() {
+        // Intentionally leave the stream open with no chunks.
+      },
+    }),
+    { headers: { "content-type": "video/mp4" } },
+  );
+}
+
 // Response.json keeps object fixtures on the standard Response body path so the
 // create read exercises the byte-bounded reader instead of an unbounded res.json().
 function streamedJsonResponse(payload: unknown): Response {
@@ -256,6 +268,39 @@ describe("openai video generation provider", () => {
         cfg: { agents: { defaults: { mediaMaxMb: 0.000001 } } },
       }),
     ).rejects.toThrow("OpenAI generated video download exceeds 1 bytes");
+  });
+
+  it("times out stalled generated video download bodies via chunkTimeoutMs", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({
+        id: "vid_stalled",
+        model: "sora-2",
+        status: "queued",
+      }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          id: "vid_stalled",
+          model: "sora-2",
+          status: "completed",
+        }),
+      })
+      .mockResolvedValueOnce(stalledVideoResponse());
+
+    const provider = buildOpenAIVideoGenerationProvider();
+    const startedAt = Date.now();
+    await expect(
+      provider.generateVideo({
+        provider: "openai",
+        model: "sora-2",
+        prompt: "short video",
+        timeoutMs: 80,
+        cfg: {},
+      }),
+    ).rejects.toThrow(/OpenAI generated video download stalled: no data received for \d+ms/);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
   });
 
   it("uses JSON input_reference.image_url for image-to-video requests", async () => {

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -184,10 +184,18 @@ async function pollOpenAIVideo(
 }
 
 function resolveOpenAIVideoDownloadTimeoutMs(timeoutMs: ProviderOperationTimeoutMs | undefined) {
+  // Re-resolve at each download stage so body reads use the remaining operation
+  // budget. A non-positive remaining budget must fail closed — never revive a
+  // fresh DEFAULT_TIMEOUT_MS after headers already consumed the deadline.
   const resolved = typeof timeoutMs === "function" ? timeoutMs() : timeoutMs;
-  return typeof resolved === "number" && Number.isFinite(resolved) && resolved > 0
-    ? resolved
-    : DEFAULT_TIMEOUT_MS;
+  const downloadTimeoutMs =
+    typeof resolved === "number" && Number.isFinite(resolved)
+      ? Math.max(0, Math.floor(resolved))
+      : DEFAULT_TIMEOUT_MS;
+  if (downloadTimeoutMs <= 0) {
+    throw new Error("OpenAI generated video download stalled: remaining budget exhausted");
+  }
+  return downloadTimeoutMs;
 }
 
 async function fetchOpenAIVideoDownload(
@@ -267,9 +275,14 @@ async function downloadOpenAIVideo(
   });
   try {
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+    // Resolve after headers so the body idle timer sees the remaining budget.
+    const chunkTimeoutMs = resolveOpenAIVideoDownloadTimeoutMs(params.timeoutMs);
     const buffer = await readResponseWithLimit(response, params.maxBytes, {
+      chunkTimeoutMs,
       onOverflow: ({ maxBytes }) =>
         new Error(`OpenAI generated video download exceeds ${maxBytes} bytes`),
+      onIdleTimeout: ({ chunkTimeoutMs: idleMs }) =>
+        new Error(`OpenAI generated video download stalled: no data received for ${idleMs}ms`),
     });
     return {
       buffer,

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -61,6 +61,29 @@ interface ProviderHttpMocks {
   >;
 }
 
+// Mirror production resolveProviderOperationTimeoutMs: remaining budget from
+// deadlineAtMs, fail closed when exhausted (never restart the original timeoutMs).
+const resolveMockProviderOperationTimeoutMs = vi.hoisted(
+  () =>
+    ({
+      defaultTimeoutMs,
+      deadline,
+    }: {
+      defaultTimeoutMs: number;
+      deadline: { label: string; timeoutMs?: number; deadlineAtMs?: number };
+    }): number => {
+      const deadlineAtMs = deadline.deadlineAtMs;
+      if (typeof deadlineAtMs !== "number") {
+        return defaultTimeoutMs;
+      }
+      const remainingMs = deadlineAtMs - Date.now();
+      if (remainingMs <= 0) {
+        throw new Error(`${deadline.label} timed out after ${deadline.timeoutMs}ms`);
+      }
+      return Math.max(1, Math.min(defaultTimeoutMs, remainingMs));
+    },
+);
+
 const providerHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
   executeProviderOperationWithRetryMock: vi.fn(),
@@ -275,6 +298,8 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: providerHttpMocks.assertOkOrThrowHttpErrorMock,
   assertOkOrThrowProviderError: providerHttpMocks.assertOkOrThrowProviderErrorMock,
+  // Match production deadline semantics: absolute deadlineAtMs so remaining
+  // budget decays across poll/header/body stages instead of restarting.
   createProviderOperationDeadline: ({
     label,
     timeoutMs,
@@ -284,11 +309,20 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   }) => ({
     label,
     timeoutMs,
+    ...(typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? { deadlineAtMs: Date.now() + timeoutMs }
+      : {}),
   }),
   createProviderOperationTimeoutResolver:
-    ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
-    () =>
+    ({
       defaultTimeoutMs,
+      deadline,
+    }: {
+      defaultTimeoutMs: number;
+      deadline: { label: string; timeoutMs?: number; deadlineAtMs?: number };
+    }) =>
+    () =>
+      resolveMockProviderOperationTimeoutMs({ defaultTimeoutMs, deadline }),
   executeProviderOperationWithRetry: providerHttpMocks.executeProviderOperationWithRetryMock,
   fetchProviderDownloadResponse: providerHttpMocks.fetchProviderDownloadResponseMock,
   fetchProviderOperationResponse: providerHttpMocks.fetchProviderOperationResponseMock,
@@ -299,8 +333,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
   providerOperationRetryConfig: (_stage: string) => true,
   readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
-  resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
-    defaultTimeoutMs,
+  resolveProviderOperationTimeoutMs: resolveMockProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
   resolveProviderRequestHeaders: providerHttpMocks.resolveProviderRequestHeadersMock,
   [providerHttpMockKeys.sanitizeConfiguredModelProviderRequest]:


### PR DESCRIPTION
## What Problem This Solves

OpenAI generated-video downloads call `readResponseWithLimit()` with a `maxBytes` cap but without `chunkTimeoutMs`. A CDN that accepts the connection and then stops sending body chunks can leave the download Promise pending indefinitely, holding Gateway connection capacity under concurrent video downloads.

## Why This Change Was Made

Wire `chunkTimeoutMs` + `onIdleTimeout` on the OpenAI video download reader, matching the landed DashScope / Google pattern. Re-resolve the remaining operation budget after headers arrive and fail closed when that budget is exhausted — never revive a fresh `DEFAULT_TIMEOUT_MS`. Teach the shared provider-HTTP test mock to use absolute `deadlineAtMs` so remaining budget decays like production. Add a caller-path `generateVideo` regression that feeds a never-chunking body.

Sibling providers (BytePlus, Runway, Together, fal, OpenRouter, MiniMax) are intentionally out of scope for this PR and will follow as separately proven one-provider PRs.

## User Impact

**Before:** A stalled OpenAI generated-video download body could hang the provider download forever.

**After:** The download body read fails closed after the remaining operation idle budget with `OpenAI generated video download stalled: no data received for Nms`, then releases the connection.

## Changed Files

| File | Change |
|------|--------|
| `extensions/openai/video-generation-provider.ts` | Remaining-budget resolver + `chunkTimeoutMs` / `onIdleTimeout` on download body read |
| `extensions/openai/video-generation-provider.test.ts` | Caller-path stalled-body regression |
| `src/plugin-sdk/test-helpers/provider-http-mocks.ts` | Deadline mock uses `deadlineAtMs` and decaying remaining budget |

## Real behavior proof

### Behavior or issue addressed

Stalled OpenAI generated-video download bodies now fail closed on the remaining operation idle budget instead of hanging forever.

### Canonical reachability path

`generateVideo` → `downloadOpenAIVideo` → `readResponseWithLimit(response, maxBytes, { chunkTimeoutMs, onIdleTimeout })` (`extensions/openai/video-generation-provider.ts`)

### Real environment tested

Real HTTP transport: a local `node:http` server on `127.0.0.1` that returns `video/mp4` headers plus one body chunk and then never sends another chunk or ends the response. The production shared reader (`readResponseWithLimit` from `openclaw/plugin-sdk/response-limit-runtime` — the exact runtime the download path imports) is driven against that live socket with the OpenAI download option bag. Node v22+.

### Exact steps or command run after this patch

```bash
# Real HTTP server sends video/mp4 headers + one chunk then stalls; drive the
# production download reader against it (idle budget 300ms):
node --import tsx scripts/proof-video-gen-idle-timeout.mts

# Supplemental caller-path regression through generateVideo:
node scripts/run-vitest.mjs extensions/openai/video-generation-provider.test.ts --reporter=verbose
```

### Evidence after fix

Real HTTP stall (production reader against a live video socket):

```text
  ok: stalled video download rejected (not hung) — elapsed=322ms
  ok: download idle-timeout error surfaced — OpenAI generated video download stalled: no data received for 300ms
  ok: terminated within ~idle budget — elapsed=322ms
  ok: unbounded video body read still hanging after 2000ms — state=still-hanging
  ok: completing video body read intact — bytes=7

ALL PROOF ASSERTIONS PASSED
```

Supplemental caller-path regression (`generateVideo` → stalled download):

```text
 ✓ openai video generation provider > times out stalled generated video download bodies via chunkTimeoutMs 81ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

### Observed result after fix

Against a real stalled `video/mp4` socket, the production download reader rejects in ~322ms with `OpenAI generated video download stalled: no data received for 300ms` and releases the connection. The negative control — an unbounded `arrayBuffer()` on the same socket — is still unresolved after a 2000ms observation window, confirming the pre-fix hang. A well-behaved completing body still reads intact. The caller-path `generateVideo` regression rejects in 81ms under an 80ms deadline (not the 120s default).

### What was not tested

Live stall against a real OpenAI Sora CDN endpoint. Sibling providers are deferred to follow-up PRs.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the remaining-budget resolver against DashScope, the decaying mock deadline contract, and caller-path plus loopback proof output.
