### PR TITLE
feat(widgets): unify show_widget across surfaces

### DIFF
--- a/docs/channels/discord-activities.md
+++ b/docs/channels/discord-activities.md
@@ -7,7 +7,7 @@ title: "Discord Activities"
 
 Discord Activities let an agent post an interactive, self-contained HTML widget to the current Discord channel. The message includes an **Open widget** button; clicking it launches the widget inside Discord.
 
-The feature is off by default. OpenClaw registers the Activity HTTP routes, `discord_widget` agent tool, and launch-button handler only when `channels.discord.activities` is present and a client secret resolves.
+The feature is off by default. OpenClaw registers the Activity HTTP routes, the `show_widget` agent tool, and the launch-button handler only when `channels.discord.activities` is present and a client secret resolves. The deprecated `discord_widget` alias remains available for one release.
 
 ## Prerequisites
 
@@ -82,7 +82,7 @@ Keep normal gateway authentication enabled. Only the Activity prefix is public, 
   </Step>
 
   <Step title="Restart and test">
-    Restart the gateway. In a Discord conversation, ask the agent to show an interactive widget. The agent can call `discord_widget`; click **Open widget** on the posted message.
+    Restart the gateway. In a Discord conversation, ask the agent to show an interactive widget. The agent calls `show_widget`; click **Open widget** on the posted message.
   </Step>
 </Steps>
 

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -1,14 +1,14 @@
 ---
-summary: "Render self-contained SVG or HTML widgets inline in web chat"
+summary: "Show self-contained HTML widgets on the current chat surface"
 title: "Show widget"
 sidebarTitle: "Show widget"
 read_when:
-  - You want an agent to render an interactive result inside web chat
+  - You want an agent to render an interactive result in web chat or Discord
   - You want widget buttons to send follow-up prompts into the chat
   - You need the show_widget input, security, or retention contract
 ---
 
-`show_widget` renders a self-contained SVG or HTML fragment inline in the Control UI chat transcript. The bundled Canvas plugin owns the tool and hosts each result as a same-origin Canvas document.
+`show_widget` shows a self-contained HTML widget on the user's current surface. In the Control UI, the Canvas plugin renders it inline in the chat transcript. In a Discord session with [Activities](/channels/discord-activities) enabled, the Discord plugin posts an **Open widget** button that launches it as an Activity.
 
 ## How widgets work
 
@@ -21,23 +21,27 @@ The wrapper document injects two small host bridges around the widget code:
 
 Everything else stays inside the frame: the document runs in an opaque origin with a strict Content Security Policy, so widget scripts cannot reach the Control UI, the Gateway, or the network.
 
-The tool is available only when the originating Gateway client declares the `inline-widgets` capability. The Control UI declares this capability automatically. Channel runs such as Telegram and WhatsApp do not receive `show_widget`.
+The Canvas implementation is available only when the originating Gateway client declares the `inline-widgets` capability. The Control UI declares this capability automatically. The Discord implementation is available only in Discord sessions with Activities configured. Other channel runs do not receive `show_widget`.
 
 Capability transport covers embedded, Codex app-server, and CLI-backed model backends. Grant-authenticated MCP callers and direct HTTP tool-invoke callers remain fail closed because they do not declare client capabilities.
 
 ## Use the tool
 
-The agent supplies two required strings:
+Both implementations use the same required fields:
 
 <ParamField path="title" type="string" required>
   Short title shown with the inline preview and in the hosted document title.
 </ParamField>
 
 <ParamField path="widget_code" type="string" required>
-  Self-contained SVG or HTML fragment. Input beginning with `<svg` after trimming is rendered in SVG mode; all other input is treated as an HTML fragment. Maximum length: 262,144 characters.
+  Self-contained HTML or SVG. In the Control UI, input beginning with `<svg` after trimming is rendered in SVG mode; maximum length is 262,144 characters. Discord accepts a complete HTML document or body fragment up to 48 KiB.
 </ParamField>
 
-The tool result includes a Canvas preview handle, so web chat renders the widget directly from the tool call and restores it after history reload. Transcripts that do not render previews still show the hosted Canvas path.
+Discord also accepts optional `button_label` text for the Activity launch button. The Canvas schema intentionally omits this Discord-only field.
+
+The Control UI result includes a Canvas preview handle, so web chat renders the widget directly from the tool call and restores it after history reload. Discord returns the stored widget and posted-message identifiers.
+
+`discord_widget` remains registered as a deprecated alias for one release. New agent calls should use `show_widget`.
 
 ## Interactive widgets
 
@@ -60,7 +64,7 @@ Accepted prompts appear in the transcript as regular user messages and start a n
 
 ## Security and storage
 
-Widget documents use a restrictive Content Security Policy: inline style and script are allowed, images may use `data:` URLs, and external fetches and resource loads are blocked. Keep all markup, styles, scripts, and image data inside `widget_code`.
+Widget documents use restrictive Content Security Policies. Inline style and script are allowed, while external fetches and resource loads are blocked. Keep all markup, styles, scripts, and image data inside `widget_code`.
 
 The iframe always omits `allow-same-origin`, even when the Control UI's global embed mode is `trusted`, so widget scripts cannot read the parent application origin. The Canvas host also serves widget documents with a `Content-Security-Policy: sandbox allow-scripts` response header, so opening the hosted URL directly still runs the widget in an opaque origin instead of the Control UI origin. Browser sandboxing does not prevent a script from navigating its own iframe; only render widget code you are willing to execute in that isolated frame.
 
@@ -71,5 +75,6 @@ Canvas retains at most 32 widgets per session (or per agent when no session is a
 ## Related
 
 - [Control UI hosted embeds](/web/control-ui#hosted-embeds)
+- [Discord Activities](/channels/discord-activities)
 - [Canvas plugin](/plugins/reference/canvas)
 - [Gateway protocol client capabilities](/gateway/protocol#client-capabilities)

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -458,7 +458,7 @@ Web Push is independent of the iOS APNS relay path (see [Configuration](/gateway
 
 Assistant messages can render hosted web content inline with the `[embed ...]` shortcode. The iframe sandbox policy is controlled by `gateway.controlUi.embedSandbox`:
 
-The bundled Canvas plugin also provides [`show_widget`](/tools/show-widget) to render self-contained SVG or HTML directly from a tool call. The browser advertises the `inline-widgets` Gateway capability, and the resulting Canvas document remains available when chat history reloads. Channel-originated runs do not receive this tool.
+The bundled Canvas plugin provides [`show_widget`](/tools/show-widget) to render self-contained SVG or HTML directly from a tool call. The browser advertises the `inline-widgets` Gateway capability, and the resulting Canvas document remains available when chat history reloads. Discord Activities provide the same tool name on Discord; other channel-originated runs do not receive it.
 
 <Tabs>
   <Tab title="strict">

--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -223,6 +223,13 @@ describe("Canvas plugin entry", () => {
       title: "Status",
       widget_code: "<p>ready</p>",
     });
+
+    const showWidgetRegistration = tools[1];
+    if (!showWidgetRegistration || typeof showWidgetRegistration.tool !== "function") {
+      throw new Error("expected show_widget factory registration");
+    }
+    const discordShowWidget = showWidgetRegistration.tool({ messageChannel: "discord" });
+    expect(discordShowWidget).toBeNull();
   });
 
   it.each([

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -65,7 +65,7 @@ function createLazyShowWidgetTool(params: {
     label: "Show Widget",
     name: "show_widget",
     description:
-      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data.",
+      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data. A global sendPrompt(text) function submits text to the chat as if the user typed it — wire it to buttons or controls to build interactive widgets. It only works after the user clicks inside the widget (plain conversational text only; slash commands are rejected), so never call it automatically.",
     parameters: ShowWidgetToolSchema,
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -65,7 +65,7 @@ function createLazyShowWidgetTool(params: {
     label: "Show Widget",
     name: "show_widget",
     description:
-      "Render self-contained SVG or HTML inline in web chat. Use for visual or interactive results; external resources are blocked, so inline all required code and data.",
+      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data.",
     parameters: ShowWidgetToolSchema,
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
@@ -183,7 +183,9 @@ export default definePluginEntry({
     );
     api.registerTool(
       (ctx) =>
-        isCanvasHostEnabled(ctx.runtimeConfig ?? ctx.config)
+        // Discord owns show_widget for Discord sessions; keep the two factories
+        // mutually exclusive before plugin tool names are de-duplicated.
+        ctx.messageChannel !== "discord" && isCanvasHostEnabled(ctx.runtimeConfig ?? ctx.config)
           ? createLazyShowWidgetTool({
               config: ctx.runtimeConfig ?? ctx.config,
               sessionId: ctx.sessionId,

--- a/extensions/canvas/src/widget-tool.ts
+++ b/extensions/canvas/src/widget-tool.ts
@@ -76,7 +76,7 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
     label: "Show Widget",
     name: "show_widget",
     description:
-      "Render self-contained SVG or HTML inline in web chat. Use for visual or interactive results; external resources are blocked, so inline all required code and data. A global sendPrompt(text) function submits text to the chat as if the user typed it — wire it to buttons or controls to build interactive widgets. It only works after the user clicks inside the widget (plain conversational text only; slash commands are rejected), so never call it automatically.",
+      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data. A global sendPrompt(text) function submits text to the chat as if the user typed it — wire it to buttons or controls to build interactive widgets. It only works after the user clicks inside the widget (plain conversational text only; slash commands are rejected), so never call it automatically.",
     parameters: ShowWidgetToolSchema,
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (_toolCallId, args) => {

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -14,6 +14,7 @@
   ],
   "contracts": {
     "tools": [
+      "show_widget",
       "discord_widget"
     ],
     "transcriptSourceProviders": [

--- a/extensions/discord/src/activities/register.test.ts
+++ b/extensions/discord/src/activities/register.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 
 function createApi(config: Record<string, unknown>) {
   const routes: unknown[] = [];
-  const tools: unknown[] = [];
+  const tools: Array<{ tool: unknown; opts?: { name?: string } }> = [];
   const warn = vi.fn();
   const resolvePath = vi.fn((input: string) => `/plugin-root/${input}`);
   const api = {
@@ -22,7 +22,7 @@ function createApi(config: Record<string, unknown>) {
       config: { current: () => config },
     },
     registerHttpRoute: vi.fn((route) => routes.push(route)),
-    registerTool: vi.fn((tool) => tools.push(tool)),
+    registerTool: vi.fn((tool, opts) => tools.push({ tool, opts })),
     resolvePath,
   } as unknown as OpenClawPluginApi;
   return { api, routes, tools, warn, resolvePath };
@@ -64,7 +64,7 @@ describe("Discord Activities registration", () => {
     expect(getDiscordActivitiesRuntime()).toBeUndefined();
   });
 
-  it("registers the public plugin route and Discord-only tool factory when configured", () => {
+  it("registers the public route and both Discord-only widget tool factories", () => {
     const test = createApi({
       channels: {
         discord: {
@@ -81,9 +81,11 @@ describe("Discord Activities registration", () => {
       match: "prefix",
     });
     expect(test.resolvePath).toHaveBeenCalledWith("assets/embedded-app-sdk.mjs");
-    expect(test.tools).toHaveLength(1);
-    const factory = test.tools[0] as (context: { messageChannel?: string }) => unknown;
-    expect(factory({ messageChannel: "slack" })).toBeNull();
-    expect(factory({ messageChannel: "discord" })).not.toBeNull();
+    expect(test.tools.map(({ opts }) => opts?.name)).toEqual(["show_widget", "discord_widget"]);
+    for (const { tool } of test.tools) {
+      const factory = tool as (context: { messageChannel?: string }) => unknown;
+      expect(factory({ messageChannel: "slack" })).toBeNull();
+      expect(factory({ messageChannel: "discord" })).not.toBeNull();
+    }
   });
 });

--- a/extensions/discord/src/activities/register.ts
+++ b/extensions/discord/src/activities/register.ts
@@ -10,7 +10,7 @@ import { createDiscordActivityHttpHandler } from "./http.js";
 import { DiscordActivitiesRuntime, setDiscordActivitiesRuntime } from "./runtime.js";
 import { DISCORD_ACTIVITY_ROUTE_PREFIX } from "./shell.js";
 import { DiscordActivityStore, openDiscordActivityStores } from "./store.js";
-import { createDiscordWidgetTool } from "./tool.js";
+import { createDiscordShowWidgetTool, createDiscordWidgetTool } from "./tool.js";
 
 export function registerDiscordActivities(api: OpenClawPluginApi): void {
   setDiscordActivitiesRuntime(undefined);
@@ -58,6 +58,10 @@ export function registerDiscordActivities(api: OpenClawPluginApi): void {
     match: "prefix",
     handler: async (req, res) => await http.handleHttpRequest(req, res),
   });
+  api.registerTool((context) => createDiscordShowWidgetTool(context, { runtime }), {
+    name: "show_widget",
+  });
+  // One-release deprecation window: remove this alias in the next release.
   api.registerTool((context) => createDiscordWidgetTool(context, { runtime }), {
     name: "discord_widget",
   });

--- a/extensions/discord/src/activities/tool.test.ts
+++ b/extensions/discord/src/activities/tool.test.ts
@@ -8,7 +8,7 @@ import { buildDiscordComponentMessage } from "../components.js";
 import type { sendDiscordComponentMessage } from "../send.components.js";
 import { createDiscordSendReceipt } from "../send.receipt.js";
 import { createActivityTestRuntime } from "./test-helpers.test-support.js";
-import { createDiscordWidgetTool } from "./tool.js";
+import { createDiscordShowWidgetTool, createDiscordWidgetTool } from "./tool.js";
 
 function discordContext(overrides: Partial<OpenClawPluginToolContext> = {}) {
   return {
@@ -26,6 +26,20 @@ describe("discord_widget", () => {
         runtime: createActivityTestRuntime(),
       }),
     ).toBeNull();
+  });
+
+  it("marks the legacy name deprecated", () => {
+    const tool = createDiscordWidgetTool(discordContext(), {
+      runtime: createActivityTestRuntime(),
+    });
+    if (!tool) {
+      throw new Error("expected deprecated Discord widget tool");
+    }
+
+    expect(tool.description).toMatch(/^Deprecated: use show_widget\./);
+    expect((tool.parameters as { properties?: Record<string, unknown> }).properties).toHaveProperty(
+      "html",
+    );
   });
 
   it("stores a wrapped widget and posts its launch button", async () => {
@@ -242,5 +256,49 @@ describe("discord_widget", () => {
     await expect(tool.execute("dm-target", { html: "hello", title: "No channel" })).rejects.toThrow(
       "requires a concrete Discord channel",
     );
+  });
+});
+
+describe("show_widget", () => {
+  it("maps widget_code to the Discord Activity document", async () => {
+    const runtime = createActivityTestRuntime();
+    const send = vi.fn(async (..._args: Parameters<typeof sendDiscordComponentMessage>) => ({
+      messageId: "message-1",
+      channelId: "987654321",
+      receipt: {},
+    }));
+    const tool = createDiscordShowWidgetTool(discordContext(), {
+      runtime,
+      sendComponentMessage: send as unknown as typeof sendDiscordComponentMessage,
+    });
+    if (!tool) {
+      throw new Error("expected unified Discord widget tool");
+    }
+
+    expect(tool.name).toBe("show_widget");
+    expect(tool.description).toMatch(/^Show an interactive, self-contained HTML widget/);
+    expect((tool.parameters as { properties?: Record<string, unknown> }).properties).toMatchObject({
+      title: expect.any(Object),
+      widget_code: expect.any(Object),
+      button_label: expect.any(Object),
+    });
+    expect(
+      (tool.parameters as { properties?: Record<string, unknown> }).properties,
+    ).not.toHaveProperty("html");
+
+    const result = await tool.execute("unified-widget", {
+      title: "Unified",
+      widget_code: "<p>Discord surface</p>",
+      button_label: "Launch",
+    });
+    const details = result.details as { widgetId: string };
+
+    await expect(runtime.store.lookupWidget(details.widgetId)).resolves.toMatchObject({
+      title: "Unified",
+      html: expect.stringContaining("<p>Discord surface</p>"),
+    });
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      blocks: [{ buttons: [{ label: "Launch" }] }],
+    });
   });
 });

--- a/extensions/discord/src/activities/tool.ts
+++ b/extensions/discord/src/activities/tool.ts
@@ -22,6 +22,12 @@ const DiscordWidgetParameters = Type.Object({
   button_label: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
 });
 
+const ShowWidgetParameters = Type.Object({
+  title: Type.String({ minLength: 1, maxLength: 80 }),
+  widget_code: Type.String({ description: "Self-contained HTML document or body fragment" }),
+  button_label: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
+});
+
 function currentConfig(context: OpenClawPluginToolContext, runtime: DiscordActivitiesRuntime) {
   return (
     context.getRuntimeConfig?.() ??
@@ -58,9 +64,36 @@ type DiscordWidgetToolDeps = {
   now?: () => number;
 };
 
-export function createDiscordWidgetTool(
+type DiscordWidgetToolVariant = {
+  name: "discord_widget" | "show_widget";
+  label: string;
+  description: string;
+  htmlParam: "html" | "widget_code";
+  parameters: typeof DiscordWidgetParameters | typeof ShowWidgetParameters;
+};
+
+const DISCORD_WIDGET_VARIANT: DiscordWidgetToolVariant = {
+  name: "discord_widget",
+  label: "Discord Widget",
+  description:
+    "Deprecated: use show_widget. Show an interactive, self-contained HTML widget to the user in Discord.",
+  htmlParam: "html",
+  parameters: DiscordWidgetParameters,
+};
+
+const SHOW_WIDGET_VARIANT: DiscordWidgetToolVariant = {
+  name: "show_widget",
+  label: "Show Widget",
+  description:
+    "Show an interactive, self-contained HTML widget to the user on their current surface. In Discord, posts an Activity launch button.",
+  htmlParam: "widget_code",
+  parameters: ShowWidgetParameters,
+};
+
+function createDiscordWidgetToolVariant(
   context: OpenClawPluginToolContext,
   deps: DiscordWidgetToolDeps,
+  variant: DiscordWidgetToolVariant,
 ): AnyAgentTool | null {
   if (context.messageChannel !== "discord") {
     return null;
@@ -75,20 +108,21 @@ export function createDiscordWidgetTool(
   }
 
   return {
-    label: "Discord Widget",
-    name: "discord_widget",
-    description:
-      "Show an interactive HTML widget to Discord users. Posts a message with an Open widget button; the widget opens inside Discord as an Activity. HTML must be fully self-contained with inline CSS and JavaScript and no external network access.",
-    parameters: DiscordWidgetParameters,
+    label: variant.label,
+    name: variant.name,
+    description: variant.description,
+    parameters: variant.parameters,
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as Record<string, unknown>;
-      const html = readStringParam(params, "html", { required: true, trim: false });
+      const html = readStringParam(params, variant.htmlParam, { required: true, trim: false });
       const title = readStringParam(params, "title", { required: true });
       const buttonLabel = readStringParam(params, "button_label") || "Open widget";
       if (!html.trim()) {
-        throw new WidgetHtmlInputError("html is required");
+        throw new WidgetHtmlInputError(`${variant.htmlParam} is required`);
       }
-      assertWidgetHtmlSize(html, DISCORD_WIDGET_HTML_MAX_BYTES);
+      assertWidgetHtmlSize(html, DISCORD_WIDGET_HTML_MAX_BYTES, {
+        inputName: variant.htmlParam,
+      });
       if (title.length > 80) {
         throw new WidgetHtmlInputError("title must be 80 characters or fewer");
       }
@@ -98,7 +132,7 @@ export function createDiscordWidgetTool(
       const channelId = resolveDiscordChannelId(context);
       if (!channelId) {
         throw new WidgetHtmlInputError(
-          "discord_widget requires a concrete Discord channel in the current session",
+          `${variant.name} requires a concrete Discord channel in the current session`,
         );
       }
       // Persist before the button can be delivered so a launch never races an absent record;
@@ -151,4 +185,18 @@ export function createDiscordWidgetTool(
       return jsonResult({ widgetId, messageId: result.messageId, channelId: result.channelId });
     },
   };
+}
+
+export function createDiscordWidgetTool(
+  context: OpenClawPluginToolContext,
+  deps: DiscordWidgetToolDeps,
+): AnyAgentTool | null {
+  return createDiscordWidgetToolVariant(context, deps, DISCORD_WIDGET_VARIANT);
+}
+
+export function createDiscordShowWidgetTool(
+  context: OpenClawPluginToolContext,
+  deps: DiscordWidgetToolDeps,
+): AnyAgentTool | null {
+  return createDiscordWidgetToolVariant(context, deps, SHOW_WIDGET_VARIANT);
 }

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -791,6 +791,7 @@ describe("createOpenClawCodingTools", () => {
         modelProvider: "openrouter",
         modelId: "openrouter/auto",
         nativeChannelId: "oc_native_chat",
+        clientCaps: ["inline-widgets"],
         toolConstructionPlan: {
           includeBaseCodingTools: false,
           includeShellTools: false,
@@ -806,6 +807,7 @@ describe("createOpenClawCodingTools", () => {
       expect(pluginToolOptions?.modelProvider).toBe("openrouter");
       expect(pluginToolOptions?.modelId).toBe("openrouter/auto");
       expect(pluginToolOptions?.nativeChannelId).toBe("oc_native_chat");
+      expect(pluginToolOptions?.clientCaps).toEqual(["inline-widgets"]);
     } finally {
       resolvePluginToolsSpy.mockRestore();
     }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -872,6 +872,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             disableMessageTool: options?.disableMessageTool,
             requesterAgentIdOverride: agentId,
             allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
+            clientCaps: options?.clientCaps,
             authProfileStore: options?.authProfileStore,
           },
           resolvedConfig: options?.config,

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -31,6 +31,7 @@ type ResolveOpenClawPluginToolsOptions = OpenClawPluginToolOptions & {
   requireExplicitMessageTarget?: boolean;
   disableMessageTool?: boolean;
   disablePluginTools?: boolean;
+  clientCaps?: string[];
   authProfileStore?: AuthProfileStore;
 };
 
@@ -92,6 +93,7 @@ export function resolveOpenClawPluginToolsForOptions(params: {
       ...(resolveApiKeyForProvider ? { resolveApiKeyForProvider } : {}),
     },
     existingToolNames,
+    clientCaps: params.options?.clientCaps,
     toolAllowlist: params.options?.pluginToolAllowlist,
     toolDenylist: params.options?.pluginToolDenylist,
     allowGatewaySubagentBinding: params.options?.allowGatewaySubagentBinding,

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -78,6 +78,23 @@ describe("plugin tool descriptor cache keys", () => {
     expect(cached.requiredClientCaps).toEqual(["inline-widgets"]);
   });
 
+  it("isolates descriptor caches by declared gateway client capabilities", () => {
+    const base = {
+      pluginId: "demo",
+      source: "/tmp/demo.js",
+      contractToolNames: ["show_widget"],
+      ctx: { workspaceDir: "/tmp/workspace" },
+    };
+
+    const caplessKey = buildPluginToolDescriptorCacheKey(base);
+    const inlineKey = buildPluginToolDescriptorCacheKey({
+      ...base,
+      clientCaps: ["inline-widgets"],
+    });
+
+    expect(caplessKey).not.toBe(inlineKey);
+  });
+
   it("keeps distinct config objects distinct within the memo", () => {
     const firstConfig = { id: "first" } as never;
     const secondConfig = { id: "second" } as never;

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -125,6 +125,7 @@ export function buildPluginToolDescriptorCacheKey(params: {
   ctx: OpenClawPluginToolContext;
   currentRuntimeConfig?: PluginLoadOptions["config"] | null;
   configCacheKeyMemo?: PluginToolDescriptorConfigCacheKeyMemo;
+  clientCaps?: readonly string[];
 }): string {
   return JSON.stringify({
     version: PLUGIN_TOOL_DESCRIPTOR_CACHE_VERSION,
@@ -133,6 +134,7 @@ export function buildPluginToolDescriptorCacheKey(params: {
     rootDir: params.rootDir ?? null,
     sourceFingerprint: sourceFingerprint(params.source),
     contractToolNames: [...params.contractToolNames].toSorted(),
+    clientCaps: [...(params.clientCaps ?? [])].toSorted(),
     context: buildDescriptorContextCacheKey({
       ctx: params.ctx,
       currentRuntimeConfig: params.currentRuntimeConfig,

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -75,6 +75,7 @@ function createContext() {
 
 function createResolveToolsParams(params?: {
   context?: ReturnType<typeof createContext> & Record<string, unknown>;
+  clientCaps?: string[];
   toolAllowlist?: readonly string[];
   toolDenylist?: readonly string[];
   existingToolNames?: Set<string>;
@@ -89,6 +90,7 @@ function createResolveToolsParams(params?: {
   );
   return {
     context: (params?.context ?? createContext()) as never,
+    ...(params?.clientCaps ? { clientCaps: params.clientCaps } : {}),
     ...(toolAllowlist.length > 0 ? { toolAllowlist } : {}),
     ...(params?.toolDenylist ? { toolDenylist: [...params.toolDenylist] } : {}),
     ...(params?.existingToolNames ? { existingToolNames: params.existingToolNames } : {}),
@@ -1996,6 +1998,79 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["canvas", "show_widget"]);
     expect(registry.diagnostics).toHaveLength(0);
+  });
+
+  it("filters client-cap tools before resolving contextual duplicate names", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "canvas",
+        optional: false,
+        source: "/tmp/canvas.js",
+        names: ["show_widget"],
+        factory: (context) =>
+          (context as { messageChannel?: string }).messageChannel === "discord"
+            ? null
+            : {
+                ...makeTool("show_widget"),
+                description: "canvas implementation",
+                requiredClientCaps: ["inline-widgets"],
+              },
+      },
+      {
+        pluginId: "discord",
+        optional: false,
+        source: "/tmp/discord.js",
+        names: ["show_widget"],
+        factory: (context) =>
+          (context as { messageChannel?: string }).messageChannel === "discord"
+            ? { ...makeTool("show_widget"), description: "discord implementation" }
+            : null,
+      },
+    ]);
+
+    const discordTools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...createContext(), messageChannel: "discord" },
+        clientCaps: ["inline-widgets"],
+      }),
+    );
+    expect(discordTools.map((tool) => [tool.name, tool.description])).toEqual([
+      ["show_widget", "discord implementation"],
+    ]);
+
+    const webTools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...createContext(), messageChannel: "webchat" },
+        clientCaps: ["inline-widgets"],
+      }),
+    );
+    expect(webTools.map((tool) => [tool.name, tool.description])).toEqual([
+      ["show_widget", "canvas implementation"],
+    ]);
+    expect(registry.diagnostics).toHaveLength(0);
+  });
+
+  it("isolates tools with malformed required client capabilities", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "multi",
+        optional: false,
+        source: "/tmp/multi.js",
+        names: ["broken_tool", "other_tool"],
+        factory: () => [
+          { ...makeTool("broken_tool"), requiredClientCaps: "inline-widgets" },
+          makeTool("other_tool"),
+        ],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams({ clientCaps: ["inline-widgets"] }));
+
+    expectResolvedToolNames(tools, ["other_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "broken_tool requiredClientCaps must be an array of strings",
+    );
   });
 
   it.each([

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -393,6 +393,24 @@ function readPluginToolName(tool: unknown): string {
   return typeof tool.name === "string" ? tool.name.trim() : "";
 }
 
+function hasRequiredClientCaps(
+  requiredClientCaps: unknown,
+  clientCaps: ReadonlySet<string>,
+): boolean {
+  // Leave malformed metadata for describeMalformedPluginTool so one plugin
+  // cannot abort resolution before the normal isolation diagnostic runs.
+  if (requiredClientCaps === undefined) {
+    return true;
+  }
+  if (
+    !Array.isArray(requiredClientCaps) ||
+    requiredClientCaps.some((requiredCap) => typeof requiredCap !== "string")
+  ) {
+    return true;
+  }
+  return !requiredClientCaps.some((requiredCap) => !clientCaps.has(requiredCap));
+}
+
 function toElapsedMs(value: number): number {
   return Math.max(0, Math.round(value));
 }
@@ -531,6 +549,13 @@ function describeMalformedPluginTool(tool: unknown): string | undefined {
   }
   if (!isRecord(tool.parameters)) {
     return `${name} missing parameters object`;
+  }
+  if (
+    tool.requiredClientCaps !== undefined &&
+    (!Array.isArray(tool.requiredClientCaps) ||
+      tool.requiredClientCaps.some((requiredCap) => typeof requiredCap !== "string"))
+  ) {
+    return `${name} requiredClientCaps must be an array of strings`;
   }
   return undefined;
 }
@@ -705,6 +730,7 @@ function buildPluginDescriptorCacheKey(params: {
   ctx: OpenClawPluginToolContext;
   currentRuntimeConfig?: PluginLoadOptions["config"] | null;
   configCacheKeyMemo?: PluginToolDescriptorConfigCacheKeyMemo;
+  clientCaps?: ReadonlySet<string>;
 }): string {
   return buildPluginToolDescriptorCacheKey({
     pluginId: params.plugin.id,
@@ -714,6 +740,7 @@ function buildPluginDescriptorCacheKey(params: {
     ctx: params.ctx,
     currentRuntimeConfig: params.currentRuntimeConfig,
     configCacheKeyMemo: params.configCacheKeyMemo,
+    clientCaps: params.clientCaps ? [...params.clientCaps] : undefined,
   });
 }
 
@@ -856,6 +883,7 @@ function resolveCachedPluginTools(params: {
   runtimeOptions: PluginLoadOptions["runtimeOptions"];
   currentRuntimeConfig?: PluginLoadOptions["config"] | null;
   configCacheKeyMemo: PluginToolDescriptorConfigCacheKeyMemo;
+  clientCaps: ReadonlySet<string>;
 }): { tools: AnyAgentTool[]; handledPluginIds: Set<string> } {
   const tools: AnyAgentTool[] = [];
   const handledPluginIds = new Set<string>();
@@ -909,6 +937,7 @@ function resolveCachedPluginTools(params: {
         ctx: params.ctx,
         currentRuntimeConfig: params.currentRuntimeConfig,
         configCacheKeyMemo: params.configCacheKeyMemo,
+        clientCaps: params.clientCaps,
       }),
     );
     if (
@@ -924,6 +953,9 @@ function resolveCachedPluginTools(params: {
     let hasNameConflict = false;
     const localNormalizedNames = new Set<string>();
     for (const cachedDescriptor of cached) {
+      if (!hasRequiredClientCaps(cachedDescriptor.requiredClientCaps, params.clientCaps)) {
+        continue;
+      }
       if (
         blocksHostRestrictedConversationReadTool({
           pluginId: plugin.id,
@@ -1262,6 +1294,7 @@ export function ensureStandalonePluginToolRegistryLoaded(params: {
 export function resolvePluginTools(params: {
   context: OpenClawPluginToolContext;
   existingToolNames?: Set<string>;
+  clientCaps?: string[];
   toolAllowlist?: string[];
   toolDenylist?: string[];
   suppressNameConflicts?: boolean;
@@ -1287,6 +1320,7 @@ export function resolvePluginTools(params: {
   const allowlist = normalizeAllowlist(params.toolAllowlist);
   const denylist = normalizeDenylist(params.toolDenylist);
   const configCacheKeyMemo = createPluginToolDescriptorConfigCacheKeyMemo();
+  const clientCaps = new Set(params.clientCaps ?? []);
   let currentRuntimeConfigForDescriptorCache: PluginLoadOptions["config"] | null | undefined =
     params.context.runtimeConfig;
   if (currentRuntimeConfigForDescriptorCache === undefined && params.context.getRuntimeConfig) {
@@ -1313,6 +1347,7 @@ export function resolvePluginTools(params: {
     runtimeOptions,
     currentRuntimeConfig: currentRuntimeConfigForDescriptorCache,
     configCacheKeyMemo,
+    clientCaps,
   });
   tools.push(...cached.tools);
   const runtimePluginIds = onlyPluginIds.filter(
@@ -1536,11 +1571,14 @@ export function resolvePluginTools(params: {
           }),
         )
       : policyAvailableList;
-    if (list.length === 0) {
+    const clientAvailableList = list.filter((tool) =>
+      isRecord(tool) ? hasRequiredClientCaps(tool.requiredClientCaps, clientCaps) : true,
+    );
+    if (clientAvailableList.length === 0) {
       continue;
     }
     const normalizedNameSet = new Set<string>();
-    for (const toolRaw of list) {
+    for (const toolRaw of clientAvailableList) {
       // Plugin factories run at request time and can return arbitrary values; isolate
       // malformed tools here so one bad plugin tool cannot poison every provider.
       const malformedReason = describeMalformedPluginTool(toolRaw);
@@ -1653,6 +1691,7 @@ export function resolvePluginTools(params: {
           ctx: params.context,
           currentRuntimeConfig: currentRuntimeConfigForDescriptorCache,
           configCacheKeyMemo,
+          clientCaps,
         }),
         descriptors,
       });


### PR DESCRIPTION
## What Problem This Solves

Agents faced two tools for the same intent: `show_widget` (Control UI inline canvas) and `discord_widget` (Discord Activities). Models had to know which surface they were on and pick the right name — the opposite of the portable-presentation goal. Worse, the plugin tool registry filtered `requiredClientCaps` only *after* duplicate-name resolution, so a capability-gated tool could shadow a same-named tool and then be filtered away, leaving neither (latent bug, previously unreachable only because no two plugins shared a name).

## Why This Change Was Made

Phase 3 (final) of the widget/canvas unification program (#108807, #108927). One agent-facing tool: `show_widget {title, widget_code}` everywhere — canvas keeps the inline iframe in `inline-widgets` clients; the Discord activities plugin registers its own `show_widget` (plus optional `button_label`) posting the Activity launch button. Factories are contextually exclusive (canvas returns null for Discord sessions, with an inline ownership comment; regression-tested including the discord+inline-widgets overlap case). The registry now filters capability-gated tools *before* duplicate-name resolution, client caps flow through all plugin assembly paths and the tool-descriptor cache key, and malformed `requiredClientCaps` metadata gets the standard per-plugin isolation diagnostic. `discord_widget` stays registered for one release as a deprecated alias. Docs updated in place, including reconciling with the freshly-landed sendPrompt prompt-bridge docs, and the canvas lazy descriptor now carries the same model-facing description as the loaded tool (fixing a drift main shipped).

## User Impact

Release-note summary: agents can call `show_widget` on both the Control UI and Discord; `discord_widget` remains as a deprecated alias for one release.

Known seam (deliberate, for the canvas-ownership follow-up): canvas prod code now names the `discord` channel in its exclusion check — acceptable single-comparison with a tested contract, to be generalized when a third channel grows widget support.

## Evidence

- Focused vitest: discord activities (register/tool), canvas (index/widget-tool), plugin registry (tools.optional, tool-descriptor-cache), agent assembly propagation — 4 shards green.
- tsgo core-test + extensions-test lanes: 0 errors (run directly; the autoreview parallel-test sandbox cannot run fnm).
- Structured autoreview (codex/gpt-5.6-sol, branch vs origin/main): clean, "patch is correct (0.87)"; an earlier Codex-side autoreview cycle found and fixed two P2s before handoff.
- Collision-order finding documented in-code: capability filter now precedes duplicate-name resolution (src/plugins/tools.ts), caps included in descriptor cache keys.
