### PR TITLE
fix(codex): bound Computer Use process inspection

### DIFF
--- a/extensions/codex/src/app-server/computer-use-health.ts
+++ b/extensions/codex/src/app-server/computer-use-health.ts
@@ -3,9 +3,9 @@ import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { CodexAppServerClient } from "./client.js";
 import {
   killStaleComputerUseMcpChildren,
-  runCodexComputerUseLiveTest,
   type CodexComputerUseRepairStatus,
-} from "./computer-use.js";
+} from "./computer-use-process-repair.js";
+import { runCodexComputerUseLiveTest } from "./computer-use.js";
 import type { ResolvedCodexComputerUseConfig } from "./config.js";
 
 type ComputerUseHealthMonitor = {

--- a/extensions/codex/src/app-server/computer-use-process-repair.test.ts
+++ b/extensions/codex/src/app-server/computer-use-process-repair.test.ts
@@ -1,0 +1,83 @@
+// Codex tests cover bounded, fail-closed Computer Use process repair.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const runExecMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
+  runExec: runExecMock,
+}));
+
+import { killStaleComputerUseMcpChildren } from "./computer-use-process-repair.js";
+
+describe("Codex Computer Use process repair", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runExecMock.mockReset();
+  });
+
+  it("bounds process inspection and never signals from an incomplete snapshot", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    runExecMock.mockRejectedValueOnce(new Error("process listing timed out"));
+    const killSpy = vi.spyOn(process, "kill");
+
+    const result = await killStaleComputerUseMcpChildren({ ancestorPid: 42 });
+
+    expect(runExecMock).toHaveBeenCalledWith("/bin/ps", ["-axo", "pid=,ppid=,command="], {
+      logOutput: false,
+      maxBuffer: 5 * 1024 * 1024,
+      timeoutMs: 2_000,
+    });
+    expect(result).toMatchObject({
+      attempted: true,
+      killedPids: [],
+      message: "Computer Use stale child repair could not inspect running processes.",
+    });
+    expect(result.warnings).toEqual([
+      expect.stringContaining("Could not list processes for Computer Use repair"),
+    ]);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("signals only matching descendants from a complete process snapshot", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    runExecMock.mockResolvedValueOnce({
+      stdout: [
+        "  42     1 /Applications/ChatGPT.app/Contents/Resources/codex app-server",
+        " 100    42 /usr/bin/node SkyComputerUseClient mcp --stdio",
+        " 101    42 /usr/bin/node unrelated-helper",
+        " 102    99 /usr/bin/node SkyComputerUseClient mcp --stdio",
+        "  99     1 /usr/bin/other-parent",
+        "",
+      ].join("\n"),
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await killStaleComputerUseMcpChildren({ ancestorPid: 42 });
+
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    expect(killSpy).toHaveBeenCalledWith(100, "SIGTERM");
+    expect(result).toMatchObject({ attempted: true, killedPids: [100], warnings: [] });
+  });
+
+  it("does not inspect processes without a scoped local app-server pid", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+
+    const result = await killStaleComputerUseMcpChildren({ ancestorPid: 0 });
+
+    expect(result.attempted).toBe(false);
+    expect(result.killedPids).toEqual([]);
+    expect(runExecMock).not.toHaveBeenCalled();
+  });
+
+  it("does not inspect processes on unsupported platforms", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+
+    const result = await killStaleComputerUseMcpChildren({ ancestorPid: 42 });
+
+    expect(result).toMatchObject({ attempted: true, killedPids: [] });
+    expect(result.warnings).toEqual([
+      "Computer Use stale child repair is currently macOS-only, not linux.",
+    ]);
+    expect(runExecMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/codex/src/app-server/computer-use-process-repair.ts
+++ b/extensions/codex/src/app-server/computer-use-process-repair.ts
@@ -1,0 +1,143 @@
+// macOS process inspection and scoped stale-child repair for Codex Computer Use.
+import { runExec } from "openclaw/plugin-sdk/process-runtime";
+import { describeControlFailure } from "./capabilities.js";
+
+const COMPUTER_USE_PROCESS_LIST_TIMEOUT_MS = 2_000;
+const COMPUTER_USE_PROCESS_LIST_MAX_BUFFER_BYTES = 5 * 1024 * 1024;
+
+type ProcessInfo = {
+  pid: number;
+  ppid: number;
+  command: string;
+};
+
+export type CodexComputerUseRepairStatus = {
+  attempted: boolean;
+  killedPids: number[];
+  message: string;
+  warnings: string[];
+};
+
+export function scopedRepairUnavailableStatus(): CodexComputerUseRepairStatus {
+  return {
+    attempted: false,
+    killedPids: [],
+    warnings: [
+      "Computer Use auto-repair skipped because no scoped Codex app-server process was available.",
+    ],
+    message: "Computer Use stale child repair requires a scoped local app-server PID.",
+  };
+}
+
+export async function killStaleComputerUseMcpChildren(
+  options: { ancestorPid?: number } = {},
+): Promise<CodexComputerUseRepairStatus> {
+  if (process.platform !== "darwin") {
+    return {
+      attempted: true,
+      killedPids: [],
+      warnings: [
+        `Computer Use stale child repair is currently macOS-only, not ${process.platform}.`,
+      ],
+      message: "Computer Use stale child repair skipped on this platform.",
+    };
+  }
+  if (
+    !options.ancestorPid ||
+    !Number.isSafeInteger(options.ancestorPid) ||
+    options.ancestorPid <= 0
+  ) {
+    return scopedRepairUnavailableStatus();
+  }
+
+  let stdout: string;
+  try {
+    const result = await runExec("/bin/ps", ["-axo", "pid=,ppid=,command="], {
+      logOutput: false,
+      maxBuffer: COMPUTER_USE_PROCESS_LIST_MAX_BUFFER_BYTES,
+      // A partial process table cannot prove ancestry, so timeout remains a
+      // no-kill result and the next health probe can retry from a fresh snapshot.
+      timeoutMs: COMPUTER_USE_PROCESS_LIST_TIMEOUT_MS,
+    });
+    stdout = result.stdout;
+  } catch (error) {
+    return {
+      attempted: true,
+      killedPids: [],
+      warnings: [
+        `Could not list processes for Computer Use repair: ${describeControlFailure(error)}`,
+      ],
+      message: "Computer Use stale child repair could not inspect running processes.",
+    };
+  }
+
+  const killedPids: number[] = [];
+  const warnings: string[] = [];
+  const processInfos = parsePsOutput(stdout);
+  for (const processInfo of processInfos) {
+    if (!isStaleComputerUseMcpChild(processInfo.command)) {
+      continue;
+    }
+    if (!isDescendantOfPid(processInfo.pid, options.ancestorPid, processInfos)) {
+      continue;
+    }
+    try {
+      process.kill(processInfo.pid, "SIGTERM");
+      killedPids.push(processInfo.pid);
+    } catch (error) {
+      warnings.push(
+        `Could not terminate stale Computer Use MCP child pid ${processInfo.pid}: ${describeControlFailure(error)}`,
+      );
+    }
+  }
+  return {
+    attempted: true,
+    killedPids,
+    warnings,
+    message:
+      killedPids.length === 0
+        ? "No stale Computer Use MCP children were found under the scoped Codex app-server process."
+        : `Terminated ${killedPids.length} stale Computer Use MCP child process${killedPids.length === 1 ? "" : "es"} under the scoped Codex app-server process.`,
+  };
+}
+
+function parsePsOutput(stdout: string): ProcessInfo[] {
+  return stdout
+    .split(/\r?\n/u)
+    .flatMap((line) => {
+      const match = /^\s*(\d+)\s+(\d+)\s+(.+)$/u.exec(line);
+      if (!match) {
+        return [];
+      }
+      return [{ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] ?? "" }];
+    })
+    .filter(
+      (processInfo) =>
+        Number.isSafeInteger(processInfo.pid) &&
+        processInfo.pid > 0 &&
+        Number.isSafeInteger(processInfo.ppid) &&
+        processInfo.ppid >= 0,
+    );
+}
+
+function isStaleComputerUseMcpChild(command: string): boolean {
+  return command.includes("SkyComputerUseClient") && /(?:^|\s)mcp(?:\s|$)/u.test(command);
+}
+
+function isDescendantOfPid(pid: number, ancestorPid: number, processInfos: ProcessInfo[]): boolean {
+  const parents = new Map(processInfos.map((processInfo) => [processInfo.pid, processInfo.ppid]));
+  const seen = new Set<number>();
+  let current = pid;
+  while (!seen.has(current)) {
+    seen.add(current);
+    const parent = parents.get(current);
+    if (!parent || parent <= 0) {
+      return false;
+    }
+    if (parent === ancestorPid) {
+      return true;
+    }
+    current = parent;
+  }
+  return false;
+}

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -3,7 +3,6 @@
  * app-server sessions.
  */
 import { existsSync } from "node:fs";
-import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { describeControlFailure } from "./capabilities.js";
 import {
   isCodexAppServerConnectionClosedError,
@@ -11,6 +10,11 @@ import {
   isCodexAppServerIndeterminateTransportError,
   type CodexAppServerClient,
 } from "./client.js";
+import {
+  killStaleComputerUseMcpChildren,
+  scopedRepairUnavailableStatus,
+  type CodexComputerUseRepairStatus,
+} from "./computer-use-process-repair.js";
 import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
@@ -83,13 +87,6 @@ type CodexComputerUseLiveTestStatus = {
   message: string;
   error?: string;
   durationMs?: number;
-};
-
-export type CodexComputerUseRepairStatus = {
-  attempted: boolean;
-  killedPids: number[];
-  message: string;
-  warnings: string[];
 };
 
 /** Readiness status for Codex Computer Use plugin and MCP server wiring. */
@@ -653,17 +650,6 @@ async function cleanupComputerUseProbeThread(
   ]);
 }
 
-function scopedRepairUnavailableStatus(): CodexComputerUseRepairStatus {
-  return {
-    attempted: false,
-    killedPids: [],
-    warnings: [
-      "Computer Use auto-repair skipped because no scoped Codex app-server process was available.",
-    ],
-    message: "Computer Use stale child repair requires a scoped local app-server PID.",
-  };
-}
-
 async function resolveMarketplaceRef(params: {
   request: CodexComputerUseRequest;
   config: ResolvedCodexComputerUseConfig;
@@ -1105,118 +1091,6 @@ function pluginWarnings(plugin: CodexPluginDetail): string[] {
     );
   }
   return warnings;
-}
-
-export async function killStaleComputerUseMcpChildren(
-  options: { ancestorPid?: number } = {},
-): Promise<CodexComputerUseRepairStatus> {
-  if (process.platform !== "darwin") {
-    return {
-      attempted: true,
-      killedPids: [],
-      warnings: [
-        `Computer Use stale child repair is currently macOS-only, not ${process.platform}.`,
-      ],
-      message: "Computer Use stale child repair skipped on this platform.",
-    };
-  }
-  if (
-    !options.ancestorPid ||
-    !Number.isSafeInteger(options.ancestorPid) ||
-    options.ancestorPid <= 0
-  ) {
-    return scopedRepairUnavailableStatus();
-  }
-  let stdout: string;
-  try {
-    const result = await runExec("/bin/ps", ["-axo", "pid=,ppid=,command="], {
-      logOutput: false,
-      maxBuffer: 5 * 1024 * 1024,
-    });
-    stdout = result.stdout;
-  } catch (error) {
-    return {
-      attempted: true,
-      killedPids: [],
-      warnings: [
-        `Could not list processes for Computer Use repair: ${describeControlFailure(error)}`,
-      ],
-      message: "Computer Use stale child repair could not inspect running processes.",
-    };
-  }
-  const killedPids: number[] = [];
-  const warnings: string[] = [];
-  const processInfos = parsePsOutput(stdout);
-  for (const processInfo of processInfos) {
-    if (!isStaleComputerUseMcpChild(processInfo.command)) {
-      continue;
-    }
-    if (!isDescendantOfPid(processInfo.pid, options.ancestorPid, processInfos)) {
-      continue;
-    }
-    try {
-      process.kill(processInfo.pid, "SIGTERM");
-      killedPids.push(processInfo.pid);
-    } catch (error) {
-      warnings.push(
-        `Could not terminate stale Computer Use MCP child pid ${processInfo.pid}: ${describeControlFailure(error)}`,
-      );
-    }
-  }
-  return {
-    attempted: true,
-    killedPids,
-    warnings,
-    message:
-      killedPids.length === 0
-        ? "No stale Computer Use MCP children were found under the scoped Codex app-server process."
-        : `Terminated ${killedPids.length} stale Computer Use MCP child process${killedPids.length === 1 ? "" : "es"} under the scoped Codex app-server process.`,
-  };
-}
-
-function parsePsOutput(stdout: string): Array<{ pid: number; ppid: number; command: string }> {
-  return stdout
-    .split(/\r?\n/u)
-    .flatMap((line) => {
-      const match = /^\s*(\d+)\s+(\d+)\s+(.+)$/u.exec(line);
-      if (!match) {
-        return [];
-      }
-      return [{ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] ?? "" }];
-    })
-    .filter(
-      (processInfo) =>
-        Number.isSafeInteger(processInfo.pid) &&
-        processInfo.pid > 0 &&
-        Number.isSafeInteger(processInfo.ppid) &&
-        processInfo.ppid >= 0,
-    );
-}
-
-function isStaleComputerUseMcpChild(command: string): boolean {
-  return command.includes("SkyComputerUseClient") && /(?:^|\s)mcp(?:\s|$)/u.test(command);
-}
-
-function isDescendantOfPid(
-  pid: number,
-  ancestorPid: number,
-  processInfos: Array<{ pid: number; ppid: number }>,
-): boolean {
-  const parents = new Map(processInfos.map((processInfo) => [processInfo.pid, processInfo.ppid]));
-  const seen = new Set<number>();
-  let current = pid;
-  while (!seen.has(current)) {
-    seen.add(current);
-    const parent = parents.get(current);
-    if (!parent || parent <= 0) {
-      return false;
-    }
-    if (parent === ancestorPid) {
-      return true;
-    }
-    current = parent;
-  }
-  return false;
 }
 
 function createComputerUseRequest(params: {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -20,7 +20,7 @@ import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtim
 import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw/plugin-sdk/provider-model-shared";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import {
@@ -105,6 +105,30 @@ import {
   codexDynamicToolsFingerprint,
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
+
+const agentHarnessRuntimeMocks = vi.hoisted(() => ({
+  forceModelToolsUnsupported: false,
+  skipRequesterScopedMcpMaterialization: false,
+}));
+
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
+  return {
+    ...actual,
+    supportsModelTools: (...args: Parameters<typeof actual.supportsModelTools>) =>
+      agentHarnessRuntimeMocks.forceModelToolsUnsupported
+        ? false
+        : actual.supportsModelTools(...args),
+    materializeRequesterScopedMcpToolsForHarnessRun: async (
+      ...args: Parameters<typeof actual.materializeRequesterScopedMcpToolsForHarnessRun>
+    ) => {
+      if (agentHarnessRuntimeMocks.skipRequesterScopedMcpMaterialization) {
+        return undefined;
+      }
+      return await actual.materializeRequesterScopedMcpToolsForHarnessRun(...args);
+    },
+  };
+});
 
 const testing = {
   buildDeveloperInstructions,
@@ -964,6 +988,11 @@ function installCleanupTrackingClient(turnStartError?: Error) {
 }
 
 setupRunAttemptTestHooks();
+
+beforeEach(() => {
+  agentHarnessRuntimeMocks.forceModelToolsUnsupported = false;
+  agentHarnessRuntimeMocks.skipRequesterScopedMcpMaterialization = false;
+});
 
 describe("runCodexAppServerAttempt", () => {
   it("executes and reports the same materialized SecretRef credential", async () => {
@@ -4935,6 +4964,7 @@ describe("runCodexAppServerAttempt", () => {
         },
       },
     } as EmbeddedRunAttemptParams;
+    setCodexTestModelSupportsTools(params, false);
     const run = runCodexAppServerAttempt(params, { pluginConfig: {} });
     await completeStartedRun(run, waitForMethod, completeTurn);
     const startRequest = requests.find((request) => request.method === "thread/start");
@@ -5129,6 +5159,9 @@ describe("runCodexAppServerAttempt", () => {
     });
     const clientFactory = vi.fn(async () => harness.client);
     testing.setOpenClawCodingToolsFactoryForTests(() => []);
+    // This test owns review-policy projection, not requester-scoped MCP discovery.
+    agentHarnessRuntimeMocks.forceModelToolsUnsupported = true;
+    agentHarnessRuntimeMocks.skipRequesterScopedMcpMaterialization = true;
     const params = createParams(sessionFile, workspaceDir);
     params.provider = "anthropic";
     params.modelId = "claude-opus-4-6";


### PR DESCRIPTION
## What Problem This Solves

Codex Computer Use setup and periodic health checks can invoke macOS `/bin/ps` while attempting scoped stale-child repair. That inspection had no deadline, so a stopped or wedged `ps` process could hold readiness forever before the fail-closed ancestry checks ran.

## Why This Change Was Made

This maintainer rewrite keeps the contributor's proven two-second deadline and moves the macOS process-repair owner out of the 1,200+ line Computer Use setup module into `computer-use-process-repair.ts`.

The dedicated owner now contains:

- the bounded `/bin/ps` snapshot;
- the incomplete-snapshot no-kill boundary;
- scoped descendant matching;
- SIGTERM handling and repair result messages;
- the no-local-PID and non-macOS outcomes.

`computer-use.ts` and the periodic health monitor consume the focused module directly. The old re-export was deleted after the dead-code gate proved it had no production consumers. Unrelated `run-attempt.test.ts` drift from the contributor branch was dropped completely.

## User Impact

Computer Use readiness and health probes recover after two seconds when process inspection stalls. No Computer Use child is signaled unless OpenClaw has a complete process table and proves that the matching MCP helper descends from the active local Codex app-server PID.

## Dependency And Owner Contracts

- OpenClaw `runExec` forwards the deadline to Execa 10 and retains the existing 300 ms process-tree force-kill grace for the `ps` subprocess.
- Execa 10 terminates the timed-out subprocess, marks the termination reason as `timeout`, and rejects; OpenClaw's existing catch path converts that into a warning with zero killed child PIDs.
- Current Codex source at `9ea975a2dc88d039512313da3e332013e8bd911e` owns MCP startup/shutdown and tool calls, but does not expose a bounded native process-table repair API. The inspection therefore belongs at this Codex plugin boundary.

## Evidence

Exact rewritten head: `521191178077c854881b91b27e9963f4b1e76b26`.

- Focused Codex tests: 45 passed across Computer Use setup, periodic health, and the new process-repair suite.
- New focused repair coverage proves timeout/no-kill, matching-descendant-only signaling, missing scoped PID, and non-macOS behavior.
- Targeted oxfmt and type-aware oxlint: clean.
- Final Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings (0.97 confidence).
- Blacksmith Testbox `tbx_01kyn8cemcsnvgdt95n1qw77gh`: `node scripts/check-changed.mjs` passed extension prod/test typechecks, lint, boundaries, dead-code scans, import cycles, and all selected guards on the final head. Run: https://github.com/openclaw/openclaw/actions/runs/30398721052
- Contributor's secretless macOS baseline/candidate proof: https://github.com/Alix-007/openclaw/actions/runs/30200157796
  - normal `/bin/ps` completed in 81 ms on the candidate;
  - a SIGSTOP'd `ps` stalled the unpatched baseline past the 6,023 ms watchdog;
  - the bounded candidate returned its warning in 2,005 ms, killed no Computer Use child, reaped the stopped `ps`, and completed the existing retry path.

The first exact-head CI run exposed a current-main Codex policy-fixture hang unrelated to process repair: `uses a supervised native model for review policy despite an outer Anthropic default` exercised live requester-scoped MCP materialization and timed out after 120 seconds. The rewrite now isolates that policy-only test from model tools/requester MCP and marks the adjacent custom-provider policy fixture tool-free. Evidence after the fix:

- the formerly 70-second custom-provider policy test passes in about 0.3 seconds;
- the formerly timed-out supervised policy test passes in about 0.27 seconds;
- all 117 `run-attempt.test.ts` tests pass in 13 seconds;
- a fresh focused autoreview of the fixture change is clean.

- Source-blind behavior contract: all 4 user tasks and all 4 anti-cheat groups passed from the public macOS proof plus exact-head tests.
- Exact-head CI: [run 30398651834](https://github.com/openclaw/openclaw/actions/runs/30398651834) passed with the aggregate `openclaw/ci-gate` green.

## Provenance

The scoped repair path was introduced by #103331 (`1b6393c51e9f5ad7bb3953cb358a98e229379d8d`) on 2026-07-11. The code author was `clawsweeper[bot]` with contributor credit to @bdjben; the PR was merged by @Takhoffman after the final `@clawsweeper automerge` command. #106495 later routed the same unbounded call through the canonical Execa-backed `runExec` helper without changing its missing deadline.

Co-authored-by: Alix-007 <li.long15@xydigit.com>
