### PR TITLE
fix(sms): idle-timeout stalled Twilio API response bodies

### DIFF
--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -540,6 +540,38 @@ describe("Twilio SMS helpers", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("times out when a Twilio success response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn(async () => {});
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"sid":'));
+            },
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+        release,
+      });
+
+      const pending = sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+      });
+      const settled = expect(pending).rejects.toThrow(
+        "Twilio SMS API response stalled: no data received for 30000ms",
+      );
+      await vi.advanceTimersByTimeAsync(30_060);
+      await settled;
+      expect(release).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("bounds guarded Twilio errors on complete UTF-8 characters and cancels overflow", async () => {
     const release = vi.fn(async () => {});
     const tracked = cancelTrackedTextResponse(`${"x".repeat(8 * 1024 - 2)}😀tail`, {

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -291,18 +291,27 @@ function appendTruncatedResponseSuffix(text: string): string {
   return `${text.trimEnd()}${TRUNCATED_RESPONSE_SUFFIX}`;
 }
 
-async function readTwilioApiResponseText(response: Response): Promise<string> {
+async function readTwilioApiResponseText(response: Response, timeoutMs: number): Promise<string> {
   const maxBytes = response.ok
     ? TWILIO_API_SUCCESS_BODY_LIMIT_BYTES
     : TWILIO_API_ERROR_BODY_LIMIT_BYTES;
+  const onIdleTimeout = ({ chunkTimeoutMs }: { chunkTimeoutMs: number }) =>
+    new Error(`Twilio SMS API response stalled: no data received for ${chunkTimeoutMs}ms`);
   if (!response.ok) {
-    const prefix = await readResponseTextPrefix(response, maxBytes);
+    const prefix = await readResponseTextPrefix(response, maxBytes, {
+      chunkTimeoutMs: timeoutMs,
+      onIdleTimeout,
+    });
     return prefix.truncated ? appendTruncatedResponseSuffix(prefix.text) : prefix.text;
   }
 
+  // fetchWithSsrFGuard / fetch resolve after headers; keep the request deadline on
+  // the success body so a stalled Twilio stream cannot hang SMS API calls.
   const body = await readResponseWithLimit(response, maxBytes, {
+    chunkTimeoutMs: timeoutMs,
     onOverflow: ({ size, maxBytes: limit }) =>
       new Error(`Twilio SMS API response body too large: ${size} bytes (limit: ${limit} bytes)`),
+    onIdleTimeout,
   });
   return new TextDecoder().decode(body);
 }
@@ -335,12 +344,13 @@ async function requestTwilioApi(params: {
       authorization: basicAuthHeader(params.account),
     },
   } satisfies RequestInit;
+  const timeoutMs = params.timeoutMs ?? TWILIO_API_TIMEOUT_MS;
   if (params.fetchImpl) {
     const response = await params.fetchImpl(params.url, init);
     return {
       ok: response.ok,
       status: response.status,
-      text: await readTwilioApiResponseText(response),
+      text: await readTwilioApiResponseText(response, timeoutMs),
     };
   }
 
@@ -350,13 +360,13 @@ async function requestTwilioApi(params: {
     auditContext: "sms-twilio-api",
     policy: { allowedHostnames: [params.allowedHostname] },
     requireHttps: true,
-    timeoutMs: params.timeoutMs ?? TWILIO_API_TIMEOUT_MS,
+    timeoutMs,
   });
   try {
     return {
       ok: guarded.response.ok,
       status: guarded.response.status,
-      text: await readTwilioApiResponseText(guarded.response),
+      text: await readTwilioApiResponseText(guarded.response, timeoutMs),
     };
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Twilio SMS API success (and error) body reads could hang after headers when the response stalled mid-body. `requestTwilioApi` already applied `timeoutMs` to the guarded fetch, but body materialization used `readResponseWithLimit` / `readResponseTextPrefix` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same request `timeoutMs` through Twilio body reads as `chunkTimeoutMs`, with an explicit stalled-body error, matching other OpenClaw response-body idle bounds.

## User Impact

**Before:** A stalled Twilio response body could hang SMS send/lookup indefinitely after headers.

**After:** Stalled bodies fail closed within the request timeout so SMS API calls can surface an error.

## Evidence

- Changed: `extensions/sms/src/twilio.ts`, `extensions/sms/src/twilio.test.ts`
- Production caller path: `sendSmsViaTwilio` → `requestTwilioApi` → `readTwilioApiResponseText` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Twilio SMS success-body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`sendSmsViaTwilio` → `requestTwilioApi` → `readTwilioApiResponseText` → `readResponseWithLimit({ chunkTimeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/sms/src/twilio.test.ts -t "times out when a Twilio success response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a Twilio success response body stalls after headers 142ms
 Test Files  1 passed (1)
      Tests  1 passed | 26 skipped (27)
```

### Observed result after fix

Stalled success body rejects with `Twilio SMS API response stalled: no data received for 30000ms`; `release()` still runs.

### What was not tested

Live stall against Twilio's production API.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Twilio body idle bound and caller-path proof output.
