### PR TITLE
fix(daemon): bound Node runtime probes

### DIFF
--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -219,7 +219,7 @@ describe("resolvePreferredNodePath", () => {
     expect(execFile).toHaveBeenCalledWith(
       darwinNode,
       ["-e", expect.stringContaining("SELECT sqlite_version() AS version")],
-      { encoding: "utf8" },
+      { encoding: "utf8", timeoutMs: 5_000 },
     );
   });
 
@@ -462,7 +462,7 @@ describe("resolveSystemNodeInfo", () => {
     expect(execFile).toHaveBeenCalledWith(
       homebrewOptNode,
       ["-e", expect.stringContaining("SELECT sqlite_version() AS version")],
-      { encoding: "utf8" },
+      { encoding: "utf8", timeoutMs: 5_000 },
     );
   });
 

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -75,11 +75,13 @@ function buildSystemNodeCandidates(
 type ExecFileAsync = (
   file: string,
   args: readonly string[],
-  options: { encoding: "utf8" },
+  options: { encoding: "utf8"; timeoutMs: number },
 ) => Promise<{ stdout: string; stderr: string }>;
 
-const execFileAsync: ExecFileAsync = async (file, args) =>
-  await runExec(file, [...args], { logOutput: false });
+const NODE_RUNTIME_PROBE_TIMEOUT_MS = 5_000;
+
+const execFileAsync: ExecFileAsync = async (file, args, options) =>
+  await runExec(file, [...args], { logOutput: false, timeoutMs: options.timeoutMs });
 
 const NODE_RUNTIME_PROBE = String.raw`
 let sqliteVersion = null;
@@ -108,6 +110,7 @@ async function resolveNodeRuntimeInfo(
   try {
     const { stdout } = await execFileImpl(nodePath, ["-e", NODE_RUNTIME_PROBE], {
       encoding: "utf8",
+      timeoutMs: NODE_RUNTIME_PROBE_TIMEOUT_MS,
     });
     const parsed = JSON.parse(stdout) as {
       nodeVersion?: unknown;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where daemon install and doctor flows could wait indefinitely while inspecting a candidate Node executable that never returned. This is an existing unbounded wait in the current code, not a regression introduced by #106495.

## Why This Change Was Made

Each existing Node runtime capability probe now receives a five-second deadline through the shared process runner. Probe failures keep the current unsupported-candidate result, so candidate selection and fallback behavior remain unchanged.

## User Impact

A nonresponsive Node candidate can no longer block runtime discovery forever. Install and diagnostic flows can reject that candidate and continue through the existing selection behavior.

## Evidence

- Node v24.15.0: `node scripts/run-vitest.mjs src/daemon/runtime-paths.test.ts` - 30 tests passed.
- `oxlint --type-aware --tsconfig config/tsconfig/oxlint.core.json` on both touched files - passed.
- `oxfmt --check` on both touched files - passed.
- `git diff --check origin/main...HEAD` - passed.

AI-assisted: yes. The change and its focused caller/fallback paths were reviewed before submission.