### PR TITLE
fix(media): idle-timeout stalled input-file fetch bodies

### DIFF
--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -549,4 +549,36 @@ describe("input image base64 validation", () => {
       ...(expectedError ? { expectedError } : {}),
     });
   });
+
+  it("times out when a media URL response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn(async () => {});
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([0xff, 0xd8, 0xff]));
+            },
+          }),
+          { status: 200, headers: { "content-type": "image/jpeg" } },
+        ),
+        release,
+      });
+      detectMimeMock.mockResolvedValue("image/jpeg");
+
+      const resultPromise = extractImageContentFromSource(
+        { type: "url", url: "https://example.com/photo.jpg" },
+        createImageSourceLimits(["image/jpeg"], true),
+      );
+      const settled = expect(resultPromise).rejects.toThrow(
+        "Media fetch stalled: no data received for 1000ms",
+      );
+      await vi.advanceTimersByTimeAsync(1_010);
+      await settled;
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -238,7 +238,11 @@ async function fetchWithGuard(params: {
       );
     }
 
-    const buffer = await readResponseWithLimit(response, params.maxBytes);
+    const buffer = await readResponseWithLimit(response, params.maxBytes, {
+      chunkTimeoutMs: params.timeoutMs,
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`Media fetch stalled: no data received for ${chunkTimeoutMs}ms`),
+    });
 
     const contentType = response.headers.get("content-type") || undefined;
     const parsed = parseContentType(contentType);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where media URL fetches for agent input files could hang after headers when the remote stalled mid-body. The guarded fetch already had `timeoutMs`, but `readResponseWithLimit` did not receive `chunkTimeoutMs`.

## Why This Change Was Made

Pass `params.timeoutMs` through the body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching sibling media/link idle bounds.

## User Impact

**Before:** A stalled media download body could hang image/file extraction after headers.

**After:** Stalled media bodies fail closed within the configured fetch timeout.

## Evidence

- Changed: `src/media/input-files.ts`, `src/media/input-files.fetch-guard.test.ts`
- Production caller path: `extractImageContentFromSource` / URL fetch → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Media input URL body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

URL media extract → guarded fetch → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/media/input-files.fetch-guard.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a media URL response body stalls after headers
```

### Observed result after fix

Stalled media body rejects with the idle stall message; release still runs.

### What was not tested

Live stall against an arbitrary remote media host.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the media fetch idle bound and caller-path proof output.
