### PR TITLE
fix(qqbot): bound remote media downloads with header and idle timeouts

### DIFF
--- a/extensions/qqbot/src/bridge/bootstrap.test.ts
+++ b/extensions/qqbot/src/bridge/bootstrap.test.ts
@@ -1,7 +1,11 @@
 // Qqbot tests cover the built-in platform adapter boundary.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getPlatformAdapter } from "../engine/adapter/index.js";
+import { QQBOT_MEDIA_FETCH_TIMEOUTS } from "../media-fetch-timeouts.js";
 import { ensurePlatformAdapter } from "./bootstrap.js";
 
 const mocks = vi.hoisted(() => ({
@@ -63,7 +67,7 @@ describe("QQBot built-in platform adapter", () => {
       maxBytes: 1024,
       maxRedirects: 2,
       timeoutMs: 5_000,
-      responseHeaderTimeoutMs: 120_000,
+      ...QQBOT_MEDIA_FETCH_TIMEOUTS,
       ssrfPolicy: { hostnameAllowlist: ["*.qq.com"] },
       requestInit: { headers: { accept: "image/png" } },
     });
@@ -75,10 +79,57 @@ describe("QQBot built-in platform adapter", () => {
       maxBytes: 1024,
       maxRedirects: 2,
       timeoutMs: 5_000,
-      responseHeaderTimeoutMs: 120_000,
+      ...QQBOT_MEDIA_FETCH_TIMEOUTS,
       ssrfPolicy: { hostnameAllowlist: ["*.qq.com"] },
       requestInit: { headers: { accept: "image/png" } },
     });
+  });
+
+  it("applies shared media timeouts when fetchMedia callers omit them", async () => {
+    mocks.readRemoteMediaBuffer.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      fileName: "remote.png",
+    });
+
+    await getPlatformAdapter().fetchMedia({
+      url: "https://media.qq.com/assets/photo.png",
+      filePathHint: "photo.png",
+    });
+
+    expect(mocks.readRemoteMediaBuffer).toHaveBeenCalledWith({
+      url: "https://media.qq.com/assets/photo.png",
+      filePathHint: "photo.png",
+      maxBytes: undefined,
+      maxRedirects: undefined,
+      timeoutMs: undefined,
+      ...QQBOT_MEDIA_FETCH_TIMEOUTS,
+      ssrfPolicy: undefined,
+      requestInit: undefined,
+    });
+  });
+
+  it("applies header and idle timeouts on adapter downloadFile", async () => {
+    mocks.readRemoteMediaBuffer.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      fileName: "remote.png",
+    });
+    const destDir = await fs.mkdtemp(path.join(os.tmpdir(), "qqbot-bootstrap-download-"));
+
+    try {
+      const destPath = await getPlatformAdapter().downloadFile(
+        "https://media.qq.com/assets/photo.png",
+        destDir,
+        "photo.png",
+      );
+      expect(destPath.endsWith("photo.png")).toBe(true);
+      expect(mocks.readRemoteMediaBuffer).toHaveBeenCalledWith({
+        url: "https://media.qq.com/assets/photo.png",
+        filePathHint: "photo.png",
+        ...QQBOT_MEDIA_FETCH_TIMEOUTS,
+      });
+    } finally {
+      await fs.rm(destDir, { recursive: true, force: true });
+    }
   });
 
   it("preserves plugin ownership and the canonical first-answer result", async () => {

--- a/extensions/qqbot/src/bridge/bootstrap.ts
+++ b/extensions/qqbot/src/bridge/bootstrap.ts
@@ -38,6 +38,7 @@ import {
   type PlatformAdapter,
 } from "../engine/adapter/index.js";
 import type { FetchMediaOptions, FetchMediaResult } from "../engine/adapter/types.js";
+import { QQBOT_MEDIA_FETCH_TIMEOUTS } from "../media-fetch-timeouts.js";
 import { getBridgeLogger } from "./logger.js";
 
 const loadReadRemoteMediaBuffer = createLazyRuntimeNamedExport(
@@ -59,8 +60,13 @@ function createBuiltinAdapter(): PlatformAdapter {
     },
 
     async downloadFile(url: string, destDir: string, filename?: string): Promise<string> {
+      // Same shared policy as fetchMedia defaults — a stalled body must not hang forever.
       const readRemoteMediaBuffer = await loadReadRemoteMediaBuffer();
-      const result = await readRemoteMediaBuffer({ url, filePathHint: filename });
+      const result = await readRemoteMediaBuffer({
+        url,
+        filePathHint: filename,
+        ...QQBOT_MEDIA_FETCH_TIMEOUTS,
+      });
       const fs = await import("node:fs");
       const path = await import("node:path");
       if (!fs.existsSync(destDir)) {
@@ -79,7 +85,12 @@ function createBuiltinAdapter(): PlatformAdapter {
         maxBytes: options.maxBytes,
         maxRedirects: options.maxRedirects,
         timeoutMs: options.timeoutMs,
-        responseHeaderTimeoutMs: options.responseHeaderTimeoutMs,
+        // Default at the adapter boundary so callers that omit timeouts
+        // (image probes, downloadFile helpers) still match channel media policy.
+        responseHeaderTimeoutMs:
+          options.responseHeaderTimeoutMs ?? QQBOT_MEDIA_FETCH_TIMEOUTS.responseHeaderTimeoutMs,
+        readIdleTimeoutMs:
+          options.readIdleTimeoutMs ?? QQBOT_MEDIA_FETCH_TIMEOUTS.readIdleTimeoutMs,
         ssrfPolicy: options.ssrfPolicy,
         requestInit: options.requestInit,
       });

--- a/extensions/qqbot/src/engine/adapter/types.ts
+++ b/extensions/qqbot/src/engine/adapter/types.ts
@@ -21,6 +21,8 @@ export interface FetchMediaOptions {
   timeoutMs?: number;
   /** Abort if final response headers have not arrived after this many milliseconds. */
   responseHeaderTimeoutMs?: number;
+  /** Abort if the response body stops yielding data for this many milliseconds. */
+  readIdleTimeoutMs?: number;
   /** SSRF policy configuration. */
   ssrfPolicy?: SsrfPolicyConfig;
   /** Extra fetch() RequestInit options. */

--- a/extensions/qqbot/src/engine/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.test.ts
@@ -26,6 +26,7 @@ vi.mock("../adapter/index.js", () => ({
   }),
 }));
 
+import { QQBOT_MEDIA_FETCH_TIMEOUTS } from "../../media-fetch-timeouts.js";
 import {
   checkFileSize,
   downloadFile,
@@ -106,7 +107,7 @@ describe("qqbot file-utils downloadFile", () => {
         ],
         allowRfc2544BenchmarkRange: true,
       },
-      responseHeaderTimeoutMs: 120_000,
+      ...QQBOT_MEDIA_FETCH_TIMEOUTS,
     });
   });
 

--- a/extensions/qqbot/src/engine/utils/file-utils.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.ts
@@ -9,6 +9,7 @@ import {
   readRegularFile,
   statRegularFileSync,
 } from "openclaw/plugin-sdk/security-runtime";
+import { QQBOT_MEDIA_FETCH_TIMEOUTS } from "../../media-fetch-timeouts.js";
 import { getPlatformAdapter } from "../adapter/index.js";
 import type { SsrfPolicyConfig } from "../adapter/types.js";
 import { MediaFileType } from "../types.js";
@@ -69,8 +70,6 @@ const QQBOT_MEDIA_SSRF_POLICY: SsrfPolicyConfig = {
   hostnameAllowlist: QQBOT_MEDIA_HOSTNAME_ALLOWLIST,
   allowRfc2544BenchmarkRange: true,
 };
-
-const QQBOT_REMOTE_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
 
 /** Result of local file-size validation. */
 interface FileSizeCheckResult {
@@ -185,7 +184,7 @@ export async function downloadFile(
       url: parsedUrl.toString(),
       filePathHint: originalFilename,
       ssrfPolicy: QQBOT_MEDIA_SSRF_POLICY,
-      responseHeaderTimeoutMs: QQBOT_REMOTE_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+      ...QQBOT_MEDIA_FETCH_TIMEOUTS,
     });
 
     let filename = normalizeOptionalString(originalFilename) ?? "";

--- a/extensions/qqbot/src/media-fetch-timeouts.ts
+++ b/extensions/qqbot/src/media-fetch-timeouts.ts
@@ -1,0 +1,7 @@
+// Match Telegram/Tlon/Mattermost inbound media and media-store downloads:
+// header wait is independent of body idle. Keep every QQBot remote-media path
+// on one policy so adapter + file-utils callers cannot drift.
+export const QQBOT_MEDIA_FETCH_TIMEOUTS = {
+  responseHeaderTimeoutMs: 120_000,
+  readIdleTimeoutMs: 30_000,
+} as const;


### PR DESCRIPTION
## What Problem This Solves

QQBot remote-media downloads could hang indefinitely when an upstream CDN
accepted the connection, returned headers (and optionally one body chunk), then
stopped sending data. Two channel-owned callers were missing a body-idle bound:

- `getPlatformAdapter().downloadFile` called `readRemoteMediaBuffer` with no
  header/idle timeouts
- `file-utils.downloadFile` / `fetchMedia` had a 120s response-header timeout
  but did not forward `readIdleTimeoutMs`
- Other `fetchMedia` callers (for example image probes) could also omit idle
  bounds and inherit the same hang

## Why This Change Was Made

Adopt the already-landed channel media timeout policy used by Telegram, Tlon,
Mattermost, and core media-store downloads — not invent a QQBot-only threshold:

- `responseHeaderTimeoutMs: 120_000`
- `readIdleTimeoutMs: 30_000`

Owned as one shared object (`QQBOT_MEDIA_FETCH_TIMEOUTS`, same shape as
`TLON_MEDIA_FETCH_TIMEOUTS`) and applied at the built-in adapter boundary so
`downloadFile`, `fetchMedia` defaults, and `file-utils.downloadFile` cannot
drift. Callers may still override via `FetchMediaOptions`. No new downloader
or config key.

## User Impact

**Before:** A stalled QQ media body could leave inbound/outbound media handling
waiting forever and retain Gateway resources.

**After:** Stalled bodies fail closed after 30s without data
(`Media download stalled: no data received for 30000ms`), releasing the
connection — matching sibling channel / media-store idle policy. Completing
transfers are unchanged. Unusually slow-but-progressing transfers remain
allowed (idle timer resets on each chunk).

## Evidence

- Changed: `extensions/qqbot/src/media-fetch-timeouts.ts`,
  `extensions/qqbot/src/bridge/bootstrap.ts`,
  `extensions/qqbot/src/bridge/bootstrap.test.ts`,
  `extensions/qqbot/src/engine/adapter/types.ts`,
  `extensions/qqbot/src/engine/utils/file-utils.ts`,
  `extensions/qqbot/src/engine/utils/file-utils.test.ts`
- Production paths:
  - adapter `downloadFile` / default `fetchMedia` → `...QQBOT_MEDIA_FETCH_TIMEOUTS`
  - `file-utils.downloadFile` → `fetchMedia({ …, ...QQBOT_MEDIA_FETCH_TIMEOUTS })`
  - `fetchMedia` applies shared defaults when callers omit timeouts

## Real behavior proof

### Behavior or issue addressed

Stalled QQBot remote-media bodies fail closed on the shared 30s idle budget
instead of hanging. Completing downloads still succeed and still carry the same
120s/30s policy.

### Canonical reachability path

`getPlatformAdapter().downloadFile` / `file-utils.downloadFile` →
`fetchMedia` / direct `readRemoteMediaBuffer` → shared guarded reader
(`chunkTimeoutMs` / idle watchdog from `readIdleTimeoutMs`)

### Shared helper / provider constraint check

Uses existing `readRemoteMediaBuffer` header + idle options. Durations match
Telegram/Tlon/Mattermost inbound media and `src/media/store.download.ts`
(`READ_IDLE_TIMEOUT_MS = 30_000`). No second downloader; SSRF allowlist /
redirect behavior unchanged.

### Real environment tested

Live `node:http` media server on `127.0.0.1` (headers + one PNG chunk, then
stall; plus a completing `/small` body). Production QQBot callers are exercised
with the real `readRemoteMediaBuffer` reader; fetch is redirected to the local
socket so the proof stays on-machine while preserving caller-supplied
timeouts. Node v22.23.1. Refactored head also re-ran focused unit tests below.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs \
  extensions/qqbot/src/bridge/media-idle-timeout.proof.test.ts \
  --reporter=verbose

# Focused argument-propagation / adapter-default regressions
node scripts/run-vitest.mjs \
  extensions/qqbot/src/bridge/bootstrap.test.ts \
  extensions/qqbot/src/engine/utils/file-utils.test.ts \
  --reporter=verbose
```

### Evidence after fix

**Case A — `getPlatformAdapter().fetchMedia` stalled live body (idle=400ms)**

```text
Case A fetchMedia: {
  elapsedMs: 2632,
  idleMs: 400,
  recorded: {
    url: 'https://media.qq.com/assets/stall.png',
    responseHeaderTimeoutMs: 120000,
    readIdleTimeoutMs: 400
  },
  error: 'Failed to fetch media … Media download stalled: no data received for 400ms'
}
✓ fetchMedia forwards readIdleTimeoutMs and fails closed on a stalled live body
```

**Case B — `getPlatformAdapter().downloadFile` production 30s idle**

```text
Case B downloadFile: {
  elapsedMs: 30019,
  recorded: {
    url: 'https://media.qq.com/assets/stall.png',
    responseHeaderTimeoutMs: 120000,
    readIdleTimeoutMs: 30000
  },
  error: 'Failed to fetch media … Media download stalled: no data received for 30000ms'
}
✓ downloadFile applies production 120s/30s policy and fails closed on a stalled live body 30028ms
```

**Case C — `file-utils.downloadFile` completing control**

```text
Case C file-utils.downloadFile: {
  bytes: 7,
  recorded: {
    url: 'https://media.qq.com/assets/small.png',
    responseHeaderTimeoutMs: 120000,
    readIdleTimeoutMs: 30000
  }
}
✓ file-utils.downloadFile completes a live body and forwards the same timeout policy
```

```text
Test Files  1 passed (1)
     Tests  3 passed (3)
```

Focused unit re-run after shared-timeouts refactor (head `49ba45fae93`):

```text
✓ applies shared media timeouts when fetchMedia callers omit them
✓ applies header and idle timeouts on adapter downloadFile
✓ downloads through the guarded media adapter with the qqbot SSRF policy
Test Files  2 passed (2)
     Tests  10 passed (10)
```

### Observed result after fix

1. Changed QQBot `downloadFile` passes `responseHeaderTimeoutMs=120000` /
   `readIdleTimeoutMs=30000` into the shared reader and rejects a live stalled
   body in ~30019ms with the idle error (not hung).
2. `fetchMedia` forwards a caller idle budget and fails closed on the same stall
   socket; omitted timeouts now also get the shared defaults at the adapter.
3. Completing `file-utils.downloadFile` still returns the full body and still
   forwards the production 120s/30s policy.

### What was not tested

- Live stall against real QQ CDN hosts (`*.qpic.cn` / `*.qq.com`) on the public
  internet (proof uses a local stall socket through the QQBot callers)
- Header-stall-only path (no body) for these callers

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the QQBot-owned timeout propagation, replaced the
incorrect OpenAI video-gen proof previously pasted into this PR body, and
captured live QQBot-path stall/complete evidence. Follow-up refactor extracted
`QQBOT_MEDIA_FETCH_TIMEOUTS` and applied adapter-boundary defaults to match
sibling channel media policy ownership.
