### PR TITLE
fix(ci): bound opengrep installer downloads with connect and max-time limits

### DIFF
--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -38,7 +38,8 @@ jobs:
           OPENGREP_VERSION: v1.22.0
           OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
+          curl -fsSL --connect-timeout 10 --max-time 120 \
+            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
             | bash -s -- -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -64,7 +64,8 @@ jobs:
           OPENGREP_VERSION: v1.22.0
           OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
+          curl -fsSL --connect-timeout 10 --max-time 120 \
+            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
             | bash -s -- -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
## What Problem This Solves

The opengrep CI workflows fetch the opengrep installer via curl-pipe-bash without connect-timeout or max-time bounds. A stalled GitHub raw content server would cause CI jobs to hang until the default job timeout.

## Why This Change Was Made

Adds --connect-timeout 10 --max-time 120 to both curl commands, matching the pattern established by recently merged CI bounding PRs.

## User Impact

- CI jobs no longer hang indefinitely on stalled opengrep installer downloads
- No change to successful downloads
- Same timeout values used by sibling CI workflows curl commands