### PR TITLE
fix(exa): idle-timeout stalled search response bodies

### DIFF
--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -77,12 +77,17 @@ type ExaSearchResponse = {
 
 async function readExaSearchResults(
   response: Response,
-  opts?: { maxBytes?: number },
+  opts?: { maxBytes?: number; timeoutMs?: number },
 ): Promise<ExaSearchResult[]> {
   const maxBytes = opts?.maxBytes ?? EXA_SEARCH_JSON_MAX_BYTES;
+  // withTrustedWebSearchEndpoint resolves after headers; keep the search
+  // timeout on the success body so a stalled Exa stream cannot hang web_search.
   const bytes = await readResponseWithLimit(response, maxBytes, {
+    chunkTimeoutMs: opts?.timeoutMs,
     onOverflow: ({ maxBytes: maxBytesLocal }) =>
       new Error(`Exa API response exceeds ${maxBytesLocal} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`Exa API response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
   try {
     return normalizeExaResults(JSON.parse(new TextDecoder().decode(bytes)));
@@ -429,7 +434,9 @@ async function runExaSearch(params: {
         const detail = await readExaErrorDetail(res);
         throw new Error(`Exa API error (${res.status}): ${detail || res.statusText}`);
       }
-      return readExaSearchResults(res);
+      return readExaSearchResults(res, {
+        timeoutMs: Math.max(1, Math.floor(params.timeoutSeconds * 1000)),
+      });
     },
   );
 }

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -333,6 +333,30 @@ describe("exa web search provider", () => {
     expect(streamed.getReadCount()).toBeLessThan(64);
   });
 
+  it("times out when an Exa search response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = testing.readExaSearchResults(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"results":'));
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+        { timeoutMs: 50 },
+      );
+      const settled = expect(pending).rejects.toThrow(
+        "Exa API response stalled: no data received for 50ms",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("bounds Exa API error bodies without using response.text()", async () => {
     const tracked = cancelTrackedResponse(`${"exa upstream unavailable ".repeat(1024)}tail`, {
       status: 503,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Exa web_search success-body reads could hang after headers when the response stalled mid-body. `runExaSearch` already applied `timeoutSeconds` to the trusted web-search fetch, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the search timeout through the success-body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching other OpenClaw response-body idle bounds.

## User Impact

**Before:** A stalled Exa search response body could hang `web_search` indefinitely after headers.

**After:** Stalled bodies fail closed within the search timeout so web_search can surface an error.

## Evidence

- Changed: `extensions/exa/src/exa-web-search-provider.runtime.ts`, `extensions/exa/src/exa-web-search-provider.test.ts`
- Production caller path: `executeExaWebSearchProviderTool` → `runExaSearch` → `readExaSearchResults` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Exa search success-body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`runExaSearch` → `readExaSearchResults({ timeoutMs })` → `readResponseWithLimit({ chunkTimeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/exa/src/exa-web-search-provider.test.ts -t "times out when an Exa search response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when an Exa search response body stalls after headers 394ms
 Test Files  1 passed (1)
      Tests  1 passed | 17 skipped (18)
```

### Observed result after fix

Stalled search body rejects with `Exa API response stalled: no data received for 50ms`.

### What was not tested

Live stall against Exa's production search API.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the Exa body idle bound and caller-path proof output.
