### PR TITLE
fix(canvas): reject malformed snapshot base64

### DIFF
--- a/extensions/canvas/src/cli-helpers.test.ts
+++ b/extensions/canvas/src/cli-helpers.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe("canvas CLI helpers", () => {
   it("parses canvas.snapshot payload", () => {
-    expect(parseCanvasSnapshotPayload({ format: "png", base64: "aGk=" })).toEqual({
+    expect(parseCanvasSnapshotPayload({ format: "png", base64: " a G k \n" })).toEqual({
       format: "png",
       base64: "aGk=",
     });
@@ -24,6 +24,15 @@ describe("canvas CLI helpers", () => {
     "rejects invalid canvas.snapshot format fields",
     (payload) => {
       expect(() => parseCanvasSnapshotPayload(payload)).toThrow(
+        /invalid canvas\.snapshot payload/i,
+      );
+    },
+  );
+
+  it.each(["not-base64!", "S", "Zh==", "Zm9=", "a\0Gk=", 'aGk=" onerror="alert(1)'])(
+    "rejects malformed canvas.snapshot base64 payloads: %s",
+    (base64) => {
+      expect(() => parseCanvasSnapshotPayload({ format: "png", base64 })).toThrow(
         /invalid canvas\.snapshot payload/i,
       );
     },

--- a/extensions/canvas/src/cli-helpers.ts
+++ b/extensions/canvas/src/cli-helpers.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import * as path from "node:path";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/security-runtime";
 import { asRecord, readStringValue } from "openclaw/plugin-sdk/string-coerce-runtime";
 
@@ -23,58 +24,14 @@ function normalizeCanvasSnapshotFormat(value: string | undefined): CanvasSnapsho
   return null;
 }
 
-function isCanvasSnapshotBase64Char(code: number): boolean {
-  return (
-    (code >= 0x41 && code <= 0x5a) ||
-    (code >= 0x61 && code <= 0x7a) ||
-    (code >= 0x30 && code <= 0x39) ||
-    code === 0x2b ||
-    code === 0x2f
-  );
-}
-
-function isCanvasSnapshotBase64Whitespace(code: number): boolean {
-  return code === 0x09 || code === 0x0a || code === 0x0c || code === 0x0d || code === 0x20;
-}
-
 function canonicalizeCanvasSnapshotBase64(value: string | undefined): string | undefined {
-  let cleaned = "";
-  let sawPadding = false;
-  let padding = 0;
-
-  for (let index = 0; index < (value?.length ?? 0); index += 1) {
-    const char = value?.[index] ?? "";
-    const code = char.charCodeAt(0);
-    if (isCanvasSnapshotBase64Whitespace(code)) {
-      continue;
-    }
-    if (char === "=") {
-      padding += 1;
-      if (padding > 2) {
-        return undefined;
-      }
-      sawPadding = true;
-      cleaned += char;
-      continue;
-    }
-    if (sawPadding || !isCanvasSnapshotBase64Char(code)) {
-      return undefined;
-    }
-    cleaned += char;
-  }
-
-  if (!cleaned) {
+  if (!value || /[\0-\x08\x0B\x0E-\x1F\x7F]/.test(value)) {
     return undefined;
   }
-  const remainder = cleaned.length % 4;
-  if (sawPadding && remainder !== 0) {
+  const canonical = canonicalizeBase64(value);
+  if (!canonical) {
     return undefined;
   }
-  if (remainder === 1) {
-    return undefined;
-  }
-  const canonical = remainder === 0 ? cleaned : `${cleaned}${"=".repeat(4 - remainder)}`;
-
   return Buffer.from(canonical, "base64").toString("base64") === canonical ? canonical : undefined;
 }
 

--- a/extensions/canvas/src/cli-helpers.ts
+++ b/extensions/canvas/src/cli-helpers.ts
@@ -30,7 +30,14 @@ function canonicalizeCanvasSnapshotBase64(value: string | undefined): string | u
   }
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
-    if (code <= 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0c && code !== 0x0d) {
+    if (
+      code <= 0x20 &&
+      code !== 0x09 &&
+      code !== 0x0a &&
+      code !== 0x0c &&
+      code !== 0x0d &&
+      code !== 0x20
+    ) {
       return undefined;
     }
   }

--- a/extensions/canvas/src/cli-helpers.ts
+++ b/extensions/canvas/src/cli-helpers.ts
@@ -23,6 +23,61 @@ function normalizeCanvasSnapshotFormat(value: string | undefined): CanvasSnapsho
   return null;
 }
 
+function isCanvasSnapshotBase64Char(code: number): boolean {
+  return (
+    (code >= 0x41 && code <= 0x5a) ||
+    (code >= 0x61 && code <= 0x7a) ||
+    (code >= 0x30 && code <= 0x39) ||
+    code === 0x2b ||
+    code === 0x2f
+  );
+}
+
+function isCanvasSnapshotBase64Whitespace(code: number): boolean {
+  return code === 0x09 || code === 0x0a || code === 0x0c || code === 0x0d || code === 0x20;
+}
+
+function canonicalizeCanvasSnapshotBase64(value: string | undefined): string | undefined {
+  let cleaned = "";
+  let sawPadding = false;
+  let padding = 0;
+
+  for (let index = 0; index < (value?.length ?? 0); index += 1) {
+    const char = value?.[index] ?? "";
+    const code = char.charCodeAt(0);
+    if (isCanvasSnapshotBase64Whitespace(code)) {
+      continue;
+    }
+    if (char === "=") {
+      padding += 1;
+      if (padding > 2) {
+        return undefined;
+      }
+      sawPadding = true;
+      cleaned += char;
+      continue;
+    }
+    if (sawPadding || !isCanvasSnapshotBase64Char(code)) {
+      return undefined;
+    }
+    cleaned += char;
+  }
+
+  if (!cleaned) {
+    return undefined;
+  }
+  const remainder = cleaned.length % 4;
+  if (sawPadding && remainder !== 0) {
+    return undefined;
+  }
+  if (remainder === 1) {
+    return undefined;
+  }
+  const canonical = remainder === 0 ? cleaned : `${cleaned}${"=".repeat(4 - remainder)}`;
+
+  return Buffer.from(canonical, "base64").toString("base64") === canonical ? canonical : undefined;
+}
+
 /** Normalizes Canvas snapshot output extensions, mapping jpeg to jpg. */
 export function normalizeCanvasSnapshotFileExtension(value: string): CanvasSnapshotFileExtension {
   const format = normalizeCanvasSnapshotFormat(value.startsWith(".") ? value.slice(1) : value);
@@ -36,7 +91,7 @@ export function normalizeCanvasSnapshotFileExtension(value: string): CanvasSnaps
 export function parseCanvasSnapshotPayload(value: unknown): CanvasSnapshotPayload {
   const obj = asRecord(value);
   const format = normalizeCanvasSnapshotFormat(readStringValue(obj.format));
-  const base64 = readStringValue(obj.base64);
+  const base64 = canonicalizeCanvasSnapshotBase64(readStringValue(obj.base64));
   if (!format || !base64) {
     throw new Error("invalid canvas.snapshot payload");
   }

--- a/extensions/canvas/src/cli-helpers.ts
+++ b/extensions/canvas/src/cli-helpers.ts
@@ -25,8 +25,14 @@ function normalizeCanvasSnapshotFormat(value: string | undefined): CanvasSnapsho
 }
 
 function canonicalizeCanvasSnapshotBase64(value: string | undefined): string | undefined {
-  if (!value || /[\0-\x08\x0B\x0E-\x1F\x7F]/.test(value)) {
+  if (!value) {
     return undefined;
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0c && code !== 0x0d) {
+      return undefined;
+    }
   }
   const canonical = canonicalizeBase64(value);
   if (!canonical) {

--- a/extensions/canvas/src/cli.test.ts
+++ b/extensions/canvas/src/cli.test.ts
@@ -139,6 +139,28 @@ describe("canvas CLI", () => {
     expect(writtenFiles).toHaveLength(0);
   });
 
+  it("rejects malformed node-controlled snapshot base64 before writing", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const nodes = program.command("nodes");
+    const { deps, writtenFiles } = createCanvasCliDeps();
+    vi.mocked(deps.callGatewayCli).mockResolvedValueOnce({
+      payload: {
+        format: "png",
+        base64: "Zh==",
+      },
+    });
+
+    registerNodesCanvasCommands(nodes, deps);
+
+    await expect(
+      program.parseAsync(["nodes", "canvas", "snapshot", "--node", "ios-node"], {
+        from: "user",
+      }),
+    ).rejects.toThrow(/invalid canvas\.snapshot payload/i);
+    expect(writtenFiles).toHaveLength(0);
+  });
+
   it("rejects unsupported snapshot formats before invoking the node", async () => {
     const program = new Command();
     program.exitOverride();

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -114,6 +114,21 @@ describe("Canvas tool", () => {
     expect(imageResultParams?.imageSanitization).toEqual({ maxDimensionPx: 1600 });
   });
 
+  it("rejects malformed snapshot base64 before creating an image result", async () => {
+    mocks.callGatewayTool.mockResolvedValue({
+      payload: {
+        format: "png",
+        base64: "Zm9=",
+      },
+    });
+    const tool = createCanvasTool();
+
+    await expect(tool.execute("tool-call-1", { action: "snapshot" })).rejects.toThrow(
+      /invalid canvas\.snapshot payload/i,
+    );
+    expect(mocks.imageResultFromFile).not.toHaveBeenCalled();
+  });
+
   it("normalizes numeric string params before invoking node canvas commands", async () => {
     mocks.callGatewayTool.mockResolvedValue({
       payload: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Canvas snapshot responses with malformed or non-canonical base64 could still be decoded and written as snapshot files because Node's base64 decoder accepts non-canonical input.

## Why This Change Was Made

Canvas snapshot payload parsing now normalizes allowed whitespace and missing padding, then decodes and re-encodes the bytes to require a canonical base64 match before the CLI or agent tool writes an image file. Valid snapshot payloads still normalize successfully, while inputs with non-zero pad bits such as `Zh==` and `Zm9=`, and non-whitespace control characters such as NUL, are rejected.

## User Impact

Users no longer get bogus Canvas snapshot files from malformed node-controlled snapshot payloads.

## Evidence

- Real Gateway/node write-boundary proof: `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec tsx proof-live.ts` started a loopback Gateway with the production `startGatewayServer`, connected a real node `GatewayClient`, ran the real `nodes canvas snapshot` CLI command, and showed valid base64 reached `writeBase64ToFile` while non-canonical base64 and a NUL-containing payload were rejected before any write.

```text
$ PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec tsx proof-live.ts
entrypoint=nodes canvas snapshot -> gateway node.invoke -> node result -> writeBase64ToFile
gateway=ws://127.0.0.1:19091
native-reencode(Zh==)=Zg==
valid: nodeInvokeRequests=1 writes=1 rejected=false
invalid-noncanonical: nodeInvokeRequests=1 writes=0 rejected=true
invalid-control: nodeInvokeRequests=1 writes=0 rejected=true
```

<details>
<summary>proof-live.ts</summary>

```ts
import { mkdtemp, rm } from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { Command } from "commander";
import {
  createDefaultCanvasCliDependencies,
  registerNodesCanvasCommands,
} from "./extensions/canvas/src/cli.js";
import { startGatewayServer } from "./src/gateway/server.js";
import { GatewayClient } from "./src/gateway/client.js";
import { loadOrCreateDeviceIdentity } from "./src/infra/device-identity.js";
import { getActiveRuntimePluginRegistry } from "./src/plugins/active-runtime-registry.js";
import {
  GATEWAY_CLIENT_MODES,
  GATEWAY_CLIENT_NAMES,
} from "./src/utils/message-channel.js";

const token = "proof-secret";
const port = 19091;
const url = `ws://127.0.0.1:${port}`;
const tmpHome = await mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-proof-"));
const originalEnv = { ...process.env };

function restoreEnv() {
  for (const key of Object.keys(process.env)) {
    if (!(key in originalEnv)) {
      delete process.env[key];
    }
  }
  Object.assign(process.env, originalEnv);
}

function createClient(params: {
  role: "operator" | "node";
  displayName: string;
  identityName: string;
  commands?: string[];
  onEvent?: (evt: { event?: string; payload?: unknown }) => void;
}) {
  let settle: ((err?: Error) => void) | undefined;
  const client = new GatewayClient({
    url,
    token,
    role: params.role,
    scopes: params.role === "operator" ? ["operator.admin", "operator.write"] : [],
    clientName:
      params.role === "node" ? GATEWAY_CLIENT_NAMES.NODE_HOST : GATEWAY_CLIENT_NAMES.TEST,
    clientDisplayName: params.displayName,
    clientVersion: "proof",
    platform: "darwin",
    mode: params.role === "node" ? GATEWAY_CLIENT_MODES.NODE : GATEWAY_CLIENT_MODES.TEST,
    commands: params.commands,
    hostDeps: {
      loadOrCreateDeviceIdentity: () =>
        loadOrCreateDeviceIdentity(path.join(tmpHome, `${params.identityName}.json`)),
    },
    onEvent: params.onEvent,
    onHelloOk: () => settle?.(),
    onConnectError: (err) => settle?.(err),
  });
  const connected = new Promise<void>((resolve, reject) => {
    const timer = setTimeout(() => reject(new Error(`${params.displayName} connect timeout`)), 10_000);
    timer.unref();
    settle = (err?: Error) => {
      clearTimeout(timer);
      if (err) {
        reject(err);
      } else {
        resolve();
      }
    };
  });
  client.start();
  return { client, connected };
}

function installCanvasPolicy() {
  const registry = getActiveRuntimePluginRegistry();
  if (!registry) {
    throw new Error("active plugin registry unavailable");
  }
  if (registry.nodeInvokePolicies.some((entry) => entry.policy.commands.includes("canvas.snapshot"))) {
    return;
  }
  registry.nodeInvokePolicies.push({
    pluginId: "canvas",
    pluginName: "Canvas",
    source: "proof",
    rootDir: "extensions/canvas",
    pluginConfig: {},
    policy: {
      commands: ["canvas.snapshot"],
      defaultPlatforms: ["ios", "android", "macos", "windows", "unknown"],
      foregroundRestrictedOnIos: false,
      handle: (ctx) => ctx.invokeNode(),
    },
  });
}

async function approvePendingCanvasCommand(operatorClient: GatewayClient) {
  const list = await operatorClient.request<{
    pending?: Array<{ requestId?: string; nodeId?: string; commands?: string[] }>;
  }>("node.pair.list", {});
  const pending = (list.pending ?? []).find((entry) =>
    entry.commands?.includes("canvas.snapshot"),
  );
  if (!pending?.requestId) {
    return;
  }
  await operatorClient.request("node.pair.approve", { requestId: pending.requestId });
}

async function runSnapshot(operatorClient: GatewayClient, base64: string) {
  let writes = 0;
  let rejected = false;
  let nodeInvokeRequests = 0;
  const node = createClient({
    role: "node",
    displayName: "loopback-canvas-proof",
    identityName: `node-${base64.replace(/[^a-z0-9]/gi, "_")}`,
    commands: ["canvas.snapshot"],
    onEvent: (evt) => {
      if (evt.event !== "node.invoke.request") {
        return;
      }
      nodeInvokeRequests += 1;
      const payload = evt.payload as { id?: string; nodeId?: string };
      void node.client.request("node.invoke.result", {
        id: payload.id ?? "",
        nodeId: payload.nodeId ?? "",
        ok: true,
        payloadJSON: JSON.stringify({ format: "png", base64 }),
      });
    },
  });
  await node.connected;
  await approvePendingCanvasCommand(operatorClient);

  const program = new Command();
  program.exitOverride();
  const nodes = program.command("nodes");
  const deps = createDefaultCanvasCliDependencies();
  deps.defaultRuntime.exit = (code) => {
    throw new Error(`exit ${code}`);
  };
  const originalWrite = deps.writeBase64ToFile;
  deps.writeBase64ToFile = async (filePath, canonicalBase64) => {
    writes += 1;
    await originalWrite(filePath, canonicalBase64);
  };
  registerNodesCanvasCommands(nodes, deps);

  try {
    await program.parseAsync(
      [
        "nodes",
        "canvas",
        "snapshot",
        "--node",
        "loopback-canvas-proof",
        "--format",
        "png",
        "--url",
        url,
        "--token",
        token,
      ],
      { from: "user" },
    );
  } catch {
    rejected = true;
  } finally {
    await node.client.stopAndWait({ timeoutMs: 1_000 }).catch(() => node.client.stop());
  }
  return { writes, rejected, nodeInvokeRequests };
}

process.env.HOME = tmpHome;
process.env.USERPROFILE = tmpHome;
process.env.NODE_ENV = "test";
process.env.OPENCLAW_STATE_DIR = path.join(tmpHome, ".openclaw");
process.env.OPENCLAW_GATEWAY_TOKEN = token;
process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = "1";
process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
process.env.OPENCLAW_SKIP_CHANNELS = "1";
process.env.OPENCLAW_SKIP_PROVIDERS = "1";
process.env.OPENCLAW_SKIP_CRON = "1";

const server = await startGatewayServer(port, {
  bind: "loopback",
  auth: { mode: "token", token },
  controlUiEnabled: false,
  sidecarStartup: "none",
});
const operator = createClient({
  role: "operator",
  displayName: "loopback-operator-proof",
  identityName: "operator",
});

try {
  await operator.connected;
  installCanvasPolicy();
  const nativeMalformedBytes = Buffer.from("Zh==", "base64").toString("base64");
  const valid = await runSnapshot(operator.client, " a G k \n");
  const invalidNonCanonical = await runSnapshot(operator.client, "Zh==");
  const invalidControl = await runSnapshot(operator.client, "a\0Gk=");

  console.log("entrypoint=nodes canvas snapshot -> gateway node.invoke -> node result -> writeBase64ToFile");
  console.log(`gateway=${url}`);
  console.log(`native-reencode(Zh==)=${nativeMalformedBytes}`);
  console.log(
    `valid: nodeInvokeRequests=${valid.nodeInvokeRequests} writes=${valid.writes} rejected=${valid.rejected}`,
  );
  console.log(
    `invalid-noncanonical: nodeInvokeRequests=${invalidNonCanonical.nodeInvokeRequests} writes=${invalidNonCanonical.writes} rejected=${invalidNonCanonical.rejected}`,
  );
  console.log(
    `invalid-control: nodeInvokeRequests=${invalidControl.nodeInvokeRequests} writes=${invalidControl.writes} rejected=${invalidControl.rejected}`,
  );
} finally {
  await operator.client.stopAndWait({ timeoutMs: 1_000 }).catch(() => operator.client.stop());
  await server.close();
  restoreEnv();
  await rm(tmpHome, { recursive: true, force: true });
}
```

</details>

- Focused regression tests: `node scripts/run-vitest.mjs extensions/canvas/src/cli-helpers.test.ts extensions/canvas/src/cli.test.ts extensions/canvas/src/tool.test.ts`

```text
Test Files  3 passed (3)
Tests  52 passed (52)
```

AI-assisted: built with Codex
