### PR TITLE
fix(auto-reply): deliverBindingPayload missing abortSignal check

### DIFF
--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -204,6 +204,8 @@ export async function handleQaInbound(params: {
   account: ResolvedQaChannelAccount;
   config: CoreConfig;
   message: QaBusMessage;
+  /** External abort signal forwarded into the dispatch replyOptions. */
+  abortSignal?: AbortSignal;
 }) {
   const runtime = getQaChannelRuntime();
   const inbound = params.message;
@@ -382,6 +384,7 @@ export async function handleQaInbound(params: {
       },
     },
     replyOptions: {
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
       allowToolLifecycleWhenProgressHidden: true,
       onPartialReply: async (payload) => {
         await preview.update(payload.text ?? "");

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
@@ -1762,6 +1762,91 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("aborts plugin-owned binding delivery during route await via abort signal", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true, reply: { text: "should not send" } },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-abort-mid-route",
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1481858418548412579",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/workspace/openclaw-app-server",
+        data: {
+          kind: "codex-app-server-session",
+          version: 1,
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/workspace/openclaw",
+        },
+      },
+    } satisfies SessionBindingRecord);
+    const abortController = new AbortController();
+
+    const originalRouteReply = mocks.routeReply.getMockImplementation();
+    mocks.routeReply.mockImplementation(async (_params: unknown) => {
+      abortController.abort();
+      return null as unknown as { ok: true; messageId: string };
+    });
+
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "discord",
+      OriginatingTo: "discord:channel:1481858418548412579",
+      To: "telegram:channel:1481858418548412579",
+      AccountId: "default",
+      SenderId: "user-9",
+      SenderUsername: "ada",
+      MessageThreadId: 77,
+      CommandAuthorized: true,
+      WasMentioned: false,
+      CommandBody: "who are you",
+      RawBody: "who are you",
+      Body: "who are you",
+      MessageSid: "msg-claim-plugin-abort-mid-route",
+      SessionKey: "agent:main:telegram:channel:1481858418548412579",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "should not run" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyOptions: { abortSignal: abortController.signal },
+      replyResolver,
+    });
+
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalled();
+
+    if (originalRouteReply) {
+      mocks.routeReply.mockImplementation(originalRouteReply);
+    } else {
+      mocks.routeReply.mockRestore();
+    }
+  });
+
   it("lets authorized gateway-style plugin commands escape plugin-owned bindings", async () => {
     setNoAbort();
     expect(

--- a/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts
@@ -245,7 +245,11 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
           : undefined,
       },
     );
+    if (params.replyOptions?.abortSignal?.aborted) {
+      return false;
+    }
     const result = await routeReplyToOriginating(bindingPayload, {
+      abortSignal: params.replyOptions?.abortSignal,
       kind: mode === "terminal" ? "final" : "tool",
       sessionKey: transcriptOwner?.sessionKey,
     });
@@ -256,6 +260,9 @@ export async function prepareDispatchDelivery(state: GatherDispatchRequestReadyS
         );
       }
       return result.ok;
+    }
+    if (params.replyOptions?.abortSignal?.aborted) {
+      return false;
     }
     markInboundDedupeReplayUnsafe();
     return mode === "additive"

--- a/src/auto-reply/reply/dispatch-from-config.prepare-operation.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-operation.ts
@@ -90,7 +90,10 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
       } satisfies ReplyPayload;
       // Routed delivery owns its destination-scoped prefix. Direct dispatchers already own
       // their prefix, so seed that live context only when no cross-channel route is used.
-      const result = await routeReplyToOriginating(payload, { responsePrefixContext });
+      const result = await routeReplyToOriginating(payload, {
+        abortSignal: params.replyOptions?.abortSignal,
+        responsePrefixContext,
+      });
       if (result) {
         queuedFinal = result.ok;
         if (isRoutedReplyDelivered(result)) {
@@ -104,7 +107,9 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
       } else {
         markInboundDedupeReplayUnsafe();
         params.replyOptions?.onModelSelected?.(modelSelection);
-        queuedFinal = dispatcher.sendFinalReply(payload);
+        if (!params.replyOptions?.abortSignal?.aborted) {
+          queuedFinal = dispatcher.sendFinalReply(payload);
+        }
       }
     } else {
       logVerbose(


### PR DESCRIPTION
## What Problem This Solves

Plugin binding notifications could still be delivered via `routeReplyToOriginating`, `dispatcher.sendToolResult`, or `dispatcher.sendFinalReply` after the dispatch operation has been aborted, because `deliverBindingPayload` did not check or propagate the dispatch abort signal. The same gap existed in the fast-abort acknowledgment path: it propagated `abortSignal` but lacked a post-route guard before the direct-dispatcher fallback.

## Why This Change Was Made

`deliverBindingPayload` was missing the same abort-signal guard that `sendPayloadAsync` (the sibling function) already implements. Aligned them by adding:

1. **Pre-check**: `params.replyOptions?.abortSignal?.aborted` early return
2. **Propagation**: pass `params.replyOptions?.abortSignal` to `routeReplyToOriginating` options
3. **Post-check**: after the async `routeReplyToOriginating` call, check `.aborted` again before falling through to `sendToolResult`/`sendFinalReply`

The fast-abort acknowledgment path had the same pattern: it propagated `abortSignal` through `routeReplyToOriginating` but did not re-check after the await, so a cancellation during routed delivery could still reach `dispatcher.sendFinalReply` on the wrong surface.

Since `deliverBindingPayload` is defined inside `prepareDispatchDelivery`'s closure (moved from the former `dispatchReplyFromConfigInner` by the #113154 refactor), `params.replyOptions?.abortSignal` is directly accessible — no need for `getDispatchAbortSignal()`.

> **Key fix difference from initial approach:** `getDispatchAbortSignal()` returns the **operation signal** (from `dispatchReplyOperation`) after `ensureDispatchReplyOperation` is called, not the original `replyOptions.abortSignal`. When an external `AbortController` fires, the operation signal does not propagate the abort. Using `params.replyOptions?.abortSignal` directly guarantees the correct signal is checked in both pre-check and post-check.

## User Impact

Users of plugin bindings may see fewer stale/misdirected binding notifications when a dispatch operation is aborted (e.g. session timeout, manual cancellation). The fast-abort acknowledgment is similarly guarded against wrong-surface delivery after cancellation. No behavior change for normal (non-aborted) dispatch paths.

## Evidence

### Test results

```
$ node scripts/run-vitest.mjs \
    src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts

 ✓ 1 file  →  276 tests passed (276)
```

### Lint and type checks

| Check | Result |
|---|---|
| `tsgo:core` (type) | ✅ |
| `oxlint` | ✅ |
| `oxfmt` | ✅ |

### E2E proof: Mid-route abort with 500ms async delay (the race window)

Uses a **real HTTP server**, **real `dispatchReplyFromConfig` pipeline**, **real `AbortController`**, and a **500ms artificial delay** in `routeReply` to simulate the async race window. Everything except `routeReply` (requires a real channel gateway) is real.

```
[PROOF] HTTP server started at http://127.0.0.1:45835
[PROOF]  +0ms    Calling dispatchReplyFromConfig with non-aborted signal...
                 ↓ signal.aborted = false
[PROOF]  +258ms  routeReply invoked — starting 500ms delay
                 ↓ async await — dispatch is WAITING for routeReply
[PROOF]  +761ms  abortController.abort() fired  ← ABORT FIRES DURING AWAIT
                 ↓ signal.aborted = true
[PROOF]  +763ms  Result: {"queuedFinal":false,"counts":{"tool":0,"block":0,"final":0}}
[PROOF]  ✅ sendFinalReply NOT called  — post-check guard active
[PROOF]  ✅ sendToolResult NOT called  — post-check guard active
[PROOF]  🎯 VERDICT: Mid-route abort guard verified at +763ms
```

The 500ms delay makes the race window observable: abort fires at +761ms *during* the async `routeReplyToOriginating` await, and the post-check catches it 2ms later at +763ms, suppressing fallback delivery.

### Fast-abort post-route guard

After the `routeReplyToOriginating` await returns null, `params.replyOptions?.abortSignal?.aborted` is checked before the `dispatcher.sendFinalReply` fallback, preventing wrong-surface delivery when cancellation races with the route.

### E2E Gateway Proof (pre-aborted signal through QA channel)

- **QA bus server**: real HTTP server
- **handleQaInbound**: real QA channel inbound handler
- **dispatchReplyWithBufferedBlockDispatcher**: real dispatch function
- **AbortController**: real, pre-aborted

```
[E2E] QA bus started: http://127.0.0.1:42989
[E2E] abortSignal:    aborted = true
[E2E] ✅ routeReply NOT called (short-circuited at entry guard)
[E2E] ✅ Binding reply SUPPRESSED
```

## Files changed

| File | ± | Change |
|------|---|--------|
| `src/auto-reply/reply/dispatch-from-config.prepare-delivery.ts` | +7/−0 | `deliverBindingPayload` pre/post abort checks + signal propagation |
| `src/auto-reply/reply/dispatch-from-config.prepare-operation.ts` | +4/−1 | Fast-abort path: signal propagation + post-route guard |
| `src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts` | +85 | Regression test: mid-route abort race window in plugin binding delivery |
| `extensions/qa-channel/src/inbound.ts` | +3 | Optional `abortSignal` parameter on `handleQaInbound`, forwarded into dispatch `replyOptions` |

> **Note:** Semantic rebase of the original fix onto the post-#113154 refactored pipeline. The `deliverBindingPayload` function and fast-abort acknowledgment path moved from the monolithic `dispatchReplyFromConfigInner` closure into `dispatch-from-config.prepare-delivery.ts` and `dispatch-from-config.prepare-operation.ts` respectively. The fix logic is unchanged.
