### PR TITLE
fix(e2e): bound docker package-install and compose readiness probes

### DIFF
--- a/scripts/e2e/compose-setup.sh
+++ b/scripts/e2e/compose-setup.sh
@@ -11,11 +11,27 @@ PROJECT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-compose-proof.XXXXXX")"
 PROJECT_NAME="openclaw-compose-proof-$$"
 CLI_NAME="$PROJECT_NAME-cli-proof"
 TOKEN="compose-proof-$$-$(date +%s)"
-COMPOSE=(docker compose --project-name "$PROJECT_NAME" --project-directory "$PROJECT_DIR" -f "$ROOT_DIR/docker-compose.yml")
+HEALTH_DEADLINE_SECONDS="${OPENCLAW_DOCKER_COMPOSE_SETUP_HEALTH_DEADLINE_SECONDS:-180}"
+COMPOSE_BASE=(compose --project-name "$PROJECT_NAME" --project-directory "$PROJECT_DIR" -f "$ROOT_DIR/docker-compose.yml")
+
+compose_e2e_cmd() {
+  local timeout_value="${DOCKER_COMMAND_TIMEOUT:-600s}"
+  DOCKER_COMMAND_TIMEOUT="$timeout_value" docker_e2e_docker_cmd "${COMPOSE_BASE[@]}" "$@"
+}
+
+compose_e2e_remaining_timeout() {
+  local deadline_at="$1"
+  local remaining=$((deadline_at - SECONDS))
+  if [ "$remaining" -lt 1 ]; then
+    remaining=1
+  fi
+  printf '%ss' "$remaining"
+}
 
 cleanup() {
   docker_e2e_docker_cmd rm -f "$CLI_NAME" >/dev/null 2>&1 || true
-  "${COMPOSE[@]}" down --remove-orphans --volumes >/dev/null 2>&1 || true
+  DOCKER_COMMAND_TIMEOUT="${OPENCLAW_DOCKER_COMPOSE_SETUP_CLEANUP_TIMEOUT:-120s}" \
+    compose_e2e_cmd down --remove-orphans --volumes >/dev/null 2>&1 || true
   docker_e2e_cleanup_package_tgz "$PACKAGE_TGZ"
   rm -rf "$PROJECT_DIR"
 }
@@ -47,33 +63,37 @@ export OPENCLAW_CURRENT_PACKAGE_TGZ="$PACKAGE_TGZ"
 docker_e2e_build_or_reuse "$IMAGE_NAME" compose-setup "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" functional
 
 echo "Launching documented Docker Compose gateway topology..."
-"${COMPOSE[@]}" up -d --no-build openclaw-gateway
-GATEWAY_ID="$("${COMPOSE[@]}" ps -q openclaw-gateway)"
+compose_e2e_cmd up -d --no-build openclaw-gateway
+GATEWAY_ID="$(compose_e2e_cmd ps -q openclaw-gateway)"
 if [ -z "$GATEWAY_ID" ]; then
   echo "Compose did not create openclaw-gateway" >&2
   exit 1
 fi
 
-for _ in $(seq 1 180); do
-  health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$GATEWAY_ID")"
+HEALTH_DEADLINE_AT=$((SECONDS + HEALTH_DEADLINE_SECONDS))
+health=""
+while [ "$SECONDS" -lt "$HEALTH_DEADLINE_AT" ]; do
+  probe_timeout="$(compose_e2e_remaining_timeout "$HEALTH_DEADLINE_AT")"
+  health="$(DOCKER_COMMAND_TIMEOUT="$probe_timeout" docker_e2e_docker_cmd inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$GATEWAY_ID" 2>/dev/null || echo unknown)"
   if [ "$health" = "healthy" ]; then
     break
   fi
   if [ "$health" = "unhealthy" ] || [ "$health" = "exited" ] || [ "$health" = "dead" ]; then
-    "${COMPOSE[@]}" logs --no-color openclaw-gateway >&2
+    DOCKER_COMMAND_TIMEOUT="$probe_timeout" compose_e2e_cmd logs --no-color openclaw-gateway >&2 || true
     exit 1
   fi
   sleep 1
 done
-if [ "$(docker inspect --format '{{.State.Health.Status}}' "$GATEWAY_ID")" != "healthy" ]; then
-  "${COMPOSE[@]}" logs --no-color openclaw-gateway >&2
+FINAL_TIMEOUT="$(compose_e2e_remaining_timeout "$HEALTH_DEADLINE_AT")"
+if [ "$(DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" docker_e2e_docker_cmd inspect --format '{{.State.Health.Status}}' "$GATEWAY_ID")" != "healthy" ]; then
+  DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" compose_e2e_cmd logs --no-color openclaw-gateway >&2 || true
   echo "Compose gateway did not become healthy" >&2
   exit 1
 fi
 
-"${COMPOSE[@]}" exec -T openclaw-gateway node dist/index.js health --token "$TOKEN"
-"${COMPOSE[@]}" run -T --no-deps --name "$CLI_NAME" openclaw-cli health --token "$TOKEN"
-GATEWAY_VERSION="$("${COMPOSE[@]}" exec -T openclaw-gateway node -p "require('./package.json').version")"
+DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" compose_e2e_cmd exec -T openclaw-gateway node dist/index.js health --token "$TOKEN"
+DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" compose_e2e_cmd run -T --no-deps --name "$CLI_NAME" openclaw-cli health --token "$TOKEN"
+GATEWAY_VERSION="$(DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" compose_e2e_cmd exec -T openclaw-gateway node -p "require('./package.json').version")"
 
 node --import tsx "$ROOT_DIR/scripts/e2e/lib/docker-artifact-proof/write-identities.ts" \
   --scenario compose-setup \

--- a/scripts/e2e/docker-package-install.sh
+++ b/scripts/e2e/docker-package-install.sh
@@ -9,12 +9,22 @@ PACKAGE_TGZ="$(docker_e2e_prepare_package_tgz docker-package-install "${OPENCLAW
 IDENTITY_PATH="${OPENCLAW_DOCKER_ARTIFACT_IDENTITY_PATH:-$ROOT_DIR/.artifacts/docker-tests/docker-package-install-identities.json}"
 CONTAINER_NAME="openclaw-package-proof-$$"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_DOCKER_PACKAGE_INSTALL_RUN_TIMEOUT:-120s}"
+READY_DEADLINE_SECONDS="${OPENCLAW_DOCKER_PACKAGE_INSTALL_READY_DEADLINE_SECONDS:-240}"
 
 cleanup() {
   docker_e2e_docker_cmd rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
   docker_e2e_cleanup_package_tgz "$PACKAGE_TGZ"
 }
 trap cleanup EXIT
+
+docker_e2e_remaining_timeout() {
+  local deadline_at="$1"
+  local remaining=$((deadline_at - SECONDS))
+  if [ "$remaining" -lt 1 ]; then
+    remaining=1
+  fi
+  printf '%ss' "$remaining"
+}
 
 docker_e2e_build_or_reuse "$IMAGE_NAME" docker-package-install "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" bare
 
@@ -34,21 +44,31 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
     exec sleep infinity
   ' >/dev/null
 
-for _ in $(seq 1 240); do
-  if docker exec "$CONTAINER_NAME" test -f /tmp/openclaw-proof-ready; then
+READY_DEADLINE_AT=$((SECONDS + READY_DEADLINE_SECONDS))
+ready=0
+while [ "$SECONDS" -lt "$READY_DEADLINE_AT" ]; do
+  probe_timeout="$(docker_e2e_remaining_timeout "$READY_DEADLINE_AT")"
+  if DOCKER_COMMAND_TIMEOUT="$probe_timeout" docker_e2e_docker_cmd exec "$CONTAINER_NAME" test -f /tmp/openclaw-proof-ready; then
+    ready=1
     break
   fi
-  if [ "$(docker inspect --format '{{.State.Running}}' "$CONTAINER_NAME")" != "true" ]; then
-    docker logs "$CONTAINER_NAME" >&2
+  if [ "$(DOCKER_COMMAND_TIMEOUT="$probe_timeout" docker_e2e_docker_cmd inspect --format '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || echo false)" != "true" ]; then
+    DOCKER_COMMAND_TIMEOUT="$probe_timeout" docker_e2e_docker_cmd logs "$CONTAINER_NAME" >&2 || true
     exit 1
   fi
   sleep 1
 done
-docker exec "$CONTAINER_NAME" test -f /tmp/openclaw-proof-ready
+FINAL_TIMEOUT="$(docker_e2e_remaining_timeout "$READY_DEADLINE_AT")"
+if [ "$ready" != "1" ]; then
+  DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" docker_e2e_docker_cmd logs "$CONTAINER_NAME" >&2 || true
+  echo "package install readiness deadline exceeded after ${READY_DEADLINE_SECONDS}s" >&2
+  exit 1
+fi
+DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" docker_e2e_docker_cmd exec "$CONTAINER_NAME" test -f /tmp/openclaw-proof-ready
 
-INSTALLED_VERSION="$(docker exec "$CONTAINER_NAME" cat /tmp/openclaw-version | tr -d '\r\n')"
+INSTALLED_VERSION="$(DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" docker_e2e_docker_cmd exec "$CONTAINER_NAME" cat /tmp/openclaw-version | tr -d '\r\n')"
 PACKAGE_ROOT="/tmp/openclaw-proof/lib/node_modules/openclaw"
-PACKAGE_VERSION="$(docker exec "$CONTAINER_NAME" node -p "require('$PACKAGE_ROOT/package.json').version")"
+PACKAGE_VERSION="$(DOCKER_COMMAND_TIMEOUT="$FINAL_TIMEOUT" docker_e2e_docker_cmd exec "$CONTAINER_NAME" node -p "require('$PACKAGE_ROOT/package.json').version")"
 if [[ "$INSTALLED_VERSION" != *"$PACKAGE_VERSION"* ]]; then
   echo "installed CLI output $INSTALLED_VERSION does not contain package version $PACKAGE_VERSION" >&2
   exit 1

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path, { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -3806,6 +3806,10 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     const composeRunner = readFileSync(COMPOSE_SETUP_E2E_PATH, "utf8");
     expect(composeRunner).not.toMatch(/(^|\n)\s*docker rm -f "\$CLI_NAME"/u);
     expect(composeRunner).toContain('docker_e2e_docker_cmd rm -f "$CLI_NAME"');
+    expect(composeRunner).toContain("compose_e2e_cmd");
+    expect(composeRunner).toContain("docker_e2e_docker_cmd inspect");
+    expect(composeRunner).not.toMatch(/(^|\n)\s*docker inspect /u);
+    expect(composeRunner).not.toMatch(/\$\{COMPOSE\[@\]\}/u);
 
     const packageRunner = readFileSync(DOCKER_PACKAGE_INSTALL_E2E_PATH, "utf8");
     expect(packageRunner).not.toMatch(/(^|\n)\s*docker rm -f "\$CONTAINER_NAME"/u);
@@ -3817,11 +3821,109 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
       'DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d',
     );
     expect(packageRunner).not.toMatch(/(^|\n)docker run -d/u);
+    expect(packageRunner).toContain("docker_e2e_remaining_timeout");
+    expect(packageRunner).toContain(
+      'DOCKER_COMMAND_TIMEOUT="$probe_timeout" docker_e2e_docker_cmd exec',
+    );
+    expect(packageRunner).not.toMatch(/(^|\n)\s*docker exec /u);
+    expect(packageRunner).not.toMatch(/(^|\n)\s*docker inspect /u);
     for (const runner of [composeRunner, packageRunner]) {
       expect(runner).toContain(
         'node --import tsx "$ROOT_DIR/scripts/e2e/lib/docker-artifact-proof/write-identities.ts"',
       );
     }
+  });
+
+  it("package-install readiness fails closed when a single docker exec stalls", () => {
+    const binDir = tempDirs.make("openclaw-package-install-stall-");
+    const dockerLog = join(binDir, "docker.log");
+    writeFileSync(
+      join(binDir, "timeout"),
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        'if [ "${1:-}" = "--kill-after=1s" ]; then exit 0; fi',
+        'kill_after=""; budget=""',
+        'while [ "$#" -gt 0 ]; do',
+        '  case "$1" in',
+        '    --kill-after=*) kill_after="${1#--kill-after=}"; shift ;;',
+        '    *s) budget="${1%s}"; shift; break ;;',
+        "    *) shift ;;",
+        "  esac",
+        "done",
+        '"$@" &',
+        "child=$!",
+        'sleep "$budget"',
+        'if kill -0 "$child" 2>/dev/null; then',
+        '  kill -TERM "$child" 2>/dev/null || true',
+        "  sleep 0.1",
+        '  kill -KILL "$child" 2>/dev/null || true',
+        '  wait "$child" 2>/dev/null || true',
+        "  exit 124",
+        "fi",
+        'wait "$child"',
+        "",
+      ].join("\n"),
+    );
+    chmodSync(join(binDir, "timeout"), 0o755);
+    writeFileSync(
+      join(binDir, "docker"),
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        `printf '%s\\n' "$*" >>${JSON.stringify(dockerLog)}`,
+        'if [ "${1:-}" = "exec" ]; then while true; do sleep 1; done; fi',
+        'if [ "${1:-}" = "inspect" ]; then echo true; exit 0; fi',
+        'if [ "${1:-}" = "logs" ]; then exit 0; fi',
+        'if [ "${1:-}" = "rm" ]; then exit 0; fi',
+        "exit 0",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(join(binDir, "docker"), 0o755);
+
+    // Drive only the readiness loop fragment with the production helpers sourced.
+    const script = [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `ROOT_DIR=${JSON.stringify(process.cwd())}`,
+      'source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"',
+      'CONTAINER_NAME="stall-proof"',
+      "READY_DEADLINE_SECONDS=3",
+      "docker_e2e_remaining_timeout() {",
+      '  local deadline_at="$1"',
+      "  local remaining=$((deadline_at - SECONDS))",
+      '  if [ "$remaining" -lt 1 ]; then remaining=1; fi',
+      "  printf '%ss' \"$remaining\"",
+      "}",
+      "READY_DEADLINE_AT=$((SECONDS + READY_DEADLINE_SECONDS))",
+      'while [ "$SECONDS" -lt "$READY_DEADLINE_AT" ]; do',
+      '  probe_timeout="$(docker_e2e_remaining_timeout "$READY_DEADLINE_AT")"',
+      '  if DOCKER_COMMAND_TIMEOUT="$probe_timeout" docker_e2e_docker_cmd exec "$CONTAINER_NAME" test -f /tmp/openclaw-proof-ready; then',
+      "    exit 0",
+      "  fi",
+      "  sleep 1",
+      "done",
+      'echo "package install readiness deadline exceeded" >&2',
+      "exit 1",
+      "",
+    ].join("\n");
+    const scriptPath = join(binDir, "ready-loop.sh");
+    writeFileSync(scriptPath, script);
+    chmodSync(scriptPath, 0o755);
+
+    const startedAt = Date.now();
+    const result = spawnSync("/bin/bash", [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("package install readiness deadline exceeded");
+    expect(readFileSync(dockerLog, "utf8")).toContain("exec stall-proof");
+    expect(Date.now() - startedAt).toBeLessThan(20_000);
   });
 
   it("routes the gateway network client through the timeout-aware run helper", () => {


### PR DESCRIPTION
## What Problem This Solves

The Docker package-install and Compose-setup readiness loops used raw `docker exec` / `docker inspect` / `docker logs` (and a raw `docker compose down` on cleanup) with **no per-command timeout**. A single stalled Docker daemon RPC could freeze the loop so the nominal 240s / 180s readiness deadline never advanced — the `for _ in $(seq 1 240)` counter loops assumed each probe returned promptly.

## Why This Change Was Made

Route every readiness probe, final check, compose up/ps/logs/exec/run/down, and inspect through the existing `docker_e2e_docker_cmd` timeout helper, and convert the fixed-count loops into `SECONDS`-based deadline loops that clamp each probe's `DOCKER_COMMAND_TIMEOUT` to the remaining wall-clock budget.

## User Impact

**Before:** One hung `docker exec`/`inspect` during package-install or compose health polling could stall the E2E job well past its intended readiness budget.

**After:** Each Docker probe is bounded by the remaining deadline; a stalled probe is killed, the loop advances, and the script fails closed within the overall readiness window. Compose cleanup `down` is also timeout-bounded.

## Evidence

- Changed: `scripts/e2e/docker-package-install.sh`, `scripts/e2e/compose-setup.sh`, `test/scripts/docker-build-helper.test.ts`
- Production caller path: package-install / compose-setup readiness loops → `DOCKER_COMMAND_TIMEOUT="$probe_timeout" docker_e2e_docker_cmd exec/inspect/...` (`scripts/e2e/docker-package-install.sh:47`).

## Real behavior proof

### Behavior or issue addressed

A stalled `docker exec` readiness probe is bounded by the production `docker_e2e_docker_cmd` timeout so the readiness loop fails closed at its deadline instead of blocking forever on the first hung probe.

### Canonical reachability path

`docker-package-install.sh` builds `READY_DEADLINE_AT=$((SECONDS + READY_DEADLINE_SECONDS))` and, each iteration, runs `DOCKER_COMMAND_TIMEOUT="$(docker_e2e_remaining_timeout "$READY_DEADLINE_AT")" docker_e2e_docker_cmd exec "$CONTAINER_NAME" test -f /tmp/openclaw-proof-ready`; `docker_e2e_docker_cmd` (`scripts/lib/docker-e2e-image.sh`) wraps the docker invocation in the host `timeout` with `DOCKER_COMMAND_TIMEOUT`.

### Real environment tested

Real shell execution of the production readiness loop with the production helper library sourced (`scripts/lib/docker-e2e-image.sh` → `docker_e2e_docker_cmd`). Two `PATH`-injected fakes stand in for external binaries: a `timeout` that faithfully emulates GNU `timeout` (runs the child under a real wall-clock budget and `SIGKILL`s it on expiry, exit 124) and a `docker` whose `exec` hangs forever (`while true; do sleep 1; done`) while `inspect` reports the container running. No Docker daemon is required; the production helper's timeout wrapping and the deadline loop run for real. macOS, Node v22.23.1 for the Vitest suite.

### Exact steps or command run after this patch

```bash
# Direct real-shell run: production readiness loop + docker_e2e_docker_cmd vs a hung `docker exec`.
env PATH="<fake-bin>:/usr/bin:/bin" bash ready-loop.sh "$PWD"   # sources scripts/lib/docker-e2e-image.sh

# Committed real-shell regressions (drive the production helper + source wiring):
node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts -- \
  -t 'readiness fails closed|timeout-aware run helper|bounded' --reporter=verbose
```

### Evidence after fix

Direct real-shell run (production readiness loop, hung `docker exec`, 3s deadline):

```text
==> readiness probe (bounded 3s)
[fake-docker] exec: hanging (simulated stuck daemon)
[fake-timeout] probe budget 3s exceeded; killing hung docker child
package install readiness deadline exceeded after 3s
(exit_code=1, wall ≈ 3s)
```

Committed real-shell regressions:

```text
 ✓ docker build helper > package-install readiness fails closed when a single docker exec stalls 4832ms
 ✓ docker build helper > keeps package-backed Docker runs bounded without the shared timeout helper 23ms
 ✓ docker build helper > routes the gateway network client through the timeout-aware run helper 2ms
 ✓ docker build helper > prints in-container Docker client logs through bounded helpers 3ms
 Tests  7 passed | 162 skipped (169)
```

### Observed result after fix

Against a hung `docker exec`, the production helper's `timeout` kills the stalled probe at the clamped remaining budget, the loop keeps advancing, and the script fails closed with `package install readiness deadline exceeded after 3s` (exit 1) in ~3s — bounded by the deadline, not blocked forever. Pre-fix, the raw `docker exec` on the first iteration had no timeout and would block the loop indefinitely. The committed source-wiring assertions also pin that neither script contains raw `docker exec ` / `docker inspect ` / `${COMPOSE[@]}` anymore.

### What was not tested

A live Docker E2E lane with a genuinely wedged daemon; the proof exercises the production readiness loop + `docker_e2e_docker_cmd` timeout path against a real hung child on the host.

### Fix classification

bugfix — timeout/hang (E2E readiness)

## AI Assistance

AI-assisted. Author reviewed the readiness-loop conversions, the `docker_e2e_docker_cmd` routing, and the real-shell proof output.
