### PR TITLE
fix(google): idle-timeout stalled OAuth HTTP response bodies

### DIFF
--- a/extensions/google/oauth.http.test.ts
+++ b/extensions/google/oauth.http.test.ts
@@ -94,6 +94,34 @@ describe("oauth.http fetchWithTimeout body byte cap", () => {
       expect.objectContaining({ signal: controller.signal }),
     );
   });
+
+  it("times out when a response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"access_token":'));
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+        finalUrl: TOKEN_URL,
+        release: releaseMock,
+      });
+
+      const resultPromise = fetchWithTimeout(TOKEN_URL, { method: "POST" }, 50);
+      const settled = expect(resultPromise).rejects.toThrow(
+        "google HTTP fetch: body stalled for 50ms",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
+      expect(releaseMock).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // Real-wire loopback proof. These tests bypass `fetchWithSsrFGuard` (which

--- a/extensions/google/oauth.http.ts
+++ b/extensions/google/oauth.http.ts
@@ -27,10 +27,15 @@ export async function fetchWithTimeout(
     // accounts.google.com mirror / enterprise proxy) cannot force the
     // runtime to buffer an unbounded body before the caller sees it.
     // Complements #97587, which caps at the call site — this is the
-    // shared entry-point cap.
+    // shared entry-point cap. fetchWithSsrFGuard resolves after headers;
+    // keep the request deadline on the body so a stalled OAuth response
+    // cannot hang token exchange/identity calls.
     const body = await readResponseWithLimit(response, GOOGLE_OAUTH_BODY_MAX_BYTES, {
+      chunkTimeoutMs: timeoutMs,
       onOverflow: ({ size, maxBytes }) =>
         new Error(`google HTTP fetch: body exceeds ${maxBytes} bytes (got ${size})`),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`google HTTP fetch: body stalled for ${chunkTimeoutMs}ms`),
     });
     // `readResponseWithLimit` returns a `Buffer` (Node Uint8Array view). The
     // global `Response` constructor accepts `BufferSource` (Uint8Array /


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gemini CLI Google OAuth token exchange/identity fetches could hang after headers when the HTTP response stalled mid-body. `fetchWithTimeout` already applied `timeoutMs` to the guarded fetch, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same request `timeoutMs` through the body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching OpenAI/Discord response-body idle bounds.

## User Impact

**Before:** A stalled Google OAuth response body could hang login or identity calls indefinitely after headers.

**After:** Stalled bodies fail closed within the request timeout so OAuth can surface an error.

## Evidence

- Changed: `extensions/google/oauth.http.ts`, `extensions/google/oauth.http.test.ts`
- Production caller path: Gemini CLI OAuth → `fetchWithTimeout` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Google OAuth HTTP body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`fetchWithTimeout` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/google/oauth.http.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a response body stalls after headers 6ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
[test] passed 1 Vitest shard in 16.60s
```

### Observed result after fix

Stalled body rejects with `google HTTP fetch: body stalled for 50ms`; `release()` still runs.

### What was not tested

Live stall against Google's production OAuth endpoints.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the OAuth body idle bound and caller-path proof output.
