### PR TITLE
fix(openai): idle-timeout stalled OAuth token response bodies

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -121,6 +121,41 @@ describe("OpenAI Codex OAuth flow", () => {
     });
   });
 
+  it("times out when a token exchange response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn(async () => undefined);
+      ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"access_token":'));
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        release,
+      });
+
+      const resultPromise = exchangeOpenAIAuthorizationCode(
+        "code",
+        "verifier",
+        resolveOpenAIRedirectUri("localhost"),
+        { timeoutMs: 50 },
+      );
+      const settled = expect(resultPromise).resolves.toMatchObject({
+        type: "failed",
+        message:
+          "OpenAI Codex token exchange error: OpenAI Codex OAuth token response stalled: no data received for 50ms",
+      });
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
+      expect(release).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("cancels token exchange requests with the caller signal", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
@@ -71,13 +71,20 @@ async function postTokenForm(
     auditContext: "openai-chatgpt-oauth-token",
   });
   try {
+    // fetchWithSsrFGuard resolves after headers; keep the request deadline on the
+    // token body so a stalled OAuth response cannot hang login/refresh.
     const responseBody = await readResponseWithLimit(
       response,
       OAUTH_TOKEN_RESPONSE_BODY_LIMIT_BYTES,
       {
+        chunkTimeoutMs: timeoutMs,
         onOverflow: ({ size, maxBytes }) =>
           new Error(
             `OpenAI Codex OAuth token response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+          ),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(
+            `OpenAI Codex OAuth token response stalled: no data received for ${chunkTimeoutMs}ms`,
           ),
       },
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenAI Codex OAuth token exchange/refresh could hang after headers when the token endpoint stalled mid-body. `postTokenForm` already applied `timeoutMs` to the guarded fetch, but the success-body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same request `timeoutMs` through the token body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching Discord/OpenRouter response-body idle bounds.

## User Impact

**Before:** A stalled OAuth token response body could hang login or refresh indefinitely after headers.

**After:** Stalled token bodies fail closed within the request timeout so login/refresh can surface an error.

## Evidence

- Changed: `extensions/openai/openai-chatgpt-oauth-token.runtime.ts`, `extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts`
- Production caller path: `exchangeOpenAIAuthorizationCode` / `refreshOpenAIAccessToken` → `postTokenForm` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

OAuth token success-body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`exchangeOpenAIAuthorizationCode` → `postTokenForm` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a token exchange response body stalls after headers
 Test Files  1 passed (1)
      Tests  13 passed (13)
[test] passed 1 Vitest shard in 4.60s
```

### Observed result after fix

Stalled token body returns `type: "failed"` with the idle stall message wrapped by the exchange error formatter; `release()` still runs.

### What was not tested

Live stall against OpenAI's production token endpoint.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the OAuth body idle bound and caller-path proof output.
