### PR TITLE
fix(doctor): bound legacy launchd cleanup

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -197,12 +197,13 @@ function setupLegacyMacService() {
 
 function launchctlFailure(
   params: {
+    message?: string;
     stderr?: string;
     stdout?: string;
     timedOut?: boolean;
   } = {},
 ) {
-  return Object.assign(new Error("launchctl failed"), {
+  return Object.assign(new Error(params.message ?? "launchctl failed"), {
     stderr: params.stderr ?? "",
     stdout: params.stdout ?? "",
     ...(params.timedOut ? { timedOut: true } : {}),
@@ -1970,7 +1971,12 @@ describe("maybeScanExtraGatewayServices", () => {
     mocks.runExec
       .mockResolvedValueOnce({ stdout: "", stderr: "" })
       .mockResolvedValueOnce({ stdout: "", stderr: "" })
-      .mockRejectedValueOnce(launchctlFailure({ timedOut: true }));
+      .mockRejectedValueOnce(
+        launchctlFailure({
+          message: "Command timed out after 5000 milliseconds",
+          stderr: "Could not find service",
+        }),
+      );
     const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
     const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1866,7 +1866,7 @@ describe("maybeScanExtraGatewayServices", () => {
     ["bootout", true],
     ["unload", false],
   ])(
-    "moves the plist when %s succeeds and the other launchctl call times out",
+    "moves the plist when %s succeeds, the other call times out, and print confirms it is gone",
     async (_, bootoutOk) => {
       setupLegacyMacService();
       const timeout = launchctlFailure({ timedOut: true });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -236,11 +236,11 @@ function expectBoundedLaunchctlCleanup() {
   expect(probeTimeout).toBeLessThanOrEqual(5_000);
 }
 
-function mockConfirmedUnloaded() {
+function mockConfirmedUnloaded(stderr = "Could not find service") {
   mocks.runExec
     .mockResolvedValueOnce({ stdout: "", stderr: "" })
     .mockResolvedValueOnce({ stdout: "", stderr: "" })
-    .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
+    .mockRejectedValueOnce(launchctlFailure({ stderr }));
 }
 
 async function runRepair(cfg: OpenClawConfig, options: { allowExecSecretRefs?: boolean } = {}) {
@@ -1844,73 +1844,25 @@ describe("maybeScanExtraGatewayServices", () => {
     );
   });
 
-  it("moves a legacy macOS plist only after print confirms the label is gone", async () => {
-    setupLegacyMacService();
-    mockConfirmedUnloaded();
-    const runtime = makeDoctorIo();
-    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
-    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
-    vi.spyOn(fs, "access").mockResolvedValue(undefined);
-
-    await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
-
-    expectBoundedLaunchctlCleanup();
-    expect(rename).toHaveBeenCalledTimes(1);
-    expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
-    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway cleanup skipped");
-    expect(runtime.log).toHaveBeenCalledWith(
-      "Legacy gateway services removed. Installing OpenClaw gateway next.",
-    );
-  });
-
-  it.each([
-    ["bootout", true],
-    ["unload", false],
-  ])(
-    "moves the plist when %s succeeds, the other call times out, and print confirms it is gone",
-    async (_, bootoutOk) => {
-      setupLegacyMacService();
-      const timeout = launchctlFailure({ timedOut: true });
-      if (bootoutOk) {
-        mocks.runExec
-          .mockResolvedValueOnce({ stdout: "", stderr: "" })
-          .mockRejectedValueOnce(timeout)
-          .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
-      } else {
-        mocks.runExec
-          .mockRejectedValueOnce(timeout)
-          .mockResolvedValueOnce({ stdout: "", stderr: "" })
-          .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
-      }
-      vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
-      vi.spyOn(fs, "access").mockResolvedValue(undefined);
-      const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
-
-      await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
-
-      expectBoundedLaunchctlCleanup();
-      expect(rename).toHaveBeenCalledTimes(1);
-      expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
-    },
-  );
-
   it.each(["Could not find service", "No such process"])(
-    "treats launchctl '%s' as already unloaded",
+    "moves a legacy macOS plist only after print reports '%s'",
     async (stderr) => {
       setupLegacyMacService();
-      mocks.runExec
-        .mockRejectedValueOnce(launchctlFailure({ stderr }))
-        .mockRejectedValueOnce(launchctlFailure({ timedOut: true }))
-        .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
+      mockConfirmedUnloaded(stderr);
+      const runtime = makeDoctorIo();
+      const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
       vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
       vi.spyOn(fs, "access").mockResolvedValue(undefined);
-      const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
 
-      await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+      await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
 
       expectBoundedLaunchctlCleanup();
       expect(rename).toHaveBeenCalledTimes(1);
       expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+      expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway cleanup skipped");
+      expect(runtime.log).toHaveBeenCalledWith(
+        "Legacy gateway services removed. Installing OpenClaw gateway next.",
+      );
     },
   );
 

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -221,6 +221,25 @@ function expectBoundedLaunchctlCleanup() {
     logOutput: false,
     timeoutMs: 5_000,
   });
+  expect(mocks.runExec).toHaveBeenNthCalledWith(
+    3,
+    "launchctl",
+    ["print", `${domain}/${LEGACY_MAC_LABEL}`],
+    {
+      logOutput: false,
+      timeoutMs: expect.any(Number),
+    },
+  );
+  const probeTimeout = mocks.runExec.mock.calls[2]?.[2]?.timeoutMs;
+  expect(probeTimeout).toBeGreaterThan(0);
+  expect(probeTimeout).toBeLessThanOrEqual(5_000);
+}
+
+function mockConfirmedUnloaded() {
+  mocks.runExec
+    .mockResolvedValueOnce({ stdout: "", stderr: "" })
+    .mockResolvedValueOnce({ stdout: "", stderr: "" })
+    .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
 }
 
 async function runRepair(cfg: OpenClawConfig, options: { allowExecSecretRefs?: boolean } = {}) {
@@ -1824,8 +1843,9 @@ describe("maybeScanExtraGatewayServices", () => {
     );
   });
 
-  it("moves a legacy macOS plist after both bounded launchctl calls succeed", async () => {
+  it("moves a legacy macOS plist only after print confirms the label is gone", async () => {
     setupLegacyMacService();
+    mockConfirmedUnloaded();
     const runtime = makeDoctorIo();
     const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
     vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
@@ -1853,11 +1873,13 @@ describe("maybeScanExtraGatewayServices", () => {
       if (bootoutOk) {
         mocks.runExec
           .mockResolvedValueOnce({ stdout: "", stderr: "" })
-          .mockRejectedValueOnce(timeout);
+          .mockRejectedValueOnce(timeout)
+          .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
       } else {
         mocks.runExec
           .mockRejectedValueOnce(timeout)
-          .mockResolvedValueOnce({ stdout: "", stderr: "" });
+          .mockResolvedValueOnce({ stdout: "", stderr: "" })
+          .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
       }
       vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
       vi.spyOn(fs, "access").mockResolvedValue(undefined);
@@ -1877,7 +1899,8 @@ describe("maybeScanExtraGatewayServices", () => {
       setupLegacyMacService();
       mocks.runExec
         .mockRejectedValueOnce(launchctlFailure({ stderr }))
-        .mockRejectedValueOnce(launchctlFailure({ timedOut: true }));
+        .mockRejectedValueOnce(launchctlFailure({ timedOut: true }))
+        .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
       vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
       vi.spyOn(fs, "access").mockResolvedValue(undefined);
       const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
@@ -1917,8 +1940,76 @@ describe("maybeScanExtraGatewayServices", () => {
     );
   });
 
+  it("keeps the plist when a successful cleanup command is followed by a loaded probe", async () => {
+    setupLegacyMacService();
+    mocks.runExec
+      .mockRejectedValueOnce(launchctlFailure({ timedOut: true }))
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "state = waiting\npid = 0\n", stderr: "" })
+      .mockRejectedValueOnce(launchctlFailure({ stderr: "Permission denied" }));
+    const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
+    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+    const runtime = makeDoctorIo();
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
+
+    expect(mocks.runExec).toHaveBeenCalledTimes(4);
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(access).not.toHaveBeenCalled();
+    expect(rename).not.toHaveBeenCalled();
+    expectNoteContaining(
+      `${LEGACY_MAC_LABEL} (launchctl could not confirm unload)`,
+      "Legacy gateway cleanup skipped",
+    );
+    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+  });
+
+  it("keeps the plist when the postcondition probe times out", async () => {
+    setupLegacyMacService();
+    mocks.runExec
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockRejectedValueOnce(launchctlFailure({ timedOut: true }));
+    const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
+    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+    const runtime = makeDoctorIo();
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
+
+    expectBoundedLaunchctlCleanup();
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(access).not.toHaveBeenCalled();
+    expect(rename).not.toHaveBeenCalled();
+    expectNoteContaining(
+      `${LEGACY_MAC_LABEL} (launchctl could not confirm unload)`,
+      "Legacy gateway cleanup skipped",
+    );
+    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+  });
+
+  it("polls a still-registered stopped label until launchd reports it gone", async () => {
+    setupLegacyMacService();
+    mocks.runExec
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "state = waiting\npid = 0\n", stderr: "" })
+      .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "access").mockResolvedValue(undefined);
+    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+
+    await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+
+    expect(mocks.runExec).toHaveBeenCalledTimes(4);
+    expect(rename).toHaveBeenCalledTimes(1);
+    expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+  });
+
   it("reports removal when launchctl confirms unload and the plist is already absent", async () => {
     setupLegacyMacService();
+    mockConfirmedUnloaded();
     vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
     vi.spyOn(fs, "access").mockRejectedValue(missing);
@@ -1934,6 +2025,7 @@ describe("maybeScanExtraGatewayServices", () => {
 
   it("does not report removal when the plist cannot be inspected", async () => {
     setupLegacyMacService();
+    mockConfirmedUnloaded();
     vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     vi.spyOn(fs, "access").mockRejectedValue(
       Object.assign(new Error("permission denied"), { code: "EACCES" }),
@@ -1953,6 +2045,7 @@ describe("maybeScanExtraGatewayServices", () => {
 
   it("does not report removal when the confirmed-unloaded plist cannot be moved", async () => {
     setupLegacyMacService();
+    mockConfirmedUnloaded();
     vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     vi.spyOn(fs, "access").mockResolvedValue(undefined);
     vi.spyOn(fs, "rename").mockRejectedValue(new Error("permission denied"));

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -48,6 +48,7 @@ const mocks = vi.hoisted(() => ({
   uninstallLegacySystemdUnits: vi.fn().mockResolvedValue([]),
   readWindowsProcessArgsSync: vi.fn(),
   readWindowsStartupFallbackRuntimeForUpdate: vi.fn(),
+  runExec: vi.fn(),
   note: vi.fn(),
 }));
 
@@ -111,6 +112,10 @@ vi.mock("../infra/windows-port-pids.js", () => ({
   readWindowsProcessArgsSync: mocks.readWindowsProcessArgsSync,
 }));
 
+vi.mock("../process/exec.js", () => ({
+  runExec: mocks.runExec,
+}));
+
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: mocks.note,
 }));
@@ -171,6 +176,50 @@ function mockProcessPlatform(platform: NodeJS.Platform) {
   Object.defineProperty(process, "platform", {
     value: platform,
     configurable: true,
+  });
+}
+
+const LEGACY_MAC_LABEL = "com.openclaw.gateway";
+const LEGACY_MAC_PLIST = "/Users/test/Library/LaunchAgents/com.openclaw.gateway.plist";
+
+function setupLegacyMacService() {
+  mockProcessPlatform("darwin");
+  mocks.findExtraGatewayServices.mockResolvedValue([
+    {
+      platform: "darwin",
+      label: LEGACY_MAC_LABEL,
+      detail: `plist: ${LEGACY_MAC_PLIST}`,
+      scope: "user",
+      legacy: true,
+    },
+  ]);
+}
+
+function launchctlFailure(
+  params: {
+    stderr?: string;
+    stdout?: string;
+    timedOut?: boolean;
+  } = {},
+) {
+  return Object.assign(new Error("launchctl failed"), {
+    stderr: params.stderr ?? "",
+    stdout: params.stdout ?? "",
+    ...(params.timedOut ? { timedOut: true } : {}),
+  });
+}
+
+function expectBoundedLaunchctlCleanup() {
+  const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+  expect(mocks.runExec).toHaveBeenNthCalledWith(
+    1,
+    "launchctl",
+    ["bootout", domain, LEGACY_MAC_PLIST],
+    { logOutput: false, timeoutMs: 5_000 },
+  );
+  expect(mocks.runExec).toHaveBeenNthCalledWith(2, "launchctl", ["unload", LEGACY_MAC_PLIST], {
+    logOutput: false,
+    timeoutMs: 5_000,
   });
 }
 
@@ -1593,9 +1642,11 @@ describe("maybeScanExtraGatewayServices", () => {
     mocks.renderGatewayServiceCleanupHints.mockReturnValue([]);
     mocks.isSystemdUnitActive.mockResolvedValue(false);
     mocks.uninstallLegacySystemdUnits.mockResolvedValue([]);
+    mocks.runExec.mockResolvedValue({ stdout: "", stderr: "" });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     mockProcessPlatform(originalPlatform);
   });
 
@@ -1769,6 +1820,153 @@ describe("maybeScanExtraGatewayServices", () => {
     });
     expectNoteContaining("clawdbot-gateway.service", "Legacy gateway removed");
     expect(runtime.log).toHaveBeenCalledWith(
+      "Legacy gateway services removed. Installing OpenClaw gateway next.",
+    );
+  });
+
+  it("moves a legacy macOS plist after both bounded launchctl calls succeed", async () => {
+    setupLegacyMacService();
+    const runtime = makeDoctorIo();
+    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "access").mockResolvedValue(undefined);
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
+
+    expectBoundedLaunchctlCleanup();
+    expect(rename).toHaveBeenCalledTimes(1);
+    expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway cleanup skipped");
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Legacy gateway services removed. Installing OpenClaw gateway next.",
+    );
+  });
+
+  it.each([
+    ["bootout", true],
+    ["unload", false],
+  ])(
+    "moves the plist when %s succeeds and the other launchctl call times out",
+    async (_, bootoutOk) => {
+      setupLegacyMacService();
+      const timeout = launchctlFailure({ timedOut: true });
+      if (bootoutOk) {
+        mocks.runExec
+          .mockResolvedValueOnce({ stdout: "", stderr: "" })
+          .mockRejectedValueOnce(timeout);
+      } else {
+        mocks.runExec
+          .mockRejectedValueOnce(timeout)
+          .mockResolvedValueOnce({ stdout: "", stderr: "" });
+      }
+      vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+      vi.spyOn(fs, "access").mockResolvedValue(undefined);
+      const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+
+      await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+
+      expectBoundedLaunchctlCleanup();
+      expect(rename).toHaveBeenCalledTimes(1);
+      expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+    },
+  );
+
+  it.each(["Could not find service", "No such process"])(
+    "treats launchctl '%s' as already unloaded",
+    async (stderr) => {
+      setupLegacyMacService();
+      mocks.runExec
+        .mockRejectedValueOnce(launchctlFailure({ stderr }))
+        .mockRejectedValueOnce(launchctlFailure({ timedOut: true }));
+      vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+      vi.spyOn(fs, "access").mockResolvedValue(undefined);
+      const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+
+      await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+
+      expectBoundedLaunchctlCleanup();
+      expect(rename).toHaveBeenCalledTimes(1);
+      expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+    },
+  );
+
+  it.each([
+    ["timeouts", launchctlFailure({ timedOut: true })],
+    ["unknown failures", launchctlFailure({ stderr: "Permission denied" })],
+  ])("keeps the plist when both launchctl calls end in %s", async (_, failure) => {
+    setupLegacyMacService();
+    mocks.runExec.mockRejectedValue(failure);
+    const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
+    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+    const runtime = makeDoctorIo();
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
+
+    expectBoundedLaunchctlCleanup();
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(access).not.toHaveBeenCalled();
+    expect(rename).not.toHaveBeenCalled();
+    expectNoteContaining(
+      `${LEGACY_MAC_LABEL} (launchctl could not confirm unload)`,
+      "Legacy gateway cleanup skipped",
+    );
+    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      "Legacy gateway services removed. Installing OpenClaw gateway next.",
+    );
+  });
+
+  it("reports removal when launchctl confirms unload and the plist is already absent", async () => {
+    setupLegacyMacService();
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    vi.spyOn(fs, "access").mockRejectedValue(missing);
+    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+
+    await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+
+    expectBoundedLaunchctlCleanup();
+    expect(rename).not.toHaveBeenCalled();
+    expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway cleanup skipped");
+  });
+
+  it("does not report removal when the plist cannot be inspected", async () => {
+    setupLegacyMacService();
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "access").mockRejectedValue(
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+    );
+    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+
+    await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+
+    expectBoundedLaunchctlCleanup();
+    expect(rename).not.toHaveBeenCalled();
+    expectNoteContaining(
+      `${LEGACY_MAC_LABEL} (could not inspect plist)`,
+      "Legacy gateway cleanup skipped",
+    );
+    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+  });
+
+  it("does not report removal when the confirmed-unloaded plist cannot be moved", async () => {
+    setupLegacyMacService();
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "access").mockResolvedValue(undefined);
+    vi.spyOn(fs, "rename").mockRejectedValue(new Error("permission denied"));
+    const runtime = makeDoctorIo();
+
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
+
+    expectBoundedLaunchctlCleanup();
+    expectNoteContaining(
+      `${LEGACY_MAC_LABEL} (could not move plist)`,
+      "Legacy gateway cleanup skipped",
+    );
+    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+    expect(runtime.log).not.toHaveBeenCalledWith(
       "Legacy gateway services removed. Installing OpenClaw gateway next.",
     );
   });

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -16,6 +16,7 @@ import {
   renderGatewayServiceCleanupHints,
   type ExtraGatewayService,
 } from "../daemon/inspect.js";
+import { isLaunchctlNotLoaded } from "../daemon/launchd.js";
 import { OPENCLAW_WRAPPER_ENV_KEY } from "../daemon/program-args.js";
 import { renderSystemNodeWarning, resolveSystemNodeInfo } from "../daemon/runtime-paths.js";
 import { readWindowsStartupFallbackRuntimeForUpdate } from "../daemon/schtasks.js";
@@ -108,8 +109,27 @@ const EXECSTART_REPAIR_CODES = new Set<string>([
   SERVICE_AUDIT_CODES.gatewayCommandMissing,
   SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
 ]);
-const runLaunchctlQuietly = (args: string[]) =>
-  runExec("launchctl", args, { logOutput: false }).catch(() => undefined);
+const DOCTOR_LAUNCHCTL_TIMEOUT_MS = 5_000;
+type LaunchctlCleanupAttempt =
+  | { status: "succeeded"; stdout: string; stderr: string }
+  | { status: "failed"; stdout: string; stderr: string };
+
+const runLaunchctlQuietly = async (args: string[]): Promise<LaunchctlCleanupAttempt> => {
+  try {
+    const output = await runExec("launchctl", args, {
+      logOutput: false,
+      timeoutMs: DOCTOR_LAUNCHCTL_TIMEOUT_MS,
+    });
+    return { status: "succeeded", ...output };
+  } catch (error) {
+    const record = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+    return {
+      status: "failed",
+      stdout: typeof record.stdout === "string" ? record.stdout : "",
+      stderr: typeof record.stderr === "string" ? record.stderr : "",
+    };
+  }
+};
 const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
 
 function detectGatewayRuntime(programArguments: string[] | undefined): GatewayDaemonRuntime {
@@ -343,10 +363,21 @@ export function extraGatewayServiceToRepairEffects(
 async function cleanupLegacyLaunchdService(params: {
   label: string;
   plistPath: string;
-}): Promise<string | null> {
+}): Promise<{ status: "removed"; destination?: string } | { status: "failed"; reason: string }> {
   const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-  await runLaunchctlQuietly(["bootout", domain, params.plistPath]);
-  await runLaunchctlQuietly(["unload", params.plistPath]);
+  const bootout = await runLaunchctlQuietly(["bootout", domain, params.plistPath]);
+  const unload = await runLaunchctlQuietly(["unload", params.plistPath]);
+
+  // A timeout only proves launchctl was killed. Keep the plist unless one command
+  // succeeded or launchctl explicitly confirmed that the job was already absent.
+  const confirmedUnloaded =
+    bootout.status === "succeeded" ||
+    unload.status === "succeeded" ||
+    isLaunchctlNotLoaded(bootout) ||
+    isLaunchctlNotLoaded(unload);
+  if (!confirmedUnloaded) {
+    return { status: "failed", reason: "launchctl could not confirm unload" };
+  }
 
   const trashDir = path.join(os.homedir(), ".Trash");
   try {
@@ -357,16 +388,19 @@ async function cleanupLegacyLaunchdService(params: {
 
   try {
     await fs.access(params.plistPath);
-  } catch {
-    return null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { status: "removed" };
+    }
+    return { status: "failed", reason: "could not inspect plist" };
   }
 
   const dest = path.join(trashDir, `${params.label}-${Date.now()}.plist`);
   try {
     await fs.rename(params.plistPath, dest);
-    return dest;
+    return { status: "removed", destination: dest };
   } catch {
-    return null;
+    return { status: "failed", reason: "could not move plist" };
   }
 }
 
@@ -416,11 +450,15 @@ async function cleanupLegacyDarwinServices(
       failed.push(`${svc.label} (missing plist path)`);
       continue;
     }
-    const dest = await cleanupLegacyLaunchdService({
+    const result = await cleanupLegacyLaunchdService({
       label: svc.label,
       plistPath,
     });
-    removed.push(dest ? `${svc.label} -> ${dest}` : svc.label);
+    if (result.status === "removed") {
+      removed.push(result.destination ? `${svc.label} -> ${result.destination}` : svc.label);
+    } else {
+      failed.push(`${svc.label} (${result.reason})`);
+    }
   }
 
   return { removed, failed };

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -132,7 +132,10 @@ const runLaunchctlQuietly = async (
       status: "failed",
       stdout: typeof record.stdout === "string" ? record.stdout : "",
       stderr: typeof record.stderr === "string" ? record.stderr : "",
-      timedOut: record.timedOut === true || /\bcommand timed out\b/i.test(message),
+      timedOut:
+        record.timedOut === true ||
+        record.noOutputTimedOut === true ||
+        /\bcommand timed out\b/i.test(message),
     };
   }
 };

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -113,7 +113,7 @@ const DOCTOR_LAUNCHCTL_TIMEOUT_MS = 5_000;
 const DOCTOR_LAUNCHCTL_CONFIRM_POLL_MS = 100;
 type LaunchctlCleanupAttempt =
   | { status: "succeeded"; stdout: string; stderr: string }
-  | { status: "failed"; stdout: string; stderr: string };
+  | { status: "failed"; stdout: string; stderr: string; timedOut: boolean };
 
 const runLaunchctlQuietly = async (
   args: string[],
@@ -127,10 +127,12 @@ const runLaunchctlQuietly = async (
     return { status: "succeeded", ...output };
   } catch (error) {
     const record = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+    const message = typeof record.message === "string" ? record.message : "";
     return {
       status: "failed",
       stdout: typeof record.stdout === "string" ? record.stdout : "",
       stderr: typeof record.stderr === "string" ? record.stderr : "",
+      timedOut: record.timedOut === true || /\bcommand timed out\b/i.test(message),
     };
   }
 };
@@ -146,7 +148,7 @@ async function confirmLegacyLaunchdServiceUnloaded(serviceTarget: string): Promi
     if (probe.status === "failed") {
       // A successful print (including a stopped job) means launchd still owns
       // the label. Unknown errors and probe timeouts stay fail-closed.
-      return isLaunchctlNotLoaded(probe);
+      return !probe.timedOut && isLaunchctlNotLoaded(probe);
     }
     const delayMs = Math.min(DOCTOR_LAUNCHCTL_CONFIRM_POLL_MS, deadline - Date.now());
     if (delayMs <= 0) {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -110,15 +110,19 @@ const EXECSTART_REPAIR_CODES = new Set<string>([
   SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
 ]);
 const DOCTOR_LAUNCHCTL_TIMEOUT_MS = 5_000;
+const DOCTOR_LAUNCHCTL_CONFIRM_POLL_MS = 100;
 type LaunchctlCleanupAttempt =
   | { status: "succeeded"; stdout: string; stderr: string }
   | { status: "failed"; stdout: string; stderr: string };
 
-const runLaunchctlQuietly = async (args: string[]): Promise<LaunchctlCleanupAttempt> => {
+const runLaunchctlQuietly = async (
+  args: string[],
+  timeoutMs = DOCTOR_LAUNCHCTL_TIMEOUT_MS,
+): Promise<LaunchctlCleanupAttempt> => {
   try {
     const output = await runExec("launchctl", args, {
       logOutput: false,
-      timeoutMs: DOCTOR_LAUNCHCTL_TIMEOUT_MS,
+      timeoutMs,
     });
     return { status: "succeeded", ...output };
   } catch (error) {
@@ -130,6 +134,30 @@ const runLaunchctlQuietly = async (args: string[]): Promise<LaunchctlCleanupAtte
     };
   }
 };
+
+async function confirmLegacyLaunchdServiceUnloaded(serviceTarget: string): Promise<boolean> {
+  const deadline = Date.now() + DOCTOR_LAUNCHCTL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const probe = await runLaunchctlQuietly(
+      ["print", serviceTarget],
+      Math.min(DOCTOR_LAUNCHCTL_TIMEOUT_MS, remainingMs),
+    );
+    if (probe.status === "failed") {
+      // A successful print (including a stopped job) means launchd still owns
+      // the label. Unknown errors and probe timeouts stay fail-closed.
+      return isLaunchctlNotLoaded(probe);
+    }
+    const delayMs = Math.min(DOCTOR_LAUNCHCTL_CONFIRM_POLL_MS, deadline - Date.now());
+    if (delayMs <= 0) {
+      break;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
+  }
+  return false;
+}
 const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
 
 function detectGatewayRuntime(programArguments: string[] | undefined): GatewayDaemonRuntime {
@@ -365,17 +393,12 @@ async function cleanupLegacyLaunchdService(params: {
   plistPath: string;
 }): Promise<{ status: "removed"; destination?: string } | { status: "failed"; reason: string }> {
   const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-  const bootout = await runLaunchctlQuietly(["bootout", domain, params.plistPath]);
-  const unload = await runLaunchctlQuietly(["unload", params.plistPath]);
+  await runLaunchctlQuietly(["bootout", domain, params.plistPath]);
+  await runLaunchctlQuietly(["unload", params.plistPath]);
 
-  // A timeout only proves launchctl was killed. Keep the plist unless one command
-  // succeeded or launchctl explicitly confirmed that the job was already absent.
-  const confirmedUnloaded =
-    bootout.status === "succeeded" ||
-    unload.status === "succeeded" ||
-    isLaunchctlNotLoaded(bootout) ||
-    isLaunchctlNotLoaded(unload);
-  if (!confirmedUnloaded) {
+  // bootout/unload can return before launchd finishes stopping the job. A plist
+  // must stay in place unless a bounded print probe observes the label gone.
+  if (!(await confirmLegacyLaunchdServiceUnloaded(`${domain}/${params.label}`))) {
     return { status: "failed", reason: "launchctl could not confirm unload" };
   }
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -854,7 +854,7 @@ export async function uninstallLaunchAgent({
   }
 }
 
-function isLaunchctlNotLoaded(res: { stdout: string; stderr: string; code: number }): boolean {
+export function isLaunchctlNotLoaded(res: { stdout: string; stderr: string }): boolean {
   const detail = normalizeLowercaseStringOrEmpty(res.stderr || res.stdout);
   return (
     detail.includes("no such process") ||


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --fix` could wait indefinitely while unloading a detected legacy macOS Gateway service. It could also move the legacy plist after an unconfirmed `launchctl` failure, leaving no file for a later repair attempt even if launchd still owned the job.

## Why This Change Was Made

The legacy doctor cleanup previously ran `launchctl bootout` and `launchctl unload` without `timeoutMs`, ignored their outcomes, and then attempted to move the plist.

This change:

- bounds `bootout` and `unload` to five seconds each;
- follows them with a bounded `launchctl print gui/<uid>/<label>` postcondition;
- treats a successful print, including a stopped job, as still owned by launchd;
- accepts only an explicit non-timeout not-loaded result as confirmation;
- rejects timeout results even when partial output contains `Could not find service`;
- leaves the plist in place on timeout or unknown state so a later doctor pass can retry;
- preserves the existing move-to-Trash path after confirmed removal.

The shared daemon install/start/stop/restart lifecycle is intentionally unchanged. This is scoped to the doctor-owned legacy cleanup path.

## User Impact

A stalled legacy cleanup now returns within a bounded window without discarding the retry artifact. A later `openclaw doctor --fix` pass can complete cleanup once launchctl responds normally.

## Evidence

Exact product head: `08e752ae6adc110c7348a9ae6a87704d30148a75`.

### Focused and static checks

- `node scripts/run-vitest.mjs src/commands/doctor-gateway-services.test.ts --run`: **62/62 passed**.
- Focused tests cover both launchctl calls, successful and stopped print probes, unknown errors, ordinary timeouts, no-output timeouts, partial not-loaded output during a timeout, bounded polling, plist move failures, and retry-preserving failure reporting.
- `oxfmt --check` on the three touched files: passed.
- Targeted type-aware oxlint with `config/tsconfig/oxlint.core.json`: passed.
- `git diff --check`: passed.
- [Exact-head CI run 29674584728](https://github.com/openclaw/openclaw/actions/runs/29674584728): `openclaw/ci-gate`, build, production types, test types, lint, dependency checks, QA smoke profiles, and required security checks passed.

### Real macOS launchd proof

[Workflow run 29674970979](https://github.com/Alix-007/openclaw/actions/runs/29674970979) passed on `macos-15` (`darwin/arm64`, Node `24.18.0`) against the exact product head above. The independent proof branch uses the real `maybeScanExtraGatewayServices` repair entry point and real `/bin/launchctl` bootstrap/print/bootout behavior. A PATH-only shim injects failure modes; product modules are not mocked.

- `timeout-loaded`: returned in 15,638 ms; plist retained, job still loaded, nothing moved to Trash.
- `partial-timeout`: returned in 15,931 ms; partial `Could not find service` output did not bypass the timeout guard; plist retained and job still loaded.
- `unknown`: returned in 30 ms; plist retained and job still loaded.
- `success`: returned in 39 ms; job confirmed absent and one plist moved to Trash.
- same-job retry: first timeout pass returned in 15,615 ms with the plist and loaded job retained; the second healthy pass completed in 116 ms, confirmed the job absent, and moved the plist.

Artifact: `doctor-launchd-cleanup-08e752ae6adc110c7348a9ae6a87704d30148a75`.

- `proof.json` SHA-256: `c0a40a962b941d07e207b292fe8ec3d9d0e4dcf6507a161215c344f2f5a27d19`
- `run.log` SHA-256: `0422537cb026d2ed20c9d588d20eb1631a9993bcf1064325f6ff091b78c2351d`

The pre-`runExec` implementation used Node `execFile`, whose documented default timeout is zero: https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback. The unbounded cleanup is present in `v2026.7.2-beta.1` but not `v2026.7.1`.

### Exact-head macOS proof (2026-07-20)

A real macOS-15 darwin/arm64 workflow re-ran the doctor cleanup path against exact product head 0a74d02a720f6fdb1a78ae46cbb2ca79a60ced66:

- Run: https://github.com/Alix-007/openclaw/actions/runs/29718986238
- Job: https://github.com/Alix-007/openclaw/actions/runs/29718986238/job/88277742952
- Artifact: https://github.com/Alix-007/openclaw/actions/runs/29718986238/artifacts/8451638734
- Artifact proof.json SHA-256: 8d0edb8c2fb3adc3de78f8211ee839f893b5b0592c9e32abd8bf091703615aa0
- timeout-loaded: 15,653 ms; service remained loaded, plist remained in place, no Trash entry.
- partial-timeout: 15,935 ms; partial Could not find service output did not bypass the timeout guard; service and plist remained.
- unknown: 61 ms; service and plist remained.
- success: 62 ms; service unloaded and one plist moved to Trash.
- Retry: first timeout 15,621 ms retained the loaded service and plist; second healthy pass 32 ms unloaded the service and moved the plist to Trash.

The proof used the real /bin/launchctl on the macOS runner with only a PATH-scoped failure shim; no product modules were mocked and no credentials were used.