### PR TITLE
fix(fal): apply request policy to provider HTTP config

### DIFF
--- a/extensions/fal/http-config.ts
+++ b/extensions/fal/http-config.ts
@@ -3,6 +3,7 @@ import type { AuthProfileStore, OpenClawConfig } from "openclaw/plugin-sdk/provi
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
   type ProviderRequestCapability,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -44,6 +45,9 @@ export async function resolveFalHttpRequestConfig(params: {
     },
     provider: "fal",
     capability: params.capability,
+    request: sanitizeConfiguredModelProviderRequest(
+      params.req.cfg?.models?.providers?.fal?.request,
+    ),
     transport: "http",
   });
 }


### PR DESCRIPTION
## Problem
extensions/fal/http-config.ts calls esolveProviderHttpRequestConfig without a equest: policy, so user-configured provider settings are ignored for all Fal providers.

## Solution
Pass sanitizeConfiguredModelProviderRequest(params.req.cfg?.models?.providers?.fal?.request) through to esolveProviderHttpRequestConfig.