### PR TITLE
fix(google): idle-timeout stalled Vertex ADC token response bodies

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1363,6 +1363,44 @@ describe("google transport stream", () => {
     });
   });
 
+  it("times out when an authorized_user ADC token response body stalls after headers", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-idle-"));
+    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
+    await writeFile(
+      credentialsPath,
+      JSON.stringify({
+        type: "authorized_user",
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "idle-refresh-token",
+      }),
+      "utf8",
+    );
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    vi.useFakeTimers();
+
+    const tokenFetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"access_token":'));
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const pendingRefresh = resolveGoogleVertexAuthorizedUserHeaders(tokenFetchMock);
+    // Attach the rejection handler before advancing fake time so the expected
+    // idle timeout cannot surface as an unhandled rejection between timer ticks.
+    const refreshError = pendingRefresh.catch((error: unknown) => error);
+    await vi.waitFor(() => expect(tokenFetchMock).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(30_060);
+    await expect(refreshError).resolves.toMatchObject({
+      message: "Google OAuth token response stalled for 30000ms",
+    });
+  });
+
   it("refreshes authorized_user ADC from a compressed token response", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-gzip-"));
     const credentialsPath = path.join(tempDir, "application_default_credentials.json");

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -301,9 +301,15 @@ async function refreshGoogleVertexAuthorizedUserAccessToken(params: {
 async function readGoogleOauthTokenResponsePayload(
   response: Response,
 ): Promise<GoogleOauthTokenResponsePayload | undefined> {
+  // Request AbortSignal stays live through body read, but mock/hostile bodies
+  // may ignore it. Idle-timeout the token payload so a stalled stream cannot
+  // hang Vertex ADC refresh after headers.
   const bytes = await readResponseWithLimit(response, GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES, {
+    chunkTimeoutMs: GOOGLE_VERTEX_ADC_TOKEN_REFRESH_TIMEOUT_MS,
     onOverflow: ({ maxBytes }) =>
       new Error(`Google OAuth token response exceeds ${maxBytes} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`Google OAuth token response stalled for ${chunkTimeoutMs}ms`),
   });
   const text = decodeGoogleOauthTokenResponseBody(bytes, response.headers.get("content-encoding"));
   if (!text.trim()) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Vertex authorized_user ADC token refresh could hang after headers when the OAuth token response stalled mid-body. Request AbortSignal stays live through body read, but mock/hostile bodies may ignore it; `readResponseWithLimit` had no `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same ADC refresh timeout through the token body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching Gemini CLI OAuth / OpenAI OAuth response-body idle bounds.

## User Impact

**Before:** A stalled Google OAuth token body could hang Vertex ADC refresh indefinitely after headers.

**After:** Stalled token bodies fail closed within the refresh timeout so Vertex requests can surface an auth error.

## Evidence

- Changed: `extensions/google/vertex-adc.ts`, `extensions/google/transport-stream.test.ts`
- Production caller path: `resolveGoogleVertexAuthorizedUserHeaders` → `refreshGoogleVertexAuthorizedUserAccessToken` → `readGoogleOauthTokenResponsePayload` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Vertex ADC OAuth token body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`resolveGoogleVertexAuthorizedUserHeaders` → `readGoogleOauthTokenResponsePayload` → `readResponseWithLimit({ chunkTimeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts -t "times out when an authorized_user ADC token response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when an authorized_user ADC token response body stalls after headers
 Test Files  1 passed (1)
      Tests  1 passed | 89 skipped (90)
```

### Observed result after fix

Stalled token body rejects with `Google OAuth token response stalled for 30000ms`.

### What was not tested

Live stall against Google's production OAuth token endpoint.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the ADC body idle bound and caller-path proof output.
