### PR TITLE
fix(agents): fail unterminated Responses streams

### DIFF
--- a/src/agents/openai-responses-transport.ts
+++ b/src/agents/openai-responses-transport.ts
@@ -1244,6 +1244,7 @@ async function processResponsesStream(
   let pendingMessageText: string | null = null;
   const streamStartedAt = Date.now();
   let eventCount = 0;
+  let sawTerminalResponseEvent = false;
   const eventTypes = new Map<string, number>();
   const sseDebugMode = resolveModelSseDebugMode();
   const blockIndex = () => output.content.length - 1;
@@ -1698,9 +1699,10 @@ async function processResponsesStream(
           currentItem = null;
         }
       }
-    } else if (type === "response.completed") {
+    } else if (type === "response.completed" || type === "response.incomplete") {
+      sawTerminalResponseEvent = true;
       if (streamingToolCalls.hasActive()) {
-        throw new Error("Responses stream completed with unresolved tool calls");
+        throw new Error("Responses stream terminated with unresolved tool calls");
       }
       const response = event.response as Record<string, unknown> | undefined;
       if (typeof response?.id === "string") {
@@ -1770,6 +1772,12 @@ async function processResponsesStream(
   }
   if (streamingToolCalls.hasActive()) {
     throw new Error("Responses stream ended with unresolved tool calls");
+  }
+  throwIfModelStreamAborted(options?.signal);
+  if (!sawTerminalResponseEvent) {
+    throw new Error(
+      `Responses stream ended before a terminal response event (events=${eventCount})`,
+    );
   }
   const eventTypeSummary = [...eventTypes.entries()]
     .slice(0, 12)

--- a/src/agents/openai-transport-stream.base.test-utils.ts
+++ b/src/agents/openai-transport-stream.base.test-utils.ts
@@ -64,6 +64,61 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("fails Responses streams that end before a terminal event", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await expect(
+      testing.processResponsesStream(
+        streamChunks([
+          { type: "response.created", response: { id: "resp_interrupted" } },
+          {
+            type: "response.output_item.added",
+            item: { type: "message", id: "msg_interrupted" },
+          },
+          { type: "response.output_text.delta", delta: "partial answer" },
+        ]),
+        output,
+        { push: vi.fn() },
+        model,
+      ),
+    ).rejects.toThrow("Responses stream ended before a terminal response event");
+
+    expect(output.responseId).toBe("resp_interrupted");
+    expect(output.content).toEqual([{ type: "text", text: "partial answer" }]);
+  });
+
+  it("accepts Responses streams that end with response.incomplete", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await testing.processResponsesStream(
+      streamChunks([
+        { type: "response.created", response: { id: "resp_incomplete" } },
+        {
+          type: "response.output_item.added",
+          item: { type: "message", id: "msg_incomplete" },
+        },
+        { type: "response.output_text.delta", delta: "truncated answer" },
+        {
+          type: "response.incomplete",
+          response: {
+            id: "resp_incomplete",
+            status: "incomplete",
+            incomplete_details: { reason: "max_output_tokens" },
+          },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    expect(output.stopReason).toBe("length");
+    expect(output.responseId).toBe("resp_incomplete");
+    expect(output.content).toEqual([{ type: "text", text: "truncated answer" }]);
+  });
+
   it("fails OpenAI completions streams when headers arrive but no first event follows", async () => {
     vi.useFakeTimers();
     try {
@@ -265,6 +320,10 @@ describe("openai transport stream", () => {
             encrypted_content: "ciphertext",
             summary: [{ type: "summary_text", text: "Need a tool." }],
           },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_reasoning_replay", status: "completed" },
         },
       ]),
       output,

--- a/src/agents/openai-transport-stream.streaming.test-utils.ts
+++ b/src/agents/openai-transport-stream.streaming.test-utils.ts
@@ -968,6 +968,10 @@ describe("openai transport stream", () => {
         { type: "response.output_item.added", item: { type: "message" } },
         { type: "response.output_text.delta", delta: "a" },
         { type: "response.output_text.delta", delta: "b" },
+        {
+          type: "response.completed",
+          response: { id: "resp_delta_partial", status: "completed" },
+        },
       ]),
       output,
       { push: (event) => events.push(event as CapturedStreamEvent) },
@@ -1057,6 +1061,10 @@ describe("openai transport stream", () => {
           {
             type: "response.output_item.done",
             item: { type: "function_call", name: "computer", arguments: "{}" },
+          },
+          {
+            type: "response.completed",
+            response: { id: "resp_idless_tool", status: "completed" },
           },
         ]),
         output,
@@ -1314,6 +1322,11 @@ describe("openai transport stream", () => {
             status: "completed",
           },
         },
+        {
+          type: "response.completed",
+          sequence_number: 7,
+          response: { id: "resp_interleaved_tools", status: "completed" },
+        },
       ]),
       output,
       { push: (event) => events.push(event as (typeof events)[number]) },
@@ -1471,7 +1484,7 @@ describe("openai transport stream", () => {
         { push: (event) => events.push(event as CapturedStreamEvent) },
         model,
       ),
-    ).rejects.toThrow("Responses stream completed with unresolved tool calls");
+    ).rejects.toThrow("Responses stream terminated with unresolved tool calls");
     expect(events.map((event) => event.type)).toEqual(["toolcall_start", "toolcall_delta"]);
   });
 
@@ -1647,7 +1660,7 @@ describe("openai transport stream", () => {
         { push: (event) => events.push(event as (typeof events)[number]) },
         model,
       ),
-    ).rejects.toThrow("Responses stream completed with unresolved tool calls");
+    ).rejects.toThrow("Responses stream terminated with unresolved tool calls");
     expect(events.filter((event) => event.type === "toolcall_start")).toHaveLength(2);
     expect(events.filter((event) => event.type === "toolcall_end")).toHaveLength(0);
   });
@@ -1845,6 +1858,10 @@ describe("openai transport stream", () => {
             arguments: '{"slot":1}',
           },
         },
+        {
+          type: "response.completed",
+          response: { id: "resp_omitted_index_suffix", status: "completed" },
+        },
       ]),
       output,
       { push: (event) => events.push(event as (typeof events)[number]) },
@@ -1915,6 +1932,10 @@ describe("openai transport stream", () => {
             arguments: '{"slot":0}',
           },
         },
+        {
+          type: "response.completed",
+          response: { id: "resp_omitted_parallel", status: "completed" },
+        },
       ]),
       output,
       { push: (event) => events.push(event as (typeof events)[number]) },
@@ -1971,6 +1992,10 @@ describe("openai transport stream", () => {
             name: "computer",
             arguments: '{"slot":0}',
           },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_omitted_mismatch", status: "completed" },
         },
       ]),
       output,
@@ -2036,6 +2061,10 @@ describe("openai transport stream", () => {
             name: "computer",
             arguments: '{"slot":1}',
           },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_sequential_omitted", status: "completed" },
         },
       ]),
       output,


### PR DESCRIPTION
Closes #108958

## Summary

- Fail Responses streams that end before a terminal response event instead of letting the default successful stop state persist.
- Treat `response.completed` and the documented `response.incomplete` event as terminal so legitimate truncated responses still map to `stopReason: "length"`.
- Add regression coverage for the interrupted stream and the valid incomplete stream, and update existing synthetic success streams to include terminal events.

## What Problem This Solves

Fixes an issue where users could see progress from a Responses stream, then have the stream end before a terminal event and be persisted as an empty successful assistant response. That hides the provider interruption from the gateway/session path and can produce an empty final result instead of a visible failure.

An existing open PR for this issue mutates the stop reason after EOF. This PR instead fails at the Responses transport boundary and preserves `response.incomplete` as a valid terminal event, covering the terminal-event gap called out on the existing attempt.

## Why This Change Was Made

The transport now records whether a terminal Responses event arrived while consuming the stream. If the async stream ends without one, it throws a provider-stream error before the success summary path can run. The same terminal branch still handles complete and incomplete Responses events, so completed responses remain `stop` and incomplete responses remain `length`.

## User Impact

Interrupted Responses streams no longer look like successful empty assistant turns. Users and gateway callers receive a failure for unterminated provider streams, while normal completed and max-token incomplete streams keep their existing behavior.

## Verification

- `./node_modules/.bin/vitest run src/agents/openai-transport-stream.test.ts --config test/vitest/vitest.agents.config.ts -t "fails Responses streams that end before a terminal event|accepts Responses streams that end with response.incomplete|rejects indexed Responses completions when call ids change|fails closed on ambiguous unindexed parallel argument events|omits accumulated partial snapshots from Responses text deltas|keeps idless Responses tool-call ids stable and response-unique|keeps interleaved Responses function calls bound to their output indices" --reporter=verbose` -> 7 passed, 327 skipped
- `git diff --check`
- `./node_modules/.bin/oxfmt --check src/agents/openai-responses-transport.ts src/agents/openai-transport-stream.base.test-utils.ts src/agents/openai-transport-stream.streaming.test-utils.ts`

## Impact Assessment

- Scope: Responses transport stream parsing and its nearest stream tests.
- Downstream: Responses streaming call sites share `processResponsesStream`, so the guard applies before gateway/session persistence sees a false successful assistant output.
- Edge cases: unterminated EOF now fails; `response.completed` succeeds; `response.incomplete` succeeds with `stopReason: "length"`; unresolved tool calls still fail closed.
- Hard-coded values: none introduced; the fix uses event types already emitted by the Responses stream contract and existing `mapResponsesStopReason`.
- Existing fixes: #108989 targets the same issue but currently omits the valid `response.incomplete` terminal event; this PR includes that path and proof.

## Real behavior proof

**Behavior addressed:** A Responses stream that naturally ends without a terminal response event now fails instead of being treated as a successful empty response, while completed and incomplete terminal events still work.

**Environment tested:** Linux, Node v24.16.0, local checkout on this branch.

**Steps run after the patch:** Called the actual patched `processResponsesStream` implementation from source through the repository's transport test support and harness.

**Evidence after fix:**

```bash
NODE_ENV=test node --import tsx --no-warnings -e '
import { testing } from "./src/agents/openai-transport-stream.test-support.ts";
import { createAzureResponsesModel, createResponsesAssistantOutput, streamChunks } from "./src/agents/openai-transport-stream.test-harness.ts";

const model = createAzureResponsesModel();

async function runInterrupted() {
  const output = createResponsesAssistantOutput(model);
  const result = { threw: false, message: "", responseId: "", content: [] };
  try {
    await testing.processResponsesStream(
      streamChunks([
        { type: "response.created", response: { id: "resp_interrupted" } },
        { type: "response.output_item.added", item: { type: "message", id: "msg_interrupted" } },
        { type: "response.output_text.delta", delta: "partial answer" },
      ]),
      output,
      { push() {} },
      model,
    );
  } catch (error) {
    result.threw = true;
    result.message = error instanceof Error ? error.message : String(error);
  }
  result.responseId = output.responseId ?? "";
  result.content = output.content;
  return result;
}

async function runCompleted() {
  const output = createResponsesAssistantOutput(model);
  await testing.processResponsesStream(
    streamChunks([
      { type: "response.created", response: { id: "resp_completed" } },
      { type: "response.output_item.added", item: { type: "message", id: "msg_completed" } },
      { type: "response.output_text.delta", delta: "complete answer" },
      { type: "response.completed", response: { id: "resp_completed", status: "completed" } },
    ]),
    output,
    { push() {} },
    model,
  );
  return {
    stopReason: output.stopReason,
    responseId: output.responseId,
    text: output.content.find((block) => block.type === "text")?.text ?? "",
  };
}

async function runIncomplete() {
  const output = createResponsesAssistantOutput(model);
  await testing.processResponsesStream(
    streamChunks([
      { type: "response.created", response: { id: "resp_incomplete" } },
      { type: "response.output_item.added", item: { type: "message", id: "msg_incomplete" } },
      { type: "response.output_text.delta", delta: "truncated answer" },
      {
        type: "response.incomplete",
        response: {
          id: "resp_incomplete",
          status: "incomplete",
          incomplete_details: { reason: "max_output_tokens" },
        },
      },
    ]),
    output,
    { push() {} },
    model,
  );
  return {
    stopReason: output.stopReason,
    responseId: output.responseId,
    text: output.content.find((block) => block.type === "text")?.text ?? "",
  };
}

console.log(JSON.stringify({
  interrupted: await runInterrupted(),
  completed: await runCompleted(),
  incomplete: await runIncomplete(),
}, null, 2));
'
```

Output:

```json
{
  "interrupted": {
    "threw": true,
    "message": "Responses stream ended before a terminal response event (events=3)",
    "responseId": "resp_interrupted",
    "content": [
      {
        "type": "text",
        "text": "partial answer"
      }
    ]
  },
  "completed": {
    "stopReason": "stop",
    "responseId": "resp_completed",
    "text": "complete answer"
  },
  "incomplete": {
    "stopReason": "length",
    "responseId": "resp_incomplete",
    "text": "truncated answer"
  }
}
```

**Observed result:** The interrupted stream throws before success finalization, the completed stream remains a normal stop, and the incomplete stream remains a length stop.

**Not tested:** A live upstream provider connection forcibly returning a 502 mid-SSE was not exercised; this proof uses the patched production stream processor with real stream events matching the reported failure boundary.
