### PR TITLE
Fix: return INVALID_PARAMS for malformed file-transfer node command JSON

### DIFF
--- a/extensions/file-transfer/index.test.ts
+++ b/extensions/file-transfer/index.test.ts
@@ -90,4 +90,21 @@ describe("file-transfer plugin entry", () => {
     });
     expect(invokeNode).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["file.fetch", "{not valid json"],
+    ["dir.list", "not-json"],
+    ["dir.fetch", "{"],
+    ["file.write", "{invalid"],
+  ])("returns INVALID_PARAMS for malformed JSON in %s", async (command, paramsJSON) => {
+    const entry = pluginEntry.nodeHostCommands?.find((c) => c.command === command);
+    expect(entry).toBeDefined();
+    const result = await entry!.handle(paramsJSON);
+    const parsed = JSON.parse(result);
+    expect(parsed).toEqual({
+      ok: false,
+      code: "INVALID_PARAMS",
+      message: expect.stringContaining("node command params must be valid JSON"),
+    });
+  });
 });

--- a/extensions/file-transfer/index.ts
+++ b/extensions/file-transfer/index.ts
@@ -17,8 +17,40 @@ type FileTransferToolDescriptor = Pick<
   "label" | "name" | "description" | "parameters"
 >;
 
-function readNodeCommandParams(paramsJSON: string | null | undefined): unknown {
-  return paramsJSON ? JSON.parse(paramsJSON) : {};
+type NodeCommandParamsParseError = {
+  ok: false;
+  code: "INVALID_PARAMS";
+  message: string;
+};
+
+function readNodeCommandParams<T>(
+  paramsJSON: string | null | undefined,
+): T | NodeCommandParamsParseError {
+  if (!paramsJSON) {
+    return {} as T;
+  }
+  try {
+    return JSON.parse(paramsJSON) as T;
+  } catch (err) {
+    return {
+      ok: false,
+      code: "INVALID_PARAMS",
+      message: `node command params must be valid JSON: ${String(err)}`,
+    };
+  }
+}
+
+function isParseError(value: unknown): value is NodeCommandParamsParseError {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "ok" in value &&
+    (value as { ok?: unknown }).ok === false &&
+    "code" in value &&
+    (value as { code?: unknown }).code === "INVALID_PARAMS" &&
+    "message" in value &&
+    typeof (value as { message?: unknown }).message === "string"
+  );
 }
 
 function createLazyTool(
@@ -45,8 +77,11 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams<Parameters<typeof handleFileFetch>[0]>(paramsJSON);
+      if (isParseError(params)) {
+        return JSON.stringify(params);
+      }
       const { handleFileFetch } = await import("./src/node-host/file-fetch.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleFileFetch>[0];
       const result = await handleFileFetch(params);
       return JSON.stringify(result);
     },
@@ -56,8 +91,11 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams<Parameters<typeof handleDirList>[0]>(paramsJSON);
+      if (isParseError(params)) {
+        return JSON.stringify(params);
+      }
       const { handleDirList } = await import("./src/node-host/dir-list.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleDirList>[0];
       const result = await handleDirList(params);
       return JSON.stringify(result);
     },
@@ -67,8 +105,11 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams<Parameters<typeof handleDirFetch>[0]>(paramsJSON);
+      if (isParseError(params)) {
+        return JSON.stringify(params);
+      }
       const { handleDirFetch } = await import("./src/node-host/dir-fetch.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleDirFetch>[0];
       const result = await handleDirFetch(params);
       return JSON.stringify(result);
     },
@@ -78,8 +119,11 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams<Parameters<typeof handleFileWrite>[0]>(paramsJSON);
+      if (isParseError(params)) {
+        return JSON.stringify(params);
+      }
       const { handleFileWrite } = await import("./src/node-host/file-write.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleFileWrite>[0];
       const result = await handleFileWrite(params);
       return JSON.stringify(result);
     },


### PR DESCRIPTION
## What Problem This Solves

`extensions/file-transfer/index.ts` parsed node-host command parameters with a bare `JSON.parse(paramsJSON)` inside `readNodeCommandParams`. When a paired node received malformed JSON for commands like `file.fetch`, `dir.list`, `dir.fetch`, or `file.write`, the parse failure propagated as an unhandled `SyntaxError`. The node-host wrapper then converted it into a generic `INVALID_REQUEST` error with a nested `error` object, which the file-transfer invoke policy does not recognize as a plugin-level failure.

This was found through static code scanning; there is no associated Issue.

## Why This Change Was Made

- Keep parameter-validation errors inside the plugin’s own error contract (`{ ok: false, code, message }`).
- Avoid wasting a dynamic `import()` of the handler when the input is already known to be unusable.
- Align the new `INVALID_PARAMS` code with the existing usage in `extensions/file-transfer/src/shared/node-invoke-policy.ts`.

## User Impact

Malicious or accidentally malformed JSON parameter payloads for file-transfer node commands now produce a clear, structured `INVALID_PARAMS` response instead of an opaque `INVALID_REQUEST` wrapper error. No behavior changes for well-formed input.

## Evidence

**Reproduction**
1. Trigger any file-transfer node-host command with invalid JSON, e.g. `file.fetch` with paramsJSON = `{"not valid`.
2. Before this change: node-host returns `{ ok: false, error: { code: "INVALID_REQUEST", message: "SyntaxError: ..." } }`.
3. After this change: the command returns `{ ok: false, code: "INVALID_PARAMS", message: "node command params must be valid JSON: ..." }`.

**Tests**
- `corepack pnpm test:extension file-transfer` — 19 files / 188 tests passed.
- `corepack pnpm exec oxlint extensions/file-transfer/index.ts extensions/file-transfer/index.test.ts` — 0 warnings, 0 errors.
- `corepack pnpm exec oxfmt --check extensions/file-transfer/index.ts extensions/file-transfer/index.test.ts` — passed.

**Scope note**: This change is confined to the `extensions/file-transfer/` bundled plugin. No core framework, gateway, channel, or runtime modules are modified.
