### PR TITLE
fix(logbook): bound snapshot subprocesses

### DIFF
--- a/extensions/logbook/src/node-host.test.ts
+++ b/extensions/logbook/src/node-host.test.ts
@@ -45,10 +45,12 @@ function rejectWhenAborted(signal: AbortSignal): Promise<never> {
 }
 
 describe("handleLogbookSnapshot", () => {
+  let timeoutSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-    vi.spyOn(AbortSignal, "timeout").mockImplementation((timeoutMs) => {
+    timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((timeoutMs) => {
       const controller = new AbortController();
       setTimeout(() => {
         controller.abort(new DOMException("snapshot command timed out", "TimeoutError"));
@@ -75,7 +77,7 @@ describe("handleLogbookSnapshot", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(runExecMock).toHaveBeenCalledTimes(1);
-    expect(AbortSignal.timeout).toHaveBeenCalledWith(25_000);
+    expect(timeoutSpy).toHaveBeenCalledWith(25_000);
     const signal = runExecSignal(0);
     expect(signal.aborted).toBe(false);
 

--- a/extensions/logbook/src/node-host.test.ts
+++ b/extensions/logbook/src/node-host.test.ts
@@ -1,0 +1,128 @@
+// Logbook node-host tests cover screenshot subprocess deadline behavior.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { readFileMock, rmMock, runExecMock } = vi.hoisted(() => ({
+  readFileMock: vi.fn(async () => Buffer.from("jpeg")),
+  rmMock: vi.fn(async () => undefined),
+  runExecMock: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  chmod: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+  readFile: readFileMock,
+  rm: rmMock,
+  writeFile: vi.fn(async () => undefined),
+}));
+
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({ runExec: runExecMock }));
+vi.mock("openclaw/plugin-sdk/temp-path", () => ({
+  resolvePreferredOpenClawTmpDir: () => "/data/openclaw-tests",
+}));
+
+import { handleLogbookSnapshot } from "./node-host.js";
+
+type RunExecOptions = { logOutput?: boolean; signal?: AbortSignal };
+
+function runExecSignal(callIndex: number): AbortSignal {
+  const options = runExecMock.mock.calls[callIndex]?.[2] as RunExecOptions | undefined;
+  if (!options?.signal) {
+    throw new Error(`missing runExec signal for call ${callIndex}`);
+  }
+  return options.signal;
+}
+
+function rejectWhenAborted(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    const rejectAbort = () =>
+      reject(signal.reason instanceof Error ? signal.reason : new Error("command aborted"));
+    if (signal.aborted) {
+      rejectAbort();
+      return;
+    }
+    signal.addEventListener("abort", rejectAbort, { once: true });
+  });
+}
+
+describe("handleLogbookSnapshot", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((timeoutMs) => {
+      const controller = new AbortController();
+      setTimeout(() => {
+        controller.abort(new DOMException("snapshot command timed out", "TimeoutError"));
+      }, timeoutMs);
+      return controller.signal;
+    });
+    runExecMock.mockReset();
+    readFileMock.mockClear();
+    rmMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("aborts a stalled capture before the node.invoke deadline and skips resize", async () => {
+    runExecMock.mockImplementationOnce(
+      async (_command: string, _args: string[], options: RunExecOptions) =>
+        await rejectWhenAborted(options.signal as AbortSignal),
+    );
+
+    const snapshot = handleLogbookSnapshot({});
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+    expect(AbortSignal.timeout).toHaveBeenCalledWith(25_000);
+    const signal = runExecSignal(0);
+    expect(signal.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(24_999);
+    expect(signal.aborted).toBe(false);
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(snapshot).resolves.toEqual({ error: "snapshot command timed out" });
+    expect(signal.aborted).toBe(true);
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(rmMock).toHaveBeenCalledOnce();
+  });
+
+  it("shares the capture deadline with the resize command", async () => {
+    runExecMock.mockImplementation(
+      async (command: string, _args: string[], options: RunExecOptions) => {
+        if (command === "screencapture") {
+          return await new Promise<{ stdout: string; stderr: string }>((resolve) => {
+            setTimeout(() => resolve({ stdout: "", stderr: "" }), 20_000);
+          });
+        }
+        return await rejectWhenAborted(options.signal as AbortSignal);
+      },
+    );
+
+    const snapshot = handleLogbookSnapshot({});
+    await vi.advanceTimersByTimeAsync(0);
+    const captureSignal = runExecSignal(0);
+
+    await vi.advanceTimersByTimeAsync(19_999);
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runExecMock).toHaveBeenCalledTimes(2);
+    const resizeSignal = runExecSignal(1);
+    expect(resizeSignal).toBe(captureSignal);
+    expect(resizeSignal.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(resizeSignal.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(snapshot).resolves.toEqual({ error: "snapshot command timed out" });
+    expect(resizeSignal.aborted).toBe(true);
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(rmMock).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/logbook/src/node-host.ts
+++ b/extensions/logbook/src/node-host.ts
@@ -15,6 +15,8 @@ type LogbookSnapshotParams = {
 
 type LogbookSnapshotPayload = { format: "jpeg"; base64: string } | { error: string };
 
+const LOGBOOK_SNAPSHOT_EXEC_TIMEOUT_MS = 25_000;
+
 function readParams(value: unknown): LogbookSnapshotParams {
   if (!value || typeof value !== "object") {
     return {};
@@ -53,11 +55,14 @@ export async function handleLogbookSnapshot(rawParams: unknown): Promise<Logbook
     // Pre-create owner-only: screencapture truncates the existing inode, so
     // the capture never becomes world-readable even if the dir mode drifts.
     await writeFile(filePath, "", { mode: 0o600 });
+    // node.invoke stops waiting after 30 seconds but cannot reap node-host children.
+    // Share an earlier deadline so both commands terminate before that outer boundary.
+    const execSignal = AbortSignal.timeout(LOGBOOK_SNAPSHOT_EXEC_TIMEOUT_MS);
     // -x: no capture sound; -C: include cursor; -D is 1-based display index.
     await runExec(
       "screencapture",
       ["-x", "-C", "-D", String(screenIndex + 1), "-t", "jpg", filePath],
-      { logOutput: false },
+      { logOutput: false, signal: execSignal },
     );
     await runExec(
       "sips",
@@ -72,7 +77,7 @@ export async function handleLogbookSnapshot(rawParams: unknown): Promise<Logbook
         String(qualityPct),
         filePath,
       ],
-      { logOutput: false },
+      { logOutput: false, signal: execSignal },
     );
     const buffer = await readFile(filePath);
     return { format: "jpeg", base64: buffer.toString("base64") };


### PR DESCRIPTION
## What Problem This Solves

`logbook.snapshot` ran the macOS `screencapture` and `sips` subprocesses without a deadline. If either native command stalled, the node invocation could stop waiting after 30 seconds while the child process and snapshot request remained alive on the node host.

## Why This Change Was Made

Give the two native commands one shared 25-second abort signal. A cumulative budget prevents the capture and resize steps from each consuming a full timeout, while leaving time for `runExec` to terminate the child and for the handler's existing `finally` cleanup to remove the temporary image before the outer node invocation boundary.

The timeout is local to the snapshot operation, does not change successful capture behavior, and preserves the existing `{ error }` response on command failure.

## User Impact

Logbook snapshots now fail with a bounded error instead of leaving a stalled native screenshot or resize process behind. Successful snapshots continue to use the same commands and output format.

## Evidence

- `node scripts/run-vitest.mjs extensions/logbook/src/node-host.test.ts --run` (2 tests passed)
- `oxfmt --check extensions/logbook/src/node-host.ts extensions/logbook/src/node-host.test.ts`
- `oxlint extensions/logbook/src/node-host.ts extensions/logbook/src/node-host.test.ts`
- `git diff --check origin/main...HEAD`
- Focused fake-timer coverage proves a stalled capture aborts at 25 seconds, skips resize, cleans up the file, and that resize receives only the remainder of the shared budget.
- A direct Node 24 `runExec` probe against an ignored-SIGTERM child completed in 395 ms with `isCanceled=true`; the child was reaped through the helper's abort/SIGKILL escalation path.

### Real macOS behavior proof

- [Visible Apple `screencapture` preflight](https://github.com/Alix-007/openclaw/actions/runs/29670951329) on macOS 15.7.7 arm64 uploaded an 81,362-byte, 1024x768 PNG. The artifact was manually inspected as a visible Finder desktop capture. This preflight validates the hosted GUI session and real `/usr/sbin/screencapture`; it does not claim to execute the product handler.
- [Immutable baseline/candidate product proof](https://github.com/Alix-007/openclaw/actions/runs/29672029299) executes the registered `logbook.snapshot` node-host handler on `macos-15`, after building each exact product revision. Both matrix jobs passed.
- Healthy product path: the baseline produced a 15,219-byte JPEG in 861 ms and the candidate produced a 15,216-byte JPEG in 1,380 ms. The proof asserts the JPEG magic bytes and verifies the snapshot temporary directory is unchanged. Screen pixels are intentionally not uploaded by this run.
- Controlled stall injection: the proof identifies the direct `/usr/sbin/screencapture` child and its `logbook-snapshot-*.jpg` command, sends `SIGSTOP`, confirms process state `T<`, and then observes the real handler. This proves a controlled capture stall; it does not claim a naturally stalled Apple binary or a stalled `sips` process.
- Baseline `1b2598276ac1ceac826f2f7ba1172c157b66f30f`: after 28,029 ms the handler still had not returned, the child remained alive, and the temporary JPEG still existed. The proof's outer watchdog then intervened solely to terminate the baseline and verified no child or temporary file remained after handler cleanup.
- Candidate `aa7f5b03b8b03c515e28ea7a954cd1d509a9436d`: the product handler returned its timeout error after 25,036 ms, before the 28-second watchdog. The watchdog did not intervene; the stopped child was reaped before return, the temporary JPEG was removed, and final residual child/file checks were empty.
- Proof harness revision: [`71bf8468cc3b0768624eeac55373d4ae868702c6`](https://github.com/Alix-007/openclaw/commit/71bf8468cc3b0768624eeac55373d4ae868702c6). Downloaded `proof.json` SHA-256: baseline `89304917aec68374aee9dfec6dbf7f14321c95d632d344aa4a0ae1945085595e`; candidate `07e586df59adc7817f3c7a39b2ccbd3d1aca0f8884407ab4ea85d594adf06777`.

### Exact-head proof continuity (immutable no-runtime-diff)
- Current PR head: `19c21a9e7b8e0c935b15732982b1d766bbbfb493`.
- Previously proven candidate: `aa7f5b03b8b03c515e28ea7a954cd1d509a9436d` ([prior macOS controlled-stall proof run](https://github.com/Alix-007/openclaw/actions/runs/29672029299)).
- The GitHub Contents API returned identical Git blob SHAs for every changed file:
  - `extensions/logbook/src/node-host.test.ts`: old `cbd476a857ad12031d6a2e15fed1865c2dddefaf` = current `cbd476a857ad12031d6a2e15fed1865c2dddefaf`
  - `extensions/logbook/src/node-host.ts`: old `fa346bb579385380900bc02c5928bcf85d194959` = current `fa346bb579385380900bc02c5928bcf85d194959`
- Exact-head CI context: [run 29716282578](https://github.com/openclaw/openclaw/actions/runs/29716282578), required lanes passed; the repository proof-context check passed in [run 29716281681](https://github.com/openclaw/openclaw/actions/runs/29716281681).
- Reproduction boundary: this is an immutable source-equivalence proof, not a claim of a new macOS execution. Both changed source/test blobs are identical to the previously proven candidate, so the linked controlled capture stall, timeout, child reaping, and cleanup behavior remains applicable to the current head.
- `PROOF_RESULT=PASS` (2/2 changed files identical; no runtime/test diff after the prior macOS proof).