### PR TITLE
fix(qa-lab): bound Crabline inbound and runtime-parity mock fetches

### DIFF
--- a/extensions/qa-lab/api.ts
+++ b/extensions/qa-lab/api.ts
@@ -116,3 +116,6 @@ export {
   runQaFlowSuite,
 } from "./src/suite.js";
 export { runQaSuite, type QaSuiteRuntimeResult } from "./src/suite-launch.runtime.js";
+// Test-only Crabline inbound seam; re-exported so production Knip sees a consumer
+// of the transport export (same pattern as qaSuiteProgressTesting above).
+export { qaLabCrablineInboundTesting } from "./src/crabline-transport.js";

--- a/extensions/qa-lab/src/crabline-inbound-bounds.test.ts
+++ b/extensions/qa-lab/src/crabline-inbound-bounds.test.ts
@@ -1,0 +1,59 @@
+// Qa Lab tests prove Crabline inbound fetch is timed and JSON-bounded.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const readProviderJsonResponseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+  readProviderJsonResponse: readProviderJsonResponseMock,
+}));
+
+import { qaLabCrablineInboundTesting } from "./crabline-transport.js";
+
+describe("qaLabCrablineInboundTesting.postCrablineInbound", () => {
+  beforeEach(() => {
+    fetchWithSsrFGuardMock.mockReset();
+    readProviderJsonResponseMock.mockReset();
+  });
+
+  it("passes timeoutMs and reads JSON through the bounded provider helper", async () => {
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      release,
+    });
+    readProviderJsonResponseMock.mockResolvedValue({
+      update: { message: { message_id: 42 } },
+    });
+
+    const messageId = await qaLabCrablineInboundTesting.postCrablineInbound({
+      adapter: {
+        channel: "telegram",
+        manifest: {
+          adminToken: "admin-token",
+          endpoints: { adminInboundUrl: "http://127.0.0.1:43123/admin/inbound" },
+        },
+      } as never,
+      providerInbound: { providerBody: { text: "ping" } } as never,
+    });
+
+    expect(messageId).toBe("42");
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: qaLabCrablineInboundTesting.timeoutMs,
+        auditContext: "qa-lab-crabline-telegram-inbound",
+        url: "http://127.0.0.1:43123/admin/inbound",
+      }),
+    );
+    expect(qaLabCrablineInboundTesting.timeoutMs).toBe(15_000);
+    expect(readProviderJsonResponseMock).toHaveBeenCalledWith(
+      expect.any(Response),
+      "qa-lab-crabline-telegram-inbound",
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -10,6 +10,7 @@ import {
 } from "@openclaw/crabline";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   isRecord,
@@ -190,10 +191,14 @@ async function waitForCrablineReady(params: {
   );
 }
 
+const QA_LAB_CRABLINE_INBOUND_TIMEOUT_MS = 15_000;
+
 async function postCrablineInbound(params: {
   adapter: StartedOpenClawCrablineAdapter;
   providerInbound: OpenClawCrablineInbound;
 }) {
+  // Match suite-runtime-gateway: timeout the guarded fetch and bound JSON so a
+  // hung admin inbound endpoint cannot stall the Crabline scenario forever.
   const { response, release } = await fetchWithSsrFGuard({
     url: params.adapter.manifest.endpoints.adminInboundUrl,
     init: {
@@ -205,6 +210,7 @@ async function postCrablineInbound(params: {
       method: "POST",
     },
     policy: { allowPrivateNetwork: true },
+    timeoutMs: QA_LAB_CRABLINE_INBOUND_TIMEOUT_MS,
     auditContext: `qa-lab-crabline-${params.adapter.channel}-inbound`,
   });
   try {
@@ -213,7 +219,10 @@ async function postCrablineInbound(params: {
         `Crabline ${params.adapter.channel} inbound injection failed with HTTP ${response.status}.`,
       );
     }
-    const result: unknown = await response.json();
+    const result = await readProviderJsonResponse<unknown>(
+      response,
+      `qa-lab-crabline-${params.adapter.channel}-inbound`,
+    );
     if (params.adapter.channel === "matrix" && isRecord(result) && isRecord(result.event)) {
       return readStringValue(result.event.event_id);
     }
@@ -443,6 +452,11 @@ class QaCrablineTransport extends QaStateBackedTransportAdapter {
     await this.#state.cleanup();
   }
 }
+
+export const qaLabCrablineInboundTesting = {
+  postCrablineInbound,
+  timeoutMs: QA_LAB_CRABLINE_INBOUND_TIMEOUT_MS,
+};
 
 export async function createQaCrablineTransportAdapter(params: {
   outputDir: string;

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -67,6 +67,8 @@ async function captureRuntimeParityWithMockRequests(params: {
   messages?: Array<Record<string, unknown>>;
   requests: Array<Record<string, unknown>>;
   scenarioResult?: Parameters<typeof captureRuntimeParityCell>[0]["scenarioResult"];
+  mockFetchTimeoutMs?: number;
+  hangDebugRequests?: boolean;
 }) {
   const parentPrompt = "Delegate one bounded QA task to a subagent.";
   const tempRoot = await seedRuntimeParityTranscript({
@@ -85,6 +87,11 @@ async function captureRuntimeParityWithMockRequests(params: {
       response.end();
       return;
     }
+    if (params.hangDebugRequests) {
+      // Accept the socket but never write headers/body so the guarded fetch
+      // deadline must fail closed instead of hanging capture forever.
+      return;
+    }
     response.setHeader("Content-Type", "application/json");
     response.end(JSON.stringify(requests));
   });
@@ -99,6 +106,7 @@ async function captureRuntimeParityWithMockRequests(params: {
       mockBaseUrl: `http://127.0.0.1:${address.port}`,
       scenarioResult: params.scenarioResult ?? { status: "pass" },
       wallClockMs: 10,
+      mockFetchTimeoutMs: params.mockFetchTimeoutMs,
     });
   } finally {
     await new Promise<void>((resolve, reject) => {
@@ -211,6 +219,21 @@ describe("runtime parity", () => {
       tool: "read_file",
       errorClass: "tool-result-missing",
     });
+  });
+
+  it("fails closed when mock /debug/requests never responds", async () => {
+    const startedAt = Date.now();
+    const cell = await captureRuntimeParityWithMockRequests({
+      requests: [{ plannedToolName: "read_file", plannedToolArgs: { path: "README.md" } }],
+      hangDebugRequests: true,
+      mockFetchTimeoutMs: 80,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    // Timed-out mock fetch returns null and falls back to the (empty) transcript
+    // tool list instead of hanging past the request deadline.
+    expect(cell.toolCalls).toEqual([]);
+    expect(elapsedMs).toBeLessThan(5_000);
   });
 
   it("keeps resolved mock tool calls eligible for no-drift parity", async () => {

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1,8 +1,9 @@
+// Qa Lab plugin module implements runtime parity behavior.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   listSessionEntries,
   loadTranscriptEventsSync,
 } from "openclaw/plugin-sdk/session-store-runtime";
-// Qa Lab plugin module implements runtime parity behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   asFiniteNumber as readFiniteNumber,
@@ -126,6 +127,8 @@ type RuntimeParityCaptureParams = {
   wallClockMs: number;
   agentId?: string;
   mockBaseUrl?: string;
+  /** Test-only override for the mock /debug/requests guarded-fetch deadline. */
+  mockFetchTimeoutMs?: number;
 };
 
 type RuntimeParitySessionEntry = {
@@ -1034,19 +1037,25 @@ async function loadRuntimeParityTranscripts(params: {
   return transcripts.join("\n");
 }
 
+const QA_LAB_RUNTIME_PARITY_MOCK_FETCH_TIMEOUT_MS = 15_000;
+
 async function loadRuntimeParityMockToolCalls(
   mockBaseUrl: string | undefined,
   parentPrompt: string,
   parentPrompts: readonly string[] = [parentPrompt],
+  timeoutMs = QA_LAB_RUNTIME_PARITY_MOCK_FETCH_TIMEOUT_MS,
 ): Promise<RuntimeParityToolCall[] | null> {
   const normalizedBaseUrl = mockBaseUrl?.trim().replace(/\/+$/u, "");
   if (!normalizedBaseUrl) {
     return null;
   }
   try {
+    // Match suite-runtime-gateway: timeout + bounded JSON so a hung mock
+    // /debug/requests endpoint cannot stall runtime-parity capture forever.
     const { response, release } = await fetchWithSsrFGuard({
       url: `${normalizedBaseUrl}/debug/requests`,
       policy: { allowPrivateNetwork: true },
+      timeoutMs,
       auditContext: "qa-lab-runtime-parity-mock-tool-calls",
     });
     let payload: unknown;
@@ -1054,7 +1063,7 @@ async function loadRuntimeParityMockToolCalls(
       if (!response.ok) {
         return null;
       }
-      payload = await response.json();
+      payload = await readProviderJsonResponse(response, "qa-lab-runtime-parity-mock-tool-calls");
     } finally {
       await release();
     }
@@ -1097,6 +1106,7 @@ export async function captureRuntimeParityCell(
     params.mockBaseUrl,
     parentPrompt,
     parentPrompts,
+    params.mockFetchTimeoutMs ?? QA_LAB_RUNTIME_PARITY_MOCK_FETCH_TIMEOUT_MS,
   );
   const gatewayLogs = params.gateway.logs?.();
   const sentinelFindings = [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab Crabline inbound injection and runtime-parity mock `/debug/requests` fetches could hang indefinitely. Both paths used `fetchWithSsrFGuard` without `timeoutMs` and then called bare `response.json()`, so a hung or never-finishing admin/mock endpoint could stall the suite forever.

## Why This Change Was Made

Copy the existing `suite-runtime-gateway` pattern: pass `timeoutMs: 15_000` into `fetchWithSsrFGuard` and read JSON through `readProviderJsonResponse` on both surfaces. Add a caller-path hang regression for runtime-parity capture and a focused Crabline inbound assertion that the production helper receives the timeout + bounded JSON reader.

## User Impact

No end-user product change. QA Lab / Crabline CI scenarios fail closed on hung inbound or mock debug endpoints instead of hanging the suite process.

## Evidence

- Changed: `extensions/qa-lab/src/crabline-transport.ts`, `extensions/qa-lab/src/crabline-inbound-bounds.test.ts`, `extensions/qa-lab/src/runtime-parity.ts`, `extensions/qa-lab/src/runtime-parity.test.ts`
- Production caller paths:
  - `postCrablineInbound` → `fetchWithSsrFGuard({ timeoutMs })` + `readProviderJsonResponse`
  - `captureRuntimeParityCell` → `loadRuntimeParityMockToolCalls` → same pattern

## Real behavior proof

### Behavior or issue addressed

QA Lab Crabline inbound and runtime-parity mock debug fetches are timed and JSON-bounded.

### Canonical reachability path

`captureRuntimeParityCell({ mockBaseUrl, mockFetchTimeoutMs })` → hung `/debug/requests` fails closed; `qaLabCrablineInboundTesting.postCrablineInbound` forwards `timeoutMs: 15_000` and uses `readProviderJsonResponse`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/runtime-parity.test.ts extensions/qa-lab/src/crabline-inbound-bounds.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ fails closed when mock /debug/requests never responds 191ms
✓ passes timeoutMs and reads JSON through the bounded provider helper 3ms
 Test Files  2 passed (2)
      Tests  18 passed (18)
[test] passed 1 Vitest shard in 23.04s
```

Hung `/debug/requests` fixture never writes headers/body. With `mockFetchTimeoutMs: 80`, capture returns in ~191ms with empty mock tool calls (transcript fallback) instead of hanging.

### Observed result after fix

Timeout + bounded JSON wiring is exercised on both production helpers; neighboring runtime-parity cases still pass.

### What was not tested

Full Crabline multi-channel live suite against a real hung admin inbound server outside unit fixtures.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the suite-runtime-gateway sibling pattern and caller-path proof output.
