### PR TITLE
fix(telegram): bound ingress claim owner lookup

### DIFF
--- a/extensions/telegram/src/telegram-ingress-claim-owner.test.ts
+++ b/extensions/telegram/src/telegram-ingress-claim-owner.test.ts
@@ -1,0 +1,53 @@
+// Telegram tests cover bounded Darwin claim-owner identity lookup.
+import childProcess from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      execFileSync: vi.fn(),
+    },
+  };
+});
+
+const execFileSyncMock = vi.mocked(childProcess.execFileSync);
+
+async function importClaimOwnerAsDarwin() {
+  vi.resetModules();
+  vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+  return await import("./telegram-ingress-claim-owner.js");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Telegram ingress claim owner", () => {
+  it("bounds the Darwin process start-time lookup", async () => {
+    execFileSyncMock.mockReturnValue("Mon Jul  6 12:34:56 2026\n");
+
+    const { TELEGRAM_SPOOLED_UPDATE_PROCESS_ID } = await importClaimOwnerAsDarwin();
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "/bin/ps",
+      ["-o", "lstart=", "-p", String(process.pid)],
+      expect.objectContaining({ timeout: 1_000 }),
+    );
+    expect(TELEGRAM_SPOOLED_UPDATE_PROCESS_ID.split(":")[1]).toBe(
+      String(Date.UTC(2026, 6, 6, 12, 34, 56) / 1000),
+    );
+  });
+
+  it("falls back to the existing x token when the Darwin lookup times out", async () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error("spawnSync /bin/ps ETIMEDOUT"), { code: "ETIMEDOUT" });
+    });
+
+    const { TELEGRAM_SPOOLED_UPDATE_PROCESS_ID } = await importClaimOwnerAsDarwin();
+
+    expect(TELEGRAM_SPOOLED_UPDATE_PROCESS_ID.split(":")[1]).toBe("x");
+  });
+});

--- a/extensions/telegram/src/telegram-ingress-claim-owner.test.ts
+++ b/extensions/telegram/src/telegram-ingress-claim-owner.test.ts
@@ -1,19 +1,12 @@
 // Telegram tests cover bounded Darwin claim-owner identity lookup.
-import childProcess from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      execFileSync: vi.fn(),
-    },
-  };
-});
+const execFileSyncMock = vi.hoisted(() => vi.fn());
 
-const execFileSyncMock = vi.mocked(childProcess.execFileSync);
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: execFileSyncMock,
+}));
 
 async function importClaimOwnerAsDarwin() {
   vi.resetModules();
@@ -23,6 +16,7 @@ async function importClaimOwnerAsDarwin() {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  execFileSyncMock.mockReset();
 });
 
 describe("Telegram ingress claim owner", () => {
@@ -34,7 +28,7 @@ describe("Telegram ingress claim owner", () => {
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "/bin/ps",
       ["-o", "lstart=", "-p", String(process.pid)],
-      expect.objectContaining({ timeout: 1_000 }),
+      expect.objectContaining({ killSignal: "SIGKILL", timeout: 1_000 }),
     );
     expect(TELEGRAM_SPOOLED_UPDATE_PROCESS_ID.split(":")[1]).toBe(
       String(Date.UTC(2026, 6, 6, 12, 34, 56) / 1000),

--- a/extensions/telegram/src/telegram-ingress-claim-owner.ts
+++ b/extensions/telegram/src/telegram-ingress-claim-owner.ts
@@ -11,6 +11,7 @@ import type {
 // Liveness default: a claim older than its lease is never live-owner protected,
 // so recovery can reclaim it even when the owner process still exists.
 const TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS = 30 * 60 * 1000;
+const TELEGRAM_PROCESS_START_TIME_LOOKUP_TIMEOUT_MS = 1_000;
 
 type TelegramSpooledClaimLivenessOptions = {
   maxAgeMs?: number;
@@ -27,11 +28,13 @@ function readProcessStartTime(pid: number): number | null {
   }
   if (process.platform === "darwin") {
     try {
+      // This runs during module initialization, so a stuck ps must not block Telegram startup.
       const startedAt = childProcess
         .execFileSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
           encoding: "utf8",
           env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
           stdio: ["ignore", "pipe", "ignore"],
+          timeout: TELEGRAM_PROCESS_START_TIME_LOOKUP_TIMEOUT_MS,
         })
         .trim();
       const startedAtMs = Date.parse(`${startedAt} UTC`);

--- a/extensions/telegram/src/telegram-ingress-claim-owner.ts
+++ b/extensions/telegram/src/telegram-ingress-claim-owner.ts
@@ -1,5 +1,5 @@
 // Telegram plugin module implements telegram ingress claim-owner identity.
-import childProcess from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import type { ChannelIngressQueueCorruptClaim } from "openclaw/plugin-sdk/channel-outbound";
@@ -29,14 +29,13 @@ function readProcessStartTime(pid: number): number | null {
   if (process.platform === "darwin") {
     try {
       // This runs during module initialization, so a stuck ps must not block Telegram startup.
-      const startedAt = childProcess
-        .execFileSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
-          encoding: "utf8",
-          env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
-          stdio: ["ignore", "pipe", "ignore"],
-          timeout: TELEGRAM_PROCESS_START_TIME_LOOKUP_TIMEOUT_MS,
-        })
-        .trim();
+      const startedAt = execFileSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
+        encoding: "utf8",
+        env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: TELEGRAM_PROCESS_START_TIME_LOOKUP_TIMEOUT_MS,
+        killSignal: "SIGKILL",
+      }).trim();
       const startedAtMs = Date.parse(`${startedAt} UTC`);
       return Number.isFinite(startedAtMs) ? Math.floor(startedAtMs / 1000) : null;
     } catch {


### PR DESCRIPTION
## What Problem This Solves

On macOS, Telegram ingress claim ownership reads the current process start time with a synchronous `/bin/ps` call during module initialization. The call had no deadline, so an unresponsive process lookup could block Telegram startup before polling or webhook ingress begins.

## Why This Change Was Made

Add the same one-second practical bound used by comparable macOS process-identity lookups, with `SIGKILL` so a child that ignores the default `SIGTERM` cannot keep this synchronous startup path waiting. The existing catch path remains authoritative: timeout or any other lookup failure uses the conservative `x` identity token, which keeps fresh claims protected by existence rather than allowing a second owner.

This is intentionally local to the current Telegram owner module. Open PR #108924 moves the owner implementation into core; if that refactor lands first or rebases across this change, its migrated copy should preserve this timeout and fallback coverage.

## User Impact

Telegram startup is no longer allowed to wait indefinitely for an ordinary stuck macOS process metadata lookup. Normal owner identity and spool lease behavior are unchanged; lookup failures retain the existing conservative fallback.

## Evidence

- Node 24.15.0 focused test: `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-claim-owner.test.ts extensions/telegram/src/telegram-ingress-spool.test.ts` -> 2 files passed, 22 tests passed.
- `oxfmt --check` and targeted `oxlint` passed for both changed files; `git diff --check HEAD^..HEAD` passed.
- Controlled Node 24.15.0 proof: a child that ignored `SIGTERM` was terminated by the configured `SIGKILL` deadline with `ETIMEDOUT` after 105 ms; the same bounded real `/bin/ps` lookup completed in 28 ms.
- Focused tests prove both the successful start-time token and the existing `x` fallback when `execFileSync` times out, and now assert the hard-kill option.
- The named ESM mock removes the prior `check-test-types` `TS2339` failure; exact-head CI is the authoritative type-check proof.
- Fresh independent adversarial review found no actionable code issues in commit `6e346bf55ce7`.
- A real macOS Telegram startup-path proof is still unavailable in this Linux environment; no claim is made that the controlled process probe is an authenticated or end-to-end Telegram run.

AI-assisted: yes (Codex). No generated code was accepted without focused tests and independent review.
