### PR TITLE
fix(xai): idle-timeout stalled OAuth response bodies

### DIFF
--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -127,6 +127,37 @@ describe("xAI OAuth", () => {
     expect(refreshed.expires).toBe(121_000);
   });
 
+  it("times out when an xAI OAuth refresh response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"access_token":'));
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      const credential = {
+        type: "oauth",
+        provider: "xai",
+        access: "access-1",
+        refresh: "refresh-1",
+        expires: 100,
+        tokenEndpoint: "https://auth.x.ai/oauth2/token",
+      } satisfies OAuthCredential & { tokenEndpoint: string };
+
+      const pending = refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 });
+      const settled = expect(pending).rejects.toThrow("xAI OAuth response stalled for 30000ms");
+      await vi.advanceTimersByTimeAsync(30_060);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rediscovers the current token endpoint for stale xAI OAuth credentials", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
       if (requestUrl(url) === XAI_OAUTH_DISCOVERY_URL) {

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -120,8 +120,13 @@ function readStringRecord(value: unknown): Record<string, unknown> {
 }
 
 async function readResponseBody(response: Response): Promise<XaiOAuthResponseBody> {
+  // Fetch resolves after headers; keep the OAuth fetch deadline on the body so a
+  // stalled discovery/token stream cannot hang login or refresh.
   const buffer = await readResponseWithLimit(response, XAI_OAUTH_RESPONSE_MAX_BYTES, {
+    chunkTimeoutMs: XAI_OAUTH_FETCH_TIMEOUT_MS,
     onOverflow: ({ maxBytes }) => new Error(`xAI OAuth response exceeds ${maxBytes} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`xAI OAuth response stalled for ${chunkTimeoutMs}ms`),
   });
   const text = new TextDecoder().decode(buffer);
   let json: unknown;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where xAI OAuth discovery/token exchange/refresh could hang after headers when the response stalled mid-body. Fetch already used `XAI_OAUTH_FETCH_TIMEOUT_MS` for the request signal, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same OAuth fetch timeout through the body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching OpenAI/Google OAuth response-body idle bounds.

## User Impact

**Before:** A stalled xAI OAuth response body could hang login or refresh indefinitely after headers.

**After:** Stalled bodies fail closed within the OAuth fetch timeout so auth can surface an error.

## Evidence

- Changed: `extensions/xai/xai-oauth.ts`, `extensions/xai/xai-oauth.test.ts`
- Production caller path: `refreshXaiOAuthCredential` / device login → `readResponseBody` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

xAI OAuth body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`refreshXaiOAuthCredential` → `exchangeXaiOAuthToken` → `readResponseBody` → `readResponseWithLimit({ chunkTimeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts -t "times out when an xAI OAuth refresh response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when an xAI OAuth refresh response body stalls after headers 27ms
 Test Files  1 passed (1)
      Tests  1 passed | 16 skipped (17)
```

### Observed result after fix

Stalled refresh body rejects with `xAI OAuth response stalled for 30000ms`.

### What was not tested

Live stall against xAI's production OAuth endpoints.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the OAuth body idle bound and caller-path proof output.
