### PR TITLE
fix(plugins/runtime): bound deprecated config API warning cache

### DIFF
--- a/src/plugins/runtime/runtime-config.test.ts
+++ b/src/plugins/runtime/runtime-config.test.ts
@@ -136,4 +136,28 @@ describe("createRuntimeConfig", () => {
       writeOptions: { afterWrite: { mode: "none", reason: "test-controlled" } },
     });
   });
+
+  it("bounds the deprecated config API warning cache and evicts least-recently-used keys", () => {
+    const maxEntries = 4096;
+    const configApi = createRuntimeConfig();
+
+    for (let i = 0; i < maxEntries; i++) {
+      withPluginRuntimePluginScope({ pluginId: `legacy-plugin-${i}` }, () =>
+        configApi.loadConfig(),
+      );
+    }
+    expect(logWarnMock).toHaveBeenCalledTimes(maxEntries);
+
+    // A duplicate read promotes legacy-plugin-0 from the LRU head without re-warning.
+    withPluginRuntimePluginScope({ pluginId: "legacy-plugin-0" }, () => configApi.loadConfig());
+    expect(logWarnMock).toHaveBeenCalledTimes(maxEntries);
+
+    // Overflow evicts legacy-plugin-1 instead of the recently used legacy-plugin-0.
+    withPluginRuntimePluginScope({ pluginId: "legacy-plugin-extra" }, () => configApi.loadConfig());
+    expect(logWarnMock).toHaveBeenCalledTimes(maxEntries + 1);
+    withPluginRuntimePluginScope({ pluginId: "legacy-plugin-0" }, () => configApi.loadConfig());
+    expect(logWarnMock).toHaveBeenCalledTimes(maxEntries + 1);
+    withPluginRuntimePluginScope({ pluginId: "legacy-plugin-1" }, () => configApi.loadConfig());
+    expect(logWarnMock).toHaveBeenCalledTimes(maxEntries + 2);
+  });
 });

--- a/src/plugins/runtime/runtime-config.ts
+++ b/src/plugins/runtime/runtime-config.ts
@@ -4,13 +4,19 @@ import {
   mutateConfigFile as mutateConfigFileInternal,
   replaceConfigFile as replaceConfigFileInternal,
 } from "../../config/mutate.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import { logWarn } from "../../logger.js";
 import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
 import type { PluginRuntime } from "./types.js";
 
 const RUNTIME_CONFIG_LOAD_WRITE_COMPAT_CODE = "runtime-config-load-write";
 
-const warnedDeprecatedConfigApis = new Set<string>();
+const MAX_WARNED_DEPRECATED_CONFIG_APIS = 4096;
+// Warning state spans fresh config snapshots; bounding it means evicted plugin keys can re-warn.
+const warnedDeprecatedConfigApis = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_DEPRECATED_CONFIG_APIS,
+});
 
 function formatDeprecatedConfigApiSubject(name: "loadConfig" | "writeConfigFile"): string {
   const scope = getPluginRuntimeGatewayRequestScope();
@@ -35,10 +41,9 @@ function warnDeprecatedConfigApiOnce(
   replacement: string,
 ): void {
   const warningKey = formatDeprecatedConfigApiWarningKey(name);
-  if (warnedDeprecatedConfigApis.has(warningKey)) {
+  if (warnedDeprecatedConfigApis.check(warningKey)) {
     return;
   }
-  warnedDeprecatedConfigApis.add(warningKey);
   logWarn(
     `${formatDeprecatedConfigApiSubject(name)} is deprecated (${RUNTIME_CONFIG_LOAD_WRITE_COMPAT_CODE}); use ${replacement}.${formatDeprecatedConfigApiSource()}`,
   );


### PR DESCRIPTION
## What Problem This Solves

`src/plugins/runtime/runtime-config.ts` kept an unbounded `Set<string>` (`warnedDeprecatedConfigApis`) for the lifetime of the process. A gateway that loads many distinct plugins over time could grow this deprecation-warning dedupe set without limit.

## Why This Change Was Made

Replaced the unbounded `Set` with the existing bounded `createDedupeCache` helper (`ttlMs: 0`, `maxSize: 4096`) already used for similar warning caches in the codebase. This caps memory usage while preserving the "warn once per plugin/key" behavior under the cap. Evicted keys simply re-warn, which is the safe failure mode for a deprecation dedupe cache.

Precedents:
- #101696 `fix(config): cap legacy toolsBySender deprecation warning cache with shared dedupe helper`
- #101643 `fix(infra): cap session-maintenance-warning dedupe cache with LRU eviction`

## User Impact

No user-facing behavior change under normal plugin counts. Long-running gateways with very large plugin churn now avoid an ever-growing in-memory deprecation-warning cache.

## Evidence

- Added `runtime-config.test.ts` case proving:
  - Warnings are emitted once per key up to the 4096 cap.
  - Least-recently-used keys are evicted and can re-warn.
- Local test run:
  ```
  node scripts/run-vitest.mjs src/plugins/runtime/runtime-config.test.ts
  ```
  Result: 7 tests passed.
- Formatted changed files with `./node_modules/.bin/oxfmt`.
## Real behavior proof

- **Behavior addressed**: The `warnedDeprecatedConfigApis` process-lifetime cache in `src/plugins/runtime/runtime-config.ts` is bounded to 4,096 entries with LRU eviction, so duplicate deprecation warnings for evicted plugin ids re-emit safely.
- **Real environment tested**: Linux x86_64, Node 22.22.0, OpenClaw worktree at PR head `873ce17b63d5`.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs src/plugins/runtime/runtime-config.test.ts --run
  ```
- **Evidence after fix**:
  ```
  Test Files  1 passed (1)
       Tests  7 passed (7)
  ```
  The regression test `bounds the deprecated config API warning cache and evicts least-recently-used keys` fills the cache to 4,096 plugin ids, refreshes `legacy-plugin-0`, overflows with `legacy-plugin-extra`, and asserts that the LRU key `legacy-plugin-1` re-warns while the recently-used key stays suppressed.
- **Observed result after fix**: Warnings emit exactly once per plugin id up to the 4,096 cap; the least-recently-used id is evicted on overflow and re-warns on the next call.
- **What was not tested**: A live long-running gateway with real plugin churn; the bounded-cache behavior is exercised directly through the production `createRuntimeConfig()` API path.
