### PR TITLE
fix(deepinfra): apply request policy to video generation requests

### DIFF
--- a/extensions/deepinfra/video-generation-provider.ts
+++ b/extensions/deepinfra/video-generation-provider.ts
@@ -8,6 +8,7 @@ import {
   postJsonRequest,
   readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import {
   asFiniteNumber,
@@ -257,6 +258,9 @@ export function buildDeepInfraVideoGenerationProvider(options?: {
           },
           provider: "deepinfra",
           capability: "video",
+          request: sanitizeConfiguredModelProviderRequest(
+            req.cfg?.models?.providers?.deepinfra?.request,
+          ),
           transport: "http",
         });
 


### PR DESCRIPTION
## Problem
extensions/deepinfra/video-generation-provider.ts calls esolveProviderHttpRequestConfig without a equest: policy. User-configured provider request settings are silently ignored for DeepInfra video generation HTTP calls.

## Solution
Pass sanitizeConfiguredModelProviderRequest(req.cfg?.models?.providers?.deepinfra?.request) through to esolveProviderHttpRequestConfig.