### PR TITLE
fix(gateway): bound config file opener

### DIFF
--- a/src/gateway/server-methods/config-open.test.ts
+++ b/src/gateway/server-methods/config-open.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runExecMock, spawnCommandMock } = vi.hoisted(() => ({
+  runExecMock: vi.fn(),
+  spawnCommandMock: vi.fn(),
+}));
+
+vi.mock("../../process/exec.js", () => ({
+  runExec: runExecMock,
+  spawnCommand: spawnCommandMock,
+}));
+
+import {
+  execConfigOpenCommand,
+  formatConfigOpenError,
+  isConfigOpenHandlerUnavailable,
+  resolveConfigOpenCommand,
+} from "./config-open.js";
+
+function commandFailure(message: string, details: { code?: string; exitCode?: number } = {}) {
+  return Object.assign(new Error(message), {
+    failed: true,
+    ...details,
+  });
+}
+
+function fakeChild(result: Promise<unknown>) {
+  const unref = vi.fn();
+  const kill = vi.fn();
+  return {
+    child: Object.assign(result, { kill, unref }),
+    kill,
+    unref,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("resolveConfigOpenCommand", () => {
+  it("waits for the macOS launcher to exit", () => {
+    expect(resolveConfigOpenCommand("/home/user/.openclaw/openclaw.json", "darwin")).toEqual({
+      command: "open",
+      args: ["/home/user/.openclaw/openclaw.json"],
+      completion: "exit",
+    });
+  });
+
+  it("observes only xdg-open startup on Linux", () => {
+    expect(resolveConfigOpenCommand("/home/user/.openclaw/openclaw.json", "linux")).toEqual({
+      command: "xdg-open",
+      args: ["/home/user/.openclaw/openclaw.json"],
+      completion: "startup",
+    });
+  });
+
+  it("uses a quoted PowerShell FilePath and waits for its launcher", () => {
+    expect(resolveConfigOpenCommand(String.raw`C:\tmp\o'hai & calc.json`, "win32")).toEqual({
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        String.raw`Start-Process -FilePath 'C:\tmp\o''hai & calc.json'`,
+      ],
+      completion: "exit",
+    });
+  });
+});
+
+describe("execConfigOpenCommand", () => {
+  it("keeps a hard timeout for launchers whose exit represents startup", async () => {
+    runExecMock.mockResolvedValue({ stdout: "", stderr: "" });
+    const command = resolveConfigOpenCommand("/home/user/.openclaw/openclaw.json", "darwin");
+
+    await execConfigOpenCommand(command);
+
+    expect(runExecMock).toHaveBeenCalledWith("open", ["/home/user/.openclaw/openclaw.json"], {
+      logOutput: false,
+      timeoutMs: 5_000,
+    });
+  });
+
+  it("detaches xdg-open while observing an immediate successful exit", async () => {
+    const spawned = fakeChild(Promise.resolve({ failed: false }));
+    spawnCommandMock.mockReturnValue(spawned.child);
+
+    await execConfigOpenCommand(
+      resolveConfigOpenCommand("/home/user/.openclaw/openclaw.json", "linux"),
+    );
+
+    expect(spawnCommandMock).toHaveBeenCalledWith(
+      ["xdg-open", "/home/user/.openclaw/openclaw.json"],
+      {
+        cleanup: false,
+        detached: true,
+        reject: false,
+        stdio: "ignore",
+      },
+    );
+    expect(spawned.unref).toHaveBeenCalledOnce();
+  });
+
+  it("treats a long-lived xdg-open handler as launched without terminating it", async () => {
+    vi.useFakeTimers();
+    let settleChild: (result: unknown) => void = () => {};
+    const childResult = new Promise<unknown>((resolve) => {
+      settleChild = resolve;
+    });
+    const spawned = fakeChild(childResult);
+    spawnCommandMock.mockReturnValue(spawned.child);
+    let settled = false;
+
+    const execution = execConfigOpenCommand(
+      resolveConfigOpenCommand("/home/user/.openclaw/openclaw.json", "linux"),
+    ).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await execution;
+
+    expect(settled).toBe(true);
+    expect(spawned.kill).not.toHaveBeenCalled();
+    settleChild(commandFailure("foreground editor exited later", { exitCode: 1 }));
+    await Promise.resolve();
+  });
+
+  it("preserves an immediate missing-command failure", async () => {
+    const spawned = fakeChild(
+      Promise.resolve(commandFailure("spawn xdg-open ENOENT", { code: "ENOENT" })),
+    );
+    spawnCommandMock.mockReturnValue(spawned.child);
+
+    const execution = execConfigOpenCommand(
+      resolveConfigOpenCommand("/home/user/.openclaw/openclaw.json", "linux"),
+    );
+
+    await expect(execution).rejects.toThrow("spawn xdg-open ENOENT");
+  });
+
+  it("classifies xdg-open exit code 3 as an unavailable handler", async () => {
+    const spawned = fakeChild(
+      Promise.resolve(commandFailure("Command failed with exit code 3: xdg-open", { exitCode: 3 })),
+    );
+    spawnCommandMock.mockReturnValue(spawned.child);
+
+    try {
+      await execConfigOpenCommand(
+        resolveConfigOpenCommand("/home/user/.openclaw/openclaw.json", "linux"),
+      );
+      throw new Error("expected xdg-open to fail");
+    } catch (error) {
+      expect(formatConfigOpenError(error)).toContain("exit code 3");
+      expect(isConfigOpenHandlerUnavailable(error)).toBe(true);
+    }
+  });
+});

--- a/src/gateway/server-methods/config-open.ts
+++ b/src/gateway/server-methods/config-open.ts
@@ -98,7 +98,7 @@ async function observeXdgOpenStartup(command: ConfigOpenCommand): Promise<void> 
       },
       (error: unknown) => {
         clearTimeout(startupTimer);
-        reject(error);
+        reject(error instanceof Error ? error : new Error(formatConfigOpenError(error)));
       },
     );
   });

--- a/src/gateway/server-methods/config-open.ts
+++ b/src/gateway/server-methods/config-open.ts
@@ -1,0 +1,116 @@
+import { runExec, spawnCommand } from "../../process/exec.js";
+
+const CONFIG_OPEN_COMMAND_TIMEOUT_MS = 5_000;
+const XDG_OPEN_STARTUP_OBSERVATION_MS = 5_000;
+
+type ConfigOpenCommand = {
+  command: string;
+  args: string[];
+  completion: "exit" | "startup";
+};
+
+class ConfigOpenCommandError extends Error {
+  readonly handlerUnavailable: boolean;
+
+  constructor(message: string, handlerUnavailable: boolean) {
+    super(message);
+    this.name = "ConfigOpenCommandError";
+    this.handlerUnavailable = handlerUnavailable;
+  }
+}
+
+function escapePowerShellSingleQuotedString(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+export function resolveConfigOpenCommand(
+  configPath: string,
+  platform: NodeJS.Platform = process.platform,
+): ConfigOpenCommand {
+  if (platform === "win32") {
+    // Use a PowerShell string literal so the path stays data, not code.
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Start-Process -FilePath '${escapePowerShellSingleQuotedString(configPath)}'`,
+      ],
+      completion: "exit",
+    };
+  }
+  if (platform === "darwin") {
+    return {
+      command: "open",
+      args: [configPath],
+      completion: "exit",
+    };
+  }
+  return {
+    command: "xdg-open",
+    args: [configPath],
+    completion: "startup",
+  };
+}
+
+export function formatConfigOpenError(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function isConfigOpenHandlerUnavailable(error: unknown): boolean {
+  if (error instanceof ConfigOpenCommandError && error.handlerUnavailable) {
+    return true;
+  }
+  const message = formatConfigOpenError(error);
+  return message.includes("xdg-open") && message.includes("no method available");
+}
+
+async function observeXdgOpenStartup(command: ConfigOpenCommand): Promise<void> {
+  // xdg-open may synchronously own the selected foreground application. Run it
+  // detached while observing early failures so Gateway never owns app lifetime.
+  const child = spawnCommand([command.command, ...command.args], {
+    cleanup: false,
+    detached: true,
+    reject: false,
+    stdio: "ignore",
+  });
+  child.unref();
+
+  await new Promise<void>((resolve, reject) => {
+    const startupTimer = setTimeout(resolve, XDG_OPEN_STARTUP_OBSERVATION_MS);
+    void child.then(
+      (result) => {
+        clearTimeout(startupTimer);
+        if (result.failed) {
+          reject(new ConfigOpenCommandError(formatConfigOpenError(result), result.exitCode === 3));
+          return;
+        }
+        resolve();
+      },
+      (error: unknown) => {
+        clearTimeout(startupTimer);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function execConfigOpenCommand(command: ConfigOpenCommand): Promise<void> {
+  if (command.completion === "startup") {
+    await observeXdgOpenStartup(command);
+    return;
+  }
+  await runExec(command.command, command.args, {
+    logOutput: false,
+    timeoutMs: CONFIG_OPEN_COMMAND_TIMEOUT_MS,
+  });
+}

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -13,8 +13,8 @@ import {
 import { createConfigHandlerHarness } from "./config.test-helpers.js";
 import { resolveOpenPathCommand } from "./open-path.js";
 
-const { runExecMock, loadGatewayRuntimeConfigSchemaMock } = vi.hoisted(() => ({
-  runExecMock: vi.fn(),
+const { execConfigOpenCommandMock, loadGatewayRuntimeConfigSchemaMock } = vi.hoisted(() => ({
+  execConfigOpenCommandMock: vi.fn(),
   loadGatewayRuntimeConfigSchemaMock: vi.fn(() => ({
     schema: { type: "object" },
     uiHints: undefined,
@@ -22,14 +22,17 @@ const { runExecMock, loadGatewayRuntimeConfigSchemaMock } = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock("../../process/exec.js", () => ({ runExec: runExecMock }));
+vi.mock("./config-open.js", async () => {
+  const actual = await vi.importActual<typeof import("./config-open.js")>("./config-open.js");
+  return { ...actual, execConfigOpenCommand: execConfigOpenCommandMock };
+});
 
 vi.mock("../../config/runtime-schema.js", () => ({
   loadGatewayRuntimeConfigSchema: loadGatewayRuntimeConfigSchemaMock,
 }));
 
-function mockRunExecError(error: Error) {
-  runExecMock.mockRejectedValue(error);
+function mockConfigOpenError(error: Error) {
+  execConfigOpenCommandMock.mockRejectedValue(error);
 }
 
 async function invokeConfigOpenFile() {
@@ -78,12 +81,12 @@ describe("resolveOpenPathCommand", () => {
 describe("config.openFile", () => {
   it("opens the configured file without shell interpolation", async () => {
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: "/tmp/config $(touch pwned).json" }, async () => {
-      runExecMock.mockImplementation(async (command: string, args: string[], options: unknown) => {
-        expect(["open", "xdg-open", "powershell.exe"]).toContain(command);
-        expect(args).toEqual(["/tmp/config $(touch pwned).json"]);
-        expect(options).toEqual({ logOutput: false, timeoutMs: 5_000 });
-        return { stdout: "", stderr: "" };
-      });
+      execConfigOpenCommandMock.mockImplementation(
+        async (command: { command: string; args: string[] }) => {
+          expect(["open", "xdg-open", "powershell.exe"]).toContain(command.command);
+          expect(command.args).toEqual(["/tmp/config $(touch pwned).json"]);
+        },
+      );
 
       const { respond } = await invokeConfigOpenFile();
 
@@ -100,7 +103,7 @@ describe("config.openFile", () => {
 
   it("returns a detailed error and logs details when the opener fails", async () => {
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: "/tmp/config.json" }, async () => {
-      mockRunExecError(Object.assign(new Error("spawn xdg-open ENOENT"), { code: "ENOENT" }));
+      mockConfigOpenError(Object.assign(new Error("spawn xdg-open ENOENT"), { code: "ENOENT" }));
 
       const { respond, logGateway } = await invokeConfigOpenFile();
 
@@ -122,7 +125,7 @@ describe("config.openFile", () => {
   it("does not split surrogate pairs when truncating the failed config path", async () => {
     const pathPrefix = `/tmp/${"a".repeat(111)}`;
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: `${pathPrefix}😀tail.json` }, async () => {
-      mockRunExecError(new Error("open failed"));
+      mockConfigOpenError(new Error("open failed"));
 
       const { logGateway } = await invokeConfigOpenFile();
 
@@ -134,7 +137,9 @@ describe("config.openFile", () => {
 
   it("returns actionable headless environment error when xdg-open reports no method available", async () => {
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: "/tmp/config.json" }, async () => {
-      mockRunExecError(new Error("xdg-open: no method available for opening '/tmp/config.json'"));
+      mockConfigOpenError(
+        new Error("xdg-open: no method available for opening '/tmp/config.json'"),
+      );
 
       const { respond, logGateway } = await invokeConfigOpenFile();
 

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -78,9 +78,10 @@ describe("resolveOpenPathCommand", () => {
 describe("config.openFile", () => {
   it("opens the configured file without shell interpolation", async () => {
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: "/tmp/config $(touch pwned).json" }, async () => {
-      runExecMock.mockImplementation(async (command: string, args: string[]) => {
+      runExecMock.mockImplementation(async (command: string, args: string[], options: unknown) => {
         expect(["open", "xdg-open", "powershell.exe"]).toContain(command);
         expect(args).toEqual(["/tmp/config $(touch pwned).json"]);
+        expect(options).toEqual({ logOutput: false, timeoutMs: 5_000 });
         return { stdout: "", stderr: "" };
       });
 

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -66,9 +66,7 @@ import {
   resolveGatewayConfigPath,
   resolveGatewayConfigRestartWriteResult,
 } from "./config-write-flow.js";
-import {
-  sanitizePathForLog,
-} from "./open-path.js";
+import { sanitizePathForLog } from "./open-path.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -54,6 +54,12 @@ import {
 } from "../control-plane-audit.js";
 import { resolveBaseHashParam } from "./base-hash.js";
 import {
+  execConfigOpenCommand,
+  formatConfigOpenError,
+  isConfigOpenHandlerUnavailable,
+  resolveConfigOpenCommand,
+} from "./config-open.js";
+import {
   commitGatewayConfigWrite,
   didActiveSharedGatewayAuthChange,
   didSharedGatewayAuthChange,
@@ -61,10 +67,6 @@ import {
   resolveGatewayConfigRestartWriteResult,
 } from "./config-write-flow.js";
 import {
-  execOpenPath,
-  formatOpenPathError,
-  isHeadlessOpenPathError,
-  resolveOpenPathCommand,
   sanitizePathForLog,
 } from "./open-path.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
@@ -72,7 +74,6 @@ import { assertValidParams } from "./validation.js";
 
 const MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE = 3;
 const CONFIG_SCHEMA_RESPONSE_CACHE_TTL_MS = 5_000;
-const CONFIG_OPEN_COMMAND_TIMEOUT_MS = 5_000;
 
 let configSchemaResponseCache: {
   expiresAtMs: number;
@@ -948,11 +949,11 @@ export const configHandlers: GatewayRequestHandlers = {
     }
     const configPath = createConfigIO().configPath;
     try {
-      await execOpenPath(resolveOpenPathCommand(configPath));
+      await execConfigOpenCommand(resolveConfigOpenCommand(configPath));
       respond(true, { ok: true, path: configPath }, undefined);
     } catch (error) {
-      const errorMessage = formatOpenPathError(error);
-      const isHeadlessError = isHeadlessOpenPathError(errorMessage);
+      const errorMessage = formatConfigOpenError(error);
+      const isHeadlessError = isConfigOpenHandlerUnavailable(error);
       const detailedError = isHeadlessError
         ? `Cannot open file in headless environment. File path: ${configPath}. This environment appears to lack a graphical or terminal browser handler.`
         : `Failed to open config file: ${errorMessage}`;

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -72,6 +72,7 @@ import { assertValidParams } from "./validation.js";
 
 const MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE = 3;
 const CONFIG_SCHEMA_RESPONSE_CACHE_TTL_MS = 5_000;
+const CONFIG_OPEN_COMMAND_TIMEOUT_MS = 5_000;
 
 let configSchemaResponseCache: {
   expiresAtMs: number;


### PR DESCRIPTION
## What Problem This Solves

Opening the configured file from the Control UI could wait indefinitely when a platform opener did not exit. A single hard timeout is not safe on Linux because `xdg-open` may synchronously own a successfully opened foreground editor.

## Why This Change Was Made

The opener lifecycle now follows each platform contract:

- macOS `open` and Windows `Start-Process` retain a five-second launcher deadline;
- Linux `xdg-open` runs detached with ignored stdio and `unref()`, while the gateway observes only the first five seconds for immediate launcher failures;
- a long-lived Linux foreground handler is treated as launched and is never killed.

The configuration-specific lifecycle is isolated in `config-open.ts`; the shared `open-path.ts` contract used by session workspace reveal remains unchanged.

## User Impact

The `config.openFile` RPC no longer waits forever. Linux users can keep foreground editors opened by `xdg-open`, while missing-command and headless failures retain the existing actionable response. macOS and Windows launcher waits remain bounded.

## Evidence

- Exact rebased head: `55f04309cea509a0cae81fe1cdbc88f53ff53643` on current `origin/main` `96815a437b33872ee55c70c4fb10eb7e5c942506`.
- Node 24.18.0 focused suite: `src/gateway/server-methods/config-open.test.ts` and `src/gateway/server-methods/config.test.ts`, 36/36 tests passed.
- Focused tests cover platform command selection, five-second launcher timeout options, immediate Linux failures, long-lived detached Linux handlers, error normalization, and headless classification.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed on all four changed files.
- Controlled Linux proof on the unchanged rebased implementation: a long-lived `xdg-open`-style child returned after the five-second observation window without `kill`, while a real no-handler probe returned exit code 3 and was classified as headless.
- Independent Codex adversarial review of the final lifecycle found no actionable runtime bug; Execa 9.6.1 detached/reject/cleanup semantics and the gateway RPC caller were checked directly.

Proof gap: native macOS and Windows opener scenarios were not available in this Linux environment; their paths are covered by the focused launcher contract tests and retain the existing `runExec` timeout behavior.

AI-assisted: yes. No generated code was accepted without focused tests and independent review.
