### PR TITLE
fix(proxy): bound debug CA generation

### DIFF
--- a/src/proxy-capture/ca.test.ts
+++ b/src/proxy-capture/ca.test.ts
@@ -1,0 +1,196 @@
+// Proxy capture CA tests cover bounded certificate generation.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+
+const { resolveSystemBinMock, runExecMock } = vi.hoisted(() => ({
+  resolveSystemBinMock: vi.fn(() => "/usr/bin/openssl"),
+  runExecMock: vi.fn(),
+}));
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  const parseMarker = (value: Buffer, prefix: string): string => {
+    const text = value.toString("utf8");
+    if (!text.startsWith(prefix)) {
+      throw new Error("invalid certificate material");
+    }
+    return text.slice(prefix.length);
+  };
+  const cryptoMock = { ...actual } as typeof actual;
+  Object.defineProperties(cryptoMock, {
+    createPrivateKey: {
+      value: (value: Buffer) => ({ marker: parseMarker(value, "ca-material-marker:") }),
+    },
+    X509Certificate: {
+      value: class {
+        readonly ca: boolean;
+        readonly marker: string;
+
+        constructor(value: Buffer) {
+          this.marker = parseMarker(value, "ca-cert-marker:");
+          this.ca = this.marker !== "not-ca";
+        }
+
+        checkPrivateKey(key: { marker?: string }): boolean {
+          return key.marker === this.marker;
+        }
+      },
+    },
+  });
+  return cryptoMock;
+});
+vi.mock("../infra/resolve-system-bin.js", () => ({ resolveSystemBin: resolveSystemBinMock }));
+vi.mock("../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../process/exec.js")>()),
+  runExec: runExecMock,
+}));
+
+import { ensureDebugProxyCa } from "./ca.js";
+
+const tempDirs = createTrackedTempDirs();
+
+function outputPath(args: string[], flag: "-config" | "-keyout" | "-out"): string {
+  const index = args.indexOf(flag);
+  const value = args[index + 1];
+  if (!value) {
+    throw new Error(`missing ${flag} output path`);
+  }
+  return value;
+}
+
+function writeGeneratedPair(args: string[], marker: string): void {
+  fs.writeFileSync(outputPath(args, "-out"), `ca-cert-marker:${marker}`);
+  fs.writeFileSync(outputPath(args, "-keyout"), `ca-material-marker:${marker}`);
+}
+
+async function makeCertPaths() {
+  const certDir = await tempDirs.make("openclaw-proxy-ca-");
+  return {
+    certDir,
+    certPath: path.join(certDir, "root-ca.pem"),
+    keyPath: path.join(certDir, "root-ca-key.pem"),
+  };
+}
+
+function generatePair(marker: string): void {
+  runExecMock.mockImplementationOnce(async (_command: string, args: string[]) => {
+    writeGeneratedPair(args, marker);
+  });
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  runExecMock.mockReset();
+  await tempDirs.cleanup();
+});
+
+describe("ensureDebugProxyCa", () => {
+  it("regenerates after partial output timeout without reusing stale final files", async () => {
+    const { certDir, certPath, keyPath } = await makeCertPaths();
+    fs.writeFileSync(certPath, "stale partial cert");
+    fs.writeFileSync(keyPath, "stale partial key");
+    let generatedConfig = "";
+    runExecMock
+      .mockImplementationOnce(async (_command: string, args: string[]) => {
+        generatedConfig = fs.readFileSync(outputPath(args, "-config"), "utf8");
+        fs.writeFileSync(outputPath(args, "-out"), "partial cert");
+        fs.writeFileSync(outputPath(args, "-keyout"), "partial key");
+        throw new Error("openssl timed out");
+      })
+      .mockImplementationOnce(async (_command: string, args: string[]) => {
+        writeGeneratedPair(args, "retry");
+      });
+
+    await expect(ensureDebugProxyCa(certDir)).rejects.toThrow("openssl timed out");
+    expect(fs.readFileSync(certPath, "utf8")).toBe("stale partial cert");
+    expect(fs.readFileSync(keyPath, "utf8")).toBe("stale partial key");
+    expect(fs.readdirSync(certDir).toSorted()).toEqual(["root-ca-key.pem", "root-ca.pem"]);
+
+    await expect(
+      Promise.all([ensureDebugProxyCa(certDir), ensureDebugProxyCa(certDir)]),
+    ).resolves.toEqual([
+      { certPath, keyPath },
+      { certPath, keyPath },
+    ]);
+    expect(runExecMock).toHaveBeenCalledTimes(2);
+    const [command, args, options] = runExecMock.mock.calls[0] as [string, string[], object];
+    expect(command).toBe("/usr/bin/openssl");
+    expect(args).toEqual(expect.arrayContaining(["req", "-extensions", "v3_ca", "-x509"]));
+    expect(path.dirname(outputPath(args, "-config"))).toBe(path.dirname(outputPath(args, "-out")));
+    expect(path.dirname(outputPath(args, "-out")).startsWith(`${certDir}${path.sep}`)).toBe(true);
+    expect(options).toEqual({ logOutput: false, timeoutMs: 30_000 });
+    expect(generatedConfig).toContain("CN = OpenClaw Debug Proxy");
+    expect(generatedConfig).toContain("basicConstraints = critical, CA:TRUE");
+    expect(generatedConfig).toContain("keyUsage = critical, keyCertSign, cRLSign");
+  });
+
+  it("rejects matching certificate material that is not a CA", async () => {
+    const { certDir } = await makeCertPaths();
+    generatePair("not-ca");
+
+    await expect(ensureDebugProxyCa(certDir)).rejects.toThrow(
+      "openssl generated invalid debug proxy certificate material",
+    );
+
+    expect(fs.readdirSync(certDir)).toEqual([]);
+  });
+
+  it("waits for a live lock owner before generating", async () => {
+    const { certDir, certPath, keyPath } = await makeCertPaths();
+    const lockPath = `${keyPath}.lock`;
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, createdAt: new Date() }));
+    generatePair("live-owner-retry");
+    const releaseOwner = setTimeout(() => fs.rmSync(lockPath, { force: true }), 150);
+
+    try {
+      await expect(ensureDebugProxyCa(certDir)).resolves.toEqual({ certPath, keyPath });
+    } finally {
+      clearTimeout(releaseOwner);
+    }
+
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers when publication is interrupted between the two renames", async () => {
+    const { certDir, certPath, keyPath } = await makeCertPaths();
+    fs.writeFileSync(certPath, "stale cert");
+    fs.writeFileSync(keyPath, "stale key");
+    runExecMock
+      .mockImplementationOnce(async (_command: string, args: string[]) => {
+        writeGeneratedPair(args, "failed-publication");
+      })
+      .mockImplementationOnce(async (_command: string, args: string[]) => {
+        writeGeneratedPair(args, "retry-after-publication");
+      });
+
+    const renameSync = fs.renameSync.bind(fs);
+    let rejectedPublishedCert = false;
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((source, destination) => {
+      const sourcePath = source.toString();
+      if (
+        !rejectedPublishedCert &&
+        destination.toString() === certPath &&
+        sourcePath.includes(`${path.sep}.root-ca-`)
+      ) {
+        rejectedPublishedCert = true;
+        throw Object.assign(new Error("certificate publication failed"), { code: "EACCES" });
+      }
+      renameSync(source, destination);
+    });
+
+    await expect(ensureDebugProxyCa(certDir)).rejects.toThrow("certificate publication failed");
+
+    expect(fs.readFileSync(certPath, "utf8")).toBe("stale cert");
+    expect(fs.readFileSync(keyPath, "utf8")).toBe("ca-material-marker:failed-publication");
+    expect(fs.readdirSync(certDir).toSorted()).toEqual(["root-ca-key.pem", "root-ca.pem"]);
+
+    renameSpy.mockRestore();
+    await expect(ensureDebugProxyCa(certDir)).resolves.toEqual({ certPath, keyPath });
+
+    expect(fs.readFileSync(certPath, "utf8")).toBe("ca-cert-marker:retry-after-publication");
+    expect(fs.readFileSync(keyPath, "utf8")).toBe("ca-material-marker:retry-after-publication");
+    expect(runExecMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/proxy-capture/ca.ts
+++ b/src/proxy-capture/ca.ts
@@ -1,8 +1,62 @@
 // Proxy capture CA helpers create and inspect local capture CA certificates.
+import { createPrivateKey, X509Certificate } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { type FileLockOptions, withFileLock } from "../infra/file-lock.js";
 import { resolveSystemBin } from "../infra/resolve-system-bin.js";
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { runExec } from "../process/exec.js";
+
+const DEBUG_PROXY_CA_GENERATION_TIMEOUT_MS = 30_000;
+const DEBUG_PROXY_CA_OPENSSL_CONFIG = [
+  "[req]",
+  "distinguished_name = subject",
+  "prompt = no",
+  "",
+  "[subject]",
+  "CN = OpenClaw Debug Proxy",
+  "",
+  "[v3_ca]",
+  "basicConstraints = critical, CA:TRUE",
+  "keyUsage = critical, keyCertSign, cRLSign",
+  "",
+].join("\n");
+const DEBUG_PROXY_CA_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    // About 36s of minimum backoff covers one full 30s OpenSSL deadline.
+    retries: 80,
+    factor: 1.3,
+    minTimeout: 25,
+    maxTimeout: 500,
+    randomize: true,
+  },
+  stale: 60_000,
+  staleRecovery: "remove-if-unchanged",
+};
+const debugProxyCaGenerationQueue = new KeyedAsyncQueue();
+
+function isValidDebugProxyCaPair(certPath: string, keyPath: string): boolean {
+  try {
+    const certStat = fs.lstatSync(certPath);
+    const keyStat = fs.lstatSync(keyPath);
+    if (!certStat.isFile() || !keyStat.isFile() || certStat.size === 0 || keyStat.size === 0) {
+      return false;
+    }
+    const cert = new X509Certificate(fs.readFileSync(certPath));
+    const key = createPrivateKey(fs.readFileSync(keyPath));
+    return cert.ca && cert.checkPrivateKey(key);
+  } catch {
+    return false;
+  }
+}
+
+function removeStagingDirBestEffort(stagingDir: string): void {
+  try {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  } catch {
+    // Cleanup failure must not replace a successful publication result.
+  }
+}
 
 // Ensure a short-lived root CA for local MITM debug proxy runs. Existing certs
 // are reused within the cert dir so repeated starts do not prompt regeneration.
@@ -13,32 +67,57 @@ export async function ensureDebugProxyCa(certDir: string): Promise<{
   fs.mkdirSync(certDir, { recursive: true });
   const certPath = path.join(certDir, "root-ca.pem");
   const keyPath = path.join(certDir, "root-ca-key.pem");
-  if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
-    return { certPath, keyPath };
-  }
-  const openssl = resolveSystemBin("openssl");
-  if (!openssl) {
-    throw new Error("openssl is required to generate debug proxy certificates");
-  }
-  await runExec(
-    openssl,
-    [
-      "req",
-      "-x509",
-      "-newkey",
-      "rsa:2048",
-      "-sha256",
-      "-days",
-      "7",
-      "-nodes",
-      "-keyout",
-      keyPath,
-      "-out",
-      certPath,
-      "-subj",
-      "/CN=OpenClaw Debug Proxy",
-    ],
-    { logOutput: false },
+  const canonicalKeyPath = path.join(fs.realpathSync(certDir), "root-ca-key.pem");
+  return await debugProxyCaGenerationQueue.enqueue(canonicalKeyPath, async () =>
+    withFileLock(canonicalKeyPath, DEBUG_PROXY_CA_LOCK_OPTIONS, async () => {
+      if (isValidDebugProxyCaPair(certPath, keyPath)) {
+        return { certPath, keyPath };
+      }
+      const openssl = resolveSystemBin("openssl");
+      if (!openssl) {
+        throw new Error("openssl is required to generate debug proxy certificates");
+      }
+      const stagingDir = fs.mkdtempSync(path.join(certDir, ".root-ca-"));
+      const stagedConfigPath = path.join(stagingDir, "openssl.cnf");
+      const stagedCertPath = path.join(stagingDir, "root-ca.pem");
+      const stagedKeyPath = path.join(stagingDir, "root-ca-key.pem");
+      try {
+        fs.writeFileSync(stagedConfigPath, DEBUG_PROXY_CA_OPENSSL_CONFIG, { mode: 0o600 });
+        await runExec(
+          openssl,
+          [
+            "req",
+            "-config",
+            stagedConfigPath,
+            "-extensions",
+            "v3_ca",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-sha256",
+            "-days",
+            "7",
+            "-nodes",
+            "-keyout",
+            stagedKeyPath,
+            "-out",
+            stagedCertPath,
+          ],
+          { logOutput: false, timeoutMs: DEBUG_PROXY_CA_GENERATION_TIMEOUT_MS },
+        );
+        if (!isValidDebugProxyCaPair(stagedCertPath, stagedKeyPath)) {
+          throw new Error("openssl generated invalid debug proxy certificate material");
+        }
+        fs.chmodSync(stagedKeyPath, 0o600);
+        fs.chmodSync(stagedCertPath, 0o644);
+        // All OpenClaw writers hold this lock. Same-directory renames replace each
+        // file atomically; validation repairs a pair interrupted between renames.
+        fs.renameSync(stagedKeyPath, keyPath);
+        fs.renameSync(stagedCertPath, certPath);
+        return { certPath, keyPath };
+      } finally {
+        removeStagingDirBestEffort(stagingDir);
+      }
+    }),
   );
-  return { certPath, keyPath };
 }

--- a/src/proxy-capture/proxy-server.managed-proxy.test.ts
+++ b/src/proxy-capture/proxy-server.managed-proxy.test.ts
@@ -1,14 +1,18 @@
 // Managed proxy tests cover proxy server lifecycle with managed capture files.
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import { Socket, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { DebugProxySettings } from "./env.js";
 import { startDebugProxyServer } from "./proxy-server.js";
 import { closeDebugProxyCaptureStore } from "./store.sqlite.js";
+
+vi.mock("./ca.js", () => ({
+  ensureDebugProxyCa: async () => ({ certPath: "test", keyPath: "test" }),
+}));
 
 let testRoot: string | undefined;
 const originalStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -32,9 +36,6 @@ async function cleanupTestDirs(): Promise<void> {
 async function makeSettings(): Promise<DebugProxySettings> {
   testRoot = await mkdtemp(join(tmpdir(), "openclaw-debug-proxy-managed-proxy-"));
   const certDir = join(testRoot, "certs");
-  await mkdir(certDir, { recursive: true });
-  await writeFile(join(certDir, "root-ca.pem"), "test root cert\n", "utf8");
-  await writeFile(join(certDir, "root-ca-key.pem"), "test root key\n", "utf8");
   process.env.OPENCLAW_STATE_DIR = testRoot;
   return {
     enabled: true,

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -1,5 +1,5 @@
 // Proxy capture server tests cover request recording and response handling.
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import {
   request as httpRequest,
   createServer as createHttpServer,
@@ -13,6 +13,10 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import type { DebugProxySettings } from "./env.js";
 import { startDebugProxyServer } from "./proxy-server.js";
 import { closeDebugProxyCaptureStore, getDebugProxyCaptureStore } from "./store.sqlite.js";
+
+vi.mock("./ca.js", () => ({
+  ensureDebugProxyCa: async () => ({ certPath: "test", keyPath: "test" }),
+}));
 
 let testRoot: string | undefined;
 const originalStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -36,9 +40,6 @@ async function cleanupTestRoot(): Promise<void> {
 async function makeSettings(): Promise<DebugProxySettings> {
   testRoot = await mkdtemp(join(tmpdir(), "openclaw-debug-proxy-server-"));
   const certDir = join(testRoot, "certs");
-  await mkdir(certDir, { recursive: true });
-  await writeFile(join(certDir, "root-ca.pem"), "test root cert\n", "utf8");
-  await writeFile(join(certDir, "root-ca-key.pem"), "test root key\n", "utf8");
   process.env.OPENCLAW_STATE_DIR = testRoot;
   return {
     enabled: true,


### PR DESCRIPTION
## What Problem This Solves

Starting the local debug proxy could wait indefinitely if OpenSSL stalled while generating its short-lived root CA. Interrupting direct writes could also leave a partial certificate pair that later starts could not use safely.

## Why This Change Was Made

The debug proxy now gives OpenSSL a 30-second deadline and generates into a private staging directory beside the final files. Before publication it verifies that the certificate is a CA and that its private key matches, then applies `0644`/`0600` modes and publishes with same-directory renames.

`KeyedAsyncQueue` serializes callers in one process, while the shared file-lock helper serializes OpenClaw writers across processes. Every caller validates the pair while holding that lock, so a process interrupted between the two renames is repaired on the next invocation instead of being reused.

The explicit OpenSSL config makes the required `CA:TRUE` and signing usage deterministic instead of depending on a host `OPENSSL_CONF`. This remains the existing seven-day local debug-proxy CA; no config surface or external API changes.

Dependency contracts checked:

- OpenSSL `req -x509` accepts explicit config/extensions and writes the requested `-keyout`/`-out` files: https://docs.openssl.org/3.5/man1/openssl-req/
- Node `fs.renameSync` replaces an existing destination file; staging in the same directory avoids cross-device rename failures: https://nodejs.org/api/fs.html#fsrenamesyncoldpath-newpath
- Node/Bun expose `X509Certificate.ca` and `checkPrivateKey`; both contracts were checked against the runtime sources used by this repository.
- `runExec` forwards `timeoutMs` to Execa 10.0.0; its timeout path terminates the child and waits for process completion before rejecting.

## User Impact

If local CA generation stalls, debug proxy startup now fails after about 30 seconds rather than hanging indefinitely. The failed attempt leaves no partial final files or orphan OpenSSL process, and a subsequent start regenerates a valid pair without manual cleanup.

## Evidence

Exact reviewed head: `5446b8da419eb41661b9bc4e22d8ab8fb4d12999`, rebased on `a8fd558d6210fdd2dbdd500a5e3a875b383f9c67`.

- Node `24.18.0` on Linux: `node scripts/run-vitest.mjs src/proxy-capture/ca.test.ts src/proxy-capture/proxy-server.test.ts src/proxy-capture/proxy-server.managed-proxy.test.ts --run` -> 3 files, 15 tests passed.
- The focused CA tests cover timeout isolation and retry, same-process deduplication, live cross-process lock contention, non-CA rejection, and recovery when publication stops between the key and certificate renames.
- Type-aware oxlint with `config/tsconfig/oxlint.core.json`, targeted `oxfmt --check`, and `git diff --check origin/main...HEAD`: passed.
- Fresh adversarial Codex review found no actionable issue after the hard-link publication approach was removed; assessed merge likelihood is 86-90%.

Real production-path proof used the actual `ensureDebugProxyCa` -> `runExec` -> `/usr/bin/openssl` path, with a controlled preload that stalls only the real OpenSSL process after it creates partial staged outputs:

```json
{"head":"5446b8da419eb41661b9bc4e22d8ab8fb4d12999","node":"v24.18.0","platform":"linux/x64","timeoutElapsedMs":30041,"timeoutObserved":true,"stalledOpenSslPid":29,"orphanOpenSslProcesses":0,"entriesAfterTimeout":[]}
{"retryElapsedMs":401,"finalEntries":["root-ca-key.pem","root-ca.pem"],"certificateIsCa":true,"privateKeyMatches":true,"certMode":420,"keyMode":384}
```

The numeric modes are `0644` for the certificate and `0600` for the private key.

### Exact-head proof continuity (immutable no-runtime-diff, 2026-07-20)

- Current PR head: `7be2615a6d10c0bda16612ca27961a1414f5721f`.
- Previously proven runtime head: `5446b8da419eb41661b9bc4e22d8ab8fb4d12999`.
- The GitHub Contents API returned identical blobs for every changed file:
  - `src/proxy-capture/ca.test.ts`: old `5b0a5b76bd44b8b1d9bf053c59e5af1a0106eae6` = current `5b0a5b76bd44b8b1d9bf053c59e5af1a0106eae6`
  - `src/proxy-capture/ca.ts`: old `728dafd2fb2f7b7bf0edaf8882bb51f85be02862` = current `728dafd2fb2f7b7bf0edaf8882bb51f85be02862`
  - `src/proxy-capture/proxy-server.managed-proxy.test.ts`: old `bd95a425b14dab59995cd4b44b949112696d5cbc` = current `bd95a425b14dab59995cd4b44b949112696d5cbc`
  - `src/proxy-capture/proxy-server.test.ts`: old `10b6bab842059ab5f2a62fee344bf9094370e1ec` = current `10b6bab842059ab5f2a62fee344bf9094370e1ec`
- Current-head CI completed successfully in [CI run 29716312742](https://github.com/openclaw/openclaw/actions/runs/29716312742).
- The existing redacted production transcript above exercised `ensureDebugProxyCa` -> `runExec` -> real OpenSSL: timeout around 30 seconds left no partial pair/orphan process, and a retry produced a valid matching CA/key pair. All changed files are byte-identical at the current head, so the runtime result transfers without a runtime diff.
- This is an immutable source-equivalence proof, not a claim of a new OpenSSL execution. `PROOF_RESULT=PASS` (4/4 changed files identical).

### Current-head proof continuity (verified import-only rebase delta, 2026-07-27)

- Current PR head: `fbdeb307505142d8c9fda5b487ff8227b79131d4`.
- Previously continuity-proven head: `7be2615a6d10c0bda16612ca27961a1414f5721f`, which already bridges to the real OpenSSL production-run head `5446b8da419eb41661b9bc4e22d8ab8fb4d12999`.
- Three of the four changed files have identical Git blob IDs. The only remaining delta is one import in `src/proxy-capture/ca.ts`: the rebase changes the self-package SDK specifier to the repository-relative SDK specifier required by current main.
- Both specifiers resolve to `src/plugin-sdk/keyed-async-queue.ts`; that module has the same blob ID at both heads: `0c4aca8ef10c5e959ce4f0e4ec4897ce2aab2dcc`. All CA timeout, locking, staged-publication, validation, and retry code is unchanged.
- Current-head repository checks are complete with zero failures and zero pending checks.
- The existing real OpenSSL timeout/cleanup/retry transcript therefore transfers through a verified import-only delta to the same implementation. No new OpenSSL execution is claimed. `PROOF_RESULT=PASS`.

### Exact-head maintenance refresh (2026-08-07)

- Current PR head: `7275badda20905bbd08a4897c4530acd3a90288b`, rebased once immediately before publication onto `a672065d5e5539331960e1671db3655fba421e4a`.
- Best-fix review confirmed `ensureDebugProxyCa` is the lifecycle owner shared by the proxy server, proxy CLI, and CA-install script. Caller-side guards would leave generation broken; the sibling Gateway TLS path has different no-clobber publication semantics and is not a reusable replacement.
- Direct macOS dependency proof found and repaired one portability defect in the prior head: `/usr/bin/openssl` (LibreSSL 3.3.6) rejected the empty `[subject]` section with `no objects specified in config file`. The explicit config now owns `CN = OpenClaw Debug Proxy`, and the duplicate `-subj` arguments are removed.
- The corrected command generated a certificate whose subject is `CN=OpenClaw Debug Proxy`, with `CA:TRUE`, certificate-signing and CRL-signing usage, and a public key matching the generated private key. This is a new real LibreSSL generation probe, not a new timeout injection.
- The earlier Linux real-path transcript still covers `ensureDebugProxyCa` -> `runExec` -> OpenSSL timeout, staged-output cleanup, orphan absence, and successful retry. The maintenance delta changes only how the same subject is supplied to OpenSSL and adds its regression assertion; no new Linux timeout run is claimed.
- Correction to the older test summary: the lock test exercises a live sidecar owner and wait/retry semantics; it does not spawn a second OS process. The production cross-process contract comes from the shared filesystem lock implementation and its inspected pinned `@openclaw/fs-safe` 0.5.2 source.
- Fresh structured AutoReview of the complete patch reported no accepted/actionable P0 findings (`patch is correct`, confidence `0.98`). `git diff --check origin/main...HEAD` passed.
- Exact-head canonical CI run [31161221865](https://github.com/openclaw/openclaw/actions/runs/31161221865) completed successfully at this head, including the aggregate `openclaw/ci-gate` job.

