### PR TITLE
fix(tailscale): bound whois identity cache growth

### DIFF
--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -138,6 +138,31 @@ describe("tailscale helpers", () => {
     expect(exec).toHaveBeenCalledTimes(2);
   });
 
+  it("bounds the whois cache while retaining active and newly inserted clients", async () => {
+    const exec = vi.fn(async (_command: string, args: string[]) => ({
+      stdout: JSON.stringify({ UserProfile: { LoginName: `${args.at(-1)}@example.com` } }),
+      stderr: "",
+    }));
+
+    await readTailscaleWhoisIdentity("fd7a:115c:a1e0::1", exec);
+    await readTailscaleWhoisIdentity("fd7a:115c:a1e0::2", exec);
+    for (let index = 3; index <= 2000; index += 1) {
+      await readTailscaleWhoisIdentity(`fd7a:115c:a1e0::${index}`, exec);
+    }
+
+    // Refresh the first client so the second client becomes the least recently used entry.
+    await readTailscaleWhoisIdentity("fd7a:115c:a1e0::1", exec);
+    await readTailscaleWhoisIdentity("fd7a:115c:a1e0::2001", exec);
+    expect(exec).toHaveBeenCalledTimes(2001);
+
+    await readTailscaleWhoisIdentity("fd7a:115c:a1e0::1", exec);
+    await readTailscaleWhoisIdentity("fd7a:115c:a1e0::2001", exec);
+    expect(exec).toHaveBeenCalledTimes(2001);
+
+    await readTailscaleWhoisIdentity("fd7a:115c:a1e0::2", exec);
+    expect(exec).toHaveBeenCalledTimes(2002);
+  });
+
   it("enableTailscaleServe attempts normal first, then sudo", async () => {
     const exec = vi
       .fn()

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -196,6 +196,7 @@ type TailscaleWhoisCacheEntry = {
   expiresAt: number;
 };
 
+const TAILSCALE_WHOIS_CACHE_MAX_SIZE = 2000;
 const whoisCache = new Map<string, TailscaleWhoisCacheEntry>();
 
 function extractExecErrorText(err: unknown) {
@@ -424,13 +425,33 @@ function readCachedWhois(ip: string, now: number): TailscaleWhoisIdentity | null
     whoisCache.delete(ip);
     return undefined;
   }
+  // Refresh insertion order so frequently active clients survive capacity eviction.
+  whoisCache.delete(ip);
+  whoisCache.set(ip, cached);
   return cached.value;
 }
 
 function writeCachedWhois(ip: string, value: TailscaleWhoisIdentity | null, ttlMs: number): void {
   const expiresAt = resolveExpiresAtMsFromDurationMs(ttlMs);
-  if (expiresAt !== undefined) {
-    whoisCache.set(ip, { value, expiresAt });
+  const now = asDateTimestampMs(Date.now());
+  if (expiresAt === undefined || now === undefined) {
+    return;
+  }
+  for (const [cachedIp, entry] of whoisCache) {
+    if (entry.expiresAt <= now) {
+      whoisCache.delete(cachedIp);
+    }
+  }
+  if (whoisCache.has(ip)) {
+    whoisCache.delete(ip);
+  }
+  whoisCache.set(ip, { value, expiresAt });
+  while (whoisCache.size > TAILSCALE_WHOIS_CACHE_MAX_SIZE) {
+    const oldestIp = whoisCache.keys().next().value;
+    if (typeof oldestIp !== "string") {
+      break;
+    }
+    whoisCache.delete(oldestIp);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateways using Tailscale identity verification could retain an unbounded number of cached client IPs when requests continuously arrived from new addresses. The per-entry TTL did not reclaim cold keys unless those exact keys were accessed again.

## Why This Change Was Made

The existing owner-local whois cache now follows the repository's bounded TTL-cache pattern: it prunes expired entries, refreshes recency on hits, and evicts the least recently used entry above 2,000 keys. Successful and failed lookup TTLs, lookup results, and the `tailscale whois` execution contract remain unchanged, limiting the Gateway auth risk to cache retention behavior.

## User Impact

Operators using Tailscale-backed Gateway authentication no longer risk unbounded process-memory growth from a long stream of distinct forwarded client IPs. Frequently active and newly seen clients remain cached as before.

## Evidence

AI-assisted.

### Real behavior proof

Environment: local Linux machine, Node `v24.18.0`, exact base `b8b064a9483ee0917648207ffe91438a2da8c828`. The harness imported and drove the production `readTailscaleWhoisIdentity` function with 2,001 unique Tailscale client keys. Its injected exec boundary returned real JSON-shaped `tailscale whois` output while counting observable lookup calls; no cache internals were exposed or copied.

Command (run once against an isolated `upstream/main` worktree and once against this branch):

```text
node --import tsx /tmp/openclaw-tailscale-cache-proof.mjs <worktree>/src/infra/tailscale.ts
```

Before (`upstream/main`):

```json
{"afterFill":2001,"afterOldestRevisit":2001,"afterNewestRevisit":2001,"repeatedKeyExecDelta":0}
```

Premise: after 2,001 unique successful lookups, revisiting the oldest key did not execute whois again (`2001` remained `2001`). This demonstrates that the old TTL-only map retained every still-valid cold key beyond the intended capacity.

After (this branch):

```json
{"afterFill":2001,"afterOldestRevisit":2002,"afterNewestRevisit":2002,"repeatedKeyExecDelta":0}
```

The oldest key was evicted and required one new lookup (`2001` to `2002`), while the newest key remained cached. The same harness's negative control queried one unchanged key twice; `repeatedKeyExecDelta: 0` on both revisions proves ordinary cache hits still avoid duplicate whois execution.

Focused validation:

```text
node scripts/run-vitest.mjs src/infra/tailscale.test.ts
Test Files  1 passed (1)
Tests       28 passed (28)

./node_modules/.bin/oxfmt --write src/infra/tailscale.ts src/infra/tailscale.test.ts
Finished in 19ms on 1 files using 7 threads.

git diff --check
# no output

.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.97)
```

Not tested: a live tailnet/Gateway request with external Tailscale credentials. The production cache caller and lookup boundary were exercised directly; this change does not alter CLI invocation, identity parsing, or Gateway request acceptance.
