### PR TITLE
fix(gradium): idle-timeout stalled TTS audio response bodies

### DIFF
--- a/extensions/gradium/tts.test.ts
+++ b/extensions/gradium/tts.test.ts
@@ -144,6 +144,41 @@ describe("gradium tts diagnostics", () => {
     expect(result).toEqual(audioData);
   });
 
+  it("times out when a TTS audio response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+
+      const pending = gradiumTTS({
+        text: "hello",
+        apiKey: "gsk_test123",
+        baseUrl: "https://api.gradium.ai",
+        voiceId: "YTpq7expH9539ERJ",
+        outputFormat: "wav",
+        timeoutMs: 50,
+      });
+      const settled = expect(pending).rejects.toThrow(
+        "Gradium TTS audio response stalled: no data received for 50ms",
+      );
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects HTTP base URLs before sending the API key", async () => {
     const fetchMock = vi
       .fn()

--- a/extensions/gradium/tts.ts
+++ b/extensions/gradium/tts.ts
@@ -54,9 +54,14 @@ export async function gradiumTTS(params: {
   try {
     await assertOkOrThrowProviderError(response, "Gradium API error");
 
+    // fetchWithSsrFGuard resolves after headers; keep the request deadline on the
+    // audio body so a stalled Gradium stream cannot hang speech synthesis.
     return await readResponseWithLimit(response, maxBytes, {
+      chunkTimeoutMs: timeoutMs,
       onOverflow: ({ maxBytes: maxBytesLocal }) =>
         new Error(`Gradium TTS audio response exceeds ${maxBytesLocal} bytes`),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`Gradium TTS audio response stalled: no data received for ${chunkTimeoutMs}ms`),
     });
   } finally {
     await release();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gradium TTS audio response-body reads could hang after headers when the response stalled mid-body. Synthesis already applied `timeoutMs` to the guarded fetch, but body materialization used `readResponseWithLimit` without `chunkTimeoutMs`.

## Why This Change Was Made

Pass the same request `timeoutMs` through the audio body read as `chunkTimeoutMs`, with an explicit stalled-body error, matching other OpenClaw response-body idle bounds.

## User Impact

**Before:** A stalled Gradium TTS audio body could hang speech synthesis indefinitely after headers.

**After:** Stalled bodies fail closed within the request timeout so TTS can surface an error.

## Evidence

- Changed: `extensions/gradium/tts.ts`, `extensions/gradium/tts.test.ts`
- Production caller path: `gradiumTTS` → `readResponseWithLimit({ chunkTimeoutMs })`

## Real behavior proof

### Behavior or issue addressed

Gradium TTS audio body reads now idle-timeout stalled streams after headers.

### Canonical reachability path

`gradiumTTS` → `readResponseWithLimit({ chunkTimeoutMs: timeoutMs })`.

### Real environment tested

Local trusted source checkout; focused Vitest via `node scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/gradium/tts.test.ts -t "times out when a TTS audio response body stalls" --reporter=verbose
```

### Evidence after fix

```text
✓ times out when a TTS audio response body stalls after headers 72ms
 Test Files  1 passed (1)
      Tests  1 passed | 8 skipped (9)
```

### Observed result after fix

Stalled audio body rejects with `Gradium TTS audio response stalled: no data received for 50ms`.

### What was not tested

Live stall against Gradium's production TTS endpoint.

### Fix classification

bugfix — timeout/hang

## AI Assistance

AI-assisted. Author reviewed the TTS body idle bound and caller-path proof output.
