### PR TITLE
fix(ui): load real Cron and Skills counts in Quick Settings Automations

### DIFF
--- a/ui/src/e2e/config-quick-automation-counts.e2e.test.ts
+++ b/ui/src/e2e/config-quick-automation-counts.e2e.test.ts
@@ -1,0 +1,171 @@
+// Control UI tests cover Quick Settings Automations inventory via mocked Gateway.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const uiProofArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "quick-automation-counts",
+);
+
+function emptyConfigResponse() {
+  const config = {};
+  return {
+    config,
+    hash: "hash-automation-1",
+    issues: [],
+    raw: JSON.stringify(config),
+    valid: true,
+  };
+}
+
+describeControlUiE2e("Control UI Quick Automations inventory mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("loads real Cron and Skills counts once on Simple settings entry", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      recordVideo: captureUiProofEnabled
+        ? { dir: uiProofArtifactDir, size: { width: 1280, height: 900 } }
+        : undefined,
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "config.get",
+        "cron.list",
+        "skills.status",
+        "system.info",
+      ],
+      methodResponses: {
+        "config.get": emptyConfigResponse(),
+        "cron.list": {
+          jobs: [{ id: "job-a" }, { id: "job-b" }, { id: "job-c" }],
+          total: 3,
+        },
+        "skills.status": {
+          skills: [{ name: "a" }, { name: "b" }, { name: "c" }, { name: "d" }, { name: "e" }],
+        },
+        "system.info": {
+          platform: "e2e",
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}config`);
+      expect(response?.status()).toBe(200);
+
+      const automations = page.locator("#settings-general-automations");
+      await automations.waitFor();
+      await expect
+        .poll(async () => automations.getByText("3 scheduled tasks", { exact: true }).count())
+        .toBe(1);
+      await expect
+        .poll(async () => automations.getByText("5 skills installed", { exact: true }).count())
+        .toBe(1);
+
+      await gateway.waitForRequest("cron.list");
+      await gateway.waitForRequest("skills.status");
+      const entryCronCalls = await gateway.getRequests("cron.list");
+      const entrySkillCalls = await gateway.getRequests("skills.status");
+      expect(entryCronCalls.length).toBe(1);
+      expect(entrySkillCalls.length).toBe(1);
+
+      // Cron change event refreshes only the cron total; Skills stays snapshot.
+      await gateway.setMethodResponse("cron.list", {
+        jobs: [{ id: "job-a" }, { id: "job-b" }, { id: "job-c" }, { id: "job-d" }],
+        total: 4,
+      });
+      await gateway.emitGatewayEvent("cron", { reason: "job-changed" });
+      await expect
+        .poll(async () => automations.getByText("4 scheduled tasks", { exact: true }).count())
+        .toBe(1);
+      await expect
+        .poll(async () => automations.getByText("5 skills installed", { exact: true }).count())
+        .toBe(1);
+
+      const afterCronEventSkillCalls = await gateway.getRequests("skills.status");
+      const afterCronEventCronCalls = await gateway.getRequests("cron.list");
+      expect(afterCronEventSkillCalls.length).toBe(1);
+      expect(afterCronEventCronCalls.length).toBeGreaterThan(1);
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await automations.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "01-automations-nonzero-counts.png"),
+        });
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "02-simple-settings-full.png"),
+          fullPage: true,
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("renders Unavailable when the Gateway omits inventory methods", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "config.get"],
+      methodResponses: {
+        "config.get": emptyConfigResponse(),
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}config`);
+      expect(response?.status()).toBe(200);
+      const automations = page.locator("#settings-general-automations");
+      await automations.waitFor();
+      await expect
+        .poll(async () => automations.getByText("Unavailable", { exact: true }).count())
+        .toBeGreaterThanOrEqual(2);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/i18n/.i18n/catalog-fallbacks.json
+++ b/ui/src/i18n/.i18n/catalog-fallbacks.json
@@ -1,5 +1,28 @@
 {
-  "fallbacks": {},
-  "sourceHash": "82b347646c147b6f3560a52a12e7b46718a567547b9dd2abf3be2ccfbbb0f30a",
+  "fallbacks": {
+    "quickSettings.automation.unavailable": [
+      "ar",
+      "de",
+      "es",
+      "fa",
+      "fr",
+      "hi",
+      "id",
+      "it",
+      "ja-JP",
+      "ko",
+      "nl",
+      "pl",
+      "pt-BR",
+      "ru",
+      "th",
+      "tr",
+      "uk",
+      "vi",
+      "zh-CN",
+      "zh-TW"
+    ]
+  },
+  "sourceHash": "c4f2e87e9b1f0cdba54ee8c71f7d74cb107283c4e3e353486cf35199eade729d",
   "version": 1
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1063,6 +1063,7 @@ export const en: TranslationMap = {
       manage: "Manage →",
       browse: "Browse →",
       configure: "Configure →",
+      unavailable: "Unavailable",
     },
     appearance: {
       title: "Appearance",

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -11,7 +11,12 @@ import type {
 } from "../../app/context.ts";
 import { loadLocalUserIdentity } from "../../app/settings.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
-import { ConfigPage, configSelectionFromSearch, supportsSystemInfo } from "./config-page.ts";
+import {
+  ConfigPage,
+  configSelectionFromSearch,
+  supportsQuickAutomation,
+  supportsSystemInfo,
+} from "./config-page.ts";
 import type { ConfigViewState } from "./view.ts";
 
 function deferred<T>() {
@@ -82,6 +87,25 @@ describe("supportsSystemInfo", () => {
     expect(supportsSystemInfo(hello)).toBe(true);
     expect(supportsSystemInfo(unsupportedHello)).toBe(false);
     expect(supportsSystemInfo(null)).toBe(false);
+  });
+});
+
+describe("supportsQuickAutomation", () => {
+  it("requires both cron.list and skills.status methods", () => {
+    const both = {
+      features: { methods: ["cron.list", "skills.status"] },
+    } as ApplicationGatewaySnapshot["hello"];
+    const partial = {
+      features: { methods: ["cron.list"] },
+    } as ApplicationGatewaySnapshot["hello"];
+    const none = {
+      features: { methods: ["health"] },
+    } as ApplicationGatewaySnapshot["hello"];
+
+    expect(supportsQuickAutomation(both)).toBe(true);
+    expect(supportsQuickAutomation(partial)).toBe(false);
+    expect(supportsQuickAutomation(none)).toBe(false);
+    expect(supportsQuickAutomation(null)).toBe(false);
   });
 });
 
@@ -192,6 +216,75 @@ describe("ConfigPage system info", () => {
     secondResponse.resolve(current);
     await secondLoad;
     expect(state.systemInfo).toBe(current);
+    page.remove();
+  });
+});
+
+describe("ConfigPage quick automation inventory", () => {
+  it("derives counts from cron.list and skills.status", async () => {
+    const client = {
+      request: vi
+        .fn()
+        .mockImplementationOnce(() => Promise.resolve({ jobs: [{}, {}, {}], total: 3 }))
+        .mockImplementationOnce(() => Promise.resolve({ skills: [{}, {}, {}, {}, {}] })),
+    } as unknown as GatewayBrowserClient;
+    const snapshot = {
+      client,
+      connected: true,
+      hello: { features: { methods: ["cron.list", "skills.status"] } },
+    } as ApplicationGatewaySnapshot;
+    const gateway = { snapshot } as ApplicationGateway;
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      context: ApplicationContext;
+      subscriptions: ReactiveController;
+      shouldUpdate: () => boolean;
+      syncQuickAutomationPolling: () => void;
+      synchronizeQuickAutomationGateway: (gateway: ApplicationGateway) => void;
+      loadQuickAutomation: () => Promise<void>;
+      quickAutomation: { cronJobCount: number; skillCount: number } | null;
+      quickAutomationUnavailable: boolean;
+    };
+    page.removeController(state.subscriptions);
+    state.shouldUpdate = () => false;
+    state.syncQuickAutomationPolling = () => undefined;
+    state.context = { gateway } as ApplicationContext;
+    document.body.append(page);
+    state.synchronizeQuickAutomationGateway(gateway);
+
+    await state.loadQuickAutomation();
+
+    expect(state.quickAutomation).toEqual({ cronJobCount: 3, skillCount: 5 });
+    expect(state.quickAutomationUnavailable).toBe(false);
+    page.remove();
+  });
+
+  it("marks the inventory unavailable when the gateway lacks support", () => {
+    const snapshot = {
+      client: {} as GatewayBrowserClient,
+      connected: true,
+      hello: { features: { methods: ["health"] } },
+    } as ApplicationGatewaySnapshot;
+    const gateway = { snapshot } as ApplicationGateway;
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      context: ApplicationContext;
+      subscriptions: ReactiveController;
+      shouldUpdate: () => boolean;
+      syncQuickAutomationPolling: () => void;
+      synchronizeQuickAutomationGateway: (gateway: ApplicationGateway) => void;
+      quickAutomation: { cronJobCount: number; skillCount: number } | null;
+      quickAutomationUnavailable: boolean;
+    };
+    page.removeController(state.subscriptions);
+    state.shouldUpdate = () => false;
+    state.syncQuickAutomationPolling = () => undefined;
+    state.context = { gateway } as ApplicationContext;
+    document.body.append(page);
+    state.synchronizeQuickAutomationGateway(gateway);
+
+    expect(state.quickAutomationUnavailable).toBe(true);
+    expect(state.quickAutomation).toBeNull();
     page.remove();
   });
 });

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -221,12 +221,51 @@ describe("ConfigPage system info", () => {
 });
 
 describe("ConfigPage quick automation inventory", () => {
+  type QuickAutomationHarness = {
+    context: ApplicationContext;
+    subscriptions: ReactiveController;
+    shouldUpdate: () => boolean;
+    pageId: string;
+    settingsMode: string;
+    syncQuickAutomationLifecycle: () => void;
+    synchronizeQuickAutomationGateway: (gateway: ApplicationGateway) => void;
+    loadQuickAutomation: (parts: { cron: boolean; skills: boolean }) => Promise<void>;
+    quickAutomation: { cronJobCount: number; skillCount: number } | null;
+    quickAutomationUnavailable: boolean;
+    quickAutomationActive: boolean;
+    quickAutomationGatewaySource: ApplicationGateway | null;
+  };
+
+  function mountQuickAutomationHarness(
+    gateway: ApplicationGateway,
+    opts: { autoLifecycle?: boolean } = {},
+  ) {
+    const page = new ConfigPage();
+    const state = page as unknown as QuickAutomationHarness;
+    page.removeController(state.subscriptions);
+    state.shouldUpdate = () => false;
+    state.pageId = "config";
+    state.settingsMode = "quick";
+    // Direct load tests stub lifecycle so gateway sync does not race a second load.
+    if (!opts.autoLifecycle) {
+      state.syncQuickAutomationLifecycle = () => undefined;
+    }
+    state.context = { gateway } as ApplicationContext;
+    document.body.append(page);
+    return { page, state };
+  }
+
   it("derives counts from cron.list and skills.status", async () => {
     const client = {
-      request: vi
-        .fn()
-        .mockImplementationOnce(() => Promise.resolve({ jobs: [{}, {}, {}], total: 3 }))
-        .mockImplementationOnce(() => Promise.resolve({ skills: [{}, {}, {}, {}, {}] })),
+      request: vi.fn(async (method: string) => {
+        if (method === "cron.list") {
+          return { jobs: [{}, {}, {}], total: 3 };
+        }
+        if (method === "skills.status") {
+          return { skills: [{}, {}, {}, {}, {}] };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
     } as unknown as GatewayBrowserClient;
     const snapshot = {
       client,
@@ -234,28 +273,86 @@ describe("ConfigPage quick automation inventory", () => {
       hello: { features: { methods: ["cron.list", "skills.status"] } },
     } as ApplicationGatewaySnapshot;
     const gateway = { snapshot } as ApplicationGateway;
-    const page = new ConfigPage();
-    const state = page as unknown as {
-      context: ApplicationContext;
-      subscriptions: ReactiveController;
-      shouldUpdate: () => boolean;
-      syncQuickAutomationPolling: () => void;
-      synchronizeQuickAutomationGateway: (gateway: ApplicationGateway) => void;
-      loadQuickAutomation: () => Promise<void>;
-      quickAutomation: { cronJobCount: number; skillCount: number } | null;
-      quickAutomationUnavailable: boolean;
-    };
-    page.removeController(state.subscriptions);
-    state.shouldUpdate = () => false;
-    state.syncQuickAutomationPolling = () => undefined;
-    state.context = { gateway } as ApplicationContext;
-    document.body.append(page);
+    const { page, state } = mountQuickAutomationHarness(gateway);
     state.synchronizeQuickAutomationGateway(gateway);
 
-    await state.loadQuickAutomation();
+    await state.loadQuickAutomation({ cron: true, skills: true });
 
     expect(state.quickAutomation).toEqual({ cronJobCount: 3, skillCount: 5 });
     expect(state.quickAutomationUnavailable).toBe(false);
+    expect(client.request).toHaveBeenCalledWith("cron.list", {});
+    expect(client.request).toHaveBeenCalledWith("skills.status", {});
+    page.remove();
+  });
+
+  it("loads both inventories once on Simple-settings entry", async () => {
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "cron.list") {
+          return { jobs: [{}, {}], total: 2 };
+        }
+        if (method === "skills.status") {
+          return { skills: [{}, {}, {}] };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+    } as unknown as GatewayBrowserClient;
+    const snapshot = {
+      client,
+      connected: true,
+      hello: { features: { methods: ["cron.list", "skills.status"] } },
+    } as ApplicationGatewaySnapshot;
+    const gateway = {
+      snapshot,
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    } as unknown as ApplicationGateway;
+    const { page, state } = mountQuickAutomationHarness(gateway, { autoLifecycle: true });
+
+    state.synchronizeQuickAutomationGateway(gateway);
+    await vi.waitFor(() => {
+      expect(state.quickAutomation).toEqual({ cronJobCount: 2, skillCount: 3 });
+    });
+
+    expect(state.quickAutomationActive).toBe(true);
+    expect(client.request).toHaveBeenCalledTimes(2);
+
+    // A second lifecycle pass while still visible must not re-poll Skills.
+    state.syncQuickAutomationLifecycle();
+    await Promise.resolve();
+    expect(client.request).toHaveBeenCalledTimes(2);
+    page.remove();
+  });
+
+  it("refreshes only cron.list on the existing cron change event", async () => {
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "cron.list") {
+          return { jobs: [{}, {}, {}, {}], total: 4 };
+        }
+        if (method === "skills.status") {
+          return { skills: [{}, {}] };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+    } as unknown as GatewayBrowserClient;
+    const snapshot = {
+      client,
+      connected: true,
+      hello: { features: { methods: ["cron.list", "skills.status"] } },
+    } as ApplicationGatewaySnapshot;
+    const gateway = { snapshot } as ApplicationGateway;
+    const { page, state } = mountQuickAutomationHarness(gateway);
+    state.synchronizeQuickAutomationGateway(gateway);
+    state.quickAutomation = { cronJobCount: 1, skillCount: 2 };
+    state.quickAutomationActive = true;
+
+    await state.loadQuickAutomation({ cron: true, skills: false });
+
+    expect(state.quickAutomation).toEqual({ cronJobCount: 4, skillCount: 2 });
+    expect(client.request).toHaveBeenCalledTimes(1);
+    expect(client.request).toHaveBeenCalledWith("cron.list", {});
+    expect(client.request).not.toHaveBeenCalledWith("skills.status", {});
     page.remove();
   });
 
@@ -266,21 +363,7 @@ describe("ConfigPage quick automation inventory", () => {
       hello: { features: { methods: ["health"] } },
     } as ApplicationGatewaySnapshot;
     const gateway = { snapshot } as ApplicationGateway;
-    const page = new ConfigPage();
-    const state = page as unknown as {
-      context: ApplicationContext;
-      subscriptions: ReactiveController;
-      shouldUpdate: () => boolean;
-      syncQuickAutomationPolling: () => void;
-      synchronizeQuickAutomationGateway: (gateway: ApplicationGateway) => void;
-      quickAutomation: { cronJobCount: number; skillCount: number } | null;
-      quickAutomationUnavailable: boolean;
-    };
-    page.removeController(state.subscriptions);
-    state.shouldUpdate = () => false;
-    state.syncQuickAutomationPolling = () => undefined;
-    state.context = { gateway } as ApplicationContext;
-    document.body.append(page);
+    const { page, state } = mountQuickAutomationHarness(gateway);
     state.synchronizeQuickAutomationGateway(gateway);
 
     expect(state.quickAutomationUnavailable).toBe(true);

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -4,7 +4,7 @@ import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
-import type { FastMode } from "../../api/types.ts";
+import type { CronJobsListResult, FastMode, SkillStatusReport } from "../../api/types.ts";
 import { pathForRoute, type RouteId } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -66,6 +66,11 @@ type ConfigFormMode = "form" | "raw";
 type ConfigSelection = { activeSection: string | null; activeSubsection: string | null };
 type LocalUiSetting = "textScale" | "chatSendShortcut" | "chatFollowUpMode" | "catalogOpenTarget";
 
+type QuickAutomationSnapshot = {
+  cronJobCount: number;
+  skillCount: number;
+};
+
 const CONFIG_PAGE_I18N_KEYS = {
   config: "config",
   communications: "communications",
@@ -86,6 +91,8 @@ const KNOWN_CHANNELS = [
 ] as const;
 
 const SYSTEM_INFO_POLL_INTERVAL_MS = 10_000;
+// Automation inventories change rarely; poll less aggressively than system info.
+const QUICK_AUTOMATION_POLL_INTERVAL_MS = 30_000;
 
 function isUnknownSystemInfoMethodError(error: unknown): boolean {
   return (
@@ -97,6 +104,20 @@ function isUnknownSystemInfoMethodError(error: unknown): boolean {
 
 export function supportsSystemInfo(hello: ApplicationGatewaySnapshot["hello"]): boolean {
   return hello?.features?.methods?.includes("system.info") === true;
+}
+
+function isUnknownQuickAutomationMethodError(error: unknown): boolean {
+  return (
+    error instanceof GatewayRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    (error.message.includes("unknown method: cron.list") ||
+      error.message.includes("unknown method: skills.status"))
+  );
+}
+
+export function supportsQuickAutomation(hello: ApplicationGatewaySnapshot["hello"]): boolean {
+  const methods = hello?.features?.methods;
+  return Boolean(methods?.includes("cron.list") && methods?.includes("skills.status"));
 }
 
 function defaultConfigSelection(pageId: ConfigPageId): ConfigSelection {
@@ -289,6 +310,20 @@ export class ConfigPage extends OpenClawLightDomElement {
     },
     false,
   );
+  @state() private quickAutomation: QuickAutomationSnapshot | null = null;
+  @state() private quickAutomationUnavailable = false;
+  private quickAutomationGatewaySource: ApplicationContext["gateway"] | null = null;
+  private quickAutomationClient: GatewayBrowserClient | null = null;
+  private quickAutomationLoading = false;
+  private quickAutomationRequestId = 0;
+  private readonly quickAutomationPolling = new PollController(
+    this,
+    QUICK_AUTOMATION_POLL_INTERVAL_MS,
+    () => {
+      void this.loadQuickAutomation();
+    },
+    false,
+  );
   private pendingRouteTargetId: string | null = null;
   private readonly subscriptions = new SubscriptionsController(this)
     .watch(
@@ -307,7 +342,10 @@ export class ConfigPage extends OpenClawLightDomElement {
     .watch(
       () => this.context?.gateway,
       (gateway, notify) => gateway.subscribe(notify),
-      (gateway) => this.synchronizeSystemInfoGateway(gateway),
+      (gateway) => {
+        this.synchronizeSystemInfoGateway(gateway);
+        this.synchronizeQuickAutomationGateway(gateway);
+      },
     )
     .watch(
       () => this.context?.webPush,
@@ -338,11 +376,15 @@ export class ConfigPage extends OpenClawLightDomElement {
 
   override disconnectedCallback() {
     this.systemInfoPolling.stop();
+    this.quickAutomationPolling.stop();
     this.invalidateSystemInfoRequest();
+    this.invalidateQuickAutomationRequest();
     this.runtimeConfigSource = null;
     this.resetConfigViewState();
     this.systemInfoGatewaySource = null;
     this.systemInfoClient = null;
+    this.quickAutomationGatewaySource = null;
+    this.quickAutomationClient = null;
     this.subscriptions.clear();
     super.disconnectedCallback();
   }
@@ -358,8 +400,10 @@ export class ConfigPage extends OpenClawLightDomElement {
     const modeChanged = changed.has("settingsMode") && changed.get("settingsMode") !== undefined;
     if (pageChanged || modeChanged) {
       this.invalidateSystemInfoRequest();
+      this.invalidateQuickAutomationRequest();
     }
     this.syncSystemInfoPolling();
+    this.syncQuickAutomationPolling();
     this.scrollToPendingRouteTarget();
     // Device labels stay hidden until the user grants mic permission; the
     // refresh button next to the picker requests it explicitly.
@@ -561,6 +605,133 @@ export class ConfigPage extends OpenClawLightDomElement {
     } finally {
       if (this.isCurrentSystemInfoRequest(requestId, client, gatewaySource)) {
         this.systemInfoLoading = false;
+      }
+    }
+  }
+
+  private synchronizeQuickAutomationGateway(gateway: ApplicationContext["gateway"]) {
+    if (gateway !== this.quickAutomationGatewaySource) {
+      this.quickAutomationPolling.stop();
+      this.invalidateQuickAutomationRequest();
+      this.quickAutomationGatewaySource = gateway;
+      this.quickAutomationClient = null;
+      this.quickAutomation = null;
+      this.quickAutomationUnavailable = false;
+    }
+    this.handleQuickAutomationGatewaySnapshot(gateway.snapshot);
+  }
+
+  private handleQuickAutomationGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
+    const clientChanged = snapshot.client !== this.quickAutomationClient;
+    const supported = supportsQuickAutomation(snapshot.hello);
+    this.quickAutomationClient = snapshot.client;
+    if (clientChanged) {
+      this.invalidateQuickAutomationRequest();
+      this.quickAutomation = null;
+      this.quickAutomationUnavailable = false;
+    } else if (!snapshot.connected) {
+      this.invalidateQuickAutomationRequest();
+      this.quickAutomation = null;
+    }
+    if (snapshot.connected && snapshot.hello) {
+      this.quickAutomationUnavailable = !supported;
+      if (!supported) {
+        this.invalidateQuickAutomationRequest();
+        this.quickAutomation = null;
+      }
+    }
+    this.syncQuickAutomationPolling();
+  }
+
+  private syncQuickAutomationPolling() {
+    // Automation counters share the Quick Settings visibility gate with the
+    // system info section; both render only while Simple settings is open.
+    const gateway = this.context.gateway.snapshot;
+    const shouldPoll =
+      this.isConnected &&
+      this.isSystemInfoVisible() &&
+      !this.quickAutomationUnavailable &&
+      gateway.connected &&
+      supportsQuickAutomation(gateway.hello) &&
+      gateway.client != null;
+    if (!shouldPoll) {
+      this.quickAutomationPolling.stop();
+      return;
+    }
+    if (this.quickAutomationPolling.start()) {
+      void this.loadQuickAutomation();
+    }
+  }
+
+  private invalidateQuickAutomationRequest() {
+    this.quickAutomationRequestId += 1;
+    this.quickAutomationLoading = false;
+  }
+
+  private isCurrentQuickAutomationRequest(
+    requestId: number,
+    client: GatewayBrowserClient,
+    gatewaySource: ApplicationContext["gateway"],
+  ): boolean {
+    const gateway = gatewaySource.snapshot;
+    return (
+      this.isConnected &&
+      this.isSystemInfoVisible() &&
+      requestId === this.quickAutomationRequestId &&
+      this.quickAutomationGatewaySource === gatewaySource &&
+      this.context.gateway === gatewaySource &&
+      gateway.connected &&
+      gateway.client === client
+    );
+  }
+
+  private async loadQuickAutomation() {
+    const gatewaySource = this.quickAutomationGatewaySource;
+    if (!gatewaySource || gatewaySource !== this.context.gateway) {
+      return;
+    }
+    const gateway = gatewaySource.snapshot;
+    const client = gateway.client;
+    if (
+      !gateway.connected ||
+      !client ||
+      !this.isSystemInfoVisible() ||
+      this.quickAutomationUnavailable ||
+      this.quickAutomationLoading
+    ) {
+      return;
+    }
+
+    const requestId = ++this.quickAutomationRequestId;
+    this.quickAutomationLoading = true;
+    try {
+      // Both inventories load in parallel; a missing scope or unsupported method
+      // on either surfaces an unavailable state rather than a misleading zero.
+      const [cronResult, skillReport] = await Promise.all([
+        client.request<CronJobsListResult>("cron.list", {}),
+        client.request<SkillStatusReport | undefined>("skills.status", {}),
+      ]);
+      if (!this.isCurrentQuickAutomationRequest(requestId, client, gatewaySource)) {
+        return;
+      }
+      const cronJobs = Array.isArray(cronResult?.jobs) ? cronResult.jobs : [];
+      const cronJobCount =
+        typeof cronResult?.total === "number" ? cronResult.total : cronJobs.length;
+      const skillCount = Array.isArray(skillReport?.skills) ? skillReport.skills.length : 0;
+      this.quickAutomation = { cronJobCount, skillCount };
+    } catch (error) {
+      if (!this.isCurrentQuickAutomationRequest(requestId, client, gatewaySource)) {
+        return;
+      }
+      if (isMissingOperatorReadScopeError(error) || isUnknownQuickAutomationMethodError(error)) {
+        this.quickAutomation = null;
+        this.quickAutomationUnavailable = true;
+        this.quickAutomationPolling.stop();
+      }
+      // Transient errors keep the last snapshot; the next poll tick retries.
+    } finally {
+      if (this.isCurrentQuickAutomationRequest(requestId, client, gatewaySource)) {
+        this.quickAutomationLoading = false;
       }
     }
   }
@@ -858,9 +1029,10 @@ export class ConfigPage extends OpenClawLightDomElement {
       fastMode: fastMode === "auto" || typeof fastMode === "boolean" ? fastMode : false,
       channels: quickChannels(configObject),
       automation: {
-        cronJobCount: 0,
-        skillCount: 0,
+        cronJobCount: this.quickAutomation?.cronJobCount ?? null,
+        skillCount: this.quickAutomation?.skillCount ?? null,
         mcpServerCount: mcpServerCount(configObject),
+        unavailable: this.quickAutomationUnavailable,
       },
       security: extractQuickSettingsSecurity(configObject),
       systemInfo: this.systemInfo,

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -91,8 +91,11 @@ const KNOWN_CHANNELS = [
 ] as const;
 
 const SYSTEM_INFO_POLL_INTERVAL_MS = 10_000;
-// Automation inventories change rarely; poll less aggressively than system info.
-const QUICK_AUTOMATION_POLL_INTERVAL_MS = 30_000;
+
+type QuickAutomationLoadParts = {
+  cron: boolean;
+  skills: boolean;
+};
 
 function isUnknownSystemInfoMethodError(error: unknown): boolean {
   return (
@@ -316,14 +319,9 @@ export class ConfigPage extends OpenClawLightDomElement {
   private quickAutomationClient: GatewayBrowserClient | null = null;
   private quickAutomationLoading = false;
   private quickAutomationRequestId = 0;
-  private readonly quickAutomationPolling = new PollController(
-    this,
-    QUICK_AUTOMATION_POLL_INTERVAL_MS,
-    () => {
-      void this.loadQuickAutomation();
-    },
-    false,
-  );
+  // Tracks whether Simple settings was already active so entry loads once
+  // per visibility epoch instead of polling the full Skills inventory.
+  private quickAutomationActive = false;
   private pendingRouteTargetId: string | null = null;
   private readonly subscriptions = new SubscriptionsController(this)
     .watch(
@@ -346,6 +344,27 @@ export class ConfigPage extends OpenClawLightDomElement {
         this.synchronizeSystemInfoGateway(gateway);
         this.synchronizeQuickAutomationGateway(gateway);
       },
+    )
+    .effect(
+      () => this.context?.gateway,
+      (gateway) =>
+        // Cron already broadcasts a change event; reuse it so idle Settings
+        // never rebuilds the full Skills status inventory on a timer.
+        gateway.subscribeEvents((event) => {
+          if (
+            this.quickAutomationGatewaySource === gateway &&
+            gateway.snapshot.connected &&
+            gateway.snapshot.client &&
+            this.isQuickAutomationVisible() &&
+            !this.quickAutomationUnavailable &&
+            this.quickAutomation != null &&
+            event.event === "cron"
+          ) {
+            // Keep the prior Skills snapshot; only the cron total can change
+            // from this event without rebuilding skills.status.
+            void this.loadQuickAutomation({ cron: true, skills: false });
+          }
+        }),
     )
     .watch(
       () => this.context?.webPush,
@@ -376,9 +395,9 @@ export class ConfigPage extends OpenClawLightDomElement {
 
   override disconnectedCallback() {
     this.systemInfoPolling.stop();
-    this.quickAutomationPolling.stop();
     this.invalidateSystemInfoRequest();
     this.invalidateQuickAutomationRequest();
+    this.quickAutomationActive = false;
     this.runtimeConfigSource = null;
     this.resetConfigViewState();
     this.systemInfoGatewaySource = null;
@@ -401,9 +420,13 @@ export class ConfigPage extends OpenClawLightDomElement {
     if (pageChanged || modeChanged) {
       this.invalidateSystemInfoRequest();
       this.invalidateQuickAutomationRequest();
+      // Leaving Simple settings ends the entry epoch so reopening reloads once.
+      if (!this.isQuickAutomationVisible()) {
+        this.quickAutomationActive = false;
+      }
     }
     this.syncSystemInfoPolling();
-    this.syncQuickAutomationPolling();
+    this.syncQuickAutomationLifecycle();
     this.scrollToPendingRouteTarget();
     // Device labels stay hidden until the user grants mic permission; the
     // refresh button next to the picker requests it explicitly.
@@ -464,6 +487,12 @@ export class ConfigPage extends OpenClawLightDomElement {
 
   private isSystemInfoVisible(): boolean {
     return this.pageId === "config" && this.settingsMode === "quick";
+  }
+
+  private isQuickAutomationVisible(): boolean {
+    // Automation counters share the Quick Settings visibility gate with the
+    // system info section; both render only while Simple settings is open.
+    return this.isSystemInfoVisible();
   }
 
   private synchronizeRuntimeConfig(runtimeConfig: ApplicationContext["runtimeConfig"]) {
@@ -611,8 +640,8 @@ export class ConfigPage extends OpenClawLightDomElement {
 
   private synchronizeQuickAutomationGateway(gateway: ApplicationContext["gateway"]) {
     if (gateway !== this.quickAutomationGatewaySource) {
-      this.quickAutomationPolling.stop();
       this.invalidateQuickAutomationRequest();
+      this.quickAutomationActive = false;
       this.quickAutomationGatewaySource = gateway;
       this.quickAutomationClient = null;
       this.quickAutomation = null;
@@ -627,10 +656,12 @@ export class ConfigPage extends OpenClawLightDomElement {
     this.quickAutomationClient = snapshot.client;
     if (clientChanged) {
       this.invalidateQuickAutomationRequest();
+      this.quickAutomationActive = false;
       this.quickAutomation = null;
       this.quickAutomationUnavailable = false;
     } else if (!snapshot.connected) {
       this.invalidateQuickAutomationRequest();
+      this.quickAutomationActive = false;
       this.quickAutomation = null;
     }
     if (snapshot.connected && snapshot.hello) {
@@ -640,27 +671,30 @@ export class ConfigPage extends OpenClawLightDomElement {
         this.quickAutomation = null;
       }
     }
-    this.syncQuickAutomationPolling();
+    this.syncQuickAutomationLifecycle();
   }
 
-  private syncQuickAutomationPolling() {
-    // Automation counters share the Quick Settings visibility gate with the
-    // system info section; both render only while Simple settings is open.
+  private syncQuickAutomationLifecycle() {
     const gateway = this.context.gateway.snapshot;
-    const shouldPoll =
+    const shouldActive =
       this.isConnected &&
-      this.isSystemInfoVisible() &&
+      this.isQuickAutomationVisible() &&
       !this.quickAutomationUnavailable &&
       gateway.connected &&
       supportsQuickAutomation(gateway.hello) &&
       gateway.client != null;
-    if (!shouldPoll) {
-      this.quickAutomationPolling.stop();
+    if (!shouldActive) {
+      this.quickAutomationActive = false;
       return;
     }
-    if (this.quickAutomationPolling.start()) {
-      void this.loadQuickAutomation();
+    // Entry / reconnect only: load both inventories once per visibility epoch.
+    // Skills have no lightweight change signal here, so they stay snapshot-
+    // until the next entry or reconnect rather than a recurring timer.
+    if (this.quickAutomationActive) {
+      return;
     }
+    this.quickAutomationActive = true;
+    void this.loadQuickAutomation({ cron: true, skills: true });
   }
 
   private invalidateQuickAutomationRequest() {
@@ -676,7 +710,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     const gateway = gatewaySource.snapshot;
     return (
       this.isConnected &&
-      this.isSystemInfoVisible() &&
+      this.isQuickAutomationVisible() &&
       requestId === this.quickAutomationRequestId &&
       this.quickAutomationGatewaySource === gatewaySource &&
       this.context.gateway === gatewaySource &&
@@ -685,7 +719,10 @@ export class ConfigPage extends OpenClawLightDomElement {
     );
   }
 
-  private async loadQuickAutomation() {
+  private async loadQuickAutomation(parts: QuickAutomationLoadParts) {
+    if (!parts.cron && !parts.skills) {
+      return;
+    }
     const gatewaySource = this.quickAutomationGatewaySource;
     if (!gatewaySource || gatewaySource !== this.context.gateway) {
       return;
@@ -695,7 +732,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     if (
       !gateway.connected ||
       !client ||
-      !this.isSystemInfoVisible() ||
+      !this.isQuickAutomationVisible() ||
       this.quickAutomationUnavailable ||
       this.quickAutomationLoading
     ) {
@@ -705,19 +742,31 @@ export class ConfigPage extends OpenClawLightDomElement {
     const requestId = ++this.quickAutomationRequestId;
     this.quickAutomationLoading = true;
     try {
-      // Both inventories load in parallel; a missing scope or unsupported method
-      // on either surfaces an unavailable state rather than a misleading zero.
+      // Entry/reconnect load both inventories; cron change events refresh only
+      // the cron total so Skills status is not rebuilt on every scheduler tick.
       const [cronResult, skillReport] = await Promise.all([
-        client.request<CronJobsListResult>("cron.list", {}),
-        client.request<SkillStatusReport | undefined>("skills.status", {}),
+        parts.cron
+          ? client.request<CronJobsListResult>("cron.list", {})
+          : Promise.resolve(undefined),
+        parts.skills
+          ? client.request<SkillStatusReport | undefined>("skills.status", {})
+          : Promise.resolve(undefined),
       ]);
       if (!this.isCurrentQuickAutomationRequest(requestId, client, gatewaySource)) {
         return;
       }
+      const previous = this.quickAutomation;
       const cronJobs = Array.isArray(cronResult?.jobs) ? cronResult.jobs : [];
-      const cronJobCount =
-        typeof cronResult?.total === "number" ? cronResult.total : cronJobs.length;
-      const skillCount = Array.isArray(skillReport?.skills) ? skillReport.skills.length : 0;
+      const cronJobCount = parts.cron
+        ? typeof cronResult?.total === "number"
+          ? cronResult.total
+          : cronJobs.length
+        : (previous?.cronJobCount ?? 0);
+      const skillCount = parts.skills
+        ? Array.isArray(skillReport?.skills)
+          ? skillReport.skills.length
+          : 0
+        : (previous?.skillCount ?? 0);
       this.quickAutomation = { cronJobCount, skillCount };
     } catch (error) {
       if (!this.isCurrentQuickAutomationRequest(requestId, client, gatewaySource)) {
@@ -726,9 +775,8 @@ export class ConfigPage extends OpenClawLightDomElement {
       if (isMissingOperatorReadScopeError(error) || isUnknownQuickAutomationMethodError(error)) {
         this.quickAutomation = null;
         this.quickAutomationUnavailable = true;
-        this.quickAutomationPolling.stop();
       }
-      // Transient errors keep the last snapshot; the next poll tick retries.
+      // Transient errors keep the last snapshot; entry/reconnect/cron retries.
     } finally {
       if (this.isCurrentQuickAutomationRequest(requestId, client, gatewaySource)) {
         this.quickAutomationLoading = false;

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -76,9 +76,10 @@ function createProps(overrides: Partial<QuickSettingsProps> = {}): QuickSettings
     channels: [],
     onChannelConfigure: vi.fn(),
     automation: {
-      cronJobCount: 0,
-      skillCount: 0,
+      cronJobCount: null,
+      skillCount: null,
       mcpServerCount: 0,
+      unavailable: false,
     },
     onManageCron: vi.fn(),
     onBrowseSkills: vi.fn(),
@@ -1056,5 +1057,88 @@ describe("renderQuickSettings", () => {
 
     expect(setTheme).toHaveBeenCalledWith("custom", { element: customButton });
     expect(onOpenCustomThemeImport).not.toHaveBeenCalled();
+  });
+
+  it("renders real automation counts from the loaded inventory", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderQuickSettings(
+        createProps({
+          automation: {
+            cronJobCount: 3,
+            skillCount: 5,
+            mcpServerCount: 2,
+            unavailable: false,
+          },
+        }),
+      ),
+      container,
+    );
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>("#settings-general-automations .settings-row"),
+    );
+    expect(rows[0]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe(
+      "3 scheduled tasks",
+    );
+    expect(rows[1]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe(
+      "5 skills installed",
+    );
+    expect(rows[2]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe(
+      "2 MCP servers",
+    );
+  });
+
+  it("renders a placeholder instead of a misleading zero before inventory loads", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderQuickSettings(
+        createProps({
+          automation: {
+            cronJobCount: null,
+            skillCount: null,
+            mcpServerCount: 0,
+            unavailable: false,
+          },
+        }),
+      ),
+      container,
+    );
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>("#settings-general-automations .settings-row"),
+    );
+    expect(rows[0]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe("-");
+    expect(rows[1]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe("-");
+    // The MCP count is derived locally, so it still renders a count.
+    expect(rows[2]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe(
+      "0 MCP servers",
+    );
+  });
+
+  it("renders an unavailable label when the gateway cannot serve the inventory", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderQuickSettings(
+        createProps({
+          automation: {
+            cronJobCount: null,
+            skillCount: null,
+            mcpServerCount: 0,
+            unavailable: true,
+          },
+        }),
+      ),
+      container,
+    );
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>("#settings-general-automations .settings-row"),
+    );
+    expect(rows[0]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe("Unavailable");
+    expect(rows[1]?.querySelector(".settings-row__title")?.textContent?.trim()).toBe("Unavailable");
   });
 });

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -58,9 +58,10 @@ export type QuickSettingsChannel = {
 };
 
 type QuickSettingsAutomation = {
-  cronJobCount: number;
-  skillCount: number;
+  cronJobCount: number | null;
+  skillCount: number | null;
   mcpServerCount: number;
+  unavailable: boolean;
 };
 
 export type QuickSettingsSecurity = {
@@ -454,32 +455,45 @@ function renderChannelsSection(props: QuickSettingsProps) {
 }
 
 function renderAutomationsSection(props: QuickSettingsProps) {
-  const { cronJobCount, skillCount, mcpServerCount } = props.automation;
+  const { cronJobCount, skillCount, mcpServerCount, unavailable } = props.automation;
   const automationRow = (title: string, actionLabel: string, onClick?: () => void) =>
     renderSettingsRow({
       title,
       control: html`<button class="btn" @click=${onClick}>${actionLabel}</button>`,
     });
+  // Counts are null until the gateway inventory loads (and while offline); a
+  // null count renders a neutral placeholder rather than a misleading "0".
+  const automationCountLabel = (
+    count: number | null,
+    singularKey: string,
+    pluralKey: string,
+  ): string => {
+    if (unavailable) {
+      return t("quickSettings.automation.unavailable");
+    }
+    if (count == null) {
+      return "-";
+    }
+    return t(count === 1 ? singularKey : pluralKey, { count: String(count) });
+  };
   return renderTargetSection(
     GENERAL_SETTINGS_TARGET_IDS.automations,
     { title: t("quickSettings.automation.title") },
     [
       automationRow(
-        t(
-          cronJobCount === 1
-            ? "quickSettings.automation.scheduledTask"
-            : "quickSettings.automation.scheduledTasks",
-          { count: String(cronJobCount) },
+        automationCountLabel(
+          cronJobCount,
+          "quickSettings.automation.scheduledTask",
+          "quickSettings.automation.scheduledTasks",
         ),
         t("quickSettings.automation.manage"),
         props.onManageCron,
       ),
       automationRow(
-        t(
-          skillCount === 1
-            ? "quickSettings.automation.installedSkill"
-            : "quickSettings.automation.installedSkills",
-          { count: String(skillCount) },
+        automationCountLabel(
+          skillCount,
+          "quickSettings.automation.installedSkill",
+          "quickSettings.automation.installedSkills",
         ),
         t("quickSettings.automation.browse"),
         props.onBrowseSkills,


### PR DESCRIPTION
Closes #107852

## What Problem This Solves

Fixes an issue where users opening **Control UI → Settings → Simple → Automations** would always see `0 scheduled tasks` and `0 skills installed`, even when the Gateway had real Cron jobs and installed Skills.

Operators could not tell a genuine empty inventory apart from counts that were simply never loaded, which sent them into unnecessary troubleshooting.

## Why This Change Was Made

Quick Settings previously passed literal zeros for Cron and Skills counts. The Config page now loads those inventories from the Gateway while Simple settings is open (via `cron.list` and `skills.status`), using the same request-id / gateway-source race guards as the adjacent `system.info` loader, and passes nullable counts into the Automations card.

Refresh policy (bounded, not continuous polling):
- Load both inventories once on Simple-settings **entry** and again after Gateway **reconnect**/client change.
- Refresh **only** the Cron total when the existing Gateway `cron` change event fires.
- Do **not** rebuild the full `skills.status` inventory on a timer while Settings stays open.

Rendering:
- Real totals when inventories succeed.
- Neutral `-` while offline/loading (never a false zero).
- Explicit **Unavailable** when the Gateway cannot serve the methods or operator-read scope is missing.
- MCP server count remains config-derived (unchanged).

Compatibility: no config/API shape change; additive UI inventory load only. Performance: one inventory pair per Simple-settings entry/reconnect, plus lightweight `cron.list` on cron events. Usability: distinguishes loading vs empty vs unavailable. Security: reuses existing operator-read scope failure path (no new trust surface).

## User Impact

The Automations card reports actual scheduled-task and installed-skill totals on a connected Gateway, and no longer pretends those inventories are empty while data is missing. Leaving Simple settings open no longer issues recurring full Skills inventory RPCs every 30 seconds.

## Evidence

Local macOS checkout on branch `fix/107852-quick-automation-counts`:

```text
node scripts/run-vitest.mjs ui/src/pages/config/config-page.test.ts ui/src/pages/config/quick.test.ts
# Test Files  2 passed (2)
# Tests  51 passed (51)

OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/config-quick-automation-counts.e2e.test.ts
# Test Files  1 passed (1)
# Tests  2 passed (2)
```

Path-scoped static checks:

```text
oxfmt --check <changed files>   # All matched files use the correct format
git diff --check                # clean
```

## Real behavior proof

- Behavior addressed: Simple Automations card loads real Cron/Skills counts without continuous Skills inventory polling; entry/reconnect + cron-event refresh only.
- Environment: local macOS checkout at HEAD after the inventory-refresh follow-up; Vitest jsdom unit suite + Playwright Control UI E2E against the mocked Gateway WebSocket helper.
- Current-main contrast: on `origin/main`, Quick Settings still hardcodes `cronJobCount: 0` / `skillCount: 0`, so non-zero inventories cannot appear.
- Exact steps after this patch:

```bash
node scripts/run-vitest.mjs ui/src/pages/config/config-page.test.ts ui/src/pages/config/quick.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/config-quick-automation-counts.e2e.test.ts
```

Key cases:
1. Unit: entry loads `cron.list` + `skills.status` once; a second lifecycle pass does not re-request.
2. Unit: cron-only refresh updates the Cron total while preserving the Skills snapshot (no second `skills.status`).
3. Unit: unsupported hello marks inventory unavailable.
4. Browser E2E: Simple Settings shows `3 scheduled tasks` / `5 skills installed` after entry load.
5. Browser E2E: Gateway `cron` event updates Cron to `4 scheduled tasks` without a second `skills.status`.
6. Browser E2E: omitted inventory methods render `Unavailable`.
7. Quick Settings still renders `-` while counts are null and keeps MCP config-derived.

- Evidence after fix: 51/51 unit tests and 2/2 Control UI E2E tests passed; local screenshot artifacts under `.artifacts/control-ui-e2e/quick-automation-counts/` (not committed).
- Observed result after fix: loaded inventories display non-zero labels; cron events update only Cron; unsupported Gateway shows Unavailable; no 30s Skills poll remains.
- What was not tested: a production/live multi-tenant Gateway session outside the local mocked Control UI E2E harness.

AI-assisted: Yes (Grok). I reviewed the implementation and understand the behavior and tests.
