### PR TITLE
fix(doctor): bound legacy crontab inspection

### DIFF
--- a/src/commands/doctor/cron/warnings.test.ts
+++ b/src/commands/doctor/cron/warnings.test.ts
@@ -1,16 +1,25 @@
 // Doctor cron delivery-target advisory tests cover concrete-vs-pseudo channel detection.
-import { describe, expect, it, vi } from "vitest";
-import { noteCronDeliveryTargetAdvisory } from "./warnings.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  collectLegacyWhatsAppCrontabHealthWarning,
+  noteCronDeliveryTargetAdvisory,
+} from "./warnings.js";
 
 const mocks = vi.hoisted(() => ({
   listReadOnlyChannelPluginsForConfig: vi.fn(),
   note: vi.fn(),
+  runExec: vi.fn(),
 }));
 
 vi.mock("../../../channels/plugins/read-only.js", () => ({
   listReadOnlyChannelPluginsForConfig: mocks.listReadOnlyChannelPluginsForConfig,
 }));
 vi.mock("../../../../packages/terminal-core/src/note.js", () => ({ note: mocks.note }));
+vi.mock("../../../process/exec.js", () => ({ runExec: mocks.runExec }));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 const STORE_PATH = "/tmp/openclaw/cron/jobs.sqlite";
 
@@ -164,5 +173,19 @@ describe("collectCronDeliveryTargetAdvisory", () => {
     });
     expect(advisory).toContain("Nightly digest -> ghost");
     expect(advisory).toContain("<unnamed> -> ghost");
+  });
+});
+
+describe("collectLegacyWhatsAppCrontabHealthWarning", () => {
+  it("bounds the best-effort crontab read", async () => {
+    mocks.runExec.mockRejectedValueOnce(new Error("crontab timed out"));
+
+    await expect(
+      collectLegacyWhatsAppCrontabHealthWarning({ platform: "linux" }),
+    ).resolves.toBeNull();
+    expect(mocks.runExec).toHaveBeenCalledWith("crontab", ["-l"], {
+      logOutput: false,
+      timeoutMs: 5_000,
+    });
   });
 });

--- a/src/commands/doctor/cron/warnings.ts
+++ b/src/commands/doctor/cron/warnings.ts
@@ -17,6 +17,7 @@ const LEGACY_WHATSAPP_HEALTH_SCRIPT_RE =
   /(?:^|\s)(?:"[^"]*ensure-whatsapp\.sh"|'[^']*ensure-whatsapp\.sh'|[^\s#;|&]*ensure-whatsapp\.sh)\b/u;
 const CRON_MODEL_OVERRIDE_EXAMPLE_LIMIT = 3;
 const CRON_DELIVERY_TARGET_ADVISORY_EXAMPLE_LIMIT = 3;
+const CRONTAB_READ_TIMEOUT_MS = 5_000;
 
 function pluralize(count: number, noun: string) {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
@@ -242,7 +243,10 @@ export function noteCronDeliveryTargetAdvisory(params: {
 }
 
 async function readUserCrontab(): Promise<{ stdout: string; stderr?: string }> {
-  const result = await runExec("crontab", ["-l"], { logOutput: false });
+  const result = await runExec("crontab", ["-l"], {
+    logOutput: false,
+    timeoutMs: CRONTAB_READ_TIMEOUT_MS,
+  });
   return {
     stdout: result.stdout,
     stderr: result.stderr,


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor` could wait indefinitely while its legacy WhatsApp health check ran `crontab -l`.

## Why This Change Was Made

The existing `runExec` call passed an options object without `timeoutMs`, which leaves the subprocess unbounded. This adds a five-second deadline at the private crontab reader, the narrow owner of the diagnostic command.

The surrounding collector is already best-effort and converts read failures to `null`, so timeout uses the existing failure contract and does not interrupt doctor.

## User Impact

A stuck crontab command can delay this advisory for at most five seconds; doctor then continues without the optional legacy warning.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor/cron/warnings.test.ts --run` (Node 24): 12 tests passed.
- The focused test asserts `timeoutMs: 5_000` reaches the production `crontab -l` call and a timeout still resolves to `null`.
- Direct type-aware oxlint with `config/tsconfig/oxlint.core.json`: passed.
- `oxfmt --check` and `git diff --check origin/main...HEAD`: passed.
