### PR TITLE
fix(github-copilot): prevent stalled catalog error streams

### DIFF
--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -763,8 +763,17 @@ describe("fetchCopilotModelCatalog", () => {
     expect(out[1]).not.toHaveProperty("contextTokens");
   });
 
-  it("throws on non-2xx HTTP responses so the caller can fall back to the static catalog", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(makeResponse(401, {}));
+  it("cancels stalled non-2xx response bodies before the caller falls back", async () => {
+    let canceled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 401 },
+    );
+    const fetchImpl = vi.fn().mockResolvedValue(response);
 
     await expect(
       fetchCopilotModelCatalog({
@@ -773,6 +782,8 @@ describe("fetchCopilotModelCatalog", () => {
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
     ).rejects.toThrow(/HTTP 401/);
+
+    expect(canceled).toBe(true);
   });
 
   it("throws provider-owned errors for malformed successful /models payloads", async () => {

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -303,6 +303,8 @@ export async function fetchCopilotModelCatalog(
       signal: params.signal ?? controller?.signal,
     });
     if (!res.ok) {
+      // Static catalog fallback never consumes this body, so release the transport before cleanup.
+      await res.body?.cancel().catch(() => undefined);
       throw new Error(`Copilot /models fetch failed: HTTP ${res.status}`);
     }
     const data = await readProviderJsonArrayFieldResponse(res, "Copilot /models", "data");


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where GitHub Copilot live model discovery could leave a failed `/models` response streaming after the plugin had already fallen back to its static catalog. A stalled non-success body could retain transport resources across repeated catalog refreshes.

## Why This Change Was Made

The Copilot model catalog owner now cancels every non-success response body before throwing its existing HTTP error. Successful bounded parsing, the request timeout, and static-catalog fallback behavior remain unchanged.

## User Impact

GitHub Copilot catalog refreshes release failed HTTP responses promptly, so repeated discovery attempts do not accumulate stalled error streams or connections.

## Evidence

- Regression red: the exact non-success test preserved the HTTP 401 error but failed because the stalled response stream's `cancel()` hook was never called.
- Unit: the complete GitHub Copilot model test file passes all 32 tests, including the stalled non-success response regression.
- Live: the production `fetchCopilotModelCatalog` function connected to a real loopback HTTP server whose 503 response sent a partial chunk and then remained open. The function preserved `Copilot /models fetch failed: HTTP 503`, rejected in 59 ms, and the server observed both the response and peer connection close before fixture cleanup.
- Static checks: targeted formatting, lint, and `git diff --check` pass.
