### PR TITLE
fix: state backups hang on dev-channel installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **State backup runtime exclusions:** skip installer-managed dev checkouts, plugin package roots, and downloaded tool runtimes during state backups, and fail stalled archive writes after a bounded idle timeout instead of leaving migration RPCs pending indefinitely.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **State backup runtime exclusions:** skip installer-managed dev checkouts, plugin package roots, and downloaded tool runtimes during state backups, and fail stalled archive writes after a bounded idle timeout instead of leaving migration RPCs pending indefinitely.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -107,7 +107,7 @@ SQLite databases under the state directory are compacted with `VACUUM INTO` so d
 
 Installed plugin source and manifest files under the state directory's `extensions/` tree are included, but their nested `node_modules/` dependency trees are skipped as rebuildable install artifacts. After restoring an archive, use `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force` if a restored plugin reports missing dependencies.
 
-Installer-managed and rebuildable runtime roots under the state directory are also skipped: `dev/`, `git/`, `npm/`, legacy `npm-runtime/`, and `tools/`. These contain managed checkouts, package trees, and downloaded runtimes rather than authoritative user state; reinstall or update the corresponding runtime or plugin after restore.
+Installer-managed and rebuildable runtime roots under the state directory are also skipped: `dev/`, `git/`, `npm/`, legacy `npm-runtime/`, and `tools/`. These contain managed checkouts, package trees, and downloaded runtimes rather than authoritative user state; reinstall or update the corresponding runtime or plugin after restore. An explicitly configured config file, credentials directory, or workspace inside one of these roots remains included.
 
 ## Invalid config behavior
 

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -107,6 +107,8 @@ SQLite databases under the state directory are compacted with `VACUUM INTO` so d
 
 Installed plugin source and manifest files under the state directory's `extensions/` tree are included, but their nested `node_modules/` dependency trees are skipped as rebuildable install artifacts. After restoring an archive, use `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force` if a restored plugin reports missing dependencies.
 
+Installer-managed and rebuildable runtime roots under the state directory are also skipped: `dev/`, `git/`, `npm/`, legacy `npm-runtime/`, and `tools/`. These contain managed checkouts, package trees, and downloaded runtimes rather than authoritative user state; reinstall or update the corresponding runtime or plugin after restore.
+
 ## Invalid config behavior
 
 `openclaw backup` bypasses the normal config preflight so it can still help during recovery. Workspace discovery depends on a valid config, so `openclaw backup create` fails fast when the config file exists but is invalid and workspace backup is still enabled.
@@ -117,7 +119,7 @@ For a partial backup in that situation, rerun with `--no-include-workspace`: it 
 
 ## Size and performance
 
-OpenClaw does not enforce a built-in maximum backup size or per-file size limit. Practical limits come from:
+OpenClaw does not enforce a built-in maximum backup size or per-file size limit. An archive write that produces no data for five minutes fails and removes its partial temporary file instead of hanging indefinitely. Practical limits otherwise come from:
 
 - Available space for the temporary archive write plus the final archive
 - Time to walk large workspace trees and compress them into a `.tar.gz`

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -108,6 +108,10 @@ const {
 describe("server-runtime-services", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    // Gateway test helpers set these at module load. Stub them off so a shared
+    // worker's import order cannot silently disable this suite's health monitor.
+    vi.stubEnv("OPENCLAW_SKIP_CHANNELS", "");
+    vi.stubEnv("OPENCLAW_SKIP_PROVIDERS", "");
     resetGatewayWorkAdmission();
     hoisted.heartbeatRunner.stop.mockClear();
     hoisted.heartbeatRunner.updateConfig.mockClear();
@@ -131,6 +135,7 @@ describe("server-runtime-services", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
     resetGatewayWorkAdmission();
   });
 

--- a/src/infra/backup-create-stream.ts
+++ b/src/infra/backup-create-stream.ts
@@ -1,15 +1,53 @@
 import { createWriteStream } from "node:fs";
+import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
+
+const BACKUP_ARCHIVE_IDLE_TIMEOUT_MS = 5 * 60_000;
 
 export async function writeArchiveStreamToFile(params: {
   archivePath: string;
   archiveStream: AsyncIterable<Uint8Array> | NodeJS.ReadableStream;
+  idleTimeoutMs?: number;
 }): Promise<void> {
   // Own both stream lifecycles so a tar read error closes the output handle
   // before retry cleanup touches the partial archive. Exclusive creation also
   // refuses a pre-existing path instead of following a symlink.
-  await pipeline(
-    params.archiveStream,
-    createWriteStream(params.archivePath, { flags: "wx", mode: 0o600 }),
-  );
+  const idleTimeoutMs = params.idleTimeoutMs ?? BACKUP_ARCHIVE_IDLE_TIMEOUT_MS;
+  const controller = new AbortController();
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let idleTimeoutError: Error | undefined;
+  const armIdleTimer = () => {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
+    idleTimer = setTimeout(() => {
+      idleTimeoutError = new Error(
+        `Backup archive write stalled: no data produced for ${idleTimeoutMs}ms`,
+      );
+      controller.abort(idleTimeoutError);
+    }, idleTimeoutMs);
+    idleTimer.unref?.();
+  };
+  const progress = new Transform({
+    transform(chunk, _encoding, callback) {
+      armIdleTimer();
+      callback(null, chunk);
+    },
+  });
+
+  armIdleTimer();
+  try {
+    await pipeline(
+      params.archiveStream,
+      progress,
+      createWriteStream(params.archivePath, { flags: "wx", mode: 0o600 }),
+      { signal: controller.signal },
+    );
+  } catch (err) {
+    throw idleTimeoutError ?? err;
+  } finally {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
+  }
 }

--- a/src/infra/backup-create-stream.ts
+++ b/src/infra/backup-create-stream.ts
@@ -4,9 +4,13 @@ import { pipeline } from "node:stream/promises";
 
 const BACKUP_ARCHIVE_IDLE_TIMEOUT_MS = 5 * 60_000;
 
+type DestroyableArchiveStream = (NodeJS.ReadableStream | AsyncIterable<Uint8Array>) & {
+  destroy(error?: Error): unknown;
+};
+
 export async function writeArchiveStreamToFile(params: {
   archivePath: string;
-  archiveStream: AsyncIterable<Uint8Array> | NodeJS.ReadableStream;
+  archiveStream: DestroyableArchiveStream;
   idleTimeoutMs?: number;
 }): Promise<void> {
   // Own both stream lifecycles so a tar read error closes the output handle
@@ -24,9 +28,9 @@ export async function writeArchiveStreamToFile(params: {
       idleTimeoutError = new Error(
         `Backup archive write stalled: no data produced for ${idleTimeoutMs}ms`,
       );
+      params.archiveStream.destroy(idleTimeoutError);
       controller.abort(idleTimeoutError);
     }, idleTimeoutMs);
-    idleTimer.unref?.();
   };
   const progress = new Transform({
     transform(chunk, _encoding, callback) {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1465,28 +1465,44 @@ describe("createBackupArchive", () => {
     );
   });
 
-  it("preserves a configured workspace nested under a managed runtime root", async () => {
+  it("preserves configured state paths nested under managed runtime roots", async () => {
     await withOpenClawTestState(
       {
         layout: "state-only",
         prefix: "openclaw-backup-managed-root-workspace-",
         scenario: "minimal",
+        env: { OPENCLAW_OAUTH_DIR: undefined },
       },
       async (state) => {
         const stateDir = state.stateDir;
         const workspaceDir = path.join(stateDir, "dev", "workspace");
         const runtimeDir = path.join(stateDir, "dev", "openclaw");
+        const configPath = path.join(stateDir, "git", "config", "openclaw.json");
+        const oauthDir = path.join(stateDir, "tools", "oauth");
+        const toolRuntimeDir = path.join(stateDir, "tools", "runtime");
         const workspaceDbPath = path.join(workspaceDir, "workspace.sqlite");
         const outputDir = state.path("backups");
-        await state.writeConfig({
-          agents: {
-            list: [{ id: "main", default: true, workspace: workspaceDir }],
-          },
-        });
+        state.envVars.OPENCLAW_CONFIG_PATH = configPath;
+        state.envVars.OPENCLAW_OAUTH_DIR = oauthDir;
+        state.applyEnv();
         await fs.mkdir(workspaceDir, { recursive: true });
         await fs.mkdir(runtimeDir, { recursive: true });
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.mkdir(oauthDir, { recursive: true });
+        await fs.mkdir(toolRuntimeDir, { recursive: true });
+        await fs.writeFile(
+          configPath,
+          `${JSON.stringify({
+            agents: {
+              list: [{ id: "main", default: true, workspace: workspaceDir }],
+            },
+          })}\n`,
+          "utf8",
+        );
+        await fs.writeFile(path.join(oauthDir, "credentials.json"), "{}\n", "utf8");
         await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "durable workspace\n", "utf8");
         await fs.writeFile(path.join(runtimeDir, "package.json"), "{}\n", "utf8");
+        await fs.writeFile(path.join(toolRuntimeDir, "tool.bin"), "runtime\n", "utf8");
         const sqlite = requireNodeSqlite();
         const workspaceDb = new sqlite.DatabaseSync(workspaceDbPath);
         try {
@@ -1511,7 +1527,14 @@ describe("createBackupArchive", () => {
         expect(
           entries.some((entry) => entry.endsWith("/state/dev/workspace/workspace.sqlite")),
         ).toBe(true);
+        expect(entries.some((entry) => entry.endsWith("/state/git/config/openclaw.json"))).toBe(
+          true,
+        );
+        expect(entries.some((entry) => entry.endsWith("/state/tools/oauth/credentials.json"))).toBe(
+          true,
+        );
         expect(entries.some((entry) => entry.includes("/state/dev/openclaw/"))).toBe(false);
+        expect(entries.some((entry) => entry.includes("/state/tools/runtime/"))).toBe(false);
 
         const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
         await expect(

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1369,7 +1369,7 @@ describe("createBackupArchive", () => {
     );
   });
 
-  it("omits installed plugin node_modules from the real archive while keeping plugin files", async () => {
+  it("omits reinstallable runtime trees and plugin dependencies while keeping plugin files", async () => {
     await withOpenClawTestState(
       {
         layout: "state-only",
@@ -1387,6 +1387,14 @@ describe("createBackupArchive", () => {
         await fs.mkdir(path.join(stateDir, "npm", "projects", "demo", "node_modules", "dep"), {
           recursive: true,
         });
+        for (const managedRoot of ["dev", "git", "npm-runtime", "tools"]) {
+          await fs.mkdir(path.join(stateDir, managedRoot, "runtime"), { recursive: true });
+          await fs.writeFile(
+            path.join(stateDir, managedRoot, "runtime", "fixture.sqlite"),
+            "reinstallable runtime content\n",
+            "utf8",
+          );
+        }
         await fs.writeFile(
           path.join(stateDir, "extensions", "demo", "openclaw.plugin.json"),
           '{"id":"demo"}\n',
@@ -1436,7 +1444,15 @@ describe("createBackupArchive", () => {
         expect(entrySuffixes).toContain("/state/extensions/demo/src/index.js");
         expect(entrySuffixes).toContain("/state/node_modules/root-dep/index.js");
         expect(entrySuffixes).toContain("/state/node_modules/root-dep/fixture.sqlite");
-        expect(entrySuffixes).toContain("/state/npm/projects/demo/node_modules/dep/fixture.sqlite");
+        for (const managedRoot of ["dev", "git", "npm", "npm-runtime", "tools"]) {
+          expect(
+            entrySuffixes.some(
+              (entry) =>
+                entry === `/state/${managedRoot}` || entry.startsWith(`/state/${managedRoot}/`),
+            ),
+            managedRoot,
+          ).toBe(false);
+        }
         const pluginNodeModuleEntries = entries.filter((entry) =>
           entry.includes("/state/extensions/demo/node_modules/"),
         );

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1465,6 +1465,62 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("preserves a configured workspace nested under a managed runtime root", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-managed-root-workspace-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const stateDir = state.stateDir;
+        const workspaceDir = path.join(stateDir, "dev", "workspace");
+        const runtimeDir = path.join(stateDir, "dev", "openclaw");
+        const workspaceDbPath = path.join(workspaceDir, "workspace.sqlite");
+        const outputDir = state.path("backups");
+        await state.writeConfig({
+          agents: {
+            list: [{ id: "main", default: true, workspace: workspaceDir }],
+          },
+        });
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(runtimeDir, { recursive: true });
+        await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "durable workspace\n", "utf8");
+        await fs.writeFile(path.join(runtimeDir, "package.json"), "{}\n", "utf8");
+        const sqlite = requireNodeSqlite();
+        const workspaceDb = new sqlite.DatabaseSync(workspaceDbPath);
+        try {
+          workspaceDb.exec(
+            "CREATE TABLE durable_state (value TEXT NOT NULL); INSERT INTO durable_state VALUES ('keep');",
+          );
+        } finally {
+          workspaceDb.close();
+        }
+        await fs.mkdir(outputDir, { recursive: true });
+
+        const result = await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: true,
+          nowMs: Date.UTC(2026, 3, 28, 12, 30, 0),
+        });
+        const entries = await listArchiveEntries(result.archivePath);
+
+        expect(entries.some((entry) => entry.endsWith("/state/dev/workspace/AGENTS.md"))).toBe(
+          true,
+        );
+        expect(
+          entries.some((entry) => entry.endsWith("/state/dev/workspace/workspace.sqlite")),
+        ).toBe(true);
+        expect(entries.some((entry) => entry.includes("/state/dev/openclaw/"))).toBe(false);
+
+        const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        await expect(
+          backupVerifyCommand(runtime, { archive: result.archivePath }),
+        ).resolves.toMatchObject({ ok: true });
+      },
+    );
+  });
+
   it("dereferences hardlinks instead of emitting restore-hostile Link entries", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -713,9 +713,13 @@ export async function createBackupArchive(
   const tempArchivePath = buildTempArchivePath(outputPath);
   const tempArchiveCleanupPaths = resolveBackupTarAttemptTempPaths(tempArchivePath);
   const stateAsset = result.assets.find((asset) => asset.kind === "state");
-  const preservedStatePaths = plan.skipped
-    .filter((asset) => asset.kind === "workspace" && asset.reason === "covered")
-    .map((asset) => asset.sourcePath);
+  const preservedStatePaths = [
+    plan.configPath,
+    plan.oauthDir,
+    ...plan.skipped
+      .filter((asset) => asset.kind === "workspace" && asset.reason === "covered")
+      .map((asset) => asset.sourcePath),
+  ].filter((entry) => stateAsset && isPathWithin(entry, stateAsset.sourcePath));
   try {
     const stateSqliteBackup = stateAsset
       ? await createStateSqliteBackupPlan({

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -363,17 +363,24 @@ function normalizeBackupFilterPath(value: string): string {
   return value.replaceAll("\\", "/").replace(/\/+$/u, "");
 }
 
-function buildExtensionsNodeModulesFilter(stateDir: string): (filePath: string) => boolean {
+const REINSTALLABLE_STATE_ROOTS = new Set(["dev", "git", "npm", "npm-runtime", "tools"]);
+
+function buildStateBackupFilter(stateDir: string): (filePath: string) => boolean {
   const normalizedStateDir = normalizeBackupFilterPath(stateDir);
-  const extensionsPrefix = `${normalizedStateDir}/extensions/`;
+  const statePrefix = `${normalizedStateDir}/`;
 
   return (filePath: string): boolean => {
     const normalizedFilePath = normalizeBackupFilterPath(filePath);
-    if (!normalizedFilePath.startsWith(extensionsPrefix)) {
+    if (!normalizedFilePath.startsWith(statePrefix)) {
       return true;
     }
 
-    return !normalizedFilePath.slice(extensionsPrefix.length).split("/").includes("node_modules");
+    const segments = normalizedFilePath.slice(statePrefix.length).split("/");
+    if (REINSTALLABLE_STATE_ROOTS.has(segments[0] ?? "")) {
+      return false;
+    }
+
+    return segments[0] !== "extensions" || !segments.includes("node_modules");
   };
 }
 
@@ -493,7 +500,7 @@ async function listStateSqlitePaths(params: {
 }): Promise<{ snapshotPaths: string[]; discoveredSourcePaths: Set<string> }> {
   const snapshotPaths = new Set<string>();
   const discoveredSourcePaths = new Set<string>();
-  const extensionsFilter = buildExtensionsNodeModulesFilter(params.stateDir);
+  const stateFilter = buildStateBackupFilter(params.stateDir);
   async function visit(dir: string): Promise<void> {
     let entries: import("node:fs").Dirent[];
     try {
@@ -509,12 +516,12 @@ async function listStateSqlitePaths(params: {
         continue;
       }
       if (entry.isDirectory()) {
-        if (extensionsFilter(entryPath) && !isStatePackageContentPath(entryPath, params.stateDir)) {
+        if (stateFilter(entryPath) && !isStatePackageContentPath(entryPath, params.stateDir)) {
           await visit(entryPath);
         }
       } else if (
         entry.isFile() &&
-        extensionsFilter(entryPath) &&
+        stateFilter(entryPath) &&
         !isStatePackageContentPath(entryPath, params.stateDir)
       ) {
         const resolvedEntryPath = path.resolve(entryPath);
@@ -722,9 +729,7 @@ export async function createBackupArchive(
     await writeJson(manifestPath, manifest, { trailingNewline: true });
 
     const tar = await loadTarRuntime();
-    const extensionsFilter = stateAsset
-      ? buildExtensionsNodeModulesFilter(stateAsset.sourcePath)
-      : undefined;
+    const stateFilter = stateAsset ? buildStateBackupFilter(stateAsset.sourcePath) : undefined;
     const volatilePlan = { stateDirs: [stateAsset?.sourcePath ?? plan.stateDir] };
     let skippedVolatileCount = 0;
     // node-tar invokes filters from async stat callbacks, so throwing inside
@@ -740,7 +745,7 @@ export async function createBackupArchive(
       if (resolvedEntryPath === manifestPath) {
         return true;
       }
-      if (extensionsFilter && !extensionsFilter(entryPath)) {
+      if (stateFilter && !stateFilter(entryPath)) {
         return false;
       }
       const sqliteSourceKind = stateAsset

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -365,9 +365,13 @@ function normalizeBackupFilterPath(value: string): string {
 
 const REINSTALLABLE_STATE_ROOTS = new Set(["dev", "git", "npm", "npm-runtime", "tools"]);
 
-function buildStateBackupFilter(stateDir: string): (filePath: string) => boolean {
+function buildStateBackupFilter(
+  stateDir: string,
+  preservedStatePaths: readonly string[] = [],
+): (filePath: string) => boolean {
   const normalizedStateDir = normalizeBackupFilterPath(stateDir);
   const statePrefix = `${normalizedStateDir}/`;
+  const resolvedPreservedPaths = preservedStatePaths.map((entry) => path.resolve(entry));
 
   return (filePath: string): boolean => {
     const normalizedFilePath = normalizeBackupFilterPath(filePath);
@@ -377,7 +381,14 @@ function buildStateBackupFilter(stateDir: string): (filePath: string) => boolean
 
     const segments = normalizedFilePath.slice(statePrefix.length).split("/");
     if (REINSTALLABLE_STATE_ROOTS.has(segments[0] ?? "")) {
-      return false;
+      const resolvedFilePath = path.resolve(filePath);
+      // Configured workspaces nested under a managed root remain authoritative
+      // user state. Keep their ancestors traversable without admitting siblings.
+      return resolvedPreservedPaths.some(
+        (preservedPath) =>
+          isPathWithin(resolvedFilePath, preservedPath) ||
+          isPathWithin(preservedPath, resolvedFilePath),
+      );
     }
 
     return segments[0] !== "extensions" || !segments.includes("node_modules");
@@ -497,10 +508,11 @@ function sanitizeGlobalStateSqliteSnapshot(db: DatabaseSync): void {
 async function listStateSqlitePaths(params: {
   stateDir: string;
   globalStateSqlitePath: string;
+  preservedStatePaths?: readonly string[];
 }): Promise<{ snapshotPaths: string[]; discoveredSourcePaths: Set<string> }> {
   const snapshotPaths = new Set<string>();
   const discoveredSourcePaths = new Set<string>();
-  const stateFilter = buildStateBackupFilter(params.stateDir);
+  const stateFilter = buildStateBackupFilter(params.stateDir, params.preservedStatePaths);
   async function visit(dir: string): Promise<void> {
     let entries: import("node:fs").Dirent[];
     try {
@@ -583,6 +595,7 @@ async function listStateSqlitePaths(params: {
 async function createStateSqliteBackupPlan(params: {
   stateDir: string;
   tempDir: string;
+  preservedStatePaths?: readonly string[];
 }): Promise<StateSqliteBackupPlan> {
   // Complete discovery before writing snapshots. chooseBackupTempRoot keeps
   // tempDir outside stateDir, and this ordering prevents future overlap from
@@ -596,6 +609,7 @@ async function createStateSqliteBackupPlan(params: {
   const discovery = await listStateSqlitePaths({
     stateDir: params.stateDir,
     globalStateSqlitePath,
+    preservedStatePaths: params.preservedStatePaths,
   });
   const snapshots: SqliteBackupAsset[] = [];
   for (const archiveSourcePath of discovery.snapshotPaths) {
@@ -699,11 +713,15 @@ export async function createBackupArchive(
   const tempArchivePath = buildTempArchivePath(outputPath);
   const tempArchiveCleanupPaths = resolveBackupTarAttemptTempPaths(tempArchivePath);
   const stateAsset = result.assets.find((asset) => asset.kind === "state");
+  const preservedStatePaths = plan.skipped
+    .filter((asset) => asset.kind === "workspace" && asset.reason === "covered")
+    .map((asset) => asset.sourcePath);
   try {
     const stateSqliteBackup = stateAsset
       ? await createStateSqliteBackupPlan({
           stateDir: stateAsset.sourcePath,
           tempDir,
+          preservedStatePaths,
         })
       : { snapshots: [], discoveredSourcePaths: new Set<string>() };
     const sourcePathRemaps = new Map<string, string>();
@@ -729,7 +747,9 @@ export async function createBackupArchive(
     await writeJson(manifestPath, manifest, { trailingNewline: true });
 
     const tar = await loadTarRuntime();
-    const stateFilter = stateAsset ? buildStateBackupFilter(stateAsset.sourcePath) : undefined;
+    const stateFilter = stateAsset
+      ? buildStateBackupFilter(stateAsset.sourcePath, preservedStatePaths)
+      : undefined;
     const volatilePlan = { stateDirs: [stateAsset?.sourcePath ?? plan.stateDir] };
     let skippedVolatileCount = 0;
     // node-tar invokes filters from async stat callbacks, so throwing inside

--- a/src/infra/backup-create.windows.test.ts
+++ b/src/infra/backup-create.windows.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { writeArchiveStreamToFile } from "./backup-create-stream.js";
 
@@ -21,5 +21,55 @@ describe("writeArchiveStreamToFile", () => {
 
     await expect(writePromise).rejects.toThrow("injected tar read failure");
     await expect(fs.rm(archivePath)).resolves.toBeUndefined();
+  });
+
+  it("aborts and closes a partial archive when the source stops producing data", async () => {
+    vi.useFakeTimers();
+    try {
+      const tempDir = tempDirs.make("openclaw-backup-stream-timeout-");
+      const archivePath = path.join(tempDir, "partial.tar.gz");
+      const archiveStream = new PassThrough();
+      const writePromise = writeArchiveStreamToFile({
+        archivePath,
+        archiveStream,
+        idleTimeoutMs: 50,
+      });
+      archiveStream.write("partial archive");
+
+      const rejection = expect(writePromise).rejects.toThrow(
+        "Backup archive write stalled: no data produced for 50ms",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      await rejection;
+      expect(archiveStream.destroyed).toBe(true);
+      await expect(fs.rm(archivePath)).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets the idle timeout when archive data keeps arriving", async () => {
+    vi.useFakeTimers();
+    try {
+      const tempDir = tempDirs.make("openclaw-backup-stream-progress-");
+      const archivePath = path.join(tempDir, "complete.tar.gz");
+      const archiveStream = new PassThrough();
+      const writePromise = writeArchiveStreamToFile({
+        archivePath,
+        archiveStream,
+        idleTimeoutMs: 50,
+      });
+
+      archiveStream.write("first");
+      await vi.advanceTimersByTimeAsync(40);
+      archiveStream.write("second");
+      await vi.advanceTimersByTimeAsync(40);
+      archiveStream.end("third");
+
+      await expect(writePromise).resolves.toBeUndefined();
+      await expect(fs.readFile(archivePath, "utf8")).resolves.toBe("firstsecondthird");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users applying migrations from a dev-channel desktop install could have the migration RPC hang indefinitely while the state backup archived the installer-managed Git checkout, including `.git` and `node_modules`.

## Why This Change Was Made

State backups now omit exact installer-managed runtime roots (`dev/`, `git/`, `npm/`, legacy `npm-runtime/`, and `tools/`) while preserving authoritative state and plugin source. The same filter applies before SQLite snapshot discovery and during archive traversal. Archive writes also fail after five minutes without output, aborting both stream ends and allowing partial-file cleanup.

This keeps arbitrary similarly named state (for example `developer/`), root package content, and explicitly configured config, credential, or workspace paths nested beneath a managed root. Each exception opens only its own traversal corridor and is shared by SQLite discovery and tar filtering, so sibling runtime trees stay excluded. A whole-backup size cap was avoided because legitimate workspaces can be large; the deadline measures stalled progress, not total backup duration.

## User Impact

Dev-channel migrations no longer tar multi-gigabyte managed checkouts. Reinstallable runtime trees stay out of backups, and a genuinely stalled archive fails instead of leaving the Control UI on “Importing…” forever.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs src/infra/backup-create.test.ts src/infra/backup-create.windows.test.ts src/commands/migrate/apply.test.ts` — 54 passed.
- Blacksmith Testbox Linux CLI proof: a backup with 10 MiB across the five managed roots completed and verified in 21.3 seconds; archive size was 23,050 bytes; managed roots were absent while `settings.json`, `developer/keep.txt`, and plugin source remained.
- Blacksmith Testbox changed gate: `pnpm check:changed` — passed, including formatting, core and test typechecks, lint, package guards, and runtime guards.
- Managed-root regression proof preserves a configured `dev/workspace` tree and SQLite database, `git/config/openclaw.json`, and `tools/oauth` credentials while excluding sibling `dev/openclaw` and `tools/runtime` trees.
- Stalled-stream regression proof uses an injected 50 ms idle deadline and verifies the destroyable source is closed and the partial archive can be removed. A companion test verifies ongoing chunks reset the deadline.
- CI flake regression: the gateway runtime-service suite failed under a leaked `OPENCLAW_SKIP_CHANNELS=1`; explicit suite env isolation makes the polluted-env run pass all 20 tests.
- Autoreview: all lifecycle/ownership findings accepted and fixed; final pass clean with no accepted or actionable findings.

AI-assisted: implementation and validation performed with Codex; behavior and diff reviewed by the submitting maintainer.
