### PR TITLE
fix(matrix): idle-timeout stalled SDK guarded fetch bodies

### DIFF
--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -500,6 +500,40 @@ describe("createMatrixGuardedFetch", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
+  it("times out when an SDK response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const cancel = vi.fn();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"next_batch":'));
+        },
+        cancel,
+      });
+      stubRuntimeFetch(
+        vi.fn(
+          async () =>
+            new Response(stream, {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        ),
+      );
+
+      const guardedFetch = createMatrixGuardedFetch({
+        ssrfPolicy: { allowPrivateNetwork: true },
+      });
+      const settled = expect(
+        guardedFetch("http://127.0.0.1:8008/_matrix/client/v3/sync"),
+      ).rejects.toThrow("Matrix SDK response stalled: no data received for 30000ms");
+      await vi.advanceTimersByTimeAsync(30_010);
+      await settled;
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("strips matrix-js-sdk state_after sync opt-in from /sync requests", async () => {
     const runtimeFetch = vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -23,6 +23,7 @@ const MATRIX_JSON_RESPONSE_MAX_BYTES = 8 * 1024 * 1024;
 // matrix-js-sdk also uses the injected fetch for raw encrypted key bundles.
 // Keep that path bounded without applying the tighter control-plane JSON cap.
 const MATRIX_SDK_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
+const MATRIX_SDK_FETCH_RESPONSE_IDLE_TIMEOUT_MS = 30_000;
 
 type QueryValue =
   | string
@@ -289,8 +290,11 @@ export function createMatrixGuardedFetch(params: {
           ),
       });
       const body = await readResponseWithLimit(response, MATRIX_SDK_RESPONSE_MAX_BYTES, {
+        chunkTimeoutMs: MATRIX_SDK_FETCH_RESPONSE_IDLE_TIMEOUT_MS,
         onOverflow: ({ maxBytes, size }) =>
           new Error(`Matrix SDK response exceeds size limit (${size} bytes > ${maxBytes} bytes)`),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(`Matrix SDK response stalled: no data received for ${chunkTimeoutMs}ms`),
       });
       return buildBufferedResponse({
         source: response,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix SDK guarded fetches (`createMatrixGuardedFetch`) could hang after headers when a homeserver stalled mid-body. The buffered SDK path capped bytes but did not apply `chunkTimeoutMs`, unlike the JSON/raw download helpers that already support idle timeouts.

## Why This Change Was Made

Apply a 30s idle chunk timeout through `readResponseWithLimit` on the SDK guarded-fetch buffer path, with an explicit stalled-body error, matching sibling Matrix JSON/media idle bounds.

## User Impact

**Before:** A stalled Matrix SDK `/sync` or similar body could hang the guarded fetch indefinitely after headers.

**After:** Stalled SDK bodies fail closed after 30s idle so Matrix client startup/sync can surface an error.

## Evidence

- Changed: `extensions/matrix/src/matrix/sdk/transport.ts`, `extensions/matrix/src/matrix/sdk/transport.test.ts`
- Production caller path: `createMatrixGuardedFetch` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Matrix SDK guarded-fetch body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`createMatrixGuardedFetch` → `readResponseWithLimit({ chunkTimeoutMs: 30_000 })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/transport.test.ts -t 'SDK response' --reporter=verbose
```

### Evidence after fix

```text
✓ times out when an SDK response body stalls after headers
✓ rejects and cancels SDK responses above the declared size limit
```

### Observed result after fix

Stalled SDK body rejects with `Matrix SDK response stalled: no data received for 30000ms` and cancels the stream.

### What was not tested

Live stall against a real Matrix homeserver.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Matrix SDK idle bound and caller-path proof output.
