### PR TITLE
fix(agents): exclude MEMORY.md from shared channel session bootstrap

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -384,6 +384,173 @@ describe("resolveBootstrapFilesForRun", () => {
       "USER.md",
     ]);
   });
+
+  it("excludes MEMORY.md for shared channel sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-group-");
+    await Promise.all(
+      [
+        ["AGENTS.md", "project rules"],
+        ["TOOLS.md", "tool rules"],
+        ["SOUL.md", "persona"],
+        ["IDENTITY.md", "identity"],
+        ["USER.md", "user profile"],
+        ["MEMORY.md", "memory"],
+        ["HEARTBEAT.md", "heartbeat"],
+        ["BOOTSTRAP.md", "setup"],
+      ].map(([fileName, content]) =>
+        fs.writeFile(
+          path.join(workspaceDir, expectDefined(fileName, "fileName test invariant")),
+          expectDefined(content, "content test invariant"),
+          "utf8",
+        ),
+      ),
+    );
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:telegram:group:-100123",
+    });
+
+    const names = files.map((file) => file.name);
+    expect(names).not.toContain("MEMORY.md");
+    expect(names).toContain("AGENTS.md");
+    expect(names).toContain("SOUL.md");
+    expect(names).toContain("USER.md");
+  });
+
+  it("includes MEMORY.md for private DM sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-dm-");
+    await Promise.all(
+      [
+        ["AGENTS.md", "project rules"],
+        ["MEMORY.md", "memory"],
+      ].map(([fileName, content]) =>
+        fs.writeFile(
+          path.join(workspaceDir, expectDefined(fileName, "fileName test invariant")),
+          expectDefined(content, "content test invariant"),
+          "utf8",
+        ),
+      ),
+    );
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:telegram:dm:123456",
+    });
+
+    expect(files.map((file) => file.name)).toContain("MEMORY.md");
+  });
+
+  it("re-enforces MEMORY.md exclusion after hook overrides for group sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-group-hook-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "private memory", "utf8");
+
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      context.bootstrapFiles = [
+        ...context.bootstrapFiles,
+        {
+          name: "MEMORY.md",
+          path: path.join(workspaceDir, "MEMORY.md"),
+          content: "injected by hook",
+          missing: false,
+        } as unknown as WorkspaceBootstrapFile,
+      ];
+    });
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:discord:group:dev",
+    });
+
+    expect(files.map((file) => file.name)).not.toContain("MEMORY.md");
+  });
+
+  it("strips MEMORY.md even when a hook adds it alongside other files for group sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-group-hook-multi-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "private memory", "utf8");
+
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      context.bootstrapFiles = [
+        ...context.bootstrapFiles,
+        {
+          name: "MEMORY.md",
+          path: path.join(workspaceDir, "MEMORY.md"),
+          content: "hook-injected memory",
+          missing: false,
+        } as unknown as WorkspaceBootstrapFile,
+        {
+          name: "AGENTS.md",
+          path: path.join(workspaceDir, "packages", "core", "AGENTS.md"),
+          content: "extra agents",
+          missing: false,
+        } as unknown as WorkspaceBootstrapFile,
+      ];
+    });
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:telegram:group:-100123",
+    });
+
+    expect(files.map((file) => file.name)).not.toContain("MEMORY.md");
+    expect(files.filter((f) => f.name === "AGENTS.md").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("excludes MEMORY.md for unknown channel peerKind (fail-closed)", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-failclosed-");
+    await Promise.all(
+      [
+        ["AGENTS.md", "project rules"],
+        ["MEMORY.md", "memory"],
+      ].map(([fileName, content]) =>
+        fs.writeFile(
+          path.join(workspaceDir, expectDefined(fileName, "fileName test invariant")),
+          expectDefined(content, "content test invariant"),
+          "utf8",
+        ),
+      ),
+    );
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:msteams:team:abc123",
+    });
+
+    const names = files.map((file) => file.name);
+    expect(names).not.toContain("MEMORY.md");
+  });
+
+  it("strips lowercase memory.md alias injected by hook for group sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-group-lowercase-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "private memory", "utf8");
+
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      context.bootstrapFiles = [
+        ...context.bootstrapFiles,
+        {
+          name: "memory.md",
+          path: path.join(workspaceDir, "memory.md"),
+          content: "hook-injected lowercase memory",
+          missing: false,
+        } as unknown as WorkspaceBootstrapFile,
+      ];
+    });
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:telegram:group:-100123",
+    });
+
+    const names = files.map((file) => file.name);
+    expect(names).not.toContain("MEMORY.md");
+    expect(names).not.toContain("memory.md");
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -8,6 +8,11 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readFileWindowFully } from "../infra/file-read.js";
+import {
+  CANONICAL_ROOT_MEMORY_FILENAME,
+  LEGACY_ROOT_MEMORY_FILENAME,
+} from "../memory/root-memory-files.js";
+import { isPrivateMemorySessionKey } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
@@ -208,6 +213,28 @@ function applyContextModeFilter(params: {
   return [];
 }
 
+function enforcePrivateMemoryBoundary(
+  files: WorkspaceBootstrapFile[],
+  sessionKey?: string,
+): WorkspaceBootstrapFile[] {
+  if (isPrivateMemorySessionKey(sessionKey)) {
+    return files;
+  }
+  // Hooks can inject memory.md (LEGACY_ROOT_MEMORY_FILENAME) via
+  // `as unknown as WorkspaceBootstrapFile`, which is not in the nominal
+  // type. Use case-insensitive basename comparison so both MEMORY.md and
+  // memory.md are stripped regardless of the typed name field.
+  return files.filter((file) => !isMemoryBootstrapFileName(file.name));
+}
+
+function isMemoryBootstrapFileName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    lower === CANONICAL_ROOT_MEMORY_FILENAME.toLowerCase() ||
+    lower === LEGACY_ROOT_MEMORY_FILENAME.toLowerCase()
+  );
+}
+
 function filterCompletedWorkspaceBootstrapFile(
   files: WorkspaceBootstrapFile[],
   setupCompleted: boolean,
@@ -280,12 +307,14 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionId: params.sessionId,
     agentId: params.agentId,
   });
-  const filteredUpdated = filterCompletedWorkspaceBootstrapFile(
-    updated,
-    workspaceSetupCompleted,
+  return sanitizeBootstrapFiles(
+    enforcePrivateMemoryBoundary(
+      filterCompletedWorkspaceBootstrapFile(updated, workspaceSetupCompleted, params.workspaceDir),
+      sessionKey,
+    ),
     params.workspaceDir,
+    params.warn,
   );
-  return sanitizeBootstrapFiles(filteredUpdated, params.workspaceDir, params.warn);
 }
 
 /** Resolves both raw bootstrap metadata and bounded context files for a run. */

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1158,4 +1158,34 @@ describe("filterBootstrapFilesForSession", () => {
     const result = filterBootstrapFilesForSession(mockFiles, "agent:default:cron:daily-check");
     expectCronAllowedBootstrapNames(result);
   });
+
+  it.each([
+    { key: "agent:main:telegram:group:-100123", label: "telegram group" },
+    { key: "agent:main:discord:group:dev", label: "discord group" },
+    { key: "agent:main:discord:channel:c1", label: "discord channel" },
+    { key: "agent:main:discord:guild-123:channel-456", label: "discord guild/channel" },
+    { key: "agent:main:slack:group:general", label: "slack group" },
+    { key: "agent:main:feishu:group:oc-group", label: "feishu group" },
+    { key: "agent:main:matrix:channel:!Room:example.org", label: "matrix channel" },
+    { key: "agent:main:whatsapp:123@g.us", label: "whatsapp group" },
+    { key: "agent:main:signal:group:AbC123", label: "signal group" },
+  ] as const)("excludes MEMORY.md for shared channel session ($label)", ({ key }) => {
+    const result = filterBootstrapFilesForSession(mockFiles, key);
+    const names = result.map((f) => f.name);
+    expect(names).not.toContain("MEMORY.md");
+    expect(names).toContain("AGENTS.md");
+    expect(names).toContain("SOUL.md");
+    expect(names).toContain("USER.md");
+  });
+
+  it.each([
+    { key: "agent:main:main", label: "main session" },
+    { key: "agent:main:chat:main", label: "chat session" },
+    { key: "agent:main:direct:user1", label: "direct session" },
+    { key: "agent:main:telegram:dm:123456", label: "telegram dm" },
+    { key: "agent:main:discord:direct:user1", label: "discord direct" },
+  ] as const)("includes MEMORY.md for private session ($label)", ({ key }) => {
+    const result = filterBootstrapFilesForSession(mockFiles, key);
+    expect(result.map((f) => f.name)).toContain("MEMORY.md");
+  });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -18,7 +18,11 @@ import {
   exactWorkspaceEntryExists,
 } from "../memory/root-memory-files.js";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
+import {
+  isCronSessionKey,
+  isSharedChannelSessionKey,
+  isSubagentSessionKey,
+} from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import {
   MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
@@ -1010,6 +1014,16 @@ const CRON_BOOTSTRAP_ALLOWLIST = new Set([
   DEFAULT_USER_FILENAME,
 ]);
 
+const GROUP_CHANNEL_BOOTSTRAP_ALLOWLIST = new Set([
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+  DEFAULT_HEARTBEAT_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
+]);
+
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],
   sessionKey?: string,
@@ -1022,6 +1036,9 @@ export function filterBootstrapFilesForSession(
   }
   if (isCronSessionKey(sessionKey)) {
     return files.filter((file) => CRON_BOOTSTRAP_ALLOWLIST.has(file.name));
+  }
+  if (isSharedChannelSessionKey(sessionKey)) {
+    return files.filter((file) => GROUP_CHANNEL_BOOTSTRAP_ALLOWLIST.has(file.name));
   }
   return files;
 }

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -94,4 +94,33 @@ describe("bootstrap-extra-files hook", () => {
     await handler(event);
     expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual(["AGENTS.md"]);
   });
+
+  it("re-applies group channel bootstrap allowlist after extras are added", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-group-");
+    const extraDir = path.join(tempDir, "packages", "core");
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "AGENTS.md"), "extra agents", "utf-8");
+
+    const cfg = createBootstrapExtraConfig(["packages/*/AGENTS.md"]);
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey: "agent:main:telegram:group:-100123",
+      rootFiles: [
+        { name: "AGENTS.md", content: "root agents" },
+        { name: "MEMORY.md", content: "private memory" },
+      ],
+    });
+
+    const event = createHookEvent(
+      "agent",
+      "bootstrap",
+      "agent:main:telegram:group:-100123",
+      context,
+    );
+    await handler(event);
+    const names = context.bootstrapFiles.map((f) => f.name);
+    expect(names).not.toContain("MEMORY.md");
+    expect(names).toContain("AGENTS.md");
+  });
 });

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -18,6 +18,8 @@ import {
   buildAgentPeerSessionKey,
   buildGroupHistoryKey,
   classifySessionKeyShape,
+  isSharedChannelSessionKey,
+  isPrivateMemorySessionKey,
   isValidAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
@@ -163,6 +165,85 @@ describe("isCronSessionKey", () => {
     { key: undefined, expected: false },
   ] as const)("matches cron key %j => $expected", ({ key, expected }) => {
     expect(isCronSessionKey(key)).toBe(expected);
+  });
+});
+
+describe("isSharedChannelSessionKey", () => {
+  it.each([
+    { key: "agent:main:telegram:group:g1", expected: true },
+    { key: "agent:main:discord:group:dev", expected: true },
+    { key: "agent:main:discord:channel:c1", expected: true },
+    { key: "agent:main:discord:guild-123:channel-456", expected: true },
+    { key: "agent:main:slack:group:general", expected: true },
+    { key: "agent:main:feishu:group:oc-group", expected: true },
+    { key: "agent:main:matrix:channel:!Room:example.org", expected: true },
+    { key: "agent:main:whatsapp:123@g.us", expected: true },
+    { key: "agent:main:signal:group:AbC123", expected: true },
+    { key: "agent:main:channel:legacy-room", expected: true },
+    { key: "agent:main:group:room:part", expected: true },
+    { key: "agent:main:telegram:group:-100123:thread:456", expected: true },
+    { key: "agent:main:feishu:group:oc_chat:topic:om_root:sender:ou_user", expected: true },
+    { key: "agent:main:main", expected: false },
+    { key: "agent:main:chat:main", expected: false },
+    { key: "agent:main:direct:user1", expected: false },
+    { key: "agent:main:discord:direct:user1", expected: false },
+    { key: "agent:main:telegram:dm:123456", expected: false },
+    { key: "agent:main:subagent:task-1", expected: false },
+    { key: "agent:main:cron:job-1", expected: false },
+    { key: undefined, expected: false },
+  ] as const)("returns $expected for %j", ({ key, expected }) => {
+    expect(isSharedChannelSessionKey(key)).toBe(expected);
+  });
+});
+
+describe("isPrivateMemorySessionKey", () => {
+  it.each([
+    { key: "agent:main:main", expected: true, label: "main session" },
+    { key: "agent:main:chat:main", expected: true, label: "chat main" },
+    { key: "agent:main:direct:user1", expected: true, label: "direct session" },
+    { key: "agent:main:dm:123456", expected: true, label: "dm session" },
+    { key: "agent:main:telegram:dm:123456", expected: true, label: "telegram dm" },
+    { key: "agent:main:discord:direct:user1", expected: true, label: "discord direct" },
+    {
+      key: "agent:main:discord:acct1:direct:user1",
+      expected: true,
+      label: "discord direct with account",
+    },
+    { key: undefined, expected: true, label: "undefined (CLI/local)" },
+    { key: "", expected: true, label: "empty string" },
+    { key: "agent:main:telegram:group:-100123", expected: false, label: "telegram group" },
+    { key: "agent:main:discord:group:dev", expected: false, label: "discord group" },
+    { key: "agent:main:discord:channel:c1", expected: false, label: "discord channel" },
+    { key: "agent:main:slack:group:general", expected: false, label: "slack group" },
+    { key: "agent:main:feishu:group:oc-group", expected: false, label: "feishu group" },
+    {
+      key: "agent:main:matrix:channel:!Room:example.org",
+      expected: false,
+      label: "matrix channel",
+    },
+    { key: "agent:main:whatsapp:123@g.us", expected: false, label: "whatsapp group" },
+    { key: "agent:main:signal:group:AbC123", expected: false, label: "signal group" },
+    { key: "agent:main:subagent:task-1", expected: false, label: "subagent" },
+    { key: "agent:main:cron:job-1", expected: false, label: "cron" },
+    {
+      key: "agent:main:msteams:team:abc123",
+      expected: false,
+      label: "unknown channel peerKind (msteams team)",
+    },
+    {
+      key: "agent:main:webex:space:room1",
+      expected: false,
+      label: "unknown channel peerKind (webex space)",
+    },
+    { key: "agent:main:channel:legacy-room", expected: false, label: "legacy channel shape" },
+    { key: "agent:main:group:room:part", expected: false, label: "legacy group shape" },
+    {
+      key: "agent:main:discord:guild-123:channel-456",
+      expected: false,
+      label: "discord guild/channel",
+    },
+  ] as const)("returns $expected for $label (%j)", ({ key, expected }) => {
+    expect(isPrivateMemorySessionKey(key)).toBe(expected);
   });
 });
 

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -23,6 +23,10 @@ export {
   type ParsedAgentSessionKey,
 } from "../sessions/session-key-utils.js";
 export {
+  isSharedChannelSessionKey,
+  isPrivateMemorySessionKey,
+} from "../sessions/session-chat-type.js";
+export {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
   normalizeOptionalAccountId,

--- a/src/sessions/session-chat-type.ts
+++ b/src/sessions/session-chat-type.ts
@@ -44,6 +44,33 @@ function derivePluginLegacySessionChatType(
   return deriveLegacySessionChatType(scopedSessionKey);
 }
 
+export function isSharedChannelSessionKey(sessionKey: string | undefined | null): boolean {
+  const chatType = deriveSessionChatType(sessionKey);
+  return chatType === "group" || chatType === "channel";
+}
+
+export function isPrivateMemorySessionKey(sessionKey: string | undefined | null): boolean {
+  if (!sessionKey) {
+    return true;
+  }
+  const chatType = deriveSessionChatType(sessionKey);
+  if (chatType === "group" || chatType === "channel") {
+    return false;
+  }
+  if (chatType === "direct") {
+    return true;
+  }
+  const raw = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (!raw) {
+    return true;
+  }
+  const scoped = parseAgentSessionKey(raw)?.rest ?? raw;
+  if (scoped === "main" || scoped === "chat:main") {
+    return true;
+  }
+  return false;
+}
+
 export function deriveSessionChatType(sessionKey: string | undefined | null): SessionKeyChatType {
   const builtInType = deriveSessionChatTypeFromKey(sessionKey);
   if (builtInType !== "unknown") {


### PR DESCRIPTION
Closes #108881

## What Problem This Solves

Shared channel sessions (Telegram groups, Discord guilds, Slack channels, etc.) receive MEMORY.md as a bootstrap file, contrary to the documented private-session-only contract. `filterBootstrapFilesForSession` returns all files unchanged for every session key that is neither subagent nor cron, so group/channel sessions retain MEMORY.md — leaking private persistent context across users in shared conversations.

## Why This Change Was Made

Current documentation (`docs/concepts/agent-workspace.md:92-93`) states "Only load MEMORY.md in the main, private session (not shared/group contexts)." However, `filterBootstrapFilesForSession` (`src/agents/workspace.ts:1027`) returns all files unchanged for any session key that is neither subagent nor cron, causing MEMORY.md to be injected into shared group/channel sessions. This is a cross-session privacy defect — group participants can receive outputs influenced by context persisted from another user's private session. The ClawSweeper review classified this as P0 / impact:security.

## User Impact

- Users with shared channel sessions (Telegram groups, Discord guilds, Slack channels, etc.) will no longer have MEMORY.md auto-injected into the agent's prompt context. Long-term memory remains accessible via `memory_search` and `memory_get` tools. Private/DM sessions are unaffected.
- Operators who intentionally relied on MEMORY.md being available in group conversations will stop receiving it after upgrade. The documented privacy contract supports this correction. No migration is needed; `MEMORY.md` is not deleted — it remains accessible via memory tools.
- No config, env, or schema changes

## Evidence

- Behavior addressed: MEMORY.md should not be injected as a bootstrap file in shared channel (group/channel) sessions
- Real environment tested: Linux, Node 24, branch `fix/group-session-memory-privacy-108881`
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/agents/workspace.test.ts src/agents/bootstrap-files.test.ts src/routing/session-key.test.ts --run
```

- Evidence after fix:

```console
$ node scripts/run-vitest.mjs src/routing/session-key.test.ts --run
 ✓ |unit-fast| src/routing/session-key.test.ts (118 tests) 48ms
 Test Files  1 passed (1)
      Tests  118 passed (118)

$ node scripts/run-vitest.mjs src/agents/workspace.test.ts --run
 ✓ |agents| src/agents/workspace.test.ts (69 tests) 2809ms
 Test Files  1 passed (1)
      Tests  69 passed (69)

$ node scripts/run-vitest.mjs src/agents/bootstrap-files.test.ts --run
 ✓ |agents| src/agents/bootstrap-files.test.ts (45 tests) 286ms
 Test Files  1 passed (1)
      Tests  45 passed (45)

$ node scripts/run-vitest.mjs src/hooks/bundled/bootstrap-extra-files/handler.test.ts --run
 ✓ |hooks| src/hooks/bundled/bootstrap-extra-files/handler.test.ts (3 tests) 390ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**Matrix-style evidence** — `isSharedChannelSessionKey` classification (via `deriveSessionChatType`):

```
Session key shape                                    => Result
agent:main:telegram:group:g1                         => true  (MEMORY.md excluded)
agent:main:discord:group:dev                         => true  (MEMORY.md excluded)
agent:main:discord:channel:c1                        => true  (MEMORY.md excluded)
agent:main:discord:guild-123:channel-456             => true  (legacy fallback, MEMORY.md excluded)
agent:main:slack:group:general                       => true  (MEMORY.md excluded)
agent:main:feishu:group:oc-group                     => true  (MEMORY.md excluded)
agent:main:matrix:channel:!Room:example.org          => true  (MEMORY.md excluded)
agent:main:whatsapp:123@g.us                         => true  (legacy fallback, MEMORY.md excluded)
agent:main:signal:group:AbC123                       => true  (MEMORY.md excluded)
agent:main:telegram:group:-100123:thread:456         => true  (thread suffix stripped, MEMORY.md excluded)
agent:main:feishu:group:oc:topic:om:sender:ou        => true  (nested topic/sender, MEMORY.md excluded)
agent:main:main                                      => false (MEMORY.md preserved)
agent:main:chat:main                                 => false (MEMORY.md preserved)
agent:main:direct:user1                              => false (MEMORY.md preserved)
agent:main:telegram:dm:123456                        => false (MEMORY.md preserved)
agent:main:discord:direct:user1                      => false (MEMORY.md preserved)
agent:main:subagent:task-1                           => false (MEMORY.md excluded by subagent allowlist)
agent:main:cron:job-1                                => false (MEMORY.md excluded by cron allowlist)
undefined                                            => false (MEMORY.md preserved)
```

**Fail-closed evidence** — `isPrivateMemorySessionKey` for unknown channel peerKinds:

```
Session key shape                                    => isPrivateMemorySessionKey => MEMORY.md
agent:main:msteams:team:abc123                       => false                     => excluded
agent:main:webex:space:room1                         => false                     => excluded
agent:main:channel:legacy-room                       => false                     => excluded
agent:main:group:room:part                           => false                     => excluded
agent:main:main                                      => true                      => preserved
agent:main:telegram:dm:123456                        => true                      => preserved
undefined                                            => true                      => preserved
```

Both `isSharedChannelSessionKey` and `isPrivateMemorySessionKey` delegate to `deriveSessionChatType` (`src/sessions/session-chat-type.ts`), which first uses the built-in classifier (`deriveSessionChatTypeFromKey`) and then queries bootstrap channel plugins for legacy session keys. This means plugin-provided `deriveLegacySessionChatType` classifiers are automatically covered — external plugins that use custom direct-session key shapes will still have their private sessions recognized.

**Lowercase alias bypass evidence** — `enforcePrivateMemoryBoundary` blocks both `MEMORY.md` and `memory.md`:

The repository defines two memory filename constants in `src/memory/root-memory-files.ts`:
- `CANONICAL_ROOT_MEMORY_FILENAME = "MEMORY.md"` — current workspace standard
- `LEGACY_ROOT_MEMORY_FILENAME = "memory.md"` — legacy alias, recognized by `system-prompt.ts:86`

`enforcePrivateMemoryBoundary` uses `isMemoryBootstrapFileName` with case-insensitive comparison to filter both:

```typescript
// src/agents/bootstrap-files.ts:230-235
function isMemoryBootstrapFileName(name: string): boolean {
  const lower = name.toLowerCase();
  return (
    lower === CANONICAL_ROOT_MEMORY_FILENAME.toLowerCase() ||
    lower === LEGACY_ROOT_MEMORY_FILENAME.toLowerCase()
  );
}
```

Test — hook injecting lowercase `memory.md`:

```console
$ node scripts/run-vitest.mjs src/agents/bootstrap-files.test.ts --run
 ✓ strips lowercase memory.md alias injected by hook for group sessions
   names => not toContain "MEMORY.md" ✓
   names => not toContain "memory.md" ✓
```

- Observed result after fix:
  1. All 9 shared channel session key types (Telegram, Discord, Slack, Feishu, Matrix, WhatsApp, Signal + thread/legacy variants) exclude MEMORY.md from bootstrap
  2. All 5 private session key types (main, chat, direct, DM) retain MEMORY.md
  3. Hook-injected MEMORY.md is re-stripped by `enforcePrivateMemoryBoundary` for group sessions
  4. Hook-injected lowercase `memory.md` alias is also re-stripped by `enforcePrivateMemoryBoundary` for group sessions
  5. Subagent and cron allowlists unchanged
  6. Plugin-provided `deriveLegacySessionChatType` classifiers are automatically covered by `deriveSessionChatType`
- Sending a real message to a live Telegram group / Discord guild and observing the agent's response not contain private memory content. This requires running gateway + channel bot credentials which are not available in CI. The deterministic test suite and live chain verification above prove the complete code path from `buildAgentPeerSessionKey` through `isSharedChannelSessionKey`/`isPrivateMemorySessionKey` through `filterBootstrapFilesForSession` through `enforcePrivateMemoryBoundary` — every production function in the critical path is exercised with real inputs and outputs.

**Third-party hook bypass — proven by code audit + tests**:

1. **Code audit**: `enforcePrivateMemoryBoundary` (`bootstrap-files.ts:216-228`) runs after `applyBootstrapHookOverrides` (`bootstrap-files.ts:307-314`) completes — all hooks (bundled and third-party) finish before it executes. After `enforcePrivateMemoryBoundary`, only `sanitizeBootstrapFiles` runs, which never adds files. No code path exists for any hook to modify `bootstrapFiles` after the boundary is enforced.

2. **Test — hook injecting MEMORY.md**: `bootstrap-files.test.ts` "re-enforces MEMORY.md exclusion after hook overrides for group sessions" — a hook explicitly injects MEMORY.md into `context.bootstrapFiles` for a Discord group session; `resolveBootstrapFilesForRun` still returns no MEMORY.md.

3. **Test — hook injecting MEMORY.md alongside other files**: `bootstrap-files.test.ts` "strips MEMORY.md even when a hook adds it alongside other files for group sessions" — a hook injects both MEMORY.md and an extra AGENTS.md; MEMORY.md is stripped, extra AGENTS.md is preserved.

4. **Test — hook injecting lowercase memory.md alias**: `bootstrap-files.test.ts` "strips lowercase memory.md alias injected by hook for group sessions" — a hook injects `memory.md` (legacy alias) into a Telegram group session; `enforcePrivateMemoryBoundary` strips both `MEMORY.md` and `memory.md` via `isMemoryBootstrapFileName`.

5. **Bundled hook self-filtering**: `bootstrap-extra-files/handler.ts:63` calls `filterBootstrapFilesForSession` itself, which now includes the `GROUP_CHANNEL_BOOTSTRAP_ALLOWLIST` branch. Even without `enforcePrivateMemoryBoundary`, the bundled hook would exclude MEMORY.md for group sessions.

6. **Test — bootstrap-extra-files hook with group session**: `bootstrap-extra-files/handler.test.ts` "re-applies group channel bootstrap allowlist after extras are added" — the bundled hook correctly excludes MEMORY.md when re-filtering for a Telegram group session.

## What Changed

- `src/sessions/session-chat-type.ts` (+27): New `isSharedChannelSessionKey` (delegates to `deriveSessionChatType`) and `isPrivateMemorySessionKey` (fail-closed, also delegates to `deriveSessionChatType`); both share the canonical plugin-aware session chat-type classifier, including bootstrap channel plugin `deriveLegacySessionChatType` classifiers
- `src/routing/session-key.ts` (+4/-2): Re-export both new functions from `session-chat-type.js`
- `src/agents/workspace.ts` (+19): `GROUP_CHANNEL_BOOTSTRAP_ALLOWLIST` (excludes MEMORY.md) + `isSharedChannelSessionKey` filter branch in `filterBootstrapFilesForSession`
- `src/agents/bootstrap-files.ts` (+37/-5): `enforcePrivateMemoryBoundary` using `isPrivateMemorySessionKey` (fail-closed) after hook overrides; `isMemoryBootstrapFileName` with case-insensitive comparison using `CANONICAL_ROOT_MEMORY_FILENAME` + `LEGACY_ROOT_MEMORY_FILENAME` from `root-memory-files.ts`
- `src/agents/bootstrap-files.test.ts` (+167): 6 new tests — shared channel exclusion, DM inclusion, hook bypass, hook+multi-file bypass, lowercase alias bypass, fail-closed for unknown peerKind
- `src/agents/workspace.test.ts` (+30): 2 parameterized test suites — 9 shared channel keys exclude MEMORY.md, 5 private keys include MEMORY.md
- `src/routing/session-key.test.ts` (+81): 2 parameterized test suites — 21 cases for `isSharedChannelSessionKey`, 24 cases for `isPrivateMemorySessionKey`
- `src/hooks/bundled/bootstrap-extra-files/handler.test.ts` (+29): 1 test — group channel allowlist re-applied after extras

## What Did NOT Change

- Private/DM session behavior (MEMORY.md still injected)
- Subagent/cron allowlists
- Hook API; config surface
- `HEARTBEAT.md` injection (handled by heartbeat runner, not bootstrap files)
- `loadWorkspaceBootstrapFiles` — lowercase `memory.md` is never loaded by the bootstrap loader (test `workspace.test.ts:941` confirms "ignores lowercase memory.md when MEMORY.md is absent")
- `deriveSessionChatType` — unchanged; `isSharedChannelSessionKey` and `isPrivateMemorySessionKey` consume its output

## Root Cause

`filterBootstrapFilesForSession` (`src/agents/workspace.ts:1027`) only checks for subagent and cron session keys. Every other session key (including all group/channel shapes) falls through to `return files`, which includes MEMORY.md. This is not a regression from a specific commit — the group exclusion gap has existed since the initial introduction of session-type-based bootstrap filtering.

Additionally, `resolveBootstrapFilesForRun` (`src/agents/bootstrap-files.ts`) had no MEMORY.md boundary check after `applyBootstrapHookOverrides`, so hooks could inject MEMORY.md (or its lowercase alias `memory.md`) into group sessions without restriction.

## Best-fix Verdict

- **Best fix**: Yes — Two-layer defense: `filterBootstrapFilesForSession` filters known group shapes via `isSharedChannelSessionKey` + `GROUP_CHANNEL_BOOTSTRAP_ALLOWLIST`; `enforcePrivateMemoryBoundary` uses `isPrivateMemorySessionKey` (fail-closed) as a post-hook safety net for all non-private sessions including unknown channel peerKinds, blocking both `MEMORY.md` and `memory.md` via `isMemoryBootstrapFileName` case-insensitive comparison. Both classifiers delegate to the canonical `deriveSessionChatType` — no duplicate routing grammar; plugin-provided classifiers are automatically covered.
- **Refactor needed**: No — Follows existing `SUBAGENT_BOOTSTRAP_ALLOWLIST`/`CRON_BOOTSTRAP_ALLOWLIST` pattern
- **Alternative considered**: Telegram-specific predicate (rejected — would leave Discord/Slack/etc. unenforced); new config option (rejected — violates AGENTS.md "config bar is high" and ClawSweeper "without adding configuration surface")

## Architecture

Three-layer defense:

```
Layer 1: filterBootstrapFilesForSession (workspace.ts:1027)
  └─ isSharedChannelSessionKey → GROUP_CHANNEL_BOOTSTRAP_ALLOWLIST (no MEMORY.md)
  └─ isSharedChannelSessionKey delegates to deriveSessionChatType
     (canonical + built-in legacy + plugin-provided classifiers)
  └─ Falls through for unknown peerKinds → return files (includes MEMORY.md)

Layer 2: bootstrap-extra-files/handler.ts:63
  └─ Re-runs filterBootstrapFilesForSession after adding extras
  └─ Same GROUP_CHANNEL_BOOTSTRAP_ALLOWLIST applied

Layer 3: enforcePrivateMemoryBoundary (bootstrap-files.ts:216-228)
  └─ isPrivateMemorySessionKey (fail-closed) → strips MEMORY.md + memory.md
  └─ isPrivateMemorySessionKey delegates to deriveSessionChatType
  └─ isMemoryBootstrapFileName: case-insensitive comparison via
     CANONICAL_ROOT_MEMORY_FILENAME + LEGACY_ROOT_MEMORY_FILENAME
  └─ Runs AFTER all hooks complete (applyBootstrapHookOverrides)
  └─ Catches unknown peerKinds and lowercase alias bypasses
```

Fail-closed guarantee: `isPrivateMemorySessionKey` returns `false` for any session key where `deriveSessionChatType` returns `"group"`, `"channel"`, or `"unknown"`, so MEMORY.md is excluded for all unrecognized shapes. Only `"direct"` and the `main`/`chat:main` sentinel shapes are classified as private.

Canonical classifier guarantee: Both `isSharedChannelSessionKey` and `isPrivateMemorySessionKey` delegate to `deriveSessionChatType` in `src/sessions/session-chat-type.ts` — the same plugin-aware classifier that owns session routing. `deriveSessionChatType` first uses the built-in classifier (`deriveSessionChatTypeFromKey`), then queries bootstrap channel plugins via `getBootstrapChannelPlugin` for legacy session key classification. No duplicate routing grammar; no drift risk. New channel types or plugin-provided legacy classifiers are automatically covered.

Alias guarantee: `isMemoryBootstrapFileName` uses case-insensitive comparison against `CANONICAL_ROOT_MEMORY_FILENAME` and `LEGACY_ROOT_MEMORY_FILENAME` from `root-memory-files.ts`. This avoids the TS2367 type error (since `WorkspaceBootstrapFileName` does not include `"memory.md"`) while still blocking hooks that inject the lowercase alias via `as unknown as WorkspaceBootstrapFile`.

## Current-head Proof Request

The Mantis Telegram Desktop recording is tied to an earlier candidate SHA. The current head consolidated session classification into the canonical `deriveSessionChatType` (including plugin-aware classifiers) and uses `isMemoryBootstrapFileName` for case-insensitive alias blocking. A maintainer with Telegram credentials can request fresh proof by posting:

> @openclaw-mantis telegram desktop proof: verify head 131ab7a excludes a redacted MEMORY.md canary in a group reply while retaining it in a DM reply.

The deterministic test suite (235+ tests across 4 files) confirms the complete production path at the current head.

## AI Assistance

- **AI-assisted**: Yes
- **AI model**: glm-5.1
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Issue analysis and code implementation for #108881 MEMORY.md cross-session privacy boundary
