### PR TITLE
fix: generated image delivered twice after image_generate completion

### DIFF
--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -1097,6 +1097,59 @@ describe("createMediaGenerationTaskLifecycle", () => {
     expect(taskRegistryDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("assigns completion-handoff ownership so the agent is not told to re-attach MEDIA", async () => {
+    // Host-owned durable delivery already carries the generated artifact. Asking
+    // the resumed agent to also attach MEDIA lines produces a second channel send.
+    subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValueOnce({
+      delivered: true,
+      path: "queued",
+    });
+    const lifecycle = createImageMediaLifecycle();
+
+    await expect(
+      lifecycle.wakeTaskCompletion({
+        handle: {
+          taskId: "task-image-once",
+          runId: "tool:image_generate:once",
+          requesterSessionKey: "agent:main:telegram:direct:123",
+          taskLabel: "proof dog image",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "telegram:123",
+          },
+        },
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "Generated 1 image.\nMEDIA:/tmp/generated-dog.png",
+        mediaUrls: ["/tmp/generated-dog.png"],
+        attachments: [
+          {
+            type: "image",
+            path: "/tmp/generated-dog.png",
+            mimeType: "image/png",
+            name: "generated-dog.png",
+          },
+        ],
+      }),
+    ).resolves.toEqual({ status: "delivered" });
+
+    const announceParams = subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mock
+      .calls[0]?.[0] as
+      | {
+          durableGeneratedMediaHandoff?: boolean;
+          internalEvents?: Array<{ replyInstruction?: string; mediaUrls?: string[] }>;
+        }
+      | undefined;
+    expect(announceParams?.durableGeneratedMediaHandoff).toBe(true);
+    const replyInstruction = announceParams?.internalEvents?.[0]?.replyInstruction ?? "";
+    expect(announceParams?.internalEvents?.[0]?.mediaUrls).toEqual(["/tmp/generated-dog.png"]);
+    expect(replyInstruction).toMatch(/owned by this completion handoff/i);
+    expect(replyInstruction).toMatch(/Do not re-send, re-attach, or echo MEDIA lines/i);
+    expect(replyInstruction).not.toMatch(/final-reply MEDIA lines/i);
+    expect(replyInstruction).not.toMatch(/every structured attachment from the internal event/i);
+    expect(replyInstruction).toMatch(/caption text only|short normal final reply caption/i);
+  });
+
   it("does not direct-deliver generated media after requester abandonment", async () => {
     // Abandoned requester sessions are terminal; direct delivery would re-open a
     // conversation the task lifecycle already decided to stop.

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -1147,7 +1147,9 @@ describe("createMediaGenerationTaskLifecycle", () => {
     expect(replyInstruction).toMatch(/Do not re-send, re-attach, or echo MEDIA lines/i);
     expect(replyInstruction).not.toMatch(/final-reply MEDIA lines/i);
     expect(replyInstruction).not.toMatch(/every structured attachment from the internal event/i);
-    expect(replyInstruction).toMatch(/caption text only|short normal final reply caption/i);
+    expect(replyInstruction).not.toMatch(/message\(action=["']send["']\)/i);
+    expect(replyInstruction).toMatch(/short normal final reply caption/i);
+    expect(replyInstruction).toMatch(/Do not call the message tool/i);
   });
 
   it("does not direct-deliver generated media after requester abandonment", async () => {

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -378,9 +378,8 @@ function failMediaGenerationTaskRun(params: {
 }
 
 /**
- * Completion handoffs own outbound media delivery (durable host-owned media /
- * direct fallback). The resumed agent may write a caption only; re-attaching
- * MEDIA paths here causes a second channel delivery of the same artifact.
+ * Durable completion handoffs fix the route/media and withhold the message tool.
+ * The resumed agent may only caption; attaching media creates a duplicate.
  */
 function buildMediaGenerationReplyInstruction(params: {
   status: "ok" | "error";
@@ -391,8 +390,8 @@ function buildMediaGenerationReplyInstruction(params: {
       `The ${params.completionLabel} is ready for the original chat.`,
       "Generated media delivery is already owned by this completion handoff.",
       "Do not re-send, re-attach, or echo MEDIA lines / structured attachments from the internal event.",
-      'Use the current visible-reply contract for caption text only: if this session requires message-tool replies, call message(action="send") with a short caption and no media, then reply only NO_REPLY.',
-      "Otherwise, write a short normal final reply caption (or reply NO_REPLY if no caption is needed).",
+      "Use the current visible-reply contract for caption text only: write a short normal final reply caption, or reply NO_REPLY if no caption is needed.",
+      "Do not call the message tool for this completion.",
     ].join(" ");
   }
   return [

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -377,6 +377,11 @@ function failMediaGenerationTaskRun(params: {
   }
 }
 
+/**
+ * Completion handoffs own outbound media delivery (durable host-owned media /
+ * direct fallback). The resumed agent may write a caption only; re-attaching
+ * MEDIA paths here causes a second channel delivery of the same artifact.
+ */
 function buildMediaGenerationReplyInstruction(params: {
   status: "ok" | "error";
   completionLabel: string;
@@ -384,8 +389,10 @@ function buildMediaGenerationReplyInstruction(params: {
   if (params.status === "ok") {
     return [
       `The ${params.completionLabel} is ready for the original chat.`,
-      'Use the current visible-reply contract: if this session requires message-tool replies, call message(action="send") with a short caption and every structured attachment from the internal event, then reply only NO_REPLY.',
-      "Otherwise, write the normal final reply and attach every generated media path with final-reply MEDIA lines.",
+      "Generated media delivery is already owned by this completion handoff.",
+      "Do not re-send, re-attach, or echo MEDIA lines / structured attachments from the internal event.",
+      'Use the current visible-reply contract for caption text only: if this session requires message-tool replies, call message(action="send") with a short caption and no media, then reply only NO_REPLY.',
+      "Otherwise, write a short normal final reply caption (or reply NO_REPLY if no caption is needed).",
     ].join(" ");
   }
   return [

--- a/src/agents/tools/music-generate-background.test.ts
+++ b/src/agents/tools/music-generate-background.test.ts
@@ -139,8 +139,11 @@ describe("music generate background helpers", () => {
       },
     });
 
+    // Shared helper assigns host-owned completion delivery; agent gets caption-only
+    // guidance (not dual-attach via final-reply MEDIA lines).
     expectReplyInstructionContains("visible-reply contract");
-    expectReplyInstructionContains("final-reply MEDIA lines");
+    expectReplyInstructionContains("completion handoff");
+    expectReplyInstructionContains("Do not re-send, re-attach, or echo MEDIA lines");
   });
 
   it("keeps failed completion notices in the durable agent-loop handoff", async () => {
@@ -190,8 +193,10 @@ describe("music generate background helpers", () => {
         },
       });
 
+      // Same shared ownership instruction for legacy group/channel keys.
       expectReplyInstructionContains("visible-reply contract");
-      expectReplyInstructionContains("final-reply MEDIA lines");
+      expectReplyInstructionContains("completion handoff");
+      expectReplyInstructionContains("Do not re-send, re-attach, or echo MEDIA lines");
     },
   );
 

--- a/src/agents/tools/music-generate-background.test.ts
+++ b/src/agents/tools/music-generate-background.test.ts
@@ -144,6 +144,7 @@ describe("music generate background helpers", () => {
     expectReplyInstructionContains("visible-reply contract");
     expectReplyInstructionContains("completion handoff");
     expectReplyInstructionContains("Do not re-send, re-attach, or echo MEDIA lines");
+    expectReplyInstructionContains("Do not call the message tool");
   });
 
   it("keeps failed completion notices in the durable agent-loop handoff", async () => {


### PR DESCRIPTION
Closes #108976

## What Problem This Solves

Fixes an issue where users generating an image in a Telegram (or other channel) chat would receive the same photo twice—once from the resumed agent reply that re-attached media, and once from the completion handoff that already owns delivery.

## Why This Change Was Made

Generated-media completion handoffs already own outbound media delivery (durable host-owned media with direct fallback). The success reply instruction previously told the resumed agent to also attach every `MEDIA` path / structured attachment, which creates a second visible delivery of the same artifact when the agent follows that prompt.

The instruction now assigns a single owner: the completion handoff delivers media; the agent may only write a short caption (or `NO_REPLY`). Image, video, and music generation share this lifecycle helper, so the ownership rule applies across those sibling tools without a Telegram-specific branch.

Compatibility: no config, API, or protocol change. Performance: prompt-text only, no extra I/O. Usability: captions remain allowed; images no longer duplicate. Security: no trust-boundary or secret changes.

## User Impact

After `image_generate` (and sibling media generation tools) completes, users receive each generated artifact once, with an optional caption, instead of two identical channel deliveries a few seconds apart.

## Evidence

Focused tests (local macOS):

```text
node scripts/run-vitest.mjs \
  src/agents/tools/music-generate-background.test.ts \
  src/agents/tools/media-generate-background-shared.test.ts
# Test Files  2 passed (2)
# Tests  35 passed (35)
```

Coverage:

- Shared regression `assigns completion-handoff ownership so the agent is not told to re-attach MEDIA` asserts the wake `replyInstruction` names completion-handoff ownership, forbids re-attaching MEDIA lines, and no longer contains the old dual-attach wording.
- Sibling `music-generate-background` expectations now match that same shared ownership contract (completion handoff owns media; agent is caption-only). This aligns the music completion path with image/video under the shared helper and clears the CI failure that still expected `final-reply MEDIA lines`.

## Real behavior proof

- Behavior addressed: generated media from `image_generate` (and sibling media tools via the shared helper) must be delivered once; completion handoff owns media while the agent may only caption.
- Environment: local macOS OpenClaw checkout; focused Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: success reply instruction told the resumed agent to attach every generated media path with final-reply MEDIA lines (or message-tool attachments) while `durableGeneratedMediaHandoff` also carries the same mediaUrls/attachments into host-owned delivery.
- Exact steps or command run after this patch:
  1. Inspect `buildMediaGenerationReplyInstruction` for status `ok`.
  2. `node scripts/run-vitest.mjs src/agents/tools/media-generate-background-shared.test.ts -t "completion-handoff ownership"`
  3. `node scripts/run-vitest.mjs src/agents/tools/music-generate-background.test.ts src/agents/tools/media-generate-background-shared.test.ts` → 35/35 pass.
- Evidence after fix: ownership regression passes; music sibling expectations assert completion-handoff ownership and forbid MEDIA re-attach; instruction text requires caption-only / NO_REPLY guidance.
- Control check: wake still sets `durableGeneratedMediaHandoff: true` and still includes `mediaUrls` / attachments on the internal event for host delivery evidence; only the agent-facing ownership instruction changed.
- Observed result after fix: completion wake no longer instructs a second media-bearing reply path for image or music (shared helper).
- Live Telegram: still needed for full acceptance (exactly one `sendPhoto` after one image-generation completion, with caption behavior). A prior Mantis Telegram Desktop run on this PR could not capture a faithful generated-media completion sequence (capture infrastructure / skipped before-after; no visual artifacts), so it did not substitute for a successful single-delivery recording. Happy to re-run or supply a redacted recording when a Telegram tenant path is available.

This PR was authored with AI assistance (Grok).
