### PR TITLE
fix(mattermost): idle-timeout stalled API success response bodies

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -19,6 +19,7 @@ import {
   normalizeMattermostBaseUrl,
   readMattermostError,
   updateMattermostPost,
+  fetchMattermostMe,
 } from "./client.js";
 
 // ── Helper: mock fetch that captures requests ────────────────────────
@@ -420,6 +421,36 @@ describe("createMattermostClient", () => {
 });
 
 // ── createMattermostPost ─────────────────────────────────────────────
+
+it("times out when a non-JSON success response body stalls after headers", async () => {
+  vi.useFakeTimers();
+  try {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("ok"));
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/plain" } },
+      ),
+      release,
+    });
+    const client = createMattermostClient({
+      baseUrl: "https://mattermost.example",
+      botToken: "tok",
+    });
+    const settled = expect(client.request("/system/ping")).rejects.toThrow(
+      "Mattermost API /system/ping: response stalled after 30000ms",
+    );
+    await vi.advanceTimersByTimeAsync(30_010);
+    await settled;
+    expect(release).toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
+});
 
 describe("createMattermostPost", () => {
   it("sends channel_id and message", async () => {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 
 const MATTERMOST_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const MATTERMOST_REQUEST_TIMEOUT_MS = 30_000;
+const MATTERMOST_RESPONSE_READ_IDLE_TIMEOUT_MS = 30_000;
 // Mattermost REST control-plane JSON (posts, users, channels, file-upload
 // results) stays well under a megabyte; cap successful JSON the same way the
 // shared provider path is capped so an untrusted/self-hosted homeserver cannot
@@ -102,8 +103,11 @@ function buildMattermostApiUrl(baseUrl: string, path: string): string {
 
 async function readMattermostSuccessText(res: Response, path: string): Promise<string> {
   const bytes = await readResponseWithLimit(res, MATTERMOST_TEXT_RESPONSE_LIMIT_BYTES, {
+    chunkTimeoutMs: MATTERMOST_RESPONSE_READ_IDLE_TIMEOUT_MS,
     onOverflow: ({ maxBytes }) =>
       new Error(`Mattermost API ${path}: text response exceeds ${maxBytes} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`Mattermost API ${path}: response stalled after ${chunkTimeoutMs}ms`),
   });
   return new TextDecoder().decode(bytes);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mattermost non-JSON success response reads could hang after headers when the API stalled mid-body. `readMattermostSuccessText` capped bytes but did not apply `chunkTimeoutMs`.

## Why This Change Was Made

Apply a 30s idle chunk timeout through `readResponseWithLimit`, with an explicit stalled-body error, matching sibling channel response-body idle bounds.

## User Impact

**Before:** A stalled Mattermost success text body could hang API callers indefinitely after headers.

**After:** Stalled success bodies fail closed after 30s of idle so the channel turn can surface an error.

## Evidence

- Changed: `extensions/mattermost/src/mattermost/client.ts`, `extensions/mattermost/src/mattermost/client.test.ts`
- Production caller path: `createMattermostClient().request` → `readMattermostSuccessText` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Mattermost non-JSON success-body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`client.request` (non-JSON content-type) → `readMattermostSuccessText` → `readResponseWithLimit({ chunkTimeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a non-JSON success response body stalls after headers
```

### Observed result after fix

Stalled text body rejects with `Mattermost API … response stalled after 30000ms`.

### What was not tested

Live stall against a real Mattermost server.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Mattermost idle bound and caller-path proof output.
