### PR TITLE
fix(msteams): bound remote media saves with header and idle timeouts

### DIFF
--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -14,6 +14,7 @@ type SavedCall = {
   direction: string;
   maxBytes: number;
   originalFilename?: string;
+  readIdleTimeoutMs?: number;
 };
 
 type MockRuntime = {
@@ -77,6 +78,7 @@ function installRuntime(): MockRuntime {
             subdir?: string;
             maxBytes?: number;
             originalFilename?: string;
+            readIdleTimeoutMs?: number;
           },
         ) => {
           const buffer = Buffer.from(await response.arrayBuffer());
@@ -86,6 +88,7 @@ function installRuntime(): MockRuntime {
             direction: options.subdir ?? "inbound",
             maxBytes: options.maxBytes ?? 0,
             originalFilename: options.originalFilename,
+            readIdleTimeoutMs: options.readIdleTimeoutMs,
           });
           return { path: state.savePath, contentType: state.savedContentType };
         },
@@ -197,9 +200,12 @@ describe("downloadMSTeamsBotFrameworkAttachment", () => {
     expect(media?.path).toBe(runtime.savePath);
     expect(media?.contentType).toBe(runtime.savedContentType);
     expect(runtime.saveCalls).toHaveLength(1);
-    expect(expectDefined(runtime.saveCalls[0], "MSTeams save call").buffer.toString("utf-8")).toBe(
-      "PDFBYTES",
-    );
+    const saveCall = expectDefined(runtime.saveCalls[0], "MSTeams save call");
+    expect(saveCall.buffer.toString("utf-8")).toBe("PDFBYTES");
+    // Regression guard: the attachmentView save call must forward the same
+    // idle-read bound as the sibling Graph/remote-media save callers, or a
+    // stalled Bot Framework attachment body can hang this path indefinitely.
+    expect(saveCall.readIdleTimeoutMs).toBe(30_000);
   });
 
   it("skips malformed attachment view content-length before saving media", async () => {

--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -15,6 +15,7 @@ import {
   type MSTeamsAttachmentDownloadLogger,
   type MSTeamsAttachmentFetchPolicy,
   type MSTeamsAttachmentResolveFn,
+  MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveAttachmentFetchPolicy,
   safeFetchWithPolicy,
 } from "./shared.js";
@@ -201,6 +202,7 @@ async function saveBotFrameworkAttachmentView(params: {
       fallbackContentType: params.contentTypeHint,
       subdir: "inbound",
       originalFilename: params.preserveFilenames ? params.fileNameHint : undefined,
+      readIdleTimeoutMs: MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS,
     });
   } catch (err) {
     params.logger?.warn?.("msteams botFramework attachmentView save failed", {

--- a/extensions/msteams/src/attachments/graph.test.ts
+++ b/extensions/msteams/src/attachments/graph.test.ts
@@ -25,6 +25,24 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: vi.fn(),
 }));
 
+const saveResponseMediaMock = vi.hoisted(() =>
+  vi.fn(
+    async (
+      response: Response,
+      options?: { fallbackContentType?: string; maxBytes?: number; readIdleTimeoutMs?: number },
+    ) => {
+      const length = Number(response.headers.get("content-length"));
+      if (Number.isFinite(length) && options?.maxBytes !== undefined && length > options.maxBytes) {
+        throw new Error("content length exceeds maxBytes");
+      }
+      return {
+        path: "/tmp/saved.png",
+        contentType: options?.fallbackContentType ?? "image/png",
+      };
+    },
+  ),
+);
+
 vi.mock("../runtime.js", () => ({
   getMSTeamsRuntime: vi.fn(() => ({
     media: {
@@ -32,25 +50,7 @@ vi.mock("../runtime.js", () => ({
     },
     channel: {
       media: {
-        saveResponseMedia: vi.fn(
-          async (
-            response: Response,
-            options?: { fallbackContentType?: string; maxBytes?: number },
-          ) => {
-            const length = Number(response.headers.get("content-length"));
-            if (
-              Number.isFinite(length) &&
-              options?.maxBytes !== undefined &&
-              length > options.maxBytes
-            ) {
-              throw new Error("content length exceeds maxBytes");
-            }
-            return {
-              path: "/tmp/saved.png",
-              contentType: options?.fallbackContentType ?? "image/png",
-            };
-          },
-        ),
+        saveResponseMedia: saveResponseMediaMock,
         saveMediaBuffer: vi.fn(async (_buf: Buffer, ct: string) => ({
           path: "/tmp/saved.png",
           contentType: ct ?? "image/png",
@@ -170,6 +170,14 @@ describe("downloadMSTeamsGraphMedia hosted content $value fallback", () => {
     );
     expect(result.media.length).toBeGreaterThan(0);
     expect(result.hostedCount).toBe(1);
+    // Regression guard: the hostedContents $value save must forward the same
+    // idle-read bound as the sibling Bot Framework/remote-media save
+    // callers, or a stalled Graph hosted-content body can hang this path
+    // indefinitely.
+    expect(saveResponseMediaMock).toHaveBeenCalledWith(
+      expect.any(Response),
+      expect.objectContaining({ readIdleTimeoutMs: 30_000 }),
+    );
   });
 
   it("skips hosted content when the list item has no id", async () => {

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -27,6 +27,7 @@ import {
   type MSTeamsAttachmentDownloadLogger,
   type MSTeamsAttachmentFetchPolicy,
   type MSTeamsAttachmentResolveFn,
+  MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS,
   normalizeContentType,
   resolveMediaSsrfPolicy,
   resolveAttachmentFetchPolicy,
@@ -208,6 +209,7 @@ async function downloadGraphHostedContent(params: {
           maxBytes: params.maxBytes,
           fallbackContentType: item.contentType ?? undefined,
           subdir: "inbound",
+          readIdleTimeoutMs: MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS,
         });
         out.push({
           path: saved.path,

--- a/extensions/msteams/src/attachments/remote-media.test.ts
+++ b/extensions/msteams/src/attachments/remote-media.test.ts
@@ -107,6 +107,13 @@ describe("downloadAndStoreMSTeamsRemoteMedia", () => {
       const calledUrl = requireFirstFetchUrl(fetchImpl);
       expect(calledUrl).toBe("https://graph.microsoft.com/v1.0/shares/abc/driveItem/content");
       expect(runtimeSaveRemoteMediaMock).not.toHaveBeenCalled();
+      expect(saveResponseMediaMock).toHaveBeenCalledWith(
+        expect.any(Response),
+        expect.objectContaining({
+          readIdleTimeoutMs: 30_000,
+          maxBytes: 1024,
+        }),
+      );
       expect(result.path).toBe("/tmp/saved.png");
     });
 
@@ -182,6 +189,13 @@ describe("downloadAndStoreMSTeamsRemoteMedia", () => {
       });
 
       expect(runtimeSaveRemoteMediaMock).toHaveBeenCalledTimes(1);
+      expect(runtimeSaveRemoteMediaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseHeaderTimeoutMs: 120_000,
+          readIdleTimeoutMs: 30_000,
+          maxBytes: 1024,
+        }),
+      );
     });
 
     it("does not use the direct path when useDirectFetch is true but fetchImpl is missing", async () => {

--- a/extensions/msteams/src/attachments/remote-media.ts
+++ b/extensions/msteams/src/attachments/remote-media.ts
@@ -2,7 +2,11 @@
 import { saveResponseMedia, type SavedRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import type { SsrFPolicy } from "../../runtime-api.js";
 import { getMSTeamsRuntime } from "../runtime.js";
-import { inferPlaceholder } from "./shared.js";
+import {
+  inferPlaceholder,
+  MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS,
+  MSTEAMS_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+} from "./shared.js";
 import type { MSTeamsInboundMedia } from "./types.js";
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -26,6 +30,7 @@ async function saveRemoteMediaDirect(params: {
       sourceUrl: params.url,
       filePathHint: params.filePathHint,
       maxBytes: params.maxBytes,
+      readIdleTimeoutMs: MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS,
       fallbackContentType: params.contentTypeHint,
       originalFilename: params.originalFilename,
     });
@@ -69,6 +74,8 @@ export async function downloadAndStoreMSTeamsRemoteMedia(params: {
       filePathHint: params.filePathHint,
       maxBytes: params.maxBytes,
       ssrfPolicy: params.ssrfPolicy,
+      responseHeaderTimeoutMs: MSTEAMS_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+      readIdleTimeoutMs: MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS,
       fallbackContentType: params.contentTypeHint,
       originalFilename,
     });

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -18,6 +18,14 @@ import { MSTEAMS_REQUEST_TIMEOUT_MS } from "../request-timeout.js";
 import { responseWithRelease } from "../response-with-release.js";
 import type { MSTeamsAttachmentLike } from "./types.js";
 
+// Align with Mattermost/Zalo/Tlon media downloads: header wait and body idle
+// are separate failure modes. Every production caller that hands a response
+// to `saveResponseMedia`/`saveRemoteMedia` must forward this idle bound, or a
+// stalled chunk on that specific caller can hang the inbound media save
+// forever even though the sibling callers are already bounded.
+export const MSTEAMS_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
+export const MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS = 30_000;
+
 type InlineImageCandidate =
   | {
       kind: "data";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Microsoft Teams inbound remote media saves could hang indefinitely when an attachment response returned headers and then stalled mid-body. `saveResponseMedia` / `saveRemoteMedia` were called without `readIdleTimeoutMs` (and without a header timeout on the runtime path), so a chunk stall never failed closed.

## Why This Change Was Made

Pass the same media timeout policy already used by Mattermost/Zalo/Tlon: `responseHeaderTimeoutMs: 120_000` and `readIdleTimeoutMs: 30_000` through every production caller that hands a response to `saveResponseMedia`/`saveRemoteMedia`, not just the direct-fetch path.

`MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS` / `MSTEAMS_MEDIA_RESPONSE_HEADER_TIMEOUT_MS` live in `shared.ts` so the SharePoint direct path, Bot Framework attachment view save, and Graph hosted-content `$value` save all reference one constant instead of drifting.

## User Impact

**Before:** A stalled Teams attachment download body could hang inbound media persistence forever — on the direct SharePoint path, the Bot Framework personal-chat attachment path, or the Graph hosted-content path.

**After:** All three attachment body reads fail closed after 30s of idle (and header waits after 120s on the guarded path), so the inbound turn can surface a media failure instead of hanging. Slow-but-progressing transfers still complete (idle resets on each chunk).

## Evidence

- Changed: `extensions/msteams/src/attachments/shared.ts`, `remote-media.ts`, `bot-framework.ts`, `graph.ts`, plus `*.test.ts` regressions asserting `readIdleTimeoutMs: 30_000` is forwarded
- Production caller paths:
  - `downloadAndStoreMSTeamsRemoteMedia` → `saveRemoteMediaDirect` → `saveResponseMedia({ readIdleTimeoutMs: 30_000 })`, and the non-direct path → `saveRemoteMedia({ responseHeaderTimeoutMs: 120_000, readIdleTimeoutMs: 30_000 })`
  - `saveBotFrameworkAttachmentView` → `saveResponseMedia({ readIdleTimeoutMs: 30_000 })`
  - Graph hosted-content `$value` → `saveResponseMedia({ readIdleTimeoutMs: 30_000 })`
- CI cleanup: removed unused committed `scripts/proof-msteams-media-idle-timeout.mts` and local-only `.pr-bodies/` from the merge commit (oxlint/knip noise). Proof stays ephemeral under `/tmp`.
- Rebased onto latest `upstream/main` and squashed to one commit (`700269d7ffb`).

## Real behavior proof

### Behavior or issue addressed

Stalled Teams remote-media bodies fail closed on the channel's production 30s idle budget when driven through `downloadAndStoreMSTeamsRemoteMedia` (not by calling `saveResponseMedia` alone). Completing and slow-but-progressing transfers still save.

### Canonical reachability path

`downloadAndStoreMSTeamsRemoteMedia({ useDirectFetch: true, fetchImpl })` → `saveRemoteMediaDirect` → `saveResponseMedia({ readIdleTimeoutMs: MSTEAMS_MEDIA_READ_IDLE_TIMEOUT_MS })`

Sibling Bot Framework / Graph callers share the same idle constant and are covered by focused vitest forwarding regressions.

### Shared helper / provider constraint check

Uses existing `saveResponseMedia` idle-read contract from `openclaw/plugin-sdk/media-runtime`. No new downloader or config key.

### Real environment tested

Live `node:http` server on `127.0.0.1` (headers + one PNG chunk then stall; completing `/small`; slow `/trickle` with per-chunk gaps under idle but total wall time above idle). Production Teams entry `downloadAndStoreMSTeamsRemoteMedia` with `useDirectFetch: true` against those sockets. Temp `OPENCLAW_STATE_DIR` media store. Node v22.23.1, head `700269d7ffb137835775a13323c3031e188050d7`.

### Exact steps or command run after this patch

```bash
# Ephemeral driver (not committed):
node --import tsx /tmp/proof-msteams-media-idle-timeout.mts
```

### Evidence after fix

```text
entry=downloadAndStoreMSTeamsRemoteMedia useDirectFetch=true idleMs=30000
OPENCLAW_STATE_DIR=/var/folders/tt/w4j113gx3v96vdh1h7x7zcxc0000gn/T/oc-msteams-media-proof-04oNNt
node=v22.23.1
  ok: stalled downloadAndStoreMSTeamsRemoteMedia rejected — elapsed=30095ms
  ok: failed within idle budget + slack — elapsed=30095ms idle=30000ms
  ok: idle-timeout failure surfaced — Failed to fetch media from http://127.0.0.1:51061/stall: Media download stalled: no data received for 30000ms
  ok: unbounded attachment read still hanging after 2000ms — state=still-hanging
  ok: completing downloadAndStoreMSTeamsRemoteMedia saved — {"path":"/var/folders/tt/w4j113gx3v96vdh1h7x7zcxc0000gn/T/oc-msteams-media-proof-04oNNt/media/inbound/6af80e09-ae20-4b27-8981-10b0728359c1.png","contentType":"image/png"}
  ok: slow-but-progressing Teams entry still saved (total > idle) — elapsed=48031ms idleBudget=30000ms

ALL PROOF ASSERTIONS PASSED
```

### Observed result after fix

Against a real stalled `image/png` socket, the production Teams entry `downloadAndStoreMSTeamsRemoteMedia` fails closed in ~30095ms with `Media download stalled: no data received for 30000ms`. Unbounded `arrayBuffer()` on the same socket is still hanging after 2000ms. A completing attachment still saves through the same entry. A trickle whose total time (48031ms) exceeds the 30000ms idle budget still saves, because idle resets on each chunk.

### What was not tested

Live stall against a real Microsoft Teams attachment host, Bot Framework connector, or Graph endpoint. Bot Framework / Graph entry points were not driven against the live socket in this proof (argument-forwarding regressions cover those call sites).

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Teams media save timeout wiring, CI cleanup (removed unused proof script), rebase onto latest main, and the entry-point real-socket proof output.
