### PR TITLE
fix(channels): prevent lifecycle listener buildup across restarts

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -1,4 +1,5 @@
 // Discord tests cover message handler.queue plugin behavior.
+import { getEventListeners } from "node:events";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DiscordRetryableInboundError } from "./inbound-dedupe.js";
@@ -438,6 +439,22 @@ describe("createDiscordMessageHandler queue behavior", () => {
 
     await finish();
     expect(setStatus.mock.calls.length).toBe(callsBeforeStop);
+  });
+
+  it("removes lifecycle abort listeners after handler deactivation", () => {
+    const abortController = new AbortController();
+    const initialListenerCount = getEventListeners(abortController.signal, "abort").length;
+    const handler = createDiscordMessageHandler(
+      createDiscordHandlerParams({ abortSignal: abortController.signal }),
+    );
+
+    expect(getEventListeners(abortController.signal, "abort")).toHaveLength(
+      initialListenerCount + 2,
+    );
+
+    handler.deactivate();
+
+    expect(getEventListeners(abortController.signal, "abort")).toHaveLength(initialListenerCount);
   });
 
   it("skips queued runs that have not started yet after deactivation", async () => {

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -100,6 +100,7 @@ export function createDiscordMessageRunQueue(
   let lifecycleActive = !params.abortSignal?.aborted;
 
   const cleanupSkippedQueuedMessages = () => {
+    params.abortSignal?.removeEventListener("abort", cleanupSkippedQueuedMessages);
     // These callbacks represent jobs accepted into the queue but not started.
     // Running jobs remove their callback before processDiscordMessage owns cleanup.
     if (!lifecycleActive && skippedCleanup.size === 0) {

--- a/src/channels/run-state-machine.test.ts
+++ b/src/channels/run-state-machine.test.ts
@@ -1,4 +1,5 @@
 // Run state machine tests cover channel run lifecycle transitions and terminal states.
+import { getEventListeners } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { createRunStateMachine } from "./run-state-machine.js";
 
@@ -37,5 +38,19 @@ describe("createRunStateMachine", () => {
     abortController.abort();
     machine.onRunEnd();
     expect(setStatus.mock.calls.length).toBe(callsBeforeAbort);
+  });
+
+  it("removes its abort listener on manual deactivation", () => {
+    const abortController = new AbortController();
+    const initialListenerCount = getEventListeners(abortController.signal, "abort").length;
+    const machine = createRunStateMachine({ abortSignal: abortController.signal });
+
+    expect(getEventListeners(abortController.signal, "abort")).toHaveLength(
+      initialListenerCount + 1,
+    );
+
+    machine.deactivate();
+
+    expect(getEventListeners(abortController.signal, "abort")).toHaveLength(initialListenerCount);
   });
 });

--- a/src/channels/run-state-machine.ts
+++ b/src/channels/run-state-machine.ts
@@ -61,6 +61,7 @@ export function createRunStateMachine(params: RunStateMachineParams) {
   const deactivate = () => {
     lifecycleActive = false;
     clearHeartbeat();
+    params.abortSignal?.removeEventListener("abort", onAbort);
   };
 
   const onAbort = () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated Discord startup or teardown attempts could accumulate stale queue lifecycle listeners when cleanup deactivated a handler before its longer-lived gateway abort signal fired.

## Why This Change Was Made

The shared run-state owner and Discord skipped-job cleanup owner now remove the abort listeners they registered whenever public handler deactivation runs, alongside the existing heartbeat and queued-job cleanup. The change is limited to lifecycle resource ownership; status behavior, queue ordering, replay handling, configuration, and public API shapes are unchanged.

## User Impact

Discord restarts and startup-failure cleanup no longer leave inactive queue closures attached to the parent lifecycle signal. This prevents listener buildup across retries without changing normal message processing.

## Evidence

- Latest-main invariant at `b8b064a9483e`: the production Discord message queue reported `listenerCountAfterCreate=2` and `listenerCountAfterDeactivate=2`, confirming the complete handler problem was still present immediately before submission review.
- Verified candidate behavior: the same production runtime probe reported `listenerCountAfterCreate=2`, `listenerCountAfterDeactivate=0`, and `problemPresent=false`.
- `node scripts/run-vitest.mjs src/channels/run-state-machine.test.ts` — 4/4 passed.
- `node scripts/run-vitest.mjs src/plugin-sdk/channel-lifecycle.queue.test.ts` — 4/4 passed.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.queue.test.ts` — 13/13 passed.
- Focused formatting, core and extension type-aware lint, and `git diff --check` passed for the changed files.
