### PR TITLE
fix(memory): indexing survives transient embedding rate limits

### DIFF
--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -218,4 +218,42 @@ describe("Gemini embedding provider", () => {
       "gemini embeddings failed: malformed JSON response",
     );
   });
+
+  it("preserves Gemini retry timing on rate-limit errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 429,
+                status: "RESOURCE_EXHAUSTED",
+                message: "Quota exceeded",
+                details: [
+                  {
+                    "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                    retryDelay: "42s",
+                  },
+                ],
+              },
+            }),
+            { status: 429 },
+          ),
+      ),
+    );
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "placeholder" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embedQuery("test query")).rejects.toMatchObject({
+      name: "ProviderHttpError",
+      status: 429,
+      retryAfterMs: 42_000,
+    });
+  });
 });

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1701,7 +1701,11 @@ describe("memory index", () => {
           embedBatch: (texts: string[]) => Promise<number[][]>;
           close: () => Promise<void>;
         };
-        waitForEmbeddingRetry: (delayMs: number, action: string) => Promise<void>;
+        waitForEmbeddingRetry: (
+          delayMs: number,
+          action: string,
+          signal?: AbortSignal,
+        ) => Promise<void>;
       }
     ).provider = {
       id: "mock",
@@ -1718,7 +1722,11 @@ describe("memory index", () => {
     };
     (
       manager as unknown as {
-        waitForEmbeddingRetry: (delayMs: number, action: string) => Promise<void>;
+        waitForEmbeddingRetry: (
+          delayMs: number,
+          action: string,
+          signal?: AbortSignal,
+        ) => Promise<void>;
       }
     ).waitForEmbeddingRetry = async () => {};
 
@@ -1758,7 +1766,11 @@ describe("memory index", () => {
     };
     (
       manager as unknown as {
-        waitForEmbeddingRetry: (delayMs: number, action: string) => Promise<void>;
+        waitForEmbeddingRetry: (
+          delayMs: number,
+          action: string,
+          signal?: AbortSignal,
+        ) => Promise<void>;
       }
     ).waitForEmbeddingRetry = async () => {};
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -39,10 +39,11 @@ import { createMemoryEmbeddingOperationError } from "./manager-embedding-errors.
 import {
   buildMemoryEmbeddingBatches,
   buildTextEmbeddingInputs,
+  createMemoryEmbeddingRetryCooldown,
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
-  resolveMemoryEmbeddingRetryDelay,
+  resolveMemoryEmbeddingRetryAfterMs,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
@@ -60,9 +61,10 @@ const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const EMBEDDING_BATCH_MAX_TOKENS = 8000;
 const EMBEDDING_INDEX_CONCURRENCY = 4;
-const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
-const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
-const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
+// Six bounded waits span a minute-scale quota window. Longer provider hints
+// fail promptly so daily or account quota exhaustion does not stall indexing.
+const EMBEDDING_INDEX_RETRY = { attempts: 7, minDelayMs: 1250, maxDelayMs: 60_000 } as const;
+const EMBEDDING_QUERY_RETRY = { attempts: 3, minDelayMs: 500, maxDelayMs: 8000 } as const;
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
@@ -215,6 +217,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureLastProvider?: string;
   protected abstract batchFailureLock: Promise<void>;
   protected abstract markLocalEmbeddingProviderDegraded(err: unknown): void;
+  private readonly embeddingRetryCooldown = createMemoryEmbeddingRetryCooldown();
 
   protected pruneEmbeddingCacheIfNeeded(): void {
     if (!this.cache.enabled) {
@@ -413,6 +416,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       return await runMemoryEmbeddingBatchRetryWithSplit({
         items: texts,
         run: async (batchTexts) => {
+          await this.embeddingRetryCooldown.wait(0);
           const timeoutMs = this.resolveEmbeddingTimeout("batch");
           log.debug("memory embeddings: batch start", {
             provider: provider.id,
@@ -435,8 +439,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         waitForRetry: async (delayMs) => {
           await this.waitForEmbeddingRetry(delayMs, "retrying");
         },
-        maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-        baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        maxAttempts: EMBEDDING_INDEX_RETRY.attempts,
+        baseDelayMs: EMBEDDING_INDEX_RETRY.minDelayMs,
+        maxDelayMs: EMBEDDING_INDEX_RETRY.maxDelayMs,
+        retryAfterMs: resolveMemoryEmbeddingRetryAfterMs,
+        onRetry: (error) => {
+          this.embeddingRetryCooldown.publish(resolveMemoryEmbeddingRetryAfterMs(error));
+        },
         onSplit: ({ itemCount, splitAt }) => {
           log.warn(
             `memory embeddings transport failed after retries; splitting batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
@@ -470,6 +479,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       return await runMemoryEmbeddingBatchRetryWithSplit({
         items: inputs,
         run: async (batchInputs) => {
+          await this.embeddingRetryCooldown.wait(0);
           const timeoutMs = this.resolveEmbeddingTimeout("batch");
           log.debug("memory embeddings: structured batch start", {
             provider: provider.id,
@@ -487,8 +497,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         waitForRetry: async (delayMs) => {
           await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
         },
-        maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-        baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        maxAttempts: EMBEDDING_INDEX_RETRY.attempts,
+        baseDelayMs: EMBEDDING_INDEX_RETRY.minDelayMs,
+        maxDelayMs: EMBEDDING_INDEX_RETRY.maxDelayMs,
+        retryAfterMs: resolveMemoryEmbeddingRetryAfterMs,
+        onRetry: (error) => {
+          this.embeddingRetryCooldown.publish(resolveMemoryEmbeddingRetryAfterMs(error));
+        },
         onSplit: ({ itemCount, splitAt }) => {
           log.warn(
             `memory embeddings transport failed after retries; splitting structured batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
@@ -505,16 +520,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
   }
 
-  private async waitForEmbeddingRetry(delayMs: number, action: string): Promise<void> {
-    const waitMs = resolveMemoryEmbeddingRetryDelay(
-      delayMs,
-      Math.random(),
-      EMBEDDING_RETRY_MAX_DELAY_MS,
-    );
-    log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
-    await new Promise((resolve) => {
-      setTimeout(resolve, waitMs);
-    });
+  private async waitForEmbeddingRetry(
+    delayMs: number,
+    action: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    log.warn(`memory embeddings retryable error; ${action} in at least ${delayMs}ms`);
+    await this.embeddingRetryCooldown.wait(delayMs, signal);
   }
 
   private resolveEmbeddingTimeout(kind: "query" | "batch"): number {
@@ -535,6 +547,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       return await runMemoryEmbeddingRetryLoop({
         run: async () => {
           signal?.throwIfAborted();
+          await this.embeddingRetryCooldown.wait(0, signal);
           const timeoutMs = this.resolveEmbeddingTimeout("query");
           log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
           return await runEmbeddingOperationWithTimeout({
@@ -547,10 +560,15 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         signal,
         isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry: async (delayMs) => {
-          await this.waitForEmbeddingRetry(delayMs, "retrying query");
+          await this.waitForEmbeddingRetry(delayMs, "retrying query", signal);
         },
-        maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-        baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        maxAttempts: EMBEDDING_QUERY_RETRY.attempts,
+        baseDelayMs: EMBEDDING_QUERY_RETRY.minDelayMs,
+        maxDelayMs: EMBEDDING_QUERY_RETRY.maxDelayMs,
+        retryAfterMs: resolveMemoryEmbeddingRetryAfterMs,
+        onRetry: (error) => {
+          this.embeddingRetryCooldown.publish(resolveMemoryEmbeddingRetryAfterMs(error));
+        },
       });
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -1,11 +1,14 @@
 // Memory Core tests cover manager embedding policy plugin behavior.
+import { createServer } from "node:http";
+import { createProviderHttpError } from "openclaw/plugin-sdk/provider-http";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
+  createMemoryEmbeddingRetryCooldown,
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
-  resolveMemoryEmbeddingRetryDelay,
+  resolveMemoryEmbeddingRetryAfterMs,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
@@ -66,6 +69,8 @@ describe("memory embedding policy", () => {
       },
       maxAttempts: 3,
       baseDelayMs: 500,
+      maxDelayMs: 8000,
+      random: () => 0.5,
     });
 
     expect(result).toBe("ok");
@@ -89,6 +94,7 @@ describe("memory embedding policy", () => {
         waitForRetry,
         maxAttempts: 3,
         baseDelayMs: 500,
+        maxDelayMs: 8000,
         signal: controller.signal,
       }),
     ).rejects.toThrow("memory embeddings query timed out after 60s");
@@ -139,6 +145,7 @@ describe("memory embedding policy", () => {
       waitForRetry: async () => {},
       maxAttempts: 3,
       baseDelayMs: 500,
+      maxDelayMs: 8000,
     });
 
     expect(result).toEqual([[97], [98], [99], [100]]);
@@ -168,6 +175,8 @@ describe("memory embedding policy", () => {
       },
       maxAttempts: 3,
       baseDelayMs: 500,
+      maxDelayMs: 8000,
+      random: () => 0.5,
     });
 
     expect(result).toBe("ok");
@@ -190,6 +199,8 @@ describe("memory embedding policy", () => {
         },
         maxAttempts: 3,
         baseDelayMs: 500,
+        maxDelayMs: 8000,
+        random: () => 0.5,
       }),
     ).rejects.toThrow("fetch failed");
 
@@ -217,6 +228,8 @@ describe("memory embedding policy", () => {
       },
       maxAttempts: 2,
       baseDelayMs: 500,
+      maxDelayMs: 8000,
+      random: () => 0.5,
       onSplit: ({ itemCount, splitAt }) => {
         splits.push(`${itemCount}:${splitAt}`);
       },
@@ -242,6 +255,7 @@ describe("memory embedding policy", () => {
         waitForRetry: async () => {},
         maxAttempts: 1,
         baseDelayMs: 500,
+        maxDelayMs: 8000,
       }),
     ).rejects.toThrow("429 rate limit");
     expect(run).toHaveBeenCalledTimes(1);
@@ -261,14 +275,214 @@ describe("memory embedding policy", () => {
         waitForRetry: async () => {},
         maxAttempts: 2,
         baseDelayMs: 500,
+        maxDelayMs: 8000,
+        random: () => 0.5,
       }),
     ).rejects.toThrow("ECONNREFUSED");
     expect(run).toHaveBeenCalledTimes(2);
   });
 
-  it("caps retry jittered delays", () => {
-    expect(resolveMemoryEmbeddingRetryDelay(500, 0, 8000)).toBe(500);
-    expect(resolveMemoryEmbeddingRetryDelay(500, 1, 8000)).toBe(600);
-    expect(resolveMemoryEmbeddingRetryDelay(10_000, 1, 8000)).toBe(8000);
+  it("reads finite non-negative provider retry delays", () => {
+    expect(resolveMemoryEmbeddingRetryAfterMs({ retryAfterMs: 1500 })).toBe(1500);
+    expect(resolveMemoryEmbeddingRetryAfterMs({ retryAfterMs: -1 })).toBeUndefined();
+    expect(resolveMemoryEmbeddingRetryAfterMs({ retryAfterMs: Number.NaN })).toBeUndefined();
+    expect(resolveMemoryEmbeddingRetryAfterMs(new Error("429"))).toBeUndefined();
+  });
+
+  it("honors bounded provider retry delays", async () => {
+    const run = vi.fn(async () => {
+      if (run.mock.calls.length === 1) {
+        throw Object.assign(new Error("gemini embeddings failed: 429"), {
+          retryAfterMs: 5000,
+        });
+      }
+      return "ok";
+    });
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        maxDelayMs: 8000,
+        retryAfterMs: resolveMemoryEmbeddingRetryAfterMs,
+        random: () => 0,
+      }),
+    ).resolves.toBe("ok");
+
+    expect(waits).toEqual([5000]);
+  });
+
+  it("waits for Google RetryInfo before retrying an HTTP request", async () => {
+    const requestTimes: number[] = [];
+    const server = createServer((_request, response) => {
+      requestTimes.push(Date.now());
+      if (requestTimes.length === 1) {
+        response.writeHead(429, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              message: "Quota exceeded",
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: "1s",
+                },
+              ],
+            },
+          }),
+        );
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        throw new Error("test server did not expose a TCP address");
+      }
+      const cooldown = createMemoryEmbeddingRetryCooldown();
+      const result = await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          const response = await fetch(`http://127.0.0.1:${address.port}/embed`);
+          if (!response.ok) {
+            throw await createProviderHttpError(response, "gemini embeddings failed");
+          }
+          return "ok";
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => await cooldown.wait(delayMs),
+        maxAttempts: 2,
+        baseDelayMs: 10,
+        maxDelayMs: 2000,
+        retryAfterMs: resolveMemoryEmbeddingRetryAfterMs,
+        onRetry: (error) => cooldown.publish(resolveMemoryEmbeddingRetryAfterMs(error)),
+        random: () => 0,
+      });
+
+      expect(result).toBe("ok");
+      expect(requestTimes).toHaveLength(2);
+      expect(requestTimes[1]! - requestTimes[0]!).toBeGreaterThanOrEqual(1000);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("fails promptly when a provider retry delay exceeds the bounded wait", async () => {
+    const error = Object.assign(new Error("gemini embeddings failed: 429"), {
+      retryAfterMs: 120_000,
+    });
+    const run = vi.fn(async () => {
+      throw error;
+    });
+    const waitForRetry = vi.fn(async () => {});
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry,
+        maxAttempts: 7,
+        baseDelayMs: 1000,
+        maxDelayMs: 60_000,
+        retryAfterMs: resolveMemoryEmbeddingRetryAfterMs,
+      }),
+    ).rejects.toBe(error);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+
+  it("extends concurrent waiters to the longest shared cooldown", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const cooldown = createMemoryEmbeddingRetryCooldown();
+      let firstFinished = false;
+      cooldown.publish(100);
+      const first = cooldown.wait(100).then(() => {
+        firstFinished = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      cooldown.publish(200);
+      const second = cooldown.wait(200);
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(firstFinished).toBe(false);
+      await vi.advanceTimersByTimeAsync(150);
+      await Promise.all([first, second]);
+      expect(firstFinished).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gates new attempts behind a published cooldown", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const cooldown = createMemoryEmbeddingRetryCooldown();
+      cooldown.publish(200);
+      let started = false;
+      const attempt = cooldown.wait(0).then(() => {
+        started = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(199);
+      expect(started).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await attempt;
+      expect(started).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps per-waiter jitter independent when the provider gives no cooldown", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const cooldown = createMemoryEmbeddingRetryCooldown();
+      let firstFinished = false;
+      let secondFinished = false;
+      const first = cooldown.wait(100).then(() => {
+        firstFinished = true;
+      });
+      await vi.advanceTimersByTimeAsync(50);
+      const second = cooldown.wait(200).then(() => {
+        secondFinished = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(firstFinished).toBe(true);
+      expect(secondFinished).toBe(false);
+      await vi.advanceTimersByTimeAsync(150);
+      await Promise.all([first, second]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts a shared cooldown wait with its caller", async () => {
+    const cooldown = createMemoryEmbeddingRetryCooldown();
+    const controller = new AbortController();
+    const waiting = cooldown.wait(60_000, controller.signal);
+
+    controller.abort(new Error("memory search cancelled"));
+
+    await expect(waiting).rejects.toThrow("aborted");
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -344,7 +344,9 @@ describe("memory embedding policy", () => {
       response.writeHead(200, { "content-type": "application/json" });
       response.end(JSON.stringify({ ok: true }));
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
 
     try {
       const address = server.address();
@@ -375,7 +377,13 @@ describe("memory embedding policy", () => {
       expect(requestTimes[1]! - requestTimes[0]!).toBeGreaterThanOrEqual(1000);
     } finally {
       await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
       });
     }
   });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -1,5 +1,7 @@
 // Memory Core plugin module implements manager embedding policy behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 
 type MemoryEmbeddingTextPart = {
   type: "text";
@@ -105,43 +107,89 @@ export function isRetryableMemoryEmbeddingError(message: string): boolean {
   );
 }
 
-export function resolveMemoryEmbeddingRetryDelay(
-  delayMs: number,
-  randomValue: number,
-  maxDelayMs: number,
-): number {
-  return Math.min(maxDelayMs, Math.round(delayMs * (1 + randomValue * 0.2)));
+export function resolveMemoryEmbeddingRetryAfterMs(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const retryAfterMs = (error as { retryAfterMs?: unknown }).retryAfterMs;
+  return typeof retryAfterMs === "number" && Number.isFinite(retryAfterMs) && retryAfterMs >= 0
+    ? retryAfterMs
+    : undefined;
+}
+
+export function createMemoryEmbeddingRetryCooldown(): {
+  publish: (retryAfterMs: number | undefined) => void;
+  wait: (delayMs: number, signal?: AbortSignal) => Promise<void>;
+} {
+  let retryNotBeforeMs = 0;
+  return {
+    publish: (retryAfterMs) => {
+      if (retryAfterMs !== undefined) {
+        retryNotBeforeMs = Math.max(retryNotBeforeMs, Date.now() + retryAfterMs);
+      }
+    },
+    wait: async (delayMs, signal) => {
+      const waiterNotBeforeMs = Date.now() + delayMs;
+      while (true) {
+        signal?.throwIfAborted();
+        const remainingMs = Math.max(0, Math.max(waiterNotBeforeMs, retryNotBeforeMs) - Date.now());
+        if (remainingMs === 0) {
+          return;
+        }
+        // Re-check after sleeping because another concurrent batch may publish a
+        // longer provider cooldown while this waiter is already paused.
+        await sleepWithAbort(remainingMs, signal);
+      }
+    },
+  };
 }
 
 export async function runMemoryEmbeddingRetryLoop<T>(params: {
   run: () => Promise<T>;
   isRetryable: (message: string) => boolean;
-  waitForRetry: (delayMs: number) => Promise<void>;
+  waitForRetry: (delayMs: number, error: unknown) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
+  maxDelayMs: number;
+  retryAfterMs?: (error: unknown) => number | undefined;
+  onRetry?: (error: unknown) => void;
+  random?: () => number;
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
-  const attempts = Math.max(1, params.maxAttempts);
-  for (const attempt of Array.from({ length: attempts }, (_, index) => index + 1)) {
-    const delayMs = params.baseDelayMs * 2 ** (attempt - 1);
-    try {
-      return await params.run();
-    } catch (err) {
+  let retryError: unknown;
+  return await retryAsync(params.run, {
+    attempts: params.maxAttempts,
+    minDelayMs: params.baseDelayMs,
+    maxDelayMs: params.maxDelayMs,
+    retryAfterMaxDelayMs: params.maxDelayMs,
+    retryAfterMs: params.retryAfterMs,
+    jitter: 0.2,
+    random: params.random,
+    shouldRetry: (err) => {
       // Abort must win over retryable-looking failures: abort reasons often
       // carry "timed out" messages that match the retryable transport
       // patterns and would otherwise keep retrying for an absent caller.
       if (params.signal?.aborted) {
-        throw err;
+        return false;
       }
       const message = formatErrorMessage(err);
-      if (!params.isRetryable(message) || attempt >= params.maxAttempts) {
-        throw err;
+      if (!params.isRetryable(message)) {
+        return false;
       }
-      await params.waitForRetry(delayMs);
-    }
-  }
-  throw new Error("retry loop exhausted");
+      const retryAfterMs = params.retryAfterMs?.(err);
+      return retryAfterMs === undefined || retryAfterMs <= params.maxDelayMs;
+    },
+    onRetry: ({ err }) => {
+      retryError = err;
+      params.onRetry?.(err);
+    },
+    sleep: async (delayMs) => {
+      const error = retryError;
+      retryError = undefined;
+      await params.waitForRetry(delayMs, error);
+    },
+  });
 }
 
 export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {
@@ -149,9 +197,13 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
   run: (items: TInput[]) => Promise<TOutput[]>;
   isRetryable: (message: string) => boolean;
   isSplittable: (message: string) => boolean;
-  waitForRetry: (delayMs: number) => Promise<void>;
+  waitForRetry: (delayMs: number, error: unknown) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
+  maxDelayMs: number;
+  retryAfterMs?: (error: unknown) => number | undefined;
+  onRetry?: (error: unknown) => void;
+  random?: () => number;
   onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
 }): Promise<TOutput[]> {
   try {
@@ -161,6 +213,10 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
       waitForRetry: params.waitForRetry,
       maxAttempts: params.maxAttempts,
       baseDelayMs: params.baseDelayMs,
+      maxDelayMs: params.maxDelayMs,
+      retryAfterMs: params.retryAfterMs,
+      onRetry: params.onRetry,
+      random: params.random,
     });
   } catch (err) {
     const message = formatErrorMessage(err);

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -273,6 +273,66 @@ describe("provider error utils", () => {
     );
   });
 
+  it("attaches the longest trustworthy provider retry delay", async () => {
+    const response = new Response(
+      JSON.stringify({
+        error: {
+          code: 429,
+          status: "RESOURCE_EXHAUSTED",
+          message: "Quota exceeded",
+          details: [
+            {
+              "@type": "type.googleapis.com/google.rpc.RetryInfo",
+              retryDelay: "12.345678901s",
+            },
+          ],
+        },
+      }),
+      {
+        status: 429,
+        headers: { "retry-after": "10" },
+      },
+    );
+
+    const error = await createProviderHttpError(response, "Provider API error");
+
+    expect(error).toMatchObject({
+      name: "ProviderHttpError",
+      retryAfterMs: 12_346,
+    } satisfies Partial<ProviderHttpError>);
+  });
+
+  it("keeps Retry-After metadata when the provider body is empty", async () => {
+    const response = new Response(null, {
+      status: 503,
+      headers: { "retry-after": "7" },
+    });
+
+    const error = await createProviderHttpError(response, "Provider API error");
+
+    expect(error).toMatchObject({ retryAfterMs: 7_000 } satisfies Partial<ProviderHttpError>);
+  });
+
+  it("ignores malformed provider retry metadata", async () => {
+    const response = new Response(
+      JSON.stringify({
+        error: {
+          details: [
+            {
+              "@type": "type.googleapis.com/google.rpc.RetryInfo",
+              retryDelay: "-1s",
+            },
+          ],
+        },
+      }),
+      { status: 429, headers: { "retry-after": "tomorrow" } },
+    );
+
+    const error = await createProviderHttpError(response, "Provider API error");
+
+    expect(error).not.toHaveProperty("retryAfterMs");
+  });
+
   it("wraps malformed successful JSON responses with provider labels", async () => {
     const response = new Response("{ nope", {
       status: 200,

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -8,6 +8,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 export { asFiniteNumber } from "../../packages/normalization-core/src/number-coercion.js";
 import { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
 import { readResponseTextPrefix, readResponseWithLimit } from "../infra/http-body.js";
+import { parseRetryAfterHeaderSeconds } from "../infra/retry-after.js";
 import { redactSensitiveText } from "../logging/redact.js";
 export { asBoolean } from "../utils/boolean.js";
 export { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
@@ -128,30 +129,86 @@ type ProviderHttpErrorInfo = {
   type?: string;
   body?: string;
   requestId?: string;
+  retryAfterMs?: number;
 };
+
+const GOOGLE_RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
+const PROTOBUF_DURATION_RE = /^(\d+)(?:\.(\d{1,9}))?s$/;
+
+function parseProtobufDurationMs(value: unknown): number | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const match = PROTOBUF_DURATION_RE.exec(value.trim());
+  if (!match) {
+    return undefined;
+  }
+  const seconds = Number(match[1]);
+  const fraction = Number(`0.${match[2] ?? "0"}`);
+  const milliseconds = (seconds + fraction) * 1000;
+  return Number.isSafeInteger(Math.ceil(milliseconds)) ? Math.ceil(milliseconds) : undefined;
+}
+
+function extractPayloadRetryAfterMs(payload: unknown): number | undefined {
+  const root = asObject(payload);
+  const error = asObject(root?.error) ?? root;
+  if (!Array.isArray(error?.details)) {
+    return undefined;
+  }
+  for (const detailValue of error.details) {
+    const detail = asObject(detailValue);
+    if (detail?.["@type"] !== GOOGLE_RETRY_INFO_TYPE) {
+      continue;
+    }
+    const retryAfterMs = parseProtobufDurationMs(detail.retryDelay);
+    if (retryAfterMs !== undefined) {
+      return retryAfterMs;
+    }
+  }
+  return undefined;
+}
+
+function extractResponseRetryAfterMs(response: Response, payload?: unknown): number | undefined {
+  const headerSeconds = parseRetryAfterHeaderSeconds(response.headers.get("retry-after"));
+  const headerMs = headerSeconds === undefined ? undefined : Math.ceil(headerSeconds * 1000);
+  const payloadMs = extractPayloadRetryAfterMs(payload);
+  if (headerMs === undefined) {
+    return payloadMs;
+  }
+  return payloadMs === undefined ? headerMs : Math.max(headerMs, payloadMs);
+}
 
 /** Extracts normalized provider error metadata while keeping the raw body bounded and redacted. */
 async function extractProviderErrorInfo(response: Response): Promise<ProviderHttpErrorInfo> {
   const rawBody = trimToUndefined(await readResponseTextLimited(response).catch(() => ""));
   const requestId = extractProviderRequestId(response);
   if (!rawBody) {
-    return requestId ? { requestId } : {};
+    const retryAfterMs = extractResponseRetryAfterMs(response);
+    return {
+      ...(requestId ? { requestId } : {}),
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    };
   }
   const body = redactProviderErrorBody(rawBody);
   try {
-    const metadata = extractProviderErrorPayloadMetadata(JSON.parse(rawBody));
+    const payload: unknown = JSON.parse(rawBody);
+    const metadata = extractProviderErrorPayloadMetadata(payload);
+    const retryAfterMs = extractResponseRetryAfterMs(response, payload);
     return {
       ...(metadata.detail ? { detail: metadata.detail } : { detail: body }),
       ...(metadata.code ? { code: metadata.code } : {}),
       ...(metadata.type ? { type: metadata.type } : {}),
       body,
       ...(requestId ? { requestId } : {}),
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
     };
   } catch {
+    const retryAfterMs = extractResponseRetryAfterMs(response);
     return {
       detail: body,
       body,
       ...(requestId ? { requestId } : {}),
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
     };
   }
 }
@@ -178,6 +235,7 @@ export class ProviderHttpError extends Error {
   readonly errorType?: string;
   readonly errorBody?: string;
   readonly requestId?: string;
+  readonly retryAfterMs?: number;
 
   constructor(
     message: string,
@@ -187,6 +245,7 @@ export class ProviderHttpError extends Error {
       type?: string;
       body?: string;
       requestId?: string;
+      retryAfterMs?: number;
     },
   ) {
     super(message);
@@ -198,6 +257,9 @@ export class ProviderHttpError extends Error {
     this.errorType = params.type;
     this.errorBody = params.body;
     this.requestId = params.requestId;
+    if (params.retryAfterMs !== undefined) {
+      this.retryAfterMs = params.retryAfterMs;
+    }
   }
 }
 
@@ -238,6 +300,7 @@ export async function createProviderHttpError(
       type: info.type,
       body: info.body,
       requestId: info.requestId,
+      retryAfterMs: info.retryAfterMs,
     },
   );
 }


### PR DESCRIPTION
Closes #108893

## What Problem This Solves

Fixes an issue where users running `openclaw memory index` could exhaust all embedding retries within about two seconds when a provider imposed a minute-scale rate-limit window, leaving the semantic memory index unavailable.

## Why This Change Was Made

Memory indexing now consumes standard `Retry-After` and Google `google.rpc.RetryInfo` timing, uses a bounded abortable cooldown shared by concurrent batches, and gives index work enough backoff attempts to cross a transient quota window. Interactive queries retain their existing short retry budget; malformed hints are ignored and hints beyond the 60-second bound fail promptly. Risk note: the main risk is delaying non-recoverable quota failures, covered by the over-bound and malformed-hint tests.

## User Impact

Transient embedding throttling no longer causes memory indexing to fail after three rapid attempts. Concurrent batches also stop issuing new provider calls during an advertised cooldown instead of extending the throttle window.

## Evidence

Before: the v2026.7.1 log in #108893 shows four concurrent Google embedding requests retrying after roughly 501 ms and 1001 ms, then `openclaw memory index` failing with `RESOURCE_EXHAUSTED`. Current main retained that three-attempt, 500 ms policy.

Premise: Google documents 429 retry with exponential backoff, and `google.rpc.RetryInfo.retryDelay` as the minimum delay before retrying:
- https://ai.google.dev/gemini-api/docs/troubleshooting
- https://docs.cloud.google.com/storage/docs/reference/rpc/google.rpc
- https://protobuf.dev/programming-guides/json/

After: a committed production-path test starts a real localhost HTTP server, returns a Google 429 with `RetryInfo.retryDelay = 1s`, runs the real provider error parser and memory retry scheduler, and verifies the second HTTP request occurs at least 1000 ms later. The same suite verifies that newly started work is gated by an existing cooldown, concurrent waiters adopt longer hints, per-worker jitter remains independent without a hint, cancellation interrupts waits, and over-bound hints fail immediately.

```text
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-embedding-policy.test.ts src/agents/provider-http-errors.test.ts extensions/google/embedding-provider.test.ts
Test Files  3 passed (3)
Tests       47 passed (47)

$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts
Test Files  1 passed (1)
Tests       74 passed (74)

$ /home/wen/projects/openclaw/node_modules/.bin/tsx scripts/generate-plugin-sdk-api-baseline.ts --check
OK docs/.generated/plugin-sdk-api-baseline.sha256

$ git diff --check
# clean
```

A live quota-enabled Google credential was not available in this checkout, so I did not deliberately exhaust a real Google project. The localhost proof exercises the real HTTP, error-normalization, retry, cooldown, and timer path against Google's documented response shape; the issue log supplies the shipped before-state.

AI-assisted: implementation was AI-assisted; validation and the production-path proof were run locally.
