### PR TITLE
fix(scripts): keep phase runner log tails UTF-8 safe

### DIFF
--- a/scripts/e2e/parallels/phase-runner.ts
+++ b/scripts/e2e/parallels/phase-runner.ts
@@ -19,7 +19,9 @@ function appendTextTail(current: string, chunk: string, maxBytes: number): strin
   // Skip leading UTF-8 continuation bytes so the tail starts at a character
   // boundary instead of producing replacement characters in diagnostic output.
   let tailStart = 0;
-  while (tailStart < rawTail.length && (rawTail[tailStart] & 0xc0) === 0x80) {
+  while (tailStart < rawTail.length) {
+    const byte = rawTail.at(tailStart);
+    if (byte === undefined || (byte & 0xc0) !== 0x80) break;
     tailStart += 1;
   }
   const tail = rawTail.subarray(tailStart).toString("utf8");

--- a/scripts/e2e/parallels/phase-runner.ts
+++ b/scripts/e2e/parallels/phase-runner.ts
@@ -15,7 +15,14 @@ function appendTextTail(current: string, chunk: string, maxBytes: number): strin
   }
   const marker = `[phase log tail truncated to last ${maxBytes} bytes]\n`;
   const tailBytes = Math.max(0, maxBytes - Buffer.byteLength(marker));
-  const tail = Buffer.from(combined).subarray(-tailBytes).toString("utf8");
+  const rawTail = Buffer.from(combined).subarray(-tailBytes);
+  // Skip leading UTF-8 continuation bytes so the tail starts at a character
+  // boundary instead of producing replacement characters in diagnostic output.
+  let tailStart = 0;
+  while (tailStart < rawTail.length && (rawTail[tailStart] & 0xc0) === 0x80) {
+    tailStart += 1;
+  }
+  const tail = rawTail.subarray(tailStart).toString("utf8");
   return `${marker}${tail}`;
 }
 

--- a/scripts/e2e/parallels/phase-runner.ts
+++ b/scripts/e2e/parallels/phase-runner.ts
@@ -21,7 +21,9 @@ function appendTextTail(current: string, chunk: string, maxBytes: number): strin
   let tailStart = 0;
   while (tailStart < rawTail.length) {
     const byte = rawTail.at(tailStart);
-    if (byte === undefined || (byte & 0xc0) !== 0x80) break;
+    if (byte === undefined || (byte & 0xc0) !== 0x80) {
+      break;
+    }
     tailStart += 1;
   }
   const tail = rawTail.subarray(tailStart).toString("utf8");

--- a/test/scripts/parallels/phase-runner.test.ts
+++ b/test/scripts/parallels/phase-runner.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PhaseRunner } from "../../../scripts/e2e/parallels/phase-runner.ts";
+
+const REPLACEMENT_CHARACTER = "�";
+
+describe("PhaseRunner log tail UTF-8 safety", () => {
+  it("skips leading continuation bytes when tail truncation starts inside a multibyte character", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phase-runner-utf8-"));
+    try {
+      // maxBytes=60 → marker≈44 bytes → tailBytes=16
+      // Combined = 40 x 'a' + '你好世界' (12 bytes) + 8 x 'b' + '\n' = 61 bytes
+      // 61 > 60 triggers truncation.
+      // subarray(-16) starts at byte 45 = 0xBD (continuation byte of 你 3rd byte).
+      const runner = new PhaseRunner(dir, 60);
+      runner.append("a".repeat(40) + "你好世界" + "b".repeat(8));
+
+      const tail = (runner as unknown as { logTail: string }).logTail;
+      expect(tail).not.toContain(REPLACEMENT_CHARACTER);
+      // Verify the multibyte content following the cut is preserved.
+      expect(tail).toContain("世界");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes through ASCII-only tails unchanged", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phase-runner-ascii-"));
+    try {
+      const runner = new PhaseRunner(dir, 60);
+      runner.append("hello world");
+      runner.append("another line");
+
+      const tail = (runner as unknown as { logTail: string }).logTail;
+      expect(tail).toContain("hello world");
+      expect(tail).not.toContain(REPLACEMENT_CHARACTER);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps tail within the configured byte budget", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phase-runner-budget-"));
+    try {
+      const runner = new PhaseRunner(dir, 100);
+      runner.append("x".repeat(200));
+
+      const tail = (runner as unknown as { logTail: string }).logTail;
+      expect(Buffer.byteLength(tail)).toBeLessThanOrEqual(100);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Parallels E2E phase runner log tails could render a
replacement character (&#xfffd;) in diagnostic output when the retained byte
window started inside a multibyte UTF-8 character. For example, a phase log
containing Chinese output that exceeded the 512 KiB tail cap would start the
truncated tail at a continuation byte, producing a broken first character.

## Why This Change Was Made

`PhaseRunner.append` feeds log text through `appendTextTail`, which takes a
byte-bounded suffix with `Buffer.from(combined).subarray(-tailBytes)` before
decoding with `toString("utf8")`. The helper now skips any leading UTF-8
continuation bytes after taking the bounded byte suffix, so the tail boundary
starts at a character boundary. This matches the existing pattern in
`src/process/exec-output.ts` (`trimTruncatedUtf8Boundary` tail branch).

## User Impact

Phase failure diagnostics in Parallels E2E runs stay readable when capped
output contains multibyte text at the retention boundary. There is no
behaviour change for ASCII-only output.

## Evidence

- Before the fix, `node -e` confirmed that a 61-byte combined string with
  `maxBytes=60` produced a tail starting with `&#xfffd;` when the 16-byte
  suffix boundary landed at byte 0xBD (continuation byte of a 3-byte CJK
  character).
- After the fix, the same input produces a tail starting with the intact
  character (`世界...`).
- `node scripts/run-vitest.mjs test/scripts/parallels/phase-runner.test.ts`
  passed with 1 test file and 3 tests:
  - multibyte character boundary safety
  - ASCII-only tail passthrough
  - byte budget enforcement
- `oxfmt --check` passed on both changed files.