### PR TITLE
fix(telegram): preserve forward origins in debounce batches

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
@@ -136,12 +136,14 @@ export function createTelegramInboundDebounceRuntime(
         }
         // Single entries return above with their original message and structured forward metadata.
         const first = expectDefined(entries.at(0), "multi-entry Telegram debounce batch");
-        const syntheticMessage = buildSyntheticTextMessage({
-          base: first.msg,
-          text: combinedText,
-          date: last.msg.date ?? first.msg.date,
-          stripForwardOrigin: true,
-        });
+        const syntheticMessage = {
+          ...buildSyntheticTextMessage({
+            base: first.msg,
+            text: combinedText,
+            date: last.msg.date ?? first.msg.date,
+          }),
+          forward_origin: undefined,
+        };
         const result = await processMessageWithReplyChain({
           ctx: buildSyntheticContext(first.ctx, syntheticMessage),
           msg: syntheticMessage,

--- a/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
@@ -134,11 +134,13 @@ export function createTelegramInboundDebounceRuntime(
           settleSpooledReplayParticipants(participants, { kind: "skipped" });
           return;
         }
+        // Single entries return above with their original message and structured forward metadata.
         const first = expectDefined(entries.at(0), "multi-entry Telegram debounce batch");
         const syntheticMessage = buildSyntheticTextMessage({
           base: first.msg,
           text: combinedText,
           date: last.msg.date ?? first.msg.date,
+          stripForwardOrigin: true,
         });
         const result = await processMessageWithReplyChain({
           ctx: buildSyntheticContext(first.ctx, syntheticMessage),
@@ -152,6 +154,7 @@ export function createTelegramInboundDebounceRuntime(
             ),
             receivedAtMs: first.receivedAtMs,
             ingressBuffer: "inbound-debounce",
+            inboundDebounceMessages: entries.map((entry) => entry.msg),
             ...promptContextBoundaryOptions(
               latestPromptContextMinTimestampMs(
                 ...entries.map((entry) => entry.promptContextMinTimestampMs),

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
@@ -143,7 +143,6 @@ export function createTelegramMessageLifecycleRuntime({
     text: string;
     date?: number;
     from?: Message["from"];
-    stripForwardOrigin?: boolean;
   }): Message => ({
     ...params.base,
     ...(params.from ? { from: params.from } : {}),
@@ -151,7 +150,6 @@ export function createTelegramMessageLifecycleRuntime({
     caption: undefined,
     caption_entities: undefined,
     entities: undefined,
-    ...(params.stripForwardOrigin ? { forward_origin: undefined } : {}),
     ...(params.date != null ? { date: params.date } : {}),
   });
   const buildSyntheticContext = (

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.runtime.ts
@@ -143,6 +143,7 @@ export function createTelegramMessageLifecycleRuntime({
     text: string;
     date?: number;
     from?: Message["from"];
+    stripForwardOrigin?: boolean;
   }): Message => ({
     ...params.base,
     ...(params.from ? { from: params.from } : {}),
@@ -150,6 +151,7 @@ export function createTelegramMessageLifecycleRuntime({
     caption: undefined,
     caption_entities: undefined,
     entities: undefined,
+    ...(params.stripForwardOrigin ? { forward_origin: undefined } : {}),
     ...(params.date != null ? { date: params.date } : {}),
   });
   const buildSyntheticContext = (

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -112,7 +112,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
     expect(payload?.ForwardedFrom).toBeUndefined();
   });
 
-  it("attributes forwarded media-only segments", async () => {
+  it("keeps mixed text and forwarded media segments ordered", async () => {
     const chat = { id: 999, type: "private" as const, first_name: "Alice" };
     const sender = { id: 42, first_name: "Alice", is_bot: false };
     const photo = [{ file_id: "photo-1", file_unique_id: "unique-1", width: 1, height: 1 }];
@@ -121,13 +121,9 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
         message_id: 2,
         chat,
         from: sender,
-        text: "",
-        photo,
+        text: "ordinary note",
       },
-      allMedia: [
-        { path: "/tmp/photo-1.jpg", contentType: "image/jpeg" },
-        { path: "/tmp/photo-2.jpg", contentType: "image/jpeg" },
-      ],
+      allMedia: [{ path: "/tmp/photo-1.jpg", contentType: "image/jpeg" }],
       options: {
         inboundDebounceMessages: [
           {
@@ -135,12 +131,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
             date: 1_700_000_000,
             chat,
             from: sender,
-            photo,
-            forward_origin: {
-              type: "hidden_user",
-              sender_user_name: "Original A",
-              date: 500,
-            },
+            text: "ordinary note",
           },
           {
             message_id: 2,
@@ -151,16 +142,16 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
             forward_origin: {
               type: "hidden_user",
               sender_user_name: "Original B",
-              date: 501,
+              date: 500,
             },
           },
         ],
       },
     });
 
-    const expectedBody =
-      /\[Forwarded from Original A[^\]]*\]\n<media:image>\n\[Forwarded from Original B[^\]]*\]\n<media:image>/;
+    const expectedBody = /ordinary note\n\[Forwarded from Original B[^\]]*\]\n<media:image>/;
     expect(context?.ctxPayload.Body).toMatch(expectedBody);
     expect(context?.ctxPayload.BodyForAgent).toMatch(expectedBody);
+    expect(context?.ctxPayload.CommandBody).toBe("ordinary note");
   });
 });

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -47,7 +47,9 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
       /ordinary note\n\[Forwarded from Original B[^\]]*\]\nforwarded note/,
     );
     expect(payload?.Body).not.toContain("Wrong inherited origin");
-    expect(payload?.BodyForAgent).toBe("ordinary note\nforwarded note");
+    expect(payload?.BodyForAgent).toMatch(
+      /ordinary note\n\[Forwarded from Original B[^\]]*\]\nforwarded note/,
+    );
     expect(payload?.ForwardedFrom).toBeUndefined();
   });
 
@@ -106,6 +108,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
     expect(payload?.Body).toContain("ordinary note\nprivate forwarded note");
     expect(payload?.Body).not.toContain("[Forwarded from");
     expect(payload?.Body).not.toContain("Hidden");
+    expect(payload?.BodyForAgent).toBe("ordinary note\nprivate forwarded note");
     expect(payload?.ForwardedFrom).toBeUndefined();
   });
 
@@ -155,8 +158,9 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
       },
     });
 
-    expect(context?.ctxPayload.Body).toMatch(
-      /\[Forwarded from Original A[^\]]*\]\n<media:image>\n\[Forwarded from Original B[^\]]*\]\n<media:image>/,
-    );
+    const expectedBody =
+      /\[Forwarded from Original A[^\]]*\]\n<media:image>\n\[Forwarded from Original B[^\]]*\]\n<media:image>/;
+    expect(context?.ctxPayload.Body).toMatch(expectedBody);
+    expect(context?.ctxPayload.BodyForAgent).toMatch(expectedBody);
   });
 });

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext forwarded debounce batches", () => {
+  it("keeps ordinary text plain while attributing only the forwarded segment", async () => {
+    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 2,
+        chat,
+        from: sender,
+        text: "ordinary note\nforwarded note",
+        forward_origin: {
+          type: "hidden_user",
+          sender_user_name: "Wrong inherited origin",
+          date: 400,
+        },
+      },
+      options: {
+        inboundDebounceMessages: [
+          {
+            message_id: 1,
+            date: 1_700_000_000,
+            chat,
+            from: sender,
+            text: "ordinary note",
+          },
+          {
+            message_id: 2,
+            date: 1_700_000_001,
+            chat,
+            from: sender,
+            text: "forwarded note",
+            forward_origin: {
+              type: "hidden_user",
+              sender_user_name: "Original B",
+              date: 500,
+            },
+          },
+        ],
+      },
+    });
+
+    const payload = context?.ctxPayload;
+    expect(payload?.Body).toMatch(
+      /ordinary note\n\[Forwarded from Original B[^\]]*\]\nforwarded note/,
+    );
+    expect(payload?.Body).not.toContain("Wrong inherited origin");
+    expect(payload?.BodyForAgent).toBe("ordinary note\nforwarded note");
+    expect(payload?.ForwardedFrom).toBeUndefined();
+  });
+
+  it("redacts a debounced forward origin denied by group context visibility", async () => {
+    const chat = { id: -1007, type: "group" as const, title: "Ops" };
+    const sender = { id: 1, first_name: "Allowed", is_bot: false };
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 2,
+        chat,
+        from: sender,
+        text: "ordinary note\nprivate forwarded note",
+      },
+      cfg: {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            contextVisibility: "allowlist",
+          },
+        },
+      },
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false, allowFrom: ["1"] },
+        topicConfig: undefined,
+      }),
+      options: {
+        inboundDebounceMessages: [
+          {
+            message_id: 1,
+            date: 1_700_000_000,
+            chat,
+            from: sender,
+            text: "ordinary note",
+          },
+          {
+            message_id: 2,
+            date: 1_700_000_001,
+            chat,
+            from: sender,
+            text: "private forwarded note",
+            forward_origin: {
+              type: "user",
+              sender_user: {
+                id: 999,
+                first_name: "Hidden",
+                is_bot: false,
+              },
+              date: 500,
+            },
+          },
+        ],
+      },
+    });
+
+    const payload = context?.ctxPayload;
+    expect(payload?.Body).toContain("ordinary note\nprivate forwarded note");
+    expect(payload?.Body).not.toContain("[Forwarded from");
+    expect(payload?.Body).not.toContain("Hidden");
+    expect(payload?.ForwardedFrom).toBeUndefined();
+  });
+
+  it("attributes forwarded media-only segments", async () => {
+    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const photo = [{ file_id: "photo-1", file_unique_id: "unique-1", width: 1, height: 1 }];
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 2,
+        chat,
+        from: sender,
+        text: "",
+        photo,
+      },
+      allMedia: [
+        { path: "/tmp/photo-1.jpg", contentType: "image/jpeg" },
+        { path: "/tmp/photo-2.jpg", contentType: "image/jpeg" },
+      ],
+      options: {
+        inboundDebounceMessages: [
+          {
+            message_id: 1,
+            date: 1_700_000_000,
+            chat,
+            from: sender,
+            photo,
+            forward_origin: {
+              type: "hidden_user",
+              sender_user_name: "Original A",
+              date: 500,
+            },
+          },
+          {
+            message_id: 2,
+            date: 1_700_000_001,
+            chat,
+            from: sender,
+            photo,
+            forward_origin: {
+              type: "hidden_user",
+              sender_user_name: "Original B",
+              date: 501,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(context?.ctxPayload.Body).toMatch(
+      /\[Forwarded from Original A[^\]]*\]\n<media:image>\n\[Forwarded from Original B[^\]]*\]\n<media:image>/,
+    );
+  });
+});

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -567,7 +567,7 @@ export async function buildTelegramInboundContextPayload(params: {
       inboundEventKind,
       body,
       rawBody,
-      bodyForAgent: bodyText,
+      bodyForAgent: hasMultiMessageDebounceBatch ? visibleBodyText : bodyText,
       commandBody,
       inboundHistory,
       sourceModality: msg.voice ? "voice" : undefined,

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -44,7 +44,9 @@ import {
   buildTelegramGroupFrom,
   buildTelegramInboundOriginTarget,
   describeReplyTarget,
+  getTelegramTextParts,
   normalizeForwardedContext,
+  resolveTelegramMediaPlaceholder,
   type TelegramReplyTarget,
   type TelegramThreadSpec,
 } from "./bot/helpers.js";
@@ -148,8 +150,19 @@ function stripReplyChainForwarded(entry: TelegramReplyChainEntry): TelegramReply
   return withoutForwarded;
 }
 
+function formatTelegramForwardedMessageBody(params: {
+  body: string;
+  forwardedFrom?: string;
+  forwardedDate?: number;
+}): string {
+  const forwardedAt = timestampMsToIsoString(params.forwardedDate);
+  const forwardPrefix = params.forwardedFrom
+    ? `[Forwarded from ${params.forwardedFrom}${forwardedAt ? ` at ${forwardedAt}` : ""}]`
+    : undefined;
+  return [forwardPrefix, params.body].filter(Boolean).join("\n");
+}
+
 function formatReplyChainEntry(entry: TelegramReplyChainEntry, index: number): string {
-  const forwardedAt = timestampMsToIsoString(entry.forwardedDate);
   const mediaPath = entry.mediaPath ? resolveTelegramPromptMediaPath(entry.mediaPath) : undefined;
   const labels = [
     `${index + 1}. ${entry.sender ?? "unknown sender"}`,
@@ -158,10 +171,11 @@ function formatReplyChainEntry(entry: TelegramReplyChainEntry, index: number): s
     entry.timestamp ? timestampMsToIsoString(entry.timestamp) : undefined,
   ].filter(Boolean);
   const bodyLines = [
-    entry.forwardedFrom
-      ? `[Forwarded from ${entry.forwardedFrom}${forwardedAt ? ` at ${forwardedAt}` : ""}]`
-      : undefined,
-    entry.isQuote && entry.body ? `"${entry.body}"` : entry.body,
+    formatTelegramForwardedMessageBody({
+      body: entry.isQuote && entry.body ? `"${entry.body}"` : (entry.body ?? ""),
+      forwardedFrom: entry.forwardedFrom,
+      forwardedDate: entry.forwardedDate,
+    }),
     entry.mediaType ? `<media:${entry.mediaType}>` : undefined,
     mediaPath ? `[media_path:${mediaPath}]` : undefined,
     entry.mediaRef ? `[media_ref:${entry.mediaRef}]` : undefined,
@@ -261,7 +275,8 @@ export async function buildTelegramInboundContextPayload(params: {
     sessionRuntime: sessionRuntimeOverride,
   } = params;
   const replyTarget = describeReplyTarget(msg);
-  const forwardOrigin = normalizeForwardedContext(msg);
+  const hasMultiMessageDebounceBatch = (options?.inboundDebounceMessages?.length ?? 0) > 1;
+  const forwardOrigin = hasMultiMessageDebounceBatch ? null : normalizeForwardedContext(msg);
   const contextVisibilityMode = resolveChannelContextVisibilityMode({
     cfg,
     channel: "telegram",
@@ -354,20 +369,48 @@ export async function buildTelegramInboundContextPayload(params: {
     return [includeForwarded ? visibleEntry : stripReplyChainForwarded(visibleEntry)];
   });
   const visibleForwardOrigin = includeForwardOrigin ? forwardOrigin : null;
-  const visibleForwardOriginAt = timestampMsToIsoString(
-    visibleForwardOrigin?.date ? visibleForwardOrigin.date * 1000 : undefined,
-  );
+  const inboundDebounceBodySegments = hasMultiMessageDebounceBatch
+    ? options?.inboundDebounceMessages?.flatMap((debouncedMessage) => {
+        const segmentBody =
+          getTelegramTextParts(debouncedMessage).text ||
+          resolveTelegramMediaPlaceholder(debouncedMessage);
+        if (!segmentBody) {
+          return [];
+        }
+        const debouncedForwardOrigin = normalizeForwardedContext(debouncedMessage);
+        const visibleDebouncedForwardOrigin =
+          debouncedForwardOrigin &&
+          shouldIncludeGroupSupplementalContext({
+            kind: "forwarded",
+            senderId: debouncedForwardOrigin.fromId,
+            senderUsername: debouncedForwardOrigin.fromUsername,
+          })
+            ? debouncedForwardOrigin
+            : null;
+        return [
+          formatTelegramForwardedMessageBody({
+            body: segmentBody,
+            forwardedFrom: visibleDebouncedForwardOrigin?.from,
+            forwardedDate: visibleDebouncedForwardOrigin?.date
+              ? visibleDebouncedForwardOrigin.date * 1000
+              : undefined,
+          }),
+        ];
+      })
+    : undefined;
+  const visibleBodyText = inboundDebounceBodySegments?.length
+    ? inboundDebounceBodySegments.join("\n")
+    : formatTelegramForwardedMessageBody({
+        body: bodyText,
+        forwardedFrom: visibleForwardOrigin?.from,
+        forwardedDate: visibleForwardOrigin?.date ? visibleForwardOrigin.date * 1000 : undefined,
+      });
   const replySuffix =
     visibleReplyChain.length > 0
       ? `\n\n[Reply chain - nearest first]\n${visibleReplyChain
           .map(formatReplyChainEntry)
           .join("\n")}\n[/Reply chain]`
       : "";
-  const forwardPrefix = visibleForwardOrigin
-    ? `[Forwarded from ${visibleForwardOrigin.from}${
-        visibleForwardOriginAt ? ` at ${visibleForwardOriginAt}` : ""
-      }]\n`
-    : "";
   const groupLabel = isGroup ? buildGroupLabel(msg, chatId, resolvedThreadId) : undefined;
   const senderName = buildSenderName(msg);
   const conversationLabel = isGroup
@@ -415,7 +458,7 @@ export async function buildTelegramInboundContextPayload(params: {
     channel: "Telegram",
     from: conversationLabel,
     timestamp: msg.date ? msg.date * 1000 : undefined,
-    body: `${forwardPrefix}${bodyText}${replySuffix}`,
+    body: `${visibleBodyText}${replySuffix}`,
     chatType: isGroup ? "group" : "direct",
     sender: {
       name: senderName,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -1,5 +1,6 @@
 // Telegram type declarations define plugin contracts.
 import type { Bot } from "grammy";
+import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   DmPolicy,
@@ -29,6 +30,7 @@ export type TelegramMessageContextOptions = {
   promptContextMinTimestampMs?: number;
   promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
   ambientTranscriptBody?: string;
+  inboundDebounceMessages?: readonly Message[];
   spooledReplay?: boolean;
   /** Use an attempt-local participant so an outer retry loop owns final spool settlement. */
   isolateSpooledReplaySettlement?: boolean;

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1592,7 +1592,11 @@ describe("createTelegramBot", () => {
       expect(payload.Body).toMatch(
         /\[Forwarded from Original A[^\]]*\]\nfirst forwarded note\n\[Forwarded from Original B[^\]]*\]\nsecond forwarded note/,
       );
-      expect(payload.BodyForAgent).toBe("first forwarded note\nsecond forwarded note");
+      expect(payload.BodyForAgent).toMatch(
+        /\[Forwarded from Original A[^\]]*\]\nfirst forwarded note\n\[Forwarded from Original B[^\]]*\]\nsecond forwarded note/,
+      );
+      expect(payload.BodyForAgent).not.toContain("Conversation info (untrusted metadata)");
+      expect(payload.CommandBody).toBe("first forwarded note\nsecond forwarded note");
       expect(payload.ForwardedFrom).toBeUndefined();
     } finally {
       setTimeoutSpy.mockRestore();

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1496,6 +1496,109 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("preserves structured origin for a single forwarded debounce entry", async () => {
+    loadConfig.mockReturnValue({
+      agents: { defaults: { envelopeTimezone: "utc" } },
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getOnHandler("message") as (
+        ctx: TelegramMiddlewareTestContext,
+      ) => Promise<void>;
+      await messageHandler({
+        message: {
+          chat: { id: 7, type: "private" },
+          text: "single forwarded note",
+          date: 1736380921,
+          message_id: 121,
+          from: { id: 42, first_name: "Ada" },
+          forward_origin: {
+            type: "hidden_user",
+            date: 621,
+            sender_user_name: "Original A",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 80);
+      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      const flush = setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
+      flush?.();
+
+      await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+      const payload = requireValue(replySpy.mock.calls[0]?.[0], "single forwarded payload");
+      expect(payload.Body).toContain("[Forwarded from Original A");
+      expect(payload.ForwardedFrom).toBe("Original A");
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("preserves distinct origins for forwarded messages in one debounce batch", async () => {
+    loadConfig.mockReturnValue({
+      agents: { defaults: { envelopeTimezone: "utc" } },
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getOnHandler("message") as (
+        ctx: TelegramMiddlewareTestContext,
+      ) => Promise<void>;
+
+      for (const [messageId, text, origin] of [
+        [121, "first forwarded note", "Original A"],
+        [122, "second forwarded note", "Original B"],
+      ] as const) {
+        await messageHandler({
+          message: {
+            chat: { id: 7, type: "private" },
+            text,
+            date: 1736380800 + messageId,
+            message_id: messageId,
+            from: { id: 42, first_name: "Ada" },
+            forward_origin: {
+              type: "hidden_user",
+              date: 500 + messageId,
+              sender_user_name: origin,
+            },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        });
+      }
+
+      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 80);
+      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      const flush = setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => void) | undefined;
+      flush?.();
+
+      await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+      const payload = requireValue(replySpy.mock.calls[0]?.[0], "forwarded batch payload");
+      expect(payload.Body).toContain("[Forwarded from Original A");
+      expect(payload.Body).toContain("[Forwarded from Original B");
+      expect(payload.Body).toMatch(
+        /\[Forwarded from Original A[^\]]*\]\nfirst forwarded note\n\[Forwarded from Original B[^\]]*\]\nsecond forwarded note/,
+      );
+      expect(payload.BodyForAgent).toBe("first forwarded note\nsecond forwarded note");
+      expect(payload.ForwardedFrom).toBeUndefined();
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("lets stop cancel pending same-chat forwarded debounce", async () => {
     const DEBOUNCE_MS = 4321;
     loadConfig.mockReturnValue({


### PR DESCRIPTION
Closes #108466

## What Problem This Solves

Fixes an issue where Telegram users forwarding multiple messages within one inbound debounce window would lose per-message source attribution. Mixed and multi-origin batches could be presented to the agent as the forwarding user's own text or be attributed entirely to the first forwarded source.

## Why This Change Was Made

The Telegram debounce path now carries the original messages into the Telegram context owner, which formats each segment with its own visible forward origin. Forward-origin visibility is evaluated per segment, the synthetic batch no longer inherits the first message's origin, and single-message debounce flushes retain their existing structured forwarding metadata. The agent-facing body is built from those attributed segments while the command body remains plain.

## User Impact

Agents can distinguish ordinary text from forwarded content and identify each visible source correctly, including forwarded media-only segments. Group context-visibility rules continue to redact origins that are not allowed.

## Evidence

### Redacted live Telegram proof

Candidate `19d0e34bb247c610e9bd0411fb1820fd2ff81903` was run with a temporary BotFather bot, an isolated candidate gateway/state/config/workspace, and a localhost-only deterministic OpenAI Responses mock. Two real text-only Telegram forwards from distinct public origins were sent in one burst.

Observed pipeline:

`2 real Bot API updates (38 ms apart) -> 1 debounce batch -> 1 dispatch -> 1 model POST -> 2 distinct forward origins in the current agent-facing turn`

Redacted runtime facts:

- Both real Bot API updates were observed exactly once.
- One Telegram inbound/queue item/run and one model POST were observed; debounce failures: zero.
- Fresh-state transcript inspection found exactly two `[Forwarded from ...]` segments with two distinct origins in the current user turn, not history.
- The agent-facing turn did not contain the untrusted-metadata envelope.
- Source contents, temporary bot username, and token were redacted.
- The temporary bot was deleted through BotFather, its token file was removed, and all isolated processes were stopped. No production bot or gateway was modified.

After the proof, the branch was rebased onto current main `0903ebe4fa5f4643aaf83e3d59cc5518f80db448`. `git range-diff` marks both commits unchanged (`=`), the combined patch-id remains `1dd854185e513d08949795a1749bf549112cef1d`, and the six-file numstat is identical. Current head: `472af1a2beb6f3d15fc767cb5df2a5052ef6bc39`.

### Automated verification on current head

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.forwarded-batch.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts`
  - 2 test files passed, 124 tests passed.
  - Covers two distinct origins, mixed ordinary/forwarded text, group visibility redaction, media-only forwards, single-forward debounce, and the downstream agent-facing body while preserving a plain command body.
- `pnpm check:test-types` passed all three phases (`core-test`, `extensions-test`, `root-test`).
- `git diff --check origin/main...HEAD` passed.
- Local Codex autoreview completed with `findings: []`, patch correct, confidence `0.88`.

AI-assisted: yes, implemented and reviewed with Codex. I reviewed the resulting code and understand the behavior and security boundary.
