### PR TITLE
fix: tag Chat Completions tool-call preambles as commentary

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -1553,8 +1553,45 @@ describe("openai-completions stop-reason tool-call guard", () => {
     });
     const result = await stream.result();
 
-    expect(result.content[0]).toEqual({ type: "text", text: "Use <" });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "Use <",
+      textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+    });
     expect(result.content[1]).toMatchObject({ type: "toolCall", id: "call_1", name: "bash" });
+  });
+
+  it("tags text before a tool-call completion as commentary", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("I'll inspect the workspace first."),
+      makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),
+      makeFinishChunk("tool_calls"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "I'll inspect the workspace first.",
+      textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+    });
+    expect(result.content[1]).toMatchObject({ type: "toolCall", id: "call_1", name: "bash" });
+  });
+
+  it("does not tag final-answer text when the turn ends without tool use", async () => {
+    mockChunksRef.chunks = [makeTextChunk("Here is the answer."), makeFinishChunk("stop")];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.content[0]).toEqual({ type: "text", text: "Here is the answer." });
   });
 
   it("strips toolCall blocks when finish_reason is length but tool_calls were accumulated", async () => {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -520,6 +520,11 @@ export const streamOpenAICompletions: StreamFunction<
 
       flushPartitionedContent();
 
+      // Chat Completions only exposes the tool boundary at completion (no per-item
+      // phase). Tag non-empty pre-tool text as commentary before text_end so the
+      // delivery gate matches the Responses transport contract.
+      tagCompletionsToolUseCommentary(output);
+
       for (const block of blocks) {
         finishBlock(block);
       }
@@ -550,6 +555,9 @@ export const streamOpenAICompletions: StreamFunction<
       if (hasToolCalls && output.stopReason !== "toolUse") {
         output.content = output.content.filter((block) => block.type !== "toolCall");
       }
+      // Re-apply after stopReason promotion so late toolUse classifications still
+      // carry phase metadata on the final assistant message.
+      tagCompletionsToolUseCommentary(output);
 
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();
@@ -1296,6 +1304,36 @@ function convertTools(
       },
     })),
   };
+}
+
+/**
+ * Completions has no per-item phase. When the completed turn is toolUse, mark
+ * any untagged non-empty text as commentary so channels withhold pre-tool
+ * narration the same way the Responses transport does.
+ */
+function tagCompletionsToolUseCommentary(output: AssistantMessage): void {
+  if (output.stopReason !== "toolUse") {
+    return;
+  }
+  const signatureId =
+    output.responseId ??
+    output.content.find((block) => block.type === "toolCall")?.id ??
+    "chat-completion";
+  const textSignature = JSON.stringify({
+    v: 1,
+    id: signatureId,
+    phase: "commentary",
+  });
+  for (const block of output.content) {
+    if (block.type !== "text" || block.text.trim().length === 0) {
+      continue;
+    }
+    // Preserve any existing transport-authored phase signature.
+    if (block.textSignature !== undefined) {
+      continue;
+    }
+    block.textSignature = textSignature;
+  }
 }
 
 function parseChunkUsage(

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -852,6 +852,12 @@ export function handleMessageUpdate(
   // unphased deltas out of durable block replies until that phase is known.
   const isPhasePendingAnthropicText =
     evtType !== "text_end" && !deliveryPhase && isAnthropicAssistantMessage(partialAssistant);
+  // Chat Completions reports tool use only after its preamble has streamed.
+  // Buffer unphased deltas until the transport can classify text_end safely.
+  const isPhasePendingOpenAiCompletionsText =
+    evtType !== "text_end" &&
+    !deliveryPhase &&
+    isOpenAiCompletionsAssistantMessage(partialAssistant);
   const hasResponsesContentIndex =
     streamContentIndex !== undefined && isResponsesApiAssistantMessage(partialAssistant);
   let streamItemChanged = false;
@@ -928,7 +934,12 @@ export function handleMessageUpdate(
 
   if (chunk) {
     ctx.state.deltaBuffer += chunk;
-    if (!skipLiveStream && !shouldUsePhaseAwareBlockReply && !isPhasePendingAnthropicText) {
+    if (
+      !skipLiveStream &&
+      !shouldUsePhaseAwareBlockReply &&
+      !isPhasePendingAnthropicText &&
+      !isPhasePendingOpenAiCompletionsText
+    ) {
       appendBlockReplyChunk(ctx, chunk);
     }
   }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -1089,6 +1089,18 @@ export function handleMessageUpdate(
       // An unphased equal/shrinking Responses item can end without a delta.
       // Rebuild its block buffer from the scoped snapshot after the boundary reset.
       appendBlockReplyChunk(ctx, cleanedText);
+    } else if (
+      // Completions deltas were buffered until text_end classification. When
+      // text_end stays unphased (normal final answer), release the accumulated
+      // visible text so onBlockReply fires at the text_end boundary instead of
+      // relying only on the later message_end safety path.
+      evtType === "text_end" &&
+      !deliveryPhase &&
+      isOpenAiCompletionsAssistantMessage(partialAssistant) &&
+      !ctx.state.lastBlockReplyText &&
+      cleanedText
+    ) {
+      replaceBlockReplyBuffer(ctx, cleanedText);
     }
 
     ctx.state.lastStreamedAssistant = nextRawStreamText;

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-anthropic-pretool-narration.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-anthropic-pretool-narration.test.ts
@@ -151,4 +151,35 @@ describe("subscribeEmbeddedAgentSession — Anthropic pre-tool narration", () =>
     });
     expect(postedBlockReplyText(onBlockReply)).toContain("Here is the full answer.");
   });
+
+  it("still delivers a non-tool OpenAI Completions final answer on text_end", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-answer",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    // Unphased Completions deltas are buffered until text_end; a normal final
+    // answer (no tool-use phase) must still reach onBlockReply at text_end.
+    const answer = "Here is the Completions final answer.";
+    emit({ type: "message_start", message: openAiCompletionsAssistant("") });
+    emit({
+      type: "message_update",
+      message: openAiCompletionsAssistant(answer),
+      assistantMessageEvent: { type: "text_delta", delta: answer },
+    });
+    emit({
+      type: "message_update",
+      message: openAiCompletionsAssistant(answer),
+      assistantMessageEvent: { type: "text_end", contentIndex: 0 },
+    });
+
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalled();
+    });
+    expect(postedBlockReplyText(onBlockReply)).toContain("Here is the Completions final answer.");
+  });
 });

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-anthropic-pretool-narration.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-anthropic-pretool-narration.test.ts
@@ -16,6 +16,17 @@ function anthropicAssistant(text: string, extra?: AssistantMessage["content"]): 
   } as unknown as AssistantMessage;
 }
 
+function openAiCompletionsAssistant(
+  text: string,
+  extra?: AssistantMessage["content"],
+): AssistantMessage {
+  return {
+    role: "assistant",
+    api: "openai-completions",
+    content: [{ type: "text", text }, ...(extra ?? [])],
+  } as unknown as AssistantMessage;
+}
+
 function postedBlockReplyText(onBlockReply: ReturnType<typeof vi.fn>): string {
   return onBlockReply.mock.calls.map((call) => call[0]?.text ?? "").join(" ");
 }
@@ -66,6 +77,49 @@ describe("subscribeEmbeddedAgentSession — Anthropic pre-tool narration", () =>
     });
 
     expect(postedBlockReplyText(onBlockReply)).not.toContain("Let me check the files");
+  });
+
+  it("withholds OpenAI Completions pre-tool narration until its phase is known", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-withhold",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+      blockReplyChunking: { minChars: 4, maxChars: 200 },
+    });
+
+    const narration = "I'll inspect the workspace before I answer. ";
+    const commentary = openAiCompletionsAssistant(narration, [
+      { type: "toolCall", id: "tool-1", name: "bash", arguments: {} },
+    ]);
+    (commentary.content[0] as { textSignature?: string }).textSignature = JSON.stringify({
+      v: 1,
+      id: "chatcmpl-test",
+      phase: "commentary",
+    });
+
+    emit({ type: "message_start", message: openAiCompletionsAssistant("") });
+    emit({
+      type: "message_update",
+      message: openAiCompletionsAssistant(narration),
+      assistantMessageEvent: { type: "text_delta", delta: narration },
+    });
+    emit({
+      type: "tool_execution_start",
+      toolName: "bash",
+      toolCallId: "tool-1",
+      args: { command: "ls" },
+    });
+    emit({
+      type: "message_update",
+      message: commentary,
+      assistantMessageEvent: { type: "text_end", contentIndex: 0, partial: commentary },
+    });
+    emit({ type: "message_end", message: commentary });
+
+    expect(postedBlockReplyText(onBlockReply)).not.toContain("I'll inspect the workspace");
   });
 
   it("still delivers a non-tool Anthropic answer in full on a text_end channel", async () => {

--- a/src/agents/openai-completions-transport.ts
+++ b/src/agents/openai-completions-transport.ts
@@ -805,6 +805,29 @@ async function processOpenAICompletionsStream(
   if (hasToolCalls && output.stopReason !== "toolUse") {
     output.content = output.content.filter((block) => block.type !== "toolCall");
   }
+  // Chat Completions only exposes the tool boundary at completion. Tag
+  // untagged pre-tool text as commentary so delivery matches Responses.
+  if (output.stopReason === "toolUse") {
+    const signatureId =
+      output.responseId ??
+      output.content.find((block) => block.type === "toolCall")?.id ??
+      "chat-completion";
+    const textSignature = JSON.stringify({
+      v: 1,
+      id: signatureId,
+      phase: "commentary",
+    });
+    for (const block of output.content) {
+      if (
+        block.type === "text" &&
+        typeof block.text === "string" &&
+        block.text.trim().length > 0 &&
+        !block.textSignature
+      ) {
+        block.textSignature = textSignature;
+      }
+    }
+  }
 }
 
 type CompletionsReasoningDelta =

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test-utils.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test-utils.ts
@@ -94,7 +94,11 @@ describe("openai transport stream", () => {
     );
 
     expect(output.content).toEqual([
-      { type: "text", text: "before  after" },
+      {
+        type: "text",
+        text: "before  after",
+        textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+      },
       {
         type: "toolCall",
         id: "call_native_1",
@@ -133,7 +137,11 @@ describe("openai transport stream", () => {
     );
 
     expect(output.content).toEqual([
-      { type: "text", text: "I'll check" },
+      {
+        type: "text",
+        text: "I'll check",
+        textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+      },
       {
         type: "toolCall",
         id: "call_native_1",
@@ -181,7 +189,11 @@ describe("openai transport stream", () => {
         arguments: { path: "/tmp/native.md" },
         partialArgs: '{"path":"/tmp/native.md"}',
       },
-      { type: "text", text: " visible" },
+      {
+        type: "text",
+        text: " visible",
+        textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+      },
     ]);
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
@@ -217,7 +229,11 @@ describe("openai transport stream", () => {
     );
 
     expect(output.content).toEqual([
-      { type: "text", text: "before " },
+      {
+        type: "text",
+        text: "before ",
+        textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+      },
       {
         type: "toolCall",
         id: "call_native_1",
@@ -225,7 +241,11 @@ describe("openai transport stream", () => {
         arguments: { path: "/tmp/native.md" },
         partialArgs: '{"path":"/tmp/native.md"}',
       },
-      { type: "text", text: " after" },
+      {
+        type: "text",
+        text: " after",
+        textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+      },
     ]);
     expect(JSON.stringify(events)).not.toContain("DSML");
   });

--- a/src/agents/openai-transport-stream.usage-and-calls.test-utils.ts
+++ b/src/agents/openai-transport-stream.usage-and-calls.test-utils.ts
@@ -1501,7 +1501,11 @@ describe("openai transport stream", () => {
       { push() {} },
     );
 
-    expect(output.content[0]).toEqual({ type: "text", text: "Use <" });
+    expect(output.content[0]).toEqual({
+      type: "text",
+      text: "Use <",
+      textSignature: JSON.stringify({ v: 1, id: "chatcmpl-test", phase: "commentary" }),
+    });
     expectRecordFields(output.content[1], {
       type: "toolCall",
       id: "call_0",


### PR DESCRIPTION
## What Problem This Solves

Chat Completions transport turns (`api: "openai-completions"`, e.g. Grok/DeepSeek) never tagged mid-turn assistant narration with a commentary `textSignature`. The delivery gate only suppresses pre-tool preamble when that phase is present, so tool-call preambles were posted into customer chats/groups. OpenAI Responses / Codex paths already tag phases correctly.

Fixes #108945

## Why This Change Was Made

Completions has no per-item phase metadata. When a completed turn is `toolUse`, the transport must assign a stable commentary signature to any untagged non-empty text blocks (preserving existing signatures). Delivery also withholds unphased Completions deltas until classification is known, matching the existing Anthropic pre-tool narration gate. At `text_end`, unphased ordinary final answers release the buffered visible text into the durable block-reply path so delivery still happens at the configured `text_end` boundary.

## User Impact

Tool-calling turns from OpenAI-compatible Completions providers no longer deliver mid-turn narration as a user-facing reply. Ordinary final answers without tool use still deliver normally after `text_end`.

## Evidence

### Summary

- Tag pre-tool Completions text as commentary in both package AI stream and agent Completions transport.
- Buffer unphased Completions text deltas in the embedded agent subscriber (same pattern as Anthropic).
- At unphased Completions `text_end`, release accumulated visible text into the durable block-reply buffer so final answers are not deferred only to `message_end`.
- Focused regression tests for transport tagging, pre-tool withhold, and final-answer `text_end` delivery.

### Verification

Verification host: local macOS (Crabbox bypass)

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-anthropic-pretool-narration.test.ts
# 4 passed (withhold + Completions final-answer text_end delivery)

node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "filters DeepSeek DSML content without disturbing|preserves DeepSeek visible content before same-chunk|filters DeepSeek DSML text queued after|keeps DeepSeek DSML state across|keeps buffered visible text before following"
# 10 passed (sibling tool-use commentary signature expectations)

node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.test.ts -t "stop-reason tool-call guard|tags text before a tool-call|keeps buffered|does not tag final"
# 22 passed
```

### Real behavior proof

- **Behavior addressed:** Completions tool-call preambles are classified as commentary and withheld from durable channel block replies; ordinary unphased final answers still deliver via `onBlockReply` at `text_end`.
- **Environment:** local macOS openclaw checkout at commit under test; focused Vitest harnesses exercising the subscriber and Completions transport (no live provider credentials in this run).
- **Current-main contrast:** On main, a Completions stream with text + `finish_reason: tool_calls` yields an unphased text block (`textSignature` absent). The delivery handler therefore treats mid-turn narration as visible reply text. Responses transport already encodes `phase: "commentary"`. Separately, buffering unphased Completions deltas without a `text_end` release left ordinary final answers empty at the `text_end` flush and dependent on `message_end` safety.
- **Exact steps or command run after this patch:**
  1. `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-anthropic-pretool-narration.test.ts`
  2. `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "filters DeepSeek DSML content without disturbing|preserves DeepSeek visible content before same-chunk|filters DeepSeek DSML text queued after|keeps DeepSeek DSML state across|keeps buffered visible text before following"`
  3. `node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.test.ts -t "stop-reason tool-call guard|tags text before a tool-call|keeps buffered|does not tag final"`
- **Evidence after fix:** Completions result text before tool calls carries `textSignature: {"v":1,"id":"chatcmpl-test","phase":"commentary"}`. Subscriber harness shows Completions pre-tool narration is not posted via `onBlockReply` on a `text_end` channel. A non-tool Completions final answer posts through `onBlockReply` after `text_end` without waiting for `message_end`.
- **Control check:** Final-answer Completions turns (finish_reason stop, no tools) remain untagged and deliverable at `text_end`; Anthropic withhold regression still passes; DeepSeek DSML + native tool-call streams keep expected content with commentary signatures on tool-use turns.
- **Observed result after fix:** Tool-call preamble no longer surfaces as a durable block reply for Completions; ordinary final answers still deliver at the configured `text_end` boundary; phase contract aligns with Responses.
- **What was not tested:** Live Grok/DeepSeek multi-channel production turns; other non-Completions transports. A redacted live channel transcript would further strengthen acceptance beyond the harness path.

### Fix quality

- **compatibility:** Additive phase metadata only on toolUse Completions turns; no config/API/schema changes; preserves existing signatures; restores `text_end` delivery for unphased final answers.
- **performance:** O(blocks) once per completed turn; subscriber gate is a single boolean check (same cost class as Anthropic).
- **usability:** Removes user-visible mid-tool narration leaks on Completions providers without new settings, while keeping ordinary final answers on the normal delivery path.
- **security:** No auth/trust-boundary change; does not suppress final answers or tool execution.

This PR was authored with AI assistance (Grok).