### PR TITLE
fix(chat): keep internal metadata out of transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Reef transcript metadata:** keep untrusted peer provenance model-visible without persisting its wrapper in chat transcripts, and strip internal control tokens after inline directives while preserving visible and forwarded content. (#109056) Thanks @sallyom.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Reef transcript metadata:** keep untrusted peer provenance model-visible without persisting its wrapper in chat transcripts, and strip internal control tokens after inline directives while preserving visible and forwarded content. (#109056) Thanks @sallyom.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveReefInboundDispatchContent } from "./inbound.js";
+
+describe("Reef inbound dispatch content", () => {
+  it("keeps provenance model-visible without storing it in the transcript body", () => {
+    const content = resolveReefInboundDispatchContent({
+      id: "message-1",
+      peer: "clanky",
+      text: "hello from Clanky",
+      provenance: "Untrusted third-party data from @clanky's agent.",
+      autonomy: "bounded",
+    });
+
+    expect(content).toEqual({
+      rawBody: "hello from Clanky",
+      extraContext: {
+        UntrustedContext: ["Untrusted third-party data from @clanky's agent."],
+        ReefProvenance: "Untrusted third-party data from @clanky's agent.",
+        ReefEnvelopeId: "message-1",
+        SenderIsBot: true,
+      },
+    });
+  });
+});

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -19,6 +19,7 @@ import {
 } from "./config-schema.js";
 import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
 import { ReefFriendManager } from "./friends.js";
+import { resolveReefInboundDispatchContent } from "./inbound.js";
 import { reefMessageAdapter, reefOutboundAdapter } from "./outbound.js";
 import { getActiveReef, getOptionalReefRuntime, getReefRuntime, setActiveReef } from "./runtime.js";
 import { reefSetupAdapter, reefSetupWizard } from "./setup.js";
@@ -197,6 +198,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         },
       });
       const onIngress = async (message: ReefIngressMessage) => {
+        const dispatchContent = resolveReefInboundDispatchContent(message);
         const budget = autonomyBudget(message.autonomy);
         const loop = recordChannelBotPairLoopAndCheckSuppression({
           scopeId: "reef:default",
@@ -223,15 +225,9 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           senderAddress: `reef:${message.peer}`,
           recipientAddress: `reef:${ctx.account.config.handle}`,
           conversationLabel: `@${message.peer}'s agent`,
-          rawBody: message.text,
-          bodyForAgent: `${message.provenance}\n\n<reef-message>${message.text}</reef-message>`,
+          ...dispatchContent,
           messageId: message.id,
           commandAuthorized: false,
-          extraContext: {
-            ReefProvenance: message.provenance,
-            ReefEnvelopeId: message.id,
-            SenderIsBot: true,
-          },
           deliver: async (payload) => {
             const text =
               payload && typeof payload === "object" && "text" in payload

--- a/extensions/reef/src/inbound.ts
+++ b/extensions/reef/src/inbound.ts
@@ -1,0 +1,13 @@
+import type { ReefIngressMessage } from "./types.js";
+
+export function resolveReefInboundDispatchContent(message: ReefIngressMessage) {
+  return {
+    rawBody: message.text,
+    extraContext: {
+      UntrustedContext: [message.provenance],
+      ReefProvenance: message.provenance,
+      ReefEnvelopeId: message.id,
+      SenderIsBot: true,
+    },
+  };
+}

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -27,7 +27,10 @@ import {
 import { isOpenClawDeliveryMirrorAssistantMessage } from "../shared/transcript-only-openclaw-assistant.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { stripEnvelopeFromMessages } from "./chat-sanitize.js";
-import { isSuppressedControlReplyText } from "./control-reply-text.js";
+import {
+  isSuppressedControlReplyText,
+  stripSuppressedControlReplyToken,
+} from "./control-reply-text.js";
 
 export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 8_000;
 
@@ -635,8 +638,15 @@ function sanitizeChatHistoryMessage(
     }
   }
 
+  const stripAssistantControlTokens =
+    role === "assistant" && !shouldPreserveAssistantControlReplyText(entry);
+
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const controlStripped = stripAssistantControlTokens
+      ? stripSuppressedControlReplyToken(entry.content)
+      : entry.content;
+    const stripped = stripInlineDirectiveTagsForDisplay(controlStripped);
+    changed ||= controlStripped !== entry.content;
     if (preserveExactToolPayload) {
       entry.content = stripped.text;
       changed ||= stripped.changed;
@@ -646,9 +656,28 @@ function sanitizeChatHistoryMessage(
       changed ||= stripped.changed || res.truncated;
     }
   } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) =>
-      sanitizeChatHistoryContentBlock(block, { preserveExactToolPayload, maxChars }),
-    );
+    const updated = entry.content.map((block) => {
+      const sanitized = sanitizeChatHistoryContentBlock(block, {
+        preserveExactToolPayload,
+        maxChars,
+      });
+      if (
+        !stripAssistantControlTokens ||
+        !sanitized.block ||
+        typeof sanitized.block !== "object" ||
+        Array.isArray(sanitized.block)
+      ) {
+        return sanitized;
+      }
+      const contentBlock = sanitized.block as { type?: unknown; text?: unknown };
+      if (!isAssistantTextContentType(contentBlock.type) || typeof contentBlock.text !== "string") {
+        return sanitized;
+      }
+      const text = stripSuppressedControlReplyToken(contentBlock.text);
+      return text === contentBlock.text
+        ? sanitized
+        : { block: { ...contentBlock, text }, changed: true };
+    });
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);
       changed = true;
@@ -672,7 +701,11 @@ function sanitizeChatHistoryMessage(
   }
 
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const controlStripped = stripAssistantControlTokens
+      ? stripSuppressedControlReplyToken(entry.text)
+      : entry.text;
+    const stripped = stripInlineDirectiveTagsForDisplay(controlStripped);
+    changed ||= controlStripped !== entry.text;
     if (preserveExactToolPayload) {
       entry.text = stripped.text;
       changed ||= stripped.changed;
@@ -710,6 +743,9 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
       return undefined;
     }
     const typed = block as { type?: unknown; text?: unknown };
+    if (isAssistantInternalReasoningContentType(typed.type)) {
+      continue;
+    }
     if (!isAssistantTextContentType(typed.type) || typeof typed.text !== "string") {
       return undefined;
     }
@@ -720,6 +756,10 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
 
 function isAssistantTextContentType(type: unknown): boolean {
   return type === "text" || type === "input_text" || type === "output_text";
+}
+
+function isAssistantInternalReasoningContentType(type: unknown): boolean {
+  return type === "thinking" || type === "reasoning" || type === "redacted_thinking";
 }
 
 function hasAssistantNonTextContent(message: unknown): boolean {
@@ -735,6 +775,49 @@ function hasAssistantNonTextContent(message: unknown): boolean {
       block &&
       typeof block === "object" &&
       !isAssistantTextContentType((block as { type?: unknown }).type),
+  );
+}
+
+function hasAssistantDisplayableNonTextContent(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some(
+    (block) =>
+      block &&
+      typeof block === "object" &&
+      !isAssistantTextContentType((block as { type?: unknown }).type) &&
+      !isAssistantInternalReasoningContentType((block as { type?: unknown }).type),
+  );
+}
+
+function shouldPreserveAssistantControlReplyText(message: Record<string, unknown>): boolean {
+  if (isProjectedSessionsSendForwardedMessage(message)) {
+    return true;
+  }
+  const content = message.text ?? message.content;
+  const texts =
+    typeof content === "string"
+      ? [content]
+      : Array.isArray(content)
+        ? content.flatMap((block) => {
+            if (!block || typeof block !== "object" || Array.isArray(block)) {
+              return [];
+            }
+            const typed = block as { type?: unknown; text?: unknown };
+            return isAssistantTextContentType(typed.type) && typeof typed.text === "string"
+              ? [typed.text]
+              : [];
+          })
+        : [];
+  return (
+    texts.length > 0 &&
+    texts.every((text) => isSuppressedControlReplyText(text)) &&
+    hasAssistantDisplayableNonTextContent(message)
   );
 }
 
@@ -927,7 +1010,9 @@ function extractMessageToolVisibleReplies(
 function isAssistantSilentControlReplyOnly(message: Record<string, unknown>): boolean {
   const text = extractAssistantTextForSilentCheck(message);
   return (
-    text !== undefined && isSuppressedControlReplyText(text) && !hasAssistantNonTextContent(message)
+    text !== undefined &&
+    isSuppressedControlReplyText(text) &&
+    !hasAssistantDisplayableNonTextContent(message)
   );
 }
 
@@ -1243,7 +1328,7 @@ function shouldDropAssistantHistoryMessage(message: unknown): boolean {
   if (text === undefined || !isSuppressedControlReplyText(text)) {
     return false;
   }
-  return !hasAssistantNonTextContent(message);
+  return !hasAssistantDisplayableNonTextContent(message);
 }
 
 export function sanitizeChatHistoryMessages(

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -642,16 +642,16 @@ function sanitizeChatHistoryMessage(
     role === "assistant" && !shouldPreserveAssistantControlReplyText(entry);
 
   if (typeof entry.content === "string") {
+    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
     const controlStripped = stripAssistantControlTokens
-      ? stripSuppressedControlReplyToken(entry.content)
-      : entry.content;
-    const stripped = stripInlineDirectiveTagsForDisplay(controlStripped);
-    changed ||= controlStripped !== entry.content;
+      ? stripSuppressedControlReplyToken(stripped.text)
+      : stripped.text;
+    changed ||= controlStripped !== stripped.text;
     if (preserveExactToolPayload) {
-      entry.content = stripped.text;
+      entry.content = controlStripped;
       changed ||= stripped.changed;
     } else {
-      const res = truncateChatHistoryText(stripped.text, maxChars);
+      const res = truncateChatHistoryText(controlStripped, maxChars);
       entry.content = res.text;
       changed ||= stripped.changed || res.truncated;
     }
@@ -701,16 +701,16 @@ function sanitizeChatHistoryMessage(
   }
 
   if (typeof entry.text === "string") {
+    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
     const controlStripped = stripAssistantControlTokens
-      ? stripSuppressedControlReplyToken(entry.text)
-      : entry.text;
-    const stripped = stripInlineDirectiveTagsForDisplay(controlStripped);
-    changed ||= controlStripped !== entry.text;
+      ? stripSuppressedControlReplyToken(stripped.text)
+      : stripped.text;
+    changed ||= controlStripped !== stripped.text;
     if (preserveExactToolPayload) {
-      entry.text = stripped.text;
+      entry.text = controlStripped;
       changed ||= stripped.changed;
     } else {
-      const res = truncateChatHistoryText(stripped.text, maxChars);
+      const res = truncateChatHistoryText(controlStripped, maxChars);
       entry.text = res.text;
       changed ||= stripped.changed || res.truncated;
     }
@@ -816,7 +816,9 @@ function shouldPreserveAssistantControlReplyText(message: Record<string, unknown
         : [];
   return (
     texts.length > 0 &&
-    texts.every((text) => isSuppressedControlReplyText(text)) &&
+    texts.every((text) =>
+      isSuppressedControlReplyText(stripInlineDirectiveTagsForDisplay(text).text),
+    ) &&
     hasAssistantDisplayableNonTextContent(message)
   );
 }
@@ -1325,7 +1327,11 @@ function shouldDropAssistantHistoryMessage(message: unknown): boolean {
     return !hasAssistantMixedToolVisibleText(message);
   }
   const text = extractAssistantTextForSilentCheck(message);
-  if (text === undefined || !isSuppressedControlReplyText(text)) {
+  // Classify after removing UI-only directives, before sanitization can erase
+  // the control token and leave a blank assistant row behind.
+  const displayText =
+    text === undefined ? undefined : stripInlineDirectiveTagsForDisplay(text).text;
+  if (displayText === undefined || !isSuppressedControlReplyText(displayText)) {
     return false;
   }
   return !hasAssistantDisplayableNonTextContent(message);

--- a/src/gateway/control-reply-text.test.ts
+++ b/src/gateway/control-reply-text.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { projectChatDisplayMessages } from "./chat-display-projection.js";
+import { stripSuppressedControlReplyToken } from "./control-reply-text.js";
+import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
+
+describe("control reply display projection", () => {
+  it("preserves text whitespace when no control token is present", () => {
+    expect(stripSuppressedControlReplyToken("  keep padded  ")).toBe("  keep padded  ");
+    expect(
+      projectChatDisplayMessages([
+        { role: "assistant", content: [{ type: "text", text: "  keep padded  " }] },
+      ]),
+    ).toEqual([{ role: "assistant", content: [{ type: "text", text: "  keep padded  " }] }]);
+  });
+
+  it("preserves control-looking text when it accompanies displayable content", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "NO_REPLY" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+      ],
+    };
+
+    expect(projectChatDisplayMessages([message])).toEqual([message]);
+  });
+
+  it("preserves control-looking text forwarded from another session", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "NO_REPLY" }],
+      provenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:webchat:source",
+        sourceTool: "sessions_send",
+      },
+    };
+
+    expect(projectChatDisplayMessages([message])).toEqual([message]);
+  });
+
+  it("strips a trailing sessions control token from substantive text", () => {
+    const text = "The handoff is complete.\n\nREPLY_SKIP";
+
+    expect(stripSuppressedControlReplyToken(text)).toBe("The handoff is complete.");
+    expect(projectLiveAssistantBufferedText(text)).toEqual({
+      text: "The handoff is complete.",
+      suppress: false,
+      pendingLeadFragment: false,
+    });
+    expect(
+      projectChatDisplayMessages([{ role: "assistant", content: [{ type: "text", text }] }]),
+    ).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "The handoff is complete." }],
+      },
+    ]);
+  });
+
+  it("hides a control-only reply that also contains model thinking", () => {
+    expect(
+      projectChatDisplayMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "The loop is complete." },
+            { type: "text", text: "REPLY_SKIP" },
+          ],
+        },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/src/gateway/control-reply-text.test.ts
+++ b/src/gateway/control-reply-text.test.ts
@@ -22,7 +22,30 @@ describe("control reply display projection", () => {
       ],
     };
 
+    expect(stripSuppressedControlReplyToken("NO_REPLY")).toBe("");
     expect(projectChatDisplayMessages([message])).toEqual([message]);
+  });
+
+  it("strips a standalone control token beside visible text", () => {
+    expect(
+      projectChatDisplayMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Visible reply" },
+            { type: "text", text: "NO_REPLY" },
+          ],
+        },
+      ]),
+    ).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Visible reply" },
+          { type: "text", text: "" },
+        ],
+      },
+    ]);
   });
 
   it("preserves control-looking text forwarded from another session", () => {
@@ -56,6 +79,38 @@ describe("control reply display projection", () => {
         content: [{ type: "text", text: "The handoff is complete." }],
       },
     ]);
+  });
+
+  it("strips a trailing control token after removing inline directives", () => {
+    expect(
+      projectChatDisplayMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "The handoff is complete.\n\nREPLY_SKIP [[audio_as_voice]]",
+            },
+          ],
+        },
+      ]),
+    ).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "The handoff is complete." }],
+      },
+    ]);
+  });
+
+  it("hides a control-only reply with an inline directive", () => {
+    expect(
+      projectChatDisplayMessages([
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "NO_REPLY [[audio_as_voice]]" }],
+        },
+      ]),
+    ).toEqual([]);
   });
 
   it("hides a control-only reply that also contains model thinking", () => {

--- a/src/gateway/control-reply-text.ts
+++ b/src/gateway/control-reply-text.ts
@@ -1,6 +1,6 @@
 // Gateway control-reply text classifier.
 // Suppresses internal auto-reply tokens before they leak to chat surfaces.
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN, stripSilentToken } from "../auto-reply/tokens.js";
 
 const SUPPRESSED_CONTROL_REPLY_TOKENS = [
   SILENT_REPLY_TOKEN,
@@ -34,6 +34,21 @@ function normalizeSuppressedControlReplyFragment(text: string): string {
 export function isSuppressedControlReplyText(text: string): boolean {
   const normalized = text.trim();
   return SUPPRESSED_CONTROL_REPLY_TOKENS.some((token) => isSilentReplyText(normalized, token));
+}
+
+/** Remove internal control tokens when a model appends one to visible reply text. */
+export function stripSuppressedControlReplyToken(text: string): string {
+  if (isSuppressedControlReplyText(text)) {
+    return "";
+  }
+  let stripped = text;
+  for (const token of SUPPRESSED_CONTROL_REPLY_TOKENS) {
+    const next = stripSilentToken(stripped, token);
+    if (next !== stripped.trim()) {
+      stripped = next;
+    }
+  }
+  return stripped;
 }
 
 /**

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -12,6 +12,7 @@ import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import {
   isSuppressedControlReplyLeadFragment,
   isSuppressedControlReplyText,
+  stripSuppressedControlReplyToken,
 } from "./control-reply-text.js";
 
 const MAX_LIVE_CHAT_BUFFER_CHARS = 500_000;
@@ -87,9 +88,13 @@ export function projectLiveAssistantBufferedText(
   if (options?.suppressLeadFragments !== false && isSuppressedControlReplyLeadFragment(rawText)) {
     return { text: rawText, suppress: true, pendingLeadFragment: true };
   }
-  const text = startsWithSilentToken(rawText, SILENT_REPLY_TOKEN)
-    ? stripLeadingSilentToken(rawText, SILENT_REPLY_TOKEN)
-    : rawText;
+  const withoutTrailingControlToken = stripSuppressedControlReplyToken(rawText);
+  if (!withoutTrailingControlToken) {
+    return { text: "", suppress: true, pendingLeadFragment: false };
+  }
+  const text = startsWithSilentToken(withoutTrailingControlToken, SILENT_REPLY_TOKEN)
+    ? stripLeadingSilentToken(withoutTrailingControlToken, SILENT_REPLY_TOKEN)
+    : withoutTrailingControlToken;
   if (!text || isSuppressedControlReplyText(text)) {
     return { text: "", suppress: true, pendingLeadFragment: false };
   }


### PR DESCRIPTION
## Summary

- keep Reef peer provenance model-visible through `UntrustedContext` without persisting the wrapper in the user-facing transcript
- strip trailing internal control tokens such as `REPLY_SKIP` from otherwise useful assistant replies
- hide control-only replies even when the model also emits internal reasoning content

## Why

PR #51739 fixed exact `ANNOUNCE_SKIP` and `REPLY_SKIP` leakage in gateway chat output, but two display shapes remained uncovered: a token appended to substantive text, and a token-only text block accompanied by a reasoning block. Both could still expose internal orchestration markers in live chat or history.

Reef also placed its untrusted provenance wrapper in `BodyForAgent`, which made the safety metadata part of the stored and displayed user message. This moves that provenance to the existing model-only `UntrustedContext` seam while preserving the raw peer message as the transcript body.

The gateway fix applies consistently to every channel displayed through chat projection. It does not change message routing or transport behavior. The Reef change preserves the model's untrusted-data warning while removing it from the UI.

## Real Evidence

The patch was cherry-picked onto the exact `v2026.7.2-beta.1` release and built as the multi-architecture image `quay.io/sallyom/openclaw@sha256:b37059168c5ce22373000ebdd324f38d8cc3e8033a900b889a079baea5c0bb61`.

A live K8s comparison used two agents connected through the same in-cluster Reef relay:

- **Clove (right, patched):** fresh inbound Reef messages display as ordinary message text.
- **Clanky (left, unmodified `v2026.7.2-beta.1`):** fresh inbound Reef messages still display the untrusted provenance and `<reef-message>` wrapper.

This demonstrates that the UI difference comes from the patch while both agents retain Reef communication and model-visible provenance handling.

<img width="2548" height="1174" alt="Screenshot 2026-07-16 at 12 00 24 PM" src="https://github.com/user-attachments/assets/d1c223a6-4056-42a6-8d26-4b5b5ff9408b" />


## Testing

- `./node_modules/.bin/vitest run extensions/reef/src/channel.test.ts src/gateway/control-reply-text.test.ts`
- core and extension production typechecks
- core and extension test typechecks
- focused `oxfmt --check`
- focused `oxlint`

The full gateway integration baseline could not run locally because Node 24.1.0 embeds a SQLite version that current OpenClaw rejects for WAL safety; the focused gateway projection tests do not use SQLite.

Related: #45084, #51739
