### PR TITLE
fix(volcengine): idle-timeout stalled TTS response bodies

### DIFF
--- a/extensions/volcengine/tts.test.ts
+++ b/extensions/volcengine/tts.test.ts
@@ -216,6 +216,40 @@ describe("Volcengine speech provider", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("times out when a Seed Speech TTS response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn();
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"code":'));
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        release,
+      });
+
+      const pending = provider.synthesize({
+        text: "hello",
+        cfg: {},
+        providerConfig: makeProviderConfig(),
+        target: "voice-note",
+        timeoutMs: 50,
+      });
+      const settled = expect(pending).rejects.toThrow(
+        "BytePlus Seed Speech TTS response stalled: no data received for 50ms",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
+      expect(release).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("drops malformed speed ratios before synthesis", async () => {
     const release = vi.fn();
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/extensions/volcengine/tts.ts
+++ b/extensions/volcengine/tts.ts
@@ -160,10 +160,17 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
   });
 
   try {
+    // fetchWithSsrFGuard resolves after headers; keep the request deadline on the
+    // TTS body so a stalled Seed stream cannot hang speech synthesis.
     const responseText = new TextDecoder().decode(
       await readResponseWithLimit(response, VOLCENGINE_TTS_RESPONSE_MAX_BYTES, {
+        chunkTimeoutMs: timeoutMs,
         onOverflow: ({ maxBytes }) =>
           new Error(`BytePlus Seed Speech TTS response exceeds ${maxBytes} bytes`),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(
+            `BytePlus Seed Speech TTS response stalled: no data received for ${chunkTimeoutMs}ms`,
+          ),
       }),
     );
     const frames = parseSeedTtsFrames(responseText);
@@ -248,10 +255,15 @@ async function legacyVolcengineTTS(
   });
 
   try {
+    // fetchWithSsrFGuard resolves after headers; keep the request deadline on the
+    // TTS body so a stalled legacy stream cannot hang speech synthesis.
     const responseText = new TextDecoder().decode(
       await readResponseWithLimit(response, VOLCENGINE_TTS_RESPONSE_MAX_BYTES, {
+        chunkTimeoutMs: timeoutMs,
         onOverflow: ({ maxBytes }) =>
           new Error(`Volcengine TTS response exceeds ${maxBytes} bytes`),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(`Volcengine TTS response stalled: no data received for ${chunkTimeoutMs}ms`),
       }),
     );
     const body = parseLegacyTtsResponse(responseText);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Volcengine/BytePlus Seed Speech TTS response-body reads could hang after headers when the response stalled mid-body. Synthesis already applied `timeoutMs` to the guarded fetch, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same request `timeoutMs` through Seed and legacy TTS body reads as `chunkTimeoutMs`, with explicit stalled-body errors, matching other OpenClaw response-body idle bounds.

## User Impact

**Before:** A stalled Volcengine TTS response body could hang speech synthesis indefinitely after headers.

**After:** Stalled bodies fail closed within the request timeout so TTS can surface an error.

## Evidence

- Changed: `extensions/volcengine/tts.ts`, `extensions/volcengine/tts.test.ts`
- Production caller path: Volcengine speech provider `synthesize` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Seed Speech TTS body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`provider.synthesize` → Seed TTS fetch → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/volcengine/tts.test.ts -t "times out when a Seed Speech TTS response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a Seed Speech TTS response body stalls after headers 42ms
 Test Files  1 passed (1)
      Tests  1 passed | 15 skipped (16)
```

### Observed result after fix

Stalled Seed TTS body rejects with `BytePlus Seed Speech TTS response stalled: no data received for 50ms`; `release()` still runs.

### What was not tested

Live stall against BytePlus/Volcengine production TTS endpoints.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the TTS body idle bound and caller-path proof output.
