### PR TITLE
fix(scripts): add curl --connect-timeout to install scripts

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -137,8 +137,9 @@ download_file() {
     detect_downloader
   fi
   if [[ "$DOWNLOADER" == "curl" ]]; then
-    # Bound post-connect stalls without imposing a total download duration.
+    # Bound connection and post-connect stalls without imposing a total download duration.
     curl -fsSL --proto '=https' --tlsv1.2 \
+      --connect-timeout 10 \
       --speed-limit 1 --speed-time 30 \
       --retry 3 --retry-delay 1 --retry-connrefused \
       -o "$output" "$url"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,8 +114,9 @@ download_file() {
         detect_downloader
     fi
     if [[ "$DOWNLOADER" == "curl" ]]; then
-        # Bound post-connect stalls without imposing a total download duration.
+        # Bound connection and post-connect stalls without imposing a total download duration.
         curl -fsSL --proto '=https' --tlsv1.2 \
+            --connect-timeout 10 \
             --speed-limit 1 --speed-time 30 \
             --retry 3 --retry-delay 1 --retry-connrefused \
             -o "$output" "$url"

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -56,8 +56,8 @@ describe("install-cli.sh", () => {
     `);
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--connect-timeout 10");
     expect(result.stdout).toContain("--speed-limit 1 --speed-time 30");
-    expect(result.stdout).not.toContain("--connect-timeout");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -97,8 +97,8 @@ describe("install.sh", () => {
     `);
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--connect-timeout 10");
     expect(result.stdout).toContain("--speed-limit 1 --speed-time 30");
-    expect(result.stdout).not.toContain("--connect-timeout");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });


### PR DESCRIPTION
## What Problem This Solves
The installer scripts (`scripts/install.sh` and `scripts/install-cli.sh`) use `curl` to download archives and remote scripts. They already bound post-connect stalls with `--speed-limit 1 --speed-time 30`, but they did not cap the TCP/TLS handshake phase. On a misbehaving mirror or network partition, `curl` could hang indefinitely while connecting, causing CI runs and user installs to stall with no actionable failure.

## Why This Change Was Made
This applies the same timeout-hardening pattern used in recent repository workflow fixes to the two public installer entry points, so downloads fail fast and retry instead of hanging during connection establishment.

## User Impact
Users running the install scripts on flaky or slow networks will now see a clear timeout error after 10 seconds if a connection cannot be established, rather than an indefinite hang. Retries remain enabled (`--retry 3`), so transient issues still have a chance to recover.

## Evidence
- Added `--connect-timeout 10` to the `curl` download path in `scripts/install.sh` and `scripts/install-cli.sh`.
- Updated regression tests in `test/scripts/install-sh.test.ts` and `test/scripts/install-cli.test.ts` to expect the new flag.
- Local focused test run: `node scripts/run-vitest.mjs test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts` — 112 tests passed.
- `git diff --check` and `bash -n` syntax checks passed.


## Real behavior proof

**Behavior addressed:** `scripts/install.sh` and `scripts/install-cli.sh` now cap the TCP/TLS handshake phase of archive/script downloads with `--connect-timeout 10`, so a stalled connection fails fast instead of hanging indefinitely.

**Real environment tested:** Local Linux shell (bash 4.4.20, curl 7.61.1) against an unreachable reserved IPv4 address that never completes the TCP handshake.

**Exact steps or command run after this patch:**

```bash
# From the repository root at head 4b9d7560cd8753cdd8e3411d27b32bacada6d422
time curl -fsSL --proto '=https' --tlsv1.2 \
  --connect-timeout 10 \
  --speed-limit 1 --speed-time 30 \
  --retry 0 \
  -o /dev/null 'https://240.0.0.1:12345/install.sh'
echo "EXIT_CODE=$?"
```

Also ran the focused regression tests:

```bash
node scripts/run-vitest.mjs test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts
```

**Evidence after fix:**

```
curl: (28) Operation timed out after 10001 milliseconds with 0 out of 0 bytes received
real    0m10.016s
EXIT_CODE=28
```

```
Test Files  2 passed (2)
     Tests  112 passed (112)
```

**Observed result after fix:** The curl invocation returned exit code 28 and terminated after ~10 seconds, confirming the new `--connect-timeout 10` flag bounds the connection establishment phase. The regression tests confirm the flag is present in both installer scripts and that timeout failures propagate correctly.

**What was not tested:** Actual installation of OpenClaw via the public install URL (no live download or install performed); wget fallback path unchanged and only covered by existing assertions.