### PR TITLE
fix(agents): completions-API models leak tool-call preambles into chats — tag pre-tool narration as commentary

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -2,7 +2,7 @@
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
-import type { Context, Model, SimpleStreamOptions } from "../types.js";
+import type { Context, Model, SimpleStreamOptions, TextContent } from "../types.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
@@ -274,6 +274,52 @@ describe("OpenAI-compatible completions params", () => {
       { type: "text", text: "Requests like this are not allowed." },
     ]);
     expect(result.stopReason).toBe("stop");
+  });
+
+  it("tags pre-tool narration as commentary on tool turns", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("Importing ORDER-1234 into the tracker…"),
+      makeToolCallChunk("call_import", "import_order", '{"id":"ORDER-1234"}'),
+      makeFinishChunk("tool_calls"),
+    ];
+
+    const result = await streamOpenAICompletions(model, context, { apiKey: "sk-test" }).result();
+    const textBlock = result.content.find((block) => block.type === "text") as
+      | TextContent
+      | undefined;
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(JSON.parse(String(textBlock?.textSignature))).toMatchObject({
+      v: 1,
+      phase: "commentary",
+    });
+  });
+
+  it("rolls back provisional tags when spurious tool calls are stripped", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("Here is the answer."),
+      makeToolCallChunk("call_spurious", "noop", "{}"),
+      makeFinishChunk("stop"),
+    ];
+
+    const result = await streamOpenAICompletions(model, context, { apiKey: "sk-test" }).result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toStrictEqual([{ type: "text", text: "Here is the answer." }]);
+  });
+
+  it("does not tag ordinary text when a provider emits an empty tool_calls array", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("Ordinary answer."),
+      {
+        id: "chatcmpl-test",
+        choices: [{ index: 0, delta: { tool_calls: [] }, finish_reason: "stop" }],
+      },
+    ];
+
+    const result = await streamOpenAICompletions(model, context, { apiKey: "sk-test" }).result();
+
+    expect(result.content).toStrictEqual([{ type: "text", text: "Ordinary answer." }]);
   });
 
   it("preserves a valid provider-reported usage cost", async () => {
@@ -1553,7 +1599,11 @@ describe("openai-completions stop-reason tool-call guard", () => {
     });
     const result = await stream.result();
 
-    expect(result.content[0]).toEqual({ type: "text", text: "Use <" });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "Use <",
+      textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+    });
     expect(result.content[1]).toMatchObject({ type: "toolCall", id: "call_1", name: "bash" });
   });
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -32,6 +32,12 @@ import type {
   Tool,
   ToolCall,
 } from "../types.js";
+import {
+  clearPendingCommentaryText,
+  rememberPendingCommentaryTags,
+  tagPendingCommentaryText,
+  type PendingCommentaryTags,
+} from "../utils/assistant-text-phase.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
@@ -177,6 +183,7 @@ export const streamOpenAICompletions: StreamFunction<
       stopReason: "stop",
       timestamp: Date.now(),
     };
+    const provisionalCommentaryTags: PendingCommentaryTags = new Map();
 
     let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
     try {
@@ -498,11 +505,15 @@ export const streamOpenAICompletions: StreamFunction<
             appendPartitionedContent(refusalText, Boolean(foundReasoningField));
           }
 
-          if (choiceDelta.tool_calls) {
+          if (choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0) {
             flushPartitionedContent();
             // The tool-call lane is also a reasoning boundary; seal the thought
             // before toolcall_start so thinking_end never trails the action.
             sealNativeReasoningBeforeText();
+            rememberPendingCommentaryTags(
+              provisionalCommentaryTags,
+              tagPendingCommentaryText(output.content),
+            );
             for (const toolCall of choiceDelta.tool_calls) {
               const block = ensureToolCallBlock(toolCall);
               if (!block.id && toolCall.id) {
@@ -578,6 +589,12 @@ export const streamOpenAICompletions: StreamFunction<
       }
       if (hasToolCalls && output.stopReason !== "toolUse") {
         output.content = output.content.filter((block) => block.type !== "toolCall");
+      }
+      if (output.stopReason !== "toolUse") {
+        clearPendingCommentaryText(provisionalCommentaryTags);
+      }
+      if (output.stopReason === "toolUse") {
+        tagPendingCommentaryText(output.content);
       }
 
       stream.push({ type: "done", reason: output.stopReason, message: output });

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -71,6 +71,7 @@ import {
   extractToolResultText,
   isImageWithMediaPayload,
 } from "../internal/shared.js";
+import { tagPendingCommentaryText } from "../utils/assistant-text-phase.js";
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
@@ -85,7 +86,6 @@ import {
   coerceTransportToolCallArguments,
   createEmptyTransportUsage,
   createWritableTransportEventStream,
-  encodeAssistantTextSignatureV1,
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
@@ -696,25 +696,6 @@ function mapStopReason(reason: string | undefined): string {
       return "stop";
     default:
       throw new Error(`Unhandled stop reason: ${String(reason)}`);
-  }
-}
-
-function tagPendingCommentaryText(content: TransportContentBlock[]): void {
-  let commentaryTextIndex = content.filter(
-    (block) => block.type === "text" && block.textSignature !== undefined,
-  ).length;
-  for (const block of content) {
-    if (
-      block.type === "text" &&
-      block.text.trim().length > 0 &&
-      block.textSignature === undefined
-    ) {
-      block.textSignature = encodeAssistantTextSignatureV1(
-        `commentary-${commentaryTextIndex}`,
-        "commentary",
-      );
-      commentaryTextIndex += 1;
-    }
   }
 }
 

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -28,6 +28,12 @@ import {
   withFirstStreamEventTimeout,
 } from "../internal/runtime.js";
 import { stripSystemPromptCacheBoundary } from "../internal/shared.js";
+import {
+  clearPendingCommentaryText,
+  rememberPendingCommentaryTags,
+  tagPendingCommentaryText,
+  type PendingCommentaryTags,
+} from "../utils/assistant-text-phase.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
 import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
 import {
@@ -388,6 +394,7 @@ async function processOpenAICompletionsStream(
   let isFlushingPendingPostToolCallDeltas = false;
   const toolCallBlocksByIndex = new Map<number, ToolCallBlock>();
   const toolCallBlocksById = new Map<string, ToolCallBlock>();
+  const provisionalCommentaryTags: PendingCommentaryTags = new Map();
   const toolCallBlockBytes = new WeakMap<ToolCallBlock, number>();
   const toolCallBlockIndices = new WeakMap<ToolCallBlock, number>();
   let sawStopFinishReason = false;
@@ -496,6 +503,10 @@ async function processOpenAICompletionsStream(
       currentBlock = null;
       flushPendingPostToolCallDeltas();
     }
+    rememberPendingCommentaryTags(
+      provisionalCommentaryTags,
+      tagPendingCommentaryText(output.content),
+    );
     const block: ToolCallBlock = {
       type: "toolCall",
       // DSML has no provider call id. A response-local counter would alias a
@@ -708,6 +719,10 @@ async function processOpenAICompletionsStream(
     if (choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0) {
       sawNativeToolCallDelta = true;
       flushReasoningTagTextPartitionerAtEnd();
+      rememberPendingCommentaryTags(
+        provisionalCommentaryTags,
+        tagPendingCommentaryText(output.content),
+      );
       for (const toolCall of choiceDelta.tool_calls) {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
         let block = streamIndex !== undefined ? toolCallBlocksByIndex.get(streamIndex) : undefined;
@@ -805,6 +820,12 @@ async function processOpenAICompletionsStream(
   }
   if (hasToolCalls && output.stopReason !== "toolUse") {
     output.content = output.content.filter((block) => block.type !== "toolCall");
+  }
+  if (output.stopReason !== "toolUse") {
+    clearPendingCommentaryText(provisionalCommentaryTags);
+  }
+  if (output.stopReason === "toolUse") {
+    tagPendingCommentaryText(output.content);
   }
 }
 

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -35,18 +35,6 @@ type TransportOutputShape = {
 };
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
-/**
- * Encodes an assistant text-block phase signature (v1). Channels and the
- * embedded handler read this to route commentary/narration out of the final
- * reply. Shared so every provider transport tags phases identically.
- */
-export function encodeAssistantTextSignatureV1(
-  id: string,
-  phase?: "commentary" | "final_answer",
-): string {
-  return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
-}
-
 export function sanitizeTransportPayloadText(text: string): string {
   if (typeof text !== "string") {
     return "";

--- a/packages/ai/src/utils/assistant-text-phase.test.ts
+++ b/packages/ai/src/utils/assistant-text-phase.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearPendingCommentaryText,
+  rememberPendingCommentaryTags,
+  tagPendingCommentaryText,
+} from "./assistant-text-phase.js";
+
+type TestTextBlock = { type: "text"; text: string; textSignature?: string };
+
+describe("assistant text phase tags", () => {
+  it("tags only unphased non-empty text and remains idempotent", () => {
+    const content = [
+      { type: "text", text: "I will check." },
+      { type: "text", text: " " },
+      { type: "text", text: "existing", textSignature: "provider-signature" },
+    ];
+    const tags = tagPendingCommentaryText(content);
+    rememberPendingCommentaryTags(tags, tagPendingCommentaryText(content));
+
+    expect(tags.size).toBe(1);
+    expect(JSON.parse(String(content[0]?.textSignature))).toMatchObject({
+      v: 1,
+      id: "commentary-1",
+      phase: "commentary",
+    });
+    expect(content[1]?.textSignature).toBeUndefined();
+    expect(content[2]?.textSignature).toBe("provider-signature");
+  });
+
+  it("rolls back only unchanged signatures created by this turn", () => {
+    const generated: TestTextBlock = { type: "text", text: "generated" };
+    const replaced: TestTextBlock = { type: "text", text: "replaced" };
+    const existing: TestTextBlock = {
+      type: "text",
+      text: "existing",
+      textSignature: "provider-signature",
+    };
+    const tags = tagPendingCommentaryText([generated, replaced, existing]);
+    replaced.textSignature = "provider-replacement";
+
+    clearPendingCommentaryText(tags);
+
+    expect(generated.textSignature).toBeUndefined();
+    expect(replaced.textSignature).toBe("provider-replacement");
+    expect(existing.textSignature).toBe("provider-signature");
+  });
+});

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -1,0 +1,55 @@
+type AssistantTextPhaseBlock = {
+  type: "text";
+  text: string;
+  textSignature?: string;
+};
+
+export type PendingCommentaryTags = Map<AssistantTextPhaseBlock, string>;
+
+function isAssistantTextPhaseBlock(block: unknown): block is AssistantTextPhaseBlock {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const record = block as { type?: unknown; text?: unknown };
+  return record.type === "text" && typeof record.text === "string";
+}
+
+function encodeAssistantTextSignatureV1(id: string, phase?: "commentary" | "final_answer"): string {
+  return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
+}
+
+/** Tags unphased narration before a tool-call event becomes consumer-visible. */
+export function tagPendingCommentaryText(content: ReadonlyArray<unknown>): PendingCommentaryTags {
+  const textBlocks = content.filter(isAssistantTextPhaseBlock);
+  let commentaryIndex = textBlocks.filter((block) => block.textSignature !== undefined).length;
+  const tagged: PendingCommentaryTags = new Map();
+  for (const block of textBlocks) {
+    if (block.text.trim().length === 0 || block.textSignature !== undefined) {
+      continue;
+    }
+    const signature = encodeAssistantTextSignatureV1(`commentary-${commentaryIndex}`, "commentary");
+    block.textSignature = signature;
+    tagged.set(block, signature);
+    commentaryIndex += 1;
+  }
+  return tagged;
+}
+
+/** Rolls back only the exact provisional signatures created by this transport turn. */
+export function clearPendingCommentaryText(tags: PendingCommentaryTags): void {
+  for (const [block, signature] of tags) {
+    if (block.textSignature === signature) {
+      delete block.textSignature;
+    }
+  }
+  tags.clear();
+}
+
+export function rememberPendingCommentaryTags(
+  target: PendingCommentaryTags,
+  tagged: PendingCommentaryTags,
+): void {
+  for (const [block, signature] of tagged) {
+    target.set(block, signature);
+  }
+}

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -849,10 +849,12 @@ export function handleMessageUpdate(
     !deliveryPhase &&
     Boolean(streamItemId) &&
     isResponsesApiAssistantMessage(partialAssistant);
-  // Anthropic commentary is known only at the tool boundary; keep early
-  // unphased deltas out of durable block replies until that phase is known.
+  // These transports resolve commentary only at the tool boundary. Withhold
+  // early unphased deltas from durable block replies until that decision exists.
   const isPhasePendingAnthropicText =
     evtType !== "text_end" && !deliveryPhase && isAnthropicAssistantMessage(partialAssistant);
+  const isPhasePendingCompletionsText =
+    !deliveryPhase && isOpenAiCompletionsAssistantMessage(partialAssistant);
   const hasResponsesContentIndex =
     streamContentIndex !== undefined && isResponsesApiAssistantMessage(partialAssistant);
   let streamItemChanged = false;
@@ -929,8 +931,10 @@ export function handleMessageUpdate(
 
   if (chunk) {
     ctx.state.deltaBuffer += chunk;
-    if (!skipLiveStream && !shouldUsePhaseAwareBlockReply && !isPhasePendingAnthropicText) {
-      appendBlockReplyChunk(ctx, chunk);
+    if (!skipLiveStream && !shouldUsePhaseAwareBlockReply) {
+      if (!isPhasePendingAnthropicText && !isPhasePendingCompletionsText) {
+        appendBlockReplyChunk(ctx, chunk);
+      }
     }
   }
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-completions-pretool-narration.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.withholds-completions-pretool-narration.test.ts
@@ -1,0 +1,169 @@
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it, vi } from "vitest";
+import { createStubSessionHarness } from "./embedded-agent-subscribe.e2e-harness.js";
+import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
+
+function completionsAssistant(text: string, extra?: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    api: "openai-completions",
+    content: [{ type: "text", text }, ...(extra ?? [])],
+  } as unknown as AssistantMessage;
+}
+
+function postedText(onBlockReply: ReturnType<typeof vi.fn>): string {
+  return onBlockReply.mock.calls.map((call) => call[0]?.text ?? "").join(" ");
+}
+
+describe("Chat Completions pre-tool narration", () => {
+  it("withholds pre-tool narration from durable text_end block replies", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-withhold",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+      blockReplyChunking: { minChars: 4, maxChars: 200 },
+    });
+
+    const narration = "Importing ORDER-1234 into the tracker… ";
+    emit({ type: "message_start", message: completionsAssistant("") });
+    emit({
+      type: "message_update",
+      message: completionsAssistant(narration),
+      assistantMessageEvent: { type: "text_delta", delta: narration },
+    });
+    emit({
+      type: "tool_execution_start",
+      toolName: "import_order",
+      toolCallId: "tool-1",
+      args: { id: "ORDER-1234" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        api: "openai-completions",
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "text",
+            text: narration,
+            textSignature: JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" }),
+          },
+          { type: "toolCall", id: "tool-1", name: "import_order", arguments: {} },
+        ],
+      } as unknown as AssistantMessage,
+    });
+
+    expect(postedText(onBlockReply)).not.toContain("Importing ORDER-1234");
+  });
+
+  it("delivers permanently unphased ordinary text in prefix-before-suffix order", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-answer",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+      blockReplyChunking: { minChars: 4, maxChars: 200 },
+    });
+
+    emit({ type: "message_start", message: completionsAssistant("") });
+    emit({
+      type: "message_update",
+      message: completionsAssistant("prefix "),
+      assistantMessageEvent: { type: "text_delta", delta: "prefix " },
+    });
+    emit({
+      type: "message_update",
+      message: completionsAssistant("prefix suffix"),
+      assistantMessageEvent: { type: "text_end", contentIndex: 0, delta: "suffix" },
+    });
+    emit({ type: "message_end", message: completionsAssistant("prefix suffix") });
+
+    await vi.waitFor(() => expect(onBlockReply).toHaveBeenCalled());
+    expect(postedText(onBlockReply)).toContain("prefix suffix");
+  });
+
+  it("delivers text when spurious tool calls were stripped and tags rolled back", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-spurious",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    const answer = "Here is the answer.";
+    emit({ type: "message_start", message: completionsAssistant("") });
+    emit({
+      type: "message_update",
+      message: completionsAssistant(answer),
+      assistantMessageEvent: { type: "text_delta", delta: answer },
+    });
+    emit({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        api: "openai-completions",
+        content: [
+          {
+            type: "text",
+            text: answer,
+            textSignature: JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" }),
+          },
+          { type: "toolCall", id: "tool-spurious", name: "noop", arguments: {} },
+        ],
+      } as unknown as AssistantMessage,
+      assistantMessageEvent: { type: "toolcall_start", contentIndex: 1 },
+    });
+    emit({ type: "message_end", message: completionsAssistant(answer) });
+
+    await vi.waitFor(() => expect(onBlockReply).toHaveBeenCalled());
+    expect(postedText(onBlockReply)).toContain(answer);
+  });
+
+  it("withholds post-tool text until final toolUse commentary classification", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedAgentSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"],
+      runId: "run-completions-post-tool",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    emit({ type: "message_start", message: completionsAssistant("") });
+    emit({
+      type: "message_update",
+      message: completionsAssistant("post-tool commentary"),
+      assistantMessageEvent: {
+        type: "text_end",
+        contentIndex: 1,
+        delta: "post-tool commentary",
+      },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        api: "openai-completions",
+        stopReason: "toolUse",
+        content: [
+          { type: "toolCall", id: "tool-1", name: "read", arguments: {} },
+          {
+            type: "text",
+            text: "post-tool commentary",
+            textSignature: JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" }),
+          },
+        ],
+      } as unknown as AssistantMessage,
+    });
+
+    expect(postedText(onBlockReply)).not.toContain("post-tool commentary");
+  });
+});

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -91,7 +91,11 @@ describe("openai transport stream", () => {
     );
 
     expect(output.content).toEqual([
-      { type: "text", text: "before  after" },
+      {
+        type: "text",
+        text: "before  after",
+        textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+      },
       {
         type: "toolCall",
         id: "call_native_1",
@@ -130,7 +134,11 @@ describe("openai transport stream", () => {
     );
 
     expect(output.content).toEqual([
-      { type: "text", text: "I'll check" },
+      {
+        type: "text",
+        text: "I'll check",
+        textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+      },
       {
         type: "toolCall",
         id: "call_native_1",
@@ -178,7 +186,11 @@ describe("openai transport stream", () => {
         arguments: { path: "/tmp/native.md" },
         partialArgs: '{"path":"/tmp/native.md"}',
       },
-      { type: "text", text: " visible" },
+      {
+        type: "text",
+        text: " visible",
+        textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+      },
     ]);
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
@@ -214,7 +226,11 @@ describe("openai transport stream", () => {
     );
 
     expect(output.content).toEqual([
-      { type: "text", text: "before " },
+      {
+        type: "text",
+        text: "before ",
+        textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+      },
       {
         type: "toolCall",
         id: "call_native_1",
@@ -222,7 +238,11 @@ describe("openai transport stream", () => {
         arguments: { path: "/tmp/native.md" },
         partialArgs: '{"path":"/tmp/native.md"}',
       },
-      { type: "text", text: " after" },
+      {
+        type: "text",
+        text: " after",
+        textSignature: '{"v":1,"id":"commentary-1","phase":"commentary"}',
+      },
     ]);
     expect(JSON.stringify(events)).not.toContain("DSML");
   });

--- a/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
+++ b/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
@@ -765,6 +765,112 @@ describe("openai transport stream", () => {
     expect(toolCalls).toHaveLength(1);
   });
 
+  it("tags narration before toolcall_start reaches consumers", async () => {
+    const model = makeCompletionsModel({
+      id: "grok-4.5",
+      name: "Grok 4.5",
+      provider: "xai",
+      baseUrl: "https://api.x.ai/v1",
+      reasoning: false,
+      contextWindow: 131072,
+    });
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+    const stream = { push: (event: unknown) => events.push(event as CapturedStreamEvent) };
+    const chunks = [
+      makeCompletionsChunk({ role: "assistant" as const, content: "" }),
+      makeCompletionsChunk({ content: "Importing ORDER-1234…" }),
+      makeCompletionsChunk(
+        {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_import",
+              function: { name: "import_order", arguments: '{"id":"ORDER-1234"}' },
+            },
+          ],
+        },
+        "tool_calls",
+      ),
+    ] as const;
+    async function* mockStream() {
+      for (const chunk of chunks) {
+        yield chunk as never;
+      }
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
+
+    const toolStart = events.find((event) => event.type === "toolcall_start") as
+      | { partial?: { content?: Array<{ type?: string; textSignature?: string }> } }
+      | undefined;
+    const partialText = toolStart?.partial?.content?.find((block) => block.type === "text");
+    expect(String(partialText?.textSignature)).toContain('"phase":"commentary"');
+  });
+
+  it("rolls back provisional tags when stop strips spurious tool calls", async () => {
+    const model = makeCompletionsModel({
+      id: "grok-4.5",
+      name: "Grok 4.5",
+      provider: "xai",
+      baseUrl: "https://api.x.ai/v1",
+      reasoning: false,
+      contextWindow: 131072,
+    });
+    const output = createAssistantOutput(model);
+    const chunks = [
+      makeCompletionsChunk({ role: "assistant" as const, content: "" }),
+      makeCompletionsChunk({ content: "Here is the answer." }),
+      makeCompletionsChunk(
+        {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_spurious",
+              function: { name: "bash", arguments: '{"cmd":"echo hi"}' },
+            },
+          ],
+        },
+        "stop",
+      ),
+    ] as const;
+    async function* mockStream() {
+      for (const chunk of chunks) {
+        yield chunk as never;
+      }
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, { push() {} });
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content).toStrictEqual([{ type: "text", text: "Here is the answer." }]);
+  });
+
+  it("keeps ordinary text unphased when tool_calls is empty", async () => {
+    const model = makeCompletionsModel({
+      id: "grok-4.5",
+      name: "Grok 4.5",
+      provider: "xai",
+      baseUrl: "https://api.x.ai/v1",
+      reasoning: false,
+      contextWindow: 131072,
+    });
+    const output = createAssistantOutput(model);
+    const chunks = [
+      makeCompletionsChunk({ role: "assistant" as const, content: "Ordinary answer." }),
+      makeCompletionsChunk({ tool_calls: [] }, "stop"),
+    ] as const;
+    async function* mockStream() {
+      for (const chunk of chunks) {
+        yield chunk as never;
+      }
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, { push() {} });
+
+    expect(output.content).toStrictEqual([{ type: "text", text: "Ordinary answer." }]);
+  });
+
   it("leaves content unchanged when no tool calls and finish_reason is stop", async () => {
     const model = makeCompletionsModel({
       id: "llama-3.3-70b",

--- a/src/agents/openai-transport-stream.usage-and-calls.test.ts
+++ b/src/agents/openai-transport-stream.usage-and-calls.test.ts
@@ -1500,7 +1500,11 @@ describe("openai transport stream", () => {
       { push() {} },
     );
 
-    expect(output.content[0]).toEqual({ type: "text", text: "Use <" });
+    expect(output.content[0]).toEqual({
+      type: "text",
+      text: "Use <",
+      textSignature: '{"v":1,"id":"commentary-0","phase":"commentary"}',
+    });
     expectRecordFields(output.content[1], {
       type: "toolCall",
       id: "call_0",

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -544,6 +544,27 @@ describe("redactTranscriptMessage", () => {
     },
   );
 
+  it.each([
+    ["openai-completions", "openrouter", "deepseek/deepseek-v4-flash"],
+    ["anthropic-messages", "anthropic", "claude-sonnet-4-6"],
+  ])("preserves commentary phase signatures for %s", (api, provider, model) => {
+    const textSignature = JSON.stringify({ v: 1, id: "commentary-0", phase: "commentary" });
+    const msg = {
+      role: "assistant",
+      api,
+      provider,
+      model,
+      content: [{ type: "text", text: "I will check.", textSignature }],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = expectDefined(
+      (msgContent(result) as Array<{ textSignature: string }>)[0],
+      "commentary text block",
+    );
+    expect(block.textSignature).toBe(textSignature);
+  });
+
   it("preserves Anthropic redacted_thinking data while redacting siblings", () => {
     const msg = {
       role: "assistant",

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -556,7 +556,11 @@ function redactTranscriptStructuredValue(
     }
     if (
       location === "assistant-content-block" &&
+      // These transports use the same validated v1 phase signature for pre-tool commentary;
+      // stripping it would resurface narration after reload or session resume.
       (isOpenAIResponsesRoute(currentAssistantRoute) ||
+        isOpenAICompletionsRoute(currentAssistantRoute) ||
+        isAnthropicReasoningRoute(currentAssistantRoute) ||
         isCustomProviderRoute(currentAssistantRoute)) &&
       source.type === "text" &&
       key === "textSignature" &&


### PR DESCRIPTION
Closes #108945
Related: #25592, #80458

## What Problem This Solves

Providers using `api: "openai-completions"` could deliver model narration such as “I’ll check that…” as an ordinary chat reply before a tool call. Chat Completions streaming exposes content deltas, tool-call deltas, and finish reasons, but no commentary phase, so OpenClaw must resolve that phase at the tool boundary.

## Why This Change Was Made

Both completions processors now provisionally tag buffered text immediately before the first consumer-visible tool-call event. A shared helper also serves the Anthropic transport, assigns deterministic v1 commentary signatures, and tracks the exact blocks/signatures generated by the current turn.

If the provider later resolves to `finish_reason: "stop"` and tool calls are stripped as spurious, only those exact provisional signatures are rolled back. Empty `tool_calls: []` arrays never trigger tagging. Confirmed tool turns receive a final backstop tag for text arriving after the last tool-call delta.

The embedded subscriber withholds unphased Chat Completions text from durable block replies until the authoritative `message_end`: commentary is suppressed, while ordinary and rolled-back spurious-tool answers use the existing final delivery path. Valid v1 phase signatures are preserved through transcript redaction for Completions and Anthropic routes, without broadening reasoning-replay exemptions.

No new config or stored-data shape is introduced; `textSignature` is an existing optional text-block field.

## User Impact

Tool-call preambles stay in the transient commentary/progress lane and never become durable chat bubbles. Final answers, ordinary no-tool replies, and text from stripped spurious tool calls remain deliverable in full and in order.

## Evidence

- Focused Vitest: 8 files, 348 tests passed across provider, transport, subscriber, DeepSeek shaping, Anthropic, helper, and transcript-redaction surfaces.
- Blacksmith changed gate: formatting, guards, core production/test types, full core/package lint, schema/storage guards, and import-cycle checks passed.
- Source-blind CLI contract against a deterministic OpenAI-compatible SSE server:
  - tool turn executed one real `read`, delivered only `FINAL_RESULT`, and omitted `PREAMBLE_SHOULD_NOT_DELIVER`;
  - plain turn delivered `PLAIN_RESULT`;
  - `finish_reason=stop` plus a spurious tool call delivered `SPURIOUS_RESULT` with no tool execution.
- Final AutoReview: clean, no accepted/actionable findings.
- `git diff --check origin/main...HEAD`: passed.

Credit is retained with `Co-authored-by: Arseniy Palagin <valeradzigurda3@gmail.com>`.
