### PR TITLE
fix(voice-call): idle-timeout stalled provider response bodies

### DIFF
--- a/extensions/voice-call/src/providers/shared/response-body.test.ts
+++ b/extensions/voice-call/src/providers/shared/response-body.test.ts
@@ -1,0 +1,28 @@
+// Voice Call tests cover shared provider response-body idle bounds.
+import { describe, expect, it, vi } from "vitest";
+import { readProviderJsonResponseText } from "./response-body.js";
+
+describe("readProviderJsonResponseText idle timeout", () => {
+  it("times out when a provider JSON response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = readProviderJsonResponseText(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"sid":'));
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      const settled = expect(pending).rejects.toThrow(
+        "provider response body stalled: no data received for 30000ms",
+      );
+      await vi.advanceTimersByTimeAsync(30_060);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/voice-call/src/providers/shared/response-body.ts
+++ b/extensions/voice-call/src/providers/shared/response-body.ts
@@ -6,6 +6,9 @@ import {
 
 const PROVIDER_JSON_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 const PROVIDER_ERROR_RESPONSE_MAX_BYTES = 8 * 1024;
+// Matches guardedJsonApiRequest's fetch timeout so stalled bodies cannot hang
+// after headers when the shared reader is used outside that client.
+const PROVIDER_RESPONSE_IDLE_TIMEOUT_MS = 30_000;
 const TRUNCATED_SUFFIX = "... [truncated]";
 
 type ReadProviderResponseTextParams = {
@@ -25,14 +28,23 @@ function appendTruncatedSuffix(text: string): string {
 async function readProviderResponseTextWithLimit(
   params: ReadProviderResponseTextParams,
 ): Promise<string> {
+  const chunkTimeoutMs = PROVIDER_RESPONSE_IDLE_TIMEOUT_MS;
+  const onIdleTimeout = ({ chunkTimeoutMs: idleMs }: { chunkTimeoutMs: number }) =>
+    new Error(`provider response body stalled: no data received for ${idleMs}ms`);
+
   if (params.truncateOnLimit) {
-    const prefix = await readResponseTextPrefix(params.response, params.maxBytes);
+    const prefix = await readResponseTextPrefix(params.response, params.maxBytes, {
+      chunkTimeoutMs,
+      onIdleTimeout,
+    });
     return prefix.truncated ? appendTruncatedSuffix(prefix.text) : prefix.text;
   }
 
   const body = await readResponseWithLimit(params.response, params.maxBytes, {
+    chunkTimeoutMs,
     onOverflow: ({ size, maxBytes }) =>
       new Error(`provider response body too large: ${size} bytes (limit: ${maxBytes} bytes)`),
+    onIdleTimeout,
   });
   return new TextDecoder().decode(body);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where voice-call provider JSON/error body reads could hang after headers when the response stalled mid-body. Shared readers already byte-capped bodies, but used `readResponseWithLimit` / `readResponseTextPrefix` without `chunkTimeoutMs`.

## Why This Change Was Made

Apply the same 30s idle bound used by `guardedJsonApiRequest`'s fetch timeout to shared provider body readers, with an explicit stalled-body error, matching other OpenClaw response-body idle bounds.

## User Impact

**Before:** A stalled Twilio/Telnyx/etc. provider response body could hang voice-call API calls indefinitely after headers.

**After:** Stalled bodies fail closed within 30s so provider calls can surface an error.

## Evidence

- Changed: `extensions/voice-call/src/providers/shared/response-body.ts`, `extensions/voice-call/src/providers/shared/response-body.test.ts`
- Production caller path: `guardedJsonApiRequest` / Twilio API → `readProviderJsonResponseText` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Shared voice-call provider JSON body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`guardedJsonApiRequest` → `readProviderJsonResponseText` → `readResponseWithLimit({ chunkTimeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/voice-call/src/providers/shared/response-body.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a provider JSON response body stalls after headers 463ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
[test] passed 1 Vitest shard in 5.73s
```

### Observed result after fix

Stalled JSON body rejects with `provider response body stalled: no data received for 30000ms`.

### What was not tested

Live stall against a real voice-call provider API.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the shared reader idle bound and caller-path proof output.
