### PR TITLE
fix(anthropic): idle-timeout stalled OAuth response bodies

### DIFF
--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -123,6 +123,35 @@ describe("Anthropic OAuth token responses", () => {
     expect(pullCount).toBeLessThanOrEqual(2);
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it("times out when an Anthropic token refresh response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode('{"access_token":'));
+                },
+              }),
+              { status: 200 },
+            ),
+        ),
+      );
+
+      const pending = refreshThroughAnthropicProvider("old-refresh-token");
+      const settled = expect(pending).rejects.toThrow(
+        "Anthropic OAuth response stalled for 30000ms",
+      );
+      await vi.advanceTimersByTimeAsync(30_060);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("Anthropic OAuth callback host", () => {

--- a/src/llm/utils/oauth/anthropic.ts
+++ b/src/llm/utils/oauth/anthropic.ts
@@ -247,8 +247,13 @@ async function postJson(
     signal: buildOAuthRequestSignal({ signal: options.signal, timeoutMs }),
   });
 
+  // Fetch resolves after headers; keep the request deadline on the body so a
+  // stalled OAuth token stream cannot hang login or refresh.
   const buffer = await readResponseWithLimit(response, OAUTH_RESPONSE_MAX_BYTES, {
+    chunkTimeoutMs: timeoutMs,
     onOverflow: ({ size }) => new Error(`Anthropic OAuth response too large: ${size} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`Anthropic OAuth response stalled for ${chunkTimeoutMs}ms`),
   });
   const responseBody = new TextDecoder().decode(buffer);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Anthropic OAuth token exchange/refresh could hang after headers when the response stalled mid-body. `postJson` already applied `timeoutMs` to the request signal, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same request `timeoutMs` through the body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching OpenAI/Google/xAI OAuth response-body idle bounds.

## User Impact

**Before:** A stalled Anthropic OAuth response body could hang login or refresh indefinitely after headers.

**After:** Stalled bodies fail closed within the request timeout so OAuth can surface an error.

## Evidence

- Changed: `src/llm/utils/oauth/anthropic.ts`, `src/llm/utils/oauth/anthropic.test.ts`
- Production caller path: `anthropicOAuthProvider.refreshToken` → `postJson` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Anthropic OAuth body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`refreshThroughAnthropicProvider` → `postJson` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/llm/utils/oauth/anthropic.test.ts -t "times out when an Anthropic token refresh response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when an Anthropic token refresh response body stalls after headers 189ms
 Test Files  1 passed (1)
      Tests  1 passed | 7 skipped (8)
```

### Observed result after fix

Stalled refresh body rejects with `Anthropic OAuth response stalled for 30000ms`.

### What was not tested

Live stall against Anthropic's production OAuth token endpoint.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the OAuth body idle bound and caller-path proof output.
