### PR TITLE
fix(links): idle-timeout stalled link-understanding fetch bodies

### DIFF
--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -199,4 +199,39 @@ describe("runLinkUnderstanding", () => {
       }),
     );
   });
+
+  it("times out when a link fetch response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn(async () => {});
+      mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("<html>"));
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/html" } },
+        ),
+        finalUrl: "https://example.com/final",
+        release,
+      });
+      mockCommand("unused");
+
+      const resultPromise = runLinkUnderstanding({
+        cfg: cfg({ type: "cli", command: "summarize", timeoutSeconds: 1 }),
+        ctx: ctx("see https://example.com/page"),
+      });
+      const settled = expect(resultPromise).resolves.toEqual({
+        urls: ["https://example.com/page"],
+        outputs: [],
+      });
+      await vi.advanceTimersByTimeAsync(1_010);
+      await settled;
+      expect(release).toHaveBeenCalledOnce();
+      expect(runCommandWithTimeout).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -104,7 +104,11 @@ async function fetchLinkContent(params: {
     if (!response.ok) {
       throw new Error(`Link fetch failed with HTTP ${response.status}`);
     }
-    const buffer = await readResponseWithLimit(response, CLI_OUTPUT_MAX_BUFFER);
+    const buffer = await readResponseWithLimit(response, CLI_OUTPUT_MAX_BUFFER, {
+      chunkTimeoutMs: params.timeoutMs,
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`Link fetch stalled: no data received for ${chunkTimeoutMs}ms`),
+    });
     const content = new TextDecoder().decode(buffer).trim();
     if (!content) {
       return null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where link-understanding fetches could hang after headers when a remote page stalled mid-body. `fetchLinkContent` already passed `timeoutMs` to the SSRF-guarded fetch, but the body read used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the resolved fetch `timeoutMs` through the body read as `chunkTimeoutMs`, with an explicit stalled-body error, so slow-drip pages fail closed within the existing link timeout budget.

## User Impact

**Before:** A stalled link fetch body could hang link understanding after headers.

**After:** Stalled link bodies fail closed within the configured link timeout so the turn can continue without hanging.

## Evidence

- Changed: `src/link-understanding/runner.ts`, `src/link-understanding/runner.test.ts`
- Production caller path: `runLinkUnderstanding` → `fetchLinkContent` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Link-understanding body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`runLinkUnderstanding` → `fetchLinkContent` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/link-understanding/runner.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a link fetch response body stalls after headers
```

### Observed result after fix

Stalled fetch leaves `outputs: []` while still reporting detected URLs; CLI processor is not invoked; release runs.

### What was not tested

Live stall against an arbitrary remote website.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the link-understanding idle bound and caller-path proof output.
