### PR TITLE
fix(tailscale): bound binary discovery commands

### DIFF
--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,9 +1,18 @@
 // Covers Tailscale whois, Serve, and Funnel helpers.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
+
+const { runExecMock } = vi.hoisted(() => ({ runExecMock: vi.fn() }));
+
+vi.mock("../process/exec.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../process/exec.js")>();
+  return { ...actual, runExec: runExecMock };
+});
+
 import * as tailscale from "./tailscale.js";
 
 const {
+  findTailscaleBinary,
   getTailnetHostname,
   readTailscaleWhoisIdentity,
   enableTailscaleServe,
@@ -37,6 +46,7 @@ describe("tailscale helpers", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   beforeEach(() => {
+    runExecMock.mockReset();
     envSnapshot = captureEnv(["OPENCLAW_TEST_TAILSCALE_BINARY", "NODE_ENV", "VITEST"]);
     process.env.OPENCLAW_TEST_TAILSCALE_BINARY = "tailscale";
     process.env.VITEST ??= "true";
@@ -46,6 +56,30 @@ describe("tailscale helpers", () => {
     vi.useRealTimers();
     envSnapshot.restore();
     vi.restoreAllMocks();
+  });
+
+  it("bounds every external command used for binary discovery", async () => {
+    runExecMock.mockRejectedValue(new Error("command unavailable"));
+
+    await expect(findTailscaleBinary()).resolves.toBeNull();
+
+    expect(runExecMock).toHaveBeenCalledWith("which", ["tailscale"], { timeoutMs: 3_000 });
+    expect(runExecMock).toHaveBeenCalledWith(
+      "find",
+      [
+        "/Applications",
+        "-maxdepth",
+        "3",
+        "-name",
+        "Tailscale",
+        "-path",
+        "*/Tailscale.app/Contents/MacOS/Tailscale",
+      ],
+      { timeoutMs: 5_000 },
+    );
+    expect(runExecMock).toHaveBeenCalledWith("locate", ["Tailscale.app"], {
+      timeoutMs: 5_000,
+    });
   });
 
   it("parses DNS name from tailscale status", async () => {

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -13,6 +13,9 @@ import { logVerbose } from "../globals.js";
 import { runExec } from "../process/exec.js";
 import { toErrorObject } from "./errors.js";
 
+const TAILSCALE_BINARY_PROBE_TIMEOUT_MS = 3_000;
+const TAILSCALE_BINARY_SEARCH_TIMEOUT_MS = 5_000;
+
 function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
@@ -39,7 +42,7 @@ export async function findTailscaleBinary(): Promise<string | null> {
       return false;
     }
     try {
-      await runExec(path, ["--version"], { timeoutMs: 3000 });
+      await runExec(path, ["--version"], { timeoutMs: TAILSCALE_BINARY_PROBE_TIMEOUT_MS });
       return true;
     } catch {
       return false;
@@ -48,7 +51,9 @@ export async function findTailscaleBinary(): Promise<string | null> {
 
   // Strategy 1: which command
   try {
-    const { stdout } = await runExec("which", ["tailscale"]);
+    const { stdout } = await runExec("which", ["tailscale"], {
+      timeoutMs: TAILSCALE_BINARY_PROBE_TIMEOUT_MS,
+    });
     const fromPath = stdout.trim();
     if (fromPath && (await checkBinary(fromPath))) {
       return fromPath;
@@ -76,7 +81,7 @@ export async function findTailscaleBinary(): Promise<string | null> {
         "-path",
         "*/Tailscale.app/Contents/MacOS/Tailscale",
       ],
-      { timeoutMs: 5000 },
+      { timeoutMs: TAILSCALE_BINARY_SEARCH_TIMEOUT_MS },
     );
     const found = stdout.trim().split("\n")[0];
     if (found && (await checkBinary(found))) {
@@ -88,7 +93,9 @@ export async function findTailscaleBinary(): Promise<string | null> {
 
   // Strategy 4: locate command
   try {
-    const { stdout } = await runExec("locate", ["Tailscale.app"]);
+    const { stdout } = await runExec("locate", ["Tailscale.app"], {
+      timeoutMs: TAILSCALE_BINARY_SEARCH_TIMEOUT_MS,
+    });
     const candidates = stdout
       .trim()
       .split("\n")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateway setup could wait indefinitely while locating Tailscale when a host `which` or `locate` command never exits.

## Why This Change Was Made

Bounds lightweight PATH and binary probes at 3 seconds and filesystem/database searches at 5 seconds, matching the existing discovery timeouts. A failed or timed-out strategy continues to the next existing discovery path. AI-assisted.

## User Impact

Gateway setup and Tailscale operations no longer hang indefinitely during binary discovery. Existing binary selection order and fallback behavior remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/infra/tailscale.test.ts src/infra/detect-binary.test.ts` — 29 tests passed.
- `./node_modules/.bin/oxfmt --check src/infra/tailscale.ts src/infra/tailscale.test.ts` — passed.
- Targeted type-aware oxlint with `config/tsconfig/oxlint.core.json` — passed.
- `git diff --check origin/main...HEAD` — passed.
