### PR TITLE
fix(plugins/provider): bound provider deprecation and fallback warning caches

### DIFF
--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -977,6 +977,84 @@ describe("provider-runtime", () => {
     expect(warning).not.toContain("\n");
   });
 
+  it("bounds the external auth fallback warning cache and re-warns evicted plugin ids", () => {
+    function setupFallbackPlugin(pluginId: string, providerId: string) {
+      resolveExternalAuthProfileCompatFallbackPluginIdsMock.mockReturnValue([pluginId]);
+      resolvePluginProvidersMock.mockReturnValue([
+        {
+          id: providerId,
+          pluginId,
+          label: `Fallback ${providerId}`,
+          auth: [],
+          resolveExternalOAuthProfiles: () => [
+            {
+              profileId: `${providerId}:external`,
+              credential: {
+                type: "oauth",
+                provider: providerId,
+                access: "access",
+                refresh: "refresh",
+                expires: Date.now() + 60_000,
+              },
+            },
+          ],
+        },
+      ]);
+    }
+
+    for (let i = 0; i < 4096; i += 1) {
+      setupFallbackPlugin(`fallback-cache-key-${i}`, `fallback-provider-${i}`);
+      resolveExternalAuthProfilesWithPlugins({
+        env: process.env,
+        context: {
+          env: process.env,
+          store: { version: 1, profiles: {} },
+        },
+      });
+    }
+    expect(providerRuntimeWarnMock).toHaveBeenCalledTimes(4096);
+
+    setupFallbackPlugin("fallback-cache-key-0", "fallback-provider-0");
+    resolveExternalAuthProfilesWithPlugins({
+      env: process.env,
+      context: {
+        env: process.env,
+        store: { version: 1, profiles: {} },
+      },
+    });
+    expect(providerRuntimeWarnMock).toHaveBeenCalledTimes(4096);
+
+    setupFallbackPlugin("fallback-cache-overflow", "fallback-provider-overflow");
+    resolveExternalAuthProfilesWithPlugins({
+      env: process.env,
+      context: {
+        env: process.env,
+        store: { version: 1, profiles: {} },
+      },
+    });
+    expect(providerRuntimeWarnMock).toHaveBeenCalledTimes(4097);
+
+    setupFallbackPlugin("fallback-cache-key-0", "fallback-provider-0");
+    resolveExternalAuthProfilesWithPlugins({
+      env: process.env,
+      context: {
+        env: process.env,
+        store: { version: 1, profiles: {} },
+      },
+    });
+    expect(providerRuntimeWarnMock).toHaveBeenCalledTimes(4097);
+
+    setupFallbackPlugin("fallback-cache-key-1", "fallback-provider-1");
+    resolveExternalAuthProfilesWithPlugins({
+      env: process.env,
+      context: {
+        env: process.env,
+        store: { version: 1, profiles: {} },
+      },
+    });
+    expect(providerRuntimeWarnMock).toHaveBeenCalledTimes(4098);
+  });
+
   it("resolves declared external auth plugins with different provider ids", () => {
     resolveExternalAuthProfileProviderPluginIdsMock.mockReturnValue(["demo-plugin"]);
     resolvePluginProvidersMock.mockReturnValue([

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -20,6 +20,7 @@ import { unwrapSecretSentinelsForProviderEgress } from "../agents/provider-secre
 import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createDedupeCache } from "../infra/dedupe.js";
 import type { UsageProviderId } from "../infra/provider-usage.types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
@@ -99,7 +100,12 @@ import type {
 } from "./types.js";
 
 const log = createSubsystemLogger("plugins/provider-runtime");
-const warnedExternalAuthFallbackPluginIds = new Set<string>();
+const MAX_WARNED_EXTERNAL_AUTH_FALLBACK_PLUGIN_IDS = 4096;
+// Warning state spans external-auth profile resolutions; bounding it means evicted plugin ids can re-warn.
+const warnedExternalAuthFallbackPluginIds = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_EXTERNAL_AUTH_FALLBACK_PLUGIN_IDS,
+});
 
 function matchesProviderPluginRef(provider: ProviderPlugin, providerId: string): boolean {
   const normalized = normalizeProviderId(providerId);
@@ -1071,8 +1077,7 @@ export function resolveExternalAuthProfilesWithPlugins(params: {
       continue;
     }
     const pluginId = plugin.pluginId ?? plugin.id;
-    if (!declaredPluginIds.has(pluginId) && !warnedExternalAuthFallbackPluginIds.has(pluginId)) {
-      warnedExternalAuthFallbackPluginIds.add(pluginId);
+    if (!declaredPluginIds.has(pluginId) && !warnedExternalAuthFallbackPluginIds.check(pluginId)) {
       log.warn(
         `Provider plugin "${sanitizeForLog(pluginId)}" uses external auth hooks without declaring contracts.externalAuthProviders. This compatibility fallback is deprecated and will be removed in a future release.`,
       );

--- a/src/plugins/provider-validation.test.ts
+++ b/src/plugins/provider-validation.test.ts
@@ -1,5 +1,5 @@
 /** Covers provider registration validation for ids, duplicates, and required hooks. */
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import { normalizeRegisteredProvider } from "./provider-validation.js";
 import type { ProviderPlugin } from "./types.js";
@@ -295,4 +295,64 @@ describe("normalizeRegisteredProvider", () => {
       });
     },
   );
+});
+
+describe("deprecated discovery provider warning dedupe cache", () => {
+  let normalizeRegisteredProviderFn: typeof normalizeRegisteredProvider;
+
+  function normalizeDiscoveryProvider(id: string, diagnostics: PluginDiagnostic[]) {
+    normalizeRegisteredProviderFn({
+      pluginId: "demo-plugin",
+      source: "/tmp/demo/index.ts",
+      provider: makeProvider({
+        id,
+        discovery: {
+          run: async () => ({
+            provider: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              models: [],
+            },
+          }),
+        },
+      }),
+      pushDiagnostic: (diag) => diagnostics.push(diag),
+    });
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("./provider-validation.js");
+    normalizeRegisteredProviderFn = mod.normalizeRegisteredProvider;
+  });
+
+  it("refreshes recent keys across registrations and re-warns evicted keys", () => {
+    const diagnostics: PluginDiagnostic[] = [];
+
+    for (let i = 0; i < 4096; i += 1) {
+      normalizeDiscoveryProvider(`legacy-discovery-${i}`, diagnostics);
+    }
+    expect(
+      diagnostics.filter((diag) => diag.message.includes("deprecated discovery")),
+    ).toHaveLength(4096);
+
+    normalizeDiscoveryProvider("legacy-discovery-0", diagnostics);
+    expect(
+      diagnostics.filter((diag) => diag.message.includes("deprecated discovery")),
+    ).toHaveLength(4096);
+
+    normalizeDiscoveryProvider("overflow-discovery", diagnostics);
+    expect(
+      diagnostics.filter((diag) => diag.message.includes("deprecated discovery")),
+    ).toHaveLength(4097);
+
+    normalizeDiscoveryProvider("legacy-discovery-0", diagnostics);
+    expect(
+      diagnostics.filter((diag) => diag.message.includes("deprecated discovery")),
+    ).toHaveLength(4097);
+
+    normalizeDiscoveryProvider("legacy-discovery-1", diagnostics);
+    expect(
+      diagnostics.filter((diag) => diag.message.includes("deprecated discovery")),
+    ).toHaveLength(4098);
+  });
 });

--- a/src/plugins/provider-validation.ts
+++ b/src/plugins/provider-validation.ts
@@ -1,11 +1,17 @@
 /** Validates and normalizes provider plugin definitions before registry registration. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
+import { createDedupeCache } from "../infra/dedupe.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import type { ProviderAuthMethod, ProviderPlugin } from "./types.js";
 import { pushPluginValidationDiagnostic } from "./validation-diagnostics.js";
 
-const warnedDeprecatedDiscoveryProviders = new Set<string>();
+const MAX_WARNED_DEPRECATED_DISCOVERY_PROVIDERS = 4096;
+// Warning state spans provider registrations; bounding it means evicted keys can re-warn.
+const warnedDeprecatedDiscoveryProviders = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_DEPRECATED_DISCOVERY_PROVIDERS,
+});
 
 type ProviderWizardSetup = NonNullable<NonNullable<ProviderPlugin["wizard"]>["setup"]>;
 type ProviderWizardModelPicker = NonNullable<NonNullable<ProviderPlugin["wizard"]>["modelPicker"]>;
@@ -365,8 +371,8 @@ export function normalizeRegisteredProvider(params: {
   }
   if (!catalog && discovery) {
     const warningKey = `${params.pluginId}:${id}:discovery`;
-    if (!warnedDeprecatedDiscoveryProviders.has(warningKey)) {
-      warnedDeprecatedDiscoveryProviders.add(warningKey);
+    // Warning state spans provider registrations; bounding it means evicted keys can re-warn.
+    if (!warnedDeprecatedDiscoveryProviders.check(warningKey)) {
       pushPluginValidationDiagnostic({
         level: "warn",
         pluginId: params.pluginId,


### PR DESCRIPTION
## What Problem This Solves

`src/plugins/provider-validation.ts` and `src/plugins/provider-runtime.ts` each keep an unbounded process-lifetime `Set<string>` for deprecation/fallback warnings. Over a long-running gateway these caches can grow without bound, leaking memory for every unique provider/plugin id encountered.

## Why This Change Was Made

Replaces the two unbounded `Set<string>` instances with bounded `createDedupeCache({ ttlMs: 0, maxSize: 4096 })` caches, following the exact pattern from:

- #101696 `fix(config): cap legacy toolsBySender deprecation warning cache with shared dedupe helper`
- #101650 `fix(channels): prevent metadata caches from growing without bound`

This bounds process-local warning state while preserving the existing "warn once per key" behavior. Evicted keys naturally re-warn if they appear again later.

## User Impact

No user-facing behavior change for normal usage. Long-running OpenClaw gateways no longer accumulate unbounded memory in these two warning caches.

## Evidence

- Added `deprecated discovery provider warning dedupe cache` test in `src/plugins/provider-validation.test.ts` that fills the 4096-slot cache, refreshes a recent key, overflows it, and proves the evicted key re-warns.
- Added `bounds the external auth fallback warning cache and re-warns evicted plugin ids` test in `src/plugins/provider-runtime.test.ts` using the same guard pattern.
- Local focused test run:
  - `node scripts/run-vitest.mjs src/plugins/provider-validation.test.ts` — 5 passed
  - `node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts` — 63 passed
  - `node scripts/run-vitest.mjs src/plugins/provider-validation.test.ts src/plugins/provider-runtime.test.ts` — 68 passed
- Formatted with `oxfmt`.
## Real behavior proof

- **Behavior addressed**: The provider deprecation warning cache (`src/plugins/provider-validation.ts`) and external-auth fallback warning cache (`src/plugins/provider-runtime.ts`) are bounded to 4,096 entries each with LRU eviction.
- **Real environment tested**: Linux x86_64, Node 22.22.0, OpenClaw worktree at PR head `d6fe4918b4aa`.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs src/plugins/provider-validation.test.ts src/plugins/provider-runtime.test.ts --run
  ```
- **Evidence after fix**:
  ```
  Test Files  2 passed (2)
       Tests  68 passed (68)
  ```
  New tests fill each 4,096-entry cache, refresh a retained key, overflow the cap, and verify the evicted key re-warns while the refreshed key remains suppressed.
- **Observed result after fix**: Each warning owner emits once per unique key up to the cap; evicted keys re-warn, preserving the existing dedupe semantics under normal load.
- **What was not tested**: Live provider discovery or auth resolution against a real external endpoint; the bounded-cache behavior is validated through the production warning-owner code paths.
