### PR TITLE
fix(googlechat): idle-timeout stalled media response bodies

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -161,14 +161,19 @@ async function fetchBuffer(
           throw new Error(`Google Chat media exceeds max bytes (${maxBytes})`);
         }
       }
-      if (!maxBytes) {
-        const buffer = Buffer.from(await res.arrayBuffer());
-        const contentType = res.headers.get("content-type") ?? undefined;
-        return { buffer, contentType };
-      }
-      const buffer = await readResponseWithLimit(res, maxBytes, {
+      // Always bound idle stalls; when callers omit maxBytes, keep a hard byte
+      // ceiling so an unbounded media endpoint cannot hang or OOM the process.
+      const limitBytes = maxBytes ?? GOOGLECHAT_JSON_RESPONSE_MAX_BYTES;
+      const buffer = await readResponseWithLimit(res, limitBytes, {
         chunkTimeoutMs: GOOGLECHAT_RESPONSE_READ_IDLE_TIMEOUT_MS,
-        onOverflow: () => new Error(`Google Chat media exceeds max bytes (${maxBytes})`),
+        onOverflow: () =>
+          new Error(
+            maxBytes
+              ? `Google Chat media exceeds max bytes (${maxBytes})`
+              : `Google Chat media exceeds max bytes (${limitBytes})`,
+          ),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(`Google Chat media response stalled after ${chunkTimeoutMs}ms`),
       });
       const contentType = res.headers.get("content-type") ?? undefined;
       return { buffer, contentType };

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -350,7 +350,18 @@ describe("downloadGoogleChatMedia", () => {
 
     const result = expect(
       downloadGoogleChatMedia({ account, resourceName: "media/123", maxBytes: 10 }),
-    ).rejects.toThrow("Media download stalled: no data received for 30000ms");
+    ).rejects.toThrow("Google Chat media response stalled after 30000ms");
+    await vi.advanceTimersByTimeAsync(30_001);
+    await result;
+  });
+
+  it("cancels a stalled media body when maxBytes is omitted", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createStalledResponse()));
+
+    const result = expect(
+      downloadGoogleChatMedia({ account, resourceName: "media/123" }),
+    ).rejects.toThrow("Google Chat media response stalled after 30000ms");
     await vi.advanceTimersByTimeAsync(30_001);
     await result;
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Chat media downloads could hang after headers when callers omitted `maxBytes` (raw `arrayBuffer()`), and when maxBytes was set the idle timeout lacked an explicit stalled-media error. A stalled media body never failed closed on the uncapped path.

## Why This Change Was Made

Always read media through `readResponseWithLimit` with the existing 30s idle timeout. When `maxBytes` is omitted, apply the shared hard byte ceiling used for Google Chat JSON responses so the uncapped path cannot hang or buffer forever.

## User Impact

**Before:** Omitting `maxBytes` could hang forever on a stalled media body via unbounded `arrayBuffer()`.

**After:** Media body reads fail closed after 30s idle (and stay byte-capped even without caller maxBytes).

## Evidence

- Changed: `extensions/googlechat/src/api.ts`, `extensions/googlechat/src/targets.test.ts`
- Production caller path: `downloadGoogleChatMedia` → `fetchBuffer` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Google Chat media body reads now idle-timeout stalled streams, including when `maxBytes` is omitted.

### Canonical reachability path

`downloadGoogleChatMedia` → `fetchBuffer` → `readResponseWithLimit({ chunkTimeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/googlechat/src/targets.test.ts -t 'stalled media' --reporter=verbose
```

### Evidence after fix

```text
✓ cancels a media body that stops producing chunks
✓ cancels a stalled media body when maxBytes is omitted
```

### Observed result after fix

Stalled media rejects with `Google Chat media response stalled after 30000ms` with or without `maxBytes`.

### What was not tested

Live stall against Google Chat media endpoints.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Google Chat media idle bound and caller-path proof output.
