### PR TITLE
fix(cross-os): clamp gateway ready/stop polls to remaining deadline

### DIFF
--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -45,7 +45,7 @@ import {
   runCommandInvocation,
   withAllocatedGatewayPort,
 } from "./process.ts";
-import { formatError, shellEscapeForSh, sleep } from "./shared.ts";
+import { clampTimeoutMs, formatError, pollUntilDeadline, shellEscapeForSh } from "./shared.ts";
 
 const INSTALLER_CONNECT_TIMEOUT_SECONDS = 10;
 const INSTALLER_REQUEST_TIMEOUT_SECONDS = 120;
@@ -584,22 +584,27 @@ export async function waitForInstalledGateway(params: {
     logPath: params.logPath,
   });
   const deadline = Date.now() + gatewayReadyDeadlineMs();
-  while (Date.now() < deadline) {
-    const result = await runInstalledCli({
-      cliPath: params.cliPath,
-      args: statusArgs,
-      cwd: params.lane.homeDir,
-      env: params.env,
-      logPath: params.logPath,
-      timeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
-      check: false,
-    });
-    if (result.exitCode === 0) {
-      return;
-    }
-    await sleep(2_000);
+  // Installed CLI status uses the same 75s command timeout as the lane waiter; clamp
+  // each attempt + sleep so readiness polling cannot overrun the ready deadline.
+  const ready = await pollUntilDeadline({
+    deadline,
+    maxAttemptTimeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
+    attempt: async (timeoutMs, _deadline) => {
+      const result = await runInstalledCli({
+        cliPath: params.cliPath,
+        args: statusArgs,
+        cwd: params.lane.homeDir,
+        env: params.env,
+        logPath: params.logPath,
+        timeoutMs,
+        check: false,
+      });
+      return result.exitCode === 0 ? "done" : "retry";
+    },
+  });
+  if (!ready) {
+    throw new Error(`Gateway did not become ready on port ${params.lane.gatewayPort}.`);
   }
-  throw new Error(`Gateway did not become ready on port ${params.lane.gatewayPort}.`);
 }
 
 export async function waitForInstalledGatewayToStop(params: {
@@ -616,25 +621,33 @@ export async function waitForInstalledGatewayToStop(params: {
     requireRpc: false,
   });
   const deadline = Date.now() + gatewayReadyDeadlineMs();
-  while (Date.now() < deadline) {
-    await runInstalledCli({
-      cliPath: params.cliPath,
-      args: statusArgs,
-      cwd: params.lane.homeDir,
-      env: params.env,
-      logPath: params.logPath,
-      timeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
-      check: false,
-    });
-    const portReachable = await canConnectToLoopbackPort(params.lane.gatewayPort);
-    if (!portReachable) {
-      return;
-    }
-    await sleep(2_000);
+  // Stop polling also arms full status-command timeouts; keep the managed-stop budget
+  // honest so manual fallback is not delayed by an unclamped final probe.
+  // The attempt receives both the clamped status-command timeout and the deadline
+  // so the loopback-port check after the status command is also clamped.
+  const stopped = await pollUntilDeadline({
+    deadline,
+    maxAttemptTimeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
+    attempt: async (timeoutMs, attemptDeadline) => {
+      await runInstalledCli({
+        cliPath: params.cliPath,
+        args: statusArgs,
+        cwd: params.lane.homeDir,
+        env: params.env,
+        logPath: params.logPath,
+        timeoutMs,
+        check: false,
+      });
+      const portTimeoutMs = clampTimeoutMs(attemptDeadline, 1_000);
+      const portReachable = await canConnectToLoopbackPort(params.lane.gatewayPort, portTimeoutMs);
+      return portReachable ? "retry" : "done";
+    },
+  });
+  if (!stopped) {
+    throw new Error(
+      `Managed gateway did not stop on port ${params.lane.gatewayPort} before manual fallback.`,
+    );
   }
-  throw new Error(
-    `Managed gateway did not stop on port ${params.lane.gatewayPort} before manual fallback.`,
-  );
 }
 
 export async function ensureManagedGatewayReady(params: {

--- a/scripts/lib/cross-os-release-checks/runtime.ts
+++ b/scripts/lib/cross-os-release-checks/runtime.ts
@@ -43,7 +43,7 @@ import {
 } from "./network-smokes.ts";
 import { registerActiveChildProcessTree, runCommand, withAllocatedGatewayPort } from "./process.ts";
 import { logLanePhase } from "./reporting.ts";
-import { formatError, sleep } from "./shared.ts";
+import { formatError, pollUntilDeadline, sleep } from "./shared.ts";
 
 export async function runOpenClaw(params: {
   lane: LaneState;
@@ -187,27 +187,30 @@ export async function startGateway(params: LaneCommandParams): Promise<GatewayHa
 export async function waitForGateway(params: LaneCommandParams) {
   const statusArgs = await resolveGatewayStatusArgs(params.lane, params.env, params.logPath);
   const deadline = Date.now() + gatewayReadyDeadlineMs();
-  while (Date.now() < deadline) {
-    let result;
-    try {
-      result = await runOpenClaw({
-        lane: params.lane,
-        env: params.env,
-        args: statusArgs,
-        logPath: params.logPath,
-        timeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
-        check: false,
-      });
-    } catch {
-      await sleep(2_000);
-      continue;
-    }
-    if (result.exitCode === 0) {
-      return;
-    }
-    await sleep(2_000);
+  // Status probes use a 75s command timeout; clamp each attempt + sleep so the final
+  // iteration cannot overrun the gateway-ready deadline by nearly a full probe budget.
+  const ready = await pollUntilDeadline({
+    deadline,
+    maxAttemptTimeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
+    attempt: async (timeoutMs, _deadline) => {
+      try {
+        const result = await runOpenClaw({
+          lane: params.lane,
+          env: params.env,
+          args: statusArgs,
+          logPath: params.logPath,
+          timeoutMs,
+          check: false,
+        });
+        return result.exitCode === 0 ? "done" : "retry";
+      } catch {
+        return "retry";
+      }
+    },
+  });
+  if (!ready) {
+    throw new Error(`Gateway did not become ready on port ${params.lane.gatewayPort}.`);
   }
-  throw new Error(`Gateway did not become ready on port ${params.lane.gatewayPort}.`);
 }
 
 async function resolveGatewayStatusArgs(lane: LaneState, env: NodeJS.ProcessEnv, logPath: string) {

--- a/scripts/lib/cross-os-release-checks/shared.ts
+++ b/scripts/lib/cross-os-release-checks/shared.ts
@@ -44,6 +44,50 @@ export function sleep(ms: number) {
   });
 }
 
+/** Milliseconds left before an absolute deadline. May be zero or negative. */
+export function remainingMs(deadline: number, now = Date.now()): number {
+  return deadline - now;
+}
+
+/**
+ * Caps a per-attempt timeout to the remaining deadline budget.
+ * Callers must check remainingMs(deadline) > 0 before starting work that needs a timeout.
+ */
+export function clampTimeoutMs(deadline: number, maxMs: number, now = Date.now()): number {
+  return Math.max(1, Math.min(maxMs, deadline - now));
+}
+
+/**
+ * Polls until `attempt` returns "done" or the deadline is exhausted.
+ * Each attempt receives the clamped timeout and the absolute deadline so that
+ * multi-step callbacks (e.g. status probe + port check) can clamp every
+ * sub-operation to the remaining budget. Interstitial sleep is also clamped.
+ */
+export async function pollUntilDeadline(params: {
+  deadline: number;
+  maxAttemptTimeoutMs: number;
+  maxSleepMs?: number;
+  attempt: (timeoutMs: number, deadline: number) => Promise<"done" | "retry">;
+  sleepFn?: (ms: number) => Promise<void>;
+}): Promise<boolean> {
+  const sleepFn = params.sleepFn ?? sleep;
+  const maxSleepMs = params.maxSleepMs ?? 2_000;
+  while (remainingMs(params.deadline) > 0) {
+    const outcome = await params.attempt(
+      clampTimeoutMs(params.deadline, params.maxAttemptTimeoutMs),
+      params.deadline,
+    );
+    if (outcome === "done") {
+      return true;
+    }
+    if (remainingMs(params.deadline) <= 0) {
+      break;
+    }
+    await sleepFn(clampTimeoutMs(params.deadline, maxSleepMs));
+  }
+  return false;
+}
+
 export function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
   if (value instanceof Error) {
     return value;

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve as resolvePath, win32 } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   agentOutputHasExpectedOkMarker,
   agentTurnUsedEmbeddedFallback,
@@ -36,6 +36,7 @@ import {
   buildInstallerSmokeScript,
   buildWindowsPathBootstrapScript,
   canConnectToLoopbackPort,
+  clampTimeoutMs,
   buildDiscordSmokeGuildsConfig,
   buildRealUpdateEnv,
   dashboardHtmlMarkerStatus,
@@ -53,6 +54,8 @@ import {
   CROSS_OS_AGENT_TURN_TIMEOUT_SECONDS,
   CROSS_OS_COMMAND_HEARTBEAT_SECONDS,
   deleteDiscordMessage,
+  pollUntilDeadline,
+  remainingMs,
   isImmutableReleaseRef,
   isRecoverableWindowsPackagedUpgradeSwapCleanupFailure,
   isRecoverableWindowsPackagedUpgradeTimeoutError,
@@ -275,6 +278,102 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     );
     expect(CROSS_OS_GATEWAY_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(180_000);
     expect(CROSS_OS_WINDOWS_GATEWAY_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(300_000);
+  });
+
+  it("clamps per-attempt timeouts to the remaining deadline budget", () => {
+    const now = 1_000_000;
+    expect(remainingMs(now + 250, now)).toBe(250);
+    expect(remainingMs(now - 1, now)).toBe(-1);
+    expect(clampTimeoutMs(now + 250, CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS, now)).toBe(250);
+    expect(clampTimeoutMs(now + 60_000, CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS, now)).toBe(
+      60_000,
+    );
+    expect(clampTimeoutMs(now + 1, 2_000, now)).toBe(1);
+  });
+
+  it("clamps gateway status poll attempt timeouts to the remaining ready deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const attemptTimeouts: number[] = [];
+    const attemptDeadlines: number[] = [];
+    const sleepTimeouts: number[] = [];
+    try {
+      const deadline = Date.now() + 250;
+      const ready = await pollUntilDeadline({
+        deadline,
+        maxAttemptTimeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
+        maxSleepMs: 2_000,
+        attempt: async (timeoutMs, attemptDeadline) => {
+          attemptTimeouts.push(timeoutMs);
+          attemptDeadlines.push(attemptDeadline);
+          return "retry";
+        },
+        sleepFn: async (ms) => {
+          sleepTimeouts.push(ms);
+          vi.setSystemTime(Date.now() + ms);
+        },
+      });
+
+      expect(ready).toBe(false);
+      expect(attemptTimeouts.length).toBeGreaterThan(0);
+      expect(attemptTimeouts.every((ms) => ms <= 250)).toBe(true);
+      expect(attemptTimeouts[0]).toBe(250);
+      expect(Math.max(...attemptTimeouts)).toBeLessThan(CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS);
+      expect(sleepTimeouts.every((ms) => ms <= 250)).toBe(true);
+      // Attempt callback receives the absolute deadline for sub-operation clamping.
+      expect(attemptDeadlines.every((d) => d === deadline)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns true when the first attempt succeeds", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    try {
+      const deadline = Date.now() + 5_000;
+      const ready = await pollUntilDeadline({
+        deadline,
+        maxAttemptTimeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
+        attempt: async () => "done",
+      });
+      expect(ready).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps the stop-waiter loopback-port probe to the remaining budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const portTimeouts: number[] = [];
+    try {
+      const deadline = Date.now() + 150;
+      // Simulate a stop-waiter: status command + port check per iteration.
+      await pollUntilDeadline({
+        deadline,
+        maxAttemptTimeoutMs: CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
+        maxSleepMs: 2_000,
+        attempt: async (timeoutMs, attemptDeadline) => {
+          // Advance time by the clamped command timeout to simulate a slow status probe.
+          vi.setSystemTime(Date.now() + timeoutMs);
+          // The port check must clamp its own timeout to the remaining budget.
+          const portTimeout = clampTimeoutMs(attemptDeadline, 1_000);
+          portTimeouts.push(portTimeout);
+          return "retry";
+        },
+        sleepFn: async (ms) => {
+          vi.setSystemTime(Date.now() + ms);
+        },
+      });
+      // Every port-check timeout must be within the original 150ms deadline budget.
+      expect(portTimeouts.length).toBeGreaterThan(0);
+      expect(portTimeouts.every((ms) => ms <= 150)).toBe(true);
+      // At least one port check should be clamped below the default 1s.
+      expect(Math.min(...portTimeouts)).toBeLessThan(1_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps gateway status RPC probing when help probing is unavailable", () => {


### PR DESCRIPTION
## What Problem This Solves

Cross-OS gateway ready/stop waits declare a total deadline (`gatewayReadyDeadlineMs`, 3–5 min) but each loop iteration still arms the full `CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS` (75s) status probe plus an unclamped 2s sleep. Near the deadline edge, `waitForGateway`, `waitForInstalledGateway`, and `waitForInstalledGatewayToStop` can overrun the advertised ready/stop budget by nearly a full probe (~75s).

## Why This Change Was Made

Add shared `remainingMs` / `clampTimeoutMs` helpers and a `pollUntilDeadline` poller that clamps each attempt timeout and interstitial sleep to the remaining budget. Route the three gateway ready/stop waiters through that poller so the final status probe cannot schedule 75s of work when only milliseconds remain.

**Key improvement over the original approach**: `pollUntilDeadline` passes the absolute deadline to the `attempt` callback so multi-step callbacks (e.g. status probe + loopback-port check) can clamp every sub-operation. The stop waiter now clamps `canConnectToLoopbackPort` to the remaining post-status budget, eliminating the ~1s residual deadline overrun that the original PR left unaddressed.

## User Impact

Cross-OS release-check gateway start/stop polling fails closed closer to the configured ready deadline instead of drifting past it on the last status attempt. Release lanes reach manual fallback / failure sooner when the gateway never becomes ready.

## Evidence

- Changed: `scripts/lib/cross-os-release-checks/{shared,runtime,installed}.ts`, `test/scripts/openclaw-cross-os-release-checks.test.ts`
- Production caller path: `waitForGateway` / `waitForInstalledGateway` / `waitForInstalledGatewayToStop` → `pollUntilDeadline` → `clampTimeoutMs(deadline, CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS)`

## Real behavior proof

### Behavior or issue addressed

Gateway ready/stop status polls no longer arm a full 75s command timeout on the last iteration when the remaining ready deadline is smaller. The stop waiter's loopback-port probe is also clamped, so the entire attempt stays within budget.

### Canonical reachability path

`waitForGateway` / `waitForInstalledGateway` / `waitForInstalledGatewayToStop` → `pollUntilDeadline` → `clampTimeoutMs(deadline, CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS)`. The stop waiter's attempt callback also calls `clampTimeoutMs(attemptDeadline, 1_000)` for the port check.

### Real environment tested

Local trusted worktree; real wall-clock timer proof script; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts \
  -t 'clamp|remaining|deadline|stop-waiter|first attempt' --reporter=verbose
```

### Wall-clock deadline overrun proof (real timers)

A local Node.js script using real `setTimeout`/wall-clock timers simulated the original unclamped loop vs the clamped `pollUntilDeadline` loop. Scaled-down config: 500ms deadline (represents 3–5 min), 300ms command (represents 75s), 200ms port probe (represents 1s).

```text
=== Original ready-wait loop (unclamped) ===
  Elapsed: 801ms (deadline: 500ms)
  Overrun: 301ms (60% beyond deadline)

=== Fixed ready-wait loop (clamped via pollUntilDeadline) ===
  Elapsed: 500ms (deadline: 500ms)
  Overrun: 0ms (0% beyond deadline)

=== Original stop-wait loop (unclamped port probe) ===
  Elapsed: 609ms (deadline: 500ms)
  Overrun: 109ms (22% beyond deadline)

=== Fixed stop-wait loop (clamped port probe via deadline) ===
  Elapsed: 500ms (deadline: 500ms)
  Overrun: 0ms (0% beyond deadline)

=== Summary ===
Ready-wait overrun:  original 301ms → fixed 0ms
Stop-wait overrun:   original 109ms → fixed 0ms

Production values (75s command, 3-5min deadline):
  Ready-wait: ~75s overrun → ~0s
  Stop-wait:  ~76s overrun → ~0s (port probe also clamped)
```

### Vitest regression proof (4/4 deadline tests pass)

```text
✓ clamps per-attempt timeouts to the remaining deadline budget
✓ clamps gateway status poll attempt timeouts to the remaining ready deadline
✓ returns true when the first attempt succeeds
✓ clamps the stop-waiter loopback-port probe to the remaining budget

 Test Files  1 passed (1)
      Tests  4 passed | 103 skipped (107)
```

Full suite (107/107 pass):

```text
··········································································
 Test Files  1 passed (1)
      Tests  107 passed (107)
```

### Summary

| Scenario | Original overrun | Fixed overrun |
|---|---|---|
| Ready-wait (gateway never ready) | ~75s (one full status command) | ~0s (clamped to remaining budget) |
| Stop-wait (gateway never stops) | ~76s (status command + port probe) | ~0s (both clamped) |
| Early success | Immediate | Same — returns on first "done" |

### What was not tested

Full Cross-OS release lane on a remote runner with a live hanging gateway status probe.

### Fix classification

bugfix — timeout budget + stop-waiter port-probe clamp

## Related work

[#109046](https://github.com/openclaw/openclaw/pull/109046) clamps dashboard/Discord loops with the same `remainingMs` / `clampTimeoutMs` helper names; this PR adds `pollUntilDeadline` and wires the gateway waiters. If both land, rebase keeps one helper pair.

## AI Assistance

AI-assisted. Author reviewed deadline clamping for the three gateway waiters, identified and fixed the stop-waiter port-probe overrun, and focused proof output.
