### PR TITLE
fix(cross-os): clamp release-check loops to remaining deadline

### DIFF
--- a/scripts/lib/cross-os-release-checks/network-smokes.ts
+++ b/scripts/lib/cross-os-release-checks/network-smokes.ts
@@ -14,7 +14,7 @@ import {
   waitForInstalledGateway,
 } from "./installed.ts";
 import { stopGateway } from "./process.ts";
-import { formatError, sleep } from "./shared.ts";
+import { clampTimeoutMs, formatError, remainingMs, sleep } from "./shared.ts";
 
 export function buildCrossOsDiscordRoundtripNonces() {
   return {
@@ -236,16 +236,36 @@ export function resolveDashboardAssetUrls(dashboardUrl: string, html: string): s
 export async function verifyDashboardAssetUrls(
   assetUrls: string[],
   fetchAsset: typeof fetch = fetch,
+  options: { deadline?: number; signal?: AbortSignal } = {},
 ): Promise<{ failures: string[]; ok: boolean }> {
   if (assetUrls.length === 0) {
     return { failures: ["no dashboard asset URLs found"], ok: false };
   }
   const failures: string[] = [];
   for (const assetUrl of assetUrls) {
+    if (options.deadline != null && remainingMs(options.deadline) <= 0) {
+      failures.push(`${assetUrl} deadline exceeded`);
+      break;
+    }
     try {
-      const response = await fetchAsset(assetUrl, {
-        signal: AbortSignal.timeout(CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS),
-      });
+      // Prefer an explicit caller signal; otherwise clamp AbortSignal.timeout to the
+      // remaining smoke deadline so the last asset fetch cannot overrun the budget.
+      let signal = options.signal;
+      if (!signal) {
+        const timeoutMs =
+          options.deadline != null
+            ? clampTimeoutMs(options.deadline, CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS)
+            : CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS;
+        signal = AbortSignal.timeout(timeoutMs);
+      } else if (options.deadline != null) {
+        signal = AbortSignal.any([
+          signal,
+          AbortSignal.timeout(
+            clampTimeoutMs(options.deadline, CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS),
+          ),
+        ]);
+      }
+      const response = await fetchAsset(assetUrl, { signal });
       await response.body?.cancel().catch(() => undefined);
       if (!response.ok) {
         failures.push(`${assetUrl} status=${response.status}`);
@@ -259,28 +279,39 @@ export async function verifyDashboardAssetUrls(
 
 async function waitForDiscordMessage(params: { token: string; channelId: string; needle: string }) {
   const deadline = Date.now() + 3 * 60 * 1000;
-  while (Date.now() < deadline) {
+  while (remainingMs(deadline) > 0) {
     let response;
     let text;
     try {
-      const init = buildDiscordFetchInit(params.token);
+      const init = buildDiscordFetchInit(params.token, {
+        signal: AbortSignal.timeout(clampTimeoutMs(deadline, CROSS_OS_DISCORD_FETCH_TIMEOUT_MS)),
+      });
       response = await fetch(
         `https://discord.com/api/v10/channels/${params.channelId}/messages?limit=20`,
         init,
       );
       text = await readBoundedCrossOsResponseText(response, undefined, { signal: init.signal });
     } catch {
-      await sleep(2_000);
+      if (remainingMs(deadline) <= 0) {
+        break;
+      }
+      await sleep(clampTimeoutMs(deadline, 2_000));
       continue;
     }
     if (!response.ok) {
-      await sleep(2_000);
+      if (remainingMs(deadline) <= 0) {
+        break;
+      }
+      await sleep(clampTimeoutMs(deadline, 2_000));
       continue;
     }
     if (text.includes(params.needle)) {
       return;
     }
-    await sleep(2_000);
+    if (remainingMs(deadline) <= 0) {
+      break;
+    }
+    await sleep(clampTimeoutMs(deadline, 2_000));
   }
   throw new Error(`Discord host-side visibility check timed out for ${params.needle}.`);
 }
@@ -359,7 +390,7 @@ async function waitForInstalledDiscordReadback(params: {
   needle: string;
 }) {
   const deadline = Date.now() + 3 * 60 * 1000;
-  while (Date.now() < deadline) {
+  while (remainingMs(deadline) > 0) {
     const response = await runInstalledCli({
       cliPath: params.cliPath,
       args: [
@@ -376,13 +407,16 @@ async function waitForInstalledDiscordReadback(params: {
       cwd: params.cwd,
       env: params.env,
       logPath: params.logPath,
-      timeoutMs: 60_000,
+      timeoutMs: clampTimeoutMs(deadline, 60_000),
       check: false,
     });
     if (response.exitCode === 0 && response.stdout.includes(params.needle)) {
       return;
     }
-    await sleep(3_000);
+    if (remainingMs(deadline) <= 0) {
+      break;
+    }
+    await sleep(clampTimeoutMs(deadline, 3_000));
   }
   throw new Error(`Discord guest readback timed out for ${params.needle}.`);
 }

--- a/scripts/lib/cross-os-release-checks/runtime.ts
+++ b/scripts/lib/cross-os-release-checks/runtime.ts
@@ -43,7 +43,7 @@ import {
 } from "./network-smokes.ts";
 import { registerActiveChildProcessTree, runCommand, withAllocatedGatewayPort } from "./process.ts";
 import { logLanePhase } from "./reporting.ts";
-import { formatError, sleep } from "./shared.ts";
+import { clampTimeoutMs, formatError, remainingMs, sleep } from "./shared.ts";
 
 export async function runOpenClaw(params: {
   lane: LaneState;
@@ -340,11 +340,13 @@ export async function runDashboardSmoke(params: Pick<LaneCommandParams, "lane" |
   const deadline = Date.now() + CROSS_OS_DASHBOARD_SMOKE_TIMEOUT_MS;
   let attempt = 0;
   try {
-    while (Date.now() < deadline) {
+    while (remainingMs(deadline) > 0) {
       attempt += 1;
       logStream.write(`${new Date().toISOString()} attempt=${attempt} url=${dashboardUrl}\n`);
       try {
-        const signal = AbortSignal.timeout(CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS);
+        const signal = AbortSignal.timeout(
+          clampTimeoutMs(deadline, CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS),
+        );
         const response = await fetch(dashboardUrl, {
           signal,
         });
@@ -352,7 +354,7 @@ export async function runDashboardSmoke(params: Pick<LaneCommandParams, "lane" |
         const markers = dashboardHtmlMarkerStatus(html);
         const assetUrls = resolveDashboardAssetUrls(dashboardUrl, html);
         if (response.ok && markers.ready) {
-          const assets = await verifyDashboardAssetUrls(assetUrls);
+          const assets = await verifyDashboardAssetUrls(assetUrls, fetch, { deadline });
           if (assets.ok) {
             logStream.write(
               `${new Date().toISOString()} dashboard-ready status=${response.status} assets=${assetUrls.length}\n`,
@@ -371,7 +373,10 @@ export async function runDashboardSmoke(params: Pick<LaneCommandParams, "lane" |
           `${new Date().toISOString()} dashboard-fetch-error ${formatError(error)}\n`,
         );
       }
-      await sleep(1_000);
+      if (remainingMs(deadline) <= 0) {
+        break;
+      }
+      await sleep(clampTimeoutMs(deadline, 1_000));
     }
   } finally {
     logStream.end();

--- a/scripts/lib/cross-os-release-checks/shared.ts
+++ b/scripts/lib/cross-os-release-checks/shared.ts
@@ -44,6 +44,19 @@ export function sleep(ms: number) {
   });
 }
 
+/** Milliseconds left before an absolute deadline. May be zero or negative. */
+export function remainingMs(deadline: number, now = Date.now()): number {
+  return deadline - now;
+}
+
+/**
+ * Caps a per-attempt timeout to the remaining deadline budget.
+ * Callers must check remainingMs(deadline) > 0 before starting work that needs a timeout.
+ */
+export function clampTimeoutMs(deadline: number, maxMs: number, now = Date.now()): number {
+  return Math.max(1, Math.min(maxMs, deadline - now));
+}
+
 export function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
   if (value instanceof Error) {
     return value;

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve as resolvePath, win32 } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   agentOutputHasExpectedOkMarker,
   agentTurnUsedEmbeddedFallback,
@@ -36,6 +36,7 @@ import {
   buildInstallerSmokeScript,
   buildWindowsPathBootstrapScript,
   canConnectToLoopbackPort,
+  clampTimeoutMs,
   buildDiscordSmokeGuildsConfig,
   buildRealUpdateEnv,
   dashboardHtmlMarkerStatus,
@@ -53,6 +54,7 @@ import {
   CROSS_OS_AGENT_TURN_TIMEOUT_SECONDS,
   CROSS_OS_COMMAND_HEARTBEAT_SECONDS,
   deleteDiscordMessage,
+  remainingMs,
   isImmutableReleaseRef,
   isRecoverableWindowsPackagedUpgradeSwapCleanupFailure,
   isRecoverableWindowsPackagedUpgradeTimeoutError,
@@ -266,6 +268,51 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
 
     expect(result.ok).toBe(false);
     expect(result.failures).toEqual(["http://127.0.0.1:18789/assets/index.js status=404"]);
+  });
+
+  it("clamps per-attempt timeouts to the remaining deadline budget", () => {
+    const now = 1_000_000;
+    expect(remainingMs(now + 250, now)).toBe(250);
+    expect(remainingMs(now - 1, now)).toBe(-1);
+    expect(clampTimeoutMs(now + 250, CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS, now)).toBe(250);
+    expect(clampTimeoutMs(now + 60_000, CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS, now)).toBe(
+      CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS,
+    );
+    expect(clampTimeoutMs(now + 1, 2_000, now)).toBe(1);
+  });
+
+  it("clamps dashboard asset AbortSignal.timeout to remaining deadline on last iteration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    try {
+      const deadline = Date.now() + 250;
+      const result = await verifyDashboardAssetUrls(
+        ["http://127.0.0.1:18789/assets/index.css"],
+        async () => new Response("", { status: 200 }),
+        { deadline },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(timeoutSpy).toHaveBeenCalledWith(250);
+      expect(timeoutSpy.mock.calls.every(([ms]) => (ms as number) <= 250)).toBe(true);
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops dashboard asset verification when the deadline is already exhausted", async () => {
+    const fetchAsset = vi.fn(async () => new Response("", { status: 200 }));
+    const result = await verifyDashboardAssetUrls(
+      ["http://127.0.0.1:18789/assets/index.css", "http://127.0.0.1:18789/assets/index.js"],
+      fetchAsset,
+      { deadline: Date.now() - 1 },
+    );
+
+    expect(fetchAsset).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.failures).toEqual(["http://127.0.0.1:18789/assets/index.css deadline exceeded"]);
   });
 
   it("keeps gateway RPC status probes patient enough for live release startup", () => {


### PR DESCRIPTION
## What Problem This Solves

Cross-OS release-check loops declare a total deadline but still armed each iteration with a full fetch/CLI timeout and an unclamped sleep. Near the deadline edge, `runDashboardSmoke`/`verifyDashboardAssetUrls` dashboard asset probes (10s each) and the Discord host/guest readback polls (60s CLI, 2–3s sleeps) could overrun the advertised budget by tens of seconds — the final asset fetch could arm a fresh 10s `AbortSignal.timeout` when only milliseconds of the smoke deadline remained.

## Why This Change Was Made

Add shared `remainingMs` / `clampTimeoutMs` helpers and clamp every per-attempt fetch timeout, CLI timeout, and sleep to the remaining deadline. `verifyDashboardAssetUrls` now accepts an optional `deadline` (and passthrough `signal`) so nested asset fetches inherit the same budget and short-circuit once it is exhausted.

## User Impact

**Before:** The last dashboard-asset fetch / Discord poll could run a full fixed timeout past the smoke deadline, drifting lanes tens of seconds beyond budget.

**After:** Cross-OS dashboard and Discord smoke loops fail closed at (not well past) their configured deadlines; the final attempt is bounded by whatever budget remains.

## Evidence

- Changed: `scripts/lib/cross-os-release-checks/{shared,runtime,network-smokes}.ts`, `test/scripts/openclaw-cross-os-release-checks.test.ts`
- Production caller path: `runDashboardSmoke` → `verifyDashboardAssetUrls(assetUrls, fetch, { deadline })` → `AbortSignal.timeout(clampTimeoutMs(deadline, CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS))` (`scripts/lib/cross-os-release-checks/network-smokes.ts:236`).

## Real behavior proof

### Behavior or issue addressed

A hung dashboard asset fetch on the final smoke iteration is aborted at the remaining deadline instead of arming a fresh 10s fetch timeout, so `verifyDashboardAssetUrls` cannot overrun the smoke budget. Reachable assets still verify OK; an already-exhausted deadline short-circuits before any fetch.

### Canonical reachability path

`runDashboardSmoke` (`scripts/lib/cross-os-release-checks/runtime.ts:340`) computes `deadline = Date.now() + CROSS_OS_DASHBOARD_SMOKE_TIMEOUT_MS` and calls `verifyDashboardAssetUrls(assetUrls, fetch, { deadline })`; each asset fetch uses `AbortSignal.timeout(clampTimeoutMs(deadline, CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS))` and the loop bails when `remainingMs(deadline) <= 0`.

### Real environment tested

Real HTTP transport: a local `node:http` server on `127.0.0.1` with two behaviors — an asset endpoint that accepts the request but **never** sends a response (hang), and a normal `200 text/css` asset. The exported production `verifyDashboardAssetUrls` is driven directly against those live sockets with the real global `fetch` and a small `deadline`, so the abort is produced by the production clamp path, not a mock. `CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS` = 10000ms. Node v22.23.1, Vitest.

### Exact steps or command run after this patch

```bash
# Real HTTP server: hung asset endpoint + a reachable asset; drive the production
# verifyDashboardAssetUrls with a small smoke deadline.
node scripts/run-vitest.mjs test/scripts/cross-os-dashboard-deadline.proof.test.ts -- --reporter=verbose

# Committed deterministic regressions (arithmetic + clamp + short-circuit):
node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts -- \
  -t 'clamp|deadline|dashboard asset' --reporter=verbose
```

### Evidence after fix

Real HTTP behavior (production `verifyDashboardAssetUrls` against live sockets):

```text
  hung-asset verify ok: false
  hung-asset elapsed: 306ms (deadline budget 300ms, fixed fetch timeout 10000ms)
  failure: http://127.0.0.1:58935/stall TimeoutError: The operation was aborted due to timeout
  reachable-asset verify ok: true

ALL PROOF ASSERTIONS PASSED
 ✓ test/scripts/cross-os-dashboard-deadline.proof.test.ts > aborts a hung asset fetch at the remaining deadline, not the 10s fetch timeout 318ms
```

Committed deterministic regressions:

```text
 ✓ … > clamps per-attempt timeouts to the remaining deadline budget 1ms
 ✓ … > clamps dashboard asset AbortSignal.timeout to remaining deadline on last iteration 2ms
 ✓ … > stops dashboard asset verification when the deadline is already exhausted 0ms
```

### Observed result after fix

Against a real hung socket with a 300ms remaining deadline, the asset fetch aborts with `TimeoutError: The operation was aborted due to timeout` in 306ms — bounded by the clamped remaining budget, far below the fixed 10000ms dashboard-fetch timeout that the pre-fix code would have armed. A reachable `200` asset still verifies OK, and an already-exhausted deadline short-circuits before any fetch (`fetchAsset` never called).

### What was not tested

A full live cross-OS release lane driving `runDashboardSmoke` end-to-end against a real gateway dashboard; the proof exercises the exported `verifyDashboardAssetUrls` clamp path directly against a real hung server.

### Fix classification

bugfix — timeout/deadline clamping

## AI Assistance

AI-assisted. Author reviewed the clamp helpers, the dashboard/Discord loop call sites, and the real-server proof output.
