### PR TITLE
fix(config): bound config I/O warning caches

### DIFF
--- a/src/config/io.invalid-config.test.ts
+++ b/src/config/io.invalid-config.test.ts
@@ -1,5 +1,6 @@
 // Verifies invalid-config errors include stable codes and details.
 import { describe, expect, it, vi } from "vitest";
+import { createDedupeCache } from "../infra/dedupe.js";
 import {
   createInvalidConfigError,
   formatInvalidConfigDetails,
@@ -45,7 +46,7 @@ describe("config io invalid config formatting", () => {
 
   it("throws INVALID_CONFIG after logging the formatted details once per path", () => {
     const logger = { error: vi.fn() };
-    const loggedConfigPaths = new Set<string>();
+    const loggedConfigPaths = createDedupeCache({ ttlMs: 0, maxSize: 4096 });
     const throwInvalid = () =>
       throwInvalidConfig({
         configPath: "/tmp/openclaw.json",

--- a/src/config/io.invalid-config.ts
+++ b/src/config/io.invalid-config.ts
@@ -3,6 +3,7 @@
  * All terminal-facing text is sanitized here so callers can reuse the same failure surface.
  */
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import type { DedupeCache } from "../infra/dedupe.js";
 import { extractErrorCode } from "../infra/errors.js";
 
 /** Minimal validation issue shape accepted from schema and mutation validation paths. */
@@ -32,13 +33,12 @@ function logInvalidConfigOnce(params: {
   configPath: string;
   details: string;
   logger: Pick<typeof console, "error">;
-  loggedConfigPaths: Set<string>;
+  loggedConfigPaths: DedupeCache;
 }): void {
-  if (params.loggedConfigPaths.has(params.configPath)) {
+  if (params.loggedConfigPaths.check(params.configPath)) {
     // Avoid repeating the same invalid config block when multiple callers observe the same path.
     return;
   }
-  params.loggedConfigPaths.add(params.configPath);
   params.logger.error(formatInvalidConfigLogMessage(params.configPath, params.details));
 }
 
@@ -64,7 +64,7 @@ export function throwInvalidConfig(params: {
   configPath: string;
   issues: ConfigValidationIssueLike[];
   logger: Pick<typeof console, "error">;
-  loggedConfigPaths: Set<string>;
+  loggedConfigPaths: DedupeCache;
 }): never {
   const details = formatInvalidConfigDetails(params.issues);
   logInvalidConfigOnce({

--- a/src/config/io.owner-display-secret.ts
+++ b/src/config/io.owner-display-secret.ts
@@ -2,7 +2,6 @@
  * Runtime-only owner display secret retention for config IO.
  * Generated secrets stay in memory by config path and are never written back into config files.
  */
-import { setBoundedConfigIoMapEntry } from "./io.state.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 /** Runtime-only owner display secrets keyed by config path during config IO. */
@@ -26,6 +25,6 @@ export function retainGeneratedOwnerDisplaySecret(params: {
 
   // Keep the generated secret available to runtime callers while preserving config object identity
   // and avoiding a write of the secret back to disk.
-  setBoundedConfigIoMapEntry(state.pendingByPath, configPath, generatedSecret);
+  state.pendingByPath.set(configPath, generatedSecret);
   return config;
 }

--- a/src/config/io.owner-display-secret.ts
+++ b/src/config/io.owner-display-secret.ts
@@ -2,8 +2,7 @@
  * Runtime-only owner display secret retention for config IO.
  * Generated secrets stay in memory by config path and are never written back into config files.
  */
-import { pruneMapToMaxSize } from "../infra/map-size.js";
-import { MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH } from "./io.state.js";
+import { setBoundedConfigIoMapEntry } from "./io.state.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 /** Runtime-only owner display secrets keyed by config path during config IO. */
@@ -27,7 +26,6 @@ export function retainGeneratedOwnerDisplaySecret(params: {
 
   // Keep the generated secret available to runtime callers while preserving config object identity
   // and avoiding a write of the secret back to disk.
-  state.pendingByPath.set(configPath, generatedSecret);
-  pruneMapToMaxSize(state.pendingByPath, MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH);
+  setBoundedConfigIoMapEntry(state.pendingByPath, configPath, generatedSecret);
   return config;
 }

--- a/src/config/io.owner-display-secret.ts
+++ b/src/config/io.owner-display-secret.ts
@@ -2,6 +2,8 @@
  * Runtime-only owner display secret retention for config IO.
  * Generated secrets stay in memory by config path and are never written back into config files.
  */
+import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH } from "./io.state.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 /** Runtime-only owner display secrets keyed by config path during config IO. */
@@ -26,5 +28,6 @@ export function retainGeneratedOwnerDisplaySecret(params: {
   // Keep the generated secret available to runtime callers while preserving config object identity
   // and avoiding a write of the secret back to disk.
   state.pendingByPath.set(configPath, generatedSecret);
+  pruneMapToMaxSize(state.pendingByPath, MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH);
   return config;
 }

--- a/src/config/io.state.test.ts
+++ b/src/config/io.state.test.ts
@@ -12,8 +12,9 @@ describe("config IO state caches", () => {
 
   describe("loggedInvalidConfigs dedupe cache", () => {
     it("caps at MAX_LOGGED_INVALID_CONFIGS and re-warns evicted paths", async () => {
-      const { loggedInvalidConfigs, MAX_LOGGED_INVALID_CONFIGS } = await import("./io.state.js");
+      const { loggedInvalidConfigs } = await import("./io.state.js");
       const { throwInvalidConfig } = await import("./io.invalid-config.js");
+      const MAX_LOGGED_INVALID_CONFIGS = 4096;
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       for (let i = 0; i < MAX_LOGGED_INVALID_CONFIGS; i++) {
@@ -66,9 +67,9 @@ describe("config IO state caches", () => {
 
   describe("warnedFutureTouchedVersions dedupe cache", () => {
     it("caps at MAX_WARNED_FUTURE_TOUCHED_VERSIONS and re-warns evicted versions", async () => {
-      const { warnedFutureTouchedVersions, MAX_WARNED_FUTURE_TOUCHED_VERSIONS } =
-        await import("./io.state.js");
+      const { warnedFutureTouchedVersions } = await import("./io.state.js");
       const { warnIfConfigFromFuture } = await import("./io.warnings.js");
+      const MAX_WARNED_FUTURE_TOUCHED_VERSIONS = 4096;
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
       for (let i = 0; i < MAX_WARNED_FUTURE_TOUCHED_VERSIONS; i++) {

--- a/src/config/io.state.test.ts
+++ b/src/config/io.state.test.ts
@@ -1,0 +1,175 @@
+// Verifies config IO warning and pending-secret caches are bounded across process lifetime.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("config IO state caches", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("loggedInvalidConfigs dedupe cache", () => {
+    it("caps at MAX_LOGGED_INVALID_CONFIGS and re-warns evicted paths", async () => {
+      const { loggedInvalidConfigs, MAX_LOGGED_INVALID_CONFIGS } = await import("./io.state.js");
+      const { throwInvalidConfig } = await import("./io.invalid-config.js");
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      for (let i = 0; i < MAX_LOGGED_INVALID_CONFIGS; i++) {
+        expect(() =>
+          throwInvalidConfig({
+            configPath: `/config-${i}.json`,
+            issues: [{ path: "root", message: "invalid" }],
+            logger: console,
+            loggedConfigPaths: loggedInvalidConfigs,
+          }),
+        ).toThrow();
+      }
+      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS);
+      expect(loggedInvalidConfigs.size()).toBe(MAX_LOGGED_INVALID_CONFIGS);
+
+      // Refresh the first entry; it stays in the cache.
+      expect(() =>
+        throwInvalidConfig({
+          configPath: "/config-0.json",
+          issues: [{ path: "root", message: "invalid" }],
+          logger: console,
+          loggedConfigPaths: loggedInvalidConfigs,
+        }),
+      ).toThrow();
+      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS);
+
+      // Overflow evicts the oldest entry (now config-1 because config-0 was refreshed).
+      expect(() =>
+        throwInvalidConfig({
+          configPath: "/overflow.json",
+          issues: [{ path: "root", message: "invalid" }],
+          logger: console,
+          loggedConfigPaths: loggedInvalidConfigs,
+        }),
+      ).toThrow();
+      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS + 1);
+
+      // The evicted entry re-warns.
+      expect(() =>
+        throwInvalidConfig({
+          configPath: "/config-1.json",
+          issues: [{ path: "root", message: "invalid" }],
+          logger: console,
+          loggedConfigPaths: loggedInvalidConfigs,
+        }),
+      ).toThrow();
+      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS + 2);
+    });
+  });
+
+  describe("warnedFutureTouchedVersions dedupe cache", () => {
+    it("caps at MAX_WARNED_FUTURE_TOUCHED_VERSIONS and re-warns evicted versions", async () => {
+      const { warnedFutureTouchedVersions, MAX_WARNED_FUTURE_TOUCHED_VERSIONS } =
+        await import("./io.state.js");
+      const { warnIfConfigFromFuture } = await import("./io.warnings.js");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      for (let i = 0; i < MAX_WARNED_FUTURE_TOUCHED_VERSIONS; i++) {
+        warnIfConfigFromFuture(
+          { meta: { lastTouchedVersion: `3000.1.${i}` } } as Parameters<
+            typeof warnIfConfigFromFuture
+          >[0],
+          console,
+        );
+      }
+      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS);
+      expect(warnedFutureTouchedVersions.size()).toBe(MAX_WARNED_FUTURE_TOUCHED_VERSIONS);
+
+      // Refresh the first entry.
+      warnIfConfigFromFuture(
+        { meta: { lastTouchedVersion: "3000.1.0" } } as Parameters<
+          typeof warnIfConfigFromFuture
+        >[0],
+        console,
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS);
+
+      // Overflow evicts the oldest entry.
+      warnIfConfigFromFuture(
+        { meta: { lastTouchedVersion: "3000.1.9999" } } as Parameters<
+          typeof warnIfConfigFromFuture
+        >[0],
+        console,
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS + 1);
+
+      // The evicted entry re-warns.
+      warnIfConfigFromFuture(
+        { meta: { lastTouchedVersion: "3000.1.1" } } as Parameters<
+          typeof warnIfConfigFromFuture
+        >[0],
+        console,
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS + 2);
+    });
+  });
+
+  describe("loggedConfigWarningFingerprints map", () => {
+    it("prunes to MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS preserving newest entries", async () => {
+      const { loggedConfigWarningFingerprints, MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS } =
+        await import("./io.state.js");
+      const { logConfigWarningsOnce } = await import("./io.warnings.js");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      for (let i = 0; i < MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS; i++) {
+        logConfigWarningsOnce({
+          configPath: `/config-${i}.json`,
+          warnings: [{ path: "root", message: `warning-${i}` }],
+          logger: console,
+        });
+      }
+      expect(loggedConfigWarningFingerprints.size).toBe(MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS);
+      expect(loggedConfigWarningFingerprints.has("/config-0.json")).toBe(true);
+
+      // Add an overflow entry; the oldest insertion-order key is evicted.
+      logConfigWarningsOnce({
+        configPath: "/overflow.json",
+        warnings: [{ path: "root", message: "overflow" }],
+        logger: console,
+      });
+      expect(loggedConfigWarningFingerprints.size).toBe(MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS);
+      expect(loggedConfigWarningFingerprints.has("/config-0.json")).toBe(false);
+      expect(loggedConfigWarningFingerprints.has("/overflow.json")).toBe(true);
+
+      expect(warnSpy).toHaveBeenCalledTimes(MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS + 1);
+    });
+  });
+
+  describe("autoOwnerDisplaySecretByPath map", () => {
+    it("prunes to MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH preserving newest entries", async () => {
+      const { autoOwnerDisplaySecretByPath, MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH } =
+        await import("./io.state.js");
+      const { retainGeneratedOwnerDisplaySecret } = await import("./io.owner-display-secret.js");
+
+      const config = {} as Parameters<typeof retainGeneratedOwnerDisplaySecret>[0]["config"];
+      for (let i = 0; i < MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH; i++) {
+        retainGeneratedOwnerDisplaySecret({
+          config,
+          configPath: `/config-${i}.json`,
+          generatedSecret: `secret-${i}`,
+          state: { pendingByPath: autoOwnerDisplaySecretByPath },
+        });
+      }
+      expect(autoOwnerDisplaySecretByPath.size).toBe(MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH);
+      expect(autoOwnerDisplaySecretByPath.has("/config-0.json")).toBe(true);
+
+      // Add an overflow entry; the oldest insertion-order key is evicted.
+      retainGeneratedOwnerDisplaySecret({
+        config,
+        configPath: "/overflow.json",
+        generatedSecret: "overflow-secret",
+        state: { pendingByPath: autoOwnerDisplaySecretByPath },
+      });
+      expect(autoOwnerDisplaySecretByPath.size).toBe(MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH);
+      expect(autoOwnerDisplaySecretByPath.has("/config-0.json")).toBe(false);
+      expect(autoOwnerDisplaySecretByPath.has("/overflow.json")).toBe(true);
+    });
+  });
+});

--- a/src/config/io.state.test.ts
+++ b/src/config/io.state.test.ts
@@ -1,176 +1,120 @@
-// Verifies config IO warning and pending-secret caches are bounded across process lifetime.
+// Verifies config IO warning and pending-secret caches stay bounded across process lifetime.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isInvalidConfigError, throwInvalidConfig } from "./io.invalid-config.js";
+import { retainGeneratedOwnerDisplaySecret } from "./io.owner-display-secret.js";
+import {
+  autoOwnerDisplaySecretByPath,
+  loggedConfigWarningFingerprints,
+  loggedInvalidConfigs,
+  warnedFutureTouchedVersions,
+} from "./io.state.js";
+import { logConfigWarningsOnce, warnIfConfigFromFuture } from "./io.warnings.js";
+
+const CACHE_MAX_SIZE = 4096;
+
+beforeEach(() => {
+  loggedInvalidConfigs.clear();
+  loggedConfigWarningFingerprints.clear();
+  warnedFutureTouchedVersions.clear();
+  autoOwnerDisplaySecretByPath.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function recordInvalidConfig(configPath: string, logger: Pick<typeof console, "error">): void {
+  try {
+    throwInvalidConfig({
+      configPath,
+      issues: [{ path: "root", message: "invalid" }],
+      logger,
+      loggedConfigPaths: loggedInvalidConfigs,
+    });
+  } catch (error) {
+    if (isInvalidConfigError(error)) {
+      return;
+    }
+    throw error;
+  }
+  throw new Error("expected invalid config error");
+}
 
 describe("config IO state caches", () => {
-  beforeEach(() => {
-    vi.resetModules();
+  it("keeps hot invalid-config paths while evicted paths re-warn", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    for (let i = 0; i < CACHE_MAX_SIZE; i++) {
+      recordInvalidConfig(`/config-${i}.json`, console);
+    }
+
+    recordInvalidConfig("/config-0.json", console);
+    recordInvalidConfig("/overflow.json", console);
+    recordInvalidConfig("/config-1.json", console);
+
+    expect(loggedInvalidConfigs.size()).toBe(CACHE_MAX_SIZE);
+    expect(errorSpy).toHaveBeenCalledTimes(CACHE_MAX_SIZE + 2);
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  describe("loggedInvalidConfigs dedupe cache", () => {
-    it("caps at MAX_LOGGED_INVALID_CONFIGS and re-warns evicted paths", async () => {
-      const { loggedInvalidConfigs } = await import("./io.state.js");
-      const { throwInvalidConfig } = await import("./io.invalid-config.js");
-      const MAX_LOGGED_INVALID_CONFIGS = 4096;
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-      for (let i = 0; i < MAX_LOGGED_INVALID_CONFIGS; i++) {
-        expect(() =>
-          throwInvalidConfig({
-            configPath: `/config-${i}.json`,
-            issues: [{ path: "root", message: "invalid" }],
-            logger: console,
-            loggedConfigPaths: loggedInvalidConfigs,
-          }),
-        ).toThrow();
-      }
-      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS);
-      expect(loggedInvalidConfigs.size()).toBe(MAX_LOGGED_INVALID_CONFIGS);
-
-      // Refresh the first entry; it stays in the cache.
-      expect(() =>
-        throwInvalidConfig({
-          configPath: "/config-0.json",
-          issues: [{ path: "root", message: "invalid" }],
-          logger: console,
-          loggedConfigPaths: loggedInvalidConfigs,
-        }),
-      ).toThrow();
-      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS);
-
-      // Overflow evicts the oldest entry (now config-1 because config-0 was refreshed).
-      expect(() =>
-        throwInvalidConfig({
-          configPath: "/overflow.json",
-          issues: [{ path: "root", message: "invalid" }],
-          logger: console,
-          loggedConfigPaths: loggedInvalidConfigs,
-        }),
-      ).toThrow();
-      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS + 1);
-
-      // The evicted entry re-warns.
-      expect(() =>
-        throwInvalidConfig({
-          configPath: "/config-1.json",
-          issues: [{ path: "root", message: "invalid" }],
-          logger: console,
-          loggedConfigPaths: loggedInvalidConfigs,
-        }),
-      ).toThrow();
-      expect(errorSpy).toHaveBeenCalledTimes(MAX_LOGGED_INVALID_CONFIGS + 2);
-    });
-  });
-
-  describe("warnedFutureTouchedVersions dedupe cache", () => {
-    it("caps at MAX_WARNED_FUTURE_TOUCHED_VERSIONS and re-warns evicted versions", async () => {
-      const { warnedFutureTouchedVersions } = await import("./io.state.js");
-      const { warnIfConfigFromFuture } = await import("./io.warnings.js");
-      const MAX_WARNED_FUTURE_TOUCHED_VERSIONS = 4096;
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-      for (let i = 0; i < MAX_WARNED_FUTURE_TOUCHED_VERSIONS; i++) {
-        warnIfConfigFromFuture(
-          { meta: { lastTouchedVersion: `3000.1.${i}` } } as Parameters<
-            typeof warnIfConfigFromFuture
-          >[0],
-          console,
-        );
-      }
-      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS);
-      expect(warnedFutureTouchedVersions.size()).toBe(MAX_WARNED_FUTURE_TOUCHED_VERSIONS);
-
-      // Refresh the first entry.
+  it("keeps hot future versions while evicted versions re-warn", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warnVersion = (version: string) =>
       warnIfConfigFromFuture(
-        { meta: { lastTouchedVersion: "3000.1.0" } } as Parameters<
-          typeof warnIfConfigFromFuture
-        >[0],
+        { meta: { lastTouchedVersion: version } } as Parameters<typeof warnIfConfigFromFuture>[0],
         console,
       );
-      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS);
+    for (let i = 0; i < CACHE_MAX_SIZE; i++) {
+      warnVersion(`3000.1.${i}`);
+    }
 
-      // Overflow evicts the oldest entry.
-      warnIfConfigFromFuture(
-        { meta: { lastTouchedVersion: "3000.1.9999" } } as Parameters<
-          typeof warnIfConfigFromFuture
-        >[0],
-        console,
-      );
-      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS + 1);
+    warnVersion("3000.1.0");
+    warnVersion("3000.1.9999");
+    warnVersion("3000.1.1");
 
-      // The evicted entry re-warns.
-      warnIfConfigFromFuture(
-        { meta: { lastTouchedVersion: "3000.1.1" } } as Parameters<
-          typeof warnIfConfigFromFuture
-        >[0],
-        console,
-      );
-      expect(warnSpy).toHaveBeenCalledTimes(MAX_WARNED_FUTURE_TOUCHED_VERSIONS + 2);
-    });
+    expect(warnedFutureTouchedVersions.size()).toBe(CACHE_MAX_SIZE);
+    expect(warnSpy).toHaveBeenCalledTimes(CACHE_MAX_SIZE + 2);
   });
 
-  describe("loggedConfigWarningFingerprints map", () => {
-    it("prunes to MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS preserving newest entries", async () => {
-      const { loggedConfigWarningFingerprints, MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS } =
-        await import("./io.state.js");
-      const { logConfigWarningsOnce } = await import("./io.warnings.js");
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-      for (let i = 0; i < MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS; i++) {
-        logConfigWarningsOnce({
-          configPath: `/config-${i}.json`,
-          warnings: [{ path: "root", message: `warning-${i}` }],
-          logger: console,
-        });
-      }
-      expect(loggedConfigWarningFingerprints.size).toBe(MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS);
-      expect(loggedConfigWarningFingerprints.has("/config-0.json")).toBe(true);
-
-      // Add an overflow entry; the oldest insertion-order key is evicted.
+  it("retains a hot warning fingerprint while evicting and re-warning the cold path", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warnPath = (configPath: string) =>
       logConfigWarningsOnce({
-        configPath: "/overflow.json",
-        warnings: [{ path: "root", message: "overflow" }],
+        configPath,
+        warnings: [{ path: "root", message: "warning" }],
         logger: console,
       });
-      expect(loggedConfigWarningFingerprints.size).toBe(MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS);
-      expect(loggedConfigWarningFingerprints.has("/config-0.json")).toBe(false);
-      expect(loggedConfigWarningFingerprints.has("/overflow.json")).toBe(true);
+    for (let i = 0; i < CACHE_MAX_SIZE; i++) {
+      warnPath(`/config-${i}.json`);
+    }
 
-      expect(warnSpy).toHaveBeenCalledTimes(MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS + 1);
-    });
+    warnPath("/config-0.json");
+    warnPath("/overflow.json");
+    expect(loggedConfigWarningFingerprints.has("/config-0.json")).toBe(true);
+    expect(loggedConfigWarningFingerprints.has("/config-1.json")).toBe(false);
+
+    warnPath("/config-1.json");
+    expect(loggedConfigWarningFingerprints.size).toBe(CACHE_MAX_SIZE);
+    expect(warnSpy).toHaveBeenCalledTimes(CACHE_MAX_SIZE + 2);
   });
 
-  describe("autoOwnerDisplaySecretByPath map", () => {
-    it("prunes to MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH preserving newest entries", async () => {
-      const { autoOwnerDisplaySecretByPath, MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH } =
-        await import("./io.state.js");
-      const { retainGeneratedOwnerDisplaySecret } = await import("./io.owner-display-secret.js");
-
-      const config = {} as Parameters<typeof retainGeneratedOwnerDisplaySecret>[0]["config"];
-      for (let i = 0; i < MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH; i++) {
-        retainGeneratedOwnerDisplaySecret({
-          config,
-          configPath: `/config-${i}.json`,
-          generatedSecret: `secret-${i}`,
-          state: { pendingByPath: autoOwnerDisplaySecretByPath },
-        });
-      }
-      expect(autoOwnerDisplaySecretByPath.size).toBe(MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH);
-      expect(autoOwnerDisplaySecretByPath.has("/config-0.json")).toBe(true);
-
-      // Add an overflow entry; the oldest insertion-order key is evicted.
+  it("retains a hot pending owner value while evicting the cold path", () => {
+    const config = {} as Parameters<typeof retainGeneratedOwnerDisplaySecret>[0]["config"];
+    const retain = (configPath: string, generatedSecret: string) =>
       retainGeneratedOwnerDisplaySecret({
         config,
-        configPath: "/overflow.json",
-        generatedSecret: "overflow-secret",
+        configPath,
+        generatedSecret,
         state: { pendingByPath: autoOwnerDisplaySecretByPath },
       });
-      expect(autoOwnerDisplaySecretByPath.size).toBe(MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH);
-      expect(autoOwnerDisplaySecretByPath.has("/config-0.json")).toBe(false);
-      expect(autoOwnerDisplaySecretByPath.has("/overflow.json")).toBe(true);
-    });
+    for (let i = 0; i < CACHE_MAX_SIZE; i++) {
+      retain(`/config-${i}.json`, `value-${i}`);
+    }
+
+    retain("/config-0.json", "value-0");
+    retain("/overflow.json", "overflow-value");
+
+    expect(autoOwnerDisplaySecretByPath.size).toBe(CACHE_MAX_SIZE);
+    expect(autoOwnerDisplaySecretByPath.get("/config-0.json")).toBe("value-0");
+    expect(autoOwnerDisplaySecretByPath.has("/config-1.json")).toBe(false);
+    expect(autoOwnerDisplaySecretByPath.get("/overflow.json")).toBe("overflow-value");
   });
 });

--- a/src/config/io.state.test.ts
+++ b/src/config/io.state.test.ts
@@ -1,9 +1,7 @@
-// Verifies config IO warning and pending-secret caches stay bounded across process lifetime.
+// Verifies config IO warning caches stay bounded across process lifetime.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isInvalidConfigError, throwInvalidConfig } from "./io.invalid-config.js";
-import { retainGeneratedOwnerDisplaySecret } from "./io.owner-display-secret.js";
 import {
-  autoOwnerDisplaySecretByPath,
   loggedConfigWarningFingerprints,
   loggedInvalidConfigs,
   warnedFutureTouchedVersions,
@@ -16,7 +14,6 @@ beforeEach(() => {
   loggedInvalidConfigs.clear();
   loggedConfigWarningFingerprints.clear();
   warnedFutureTouchedVersions.clear();
-  autoOwnerDisplaySecretByPath.clear();
 });
 
 afterEach(() => {
@@ -94,27 +91,5 @@ describe("config IO state caches", () => {
     warnPath("/config-1.json");
     expect(loggedConfigWarningFingerprints.size).toBe(CACHE_MAX_SIZE);
     expect(warnSpy).toHaveBeenCalledTimes(CACHE_MAX_SIZE + 2);
-  });
-
-  it("retains a hot pending owner value while evicting the cold path", () => {
-    const config = {} as Parameters<typeof retainGeneratedOwnerDisplaySecret>[0]["config"];
-    const retain = (configPath: string, generatedSecret: string) =>
-      retainGeneratedOwnerDisplaySecret({
-        config,
-        configPath,
-        generatedSecret,
-        state: { pendingByPath: autoOwnerDisplaySecretByPath },
-      });
-    for (let i = 0; i < CACHE_MAX_SIZE; i++) {
-      retain(`/config-${i}.json`, `value-${i}`);
-    }
-
-    retain("/config-0.json", "value-0");
-    retain("/overflow.json", "overflow-value");
-
-    expect(autoOwnerDisplaySecretByPath.size).toBe(CACHE_MAX_SIZE);
-    expect(autoOwnerDisplaySecretByPath.get("/config-0.json")).toBe("value-0");
-    expect(autoOwnerDisplaySecretByPath.has("/config-1.json")).toBe(false);
-    expect(autoOwnerDisplaySecretByPath.get("/overflow.json")).toBe("overflow-value");
   });
 });

--- a/src/config/io.state.ts
+++ b/src/config/io.state.ts
@@ -1,12 +1,12 @@
 import { createDedupeCache } from "../infra/dedupe.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 
-const CONFIG_IO_CACHE_MAX_SIZE = 4096;
+const CONFIG_IO_WARNING_CACHE_MAX_SIZE = 4096;
 
 // Warning state spans fresh config snapshots; bounding it means evicted paths can re-warn.
 export const loggedInvalidConfigs = createDedupeCache({
   ttlMs: 0,
-  maxSize: CONFIG_IO_CACHE_MAX_SIZE,
+  maxSize: CONFIG_IO_WARNING_CACHE_MAX_SIZE,
 });
 
 export const loggedConfigWarningFingerprints = new Map<string, string>();
@@ -14,14 +14,14 @@ export const loggedConfigWarningFingerprints = new Map<string, string>();
 // Warning state spans fresh config snapshots; bounding it means evicted versions can re-warn.
 export const warnedFutureTouchedVersions = createDedupeCache({
   ttlMs: 0,
-  maxSize: CONFIG_IO_CACHE_MAX_SIZE,
+  maxSize: CONFIG_IO_WARNING_CACHE_MAX_SIZE,
 });
 
 export const autoOwnerDisplaySecretByPath = new Map<string, string>();
 
-/** Retains a config-I/O map entry as most-recently used while enforcing the shared bound. */
-export function setBoundedConfigIoMapEntry<K, V>(map: Map<K, V>, key: K, value: V): void {
+/** Retains a warning fingerprint as most-recently used while enforcing the shared bound. */
+export function setBoundedConfigIoWarningEntry<K, V>(map: Map<K, V>, key: K, value: V): void {
   map.delete(key);
   map.set(key, value);
-  pruneMapToMaxSize(map, CONFIG_IO_CACHE_MAX_SIZE);
+  pruneMapToMaxSize(map, CONFIG_IO_WARNING_CACHE_MAX_SIZE);
 }

--- a/src/config/io.state.ts
+++ b/src/config/io.state.ts
@@ -1,22 +1,27 @@
-import { createDedupeCache, type DedupeCache } from "../infra/dedupe.js";
+import { createDedupeCache } from "../infra/dedupe.js";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
 
-const MAX_LOGGED_INVALID_CONFIGS = 4096;
-export const MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS = 4096;
-const MAX_WARNED_FUTURE_TOUCHED_VERSIONS = 4096;
-export const MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH = 4096;
+const CONFIG_IO_CACHE_MAX_SIZE = 4096;
 
 // Warning state spans fresh config snapshots; bounding it means evicted paths can re-warn.
-export const loggedInvalidConfigs: DedupeCache = createDedupeCache({
+export const loggedInvalidConfigs = createDedupeCache({
   ttlMs: 0,
-  maxSize: MAX_LOGGED_INVALID_CONFIGS,
+  maxSize: CONFIG_IO_CACHE_MAX_SIZE,
 });
 
 export const loggedConfigWarningFingerprints = new Map<string, string>();
 
 // Warning state spans fresh config snapshots; bounding it means evicted versions can re-warn.
-export const warnedFutureTouchedVersions: DedupeCache = createDedupeCache({
+export const warnedFutureTouchedVersions = createDedupeCache({
   ttlMs: 0,
-  maxSize: MAX_WARNED_FUTURE_TOUCHED_VERSIONS,
+  maxSize: CONFIG_IO_CACHE_MAX_SIZE,
 });
 
 export const autoOwnerDisplaySecretByPath = new Map<string, string>();
+
+/** Retains a config-I/O map entry as most-recently used while enforcing the shared bound. */
+export function setBoundedConfigIoMapEntry<K, V>(map: Map<K, V>, key: K, value: V): void {
+  map.delete(key);
+  map.set(key, value);
+  pruneMapToMaxSize(map, CONFIG_IO_CACHE_MAX_SIZE);
+}

--- a/src/config/io.state.ts
+++ b/src/config/io.state.ts
@@ -1,4 +1,23 @@
-export const loggedInvalidConfigs = new Set<string>();
+import { createDedupeCache, type DedupeCache } from "../infra/dedupe.js";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
+
+export const MAX_LOGGED_INVALID_CONFIGS = 4096;
+export const MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS = 4096;
+export const MAX_WARNED_FUTURE_TOUCHED_VERSIONS = 4096;
+export const MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH = 4096;
+
+// Warning state spans fresh config snapshots; bounding it means evicted paths can re-warn.
+export const loggedInvalidConfigs: DedupeCache = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_LOGGED_INVALID_CONFIGS,
+});
+
 export const loggedConfigWarningFingerprints = new Map<string, string>();
-export const warnedFutureTouchedVersions = new Set<string>();
+
+// Warning state spans fresh config snapshots; bounding it means evicted versions can re-warn.
+export const warnedFutureTouchedVersions: DedupeCache = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_FUTURE_TOUCHED_VERSIONS,
+});
+
 export const autoOwnerDisplaySecretByPath = new Map<string, string>();

--- a/src/config/io.state.ts
+++ b/src/config/io.state.ts
@@ -1,9 +1,8 @@
 import { createDedupeCache, type DedupeCache } from "../infra/dedupe.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 
-export const MAX_LOGGED_INVALID_CONFIGS = 4096;
+const MAX_LOGGED_INVALID_CONFIGS = 4096;
 export const MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS = 4096;
-export const MAX_WARNED_FUTURE_TOUCHED_VERSIONS = 4096;
+const MAX_WARNED_FUTURE_TOUCHED_VERSIONS = 4096;
 export const MAX_AUTO_OWNER_DISPLAY_SECRET_BY_PATH = 4096;
 
 // Warning state spans fresh config snapshots; bounding it means evicted paths can re-warn.

--- a/src/config/io.warnings.ts
+++ b/src/config/io.warnings.ts
@@ -1,7 +1,12 @@
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { VERSION } from "../version.js";
 import { hashConfigRaw } from "./io.read-helpers.js";
-import { loggedConfigWarningFingerprints, warnedFutureTouchedVersions } from "./io.state.js";
+import {
+  loggedConfigWarningFingerprints,
+  MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS,
+  warnedFutureTouchedVersions,
+} from "./io.state.js";
 import type { OpenClawConfig } from "./types.js";
 import { shouldWarnOnTouchedVersion } from "./version.js";
 
@@ -40,6 +45,7 @@ export function logConfigWarningsOnce(params: {
     return;
   }
   loggedConfigWarningFingerprints.set(params.configPath, fingerprint);
+  pruneMapToMaxSize(loggedConfigWarningFingerprints, MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS);
   params.logger.warn(`Config warnings:\n${details}`);
 }
 
@@ -51,10 +57,9 @@ export function warnIfConfigFromFuture(
   if (!touched || !shouldWarnOnTouchedVersion(VERSION, touched)) {
     return;
   }
-  if (warnedFutureTouchedVersions.has(touched)) {
+  if (warnedFutureTouchedVersions.check(touched)) {
     return;
   }
-  warnedFutureTouchedVersions.add(touched);
   logger.warn(
     [
       `Your OpenClaw config was written by version ${touched}, but this command is running ${VERSION}.`,

--- a/src/config/io.warnings.ts
+++ b/src/config/io.warnings.ts
@@ -1,10 +1,9 @@
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { VERSION } from "../version.js";
 import { hashConfigRaw } from "./io.read-helpers.js";
 import {
   loggedConfigWarningFingerprints,
-  MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS,
+  setBoundedConfigIoMapEntry,
   warnedFutureTouchedVersions,
 } from "./io.state.js";
 import type { OpenClawConfig } from "./types.js";
@@ -42,10 +41,10 @@ export function logConfigWarningsOnce(params: {
     .join("\n");
   const fingerprint = hashConfigRaw(details);
   if (loggedConfigWarningFingerprints.get(params.configPath) === fingerprint) {
+    setBoundedConfigIoMapEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
     return;
   }
-  loggedConfigWarningFingerprints.set(params.configPath, fingerprint);
-  pruneMapToMaxSize(loggedConfigWarningFingerprints, MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS);
+  setBoundedConfigIoMapEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
   params.logger.warn(`Config warnings:\n${details}`);
 }
 

--- a/src/config/io.warnings.ts
+++ b/src/config/io.warnings.ts
@@ -3,7 +3,7 @@ import { VERSION } from "../version.js";
 import { hashConfigRaw } from "./io.read-helpers.js";
 import {
   loggedConfigWarningFingerprints,
-  setBoundedConfigIoMapEntry,
+  setBoundedConfigIoWarningEntry,
   warnedFutureTouchedVersions,
 } from "./io.state.js";
 import type { OpenClawConfig } from "./types.js";
@@ -41,10 +41,10 @@ export function logConfigWarningsOnce(params: {
     .join("\n");
   const fingerprint = hashConfigRaw(details);
   if (loggedConfigWarningFingerprints.get(params.configPath) === fingerprint) {
-    setBoundedConfigIoMapEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
+    setBoundedConfigIoWarningEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
     return;
   }
-  setBoundedConfigIoMapEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
+  setBoundedConfigIoWarningEntry(loggedConfigWarningFingerprints, params.configPath, fingerprint);
   params.logger.warn(`Config warnings:\n${details}`);
 }
 

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -2,6 +2,7 @@ import type fs from "node:fs";
 import path from "node:path";
 import { isVerbose } from "../global-state.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
 import { maintainConfigBackups } from "./backup-rotation.js";
 import { EnvRefArrayMutationError, restoreEnvVarRefs } from "./env-preserve.js";
@@ -25,7 +26,10 @@ import {
   resolveGatewayMode,
   restoreAuthoredTildePathsForWrite,
 } from "./io.read-helpers.js";
-import { loggedConfigWarningFingerprints } from "./io.state.js";
+import {
+  loggedConfigWarningFingerprints,
+  MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS,
+} from "./io.state.js";
 import type {
   ConfigWriteOptions,
   InternalConfigWriteResult,
@@ -413,6 +417,10 @@ export async function writeConfigFileFromContext(
                 loggedConfigWarningFingerprints.delete(configPath);
               } else {
                 loggedConfigWarningFingerprints.set(configPath, previousWarningFingerprint);
+                pruneMapToMaxSize(
+                  loggedConfigWarningFingerprints,
+                  MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS,
+                );
               }
             },
           }

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -25,7 +25,7 @@ import {
   resolveGatewayMode,
   restoreAuthoredTildePathsForWrite,
 } from "./io.read-helpers.js";
-import { loggedConfigWarningFingerprints, setBoundedConfigIoMapEntry } from "./io.state.js";
+import { loggedConfigWarningFingerprints, setBoundedConfigIoWarningEntry } from "./io.state.js";
 import type {
   ConfigWriteOptions,
   InternalConfigWriteResult,
@@ -412,7 +412,7 @@ export async function writeConfigFileFromContext(
               if (previousWarningFingerprint === undefined) {
                 loggedConfigWarningFingerprints.delete(configPath);
               } else {
-                setBoundedConfigIoMapEntry(
+                setBoundedConfigIoWarningEntry(
                   loggedConfigWarningFingerprints,
                   configPath,
                   previousWarningFingerprint,

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -2,7 +2,6 @@ import type fs from "node:fs";
 import path from "node:path";
 import { isVerbose } from "../global-state.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
 import { maintainConfigBackups } from "./backup-rotation.js";
 import { EnvRefArrayMutationError, restoreEnvVarRefs } from "./env-preserve.js";
@@ -26,10 +25,7 @@ import {
   resolveGatewayMode,
   restoreAuthoredTildePathsForWrite,
 } from "./io.read-helpers.js";
-import {
-  loggedConfigWarningFingerprints,
-  MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS,
-} from "./io.state.js";
+import { loggedConfigWarningFingerprints, setBoundedConfigIoMapEntry } from "./io.state.js";
 import type {
   ConfigWriteOptions,
   InternalConfigWriteResult,
@@ -416,10 +412,10 @@ export async function writeConfigFileFromContext(
               if (previousWarningFingerprint === undefined) {
                 loggedConfigWarningFingerprints.delete(configPath);
               } else {
-                loggedConfigWarningFingerprints.set(configPath, previousWarningFingerprint);
-                pruneMapToMaxSize(
+                setBoundedConfigIoMapEntry(
                   loggedConfigWarningFingerprints,
-                  MAX_LOGGED_CONFIG_WARNING_FINGERPRINTS,
+                  configPath,
+                  previousWarningFingerprint,
                 );
               }
             },


### PR DESCRIPTION
## What Problem This Solves

Three process-lifetime config warning caches could retain an unbounded number of distinct paths or version strings in long-running processes:

- `loggedInvalidConfigs`
- `loggedConfigWarningFingerprints`
- `warnedFutureTouchedVersions`

## Why This Change Was Made

The two suppression-only sets now use the shared `createDedupeCache({ ttlMs: 0, maxSize: 4096 })`. The path-to-fingerprint map uses the shared `pruneMapToMaxSize` policy through one config-I/O helper, with delete/set promotion so frequently observed paths remain hot.

Evicted warning keys can safely warn again. Generated owner-display secrets are intentionally not bounded here: they are non-persisted runtime identity, and eviction would silently change the same config path's owner-display hash.

## Maintainer Repairs

- Rebased onto current main.
- Removed pending owner-secret eviction after deep lifecycle review.
- Centralized bounded warning-map writes, including post-commit rollback restoration.
- Added hot-retention, cold-eviction, and re-warning coverage.
- Replaced module-reset-heavy tests; focused cache test execution dropped from 1.51 seconds to 54 milliseconds on the same host.

## Evidence

### Real behavior proof

A one-process production-function probe imported `io.invalid-config.ts`, `io.state.ts`, and `io.warnings.ts`, inserted 4,096 unique keys, refreshed key 0, inserted an overflow key, then revisited cold key 1.

```json
{"invalid":{"size":4096,"emitted":4098},"future":{"size":4096,"emitted":4098},"warning":{"size":4096,"hotRetained":true,"coldRewarned":true,"totalWarnings":8196}}
```

The two dedupe caches stayed at 4,096 and re-emitted evicted keys. The fingerprint map retained the refreshed path, evicted the cold path, and re-warned when that cold path returned.

### Focused tests

- `node scripts/run-vitest.mjs src/config/io.state.test.ts src/config/io.invalid-config.test.ts src/config/io.owner-display-secret.test.ts` — 8/8 passed.
- `node scripts/run-vitest.mjs src/config/io.write-config.test.ts` — 79/79 passed.
- Fresh autoreview of the full branch — clean, correctness 0.96.
- Hosted changed checks passed formatting, guards, dependency policy, duplicate coverage, and max-lines checks. The wrapper then encountered the repository-wide Plugin SDK baseline hash drift also present on current main; exact-head GitHub CI remains the landing authority.

## User Impact

Normal warning suppression is unchanged. Only keys displaced after more than 4,096 distinct warning identities can warn again. Runtime owner-display identity remains stable.
