### PR TITLE
fix(browser): idle-timeout stalled control response bodies

### DIFF
--- a/extensions/browser/src/browser/client-fetch.timeout.test.ts
+++ b/extensions/browser/src/browser/client-fetch.timeout.test.ts
@@ -63,4 +63,34 @@ describe("fetchBrowserJson timeout forwarding", () => {
       }),
     );
   });
+
+  it("times out when a success response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"ok":'));
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        finalUrl: browserControlUrl,
+        release,
+      });
+
+      const pending = fetchBrowserJson(browserControlUrl, { timeoutMs: 50 });
+      const settled = expect(pending).rejects.toMatchObject({
+        name: "BrowserServiceError",
+        message: "Browser control response stalled for 50ms",
+      });
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -302,9 +302,12 @@ async function fetchHttpJson<T>(
         );
       }
       // Overflow cancels the stream and releases its reader lock before the guarded fetch below.
-      const body = await readResponseWithLimit(res, BROWSER_ERROR_BODY_LIMIT_BYTES).catch(
-        () => undefined,
-      );
+      // Idle-timeout error bodies too so a stalled failure payload cannot hang the client.
+      const body = await readResponseWithLimit(res, BROWSER_ERROR_BODY_LIMIT_BYTES, {
+        chunkTimeoutMs: timeoutMs,
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new BrowserServiceError(`Browser control error response stalled for ${chunkTimeoutMs}ms`),
+      }).catch(() => undefined);
       const text = body ? new TextDecoder().decode(body) : "";
       let parsed: unknown;
       if (text) {
@@ -316,9 +319,14 @@ async function fetchHttpJson<T>(
       }
       throw browserServiceErrorFromPayload(parsed, text || `HTTP ${res.status}`, res.status);
     }
+    // fetchWithSsrFGuard resolves after headers; keep the request deadline on the
+    // success body so a stalled control JSON stream cannot hang browser tools.
     const body = await readResponseWithLimit(res, BROWSER_SUCCESS_BODY_LIMIT_BYTES, {
+      chunkTimeoutMs: timeoutMs,
       onOverflow: ({ maxBytes }) =>
         new BrowserServiceError(`Browser control response exceeded ${maxBytes} bytes`),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new BrowserServiceError(`Browser control response stalled for ${chunkTimeoutMs}ms`),
     });
     return JSON.parse(new TextDecoder().decode(body)) as T;
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where browser-control JSON fetches could hang after headers when the success (or error) response stalled mid-body. `fetchHttpJson` already applied `timeoutMs` to the guarded fetch and AbortController, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same resolved request `timeoutMs` through success and error body reads as `chunkTimeoutMs`, with explicit stalled-body `BrowserServiceError`s, matching other OpenClaw response-body idle bounds.

## User Impact

**Before:** A stalled browser-control response body could hang browser tools indefinitely after headers.

**After:** Stalled bodies fail closed within the request timeout so browser tools can surface an error.

## Evidence

- Changed: `extensions/browser/src/browser/client-fetch.ts`, `extensions/browser/src/browser/client-fetch.timeout.test.ts`
- Production caller path: `fetchBrowserJson` → `fetchHttpJson` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Browser-control success-body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`fetchBrowserJson` → `fetchHttpJson` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/client-fetch.timeout.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a success response body stalls after headers 6ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
[test] passed 1 Vitest shard in 35.76s
```

### Observed result after fix

Stalled success body rejects with `Browser control response stalled for 50ms`; `release()` still runs.

### What was not tested

Live stall against a real browser-control peer.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the browser-control body idle bound and caller-path proof output.
