### PR TITLE
fix(agent-core): settle exec timeout and abort without waiting on close

### DIFF
--- a/packages/agent-core/src/harness/env/nodejs.test.ts
+++ b/packages/agent-core/src/harness/env/nodejs.test.ts
@@ -147,6 +147,49 @@ describe("NodeExecutionEnv timeout handling", () => {
       await expect(resultPromise).resolves.toMatchObject({ ok: true });
     },
   );
+
+  it("settles timeout even when the child never emits close", async () => {
+    const child = mockSpawnChild();
+    const resultPromise = env.exec("sleep forever", { timeout: 0.05 });
+    await waitForSpawnCall();
+    const result = await resultPromise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("timeout");
+    }
+    // Late close must not throw or re-settle.
+    expect(() => child.emit("close", 0)).not.toThrow();
+  });
+
+  it("settles abort even when the child never emits close", async () => {
+    const child = mockSpawnChild();
+    const abort = new AbortController();
+    const resultPromise = env.exec("sleep forever", { abortSignal: abort.signal });
+    await waitForSpawnCall();
+    abort.abort();
+    const result = await resultPromise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("aborted");
+    }
+    expect(() => child.emit("close", 0)).not.toThrow();
+  });
+
+  it("prefers the first of abort and timeout when both race", async () => {
+    mockSpawnChild();
+    const abort = new AbortController();
+    const resultPromise = env.exec("sleep forever", {
+      timeout: 5,
+      abortSignal: abort.signal,
+    });
+    await waitForSpawnCall();
+    abort.abort();
+    const result = await resultPromise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("aborted");
+    }
+  });
 });
 
 describe("NodeExecutionEnv exec stream errors", () => {

--- a/packages/agent-core/src/harness/env/nodejs.ts
+++ b/packages/agent-core/src/harness/env/nodejs.ts
@@ -158,20 +158,30 @@ async function runCommand(
 ): Promise<{ stdout: string; status: number | null }> {
   return await new Promise((resolveLocal) => {
     let stdout = "";
+    let settled = false;
     let child: ReturnType<typeof spawn>;
+    const settleLocal = (result: { stdout: string; status: number | null }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolveLocal(result);
+    };
     try {
       child = spawn(command, args, {
         stdio: ["ignore", "pipe", "ignore"],
         windowsHide: true,
       });
     } catch {
-      resolveLocal({ stdout: "", status: null });
+      settleLocal({ stdout: "", status: null });
       return;
     }
+    // Timeout must settle even when kill fails or the child never emits close.
     const timeout = setTimeout(() => {
       if (child.pid) {
         killProcessTree(child.pid, { force: true, detached: false });
       }
+      settleLocal({ stdout: "", status: null });
     }, timeoutMs);
     child.stdout?.setEncoding("utf8");
     child.stdout?.on("data", (chunk: string) => {
@@ -182,15 +192,15 @@ async function runCommand(
         killProcessTree(child.pid, { force: true, detached: false });
       }
       clearTimeout(timeout);
-      resolveLocal({ stdout: "", status: null });
+      settleLocal({ stdout: "", status: null });
     });
     child.on("error", () => {
       clearTimeout(timeout);
-      resolveLocal({ stdout: "", status: null });
+      settleLocal({ stdout: "", status: null });
     });
     child.on("close", (status) => {
       clearTimeout(timeout);
-      resolveLocal({ stdout, status });
+      settleLocal({ stdout, status });
     });
   });
 }
@@ -306,12 +316,10 @@ export class NodeExecutionEnv implements ExecutionEnv {
       let stdout = "";
       let stderr = "";
       let settled = false;
-      let timedOut = false;
-      let callbackError: ExecutionError | undefined;
       let child: ReturnType<typeof spawn> | undefined;
       const timeoutRef: { current?: ReturnType<typeof setTimeout> } = {};
 
-      const onAbort = () => {
+      const killChild = () => {
         if (child?.pid) {
           killProcessTree(child.pid, { force: true });
         }
@@ -333,6 +341,18 @@ export class NodeExecutionEnv implements ExecutionEnv {
         resolvePromise(result);
       };
 
+      // Kill best-effort, then settle immediately so timeout/abort never wait on close.
+      const settleAfterKill = (
+        result: Result<{ stdout: string; stderr: string; exitCode: number }, ExecutionError>,
+      ) => {
+        killChild();
+        settle(result);
+      };
+
+      const onAbort = () => {
+        settleAfterKill(err(new ExecutionError("aborted", "aborted")));
+      };
+
       try {
         child = spawn(shellConfig.value.shell, [...shellConfig.value.args, command], {
           cwd,
@@ -352,10 +372,7 @@ export class NodeExecutionEnv implements ExecutionEnv {
         timeoutMs === undefined
           ? undefined
           : setTimeout(() => {
-              timedOut = true;
-              if (child?.pid) {
-                killProcessTree(child.pid, { force: true });
-              }
+              settleAfterKill(err(new ExecutionError("timeout", `timeout:${options?.timeout}`)));
             }, timeoutMs);
 
       if (options?.abortSignal) {
@@ -369,23 +386,27 @@ export class NodeExecutionEnv implements ExecutionEnv {
       child.stdout?.setEncoding("utf8");
       child.stderr?.setEncoding("utf8");
       child.stdout?.on("data", (chunk: string) => {
+        if (settled) {
+          return;
+        }
         stdout += chunk;
         try {
           options?.onStdout?.(chunk);
         } catch (error) {
           const cause = toErrorObject(error, "Non-Error thrown");
-          callbackError = new ExecutionError("callback_error", cause.message, cause);
-          onAbort();
+          settleAfterKill(err(new ExecutionError("callback_error", cause.message, cause)));
         }
       });
       child.stderr?.on("data", (chunk: string) => {
+        if (settled) {
+          return;
+        }
         stderr += chunk;
         try {
           options?.onStderr?.(chunk);
         } catch (error) {
           const cause = toErrorObject(error, "Non-Error thrown");
-          callbackError = new ExecutionError("callback_error", cause.message, cause);
-          onAbort();
+          settleAfterKill(err(new ExecutionError("callback_error", cause.message, cause)));
         }
       });
 
@@ -396,8 +417,7 @@ export class NodeExecutionEnv implements ExecutionEnv {
         if (settled) {
           return;
         }
-        onAbort();
-        settle(
+        settleAfterKill(
           err(new ExecutionError("spawn_error", `${stream} read error: ${error.message}`, error)),
         );
       };
@@ -408,16 +428,8 @@ export class NodeExecutionEnv implements ExecutionEnv {
       });
 
       child.on("close", (code) => {
-        if (callbackError) {
-          settle(err(callbackError));
-          return;
-        }
-        if (timedOut) {
-          settle(err(new ExecutionError("timeout", `timeout:${options?.timeout}`)));
-          return;
-        }
-        if (options?.abortSignal?.aborted) {
-          settle(err(new ExecutionError("aborted", "aborted")));
+        // Late close after timeout/abort/callback settle is ignored.
+        if (settled) {
           return;
         }
         settle(ok({ stdout, stderr, exitCode: code ?? 0 }));


### PR DESCRIPTION
## What Problem This Solves

`NodeExecutionEnv.exec()` treated timeout/abort as "kill the process tree", but the Promise only settled inside the child `close` handler (via `timedOut`/`callbackError`/abort flags). If kill failed, a child never exited, or — most commonly — a surviving detached grandchild kept the captured stdout pipe open, `close` was delayed or never fired, so a nominal timeout/abort could hang far past its deadline. The shell-discovery `runCommand()` helper had the same close-only settle gap.

## Why This Change Was Made

On timeout/abort (and callback/stream failures that force a kill), settle the Promise immediately after a best-effort kill via a single `settleAfterKill`/`settleLocal` guard. Ignore late `close`/`data` once settled, so callers always unbind within the timeout/abort contract regardless of grandchild survival or kill success.

## User Impact

**Before:** Agent harness shell exec could hang well past its timeout/abort when the child did not promptly emit `close` (e.g. a surviving grandchild holding stdout).

**After:** Timeout and abort settle the exec Promise immediately after best-effort kill; a late `close` is ignored.

## Evidence

- Changed: `packages/agent-core/src/harness/env/nodejs.ts`, `packages/agent-core/src/harness/env/nodejs.test.ts`
- Production caller path: `NodeExecutionEnv.exec` timeout/abort handlers → `settleAfterKill(...)` (and `runCommand` → `settleLocal(...)`).

## Real behavior proof

### Behavior or issue addressed

`exec()` timeout settles immediately after best-effort kill even when the spawned process tree keeps the captured stdout pipe open so the child's `close` event is delayed for seconds.

### Canonical reachability path

Caller → `NodeExecutionEnv.exec(command, { timeout })` → `setTimeout(() => settleAfterKill(err(new ExecutionError("timeout", …))), timeoutMs)` → `killChild()` (best-effort) + `settle(...)`; the `child.on("close")` handler now returns early when `settled` (`packages/agent-core/src/harness/env/nodejs.ts:341`).

### Real environment tested

Real process spawning (no spawn mock): the production `NodeExecutionEnv.exec` runs a real shell command that spawns a **detached grandchild** which inherits the exec's stdout pipe and lives 4000ms. A process-tree kill of the shell child cannot reap the detached grandchild, so the exec's `close` event is delayed until the grandchild exits (~4s). The exec timeout is set to 500ms. A separate negative-control spawns the same command directly and waits only for `close` (the pre-fix settle path) to measure the real delay. Node v22.23.1, Vitest.

### Exact steps or command run after this patch

```bash
# Real process-tree proof (fixed exec) + negative control (close-only wait):
node scripts/run-vitest.mjs packages/agent-core/src/harness/env/nodejs.real-timeout.proof.test.ts -- --reporter=verbose

# Committed deterministic regressions (mock child that never emits close):
node scripts/run-vitest.mjs packages/agent-core/src/harness/env/nodejs.test.ts -- \
  -t 'never emits close|race' --reporter=verbose
```

### Evidence after fix

Real process-tree behavior (production `NodeExecutionEnv.exec`, detached grandchild holds stdout 4000ms, timeout 500ms):

```text
  exec ok: false
  error code: timeout
  observed settle time: 504ms (timeout 500ms)
  grandchild lifetime (pre-fix close wait): 4000ms
ALL PROOF ASSERTIONS PASSED
 ✓ … > settles a timeout without waiting for a surviving grandchild to close stdout 587ms

  pre-fix close-only wait: 4142ms (killed child at 500ms)
 ✓ … > negative control: resolving only on `close` waits for the grandchild (~4s) 4152ms
```

Committed deterministic regressions:

```text
 ✓ … > settles timeout even when the child never emits close 87ms
 ✓ … > settles abort even when the child never emits close 1ms
 ✓ … > prefers the first of abort and timeout when both race 1ms
```

### Observed result after fix

With a 500ms timeout and a grandchild holding the stdout pipe for 4000ms, the production exec settles in 504ms with `error.code === "timeout"` — it does **not** wait for the grandchild. The negative control confirms the pre-fix hazard: resolving only on `close` (killing the shell child at 500ms) does not return until 4142ms, because the surviving grandchild keeps the pipe open. So the fix converts a ~4s (up to unbounded) hang into a prompt 500ms settle.

### What was not tested

Windows-specific kill/close semantics (proof ran on macOS); the committed mock-child regressions cover the platform-agnostic settle contract.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the settle-guard consolidation and the real process-tree proof output.
