### PR TITLE
fix(e2e): share ClawHub preflight timeout across fetch and body

### DIFF
--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -846,46 +846,28 @@ async function assertClawHubPreflight() {
   ).replace(/\/+$/, "");
   const token = process.env.CLAWHUB_TOKEN || process.env.CLAWHUB_AUTH_TOKEN || "";
   const preflightUrl = `${baseUrl}/api/v1/packages/${encodeURIComponent(packageName)}`;
-  const response = await withTimeout(
+  // One deadline covers fetch + body read. timeoutMs is a total budget, not per phase.
+  const detail = await withTimeout(
     `ClawHub package preflight for ${packageName}`,
     limits.timeoutMs,
-    (signal) =>
-      fetch(preflightUrl, {
+    async (signal, timeoutPromise) => {
+      const response = await fetch(preflightUrl, {
         headers: token ? { Authorization: `Bearer ${token}` } : undefined,
         signal,
-      }),
-  );
-  if (!response.ok) {
-    const body = await withTimeout(
-      `ClawHub package preflight response for ${packageName}`,
-      limits.timeoutMs,
-      (_signal, timeoutPromise) =>
-        readBoundedResponseText(
-          response,
-          `ClawHub package preflight response for ${packageName}`,
-          limits.bodyMaxBytes,
-          timeoutPromise,
-        ),
-    );
-    throw new Error(
-      `ClawHub package preflight failed for ${packageName}: ${response.status} ${body}`,
-    );
-  }
-  const rawDetail = await withTimeout(
-    `ClawHub package preflight response for ${packageName}`,
-    limits.timeoutMs,
-    (_signal, timeoutPromise) =>
-      readBoundedResponseText(
+      });
+      const rawDetail = await readBoundedResponseText(
         response,
         `ClawHub package preflight response for ${packageName}`,
         limits.bodyMaxBytes,
         timeoutPromise,
-      ),
-  );
-  const detail = await withTimeout(
-    `ClawHub package preflight JSON for ${packageName}`,
-    limits.timeoutMs,
-    () => JSON.parse(rawDetail),
+      );
+      if (!response.ok) {
+        throw new Error(
+          `ClawHub package preflight failed for ${packageName}: ${response.status} ${rawDetail}`,
+        );
+      }
+      return JSON.parse(rawDetail);
+    },
   );
   const family = detail.package?.family;
   if (family !== "code-plugin" && family !== "bundle-plugin") {

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -225,7 +225,10 @@ describe("plugins Docker assertions", () => {
     expect(script).toContain("run(controller.signal, timeoutPromise)");
     expect(
       script.match(/readBoundedResponseText\([\s\S]*?limits\.bodyMaxBytes,\n\s+timeoutPromise,/gu),
-    ).toHaveLength(2);
+    ).toHaveLength(1);
+    expect(script).toMatch(
+      /withTimeout\(\s*`ClawHub package preflight for \$\{packageName\}`,\s*limits\.timeoutMs,\s*async \(signal, timeoutPromise\) => \{[\s\S]*?fetch\([\s\S]*?readBoundedResponseText\([\s\S]*?JSON\.parse\(rawDetail\)/u,
+    );
   });
 
   it("keeps sweep artifact paths aligned with the assertion scratch root", () => {
@@ -1444,8 +1447,53 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain(
-        "ClawHub package preflight response for @openclaw/kitchen-sink timed out after 75ms",
+        "ClawHub package preflight for @openclaw/kitchen-sink timed out after 75ms",
       );
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("keeps ClawHub preflight wall time within one shared timeout budget", async () => {
+    const timeoutMs = 300;
+    const headerDelayMs = 250;
+    // Shared budget finishes near spawn + timeoutMs. Stacked per-phase budgets need at
+    // least spawn + headerDelayMs + timeoutMs, so they cannot pass this ceiling.
+    const maxSharedElapsedMs = timeoutMs + 240;
+    const server = createServer((_request, response) => {
+      const timer = setTimeout(() => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.flushHeaders();
+        response.write("{");
+      }, headerDelayMs);
+      timer.unref?.();
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP server address");
+      }
+      const started = Date.now();
+      const result = await runAssertionAsync(["clawhub-preflight"], {
+        CLAWHUB_PLUGIN_ID: "openclaw-kitchen-sink-fixture",
+        CLAWHUB_PLUGIN_SPEC: "clawhub:@openclaw/kitchen-sink",
+        OPENCLAW_CLAWHUB_URL: `http://127.0.0.1:${address.port}`,
+        OPENCLAW_PLUGINS_E2E_CLAWHUB_PREFLIGHT_TIMEOUT_MS: String(timeoutMs),
+      });
+      const elapsedMs = Date.now() - started;
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        `ClawHub package preflight for @openclaw/kitchen-sink timed out after ${timeoutMs}ms`,
+      );
+      expect(maxSharedElapsedMs).toBeLessThan(headerDelayMs + timeoutMs);
+      expect(elapsedMs).toBeLessThan(maxSharedElapsedMs);
     } finally {
       await new Promise<void>((resolve) => {
         server.close(() => resolve());


### PR DESCRIPTION
## What Problem This Solves

ClawHub package preflight in the plugins E2E helper stacked separate deadlines for
HTTP fetch, bounded body read, and JSON parse. A slow header phase plus a stalled
body could therefore consume more than one configured
`OPENCLAW_PLUGINS_E2E_CLAWHUB_PREFLIGHT_TIMEOUT_MS` budget before failing.

## Why This Change Was Made

Put fetch, `readBoundedResponseText`, and `JSON.parse` under one outer
`withTimeout` whose `timeoutPromise` is also passed into the bounded reader.
`timeoutMs` is a total wall-clock budget for the preflight, not a per-phase
allowance.

## User Impact

No end-user product change. Plugin E2E ClawHub preflight fails closed within one
configured deadline when package metadata headers or bodies stall, instead of
overrunning stacked phase budgets.

## Evidence

- Changed: `scripts/e2e/lib/plugins/assertions.mjs`,
  `test/scripts/plugins-assertions.test.ts`
- Production caller path: plugins E2E `clawhub-preflight` →
  `assertClawHubPreflight` → one `withTimeout(…, limits.timeoutMs, …)` covering
  `fetch` + `readBoundedResponseText(…, timeoutPromise)` + `JSON.parse`
- Compatibility: same env knobs
  (`OPENCLAW_PLUGINS_E2E_CLAWHUB_PREFLIGHT_TIMEOUT_MS`,
  `OPENCLAW_PLUGINS_E2E_CLAWHUB_PREFLIGHT_BODY_MAX_BYTES`); only the deadline
  model changes from phase-stacked to shared total

## Real behavior proof

### Behavior or issue addressed

Against a live loopback ClawHub package-metadata endpoint that delays headers
then never finishes the JSON body, production `clawhub-preflight` fails within
one shared `timeoutMs` budget. A completing metadata response still parses and
prints the package family on the same path.

### Canonical reachability path

`node scripts/e2e/lib/plugins/assertions.mjs clawhub-preflight` →
`assertClawHubPreflight` (`scripts/e2e/lib/plugins/assertions.mjs`) →
`withTimeout("ClawHub package preflight for …", limits.timeoutMs, …)` →
`fetch(preflightUrl, { signal })` →
`readBoundedResponseText(…, timeoutPromise)` → `JSON.parse(rawDetail)`

### Shared helper / provider constraint check

Reuses existing `withTimeout` + `readBoundedResponseText`; no new timeout env
surface. The outer `timeoutPromise` is forwarded into the body reader so the
shared deadline covers headers and body together.

### Real environment tested

Real HTTP transport: local `node:http` ClawHub stand-in on `127.0.0.1` serving
`/api/v1/packages/%40openclaw%2Fkitchen-sink`.

1. **Stalled:** delay headers 1000ms, write a partial JSON chunk, never end —
   drive production `assertions.mjs clawhub-preflight` with
   `OPENCLAW_PLUGINS_E2E_CLAWHUB_PREFLIGHT_TIMEOUT_MS=1500`.
2. **Completing:** return a full `code-plugin` package JSON on the same path
   with `timeoutMs=5000`.

Node v22.23.1, PR head `f664f7f640c9a83d65af4ca7c1ff5720e12af7d8`.

### Exact steps or command run after this patch

Production entrypoint driven against a live loopback ClawHub metadata server:

```bash
# Server A (stalled): delay headers 1000ms, write '{"package":', never end.
# Server B (complete): 200 + {"package":{"family":"code-plugin","runtimeId":"openclaw-kitchen-sink-fixture"}}
# For each server:
CLAWHUB_PLUGIN_ID=openclaw-kitchen-sink-fixture \
CLAWHUB_PLUGIN_SPEC='clawhub:@openclaw/kitchen-sink' \
OPENCLAW_CLAWHUB_URL="http://127.0.0.1:<port>" \
OPENCLAW_PLUGINS_E2E_CLAWHUB_PREFLIGHT_TIMEOUT_MS=<1500|5000> \
node scripts/e2e/lib/plugins/assertions.mjs clawhub-preflight
```

Supplemental focused regression on the same assertion helper:

```bash
node scripts/run-vitest.mjs test/scripts/plugins-assertions.test.ts -t "keeps ClawHub preflight wall time" --reporter=dot
```

### Evidence after fix

```text
proof root: /private/tmp/openclaw-pr-109045
assertions: /private/tmp/openclaw-pr-109045/scripts/e2e/lib/plugins/assertions.mjs
node: v22.23.1
head: f664f7f640c9a83d65af4ca7c1ff5720e12af7d8

=== stalled body under shared deadline ===
  ok: ceiling 2000ms is below stacked budget 2500ms
[stalled] loopback ClawHub at http://127.0.0.1:58205/api/v1/packages/%40openclaw%2Fkitchen-sink (headerDelay=1000ms, timeoutMs=1500)
  ok: stalled preflight exits non-zero — status=1
  ok: stalled preflight uses shared outer deadline — stderr contains: ClawHub package preflight for @openclaw/kitchen-sink timed out after 1500ms
  ok: stalled preflight stays within one shared budget — elapsed=1638ms < 2000ms (stacked would need >= 2500ms)
  detail: status=1 elapsed=1638ms stderr=… Error: ClawHub package preflight for @openclaw/kitchen-sink timed out after 1500ms … at assertClawHubPreflight (…/assertions.mjs:850:24) … code: 'ETIMEDOUT'

=== completing body under shared deadline ===
[complete] loopback ClawHub at http://127.0.0.1:58216/api/v1/packages/%40openclaw%2Fkitchen-sink (timeoutMs=5000)
  ok: completing preflight exits 0 — status=0
  ok: completing preflight parses family through shared deadline path
  detail: status=0 elapsed=155ms stdout="Using ClawHub package @openclaw/kitchen-sink (code-plugin)."

ALL PROOF ASSERTIONS PASSED
```

### Observed result after fix

With headers delayed 1000ms and a stalled body, production `clawhub-preflight`
fails closed at ~1638ms under a 1500ms shared budget — below the 2000ms shared
ceiling and well under the old stacked allowance (≥2500ms =
headerDelay + timeoutMs). The error is the outer preflight timeout
(`ETIMEDOUT` from `assertClawHubPreflight`), not a second per-phase body
deadline. A completing metadata body still succeeds and prints the package
family.

### What was not tested

Live stall against production `https://clawhub.ai` package metadata outside the
loopback harness.

### Fix classification

bugfix — timeout/hang (E2E automation)

## AI Assistance

AI-assisted. Author reviewed the shared-deadline wiring and the loopback
changed-path proof output for `clawhub-preflight`.
