### PR TITLE
fix(qa): stop Docker startup hangs on stalled health checks

### DIFF
--- a/extensions/qa-lab/src/docker-up.runtime.test.ts
+++ b/extensions/qa-lab/src/docker-up.runtime.test.ts
@@ -339,6 +339,7 @@ describe("runQaDockerUp", () => {
   it("falls back to the container IP when the host gateway port is unreachable", async () => {
     const calls: string[] = [];
     const fetchCalls: string[] = [];
+    const fetchSignals: AbortSignal[] = [];
     const hostGatewayCancel = vi.fn(async () => {});
     const outputDir = await mkdtemp(path.join(os.tmpdir(), "qa-docker-up-"));
     const repoRoot = path.resolve("/repo/openclaw");
@@ -369,8 +370,11 @@ describe("runQaDockerUp", () => {
             }
             return { stdout: "", stderr: "" };
           },
-          fetchImpl: vi.fn(async (input: string) => {
+          fetchImpl: vi.fn(async (input: string, init?: Pick<RequestInit, "signal">) => {
             fetchCalls.push(input);
+            if (init?.signal) {
+              fetchSignals.push(init.signal);
+            }
             if (input === "http://127.0.0.1:18889/healthz") {
               return { ok: false, body: { cancel: hostGatewayCancel } };
             }
@@ -396,6 +400,7 @@ describe("runQaDockerUp", () => {
         "http://127.0.0.1:18889/healthz",
         "http://192.168.165.4:18789/healthz",
       ]);
+      expect(fetchSignals).toHaveLength(3);
       expect(result.gatewayUrl).toBe("http://192.168.165.4:18789/");
       expect(hostGatewayCancel).toHaveBeenCalledTimes(1);
     } finally {

--- a/extensions/qa-lab/src/docker-up.runtime.ts
+++ b/extensions/qa-lab/src/docker-up.runtime.ts
@@ -15,6 +15,8 @@ import {
 } from "./docker-runtime.js";
 import { shellQuote } from "./shell-quote.js";
 
+const QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS = 2_000;
+
 type QaDockerUpResult = {
   outputDir: string;
   composeFile: string;
@@ -30,7 +32,9 @@ function resolveDefaultQaDockerDir(repoRoot: string) {
 async function isQaLabDockerHealthReachable(url: string, fetchImpl: FetchLike) {
   let response: Awaited<ReturnType<FetchLike>> | undefined;
   try {
-    response = await fetchImpl(url);
+    response = await fetchImpl(url, {
+      signal: AbortSignal.timeout(QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS),
+    });
     return response.ok;
   } catch {
     return false;

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
@@ -37,11 +37,13 @@ export async function isMatrixVersionsReachable(
   baseUrl: string,
   fetchImpl: FetchLike,
   timeoutMs = MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS,
+  signal?: AbortSignal,
 ) {
   let response: Awaited<ReturnType<FetchLike>> | undefined;
   try {
+    const timeoutSignal = AbortSignal.timeout(Math.max(1, timeoutMs));
     response = await fetchImpl(buildVersionsUrl(baseUrl), {
-      signal: AbortSignal.timeout(Math.max(1, timeoutMs)),
+      signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
     });
     return response.ok;
   } catch {
@@ -88,30 +90,46 @@ export async function waitForReachableMatrixBaseUrl(params: {
   const pollMs = params.pollMs ?? 1_000;
   const startedAt = Date.now();
   const deadline = startedAt + timeoutMs;
+  const candidateBaseUrls = params.containerBaseUrl
+    ? [params.hostBaseUrl, params.containerBaseUrl]
+    : [params.hostBaseUrl];
 
   while (Date.now() < deadline) {
-    const hostRemainingMs = deadline - Date.now();
-    if (
-      hostRemainingMs > 0 &&
-      (await isMatrixVersionsReachable(
-        params.hostBaseUrl,
-        params.fetchImpl,
-        Math.min(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS, hostRemainingMs),
-      ))
-    ) {
-      return params.hostBaseUrl;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      break;
     }
-    const containerRemainingMs = deadline - Date.now();
-    if (
-      params.containerBaseUrl &&
-      containerRemainingMs > 0 &&
-      (await isMatrixVersionsReachable(
-        params.containerBaseUrl,
-        params.fetchImpl,
-        Math.min(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS, containerRemainingMs),
-      ))
-    ) {
-      return params.containerBaseUrl;
+    const probeController = new AbortController();
+    let reachableCandidate: string | undefined;
+    try {
+      // Race both network paths so neither stalled probe can starve or delay
+      // a healthy peer. The outer deadline also bounds injected fetch fakes.
+      reachableCandidate = await withMatrixQaHarnessTimeout(
+        "Matrix health probes",
+        remainingMs,
+        Promise.any(
+          candidateBaseUrls.map(async (baseUrl) => {
+            if (
+              await isMatrixVersionsReachable(
+                baseUrl,
+                params.fetchImpl,
+                Math.min(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS, remainingMs),
+                probeController.signal,
+              )
+            ) {
+              return baseUrl;
+            }
+            throw new Error("Matrix versions endpoint unreachable");
+          }),
+        ),
+      );
+    } catch {
+      // Poll again after every candidate fails or the discovery deadline expires.
+    } finally {
+      probeController.abort();
+    }
+    if (reachableCandidate) {
+      return reachableCandidate;
     }
     const remainingSleepMs = deadline - Date.now();
     if (remainingSleepMs > 0) {

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
@@ -9,6 +9,7 @@ export const MATRIX_QA_DEFAULT_PORT = 28008;
 export const MATRIX_QA_INTERNAL_PORT = 8008;
 export const MATRIX_QA_SERVICE = "matrix-qa-homeserver";
 export const MATRIX_QA_CLEANUP_TIMEOUT_MS = 90_000;
+const MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS = 2_000;
 
 type MatrixQaHarnessManifest = {
   image: string;
@@ -32,10 +33,16 @@ export function buildVersionsUrl(baseUrl: string) {
   return `${baseUrl}_matrix/client/versions`;
 }
 
-export async function isMatrixVersionsReachable(baseUrl: string, fetchImpl: FetchLike) {
+export async function isMatrixVersionsReachable(
+  baseUrl: string,
+  fetchImpl: FetchLike,
+  timeoutMs = MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS,
+) {
   let response: Awaited<ReturnType<FetchLike>> | undefined;
   try {
-    response = await fetchImpl(buildVersionsUrl(baseUrl));
+    response = await fetchImpl(buildVersionsUrl(baseUrl), {
+      signal: AbortSignal.timeout(Math.max(1, timeoutMs)),
+    });
     return response.ok;
   } catch {
     return false;
@@ -80,18 +87,36 @@ export async function waitForReachableMatrixBaseUrl(params: {
   const timeoutMs = params.timeoutMs ?? 60_000;
   const pollMs = params.pollMs ?? 1_000;
   const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
 
-  while (Date.now() - startedAt < timeoutMs) {
-    if (await isMatrixVersionsReachable(params.hostBaseUrl, params.fetchImpl)) {
+  while (Date.now() < deadline) {
+    const hostRemainingMs = deadline - Date.now();
+    if (
+      hostRemainingMs > 0 &&
+      (await isMatrixVersionsReachable(
+        params.hostBaseUrl,
+        params.fetchImpl,
+        Math.min(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS, hostRemainingMs),
+      ))
+    ) {
       return params.hostBaseUrl;
     }
+    const containerRemainingMs = deadline - Date.now();
     if (
       params.containerBaseUrl &&
-      (await isMatrixVersionsReachable(params.containerBaseUrl, params.fetchImpl))
+      containerRemainingMs > 0 &&
+      (await isMatrixVersionsReachable(
+        params.containerBaseUrl,
+        params.fetchImpl,
+        Math.min(MATRIX_QA_HEALTH_REQUEST_TIMEOUT_MS, containerRemainingMs),
+      ))
     ) {
       return params.containerBaseUrl;
     }
-    await params.sleepImpl(pollMs);
+    const remainingSleepMs = deadline - Date.now();
+    if (remainingSleepMs > 0) {
+      await params.sleepImpl(Math.min(pollMs, remainingSleepMs));
+    }
   }
 
   const candidateLabel = params.containerBaseUrl

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -289,6 +289,78 @@ describe("matrix harness runtime", () => {
     expect(sleepImpl).not.toHaveBeenCalled();
   });
 
+  it("probes the container fallback when the host versions probe stalls", async () => {
+    let hostProbeSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(async (input: string, init?: Pick<RequestInit, "signal">) => {
+      if (input.startsWith("http://172.18.0.10:8008/")) {
+        return { ok: true };
+      }
+      return await new Promise<never>((_resolve, reject) => {
+        hostProbeSignal = init?.signal ?? undefined;
+        if (!hostProbeSignal) {
+          reject(new Error("versions probe signal missing"));
+          return;
+        }
+        const rejectAborted = () => reject(new Error("versions probe aborted"));
+        if (hostProbeSignal.aborted) {
+          rejectAborted();
+          return;
+        }
+        hostProbeSignal.addEventListener("abort", rejectAborted, { once: true });
+      });
+    });
+
+    await expect(
+      testing.waitForReachableMatrixBaseUrl({
+        composeFile: "/tmp/docker-compose.matrix-qa.yml",
+        containerBaseUrl: "http://172.18.0.10:8008/",
+        fetchImpl,
+        hostBaseUrl: "http://127.0.0.1:28008/",
+        sleepImpl: vi.fn(async () => {}),
+        timeoutMs: 25,
+      }),
+    ).resolves.toBe("http://172.18.0.10:8008/");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(hostProbeSignal?.aborted).toBe(true);
+  });
+
+  it("returns the host without waiting for a stalled container versions probe", async () => {
+    let containerProbeSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(async (input: string, init?: Pick<RequestInit, "signal">) => {
+      if (input.startsWith("http://127.0.0.1:28008/")) {
+        return { ok: true };
+      }
+      return await new Promise<never>((_resolve, reject) => {
+        containerProbeSignal = init?.signal ?? undefined;
+        if (!containerProbeSignal) {
+          reject(new Error("versions probe signal missing"));
+          return;
+        }
+        const rejectAborted = () => reject(new Error("versions probe aborted"));
+        if (containerProbeSignal.aborted) {
+          rejectAborted();
+          return;
+        }
+        containerProbeSignal.addEventListener("abort", rejectAborted, { once: true });
+      });
+    });
+
+    await expect(
+      testing.waitForReachableMatrixBaseUrl({
+        composeFile: "/tmp/docker-compose.matrix-qa.yml",
+        containerBaseUrl: "http://172.18.0.10:8008/",
+        fetchImpl,
+        hostBaseUrl: "http://127.0.0.1:28008/",
+        sleepImpl: vi.fn(async () => {}),
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBe("http://127.0.0.1:28008/");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(containerProbeSignal?.aborted).toBe(true);
+  });
+
   it("falls back to the container IP when the host port is unreachable", async () => {
     const calls: string[] = [];
 
@@ -335,6 +407,7 @@ describe("matrix harness runtime", () => {
         expect(fetchCalls).toEqual([
           "http://127.0.0.1:28008/_matrix/client/versions",
           "http://127.0.0.1:28008/_matrix/client/versions",
+          "http://172.18.0.10:8008/_matrix/client/versions",
           "http://127.0.0.1:28008/_matrix/client/versions",
         ]);
       },

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -244,8 +244,49 @@ describe("matrix harness runtime", () => {
       testing.isMatrixVersionsReachable("http://127.0.0.1:28008/", fetchImpl),
     ).resolves.toBe(true);
 
-    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:28008/_matrix/client/versions");
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:28008/_matrix/client/versions", {
+      signal: expect.any(AbortSignal),
+    });
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds a stalled versions probe by the remaining discovery deadline", async () => {
+    let probeSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(
+      async (_input: string, init?: Pick<RequestInit, "signal">) =>
+        await new Promise<never>((_resolve, reject) => {
+          probeSignal = init?.signal ?? undefined;
+          if (!probeSignal) {
+            reject(new Error("versions probe signal missing"));
+            return;
+          }
+          const rejectAborted = () => reject(new Error("versions probe aborted"));
+          if (probeSignal.aborted) {
+            rejectAborted();
+            return;
+          }
+          probeSignal.addEventListener("abort", rejectAborted, { once: true });
+        }),
+    );
+    const sleepImpl = vi.fn(async () => {});
+    const startedAt = Date.now();
+
+    await expect(
+      testing.waitForReachableMatrixBaseUrl({
+        composeFile: "/tmp/docker-compose.matrix-qa.yml",
+        containerBaseUrl: null,
+        fetchImpl,
+        hostBaseUrl: "http://127.0.0.1:28008/",
+        sleepImpl,
+        timeoutMs: 25,
+        pollMs: 1_000,
+      }),
+    ).rejects.toThrow("did not become healthy");
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(probeSignal?.aborted).toBe(true);
+    expect(sleepImpl).not.toHaveBeenCalled();
   });
 
   it("falls back to the container IP when the host port is unreachable", async () => {

--- a/src/plugin-sdk/qa-runtime.test.ts
+++ b/src/plugin-sdk/qa-runtime.test.ts
@@ -309,7 +309,9 @@ describe("plugin-sdk qa-runtime", () => {
     ).resolves.toBe("http://172.18.0.4:18789/");
 
     expect(runCommand).toHaveBeenCalledTimes(2);
-    expect(fetchImpl).toHaveBeenCalledWith("http://172.18.0.4:18789/healthz");
+    expect(fetchImpl).toHaveBeenCalledWith("http://172.18.0.4:18789/healthz", {
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("cancels compose service health probe response bodies", async () => {
@@ -356,6 +358,44 @@ describe("plugin-sdk qa-runtime", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(first.wasCanceled()).toBe(true);
     expect(second.wasCanceled()).toBe(true);
+  });
+
+  it("bounds a stalled waitForHealth probe by the remaining overall deadline", async () => {
+    const module = await import("./qa-runtime.js");
+    const runtime = module.createQaDockerRuntime({ auditContext: "qa-test" });
+    let probeSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(
+      async (_input: string, init?: Pick<RequestInit, "signal">) =>
+        await new Promise<never>((_resolve, reject) => {
+          probeSignal = init?.signal ?? undefined;
+          if (!probeSignal) {
+            reject(new Error("health probe signal missing"));
+            return;
+          }
+          const rejectAborted = () => reject(new Error("health probe aborted"));
+          if (probeSignal.aborted) {
+            rejectAborted();
+            return;
+          }
+          probeSignal.addEventListener("abort", rejectAborted, { once: true });
+        }),
+    );
+    const sleepImpl = vi.fn(async () => {});
+    const startedAt = Date.now();
+
+    await expect(
+      runtime.waitForHealth("http://127.0.0.1:18789/healthz", {
+        fetchImpl,
+        sleepImpl,
+        timeoutMs: 25,
+        pollMs: 1_000,
+      }),
+    ).rejects.toThrow("did not become healthy");
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(probeSignal?.aborted).toBe(true);
+    expect(sleepImpl).not.toHaveBeenCalled();
   });
 
   it("resolves an unpinned QA Docker host port away from an occupied loopback default", async () => {

--- a/src/plugin-sdk/qa-runtime.ts
+++ b/src/plugin-sdk/qa-runtime.ts
@@ -246,9 +246,13 @@ export type QaDockerFetchResponse = {
   ok: boolean;
   body?: { cancel?: () => unknown } | null;
 };
-export type QaDockerFetchLike = (input: string) => Promise<QaDockerFetchResponse>;
+export type QaDockerFetchLike = (
+  input: string,
+  init?: Pick<RequestInit, "signal">,
+) => Promise<QaDockerFetchResponse>;
 
 const DEFAULT_QA_DOCKER_COMMAND_TIMEOUT_MS = 120_000;
+const DEFAULT_QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS = 2_000;
 
 function pushQaReportDetailsBlock(lines: string[], label: string, details: string, indent = "") {
   if (!details.includes("\n")) {
@@ -480,10 +484,16 @@ function parseDockerComposePsRows(stdout: string) {
   }
 }
 
-async function isQaDockerHealthy(url: string, fetchImpl: QaDockerFetchLike) {
+async function isQaDockerHealthy(
+  url: string,
+  fetchImpl: QaDockerFetchLike,
+  timeoutMs = DEFAULT_QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS,
+) {
   let response: QaDockerFetchResponse | undefined;
   try {
-    response = await fetchImpl(url);
+    response = await fetchImpl(url, {
+      signal: AbortSignal.timeout(Math.max(1, timeoutMs)),
+    });
     return response.ok;
   } catch {
     return false;
@@ -508,12 +518,11 @@ export function createQaDockerRuntime(params: {
       ? DEFAULT_QA_DOCKER_COMMAND_TIMEOUT_MS
       : params.commandTimeoutMs;
 
-  const fetchHealthUrl = async (url: string): Promise<{ ok: boolean }> => {
+  const fetchHealthUrl: QaDockerFetchLike = async (url, init) => {
     const { response, release } = await fetchWithSsrFGuard({
       url,
-      init: {
-        signal: AbortSignal.timeout(2_000),
-      },
+      signal: init?.signal ?? undefined,
+      timeoutMs: DEFAULT_QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS,
       policy: { allowPrivateNetwork: true },
       auditContext: params.auditContext,
     });
@@ -554,9 +563,17 @@ export function createQaDockerRuntime(params: {
     let lastError: unknown = null;
 
     while (Date.now() < deadline) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
       let response: QaDockerFetchResponse | undefined;
       try {
-        response = await deps.fetchImpl(url);
+        response = await deps.fetchImpl(url, {
+          signal: AbortSignal.timeout(
+            Math.max(1, Math.min(DEFAULT_QA_DOCKER_HEALTH_REQUEST_TIMEOUT_MS, remainingMs)),
+          ),
+        });
         if (response.ok) {
           return;
         }
@@ -566,7 +583,10 @@ export function createQaDockerRuntime(params: {
       } finally {
         await releaseQaDockerFetchResponse(response);
       }
-      await deps.sleepImpl(pollMs);
+      const remainingSleepMs = deadline - Date.now();
+      if (remainingSleepMs > 0) {
+        await deps.sleepImpl(Math.min(pollMs, remainingSleepMs));
+      }
     }
 
     const elapsedSec = Math.round((Date.now() - startMs) / 1000);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers starting QA Docker or Matrix environments could wait past the configured readiness window when an HTTP health check or its network preflight stalled.

## Why This Change Was Made

Apply a per-request timeout to direct QA health checks and bound every readiness probe and polling delay by the remaining overall deadline. The shared QA runtime passes that deadline through the guarded-fetch boundary, while the Matrix harness enforces the same invariant for its host and container probes; healthy startup behavior and existing diagnostics remain unchanged.

## User Impact

QA Docker and Matrix startup now fail within their configured readiness window instead of hanging indefinitely on a stalled HTTP health check. Successful startup flows are unchanged.

## Evidence

- Node v24.15.0: focused repository test wrapper passed 33/33 tests across `src/plugin-sdk/qa-runtime.test.ts`, `extensions/qa-lab/src/docker-up.runtime.test.ts`, and `extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts`.
- Regression tests use stalled fetches that reject only when their supplied signal aborts, and verify the overall deadline prevents an additional polling sleep.
- Node v24.15.0 runtime probe confirmed `AbortSignal.timeout()` aborts with `TimeoutError`.
- `oxfmt --check` on all six changed files: passed.
- `oxlint` on all six changed files: passed.
- `git diff --check`: passed before and after rebasing onto current `main`.
- Live duplicate PR/issue searches and an exact changed-file overlap check across the 100 most recently updated open PRs found no match.
- Fresh independent review of the full callers, guarded-fetch dependency path, sibling readiness loops, and tests reported zero actionable findings.

Focused validation used the repository local test wrapper under Node 24; no broad local suite or Docker end-to-end run was performed.

AI-assisted: yes. I reviewed and understand the change.
