### PR TITLE
feat: add title tooltips to composer footer status values

### DIFF
--- a/ui/src/pages/chat/components/chat-composer-context.ts
+++ b/ui/src/pages/chat/components/chat-composer-context.ts
@@ -394,7 +394,7 @@ export function renderContextNotice(
         <summary
           class="context-ring ${model?.warning ? "context-ring--warning" : ""}"
           aria-label=${summary}
-          title=${t("chat.composer.contextUsage.open")}
+          title=${`${summary}\n${t("chat.composer.contextUsage.open")}`}
         >
           <svg
             class="context-ring__dial"

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -640,6 +640,7 @@ function renderChatModelReasoningSelect(params: {
         aria-label="${t("chat.selectors.model")}, ${t(
           "chat.selectors.thinkingLevel",
         )}: ${triggerTitle}"
+        title="${t("chat.selectors.thinkingLevel")}: ${triggerThinking}"
         aria-disabled=${disabled ? "true" : "false"}
         @click=${(event: MouseEvent) => {
           if (disabled) {


### PR DESCRIPTION
Closes #107928

## What Problem This Solves

The chat composer footer renders compact status values — `claude-opus-4-8 · Off · 10%` — without any labels, `title` attributes, or tooltips. A sighted user hovering over "Off" has no way to discover it represents the thinking/reasoning level, and hovering over "10%" in the context ring shows "Open context usage details" rather than explaining what the percentage measures.

This affects the main chat composer footer (`ui/src/pages/chat/components/chat-composer.ts`).

## Why This Change Was Made

Both values already had complete accessible descriptions via `aria-label` — they existed for screen readers but were not surfaced to sighted users via hover.

The fix reuses existing localized strings as `title` attributes — no new i18n keys, no new concepts, no layout changes, and no behavioral modifications.

Changes:
- `chat-composer.ts`: replaces the generic "Open context usage details" title with the actual context usage summary, keeping "Open context usage details" as a second line
- `chat-model-controls.ts`: adds a focused title that labels the thinking level value, explaining what "Off" refers to

## User Impact

- Hovering over the thinking-level value in the model selector (e.g. `Off`) now shows: "Chat thinking level: Off"
- Hovering over the context usage percentage (e.g. `10%`) now shows two lines: "Thread context usage: 46k of 200k (23%)" followed by "Open context usage details"
- Screen reader behavior is unchanged — existing `aria-label` values are preserved
- All localized languages are fully supported since the change reuses existing translation keys

## Evidence

### Before

| Model/reasoning trigger | Context usage ring |
|---|---|
| <img width="1911" height="905" alt="2026-07-22_before1" src="https://github.com/user-attachments/assets/512356df-fc60-4abc-81ce-a96903fdca53" /> | <img width="1917" height="936" alt="2026-07-22_before2" src="https://github.com/user-attachments/assets/77019711-88ba-4997-804f-d3df091b71c4" /> |
| No tooltip on hover. "Off" meaning is ambiguous. | Tooltip shows "Open context usage details" — tells what clicking does, not what the value means. |

### After

| Model/reasoning trigger | Context usage ring |
|---|---|
| <img width="1907" height="928" alt="2026-07-22_after1" src="https://github.com/user-attachments/assets/97c4e415-6320-4c26-a2a9-648d872ea8b7" /> | <img width="1911" height="952" alt="2026-07-22_after2" src="https://github.com/user-attachments/assets/beb6cbfc-e760-4478-9067-73f27628351a" /> |
| Tooltip explains "Chat thinking level: Off". | Tooltip shows "Thread context usage: 0 of 200k (0%)" followed by "Open context usage details". |

### Validation

- `pnpm format:check` — format clean
- `pnpm ui:i18n:verify` — i18n clean (no new keys added)
- `ui/src/pages/chat/chat-composer.test.ts` — confirm no regressions
- `ui/src/pages/chat/chat-controls.test.ts` — confirm no regressions
- `git diff --stat`: 2 files changed, 2 insertions(+), 1 deletion(-)

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
