### PR TITLE
fix(gateway): idle-timeout stalled Control UI GitHub response bodies

### DIFF
--- a/src/gateway/control-ui-github-api.test.ts
+++ b/src/gateway/control-ui-github-api.test.ts
@@ -1,0 +1,31 @@
+// Verifies Control UI GitHub bounded response reads include idle timeouts.
+import { describe, expect, it, vi } from "vitest";
+import { GITHUB_REQUEST_TIMEOUT_MS, readBoundedResponse } from "./control-ui-github-api.js";
+
+describe("readBoundedResponse", () => {
+  it("times out when a GitHub response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"ok":'));
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+      const settled = expect(readBoundedResponse(response, 1024)).rejects.toThrow(
+        `GitHub API response stalled: no data received for ${GITHUB_REQUEST_TIMEOUT_MS}ms`,
+      );
+      await vi.advanceTimersByTimeAsync(GITHUB_REQUEST_TIMEOUT_MS + 10);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns under-cap bodies", async () => {
+    const payload = Buffer.from('{"ok":true}');
+    await expect(readBoundedResponse(new Response(payload), 1024)).resolves.toEqual(payload);
+  });
+});

--- a/src/gateway/control-ui-github-api.ts
+++ b/src/gateway/control-ui-github-api.ts
@@ -113,7 +113,13 @@ export async function discardResponse(response: Response): Promise<void> {
 
 export async function readBoundedResponse(response: Response, maxBytes: number): Promise<Buffer> {
   try {
-    return await readResponseWithLimit(response, maxBytes);
+    // Request-level AbortSignal covers connect/headers; keep an idle bound on the
+    // body so a slow-drip GitHub response cannot hang Control UI previews.
+    return await readResponseWithLimit(response, maxBytes, {
+      chunkTimeoutMs: GITHUB_REQUEST_TIMEOUT_MS,
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`GitHub API response stalled: no data received for ${chunkTimeoutMs}ms`),
+    });
   } finally {
     await discardResponse(response);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI GitHub proxy/preview reads could hang after headers when `api.github.com` stalled mid-body. `readBoundedResponse` capped bytes but did not apply `chunkTimeoutMs`.

## Why This Change Was Made

Pass `GITHUB_REQUEST_TIMEOUT_MS` through `readResponseWithLimit` as the idle chunk timeout, with an explicit stalled-body error, while preserving existing byte caps and response discard cleanup.

## User Impact

**Before:** A stalled GitHub API body could hang Control UI link previews / PR chips indefinitely after headers.

**After:** Stalled bodies fail closed within the existing 8s GitHub request budget.

## Evidence

- Changed: `src/gateway/control-ui-github-api.ts`, `src/gateway/control-ui-github-api.test.ts`
- Production caller path: Control UI GitHub surfaces → `readBoundedResponse` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Control UI GitHub bounded reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`readBoundedResponse` → `readResponseWithLimit({ chunkTimeoutMs: GITHUB_REQUEST_TIMEOUT_MS })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/control-ui-github-api.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a GitHub response body stalls after headers
✓ returns under-cap bodies
```

### Observed result after fix

Stalled bodies reject with the GitHub idle stall message; under-cap reads still succeed.

### What was not tested

Live stall against api.github.com.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Control UI GitHub idle bound and caller-path proof output.
