### PR TITLE
fix(ui): tool catalog group and profile names stay English in localized UIs

### DIFF
--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -1,6 +1,8 @@
 // Control UI tests cover agents utils behavior.
 import { describe, expect, it } from "vitest";
 import { AVATAR_MAX_DATA_URL_CHARS } from "../../../../src/shared/avatar-limits.js";
+import type { ToolsCatalogResult } from "../../api/types.ts";
+import { i18n, t } from "../../i18n/index.ts";
 import {
   assistantAvatarFallbackUrl,
   isRenderableControlUiAvatarUrl,
@@ -13,7 +15,63 @@ import {
   formatBytes,
   listSelectableAgents,
   resolveEffectiveModelFallbacks,
+  resolveToolProfileOptions,
+  resolveToolSections,
 } from "./display.ts";
+
+const TOOLS_CATALOG_RESULT: ToolsCatalogResult = {
+  agentId: "main",
+  profiles: [
+    { id: "minimal", label: "Minimal" },
+    { id: "full", label: "Full" },
+  ],
+  groups: [
+    {
+      id: "fs",
+      label: "Files",
+      source: "core",
+      tools: [
+        {
+          id: "read",
+          label: "read",
+          description: "Read file contents",
+          source: "core",
+          defaultProfiles: ["coding"],
+        },
+      ],
+    },
+    {
+      id: "runtime",
+      label: "Runtime",
+      source: "core",
+      tools: [
+        {
+          id: "exec",
+          label: "exec",
+          description: "Run shell commands",
+          source: "core",
+          defaultProfiles: ["coding"],
+        },
+      ],
+    },
+    {
+      id: "plugin:my-plugin",
+      label: "My Plugin",
+      source: "plugin",
+      pluginId: "my-plugin",
+      tools: [
+        {
+          id: "my_tool",
+          label: "my_tool",
+          description: "Plugin tool",
+          source: "plugin",
+          pluginId: "my-plugin",
+          defaultProfiles: [],
+        },
+      ],
+    },
+  ],
+};
 
 describe("listSelectableAgents", () => {
   it("excludes semantic system rows without depending on identity", () => {
@@ -25,6 +83,75 @@ describe("listSelectableAgents", () => {
 
     expect(listSelectableAgents(agents)).toEqual([agents[0], agents[2]]);
     expect(agents).toHaveLength(3);
+  });
+});
+
+describe("resolveToolSections", () => {
+  it("keeps English core group labels identical to the gateway catalog", () => {
+    const sections = resolveToolSections(TOOLS_CATALOG_RESULT);
+    expect(sections.map((section) => section.label)).toEqual(["Files", "Runtime", "My Plugin"]);
+  });
+
+  // Regression: gateway catalog labels are English-only, so localized UIs
+  // rendered "Files"/"Runtime" section names even though translations exist.
+  it("translates known core group labels in non-English locales", async () => {
+    await i18n.setLocale("zh-CN");
+    try {
+      const sections = resolveToolSections(TOOLS_CATALOG_RESULT);
+      expect(sections.map((section) => section.label)).toEqual([
+        t("agents.toolCatalog.groups.files"),
+        t("agents.toolCatalog.groups.runtime"),
+        "My Plugin",
+      ]);
+      expect(sections[0]?.label).not.toBe("Files");
+      expect(sections[1]?.label).not.toBe("Runtime");
+    } finally {
+      await i18n.setLocale("en");
+    }
+  });
+
+  it("keeps catalog tool wiring intact while translating group labels", async () => {
+    await i18n.setLocale("zh-CN");
+    try {
+      const sections = resolveToolSections(TOOLS_CATALOG_RESULT);
+      expect(sections[0]?.id).toBe("fs");
+      expect(sections[0]?.source).toBe("core");
+      expect(sections[0]?.tools).toEqual([
+        {
+          id: "read",
+          label: "read",
+          description: "Read file contents",
+          source: "core",
+          pluginId: undefined,
+          optional: undefined,
+          defaultProfiles: ["coding"],
+        },
+      ]);
+      expect(sections[2]?.pluginId).toBe("my-plugin");
+    } finally {
+      await i18n.setLocale("en");
+    }
+  });
+});
+
+describe("resolveToolProfileOptions", () => {
+  it("keeps English profile labels identical to the gateway catalog", () => {
+    const profiles = resolveToolProfileOptions(TOOLS_CATALOG_RESULT);
+    expect(profiles.map((profile) => profile.label)).toEqual(["Minimal", "Full"]);
+  });
+
+  it("translates known profile labels in non-English locales", async () => {
+    await i18n.setLocale("zh-CN");
+    try {
+      const profiles = resolveToolProfileOptions(TOOLS_CATALOG_RESULT);
+      expect(profiles.map((profile) => profile.label)).toEqual([
+        t("agents.toolCatalog.profiles.minimal"),
+        t("agents.toolCatalog.profiles.full"),
+      ]);
+      expect(profiles[0]?.label).not.toBe("Minimal");
+    } finally {
+      await i18n.setLocale("en");
+    }
   });
 });
 

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -225,25 +225,39 @@ export const PROFILE_OPTIONS = [
   { id: "full", labelKey: "agents.toolCatalog.profiles.full" },
 ] as const;
 
+// Gateway catalog labels are English-only strings. Translate the known core
+// group/profile enum labels locally so localized UIs don't render English
+// section names; plugin groups (`plugin:<id>` ids) never match and keep the
+// catalog-provided label.
+const CORE_GROUP_LABEL_KEYS = new Map<string, string>(
+  FALLBACK_TOOL_SECTIONS.map((section) => [section.id, section.labelKey]),
+);
+const PROFILE_LABEL_KEYS = new Map<string, string>(
+  PROFILE_OPTIONS.map((profile) => [profile.id, profile.labelKey]),
+);
+
 export function resolveToolSections(
   toolsCatalogResult: ToolsCatalogResult | null,
 ): AgentToolSection[] {
   if (toolsCatalogResult?.groups?.length) {
-    return toolsCatalogResult.groups.map((group) => ({
-      id: group.id,
-      label: group.label,
-      source: group.source,
-      pluginId: group.pluginId,
-      tools: group.tools.map((tool) => ({
-        id: tool.id,
-        label: tool.label,
-        description: tool.description,
-        source: tool.source,
-        pluginId: tool.pluginId,
-        optional: tool.optional,
-        defaultProfiles: [...tool.defaultProfiles],
-      })),
-    }));
+    return toolsCatalogResult.groups.map((group) => {
+      const labelKey = CORE_GROUP_LABEL_KEYS.get(group.id);
+      return {
+        id: group.id,
+        label: labelKey ? t(labelKey) : group.label,
+        source: group.source,
+        pluginId: group.pluginId,
+        tools: group.tools.map((tool) => ({
+          id: tool.id,
+          label: tool.label,
+          description: tool.description,
+          source: tool.source,
+          pluginId: tool.pluginId,
+          optional: tool.optional,
+          defaultProfiles: [...tool.defaultProfiles],
+        })),
+      };
+    });
   }
   return FALLBACK_TOOL_SECTIONS.map((section) => ({
     id: section.id,
@@ -260,7 +274,10 @@ export function resolveToolProfileOptions(
   toolsCatalogResult: ToolsCatalogResult | null,
 ): readonly ToolCatalogProfile[] | ReadonlyArray<{ id: string; label: string }> {
   if (toolsCatalogResult?.profiles?.length) {
-    return toolsCatalogResult.profiles;
+    return toolsCatalogResult.profiles.map((profile) => {
+      const labelKey = PROFILE_LABEL_KEYS.get(profile.id);
+      return labelKey ? { id: profile.id, label: t(labelKey) } : profile;
+    });
   }
   return PROFILE_OPTIONS.map((profile) => ({
     id: profile.id,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the Control UI in a non-English language (for example Simplified Chinese) would still see English section names — "Files", "Runtime", "Web", "Memory", … — and English profile names ("Minimal", "Coding", …) in Settings → Agents → Tools, even though translations for every one of these labels already ship in the locale bundles.

The gateway `tools.catalog` response carries English-only labels. The Control UI used those labels directly whenever the catalog was present (which is always, on a connected gateway), so the translated `agents.toolCatalog.groups.*` / `agents.toolCatalog.profiles.*` strings were only reachable through the no-catalog fallback path that never runs in practice.

## Why This Change Was Made

`resolveToolSections` and `resolveToolProfileOptions` now translate the known core group ids (`fs`, `runtime`, `web`, …) and profile ids (`minimal`, `coding`, `messaging`, `full`) through the existing i18n keys, reusing the id→key maps already defined for the fallback path. Plugin groups (`plugin:<id>` ids) never match the core map and keep their catalog-provided label. No new i18n keys, no locale bundle changes, and no gateway/protocol changes; the English locale renders byte-identical labels to the catalog.

## User Impact

Settings → Agents → Tools now shows tool group and profile names in the selected UI language (e.g. 文件 / 运行时 / 网络 and 最小 / 编码 in Simplified Chinese). English UIs and plugin-provided groups are unchanged.

## Evidence

- New regression tests in `ui/src/lib/agents/display.test.ts`: with the fix, 22 tests pass; against the unfixed resolver the two new locale tests fail (core groups/profiles render "Files"/"Runtime"/"Minimal" under zh-CN). The tests drive the real zh-CN locale bundle through the real `ToolsCatalogResult` shape, and assert plugin group labels and tool wiring stay untouched.
- `node scripts/run-vitest.mjs ui/src/lib/agents/display.test.ts` → 22 passed; `ui/src/pages/agents` surface → 98 passed.
- `pnpm ui:i18n:verify` passes (no key/baseline changes needed — all keys already exist in every locale).
- Scoped `oxlint`, `oxfmt`, and `git diff --check` pass on the two changed files.

before：
<img width="1119" height="864" alt="工具目录" src="https://github.com/user-attachments/assets/87cc0ca0-d454-4c2d-adfe-d1eda91fdbb6" />
after：
<img width="1051" height="833" alt="工具目录2" src="https://github.com/user-attachments/assets/232d1e84-2579-4e6f-8d35-b0b46eba23d4" />
