### PR TITLE
fix(agents): claude-cli sessions wiped by preflight byte-guard compaction

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2006,6 +2006,74 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it("skips transcript-byte preflight when model policy routes Anthropic to claude-cli without a session runtime pin", async () => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+          ownsNativeCompaction: true,
+        },
+      ],
+    });
+    const sessionFile = path.join(rootDir, "cli-routed-large-session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(256) } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 4,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: { models: [{ id: "claude-opus-4-6", contextWindow: 350_000 }] },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
+            },
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: {
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes: "10b",
+            },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(entry?.compactionCount).toBe(0);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("keeps the OpenAI API context window for persisted OpenClaw runtime overrides", async () => {
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -324,13 +324,7 @@ function followupOwnsNativeCompaction(params: FollowupCliRuntimeParams): boolean
   return false;
 }
 
-function resolveFollowupContextConfigProvider(params: {
-  cfg: OpenClawConfig;
-  followupRun: FollowupRun;
-  sessionEntry?: SessionEntry;
-  sessionKey?: string;
-  runtimePolicySessionKey?: string;
-}): string {
+function resolveFollowupContextConfigProvider(params: FollowupCliRuntimeParams): string {
   const provider = params.followupRun.run.provider;
   return resolveContextConfigProviderForRuntime({
     provider,
@@ -339,13 +333,8 @@ function resolveFollowupContextConfigProvider(params: {
   });
 }
 
-function resolveFollowupAgentRuntimeId(params: {
-  cfg: OpenClawConfig;
-  followupRun: FollowupRun;
-  sessionEntry?: SessionEntry;
-  sessionKey?: string;
-  runtimePolicySessionKey?: string;
-}): string {
+function resolveFollowupAgentRuntimeId(params: FollowupCliRuntimeParams): string {
+  // Only sessionId + runtime pin fields are needed; callers may pass a Pick.
   const matchingSessionEntry =
     params.sessionEntry?.sessionId === params.followupRun.run.sessionId
       ? params.sessionEntry
@@ -364,13 +353,7 @@ function resolveFollowupAgentRuntimeId(params: {
   });
 }
 
-function followupUsesCodexRuntime(params: {
-  cfg: OpenClawConfig;
-  followupRun: FollowupRun;
-  sessionEntry?: SessionEntry;
-  sessionKey?: string;
-  runtimePolicySessionKey?: string;
-}): boolean {
+function followupUsesCodexRuntime(params: FollowupCliRuntimeParams): boolean {
   return normalizeLowercaseStringOrEmpty(resolveFollowupAgentRuntimeId(params)) === "codex";
 }
 

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -8,6 +8,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
+import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
@@ -266,23 +267,61 @@ function resolveMemoryFlushModelFallbackOptions(
   };
 }
 
-function followupUsesCliRuntime(params: {
+type FollowupCliRuntimeParams = {
   cfg: OpenClawConfig;
   followupRun: FollowupRun;
   sessionEntry?: Pick<
     SessionEntry,
-    "agentHarnessId" | "agentRuntimeOverride" | "modelSelectionLocked"
+    "agentHarnessId" | "agentRuntimeOverride" | "modelSelectionLocked" | "sessionId"
   >;
-}): boolean {
+  sessionKey?: string;
+  runtimePolicySessionKey?: string;
+};
+
+function followupUsesCliRuntime(params: FollowupCliRuntimeParams): boolean {
   const provider = params.followupRun.run.provider;
   if (isCliProvider(provider, params.cfg)) {
     return true;
   }
+  if (
+    isCliRuntimeAliasForProvider({
+      provider,
+      runtime: resolvePersistedSessionRuntimeId(params.sessionEntry),
+      cfg: params.cfg,
+    })
+  ) {
+    return true;
+  }
+  // Model/policy-selected CLI runtimes (e.g. anthropic → claude-cli) must also
+  // skip OpenClaw compaction even when the session entry has no runtime pin yet.
   return isCliRuntimeAliasForProvider({
     provider,
-    runtime: resolvePersistedSessionRuntimeId(params.sessionEntry),
+    runtime: resolveFollowupAgentRuntimeId(params),
     cfg: params.cfg,
   });
+}
+
+/**
+ * True when the effective CLI backend for this turn declares native compaction
+ * ownership. Defense in depth for routes that reach claude-cli (or similar)
+ * without `followupUsesCliRuntime` recognizing the provider string alone.
+ */
+function followupOwnsNativeCompaction(params: FollowupCliRuntimeParams): boolean {
+  const candidates = [
+    params.followupRun.run.provider,
+    resolvePersistedSessionRuntimeId(params.sessionEntry),
+    resolveFollowupAgentRuntimeId(params),
+  ];
+  for (const candidate of candidates) {
+    const runtimeId = candidate?.trim();
+    if (!runtimeId) {
+      continue;
+    }
+    if (resolveCliBackendConfig(runtimeId, params.cfg)?.ownsNativeCompaction === true) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function resolveFollowupContextConfigProvider(params: {
@@ -772,12 +811,21 @@ export async function runPreflightCompactionIfNeeded(params: {
     return entry ?? params.sessionEntry;
   }
 
-  const isCli = followupUsesCliRuntime({
+  const cliRuntimeParams = {
     cfg: params.cfg,
     followupRun: params.followupRun,
     sessionEntry: entry,
-  });
-  if (params.isHeartbeat || isCli) {
+    sessionKey: params.sessionKey,
+    runtimePolicySessionKey: params.runtimePolicySessionKey,
+  };
+  const isCli = followupUsesCliRuntime(cliRuntimeParams);
+  const ownsNativeCompaction = followupOwnsNativeCompaction(cliRuntimeParams);
+  if (params.isHeartbeat || isCli || ownsNativeCompaction) {
+    if (ownsNativeCompaction && !isCli && !params.isHeartbeat) {
+      logVerbose(
+        `preflightCompaction skipped: sessionKey=${params.sessionKey} reason=owns_native_compaction`,
+      );
+    }
     return entry ?? params.sessionEntry;
   }
   if (
@@ -1125,11 +1173,21 @@ export async function runMemoryFlushIfNeeded(params: {
   let entry =
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
-  const isCli = followupUsesCliRuntime({
-    cfg: params.cfg,
-    followupRun: params.followupRun,
-    sessionEntry: entry,
-  });
+  const isCli =
+    followupUsesCliRuntime({
+      cfg: params.cfg,
+      followupRun: params.followupRun,
+      sessionEntry: entry,
+      sessionKey: params.sessionKey,
+      runtimePolicySessionKey: params.runtimePolicySessionKey,
+    }) ||
+    followupOwnsNativeCompaction({
+      cfg: params.cfg,
+      followupRun: params.followupRun,
+      sessionEntry: entry,
+      sessionKey: params.sessionKey,
+      runtimePolicySessionKey: params.runtimePolicySessionKey,
+    });
   const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,


### PR DESCRIPTION
Closes #108984

## What Problem This Solves

Fixes an issue where users running long claude-cli sessions (including Anthropic models routed to claude-cli via model policy) would lose conversation continuity when OpenClaw's transcript-byte preflight compaction fired. The OpenClaw message view for those sessions is near-empty, so the summarizer produced an empty summary and `truncateAfterCompaction` rotated the session mid-thread.

## Why This Change Was Made

Preflight only deferred for CLI when the provider string or a persisted session runtime pin looked like CLI. Routes that keep provider=`anthropic` while the effective turn runtime is `claude-cli` still reached the `transcript_bytes` path. The CLI backend contract already says `ownsNativeCompaction: true` backends own context management; preflight now resolves that effective backend the same way execution does and defers when ownership is set. Memory flush uses the same gate so it stays consistent.

## User Impact

claude-cli / native-compaction-owning backends no longer get empty OpenClaw safeguard summaries that wipe active context. Embedded non-CLI compaction behavior is unchanged.

## Evidence

- Added regression: Anthropic provider + model policy `agentRuntime: claude-cli`, no session runtime pin, oversized transcript + `truncateAfterCompaction` — preflight must not call `compactEmbeddedAgentSession`.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts` — 55 passed.