### PR TITLE
fix(ci): bound cross-OS release artifact verification fetch with timeout

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -804,8 +804,11 @@ jobs:
             });
           }
 
+          const ARTIFACT_API_TIMEOUT_MS = 30_000;
+
           const request = async (path) => {
             const response = await fetch(`${apiUrl}/repos/${repository}/${path}`, {
+              signal: AbortSignal.timeout(ARTIFACT_API_TIMEOUT_MS),
               headers: {
                 Accept: "application/vnd.github+json",
                 Authorization: `Bearer ${token}`,

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -300,6 +300,9 @@ describe("cross-OS release checks workflow", () => {
     expect(binding.run).toContain("actions/runs/${tuple.runId}/attempts/${tuple.runAttempt}");
     expect(binding.run).toContain("String(attempt.run_attempt) !== tuple.runAttempt");
 
+    expect(binding.run).toContain("const ARTIFACT_API_TIMEOUT_MS = 30_000;");
+    expect(binding.run).toContain("signal: AbortSignal.timeout(ARTIFACT_API_TIMEOUT_MS)");
+
     for (const name of ["Download candidate artifact", "Retry candidate artifact download"]) {
       const download = step(consumer, name);
       expect(download.with?.["artifact-ids"], name).toBe(


### PR DESCRIPTION
## What Problem This Solves

The cross-OS release checks reusable workflow verifies prepared artifacts by calling the GitHub REST API (`actions/artifacts/{id}` and `actions/runs/{id}/attempts/{attempt}`) with an inline `fetch()`. That request had no deadline, so a stalled connection or a GitHub API endpoint that accepts the TCP handshake but never sends headers could hold the verification step indefinitely.

## Why This Change Was Made

Added `AbortSignal.timeout(ARTIFACT_API_TIMEOUT_MS)` to the inline fetch call, with a 30-second deadline (`ARTIFACT_API_TIMEOUT_MS = 30_000`). This matches the existing `timeout --preserve-status 300s npm pack` guard in the same workflow and prevents a stalled artifact API call from consuming runner time.

## User Impact

Cross-OS release artifact verification now fails within a finite window if the GitHub API stalls, instead of hanging the reusable workflow step.

## Evidence

- Guard test: `test/scripts/openclaw-cross-os-release-workflow.test.ts` asserts the `Validate prepared candidate artifact binding` step contains `const ARTIFACT_API_TIMEOUT_MS = 30_000;` and `signal: AbortSignal.timeout(ARTIFACT_API_TIMEOUT_MS)`.
- `node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-workflow.test.ts` passes (6/6).
- Live proof: a local Node script starts a stalled HTTP server and confirms `fetch(url, { signal: AbortSignal.timeout(2000) })` rejects after ~2s with `The operation was aborted due to timeout`.
- Controlled stall proof: scaling the timeout to 500ms rejects after ~500ms, and scaling to 2s rejects after ~2s, showing the deadline is honored.

## Scope

- `.github/workflows/openclaw-cross-os-release-checks-reusable.yml`: add timeout to the artifact/run-attempt verification fetch.
- `test/scripts/openclaw-cross-os-release-workflow.test.ts`: guard the new timeout signal in the existing workflow test.
