### PR TITLE
fix(codex): keep stderr diagnostics valid at tail limits

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -445,6 +445,21 @@ describe("CodexAppServerClient", () => {
     );
   });
 
+  it("keeps bounded stderr tails on UTF-16 boundaries", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    const pending = harness.client.request("test/method");
+
+    harness.process.stderr.write(`🎉${"x".repeat(1_999)}`);
+    harness.process.emit("exit", 1, null);
+
+    await expect(pending).rejects.toThrow(
+      `codex app-server exited: code=1 signal=null stderr=${JSON.stringify(
+        `${"x".repeat(500)}...`,
+      )}`,
+    );
+  });
+
   it("does not write to stdin after the child process exits", () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -5,7 +5,7 @@
 import { randomUUID } from "node:crypto";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { parse as parseSemver } from "semver";
 import { resolveCodexAppServerRuntimeOptions, type CodexAppServerStartOptions } from "./config.js";
 import {
@@ -1002,7 +1002,7 @@ function redactCodexAppServerLinePreview(value: string): string {
 
 function appendBoundedTail(current: string, next: string, maxLength: number): string {
   const combined = `${current}${next}`;
-  return combined.length > maxLength ? combined.slice(combined.length - maxLength) : combined;
+  return combined.length > maxLength ? sliceUtf16Safe(combined, -maxLength) : combined;
 }
 
 function buildCodexAppServerExitError(code: unknown, signal: unknown, stderrTail: string): Error {


### PR DESCRIPTION
Related: #108335

## What Problem This Solves

Fixes an issue where Codex app-server exit diagnostics could begin with a broken Unicode surrogate when stderr exceeded the retained 2,000-code-unit tail and the retention boundary split an emoji.

## Why This Change Was Made

The bounded stderr tail now uses the shared UTF-16-safe slicer instead of a raw string slice. An exact boundary regression test covers the diagnostic emitted to pending requests. This PR is AI-assisted and maintainer-reviewed.

## User Impact

Codex startup and transport failures keep valid Unicode diagnostics even when long stderr output is tail-truncated.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/client.test.ts` — 30/30 passed.
- Regression strength: the same test file with the old raw suffix slice failed only the new boundary case, exposing a leading `\udf89`; restoring the fix passed 30/30.
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/client.ts extensions/codex/src/app-server/client.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29499417757
- Fresh autoreview: clean, correctness 0.99.
