### PR TITLE
fix(ui): bound browser gateway WebSocket opening

### DIFF
--- a/packages/gateway-client/src/browser.ts
+++ b/packages/gateway-client/src/browser.ts
@@ -4,6 +4,7 @@ export * from "./device-auth.js";
 export * from "./connect-auth.js";
 export * from "./protocol-client.js";
 export * from "./reconnect-policy.js";
+export { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS } from "./timeouts.js";
 export * from "@openclaw/gateway-protocol/client-info";
 export * from "@openclaw/gateway-protocol/connect-error-details";
 export * from "@openclaw/gateway-protocol/startup-unavailable";

--- a/ui/src/api/gateway-browser-socket.test.ts
+++ b/ui/src/api/gateway-browser-socket.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment node */
-import { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS } from "@openclaw/gateway-client/timeouts";
+import { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBrowserGatewaySocket } from "./gateway-browser-socket.ts";
 

--- a/ui/src/api/gateway-browser-socket.test.ts
+++ b/ui/src/api/gateway-browser-socket.test.ts
@@ -1,0 +1,120 @@
+/** @vitest-environment node */
+import { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS } from "@openclaw/gateway-client/timeouts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBrowserGatewaySocket } from "./gateway-browser-socket.ts";
+
+type MockSocketEvent = { code?: number; data?: unknown; reason?: string };
+type MockSocketHandler = (event: MockSocketEvent) => void;
+
+const sockets: MockWebSocket[] = [];
+
+class MockWebSocket {
+  static readonly OPEN = 1;
+  readonly close = vi.fn();
+  readonly handlers = new Map<string, MockSocketHandler[]>();
+  readyState = 0;
+
+  constructor(readonly url: string) {
+    sockets.push(this);
+  }
+
+  addEventListener(type: string, handler: MockSocketHandler) {
+    const handlers = this.handlers.get(type) ?? [];
+    handlers.push(handler);
+    this.handlers.set(type, handlers);
+  }
+
+  send(_data: string) {}
+
+  emit(type: string, event: MockSocketEvent = {}) {
+    for (const handler of this.handlers.get(type) ?? []) {
+      handler(event);
+    }
+  }
+}
+
+function createHandlers() {
+  return {
+    open: vi.fn(),
+    message: vi.fn(),
+    close: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("createBrowserGatewaySocket", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sockets.length = 0;
+    vi.stubGlobal("WebSocket", MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("closes a websocket that never finishes opening", async () => {
+    const handlers = createHandlers();
+    createBrowserGatewaySocket("wss://gateway.example", handlers);
+    const socket = sockets[0];
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+
+    expect(handlers.error).toHaveBeenCalledOnce();
+    expect(handlers.error.mock.calls[0]?.[0]).toEqual(
+      new Error(
+        `gateway websocket opening timed out after ${DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS}ms`,
+      ),
+    );
+    expect(socket?.close).toHaveBeenCalledOnce();
+
+    socket?.emit("error");
+    socket?.emit("close", { code: 1006, reason: "" });
+    expect(handlers.error).toHaveBeenCalledOnce();
+    expect(handlers.close).toHaveBeenCalledWith(1006, "");
+  });
+
+  it("clears the opening deadline after the socket opens", async () => {
+    const handlers = createHandlers();
+    createBrowserGatewaySocket("wss://gateway.example", handlers);
+    const socket = sockets[0];
+
+    if (socket) {
+      socket.readyState = MockWebSocket.OPEN;
+      socket.emit("open");
+    }
+    await vi.advanceTimersByTimeAsync(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+
+    expect(handlers.open).toHaveBeenCalledOnce();
+    expect(handlers.error).not.toHaveBeenCalled();
+    expect(socket?.close).not.toHaveBeenCalled();
+  });
+
+  it("clears the opening deadline after a native transport failure", async () => {
+    const handlers = createHandlers();
+    createBrowserGatewaySocket("wss://gateway.example", handlers);
+    const socket = sockets[0];
+
+    socket?.emit("error");
+    socket?.emit("close", { code: 1006, reason: "" });
+    await vi.advanceTimersByTimeAsync(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+
+    expect(handlers.error).toHaveBeenCalledOnce();
+    expect(handlers.error).toHaveBeenCalledWith(new Error("websocket error"));
+    expect(handlers.close).toHaveBeenCalledWith(1006, "");
+    expect(socket?.close).not.toHaveBeenCalled();
+  });
+
+  it("clears the opening deadline when the client closes the socket", async () => {
+    const handlers = createHandlers();
+    const socketAdapter = createBrowserGatewaySocket("wss://gateway.example", handlers);
+    const socket = sockets[0];
+
+    socketAdapter.close(1000, "stopped");
+    await vi.advanceTimersByTimeAsync(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+
+    expect(socket?.close).toHaveBeenCalledWith(1000, "stopped");
+    expect(handlers.error).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/api/gateway-browser-socket.ts
+++ b/ui/src/api/gateway-browser-socket.ts
@@ -1,8 +1,8 @@
-import type {
-  GatewayProtocolSocket,
-  GatewayProtocolSocketHandlers,
+import {
+  DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
+  type GatewayProtocolSocket,
+  type GatewayProtocolSocketHandlers,
 } from "@openclaw/gateway-client/browser";
-import { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS } from "@openclaw/gateway-client/timeouts";
 
 export function createBrowserGatewaySocket(
   url: string,

--- a/ui/src/api/gateway-browser-socket.ts
+++ b/ui/src/api/gateway-browser-socket.ts
@@ -2,19 +2,66 @@ import type {
   GatewayProtocolSocket,
   GatewayProtocolSocketHandlers,
 } from "@openclaw/gateway-client/browser";
+import { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS } from "@openclaw/gateway-client/timeouts";
 
 export function createBrowserGatewaySocket(
   url: string,
   handlers: GatewayProtocolSocketHandlers,
 ): GatewayProtocolSocket {
   const socket = new WebSocket(url);
-  socket.addEventListener("open", handlers.open);
+  let opening = true;
+  let openingTimedOut = false;
+  let openingTimer: ReturnType<typeof setTimeout> | undefined;
+  const finishOpening = () => {
+    opening = false;
+    if (openingTimer !== undefined) {
+      clearTimeout(openingTimer);
+      openingTimer = undefined;
+    }
+  };
+
+  socket.addEventListener("open", () => {
+    finishOpening();
+    handlers.open();
+  });
   socket.addEventListener("message", (event) => handlers.message(String(event.data ?? "")));
-  socket.addEventListener("close", (event) => handlers.close(event.code, event.reason ?? ""));
-  socket.addEventListener("error", () => handlers.error(new Error("websocket error")));
+  socket.addEventListener("close", (event) => {
+    finishOpening();
+    handlers.close(event.code, event.reason ?? "");
+  });
+  socket.addEventListener("error", () => {
+    finishOpening();
+    if (!openingTimedOut) {
+      handlers.error(new Error("websocket error"));
+    }
+  });
+
+  // The protocol challenge timer starts after `open`. Bound the browser's
+  // opening phase to the same default preauth budget used by the Node client.
+  openingTimer = setTimeout(() => {
+    openingTimer = undefined;
+    if (!opening) {
+      return;
+    }
+    opening = false;
+    openingTimedOut = true;
+    try {
+      handlers.error(
+        new Error(
+          `gateway websocket opening timed out after ${DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS}ms`,
+        ),
+      );
+    } finally {
+      socket.close();
+    }
+  }, DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+
   return {
     isOpen: () => socket.readyState === WebSocket.OPEN,
     send: (data) => socket.send(data),
-    close: (code, reason) => socket.close(code, reason),
+    close: (code, reason) => {
+      finishOpening();
+      socket.close(code, reason);
+    },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The Control UI browser adapter creates its Gateway WebSocket without an opening deadline. The shared protocol challenge timer starts only after the browser emits `open`, so a TCP peer or proxy that accepts the connection but never completes the WebSocket upgrade can leave the initial Control UI connection pending indefinitely.

## Why This Change Was Made

Bound the browser WebSocket opening phase to the existing 15-second `DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS` budget that now protects the Node Gateway client as well. The adapter clears the deadline on open, native error, native close, and explicit client close. On timeout it reports one synthetic error, closes the native socket, suppresses the duplicate native error, and still forwards the native close so the existing protocol client owns retry behavior.

This changes one connection phase from unbounded to a fixed 15-second default. It adds no new config surface. A very slow but eventually valid browser ingress will be closed and retried after that budget; unlike the Node client, the browser adapter has no existing path for receiving a server-side custom handshake timeout.

## User Impact

The Control UI no longer stays forever on its opening state when a Gateway WebSocket upgrade stalls. After about 15 seconds it reaches the existing failure/retry path and releases the stalled browser connection.

## Evidence

- Node 24.15.0 focused test: `node scripts/run-vitest.mjs ui/src/api/gateway-browser-socket.test.ts --run` -> 1 file, 4 tests passed.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check origin/main...HEAD`: passed.
- Real Chromium 149 proof used the production adapter against a loopback TCP server that accepted a valid WebSocket Upgrade request and deliberately sent no response:

```text
sawUpgradeRequest=true
browser error elapsed_ms=15003.5 message="gateway websocket opening timed out after 15000ms"
browser close elapsed_ms=15004.7 code=1006
tcp closed elapsed_ms=15003
connections=1
```

- The focused tests also cover normal open, native transport failure, explicit client close, and duplicate-error suppression after timeout.
- Fresh non-author Codex adversarial review found no runtime blocker and estimated 85-90% landability. Full Control UI startup proof was blocked by missing shared-worktree WebAwesome/TanStack dependencies, so the live proof bundled only the production socket adapter and ran it in real Chromium.
