### PR TITLE
fix(build): plugin SDK declaration budget flakes across machines

### DIFF
--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -14,6 +14,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
   MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+  PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES,
   evaluatePluginSdkDeclarationBudget,
   isPrivateQaPluginSdkBuild,
 } from "./lib/plugin-sdk-declaration-budget.mjs";
@@ -186,15 +187,18 @@ if (declarationBudget.shouldFail) {
   console.error(
     `${budgetLabel} DTS TOO LARGE: ${declarationBytes} bytes exceeds ${declarationBudget.budgetBytes} bytes.`,
   );
+  console.error(
+    `Budget: ${declarationBudget.ratchetBytes}-byte ratchet + ${declarationBudget.varianceBytes}-byte Rolldown output variance.`,
+  );
   console.error("Keep plugin SDK declarations in the canonical unified tsdown graph.");
   missing += 1;
 } else if (declarationBudget.budgetKind === "private-qa-public-entry") {
   console.log(
-    `Private QA build public-entry declaration graph: ${declarationBytes}/${MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES} bytes; publication budget ${MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES} bytes is not applied.`,
+    `Private QA build public-entry declaration graph: ${declarationBytes}/${declarationBudget.budgetBytes} bytes (${MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES}-byte ratchet + ${PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES}-byte output variance); publication ratchet ${MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES} bytes is not applied.`,
   );
 } else {
   console.log(
-    `Public plugin SDK declaration graph: ${declarationBytes}/${MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES} bytes.`,
+    `Public plugin SDK declaration graph: ${declarationBytes}/${declarationBudget.budgetBytes} bytes (${MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES}-byte ratchet + ${PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES}-byte output variance).`,
   );
 }
 

--- a/scripts/lib/plugin-sdk-declaration-budget.d.mts
+++ b/scripts/lib/plugin-sdk-declaration-budget.d.mts
@@ -8,7 +8,10 @@ export function evaluatePluginSdkDeclarationBudget({
 }): {
   budgetBytes: number;
   budgetKind: string;
+  ratchetBytes: number;
   shouldFail: boolean;
+  varianceBytes: number;
 };
 export const MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES: 5200000;
 export const MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES: 5225000;
+export const PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES: 65536;

--- a/scripts/lib/plugin-sdk-declaration-budget.mjs
+++ b/scripts/lib/plugin-sdk-declaration-budget.mjs
@@ -4,18 +4,24 @@ export const MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES = 5_200_000;
 // Private-only entrypoints reshape chunks reachable from public roots but are never published.
 // Bound that topology overhead without counting local-only declarations as package surface.
 export const MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES = 5_225_000;
+// Rolldown can repartition equivalent declaration chunks between clean builds; measured spread is
+// about 29 KiB across hosts. Keep one 64 KiB scheduling window above the intentional size ratchet.
+export const PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES = 64 * 1024;
 
 export function isPrivateQaPluginSdkBuild(env) {
   return env.OPENCLAW_BUILD_PRIVATE_QA === "1";
 }
 
 export function evaluatePluginSdkDeclarationBudget({ declarationBytes, buildPrivateQa }) {
-  const budgetBytes = buildPrivateQa
+  const ratchetBytes = buildPrivateQa
     ? MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES
     : MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES;
+  const budgetBytes = ratchetBytes + PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES;
   return {
     budgetBytes,
     budgetKind: buildPrivateQa ? "private-qa-public-entry" : "public",
+    ratchetBytes,
     shouldFail: declarationBytes > budgetBytes,
+    varianceBytes: PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES,
   };
 }

--- a/test/scripts/plugin-sdk-declaration-budget.test.ts
+++ b/test/scripts/plugin-sdk-declaration-budget.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
   MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+  PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES,
   evaluatePluginSdkDeclarationBudget,
   isPrivateQaPluginSdkBuild,
 } from "../../scripts/lib/plugin-sdk-declaration-budget.mjs";
@@ -14,48 +15,61 @@ describe("plugin SDK declaration budget", () => {
   });
 
   it("enforces the publication budget at its exact boundary", () => {
+    const budgetBytes =
+      MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES + PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES;
     expect(
       evaluatePluginSdkDeclarationBudget({
         buildPrivateQa: false,
-        declarationBytes: MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+        declarationBytes: budgetBytes,
       }),
     ).toEqual({
-      budgetBytes: MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+      budgetBytes,
       budgetKind: "public",
+      ratchetBytes: MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
       shouldFail: false,
+      varianceBytes: PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES,
     });
     expect(
       evaluatePluginSdkDeclarationBudget({
         buildPrivateQa: false,
-        declarationBytes: MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES + 1,
+        declarationBytes: budgetBytes + 1,
       }),
     ).toEqual({
-      budgetBytes: MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+      budgetBytes,
       budgetKind: "public",
+      ratchetBytes: MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
       shouldFail: true,
+      varianceBytes: PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES,
     });
   });
 
   it("tracks private-build public-entry chunk growth under a separate budget", () => {
+    const budgetBytes =
+      MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES +
+      PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES;
     expect(
       evaluatePluginSdkDeclarationBudget({
         buildPrivateQa: true,
-        declarationBytes: MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+        declarationBytes: budgetBytes,
       }),
     ).toEqual({
-      budgetBytes: MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+      budgetBytes,
       budgetKind: "private-qa-public-entry",
+      ratchetBytes: MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
       shouldFail: false,
+      varianceBytes: PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES,
     });
     expect(
       evaluatePluginSdkDeclarationBudget({
         buildPrivateQa: true,
-        declarationBytes: MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES + 1,
+        declarationBytes: budgetBytes + 1,
       }),
     ).toEqual({
-      budgetBytes: MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
+      budgetBytes,
       budgetKind: "private-qa-public-entry",
+      ratchetBytes: MAX_PRIVATE_QA_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES,
       shouldFail: true,
+      varianceBytes: PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES,
     });
   });
 });


### PR DESCRIPTION
Closes #109105

## What Problem This Solves

Fixes an issue where maintainers running a clean build could have the plugin SDK declaration-size guard pass or fail for identical source when Rolldown produced a different declaration chunk topology on that run or host.

## Why This Change Was Made

The existing 5,200,000-byte value remains the intentional public-surface ratchet. The guard now adds a separately named 64 KiB Rolldown output-variance allowance, reports both components, and tests the combined boundary for public and private-QA builds. This gives the reported 5,207,970-byte high-water build 57,566 bytes of headroom without hiding growth in the ratchet itself.

The variance occurs after TypeScript declaration generation: repeated clean builds differed on one four-core host, and neither an isolated `rolldown-plugin-dts` TypeScript context nor `RAYON_NUM_THREADS=1` made totals deterministic.

## User Impact

No user-visible runtime change. Maintainers and release jobs can clean-build the same source across machines without a declaration-topology fluctuation alone failing the package-size guard; genuine declaration growth still consumes the 5,200,000-byte ratchet.

## Evidence

- Before: same-SHA cross-host output was reported at 5,178,578 and 5,207,970 bytes, a 29,392-byte spread across the 5,200,000-byte cap.
- Reproduction on current `main`: two clean builds on the same four-core Testbox emitted 4,742,089 and 4,742,070 bytes.
- Isolated TypeScript-context experiment: repeated clean totals still differed, 4,742,089 versus 4,742,070 bytes.
- Single-Rayon-thread experiment: repeated clean totals still differed, 4,742,127 versus 4,742,070 bytes.
- `pnpm test test/scripts/plugin-sdk-declaration-budget.test.ts`: 3 tests passed.
- Clean `pnpm build:strict-smoke`: passed; reported `4742089/5265536 bytes (5200000-byte ratchet + 65536-byte output variance)`.
- Changed-surface gate: formatting, SDK exports/surface, deprecated API, plugin boundaries, script/root-test typechecks, and lint passed.
- Autoreview: clean, no accepted or actionable findings.
- Remote proof: Blacksmith Testbox `tbx_01kxnqdep389t5fjc01f0pxct6`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/29509623833).

## AI Assistance

- [x] AI-assisted investigation and implementation.
- [x] I understand the change and reviewed the dependency behavior and generated output diffs.
- [x] Local Codex autoreview completed cleanly.
