### PR TITLE
fix(gateway): sidebar agent dropdown shows raw agent id instead of the agent's display name

### DIFF
--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -95,6 +95,30 @@ function normalizeEmojiValue(value: string | undefined): string | undefined {
   return value;
 }
 
+/**
+ * Assistant display name from ui.assistant, agent config identity, and the
+ * workspace IDENTITY.md; undefined when none of them name the agent. Shared
+ * by agent.identity.get and agents.list so sidebar agent labels cannot drift
+ * from the chat-header identity (#108373).
+ */
+export function resolveAssistantDisplayName(params: {
+  cfg: OpenClawConfig;
+  agentId?: string | null;
+  workspaceDir?: string | null;
+}): string | undefined {
+  const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(params.cfg));
+  const agentId = normalizeAgentId(params.agentId ?? defaultAgentId);
+  const isDefaultAgent = agentId === defaultAgentId;
+  const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
+  const uiName = normalizeIdentityValue("name", params.cfg.ui?.assistant?.name);
+  const agentName = normalizeIdentityValue("name", resolveAgentIdentity(params.cfg, agentId)?.name);
+  const fileName = normalizeIdentityValue(
+    "name",
+    workspaceDir ? loadAgentIdentity(workspaceDir)?.name : undefined,
+  );
+  return isDefaultAgent ? (uiName ?? agentName ?? fileName) : (agentName ?? fileName ?? uiName);
+}
+
 /** Resolve the display name/avatar/emoji for an agent-facing assistant identity. */
 export function resolveAssistantIdentity(params: {
   cfg: OpenClawConfig;
@@ -109,11 +133,10 @@ export function resolveAssistantIdentity(params: {
   const agentIdentity = resolveAgentIdentity(params.cfg, agentId);
   const fileIdentity = workspaceDir ? loadAgentIdentity(workspaceDir) : null;
 
-  const uiName = normalizeIdentityValue("name", configAssistant?.name);
-  const agentName = normalizeIdentityValue("name", agentIdentity?.name);
-  const fileName = normalizeIdentityValue("name", fileIdentity?.name);
+  // One canonical name chain; the extra IDENTITY.md read inside the helper is
+  // acceptable for this operator RPC and keeps agents.list from drifting.
   const name =
-    (isDefaultAgent ? (uiName ?? agentName ?? fileName) : (agentName ?? fileName ?? uiName)) ??
+    resolveAssistantDisplayName({ cfg: params.cfg, agentId, workspaceDir }) ??
     DEFAULT_ASSISTANT_IDENTITY.name;
 
   const uiAvatar = normalizeAvatarValue(configAssistant?.avatar);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -18,6 +18,7 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plug
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv as withRawStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { withTempDirSync } from "../test-helpers/temp-dir.js";
 import { registerSessionAutomationSource } from "./session-automation-index.js";
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { capArrayByJsonBytes } from "./session-transcript-readers.js";
@@ -1849,19 +1850,59 @@ describe("gateway session utils", () => {
   });
 
   test("listAgentsForGateway leaves name unset when both configured and identity names are absent", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: {
-        list: [{ id: "main", default: true, identity: {} }],
-      },
-    } as OpenClawConfig;
+    withTempDirSync({ prefix: "session-utils-no-identity-" }, (workspace) => {
+      const cfg = {
+        session: { mainKey: "main" },
+        agents: {
+          list: [{ id: "main", default: true, workspace, identity: {} }],
+        },
+      } as OpenClawConfig;
 
-    const result = listAgentsForGateway(cfg);
+      const result = listAgentsForGateway(cfg);
 
-    expect(result.agents[0]).toMatchObject({
-      id: "main",
-      name: undefined,
-      identity: {},
+      expect(result.agents[0]).toMatchObject({
+        id: "main",
+        name: undefined,
+        identity: {},
+      });
+    });
+  });
+
+  test("listAgentsForGateway resolves name from workspace IDENTITY.md when config has none", () => {
+    withTempDirSync({ prefix: "session-utils-file-identity-" }, (workspace) => {
+      fs.writeFileSync(path.join(workspace, "IDENTITY.md"), "- Name: 诸葛黯\n", "utf8");
+      const cfg = {
+        session: { mainKey: "main" },
+        agents: {
+          list: [{ id: "main", default: true, workspace }],
+        },
+      } as OpenClawConfig;
+
+      const result = listAgentsForGateway(cfg);
+
+      expect(result.agents[0]).toMatchObject({
+        id: "main",
+        name: "诸葛黯",
+      });
+    });
+  });
+
+  test("listAgentsForGateway prefers configured names over workspace IDENTITY.md", () => {
+    withTempDirSync({ prefix: "session-utils-config-wins-" }, (workspace) => {
+      fs.writeFileSync(path.join(workspace, "IDENTITY.md"), "- Name: File Name\n", "utf8");
+      const cfg = {
+        session: { mainKey: "main" },
+        agents: {
+          list: [{ id: "main", default: true, workspace, identity: { name: "开发助手" } }],
+        },
+      } as OpenClawConfig;
+
+      const result = listAgentsForGateway(cfg);
+
+      expect(result.agents[0]).toMatchObject({
+        id: "main",
+        name: "开发助手",
+      });
     });
   });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -103,6 +103,7 @@ import { normalizeSessionDeliveryFields } from "../utils/delivery-context.shared
 import type { ModelCostConfig } from "../utils/usage-format.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import { listGatewayAgentIds } from "./agent-list.js";
+import { resolveAssistantDisplayName } from "./assistant-identity.js";
 import { sessionHasAutomation } from "./session-automation-index.js";
 import { sortAndLimitSessionEntries, type SessionEntryPair } from "./session-list-order.js";
 import {
@@ -1267,10 +1268,15 @@ export function listAgentsForGateway(
     // Must mirror the sessions.create worktree preflight: subdirectory workspaces inside a
     // repo are worktree-capable, so the UI toggle and the create path cannot diverge.
     const workspaceGit = insideGitCheckout(workspace);
+    // The chat header names agents via agent.identity.get (config identity ->
+    // workspace IDENTITY.md -> ui.assistant). Rows without a configured name
+    // reuse that chain so sidebar agent labels match the chat header.
+    const name =
+      meta?.name ?? resolveAssistantDisplayName({ cfg, agentId: id, workspaceDir: workspace });
     return Object.assign(
       {
         id,
-        name: meta?.name,
+        name,
         identity: meta?.identity,
         workspace,
         workspaceGit,


### PR DESCRIPTION
Closes #108373

## What Problem This Solves

Fixes an issue where the Control UI sidebar conversation dropdown (agent chip and agent menu) shows the raw agent id — reported as "assistant" — instead of the agent's actual display name (e.g. "诸葛黯"), while the chat header on the same screen shows the correct name.

## Why This Change Was Made

The two surfaces resolved names through different chains. The chat header uses `agent.identity.get` → `resolveAssistantIdentity`, which falls back from config identity to the workspace `IDENTITY.md` (where onboarding writes the agent's name) to `ui.assistant`. The sidebar uses `agents.list` → `listAgentsForGateway`, whose rows only carried names from explicit `agents.list` config entries — so an agent named via `IDENTITY.md` had no name in the row and the UI's `normalizeAgentLabel` fell back to the raw agent id.

The fix extracts the chat header's name chain into a shared `resolveAssistantDisplayName` helper (returning `undefined` instead of the hard "Assistant" default) and reuses it in `listAgentsForGateway` for rows without a configured name. `resolveAssistantIdentity` now delegates to the same helper, so the two surfaces cannot drift again. Explicitly configured `agents.list` names keep their existing precedence — the fallback only fires when config provides no name at all.

Known boundaries (called out rather than expanded): the row `identity` (emoji/avatar) still comes from config only, so an `IDENTITY.md`-only emoji/avatar still doesn't reach the sidebar chip; and a default agent with both `agents.list.name` and `ui.assistant.name` set keeps the configured name in the sidebar (pre-existing precedence pinned by tests).

## User Impact

Agents named through the workspace `IDENTITY.md` — the onboarding default — now show their real display name in the sidebar agent chip and agent dropdown, matching the chat header, instead of the raw agent id.

## Evidence

- New/updated tests in `src/gateway/session-utils.test.ts`: name resolves from workspace `IDENTITY.md` when config has none; configured names still win over `IDENTITY.md`; unnamed agents with an empty workspace stay unnamed (now hermetic via `withTempDirSync` instead of reading the developer's real workspace).
- `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts -- -t "listAgentsForGateway"` → `Tests 14 passed | 108 skipped`.
- `node scripts/run-vitest.mjs src/gateway/assistant-identity.test.ts` → `Tests 14 passed (14)` (identity chain unchanged through the extracted helper).
- Note: the broader `session-utils.test.ts` suite has 58 pre-existing failures on this machine from an environment gate (Node 24.13.1 embeds SQLite 3.51.2, rejected by the repo's WAL-safety check) — identical count with and without this change (verified via stash baseline); all `listAgentsForGateway` and identity tests pass.
- `oxfmt`, `oxlint`, and `git diff --check` clean.
