### PR TITLE
fix(tools): bound GitHub releases API response read with maxBytes

### DIFF
--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -21,12 +21,14 @@ import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
+import { readResponseWithLimit } from "../../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { APP_NAME, getBinDir } from "../config.js";
 
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
+const GITHUB_RELEASES_MAX_BYTES = 64 * 1024;
 const MAX_ARCHIVE_BYTES = 100 * 1024 * 1024;
 const MAX_EXTRACTED_BYTES = 500 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 1_000;
@@ -156,7 +158,10 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const buffer = await readResponseWithLimit(response, GITHUB_RELEASES_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) => new Error(`GitHub releases response exceeds ${maxBytes} bytes`),
+    });
+    const data = JSON.parse(buffer.toString("utf8")) as { tag_name: string };
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

`getLatestVersion` in `src/agents/utils/tools-manager.ts` reads the GitHub `/releases/latest` API response with `response.json()`, which buffers the entire body without a size limit. A compromised or faulty GitHub API could return an unexpectedly large response, causing unbounded memory consumption.

## Why This Change Was Made

Replaces `response.json()` with `readResponseWithLimit(response, 64KB)` matching the bounded-read pattern already used in `clawhub.ts`, `push-apns.relay.ts`, and `oauth/anthropic.ts`. The 64KB limit is generous for a release JSON object (typically <5KB).

## User Impact

- GitHub API responses exceeding 64KB now throw a clear error instead of silently consuming memory
- No change to normal operation — typical GitHub releases responses are well under 64KB

## Evidence

- Uses `readResponseWithLimit` from the established `src/infra/http-body.ts` pattern
- +6/-1 line change, same pattern as sibling bounded-read fixes
- Existing `tools-manager.test.ts` (248 lines) covers the `getLatestVersion` path