### PR TITLE
fix(models): idle-timeout stalled OpenRouter capabilities catalog body

### DIFF
--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
@@ -312,6 +312,43 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
+  it("times out when an OpenRouter catalog response body stalls after headers", async () => {
+    await withOpenRouterStateDir(async () => {
+      vi.useFakeTimers();
+      try {
+        const cancel = vi.fn(async () => undefined);
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"data":['));
+            // Leave the stream open so the idle timer is the only exit.
+          },
+          cancel,
+        });
+        const fetchSpy = vi.fn(
+          async () =>
+            new Response(stream, {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchSpy);
+
+        const module = await importOpenRouterModelCapabilities("stalled-catalog-body");
+        const loadPromise = module.loadOpenRouterModelCapabilities("acme/missing-model");
+        // Catalog failures are swallowed by doFetch; advance past the idle bound
+        // and assert the load settles without caching a poisoned entry.
+        await vi.advanceTimersByTimeAsync(10_000);
+        await expect(loadPromise).resolves.toBeUndefined();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(module.getOpenRouterModelCapabilities("acme/missing-model")).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("bounds an oversized streamed OpenRouter catalog instead of buffering it whole", async () => {
     await withOpenRouterStateDir(async () => {
       // First pull emits a chunk larger than the cap; a well-behaved bounded read

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
@@ -203,8 +203,13 @@ async function doFetch(): Promise<void> {
       return;
     }
 
+    // fetch resolves after headers; keep idle bounds on the catalog body so a
+    // stalled OpenRouter stream cannot hang past the scan-style sibling fix.
     const bytes = await readResponseWithLimit(response, OPENROUTER_MODELS_RESPONSE_MAX_BYTES, {
+      chunkTimeoutMs: FETCH_TIMEOUT_MS,
       onOverflow: ({ size }) => new Error(`OpenRouter models response too large: ${size} bytes`),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`OpenRouter models response stalled after ${chunkTimeoutMs}ms`),
     });
     const data = JSON.parse(bytes.toString("utf8")) as { data?: OpenRouterApiModel[] };
     const models = data.data ?? [];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the embedded OpenRouter model-capabilities catalog fetch could hang after headers when `/models` stalled mid-body. The sibling `scanOpenRouterModels` path already applies `chunkTimeoutMs` during the catalog read (#108972), but `openrouter-model-capabilities` only capped bytes.

## Why This Change Was Made

Apply the same idle bound used by the scan path: `chunkTimeoutMs: FETCH_TIMEOUT_MS` with an explicit stalled-body error while reading the catalog through `readResponseWithLimit`. Existing oversized-body cancel and SQLite cache behavior stay unchanged.

## User Impact

**Before:** A stalled OpenRouter `/models` body could leave capability loading hanging until process-level intervention.

**After:** Stalled catalog bodies fail closed within the existing 10s fetch budget so capability lookup can fall back without hanging.

## Evidence

- Changed: `src/agents/embedded-agent-runner/openrouter-model-capabilities.ts`, `src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts`
- Production caller path: `loadOpenRouterModelCapabilities` → `doFetch` → `readResponseWithLimit({ chunkTimeoutMs: FETCH_TIMEOUT_MS })`

## Real behavior proof

### Behavior or issue addressed

OpenRouter model-capabilities catalog body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`loadOpenRouterModelCapabilities` → `doFetch` → `readResponseWithLimit` with `chunkTimeoutMs: FETCH_TIMEOUT_MS`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when an OpenRouter catalog response body stalls after headers
✓ bounds an oversized streamed OpenRouter catalog instead of buffering it whole
✓ round-trips a chunked under-cap catalog through the SQLite cache
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

### Observed result after fix

A stalled catalog stream is cancelled and leaves no poisoned cache entry; oversized and under-cap cache round-trips still pass.

### What was not tested

Live stall against OpenRouter's production `/models` endpoint.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the catalog idle bound and caller-path proof output.
