### PR TITLE
fix(anthropic): honor server retry timing

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -319,6 +319,8 @@ export interface AssistantMessage {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  httpStatus?: number;
+  retryAfterSeconds?: number;
   timestamp: number; // Unix timestamp in milliseconds
 }
 

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -15,6 +15,10 @@ const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
 
 vi.mock("./provider-transport-fetch.js", () => ({
   buildGuardedModelFetch: buildGuardedModelFetchMock,
+  parseRetryAfterSeconds: (headers: Headers) => {
+    const value = headers.get("retry-after");
+    return value && /^\d+$/.test(value) ? Number(value) : undefined;
+  },
 }));
 
 let createAnthropicMessagesTransportStreamFn: typeof import("./anthropic-transport-stream.js").createAnthropicMessagesTransportStreamFn;
@@ -4101,6 +4105,28 @@ describe("anthropic transport stream", () => {
     // surfaces the SSE error as an explicit "error" event or silently ends the
     // stream (a timing artefact of synchronous mock SSE delivery).
     expect(eventTypes).not.toContain("start");
+  });
+
+  it("preserves status and retry-after metadata from HTTP failures", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response('{"type":"error","error":{"type":"rate_limit_error"}}', {
+        status: 429,
+        headers: { "retry-after": "30" },
+      }),
+    );
+    const stream = await createAnthropicMessagesTransportStreamFn()(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hi" }] } as AnthropicStreamContext,
+      { apiKey: "x" } as AnthropicStreamOptions,
+    );
+
+    const result = await stream.result();
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      httpStatus: 429,
+      retryAfterSeconds: 30,
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -73,7 +73,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dyn
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { unwrapModelHeaderSentinelsForProviderEgress } from "./provider-secret-egress.js";
-import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
+import { buildGuardedModelFetch, parseRetryAfterSeconds } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
@@ -836,8 +836,12 @@ function createAnthropicMessagesClient(params: {
         });
         if (!response.ok) {
           const detail = await readAnthropicMessagesErrorBodySnippet(response);
-          throw new Error(
-            detail || `Anthropic Messages request failed with HTTP ${response.status}`,
+          throw Object.assign(
+            new Error(detail || `Anthropic Messages request failed with HTTP ${response.status}`),
+            {
+              httpStatus: response.status,
+              retryAfterSeconds: parseRetryAfterSeconds(response.headers),
+            },
           );
         }
         if (!response.body) {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -452,7 +452,7 @@ async function requestBodyHasStreamTrue(
   }
 }
 
-function parseRetryAfterSeconds(headers: Headers): number | undefined {
+export function parseRetryAfterSeconds(headers: Headers): number | undefined {
   const retryAfterMs = headers.get("retry-after-ms");
   if (retryAfterMs) {
     const trimmedRetryAfterMs = retryAfterMs.trim();

--- a/src/agents/sessions/agent-session-execution.ts
+++ b/src/agents/sessions/agent-session-execution.ts
@@ -8,6 +8,8 @@ import type { BashExecutionMessage } from "./messages.js";
 import type { BashOperations } from "./tools/bash-operations.js";
 import { createLocalBashOperations } from "./tools/bash.js";
 
+const MAX_SERVER_RETRY_DELAY_MS = 60_000;
+
 export abstract class AgentSessionExecution extends AgentSessionExtensions {
   // =========================================================================
   // Auto-Retry
@@ -41,6 +43,15 @@ export abstract class AgentSessionExecution extends AgentSessionExtensions {
       return false;
     }
 
+    const serverDelayMs = Number.isFinite(message.retryAfterSeconds)
+      ? Math.ceil(Math.max(0, message.retryAfterSeconds ?? 0) * 1000)
+      : 0;
+    if (serverDelayMs > MAX_SERVER_RETRY_DELAY_MS) {
+      // A capped wait would violate the provider's cooldown. Leave long delays
+      // to the caller's final-error/failover path instead of retrying early.
+      return false;
+    }
+
     this.retryCount++;
 
     if (this.retryCount > settings.maxRetries) {
@@ -49,7 +60,9 @@ export abstract class AgentSessionExecution extends AgentSessionExtensions {
       return false;
     }
 
-    const delayMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
+    const backoffMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
+    // Provider cooldown is a lower bound; local backoff still applies when it is longer.
+    const delayMs = Math.max(backoffMs, serverDelayMs);
 
     this.emit({
       type: "auto_retry_start",

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -725,7 +725,7 @@ describe("createAgentSession thinking level defaults", () => {
 });
 
 describe("AgentSession retry behavior", () => {
-  async function createRetrySession() {
+  async function createRetrySession(baseDelayMs = 0) {
     const authStorage = AuthStorage.inMemory();
     authStorage.setRuntimeApiKey(testModel.provider, "test-api-key");
     return await createAgentSession({
@@ -733,7 +733,7 @@ describe("AgentSession retry behavior", () => {
       resourceLoader: createEmptyResourceLoader(),
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory({
-        retry: { baseDelayMs: 0, maxRetries: 1 },
+        retry: { baseDelayMs, maxRetries: 1 },
       }),
       modelRegistry: ModelRegistry.inMemory(authStorage),
     });
@@ -775,5 +775,83 @@ describe("AgentSession retry behavior", () => {
     expect(streamMocks.streamSimple.mock.calls.length).toBeGreaterThan(1);
     expect(transientEvents).toContain("auto_retry_start");
     expect(transientEvents).toContain("auto_retry_end");
+  });
+
+  it("uses bounded provider retry timing as the backoff lower bound", async () => {
+    streamMocks.streamSimple.mockReset();
+    streamMocks.streamSimple
+      .mockImplementationOnce(() =>
+        createAssistantResultStream({
+          ...createAssistantError("HTTP 429 temporary provider response"),
+          retryAfterSeconds: 0.01,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        createAssistantResultStream({
+          ...createAssistantError(""),
+          content: [{ type: "text", text: "recovered" }],
+          stopReason: "stop",
+          errorMessage: undefined,
+        }),
+      );
+    const { session } = await createRetrySession();
+    const retryDelays: number[] = [];
+    session.subscribe((event) => {
+      if (event.type === "auto_retry_start") {
+        retryDelays.push(event.delayMs);
+      }
+    });
+
+    await session.prompt("test provider retry timing");
+
+    expect(retryDelays).toEqual([10]);
+  });
+
+  it("does not retry before provider cooldowns longer than the session limit", async () => {
+    streamMocks.streamSimple.mockReset();
+    streamMocks.streamSimple.mockImplementation(() =>
+      createAssistantResultStream({
+        ...createAssistantError("HTTP 429 temporary provider response"),
+        retryAfterSeconds: 61,
+      }),
+    );
+    const { session } = await createRetrySession();
+    const retryEvents: string[] = [];
+    session.subscribe((event) => retryEvents.push(event.type));
+
+    await session.prompt("test long provider cooldown");
+
+    expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
+    expect(retryEvents).not.toContain("auto_retry_start");
+  });
+
+  it("preserves exponential backoff when it exceeds provider retry timing", async () => {
+    streamMocks.streamSimple.mockReset();
+    streamMocks.streamSimple
+      .mockImplementationOnce(() =>
+        createAssistantResultStream({
+          ...createAssistantError("HTTP 429 temporary provider response"),
+          retryAfterSeconds: 0.01,
+        }),
+      )
+      .mockImplementationOnce(() =>
+        createAssistantResultStream({
+          ...createAssistantError(""),
+          content: [{ type: "text", text: "recovered" }],
+          stopReason: "stop",
+          errorMessage: undefined,
+        }),
+      );
+    const { session } = await createRetrySession(20);
+    const retryDelays: number[] = [];
+    session.subscribe((event) => {
+      if (event.type === "auto_retry_start") {
+        retryDelays.push(event.delayMs);
+      }
+    });
+
+    await session.prompt("test longer exponential backoff");
+
+    expect(retryDelays).toEqual([20]);
   });
 });

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -114,4 +114,23 @@ describe("transport stream shared helpers", () => {
       expect(output.errorMessage).toBeTruthy();
     }
   });
+
+  it("preserves structured HTTP retry metadata", () => {
+    const output: {
+      stopReason: string;
+      httpStatus?: number;
+      retryAfterSeconds?: number;
+    } = { stopReason: "stop" };
+
+    assignTransportErrorDetails(
+      output,
+      Object.assign(new Error("rate limited"), { httpStatus: 429, retryAfterSeconds: 30 }),
+    );
+
+    expect(output).toMatchObject({
+      stopReason: "error",
+      httpStatus: 429,
+      retryAfterSeconds: 30,
+    });
+  });
 });

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -30,6 +30,8 @@ type TransportOutputShape = {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  httpStatus?: number;
+  retryAfterSeconds?: number;
 };
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
@@ -149,7 +151,17 @@ type TransportErrorDetails = {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  httpStatus?: number;
+  retryAfterSeconds?: number;
 };
+
+function readFiniteNumberProperty(value: unknown, key: string): number | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+}
 
 function readStringLikeProperty(value: unknown, key: string): string | undefined {
   if (!value || typeof value !== "object") {
@@ -229,11 +241,15 @@ function extractTransportErrorDetails(error: unknown): TransportErrorDetails {
     normalizeTransportErrorBody(readStringLikeProperty(errorObject, "body")) ??
     normalizeTransportErrorBody(readObjectProperty(errorObject, "body")) ??
     normalizeTransportErrorBody(nestedError);
+  const httpStatus = readFiniteNumberProperty(errorObject, "httpStatus");
+  const retryAfterSeconds = readFiniteNumberProperty(errorObject, "retryAfterSeconds");
 
   return {
     ...(errorCode ? { errorCode } : {}),
     ...(errorType ? { errorType } : {}),
     ...(errorBody ? { errorBody } : {}),
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
   };
 }
 


### PR DESCRIPTION
Closes #103849

## What Problem This Solves

Fixes an issue where Anthropic API rate-limit and overload responses lost their HTTP status and `Retry-After` timing before reaching session auto-retry. OpenClaw could retry earlier than the server-requested cooldown, increasing the chance of repeated failures.

## Why This Change Was Made

Anthropic transport errors now carry provider-generic HTTP status and retry timing metadata through the shared assistant-message projection. Session auto-retry uses supported provider delays up to 60 seconds as a lower bound while retaining longer exponential backoff. If a provider requests more than 60 seconds, session auto-retry declines the retry so the final-error/failover path can proceed without violating the cooldown.

The two added AssistantMessage fields are optional transient transport metadata. No SQLite schema, serialized session-entry shape, vector store, or migration changes are introduced.

## User Impact

Anthropic sessions respect server-provided cooldown timing without retrying early. Long cooldowns no longer get truncated to 60 seconds, and providers that do not supply retry metadata keep the existing retry behavior.

## Evidence

- Exact head: `03a0de073`
- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts src/agents/transport-stream-shared.test.ts src/agents/sessions/sdk.test.ts`: 145/145 tests passed.
- Boundary coverage proves a 61-second provider cooldown emits no `auto_retry_start`, and a 20 ms exponential backoff remains longer than a 10 ms provider hint.
- The prior `check-test-types` failure was fixed by awaiting the possibly async transport stream before reading `.result()`.
- `node_modules/.bin/oxfmt --check ...`: all three updated files passed formatting.
- `git diff --check`: passed.
- Exact-head Claude autoreview: clean, no accepted/actionable findings, correctness 0.95.
- Blacksmith Testbox remained unavailable because the local `blacksmith` CLI is not installed.

Exact-head real behavior proof used a real loopback HTTP server and the production Anthropic transport. The server returned a standards-compliant `429` with `Retry-After: 1`; the resulting AssistantMessage was then passed unchanged into the production session retry path:

```text
RESULT http_requests=1
RESULT stopReason=error
RESULT httpStatus=429
RESULT retryAfterSeconds=1
EVENT auto_retry_start delayMs=1000
EVENT auto_retry_end success=true
RESULT source_httpStatus=429
RESULT source_retryAfterSeconds=1
RESULT retry_delays=[1000]
```

The temporary proof harness and generated message artifact were removed after the passing run and are not part of the PR diff.

AI-assisted: yes. I reviewed the implementation, metadata flow, long-cooldown policy, and focused test behavior.
