### PR TITLE
fix(infra): bound macOS process start probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,7 @@ Docs: https://docs.openclaw.ai
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
+- **macOS process identity probes:** bound synchronous `ps` lookups during file-lock and worktree lease checks so stalled probes fail conservatively instead of blocking indefinitely. (#109064) Thanks @Alix-007.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,7 +295,6 @@ Docs: https://docs.openclaw.ai
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
-- **macOS process identity probes:** bound synchronous `ps` lookups during file-lock and worktree lease checks so stalled probes fail conservatively instead of blocking indefinitely. (#109064) Thanks @Alix-007.
 
 ## 2026.7.1
 

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -171,9 +171,12 @@ describe("process start times", () => {
     });
   });
 
-  it("returns null for unavailable Darwin file-lock start times", () => {
+  it("fails conservatively when the Darwin file-lock start-time probe times out", () => {
     vi.spyOn(childProcess, "execFileSync").mockImplementation(() => {
-      throw new Error("missing process");
+      throw Object.assign(new Error("spawnSync /bin/ps ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+        signal: "SIGTERM",
+      });
     });
 
     return withMockedPlatform("darwin", async () => {

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -165,6 +165,7 @@ describe("process start times", () => {
         expect.objectContaining({
           encoding: "utf8",
           env: expect.objectContaining({ LC_ALL: "C", TZ: "UTC" }),
+          timeout: 1000,
         }),
       );
     });

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -2,6 +2,8 @@
 import childProcess from "node:child_process";
 import fsSync from "node:fs";
 
+const DARWIN_PS_TIMEOUT_MS = 1000;
+
 function isValidPid(pid: number): boolean {
   return Number.isInteger(pid) && pid > 0;
 }
@@ -59,6 +61,7 @@ function getDarwinProcessStartTime(pid: number): number | null {
         encoding: "utf8",
         env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
         stdio: ["ignore", "pipe", "ignore"],
+        timeout: DARWIN_PS_TIMEOUT_MS,
       })
       .trim();
     // Darwin's lstart output has no timezone. Force UTC for both ps and parsing so


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS file-lock and run-lease ownership checks could block without a practical upper bound when the process start-time `ps` probe stalls.

## Why This Change Was Made

The fixed `/bin/ps` start-time probe now requests termination after 1,000 ms and continues to use the existing error path, which returns an unknown start time for conservative owner handling. This is a practical bound for ordinary stalled probes, not an absolute wall-clock deadline: Node waits for the child to exit after sending the timeout signal.

This change is AI-assisted. The affected helper, its callers, and the Node `execFileSync` timeout contract were reviewed before submission.

## User Impact

On macOS, lock ownership checks no longer wait indefinitely on an ordinarily stalled start-time probe. If the probe times out, OpenClaw keeps the owner identity unknown rather than treating the lock or lease as safe to delete.

## Evidence

- Node 24.18.0 focused Vitest: `src/shared/pid-alive.test.ts` (1 file, 16 tests passed).
- `oxfmt --check src/shared/pid-alive.ts src/shared/pid-alive.test.ts`
- Type-aware `oxlint` with `config/tsconfig/oxlint.core.json` on both touched files.
- `git diff --check origin/main...HEAD`
