### PR TITLE
refactor(test): complete plugin runtime activity mock

### DIFF
--- a/extensions/mattermost/src/channel.send-loopback.test.ts
+++ b/extensions/mattermost/src/channel.send-loopback.test.ts
@@ -1,7 +1,7 @@
 // Mattermost tests cover the action-to-REST send path over loopback.
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withServer } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mattermostPlugin } from "./channel.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { setMattermostRuntime } from "./runtime.js";
@@ -29,16 +29,7 @@ describe("Mattermost send action loopback", () => {
         });
       },
       async (baseUrl) => {
-        setMattermostRuntime(
-          createPluginRuntimeMock({
-            channel: {
-              activity: {
-                record: vi.fn(),
-                get: vi.fn(() => ({ inboundAt: null, outboundAt: null })),
-              },
-            },
-          }),
-        );
+        setMattermostRuntime(createPluginRuntimeMock());
         const cfg = {
           channels: {
             mattermost: {

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -785,7 +785,10 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           runtimeContexts.watch,
         ) as unknown as PluginRuntime["channel"]["runtimeContexts"]["watch"],
       },
-      activity: {} as PluginRuntime["channel"]["activity"],
+      activity: {
+        record: vi.fn(),
+        get: vi.fn(() => ({ inboundAt: null, outboundAt: null })),
+      },
     },
     events: {
       onAgentEvent: vi.fn(() => () => {}) as unknown as PluginRuntime["events"]["onAgentEvent"],


### PR DESCRIPTION
## What Problem This Solves

Resolves a test-infrastructure gap where plugin tests using the shared runtime mock could crash on a real outbound send because `channel.activity` was typed as complete but contained no `record` or `get` functions.

## Why This Change Was Made

The shared plugin runtime mock now provides default activity spies and the same empty activity snapshot as the runtime contract. The Mattermost loopback test can therefore use the canonical mock without a local contract patch. This is the bounded follow-up requested after #108281.

## User Impact

No production behavior changes. Plugin tests can exercise real outbound send paths with the shared runtime fixture, with six fewer lines of test plumbing overall.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts extensions/mattermost/src/channel.send-loopback.test.ts` — 2 shards, 2 files, 6 tests passed.
- `node scripts/check-changed.mjs -- src/plugin-sdk/test-helpers/plugin-runtime-mock.ts extensions/mattermost/src/channel.send-loopback.test.ts` — hosted Testbox passed all core and extension production/test typechecks, SDK surface/boundary checks, formatting, lint, import cycles, and guards: https://github.com/openclaw/openclaw/actions/runs/29499648144
- `git diff --check` passed.
- Maintainer autoreview passed with no actionable findings (0.98 confidence).
- Diff is LOC-negative: 6 insertions, 12 deletions.

AI-assisted: yes.
