### PR TITLE
fix(ci): bound Docker release BuildKit pre-pull with timeout retries

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -137,20 +137,13 @@ jobs:
         shell: bash
         env:
           BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1
+          # Bounded per-attempt pull so a hung daemon/registry cannot skip retries.
+          OPENCLAW_DOCKER_PULL_ATTEMPTS: "4"
+          OPENCLAW_DOCKER_PULL_TIMEOUT_SECONDS: "180"
+          OPENCLAW_DOCKER_PULL_RETRY_DELAY_SECONDS: "10"
         run: |
           set -euo pipefail
-          for attempt in 1 2 3 4; do
-            if docker pull "${BUILDKIT_IMAGE}"; then
-              exit 0
-            fi
-            if [[ "${attempt}" == "4" ]]; then
-              echo "::error::Failed to pull ${BUILDKIT_IMAGE} after ${attempt} attempts"
-              exit 1
-            fi
-            sleep_seconds=$((attempt * 10))
-            echo "BuildKit image pull failed; retrying in ${sleep_seconds}s (${attempt}/4)."
-            sleep "${sleep_seconds}"
-          done
+          bash scripts/ci-docker-pull-retry.sh "${BUILDKIT_IMAGE}"
 
       - name: Set up Docker Builder
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4

--- a/test/scripts/ci-docker-pull-retry.test.ts
+++ b/test/scripts/ci-docker-pull-retry.test.ts
@@ -204,4 +204,74 @@ describe("scripts/ci-docker-pull-retry.sh", () => {
       /^2\b/u,
     );
   });
+
+  it("kills a hung first pull so a later retry can succeed", () => {
+    const binDir = makeTempBin("openclaw-ci-docker-pull-hang-retry-");
+    const attemptPath = path.join(binDir, "attempts");
+    writeFileSync(attemptPath, "0", "utf8");
+
+    writeExecutable(
+      path.join(binDir, "timeout"),
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        'if [ "${1:-}" = "--kill-after=1s" ]; then exit 0; fi',
+        // Emulate GNU timeout: run the command under a wall-clock budget.
+        'kill_after=""; budget=""',
+        'while [ "$#" -gt 0 ]; do',
+        '  case "$1" in',
+        '    --kill-after=*) kill_after="${1#--kill-after=}"; shift ;;',
+        '    *s) budget="${1%s}"; shift; break ;;',
+        "    *) shift ;;",
+        "  esac",
+        "done",
+        '"$@" &',
+        "child=$!",
+        'sleep "$budget"',
+        'if kill -0 "$child" 2>/dev/null; then',
+        '  kill -TERM "$child" 2>/dev/null || true',
+        "  sleep 0.1",
+        '  kill -KILL "$child" 2>/dev/null || true',
+        '  wait "$child" 2>/dev/null || true',
+        "  exit 124",
+        "fi",
+        'wait "$child"',
+        "",
+      ].join("\n"),
+    );
+    writeExecutable(
+      path.join(binDir, "docker"),
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        `attempt_file=${JSON.stringify(attemptPath)}`,
+        'attempt="$(<"$attempt_file")"',
+        "attempt=$((attempt + 1))",
+        'printf "%s" "$attempt" >"$attempt_file"',
+        'if [ "$attempt" -eq 1 ]; then',
+        "  while true; do sleep 1; done",
+        "  exit 1",
+        "fi",
+        "exit 0",
+        "",
+      ].join("\n"),
+    );
+
+    const result = spawnSync("/bin/bash", [SCRIPT_PATH, "registry.example/openclaw:test"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_DOCKER_PULL_ATTEMPTS: "2",
+        OPENCLAW_DOCKER_PULL_TIMEOUT_SECONDS: "1",
+        OPENCLAW_DOCKER_PULL_RETRY_DELAY_SECONDS: "0",
+        // Keep system sleep/kill available; prefer the fake timeout/docker first.
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(execFileSync("cat", [attemptPath], { encoding: "utf8" }).trim()).toBe("2");
+    expect(result.stderr).toContain("Docker pull failed or timed out after 1s");
+  });
 });

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1583,6 +1583,11 @@ describe("package artifact reuse", () => {
     );
     expect(dockerE2ePlanAction.match(/bash scripts\/ci-docker-pull-retry\.sh/g)?.length).toBe(2);
     expect(dockerE2ePlanAction).not.toContain('docker pull "${OPENCLAW_DOCKER_E2E_');
+
+    const dockerRelease = readFileSync(".github/workflows/docker-release.yml", "utf8");
+    expect(dockerRelease).toContain('bash scripts/ci-docker-pull-retry.sh "${BUILDKIT_IMAGE}"');
+    expect(dockerRelease).toContain('OPENCLAW_DOCKER_PULL_ATTEMPTS: "4"');
+    expect(dockerRelease).not.toMatch(/if docker pull "\$\{BUILDKIT_IMAGE\}"/u);
   });
 
   it("uses Blacksmith Docker build caching for prepared E2E images", () => {


### PR DESCRIPTION
## What Problem This Solves

The Docker release "Pre-pull BuildKit image" step used a 4-attempt retry loop around a bare `docker pull` with **no per-attempt process timeout**. When the Docker daemon, DNS, or registry half-opens, the first `docker pull` never returns, so the loop blocks on attempt 1 forever and the remaining retries never run — the job stalls until the runner/job-level timeout.

## Why This Change Was Made

Route the BuildKit pre-pull through the existing bounded helper `scripts/ci-docker-pull-retry.sh`, which wraps each `docker pull` in the host `timeout`/`gtimeout` (with a `--kill-after` grace period) and retries. This matches the other CI Docker pull sites and makes a hung pull killable so retries can proceed.

## User Impact

**Before:** A hung `docker pull` during a Docker release could stall the job indefinitely (until the runner/job timeout), skipping all retries.

**After:** Each BuildKit pull attempt is bounded (default 180s, `--kill-after=30s`); a hung pull is killed and retried up to four times.

## Evidence

- Changed: `.github/workflows/docker-release.yml`, `test/scripts/ci-docker-pull-retry.test.ts`, `test/scripts/package-acceptance-workflow.test.ts`
- Production caller path: docker-release `Pre-pull BuildKit image` step → `bash scripts/ci-docker-pull-retry.sh "${BUILDKIT_IMAGE}"` → `openclaw_host_timeout_bin` → `timeout --kill-after=30s "${timeout_seconds}s" docker pull "$image"`.

## Real behavior proof

### Behavior or issue addressed

A permanently hung first `docker pull` is killed at its per-attempt timeout so a later retry can succeed, instead of blocking the retry loop indefinitely.

### Canonical reachability path

Workflow step → `bash scripts/ci-docker-pull-retry.sh "${BUILDKIT_IMAGE}"` (`.github/workflows/docker-release.yml:137`) → `run_docker_pull` → `"$timeout_bin" --kill-after=30s "${timeout_seconds}s" docker pull "$image"` (`scripts/ci-docker-pull-retry.sh`).

### Real environment tested

Real shell execution of the production `scripts/ci-docker-pull-retry.sh` via `/bin/bash`. Two `PATH`-injected fakes stand in for external binaries: a `timeout` that faithfully emulates GNU `timeout` (runs the child under a real wall-clock budget and `SIGTERM`/`SIGKILL`s it on expiry, exit 124) and a `docker` whose first `pull` hangs forever (`while true; do sleep 1; done`) and whose second `pull` succeeds. No Docker daemon is required; the script's own timeout-selection, kill-after, retry, and exit-status logic run for real. macOS, Node v22.23.1 for the Vitest suite.

### Exact steps or command run after this patch

```bash
# Direct real-shell run of the production script: hung attempt 1, OK attempt 2.
PATH="<fake-bin>:/usr/bin:/bin" \
  OPENCLAW_DOCKER_PULL_ATTEMPTS=3 OPENCLAW_DOCKER_PULL_TIMEOUT_SECONDS=2 \
  OPENCLAW_DOCKER_PULL_RETRY_DELAY_SECONDS=0 \
  bash scripts/ci-docker-pull-retry.sh registry.example/openclaw:test

# Committed real-shell regressions (spawn the script against fake docker/timeout):
node scripts/run-vitest.mjs test/scripts/ci-docker-pull-retry.test.ts -- --reporter=verbose
```

### Evidence after fix

Direct real-shell run (production script, hung first pull bounded and retried):

```text
==> Pull Docker image attempt 1/3: registry.example/openclaw:test
[fake-docker] attempt 1: hanging (simulated stuck registry)
[fake-timeout] budget 2s exceeded (kill-after=30s); killing hung child
Docker pull failed or timed out after 2s: status=124
==> Pull Docker image attempt 2/3: registry.example/openclaw:test
[fake-docker] attempt 2: pull OK
----
script_exit_code=0  approx_wall_s=4  attempts_run=2
```

Committed real-shell regressions (production script via `/bin/bash`):

```text
 ✓ scripts/ci-docker-pull-retry.sh > uses a kill-after grace period when timeout supports it 1022ms
 ✓ scripts/ci-docker-pull-retry.sh > falls back to plain timeout when kill-after is unavailable 460ms
 ✓ scripts/ci-docker-pull-retry.sh > uses gtimeout when timeout is unavailable 491ms
 ✓ scripts/ci-docker-pull-retry.sh > fails fast when timeout and gtimeout are unavailable 6ms
 ✓ scripts/ci-docker-pull-retry.sh > returns the last pull failure status after retries are exhausted 491ms
 ✓ scripts/ci-docker-pull-retry.sh > kills a hung first pull so a later retry can succeed 2384ms
 Tests  6 passed (6)
```

### Observed result after fix

The hung first `docker pull` is killed at the 2s per-attempt budget (`status=124`), the loop advances, attempt 2 succeeds, and the script exits `0` after running exactly 2 attempts. Pre-fix, the bare `docker pull` on attempt 1 would never return, so the loop would block on the first attempt indefinitely and never retry. The `package-acceptance-workflow` test also pins that `docker-release.yml` now calls the bounded helper with `OPENCLAW_DOCKER_PULL_ATTEMPTS: "4"` and no longer contains the raw `if docker pull "${BUILDKIT_IMAGE}"` loop.

### What was not tested

A live GitHub Actions runner pulling `moby/buildkit` against a genuinely wedged registry; the proof exercises the production script's bounding/retry logic against a real hung child on the host.

### Fix classification

bugfix — CI timeout/hang

## AI Assistance

AI-assisted. Author reviewed the workflow step change and the real-shell proof output.
