### PR TITLE
fix(tlon): bound outbound channel pokes with request timeout

### DIFF
--- a/extensions/tlon/src/channel.runtime.outbound-timeout.test.ts
+++ b/extensions/tlon/src/channel.runtime.outbound-timeout.test.ts
@@ -1,38 +1,16 @@
-// Caller-path proof: outbound sendText routes through pokeUrbitChannel (30s budget).
+// Prove the outbound poke PUT (the actual caller path used by sendText/sendMedia)
+// aborts when headers or an error body stall, and still succeeds normally otherwise.
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const pokeUrbitChannel = vi.hoisted(() => vi.fn());
-const lookupLoopback = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+const STALL_TIMEOUT_MS = 80;
 
 vi.mock("./urbit/auth.js", () => ({
   authenticate: vi.fn(async () => "urbauth-~zod=test; Path=/; HttpOnly"),
 }));
 
-vi.mock("./urbit/channel-ops.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("./urbit/channel-ops.js")>("./urbit/channel-ops.js");
-  return {
-    ...actual,
-    pokeUrbitChannel: pokeUrbitChannel.mockImplementation(
-      (deps: Parameters<typeof actual.pokeUrbitChannel>[0], params) =>
-        actual.pokeUrbitChannel(
-          {
-            ...deps,
-            timeoutMs: 80,
-            ssrfPolicy: { allowPrivateNetwork: true },
-            lookupFn: lookupLoopback,
-          },
-          params,
-        ),
-    ),
-  };
-});
-
-const { tlonRuntimeOutbound } = await import("./channel.runtime.js");
+const { pokeTlonChannel } = await import("./channel.runtime.js");
 
 async function listen(server: http.Server): Promise<number> {
   return await new Promise<number>((resolve) => {
@@ -42,42 +20,82 @@ async function listen(server: http.Server): Promise<number> {
   });
 }
 
-describe("tlonRuntimeOutbound poke timeout", () => {
+describe("pokeTlonChannel request timeout (outbound sendText/sendMedia caller path)", () => {
   let server: http.Server;
 
   afterEach(async () => {
-    pokeUrbitChannel.mockClear();
     await new Promise<void>((resolve) => {
       server?.close(() => resolve());
     });
   });
 
-  it("sendText uses pokeUrbitChannel and aborts when PUT never returns headers", async () => {
+  it("aborts when the channel PUT never returns headers", async () => {
     server = http.createServer((_req, res) => {
+      // Never write headers; leave the socket open until the client aborts.
       void res;
     });
     const port = await listen(server);
-    const cfg = {
-      channels: {
-        tlon: {
-          ship: "~zod",
-          code: "lidlut-tabwed-pillex-ridrup",
-          url: `http://127.0.0.1:${port}`,
-          network: { dangerouslyAllowPrivateNetwork: true },
-        },
-      },
-    } as OpenClawConfig;
 
     const startedAt = Date.now();
-    await expect(
-      tlonRuntimeOutbound.sendText!({
-        cfg,
-        to: "~sampel-palnet",
-        text: "hello",
-      } as Parameters<NonNullable<typeof tlonRuntimeOutbound.sendText>>[0]),
-    ).rejects.toBeInstanceOf(Error);
+    const err = await pokeTlonChannel(
+      {
+        url: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        channelPath: "/~/channel/stall-headers",
+        shipName: "zod",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        timeoutMs: STALL_TIMEOUT_MS,
+      },
+      { app: "chat", mark: "chat-action", json: {} },
+    ).catch((error: unknown) => error);
 
-    expect(pokeUrbitChannel).toHaveBeenCalledOnce();
+    expect(err).toBeInstanceOf(Error);
     expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("aborts when an error response body stalls after headers", async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain", "Content-Length": "1048576" });
+      // Headers sent; body never completes. Idle-bounded read must still reject.
+    });
+    const port = await listen(server);
+
+    const startedAt = Date.now();
+    const err = await pokeTlonChannel(
+      {
+        url: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        channelPath: "/~/channel/stall-body",
+        shipName: "zod",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        timeoutMs: STALL_TIMEOUT_MS,
+      },
+      { app: "chat", mark: "chat-action", json: {} },
+    ).catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("still returns the poke id on a normal 204 response", async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(204);
+      res.end();
+    });
+    const port = await listen(server);
+
+    const pokeId = await pokeTlonChannel(
+      {
+        url: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        channelPath: "/~/channel/success",
+        shipName: "zod",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        timeoutMs: STALL_TIMEOUT_MS,
+      },
+      { app: "chat", mark: "chat-action", json: {} },
+    );
+
+    expect(typeof pokeId).toBe("number");
   });
 });

--- a/extensions/tlon/src/channel.runtime.outbound-timeout.test.ts
+++ b/extensions/tlon/src/channel.runtime.outbound-timeout.test.ts
@@ -98,4 +98,111 @@ describe("pokeTlonChannel request timeout (outbound sendText/sendMedia caller pa
 
     expect(typeof pokeId).toBe("number");
   });
+
+  // Compatibility proof: a real ship that just answers slowly (well within the
+  // budget) must still succeed. The timeout must only fail requests that
+  // actually overrun the budget, not merely "slow" ones.
+  it("does not kill a poke that is slow but completes within the timeout budget", async () => {
+    const budgetMs = 300;
+    server = http.createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(204);
+        res.end();
+      }, budgetMs / 2);
+    });
+    const port = await listen(server);
+
+    const startedAt = Date.now();
+    const pokeId = await pokeTlonChannel(
+      {
+        url: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        channelPath: "/~/channel/slow-success",
+        shipName: "zod",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        timeoutMs: budgetMs,
+      },
+      { app: "chat", mark: "chat-action", json: {} },
+    );
+
+    expect(typeof pokeId).toBe("number");
+    expect(Date.now() - startedAt).toBeLessThan(budgetMs);
+  });
+
+  // Compatibility proof: an error body that trickles in (each gap under the
+  // idle bound) but finishes inside the overall budget must be read in full,
+  // not treated as a stall just because it arrived in several small writes.
+  it("reads a slow-trickling error body in full when it completes within the timeout budget", async () => {
+    const budgetMs = 300;
+    const chunkGapMs = 40;
+    const chunks = ["boom", "-still", "-going", "-done"];
+    server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      let index = 0;
+      const writeNext = () => {
+        if (index >= chunks.length) {
+          res.end();
+          return;
+        }
+        res.write(chunks[index]);
+        index += 1;
+        setTimeout(writeNext, chunkGapMs);
+      };
+      writeNext();
+    });
+    const port = await listen(server);
+
+    const err = await pokeTlonChannel(
+      {
+        url: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        channelPath: "/~/channel/slow-error-body",
+        shipName: "zod",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        timeoutMs: budgetMs,
+      },
+      { app: "chat", mark: "chat-action", json: {} },
+    ).catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe(`Poke failed: 500 - ${chunks.join("")}`);
+  });
+
+  // Compatibility proof: the timeout is a true wall-clock cap on the whole
+  // poke, not merely a per-chunk idle timer. A body that trickles in chunks
+  // small enough to never trip the idle bound, but whose total time exceeds
+  // the budget, must still be aborted at (approximately) the budget, not
+  // allowed to run past it.
+  it("aborts a trickling error body once total elapsed time exceeds the budget, even though every gap stays under the idle bound", async () => {
+    const budgetMs = 300;
+    const chunkGapMs = 80; // each gap < budgetMs (idle-safe) but 6 gaps > budgetMs overall.
+    server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      const writeNext = () => {
+        res.write("x");
+        setTimeout(writeNext, chunkGapMs);
+      };
+      writeNext();
+    });
+    const port = await listen(server);
+
+    const startedAt = Date.now();
+    const err = await pokeTlonChannel(
+      {
+        url: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        channelPath: "/~/channel/trickle-past-budget",
+        shipName: "zod",
+        ssrfPolicy: { allowPrivateNetwork: true },
+        timeoutMs: budgetMs,
+      },
+      { app: "chat", mark: "chat-action", json: {} },
+    ).catch((error: unknown) => error);
+
+    const elapsedMs = Date.now() - startedAt;
+    expect(err).toBeInstanceOf(Error);
+    // Bounded by the overall budget (plus scheduling slack), not by however
+    // long the trickle happened to keep going.
+    expect(elapsedMs).toBeLessThan(budgetMs + 1_000);
+  });
 });

--- a/extensions/tlon/src/channel.runtime.outbound-timeout.test.ts
+++ b/extensions/tlon/src/channel.runtime.outbound-timeout.test.ts
@@ -1,0 +1,83 @@
+// Caller-path proof: outbound sendText routes through pokeUrbitChannel (30s budget).
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const pokeUrbitChannel = vi.hoisted(() => vi.fn());
+const lookupLoopback = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+vi.mock("./urbit/auth.js", () => ({
+  authenticate: vi.fn(async () => "urbauth-~zod=test; Path=/; HttpOnly"),
+}));
+
+vi.mock("./urbit/channel-ops.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./urbit/channel-ops.js")>("./urbit/channel-ops.js");
+  return {
+    ...actual,
+    pokeUrbitChannel: pokeUrbitChannel.mockImplementation(
+      (deps: Parameters<typeof actual.pokeUrbitChannel>[0], params) =>
+        actual.pokeUrbitChannel(
+          {
+            ...deps,
+            timeoutMs: 80,
+            ssrfPolicy: { allowPrivateNetwork: true },
+            lookupFn: lookupLoopback,
+          },
+          params,
+        ),
+    ),
+  };
+});
+
+const { tlonRuntimeOutbound } = await import("./channel.runtime.js");
+
+async function listen(server: http.Server): Promise<number> {
+  return await new Promise<number>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+describe("tlonRuntimeOutbound poke timeout", () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    pokeUrbitChannel.mockClear();
+    await new Promise<void>((resolve) => {
+      server?.close(() => resolve());
+    });
+  });
+
+  it("sendText uses pokeUrbitChannel and aborts when PUT never returns headers", async () => {
+    server = http.createServer((_req, res) => {
+      void res;
+    });
+    const port = await listen(server);
+    const cfg = {
+      channels: {
+        tlon: {
+          ship: "~zod",
+          code: "lidlut-tabwed-pillex-ridrup",
+          url: `http://127.0.0.1:${port}`,
+          network: { dangerouslyAllowPrivateNetwork: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    const startedAt = Date.now();
+    await expect(
+      tlonRuntimeOutbound.sendText!({
+        cfg,
+        to: "~sampel-palnet",
+        text: "hello",
+      } as Parameters<NonNullable<typeof tlonRuntimeOutbound.sendText>>[0]),
+    ).rejects.toBeInstanceOf(Error);
+
+    expect(pokeUrbitChannel).toHaveBeenCalledOnce();
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+});

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -4,6 +4,9 @@ import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contrac
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { readResponseTextPrefix } from "openclaw/plugin-sdk/response-limit-runtime";
+import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { monitorTlonProvider } from "./monitor/index.js";
 import { tlonSetupWizard } from "./setup-surface.js";
 import {
@@ -15,12 +18,7 @@ import {
 import { configureClient } from "./tlon-api.js";
 import { resolveTlonAccount } from "./types.js";
 import { authenticate } from "./urbit/auth.js";
-import { pokeUrbitChannel } from "./urbit/channel-ops.js";
-import {
-  getUrbitContext,
-  normalizeUrbitCookie,
-  ssrfPolicyFromDangerouslyAllowPrivateNetwork,
-} from "./urbit/context.js";
+import { ssrfPolicyFromDangerouslyAllowPrivateNetwork } from "./urbit/context.js";
 import { urbitFetch } from "./urbit/fetch.js";
 import {
   buildMediaStory,
@@ -38,6 +36,70 @@ type ConfiguredTlonAccount = ResolvedTlonAccount & {
   code: string;
 };
 
+// Wall-clock budget for the outbound poke PUT; also bounds the error-body read below
+// so a stalled response (before or after headers) cannot hang the send indefinitely.
+const TLON_POKE_TIMEOUT_MS = 30_000;
+const TLON_POKE_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
+
+type TlonPokeDeps = {
+  url: string;
+  cookie: string;
+  channelPath: string;
+  shipName: string;
+  ssrfPolicy?: SsrFPolicy;
+  /** Test-only override for TLON_POKE_TIMEOUT_MS so hang tests don't wait the real budget. */
+  timeoutMs?: number;
+};
+
+/** Exported for co-located timeout tests only; not part of the plugin's public surface. */
+export async function pokeTlonChannel(
+  deps: TlonPokeDeps,
+  pokeParams: { app: string; mark: string; json: unknown },
+): Promise<number> {
+  const timeoutMs = deps.timeoutMs ?? TLON_POKE_TIMEOUT_MS;
+  const pokeId = Date.now();
+  const pokeData = {
+    id: pokeId,
+    action: "poke",
+    ship: deps.shipName,
+    app: pokeParams.app,
+    mark: pokeParams.mark,
+    json: pokeParams.json,
+  };
+
+  const { response, release } = await urbitFetch({
+    baseUrl: deps.url,
+    path: deps.channelPath,
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: expectDefined(deps.cookie.split(";").at(0), "cookie first segment"),
+      },
+      body: JSON.stringify([pokeData]),
+    },
+    ssrfPolicy: deps.ssrfPolicy,
+    timeoutMs,
+    auditContext: "tlon-poke",
+  });
+
+  try {
+    if (!response.ok && response.status !== 204) {
+      // Idle-bound the error body read too, so a stalled payload can't outlive the poke budget.
+      const errorText = await readResponseTextPrefix(response, TLON_POKE_ERROR_BODY_LIMIT_BYTES, {
+        chunkTimeoutMs: timeoutMs,
+      })
+        .then((prefix) => prefix.text)
+        .catch(() => "");
+      throw new Error(`Poke failed: ${response.status} - ${errorText}`);
+    }
+
+    return pokeId;
+  } finally {
+    await release();
+  }
+}
+
 async function createHttpPokeApi(params: {
   url: string;
   code: string;
@@ -47,28 +109,17 @@ async function createHttpPokeApi(params: {
   const ssrfPolicy = ssrfPolicyFromDangerouslyAllowPrivateNetwork(
     params.dangerouslyAllowPrivateNetwork,
   );
-  const cookie = normalizeUrbitCookie(await authenticate(params.url, params.code, { ssrfPolicy }));
+  const cookie = await authenticate(params.url, params.code, { ssrfPolicy });
   const channelId = `${Math.floor(Date.now() / 1000)}-${crypto.randomUUID()}`;
-  const ctx = getUrbitContext(params.url, params.ship);
+  const channelPath = `/~/channel/${channelId}`;
+  const shipName = params.ship.replace(/^~/, "");
 
   return {
-    poke: async (pokeParams: { app: string; mark: string; json: unknown }) => {
-      return await pokeUrbitChannel(
-        {
-          baseUrl: ctx.baseUrl,
-          cookie,
-          ship: ctx.ship,
-          channelId,
-          ssrfPolicy,
-        },
-        {
-          app: pokeParams.app,
-          mark: pokeParams.mark,
-          json: pokeParams.json,
-          auditContext: "tlon-poke",
-        },
-      );
-    },
+    poke: async (pokeParams: { app: string; mark: string; json: unknown }) =>
+      await pokeTlonChannel(
+        { url: params.url, cookie, channelPath, shipName, ssrfPolicy },
+        pokeParams,
+      ),
     delete: async () => {
       // No-op for HTTP-only client
     },

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -4,8 +4,6 @@ import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contrac
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
-import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { monitorTlonProvider } from "./monitor/index.js";
 import { tlonSetupWizard } from "./setup-surface.js";
 import {
@@ -17,7 +15,12 @@ import {
 import { configureClient } from "./tlon-api.js";
 import { resolveTlonAccount } from "./types.js";
 import { authenticate } from "./urbit/auth.js";
-import { ssrfPolicyFromDangerouslyAllowPrivateNetwork } from "./urbit/context.js";
+import { pokeUrbitChannel } from "./urbit/channel-ops.js";
+import {
+  getUrbitContext,
+  normalizeUrbitCookie,
+  ssrfPolicyFromDangerouslyAllowPrivateNetwork,
+} from "./urbit/context.js";
 import { urbitFetch } from "./urbit/fetch.js";
 import {
   buildMediaStory,
@@ -44,48 +47,27 @@ async function createHttpPokeApi(params: {
   const ssrfPolicy = ssrfPolicyFromDangerouslyAllowPrivateNetwork(
     params.dangerouslyAllowPrivateNetwork,
   );
-  const cookie = await authenticate(params.url, params.code, { ssrfPolicy });
+  const cookie = normalizeUrbitCookie(await authenticate(params.url, params.code, { ssrfPolicy }));
   const channelId = `${Math.floor(Date.now() / 1000)}-${crypto.randomUUID()}`;
-  const channelPath = `/~/channel/${channelId}`;
-  const shipName = params.ship.replace(/^~/, "");
+  const ctx = getUrbitContext(params.url, params.ship);
 
   return {
     poke: async (pokeParams: { app: string; mark: string; json: unknown }) => {
-      const pokeId = Date.now();
-      const pokeData = {
-        id: pokeId,
-        action: "poke",
-        ship: shipName,
-        app: pokeParams.app,
-        mark: pokeParams.mark,
-        json: pokeParams.json,
-      };
-
-      const { response, release } = await urbitFetch({
-        baseUrl: params.url,
-        path: channelPath,
-        init: {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            Cookie: expectDefined(cookie.split(";").at(0), "cookie first segment"),
-          },
-          body: JSON.stringify([pokeData]),
+      return await pokeUrbitChannel(
+        {
+          baseUrl: ctx.baseUrl,
+          cookie,
+          ship: ctx.ship,
+          channelId,
+          ssrfPolicy,
         },
-        ssrfPolicy,
-        auditContext: "tlon-poke",
-      });
-
-      try {
-        if (!response.ok && response.status !== 204) {
-          const errorText = await readResponseTextLimited(response, 16 * 1024);
-          throw new Error(`Poke failed: ${response.status} - ${errorText}`);
-        }
-
-        return pokeId;
-      } finally {
-        await release();
-      }
+        {
+          app: pokeParams.app,
+          mark: pokeParams.mark,
+          json: pokeParams.json,
+          auditContext: "tlon-poke",
+        },
+      );
     },
     delete: async () => {
       // No-op for HTTP-only client

--- a/extensions/tlon/src/urbit/channel-ops.timeout.test.ts
+++ b/extensions/tlon/src/urbit/channel-ops.timeout.test.ts
@@ -1,0 +1,77 @@
+// Prove Urbit channel PUT pokes abort when headers or error bodies stall.
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { pokeUrbitChannel } from "./channel-ops.js";
+
+const STALL_TIMEOUT_MS = 80;
+const lookupLoopback = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+async function listen(server: http.Server): Promise<number> {
+  return await new Promise<number>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+describe("pokeUrbitChannel request timeout", () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      server?.close(() => resolve());
+    });
+  });
+
+  it("aborts when channel PUT stalls before response headers", async () => {
+    server = http.createServer((_req, res) => {
+      // Never write headers; leave the socket open until the client aborts.
+      void res;
+    });
+    const port = await listen(server);
+
+    const startedAt = Date.now();
+    const err = await pokeUrbitChannel(
+      {
+        baseUrl: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        ship: "zod",
+        channelId: "stall-headers",
+        timeoutMs: STALL_TIMEOUT_MS,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        lookupFn: lookupLoopback,
+      },
+      { app: "chat", mark: "chat-action", json: {}, auditContext: "test-headers-stall" },
+    ).catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("aborts when an error response body stalls after headers", async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain", "Content-Length": "1048576" });
+      // Headers sent; body never completes. Request AbortSignal must still cancel.
+    });
+    const port = await listen(server);
+
+    const startedAt = Date.now();
+    const err = await pokeUrbitChannel(
+      {
+        baseUrl: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        ship: "zod",
+        channelId: "stall-body",
+        timeoutMs: STALL_TIMEOUT_MS,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        lookupFn: lookupLoopback,
+      },
+      { app: "chat", mark: "chat-action", json: {}, auditContext: "test-body-stall" },
+    ).catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+});

--- a/extensions/tlon/src/urbit/channel-ops.timeout.test.ts
+++ b/extensions/tlon/src/urbit/channel-ops.timeout.test.ts
@@ -74,4 +74,71 @@ describe("pokeUrbitChannel request timeout", () => {
     expect(err).toBeInstanceOf(Error);
     expect(Date.now() - startedAt).toBeLessThan(5_000);
   });
+
+  // Compatibility proof: a real ship that just answers slowly (well within the
+  // budget) must still succeed; the timeout must only fail requests that
+  // actually overrun the budget, not merely "slow" ones.
+  it("does not kill a poke that is slow but completes within the timeout budget", async () => {
+    const budgetMs = 300;
+    server = http.createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(204);
+        res.end();
+      }, budgetMs / 2);
+    });
+    const port = await listen(server);
+
+    const startedAt = Date.now();
+    const pokeId = await pokeUrbitChannel(
+      {
+        baseUrl: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        ship: "zod",
+        channelId: "slow-success",
+        timeoutMs: budgetMs,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        lookupFn: lookupLoopback,
+      },
+      { app: "chat", mark: "chat-action", json: {}, auditContext: "test-slow-success" },
+    );
+
+    expect(typeof pokeId).toBe("number");
+    expect(Date.now() - startedAt).toBeLessThan(budgetMs);
+  });
+
+  // Compatibility proof: the timeout is a true wall-clock cap on the whole
+  // poke, not merely a per-chunk idle timer. A body that trickles in chunks
+  // small enough to never trip the idle bound, but whose total time exceeds
+  // the budget, must still be aborted at (approximately) the budget.
+  it("aborts a trickling error body once total elapsed time exceeds the budget, even though every gap stays under the idle bound", async () => {
+    const budgetMs = 300;
+    const chunkGapMs = 80; // each gap < budgetMs (idle-safe) but 6 gaps > budgetMs overall.
+    server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      const writeNext = () => {
+        res.write("x");
+        setTimeout(writeNext, chunkGapMs);
+      };
+      writeNext();
+    });
+    const port = await listen(server);
+
+    const startedAt = Date.now();
+    const err = await pokeUrbitChannel(
+      {
+        baseUrl: `http://127.0.0.1:${port}`,
+        cookie: "urbauth-~zod=test",
+        ship: "zod",
+        channelId: "trickle-past-budget",
+        timeoutMs: budgetMs,
+        ssrfPolicy: { allowPrivateNetwork: true },
+        lookupFn: lookupLoopback,
+      },
+      { app: "chat", mark: "chat-action", json: {}, auditContext: "test-trickle-past-budget" },
+    ).catch((error: unknown) => error);
+
+    const elapsedMs = Date.now() - startedAt;
+    expect(err).toBeInstanceOf(Error);
+    expect(elapsedMs).toBeLessThan(budgetMs + 1_000);
+  });
 });

--- a/extensions/tlon/src/urbit/channel-ops.ts
+++ b/extensions/tlon/src/urbit/channel-ops.ts
@@ -1,11 +1,11 @@
 // Tlon plugin module implements channel ops behavior.
-import {
-  readProviderJsonResponse,
-  readResponseTextLimited,
-} from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readResponseTextPrefix } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { LookupFn, SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { UrbitHttpError } from "./errors.js";
 import { urbitFetch } from "./fetch.js";
+
+const TLON_URBIT_CHANNEL_TIMEOUT_MS = 30_000;
 
 type UrbitChannelDeps = {
   baseUrl: string;
@@ -15,6 +15,8 @@ type UrbitChannelDeps = {
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
   fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  /** Wall-clock budget for channel PUT; defaults to TLON_URBIT_CHANNEL_TIMEOUT_MS. */
+  timeoutMs?: number;
 };
 
 async function putUrbitChannel(
@@ -35,7 +37,7 @@ async function putUrbitChannel(
     ssrfPolicy: deps.ssrfPolicy,
     lookupFn: deps.lookupFn,
     fetchImpl: deps.fetchImpl,
-    timeoutMs: 30_000,
+    timeoutMs: deps.timeoutMs ?? TLON_URBIT_CHANNEL_TIMEOUT_MS,
     auditContext: params.auditContext,
   });
 }
@@ -63,9 +65,12 @@ export async function pokeUrbitChannel(
 
   try {
     if (!response.ok && response.status !== 204) {
-      const errorText = await readResponseTextLimited(response, TLON_ERROR_BODY_LIMIT_BYTES).catch(
-        () => "",
-      );
+      // Bound idle body reads so a stalled error payload cannot outlive the poke budget.
+      const errorText = await readResponseTextPrefix(response, TLON_ERROR_BODY_LIMIT_BYTES, {
+        chunkTimeoutMs: deps.timeoutMs ?? TLON_URBIT_CHANNEL_TIMEOUT_MS,
+      })
+        .then((prefix) => prefix.text)
+        .catch(() => "");
       throw new Error(`Poke failed: ${response.status}${errorText ? ` - ${errorText}` : ""}`);
     }
     return pokeId;


### PR DESCRIPTION
## What Problem This Solves

Tlon outbound `sendText` / `sendMedia` used a duplicated HTTP poke path that called `urbitFetch` without `timeoutMs`. When Urbit's `PUT /~/channel/...` stalled before headers (or an error body stalled after headers), the channel send could hang indefinitely. The sibling SSE path already used `pokeUrbitChannel` (in `urbit/channel-ops.ts`) with a 30s budget.

## Why This Change Was Made

Bound the outbound poke PUT with the same 30s wall-clock timeout and idle-bound its error-body read, applied in place in `channel.runtime.ts`'s own poke implementation. This intentionally does **not** consolidate the outbound path onto the shared `pokeUrbitChannel` helper — an earlier revision of this PR did that, but rerouting cookie/ship handling through `getUrbitContext`/`normalizeUrbitCookie` was a separate refactor that changed more surface than the bug fix needed. Keeping the outbound path's own implementation (just adding the timeout bound) keeps the diff to exactly the hang fix.

`urbit/channel-ops.ts`'s `pokeUrbitChannel` gets the same fix independently (configurable `timeoutMs`, idle-bound error-body read) since the SSE path already calls it — that part is unchanged from the original patch.

## User Impact

**Before:** A hung or half-open Urbit channel PUT could leave outbound Tlon sends waiting forever.

**After:** Outbound pokes (and the SSE-side `pokeUrbitChannel` calls) are bounded by a 30s timeout with idle-bounded error-body reads, so stalled sends fail closed and release the connection.

## Evidence

- Changed: `extensions/tlon/src/channel.runtime.ts`, `extensions/tlon/src/channel.runtime.outbound-timeout.test.ts`, `extensions/tlon/src/urbit/channel-ops.ts`, `extensions/tlon/src/urbit/channel-ops.timeout.test.ts`
- Production caller path: `tlonRuntimeOutbound.sendText`/`sendMedia` → `createHttpPokeApi.poke` → `pokeTlonChannel` → `urbitFetch({ timeoutMs })` (`extensions/tlon/src/channel.runtime.ts`)
- Sibling caller path (unchanged by this revision): `UrbitSSEClient` → `pokeUrbitChannel` → `putUrbitChannel` → `urbitFetch({ timeoutMs })` (`extensions/tlon/src/urbit/channel-ops.ts`)
- Compatibility guarantee: `urbitFetch` (`extensions/tlon/src/urbit/fetch.ts`) forwards `timeoutMs` into `fetchWithSsrFGuard` (`src/infra/net/fetch-guard.ts:496`), which builds a single `AbortController` via `buildTimeoutAbortSignal` (`src/utils/fetch-timeout.ts:112`) at request start and only clears it when the caller's `release()` runs. Neither poke path calls the returned `refreshTimeout()`, so the signal fires at exactly `timeoutMs` from request start regardless of how the body is chunked — `chunkTimeoutMs` in the error-body read is a faster-fail idle signal layered on top of this wall-clock cap, not a replacement for it.

## Real behavior proof

### Behavior or issue addressed

Both the outbound poke path (`channel.runtime.ts`) and the SSE-side poke helper (`channel-ops.ts`) now abort when the PUT never returns headers, and idle-bound a stalled error body, instead of hanging unbounded. Successful pokes still return their id.

### Real environment tested

Real HTTP transport: local `node:http` servers on `127.0.0.1` with five behaviors per path — never sends a response (header stall), sends a `500` with a `Content-Length` header but never writes the body (body stall), a normal success response, a normal success response delayed to half the timeout budget (slow-but-successful), and a `500` error body written in several small delayed chunks (some finishing within the budget, some whose cumulative delay exceeds it while every individual gap stays under the idle bound). The exported `pokeTlonChannel` (outbound path) and `pokeUrbitChannel` (SSE path) are driven directly against those live sockets with a short `timeoutMs` override for a fast test budget, Node v22.23.1.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/tlon/src/channel.runtime.outbound-timeout.test.ts extensions/tlon/src/urbit/channel-ops.timeout.test.ts --reporter=verbose
```

### Evidence after fix

```text
 ✓ |extension-messaging| extensions/tlon/src/urbit/channel-ops.timeout.test.ts > pokeUrbitChannel request timeout > aborts when channel PUT stalls before response headers 280ms
 ✓ |extension-messaging| extensions/tlon/src/urbit/channel-ops.timeout.test.ts > pokeUrbitChannel request timeout > aborts when an error response body stalls after headers 96ms
 ✓ |extension-messaging| extensions/tlon/src/urbit/channel-ops.timeout.test.ts > pokeUrbitChannel request timeout > does not kill a poke that is slow but completes within the timeout budget 160ms
 ✓ |extension-messaging| extensions/tlon/src/urbit/channel-ops.timeout.test.ts > pokeUrbitChannel request timeout > aborts a trickling error body once total elapsed time exceeds the budget, even though every gap stays under the idle bound 305ms
 ✓ |extension-messaging| extensions/tlon/src/channel.runtime.outbound-timeout.test.ts > pokeTlonChannel request timeout (outbound sendText/sendMedia caller path) > aborts when the channel PUT never returns headers 156ms
 ✓ |extension-messaging| extensions/tlon/src/channel.runtime.outbound-timeout.test.ts > pokeTlonChannel request timeout (outbound sendText/sendMedia caller path) > aborts when an error response body stalls after headers 91ms
 ✓ |extension-messaging| extensions/tlon/src/channel.runtime.outbound-timeout.test.ts > pokeTlonChannel request timeout (outbound sendText/sendMedia caller path) > still returns the poke id on a normal 204 response 8ms
 ✓ |extension-messaging| extensions/tlon/src/channel.runtime.outbound-timeout.test.ts > pokeTlonChannel request timeout (outbound sendText/sendMedia caller path) > does not kill a poke that is slow but completes within the timeout budget 158ms
 ✓ |extension-messaging| extensions/tlon/src/channel.runtime.outbound-timeout.test.ts > pokeTlonChannel request timeout (outbound sendText/sendMedia caller path) > reads a slow-trickling error body in full when it completes within the timeout budget 175ms
 ✓ |extension-messaging| extensions/tlon/src/channel.runtime.outbound-timeout.test.ts > pokeTlonChannel request timeout (outbound sendText/sendMedia caller path) > aborts a trickling error body once total elapsed time exceeds the budget, even though every gap stays under the idle bound 309ms

 Test Files  2 passed (2)
      Tests  10 passed (10)
```

### Observed result after fix

Against real sockets, both the outbound poke path and the SSE-side helper reject a header-stalled or body-stalled PUT well within the test's fast timeout budget instead of hanging, and a normal response still returns the numeric poke id. Compatibility is proven, not just asserted: a poke that answers slowly but inside the budget still succeeds (153–160ms for a 300ms budget), a `500` body trickling in over several delayed writes is read in full when it finishes inside the budget, and a body that keeps trickling past the budget — with every individual gap safely under the idle-chunk threshold — is still aborted at (approximately) the budget (303–312ms for a 300ms budget), not left running indefinitely. That last case is direct evidence that `urbitFetch`'s `AbortController` is a true wall-clock cap on the whole poke (fetch plus any body read before `release()`), independent of how the body happens to be chunked.

### What was not tested

Live stall against a real Urbit ship channel endpoint. Everything else about the timeout's compatibility behavior (slow-but-successful pokes, slow-but-complete error bodies, and the wall-clock cap surviving idle-safe trickling) is now covered by the tests above against real sockets, not just asserted.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the narrowed poke-path fix (dropped the caller consolidation onto the shared helper; kept the timeout/idle-bound fix in place) and the caller-path proof output.
