### PR TITLE
fix(ci): bound opengrep installer downloads

### DIFF
--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -38,9 +38,13 @@ jobs:
           OPENGREP_VERSION: v1.22.0
           OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
-          curl -fsSL --connect-timeout 30 --max-time 120 \
-            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
-            | bash -s -- -v "$OPENGREP_VERSION"
+          # Download first so a timed-out transfer cannot execute a partial installer.
+          installer="$(mktemp "${RUNNER_TEMP}/opengrep-install.XXXXXX")"
+          trap 'rm -f "$installer"' EXIT
+          curl -fsSL --connect-timeout 10 --max-time 120 \
+            -o "$installer" \
+            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh"
+          bash "$installer" -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - name: Verify opengrep

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -64,9 +64,13 @@ jobs:
           OPENGREP_VERSION: v1.22.0
           OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
-          curl -fsSL --connect-timeout 30 --max-time 120 \
-            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
-            | bash -s -- -v "$OPENGREP_VERSION"
+          # Download first so a timed-out transfer cannot execute a partial installer.
+          installer="$(mktemp "${RUNNER_TEMP}/opengrep-install.XXXXXX")"
+          trap 'rm -f "$installer"' EXIT
+          curl -fsSL --connect-timeout 10 --max-time 120 \
+            -o "$installer" \
+            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh"
+          bash "$installer" -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - name: Verify opengrep

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1670,6 +1670,30 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("downloads the opengrep installer completely before execution", () => {
+    for (const workflowPath of [OPENGREP_PR_DIFF_WORKFLOW, OPENGREP_FULL_WORKFLOW]) {
+      const workflow = parse(readFileSync(workflowPath, "utf8"));
+      const installStep = workflow.jobs.scan.steps.find(
+        (step: WorkflowStep) => step.name === "Install opengrep",
+      );
+
+      expect(installStep, workflowPath).toBeDefined();
+      const run = installStep.run as string;
+
+      expect(run, workflowPath).toContain(
+        'installer="$(mktemp "${RUNNER_TEMP}/opengrep-install.XXXXXX")"',
+      );
+      expect(run, workflowPath).toContain("curl -fsSL --connect-timeout 10 --max-time 120 \\");
+      expect(run, workflowPath).toContain('-o "$installer"');
+      expect(run, workflowPath).toContain('bash "$installer" -v "$OPENGREP_VERSION"');
+      expect(run, workflowPath).toContain("trap 'rm -f \"$installer\"' EXIT");
+      expect(run.indexOf('-o "$installer"'), workflowPath).toBeLessThan(
+        run.indexOf('bash "$installer"'),
+      );
+      expect(run, workflowPath).not.toMatch(/curl[^\n]+\|\s*bash/u);
+    }
+  });
+
   it("runs real behavior proof from the trusted workflow revision", () => {
     const workflow = readRealBehaviorProofWorkflow();
     const source = readFileSync(".github/workflows/real-behavior-proof.yml", "utf8");
@@ -4280,10 +4304,4 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
   });
 
-  it("bounds Opengrep installer downloads with connect timeout", () => {
-    for (const path of [OPENGREP_PR_DIFF_WORKFLOW, OPENGREP_FULL_WORKFLOW]) {
-      const workflow = readFileSync(path, "utf8");
-      expect(workflow).toContain("curl -fsSL --connect-timeout 30 --max-time 120");
-    }
-  });
 });

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1673,12 +1673,11 @@ describe("ci workflow guards", () => {
   it("downloads the opengrep installer completely before execution", () => {
     for (const workflowPath of [OPENGREP_PR_DIFF_WORKFLOW, OPENGREP_FULL_WORKFLOW]) {
       const workflow = parse(readFileSync(workflowPath, "utf8"));
-      const installStep = workflow.jobs.scan.steps.find(
-        (step: WorkflowStep) => step.name === "Install opengrep",
+      const run = expectDefined(
+        workflow.jobs.scan.steps.find((step: WorkflowStep) => step.name === "Install opengrep")
+          ?.run,
+        `Install opengrep step in ${workflowPath}`,
       );
-
-      expect(installStep, workflowPath).toBeDefined();
-      const run = installStep.run as string;
 
       expect(run, workflowPath).toContain(
         'installer="$(mktemp "${RUNNER_TEMP}/opengrep-install.XXXXXX")"',
@@ -1690,7 +1689,7 @@ describe("ci workflow guards", () => {
       expect(run.indexOf('-o "$installer"'), workflowPath).toBeLessThan(
         run.indexOf('bash "$installer"'),
       );
-      expect(run, workflowPath).not.toMatch(/curl[^\n]+\|\s*bash/u);
+      expect(run, workflowPath).not.toMatch(/\|\s*bash/u);
     }
   });
 
@@ -4303,5 +4302,4 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       'call.getFile().getRelativePath() = "extensions/codex/src/app-server/transport-websocket.ts"',
     );
   });
-
 });


### PR DESCRIPTION
## What Problem This Solves

Both OpenGrep CI workflows streamed the pinned installer directly from `curl` into Bash. Current `main` now bounds those transfers through #109576, but Bash can still execute a partial response before curl reaches its deadline and fails the pipeline.

## Why This Change Was Made

Download the pinned installer completely into `RUNNER_TEMP` with explicit connection and total-transfer deadlines, then execute it only after curl succeeds. This matches the existing OpenShell installer contract while preserving the OpenGrep commit pin and `-v "$OPENGREP_VERSION"` invocation.

The rebase onto current `main` also folded #109576's simpler timeout-only guard into one stronger regression test, avoiding duplicate policy tests.

## User Impact

No product behavior changes. OpenGrep PR-diff and full-scan jobs fail cleanly on a stalled or incomplete installer response instead of hanging or executing partial installer bytes.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 75 passed, 1 skipped.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'downloads the opengrep installer completely before execution'` — 1 passed, 75 skipped after final formatting/review fixes.
- `node scripts/check-changed.mjs -- .github/workflows/opengrep-precise.yml .github/workflows/opengrep-precise-full.yml test/scripts/ci-workflow-guards.test.ts` — passed on Blacksmith Testbox `tbx_01kxqasjgzmtp7v6j0dbw9vf5n`: https://github.com/openclaw/openclaw/actions/runs/29558996916
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, confidence 0.99.
- `git diff --check origin/main...HEAD` — passed.

The guard covers both workflows, the temp-file path and cleanup trap, curl's `10s` connect / `120s` total bounds, execution ordering, and rejection of whitespace variants of direct pipe-to-Bash execution.

### Upstream contract

The pinned OpenGrep SHA remains `f458d7f0d52cc58eae1ca3cf3d5caf101e637519`, the `v1.22.0` tag commit. Its installer accepts `-v <version>` both from a file and stdin; only the transport/execution boundary changes.

### Scope

Only the two OpenGrep installer steps and their shared workflow guard test.

AI-assisted; maintainer-reviewed and understood.
