### PR TITLE
fix(discord): idle-timeout stalled API success response bodies

### DIFF
--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -322,6 +322,37 @@ describe("fetchDiscord", () => {
     expect(clearTimeoutSpy).toHaveBeenCalledWith(setTimeoutSpy.mock.results[0]?.value);
   });
 
+  it("times out when a successful Discord API response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetcher = withFetchPreconnect(async () => {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"id":'));
+              // Leave the stream open so only the idle timeout can finish the read.
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      });
+
+      const rejection = expect(
+        requestDiscord<{ id: string }>("/channels/c/messages", "test", {
+          fetcher,
+          retry: { attempts: 1 },
+          timeoutMs: 50,
+        }),
+      ).rejects.toThrow(
+        "Discord API /channels/c/messages response stalled: no data received for 50ms",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("throws DiscordApiError on malformed JSON success response body", async () => {
     const fetcher = withFetchPreconnect(async () => new Response("NOT JSON {{{", { status: 200 }));
 

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -22,6 +22,9 @@ const DISCORD_API_RETRY_DEFAULTS = {
 const DISCORD_API_429_FALLBACK_RETRY_AFTER_SECONDS = 60;
 const DISCORD_API_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const DISCORD_API_RESPONSE_BODY_LIMIT_BYTES = 4 * 1024 * 1024;
+// Bound post-header success-body stalls when callers omit timeoutMs (probe/REST
+// siblings already pass an idle budget through readResponseWithLimit).
+const DISCORD_API_RESPONSE_IDLE_TIMEOUT_MS = 30_000;
 export const DISCORD_DIRECTORY_LOOKUP_TIMEOUT_MS = 10_000;
 
 type DiscordApiErrorPayload = {
@@ -208,13 +211,22 @@ export async function requestDiscord<T>(
             retryAfter,
           );
         }
+        const idleTimeoutMs =
+          typeof options?.timeoutMs === "number"
+            ? resolveTimerTimeoutMs(options.timeoutMs, 1)
+            : DISCORD_API_RESPONSE_IDLE_TIMEOUT_MS;
         const responseBody = await readResponseWithLimit(
           res,
           DISCORD_API_RESPONSE_BODY_LIMIT_BYTES,
           {
+            chunkTimeoutMs: idleTimeoutMs,
             onOverflow: ({ size, maxBytes }) =>
               new Error(
                 `Discord API ${path} response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+              ),
+            onIdleTimeout: ({ chunkTimeoutMs }) =>
+              new Error(
+                `Discord API ${path} response stalled: no data received for ${chunkTimeoutMs}ms`,
               ),
           },
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord's public `requestDiscord` / `fetchDiscord` success path could hang after headers when the API returned a stalled body. The probe and internal REST helpers already passed `chunkTimeoutMs` into `readResponseWithLimit`, but the main API module only enforced a byte cap.

## Why This Change Was Made

Pass an idle timeout through the success-body read: use the caller's `timeoutMs` when provided, otherwise a 30s default, with an explicit stalled-body error. Existing byte-cap, retry, and malformed-JSON behavior stay unchanged.

## User Impact

**Before:** A Discord API success response that stalled mid-body could hang directory lookups and other `requestDiscord` callers indefinitely.

**After:** Stalled success bodies fail closed within the request idle budget so the caller can surface an error instead of hanging.

## Evidence

- Changed: `extensions/discord/src/api.ts`, `extensions/discord/src/api.test.ts`
- Production caller path: `requestDiscord` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Discord API success-body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`requestDiscord` / `fetchDiscord` → success `readResponseWithLimit` with `chunkTimeoutMs`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/discord/src/api.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a successful Discord API response body stalls after headers
✓ returns under-cap requestDiscord responses from a real loopback HTTP server
✓ rejects oversized valid JSON requestDiscord responses from a real loopback HTTP server
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

### Observed result after fix

A stalled success body rejects with `response stalled: no data received for 50ms` when `timeoutMs: 50`; loopback under-cap and oversized proofs still pass.

### What was not tested

Live stall against Discord's production REST API.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Discord API idle bound and caller-path proof output.
