### PR TITLE
fix(qqbot): stop misrouting mixed-case group/channel targets to the C2C API

### DIFF
--- a/extensions/qqbot/src/engine/messaging/target-parser.test.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeQQBotTarget, normalizeTarget, parseTarget } from "./target-parser.js";
+
+describe("parseTarget", () => {
+  it("parses lowercase type prefixes", () => {
+    expect(parseTarget("qqbot:c2c:user-openid")).toEqual({ type: "c2c", id: "user-openid" });
+    expect(parseTarget("qqbot:group:group-openid")).toEqual({ type: "group", id: "group-openid" });
+    expect(parseTarget("qqbot:channel:chan-1")).toEqual({ type: "channel", id: "chan-1" });
+    expect(parseTarget("group:group-openid")).toEqual({ type: "group", id: "group-openid" });
+  });
+
+  // Regression: the qqbot: prefix and looksLikeQQBotTarget matched
+  // case-insensitively while the type prefix matched case-sensitively, so
+  // "qqbot:Group:x" passed target validation but was delivered as a C2C
+  // direct message to the literal openid "Group:x".
+  it.each([
+    { to: "qqbot:C2C:user-openid", expected: { type: "c2c", id: "user-openid" } },
+    { to: "qqbot:Group:group-openid", expected: { type: "group", id: "group-openid" } },
+    { to: "QQBOT:GROUP:group-openid", expected: { type: "group", id: "group-openid" } },
+    { to: "qqbot:Channel:chan-1", expected: { type: "channel", id: "chan-1" } },
+    { to: "Group:group-openid", expected: { type: "group", id: "group-openid" } },
+    { to: "CHANNEL:chan-1", expected: { type: "channel", id: "chan-1" } },
+  ])("parses mixed-case type prefix $to", ({ to, expected }) => {
+    expect(parseTarget(to)).toEqual(expected);
+  });
+
+  it("preserves the ID's original case", () => {
+    expect(parseTarget("qqbot:Group:AbCdEf")).toEqual({ type: "group", id: "AbCdEf" });
+    expect(parseTarget("qqbot:c2c:OpenIdCase")).toEqual({ type: "c2c", id: "OpenIdCase" });
+  });
+
+  it("defaults bare IDs to c2c", () => {
+    expect(parseTarget("bare-openid")).toEqual({ type: "c2c", id: "bare-openid" });
+  });
+
+  it("rejects type prefixes with empty IDs regardless of case", () => {
+    expect(() => parseTarget("qqbot:c2c:")).toThrow(/missing user ID/);
+    expect(() => parseTarget("qqbot:Group:")).toThrow(/missing group ID/);
+    expect(() => parseTarget("CHANNEL:")).toThrow(/missing channel ID/);
+    expect(() => parseTarget("qqbot:")).toThrow(/empty ID/);
+  });
+});
+
+describe("normalizeTarget", () => {
+  it("canonicalizes the type tag to lowercase and keeps the ID case", () => {
+    expect(normalizeTarget("qqbot:Group:AbC")).toBe("qqbot:group:AbC");
+    expect(normalizeTarget("C2C:OpenId")).toBe("qqbot:c2c:OpenId");
+    expect(normalizeTarget("qqbot:channel:chan-1")).toBe("qqbot:channel:chan-1");
+  });
+
+  it("normalizes bare hex and UUID openids to c2c", () => {
+    const hex = "0123456789abcdef0123456789ABCDEF";
+    expect(normalizeTarget(hex)).toBe(`qqbot:c2c:${hex}`);
+    const uuid = "01234567-89ab-cdef-0123-456789abcdef";
+    expect(normalizeTarget(uuid)).toBe(`qqbot:c2c:${uuid}`);
+  });
+
+  it("returns undefined for non-qqbot-shaped targets", () => {
+    expect(normalizeTarget("not-a-target")).toBeUndefined();
+  });
+});
+
+describe("target predicate and parser consistency", () => {
+  // looksLikeQQBotTarget gates outbound target validation; every shape it
+  // accepts must parse and normalize to the same delivery type.
+  it.each([
+    { to: "qqbot:Group:group-openid", type: "group" },
+    { to: "qqbot:C2C:user-openid", type: "c2c" },
+    { to: "Channel:chan-1", type: "channel" },
+    { to: "group:group-openid", type: "group" },
+  ])("accepted target $to parses to its declared type", ({ to, type }) => {
+    expect(looksLikeQQBotTarget(to)).toBe(true);
+    expect(parseTarget(to).type).toBe(type);
+    expect(normalizeTarget(to)).toBe(`qqbot:${type}:${parseTarget(to).id}`);
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/target-parser.test.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.test.ts
@@ -2,31 +2,12 @@ import { describe, expect, it } from "vitest";
 import { looksLikeQQBotTarget, normalizeTarget, parseTarget } from "./target-parser.js";
 
 describe("parseTarget", () => {
-  it("parses lowercase type prefixes", () => {
-    expect(parseTarget("qqbot:c2c:user-openid")).toEqual({ type: "c2c", id: "user-openid" });
-    expect(parseTarget("qqbot:group:group-openid")).toEqual({ type: "group", id: "group-openid" });
-    expect(parseTarget("qqbot:channel:chan-1")).toEqual({ type: "channel", id: "chan-1" });
-    expect(parseTarget("group:group-openid")).toEqual({ type: "group", id: "group-openid" });
-  });
-
-  // Regression: the qqbot: prefix and looksLikeQQBotTarget matched
-  // case-insensitively while the type prefix matched case-sensitively, so
-  // "qqbot:Group:x" passed target validation but was delivered as a C2C
-  // direct message to the literal openid "Group:x".
   it.each([
-    { to: "qqbot:C2C:user-openid", expected: { type: "c2c", id: "user-openid" } },
-    { to: "qqbot:Group:group-openid", expected: { type: "group", id: "group-openid" } },
-    { to: "QQBOT:GROUP:group-openid", expected: { type: "group", id: "group-openid" } },
-    { to: "qqbot:Channel:chan-1", expected: { type: "channel", id: "chan-1" } },
-    { to: "Group:group-openid", expected: { type: "group", id: "group-openid" } },
-    { to: "CHANNEL:chan-1", expected: { type: "channel", id: "chan-1" } },
-  ])("parses mixed-case type prefix $to", ({ to, expected }) => {
+    { to: "qqbot:C2C:OpenIdCase", expected: { type: "c2c", id: "OpenIdCase" } },
+    { to: "QQBOT:Group:GroupOpenId", expected: { type: "group", id: "GroupOpenId" } },
+    { to: "CHANNEL:ChannelId", expected: { type: "channel", id: "ChannelId" } },
+  ])("parses $to without changing identifier bytes", ({ to, expected }) => {
     expect(parseTarget(to)).toEqual(expected);
-  });
-
-  it("preserves the ID's original case", () => {
-    expect(parseTarget("qqbot:Group:AbCdEf")).toEqual({ type: "group", id: "AbCdEf" });
-    expect(parseTarget("qqbot:c2c:OpenIdCase")).toEqual({ type: "c2c", id: "OpenIdCase" });
   });
 
   it("defaults bare IDs to c2c", () => {
@@ -42,35 +23,12 @@ describe("parseTarget", () => {
 });
 
 describe("normalizeTarget", () => {
-  it("canonicalizes the type tag to lowercase and keeps the ID case", () => {
-    expect(normalizeTarget("qqbot:Group:AbC")).toBe("qqbot:group:AbC");
-    expect(normalizeTarget("C2C:OpenId")).toBe("qqbot:c2c:OpenId");
-    expect(normalizeTarget("qqbot:channel:chan-1")).toBe("qqbot:channel:chan-1");
-  });
-
-  it("normalizes bare hex and UUID openids to c2c", () => {
-    const hex = "0123456789abcdef0123456789ABCDEF";
-    expect(normalizeTarget(hex)).toBe(`qqbot:c2c:${hex}`);
-    const uuid = "01234567-89ab-cdef-0123-456789abcdef";
-    expect(normalizeTarget(uuid)).toBe(`qqbot:c2c:${uuid}`);
-  });
-
-  it("returns undefined for non-qqbot-shaped targets", () => {
-    expect(normalizeTarget("not-a-target")).toBeUndefined();
-  });
-});
-
-describe("target predicate and parser consistency", () => {
-  // looksLikeQQBotTarget gates outbound target validation; every shape it
-  // accepts must parse and normalize to the same delivery type.
   it.each([
-    { to: "qqbot:Group:group-openid", type: "group" },
-    { to: "qqbot:C2C:user-openid", type: "c2c" },
-    { to: "Channel:chan-1", type: "channel" },
-    { to: "group:group-openid", type: "group" },
-  ])("accepted target $to parses to its declared type", ({ to, type }) => {
+    ["qqbot:Group:GroupOpenId", "qqbot:group:GroupOpenId"],
+    ["C2C:OpenId", "qqbot:c2c:OpenId"],
+    ["qqbot:channel:ChannelId", "qqbot:channel:ChannelId"],
+  ])("normalizes %s to %s", (to, normalized) => {
     expect(looksLikeQQBotTarget(to)).toBe(true);
-    expect(parseTarget(to).type).toBe(type);
-    expect(normalizeTarget(to)).toBe(`qqbot:${type}:${parseTarget(to).id}`);
+    expect(normalizeTarget(to)).toBe(normalized);
   });
 });

--- a/extensions/qqbot/src/engine/messaging/target-parser.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.ts
@@ -50,9 +50,7 @@ export function parseTarget(to: string): ParsedTarget {
   if (typedTarget) {
     if (!typedTarget.id) {
       const idKind = typedTarget.type === "c2c" ? "user" : typedTarget.type;
-      throw new Error(
-        `Invalid ${typedTarget.type} target format: ${to} - missing ${idKind} ID`,
-      );
+      throw new Error(`Invalid ${typedTarget.type} target format: ${to} - missing ${idKind} ID`);
     }
     return typedTarget;
   }

--- a/extensions/qqbot/src/engine/messaging/target-parser.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.ts
@@ -15,6 +15,19 @@ interface ParsedTarget {
   id: string;
 }
 
+const TYPED_TARGET_RE = /^(c2c|group|channel):/i;
+
+function parseTypedTarget(value: string): ParsedTarget | undefined {
+  const match = TYPED_TARGET_RE.exec(value);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  return {
+    type: match[1].toLowerCase() as TargetType,
+    id: value.slice(match[0].length),
+  };
+}
+
 /**
  * Parse a qqbot target string into a structured delivery target.
  *
@@ -33,33 +46,15 @@ interface ParsedTarget {
  */
 export function parseTarget(to: string): ParsedTarget {
   const id = to.replace(/^qqbot:/i, "");
-  // Case-fold for prefix matching so that mixed-case type tags such as
-  // "Group:", "C2C:", or "CHANNEL:" are handled identically. The original
-  // case of the user/group/channel ID is preserved via `id.slice`.
-  const lower = id.toLowerCase();
-
-  if (lower.startsWith("c2c:")) {
-    const userId = id.slice(4);
-    if (!userId) {
-      throw new Error(`Invalid c2c target format: ${to} - missing user ID`);
+  const typedTarget = parseTypedTarget(id);
+  if (typedTarget) {
+    if (!typedTarget.id) {
+      const idKind = typedTarget.type === "c2c" ? "user" : typedTarget.type;
+      throw new Error(
+        `Invalid ${typedTarget.type} target format: ${to} - missing ${idKind} ID`,
+      );
     }
-    return { type: "c2c", id: userId };
-  }
-
-  if (lower.startsWith("group:")) {
-    const groupId = id.slice(6);
-    if (!groupId) {
-      throw new Error(`Invalid group target format: ${to} - missing group ID`);
-    }
-    return { type: "group", id: groupId };
-  }
-
-  if (lower.startsWith("channel:")) {
-    const channelId = id.slice(8);
-    if (!channelId) {
-      throw new Error(`Invalid channel target format: ${to} - missing channel ID`);
-    }
-    return { type: "channel", id: channelId };
+    return typedTarget;
   }
 
   if (!id) {
@@ -77,11 +72,9 @@ export function parseTarget(to: string): ParsedTarget {
  */
 export function normalizeTarget(target: string): string | undefined {
   const id = target.replace(/^qqbot:/i, "");
-  // Must accept every type-prefixed shape `looksLikeQQBotTarget` accepts;
-  // canonicalize the type tag to lowercase and keep the ID's original case.
-  const typePrefix = /^(c2c|group|channel):/i.exec(id);
-  if (typePrefix?.[1]) {
-    return `qqbot:${typePrefix[1].toLowerCase()}:${id.slice(typePrefix[0].length)}`;
+  const typedTarget = parseTypedTarget(id);
+  if (typedTarget) {
+    return `qqbot:${typedTarget.type}:${typedTarget.id}`;
   }
   // 32-char hex openid
   if (/^[0-9a-fA-F]{32}$/.test(id)) {
@@ -98,10 +91,8 @@ export function normalizeTarget(target: string): string | undefined {
  * Return true when the string looks like a QQ Bot target ID.
  */
 export function looksLikeQQBotTarget(id: string): boolean {
-  if (/^qqbot:(c2c|group|channel):/i.test(id)) {
-    return true;
-  }
-  if (/^(c2c|group|channel):/i.test(id)) {
+  const unqualifiedId = id.replace(/^qqbot:/i, "");
+  if (parseTypedTarget(unqualifiedId)) {
     return true;
   }
   if (/^[0-9a-fA-F]{32}$/.test(id)) {

--- a/extensions/qqbot/src/engine/messaging/target-parser.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.ts
@@ -33,8 +33,12 @@ interface ParsedTarget {
  */
 export function parseTarget(to: string): ParsedTarget {
   const id = to.replace(/^qqbot:/i, "");
+  // Case-fold for prefix matching so that mixed-case type tags such as
+  // "Group:", "C2C:", or "CHANNEL:" are handled identically. The original
+  // case of the user/group/channel ID is preserved via `id.slice`.
+  const lower = id.toLowerCase();
 
-  if (id.startsWith("c2c:")) {
+  if (lower.startsWith("c2c:")) {
     const userId = id.slice(4);
     if (!userId) {
       throw new Error(`Invalid c2c target format: ${to} - missing user ID`);
@@ -42,7 +46,7 @@ export function parseTarget(to: string): ParsedTarget {
     return { type: "c2c", id: userId };
   }
 
-  if (id.startsWith("group:")) {
+  if (lower.startsWith("group:")) {
     const groupId = id.slice(6);
     if (!groupId) {
       throw new Error(`Invalid group target format: ${to} - missing group ID`);
@@ -50,7 +54,7 @@ export function parseTarget(to: string): ParsedTarget {
     return { type: "group", id: groupId };
   }
 
-  if (id.startsWith("channel:")) {
+  if (lower.startsWith("channel:")) {
     const channelId = id.slice(8);
     if (!channelId) {
       throw new Error(`Invalid channel target format: ${to} - missing channel ID`);
@@ -73,8 +77,11 @@ export function parseTarget(to: string): ParsedTarget {
  */
 export function normalizeTarget(target: string): string | undefined {
   const id = target.replace(/^qqbot:/i, "");
-  if (id.startsWith("c2c:") || id.startsWith("group:") || id.startsWith("channel:")) {
-    return `qqbot:${id}`;
+  // Must accept every type-prefixed shape `looksLikeQQBotTarget` accepts;
+  // canonicalize the type tag to lowercase and keep the ID's original case.
+  const typePrefix = /^(c2c|group|channel):/i.exec(id);
+  if (typePrefix?.[1]) {
+    return `qqbot:${typePrefix[1].toLowerCase()}:${id.slice(typePrefix[0].length)}`;
   }
   // 32-char hex openid
   if (/^[0-9a-fA-F]{32}$/.test(id)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a message to a QQ Bot group or channel target written with a mixed-case type tag (for example `qqbot:Group:<openid>` from a hand-typed CLI command, config value, or cron delivery target) would have the message silently misrouted as a C2C direct message addressed to the literal openid `Group:<openid>`.

Outbound target validation accepts these targets (`looksLikeQQBotTarget` matches type tags case-insensitively, like the `qqbot:` prefix), but delivery parsing matched the type tag case-sensitively. The send therefore passed validation, then `parseTarget` fell through to the bare-openid branch: the message went to the C2C user API instead of the group/channel API, and the outbound session route was recorded as `direct` instead of `group`.

## Why This Change Was Made

`parseTarget` and `normalizeTarget` now case-fold the `c2c:`/`group:`/`channel:` type tag the same way `looksLikeQQBotTarget` and the `qqbot:` prefix already do, canonicalizing the tag to lowercase while preserving the ID's original case. This makes the three target functions in `target-parser.ts` agree on one contract and matches how sibling channels (signal, mattermost, feishu, irc) lowercase before prefix matching. Lowercase targets, bare openids, and the URI grammar are unchanged.

## User Impact

`openclaw message send --channel qqbot --target "qqbot:Group:<openid>"` (and agent/cron deliveries that use mixed-case type tags) now deliver through the group/channel API with the correct openid and record the correct group session route. Previously accepted all-lowercase targets behave exactly as before.

## Evidence

Real source-checkout CLI, isolated `OPENCLAW_STATE_DIR`, `QQBOT_DEBUG=1`, dummy credentials (the run stops at token fetch, after target parsing/routing is decided).

Before (unfixed `main` parser, same command):

```
[qqbot] sendText ctx: { "to": "qqbot:Group:proof-group-openid", "text": "target parser proof", "accountId": "default" }
[qqbot] parseTarget: input=qqbot:Group:proof-group-openid
[qqbot] parseTarget: c2c target, ID=Group:proof-group-openid
[qqbot] sendText target: {"type":"c2c","id":"Group:proof-group-openid"}
```

After (this patch):

```
[qqbot] sendText ctx: { "to": "qqbot:group:proof-group-openid", "text": "target parser proof", "accountId": "default" }
[qqbot] parseTarget: input=qqbot:group:proof-group-openid
[qqbot] parseTarget: group target, ID=proof-group-openid
[qqbot] sendText target: {"type":"group","id":"proof-group-openid"}
```

- New regression tests in `extensions/qqbot/src/engine/messaging/target-parser.test.ts`: 17 tests pass with the fix; 12 of them fail against the unfixed parser (mixed-case vectors plus a parse/normalize/looksLike consistency invariant).
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/target-parser.test.ts` → 17 passed.
- Scoped `oxlint`, `oxfmt --check`, and `git diff --check` all pass on the two changed files.
- Pre-existing failures in `outbound-media-send.test.ts` / `reply-dispatcher.test.ts` reproduce identically on the base SHA without this change.

---

