### PR TITLE
fix(tui): add 10s timeout to codex binary resolution subprocess

### DIFF
--- a/src/tui/tui.resolve-codex-bin.test.ts
+++ b/src/tui/tui.resolve-codex-bin.test.ts
@@ -41,7 +41,7 @@ describe("resolveCodexCliBin", () => {
     expect(execFileSyncMock).toHaveBeenCalledWith(
       path.win32.join("D:\\Windows", "System32", "where.exe"),
       ["codex"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -116,13 +116,22 @@ type RunTuiOptions = TuiOptions & {
   title?: string;
 };
 
+// Binary-resolution subprocesses may hang on a busy or misconfigured host.
+// Node waits for synchronous children to exit after a timeout signal;
+// SIGKILL keeps a stalled child from ignoring the deadline.
+const BIN_RESOLVE_TIMEOUT_MS = 10_000;
+
 /** Resolve the absolute path to the `codex` CLI binary, or `null` if not installed. */
 export function resolveCodexCliBin(): string | null {
   try {
     const lookupCmd =
       process.platform === "win32" ? getWindowsSystem32ExePath("where.exe") : "which";
     // `where` on Windows can return multiple lines; take the first match.
-    const raw = execFileSync(lookupCmd, ["codex"], { encoding: "utf8" }).trim();
+    const raw = execFileSync(lookupCmd, ["codex"], {
+      encoding: "utf8",
+      timeout: BIN_RESOLVE_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    }).trim();
     return raw.split(/\r?\n/)[0] || null;
   } catch {
     return null;


### PR DESCRIPTION
## What Problem This Solves

`which` / `where.exe codex` can hang indefinitely on a busy or misconfigured host. Since `resolveCodexCliBin()` uses `execFileSync` with no deadline, a stalled child blocks the TUI caller with no recovery path.

## Why This Change Was Made

Same pattern as the port-inspection timeout in `src/cli/ports.ts` (merged in #108706): `execFileSync` subprocesses that inspect the host should have a timeout so a wedged binary-resolution child does not block the caller. The function already handles errors by returning `null`, so a timeout error is caught and handled gracefully.

## What Changed

- `src/tui/tui.ts`: add `BIN_RESOLVE_TIMEOUT_MS = 10_000` constant, apply `timeout` + `killSignal: "SIGKILL"` to the `execFileSync` call in `resolveCodexCliBin()`
- `src/tui/tui.resolve-codex-bin.test.ts`: update the existing Windows `where.exe` assertion to cover the new timeout and killSignal options

## Evidence

- `node scripts/run-vitest.mjs src/tui/tui.resolve-codex-bin.test.ts --no-coverage`: 1 test passed
- `node scripts/run-vitest.mjs src/tui/tui.test.ts --no-coverage`: 59 tests passed (no regressions)
- The function already returns `null` on error; the added timeout is a safety net, not a behavior change

## Merge Risk

Low. The patch only bounds a fixed-argv subprocess call whose caller already handles all errors by returning `null`. A timeout results in the same `null` return as any other subprocess failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)