### PR TITLE
fix(doctor): bound launchctl environment probes

### DIFF
--- a/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
+++ b/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
@@ -1,7 +1,16 @@
 // Doctor launchctl environment tests cover macOS gateway platform warnings for env overrides.
 import fs from "node:fs";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+
+const processMocks = vi.hoisted(() => ({
+  runExec: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runExec: processMocks.runExec,
+}));
+
 import {
   collectMacGatewayPlatformWarnings,
   noteMacLaunchctlGatewayEnvOverrides,
@@ -17,6 +26,10 @@ function requireNoteCall(noteFn: { mock: { calls: unknown[][] } }, index = 0): u
 }
 
 describe("noteMacLaunchctlGatewayEnvOverrides", () => {
+  beforeEach(() => {
+    processMocks.runExec.mockReset().mockResolvedValue({ stdout: "", stderr: "" });
+  });
+
   it("collects clear unsetenv instructions for token override", async () => {
     const noteFn = vi.fn();
     const getenv = vi.fn(async (name: string) =>
@@ -116,6 +129,34 @@ describe("noteMacLaunchctlGatewayEnvOverrides", () => {
     await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "linux", getenv, noteFn });
 
     expect(getenv).not.toHaveBeenCalled();
+    expect(noteFn).not.toHaveBeenCalled();
+  });
+
+  it("bounds launchctl getenv calls and ignores timeout failures", async () => {
+    const noteFn = vi.fn();
+    processMocks.runExec.mockRejectedValue(new Error("timed out"));
+    const cfg = {
+      gateway: {
+        auth: {
+          token: "config-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", noteFn });
+
+    expect(processMocks.runExec).toHaveBeenNthCalledWith(
+      1,
+      "/bin/launchctl",
+      ["getenv", "OPENCLAW_GATEWAY_TOKEN"],
+      { logOutput: false, timeoutMs: 5_000 },
+    );
+    expect(processMocks.runExec).toHaveBeenNthCalledWith(
+      2,
+      "/bin/launchctl",
+      ["getenv", "OPENCLAW_GATEWAY_PASSWORD"],
+      { logOutput: false, timeoutMs: 5_000 },
+    );
     expect(noteFn).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -12,6 +12,8 @@ import { resolveGatewayService, type GatewayService } from "../daemon/service.js
 import { runExec } from "../process/exec.js";
 import { shortenHomePath } from "../utils.js";
 
+const DOCTOR_LAUNCHCTL_TIMEOUT_MS = 5_000;
+
 function resolveHomeDir(): string {
   return process.env.HOME ?? os.homedir();
 }
@@ -104,7 +106,10 @@ export async function noteMacStaleOpenClawUpdateLaunchdJobs(deps?: {
 
 async function launchctlGetenv(name: string): Promise<string | undefined> {
   try {
-    const result = await runExec("/bin/launchctl", ["getenv", name], { logOutput: false });
+    const result = await runExec("/bin/launchctl", ["getenv", name], {
+      logOutput: false,
+      timeoutMs: DOCTOR_LAUNCHCTL_TIMEOUT_MS,
+    });
     const value = normalizeOptionalString(result.stdout) ?? "";
     return value.length > 0 ? value : undefined;
   } catch {


### PR DESCRIPTION
## What Problem This Solves

The macOS doctor platform notes could wait indefinitely while reading host-wide Gateway credentials with `/bin/launchctl getenv`.

## Why This Change Was Made

The private reader passes an options object to `runExec`; without `timeoutMs`, both sequential subprocesses are unbounded. This adds a five-second deadline per local launchctl probe while preserving `logOutput: false` for credential-sensitive output.

Timeout keeps the existing optional-diagnostic contract: the reader catches command failures and returns `undefined`, so doctor simply omits a warning it could not verify. The limit stays at this doctor call site rather than changing the shared daemon launchctl lifecycle used by install, start, stop, and restart.

This is an existing boundedness gap, not a regression from a previous ten-second limit: the pre-`runExec` implementation used Node `execFile`, whose documented default timeout is zero. The unbounded implementation is present in `v2026.7.2-beta.1` but not `v2026.7.1`.

## User Impact

On macOS, a stuck launchctl credential probe can delay doctor for at most five seconds per variable; doctor then continues without the optional override warning.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts --run` (Node 24): 12 tests passed.
- The focused test executes the real private helper through `noteMacLaunchctlGatewayEnvOverrides`, asserts both `launchctl getenv` calls receive `timeoutMs: 5_000`, and proves rejected calls remain fail-soft.
- Direct type-aware oxlint with `config/tsconfig/oxlint.core.json`: passed.
- `oxfmt --check` and `git diff --check origin/main...HEAD`: passed.
- Node documents `execFile` timeout defaulting to zero: https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback
