### PR TITLE
fix(azure-speech): idle-timeout stalled TTS audio response bodies

### DIFF
--- a/extensions/azure-speech/tts.test.ts
+++ b/extensions/azure-speech/tts.test.ts
@@ -121,6 +121,42 @@ describe("azure speech tts", () => {
     expect(streamed.getReadCount()).toBeLessThan(20);
   });
 
+  it("times out when a TTS audio response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+
+      const pending = azureSpeechTTS({
+        text: "hello",
+        apiKey: "speech-key",
+        region: "eastus",
+        voice: "en-US-JennyNeural",
+        lang: "en-US",
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        timeoutMs: 50,
+      });
+      const settled = expect(pending).rejects.toThrow(
+        "Azure Speech TTS audio response stalled: no data received for 50ms",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("lists voices with timeout and filters deprecated entries", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/extensions/azure-speech/tts.ts
+++ b/extensions/azure-speech/tts.ts
@@ -225,12 +225,20 @@ export async function azureSpeechTTS(params: {
 
   try {
     await assertOkOrThrowProviderError(response, "Azure Speech TTS API error");
+    // fetchWithSsrFGuard resolves after headers; keep the request deadline on the
+    // audio body so a stalled TTS stream cannot hang speech synthesis.
+    const timeoutMs = params.timeoutMs ?? DEFAULT_AZURE_SPEECH_VOICE_LIST_TIMEOUT_MS;
     return await readResponseWithLimit(
       response,
       params.maxBytes ?? DEFAULT_AZURE_SPEECH_MAX_BYTES,
       {
+        chunkTimeoutMs: timeoutMs,
         onOverflow: ({ maxBytes }) =>
           new Error(`Azure Speech TTS audio response exceeds ${maxBytes} bytes`),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(
+            `Azure Speech TTS audio response stalled: no data received for ${chunkTimeoutMs}ms`,
+          ),
       },
     );
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Azure Speech TTS audio response-body reads could hang after headers when the response stalled mid-body. Synthesis already applied `timeoutMs` to the guarded fetch, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the request timeout (or the shared 30s default) through the audio body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching other OpenClaw response-body idle bounds.

## User Impact

**Before:** A stalled Azure Speech TTS audio body could hang speech synthesis indefinitely after headers.

**After:** Stalled bodies fail closed within the request timeout so TTS can surface an error.

## Evidence

- Changed: `extensions/azure-speech/tts.ts`, `extensions/azure-speech/tts.test.ts`
- Production caller path: `azureSpeechTTS` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Azure Speech TTS audio body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`azureSpeechTTS` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/azure-speech/tts.test.ts -t "times out when a TTS audio response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a TTS audio response body stalls after headers 55ms
 Test Files  1 passed (1)
      Tests  1 passed | 5 skipped (6)
```

### Observed result after fix

Stalled audio body rejects with `Azure Speech TTS audio response stalled: no data received for 50ms`.

### What was not tested

Live stall against Azure Speech production TTS endpoints.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the TTS body idle bound and caller-path proof output.
