### PR TITLE
refactor(protocol): unify Swift generated property naming

### DIFF
--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -100,9 +100,9 @@ function safeName(name: string) {
   return cc;
 }
 
-function swiftPropertyName(structName: string, key: string): string {
-  // Stored properties and canonical initializer labels must stay identical; compatibility
-  // initializers declare legacy labels separately.
+// Canonical initializer labels must match stored properties; compatibility initializers
+// declare legacy labels separately.
+function swiftStoredPropertyName(structName: string, key: string): string {
   if (structName === "ChatSendParams" && key === "fastMode") {
     return "fastmodevalue";
   }
@@ -394,7 +394,7 @@ function emitStruct(name: string, schema: JsonSchema): string {
   lines.push(`public struct ${name}: Codable, Sendable {`);
   const codingKeys: string[] = [];
   for (const [key, propSchema] of Object.entries(props)) {
-    const propName = swiftPropertyName(name, key);
+    const propName = swiftStoredPropertyName(name, key);
     const propType = swiftType(propSchema, required.has(key), true);
     lines.push(`    public let ${propName}: ${propType}`);
     lines.push(...swiftCompatibilityPropertyLines(name, key));
@@ -408,7 +408,7 @@ function emitStruct(name: string, schema: JsonSchema): string {
     "\n    public init(\n" +
       Object.entries(props)
         .map(([key, prop]) => {
-          const propName = swiftPropertyName(name, key);
+          const propName = swiftStoredPropertyName(name, key);
           const req = required.has(key);
           if (name === "AgentsUpdateParams" && key === "model") {
             // Keep the raw nullable value explicit so the source-compatible initializer stays
@@ -426,7 +426,7 @@ function emitStruct(name: string, schema: JsonSchema): string {
       "    {\n" +
       Object.entries(props)
         .map(([key]) => {
-          const propName = swiftPropertyName(name, key);
+          const propName = swiftStoredPropertyName(name, key);
           return `        self.${propName} = ${propName}`;
         })
         .join("\n") +
@@ -452,7 +452,7 @@ function emitStructCustomCodable(
     return "";
   }
   const decodedProperties = Object.entries(props).map(([key, propSchema]) => {
-    const propName = swiftPropertyName(name, key);
+    const propName = swiftStoredPropertyName(name, key);
     if (key === "model") {
       // decodeIfPresent collapses an explicit JSON null into nil. Presence-aware decoding
       // preserves the Gateway patch distinction between clearing and omitting the model.
@@ -464,7 +464,7 @@ function emitStructCustomCodable(
     return `        self.${propName} = try container.decodeIfPresent(${swiftType(propSchema, true, true)}.self, forKey: .${propName})`;
   });
   const encodedProperties = Object.keys(props).map((key) => {
-    const propName = swiftPropertyName(name, key);
+    const propName = swiftStoredPropertyName(name, key);
     if (required.has(key)) {
       return `        try container.encode(${propName}, forKey: .${propName})`;
     }
@@ -489,7 +489,7 @@ function emitStructCompatibilityInitializer(
 ): string {
   if (name === "AgentsUpdateParams" && props.model) {
     const initializerParams = Object.entries(props).map(([key, prop]) => {
-      const propName = swiftPropertyName(name, key);
+      const propName = swiftStoredPropertyName(name, key);
       if (key === "model") {
         return "        model: String? = nil";
       }
@@ -500,7 +500,7 @@ function emitStructCompatibilityInitializer(
       })}`;
     });
     const delegatedArgs = Object.keys(props).map((key) => {
-      const propName = swiftPropertyName(name, key);
+      const propName = swiftStoredPropertyName(name, key);
       if (key === "model") {
         return "            modelvalue: model.map { AnyCodable($0) }";
       }
@@ -528,7 +528,7 @@ function emitStructCompatibilityInitializer(
     if (!prop) {
       throw new Error(`missing ${name}.${key} schema`);
     }
-    const propName = swiftPropertyName(name, key);
+    const propName = swiftStoredPropertyName(name, key);
     if (key === "fastMode") {
       return "        fastmode: Bool?";
     }
@@ -539,7 +539,7 @@ function emitStructCompatibilityInitializer(
     })}`;
   });
   const delegatedArgs = Object.keys(props).map((key) => {
-    const propName = swiftPropertyName(name, key);
+    const propName = swiftStoredPropertyName(name, key);
     if (key === "fastMode") {
       return "            fastmodevalue: fastmode.map { AnyCodable($0) }";
     }

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -100,20 +100,9 @@ function safeName(name: string) {
   return cc;
 }
 
-function swiftStoredPropertyName(structName: string, key: string): string {
-  if (structName === "ChatSendParams" && key === "fastMode") {
-    return "fastmodevalue";
-  }
-  if (structName === "AgentsUpdateParams" && key === "model") {
-    return "modelvalue";
-  }
-  if (structName === "ChatSendParams" && key === "fast_seconds") {
-    return "fastseconds";
-  }
-  return safeName(key);
-}
-
-function swiftInitializerName(structName: string, key: string): string {
+function swiftPropertyName(structName: string, key: string): string {
+  // Stored properties and canonical initializer labels must stay identical; compatibility
+  // initializers declare legacy labels separately.
   if (structName === "ChatSendParams" && key === "fastMode") {
     return "fastmodevalue";
   }
@@ -405,7 +394,7 @@ function emitStruct(name: string, schema: JsonSchema): string {
   lines.push(`public struct ${name}: Codable, Sendable {`);
   const codingKeys: string[] = [];
   for (const [key, propSchema] of Object.entries(props)) {
-    const propName = swiftStoredPropertyName(name, key);
+    const propName = swiftPropertyName(name, key);
     const propType = swiftType(propSchema, required.has(key), true);
     lines.push(`    public let ${propName}: ${propType}`);
     lines.push(...swiftCompatibilityPropertyLines(name, key));
@@ -419,7 +408,7 @@ function emitStruct(name: string, schema: JsonSchema): string {
     "\n    public init(\n" +
       Object.entries(props)
         .map(([key, prop]) => {
-          const propName = swiftInitializerName(name, key);
+          const propName = swiftPropertyName(name, key);
           const req = required.has(key);
           if (name === "AgentsUpdateParams" && key === "model") {
             // Keep the raw nullable value explicit so the source-compatible initializer stays
@@ -437,9 +426,8 @@ function emitStruct(name: string, schema: JsonSchema): string {
       "    {\n" +
       Object.entries(props)
         .map(([key]) => {
-          const propName = swiftStoredPropertyName(name, key);
-          const paramName = swiftInitializerName(name, key);
-          return `        self.${propName} = ${paramName}`;
+          const propName = swiftPropertyName(name, key);
+          return `        self.${propName} = ${propName}`;
         })
         .join("\n") +
       "\n    }" +
@@ -464,7 +452,7 @@ function emitStructCustomCodable(
     return "";
   }
   const decodedProperties = Object.entries(props).map(([key, propSchema]) => {
-    const propName = swiftStoredPropertyName(name, key);
+    const propName = swiftPropertyName(name, key);
     if (key === "model") {
       // decodeIfPresent collapses an explicit JSON null into nil. Presence-aware decoding
       // preserves the Gateway patch distinction between clearing and omitting the model.
@@ -476,7 +464,7 @@ function emitStructCustomCodable(
     return `        self.${propName} = try container.decodeIfPresent(${swiftType(propSchema, true, true)}.self, forKey: .${propName})`;
   });
   const encodedProperties = Object.keys(props).map((key) => {
-    const propName = swiftStoredPropertyName(name, key);
+    const propName = swiftPropertyName(name, key);
     if (required.has(key)) {
       return `        try container.encode(${propName}, forKey: .${propName})`;
     }
@@ -501,7 +489,7 @@ function emitStructCompatibilityInitializer(
 ): string {
   if (name === "AgentsUpdateParams" && props.model) {
     const initializerParams = Object.entries(props).map(([key, prop]) => {
-      const propName = swiftInitializerName(name, key);
+      const propName = swiftPropertyName(name, key);
       if (key === "model") {
         return "        model: String? = nil";
       }
@@ -512,7 +500,7 @@ function emitStructCompatibilityInitializer(
       })}`;
     });
     const delegatedArgs = Object.keys(props).map((key) => {
-      const propName = swiftInitializerName(name, key);
+      const propName = swiftPropertyName(name, key);
       if (key === "model") {
         return "            modelvalue: model.map { AnyCodable($0) }";
       }
@@ -540,7 +528,7 @@ function emitStructCompatibilityInitializer(
     if (!prop) {
       throw new Error(`missing ${name}.${key} schema`);
     }
-    const propName = swiftInitializerName(name, key);
+    const propName = swiftPropertyName(name, key);
     if (key === "fastMode") {
       return "        fastmode: Bool?";
     }
@@ -551,7 +539,7 @@ function emitStructCompatibilityInitializer(
     })}`;
   });
   const delegatedArgs = Object.keys(props).map((key) => {
-    const propName = swiftInitializerName(name, key);
+    const propName = swiftPropertyName(name, key);
     if (key === "fastMode") {
       return "            fastmodevalue: fastmode.map { AnyCodable($0) }";
     }


### PR DESCRIPTION
Follow-up to #108734.

AI-assisted: yes (Codex).

## What Problem This Solves

The Swift protocol generator carried separate stored-property and initializer-name helpers with identical compatibility spelling rules. Every special-case name had to be maintained twice, creating an avoidable drift risk in generated client APIs.

## Why This Change Was Made

Use the stored-property naming policy for canonical initializer labels and delete the duplicate helper. Legacy compatibility initializer labels remain explicit and unchanged.

## User Impact

No user-visible or generated-client API change. This makes future protocol generator maintenance smaller and safer.

## Evidence

- `node --import tsx scripts/protocol-gen-swift.ts`: generated `GatewayModels.swift` stayed byte-identical to `origin/main` (`bf9e1a09cd714d1210e7c6b938d5f000092e86d98053c8c1fd6745df72cdb89c`).
- `swift test --package-path apps/shared/OpenClawKit --filter GatewayModelsCompatibilityTests`: 5 tests passed.
- `node scripts/check-changed.mjs -- scripts/protocol-gen-swift.ts`: passed all tooling lanes on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/29497224842)).
- `.agents/skills/autoreview/scripts/autoreview --mode branch`: clean; no accepted/actionable findings.
