### PR TITLE
fix(tls): bound self-signed certificate generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.
+- **Gateway TLS certificate generation:** bound automatic OpenSSL generation and stage, validate, and publish key/certificate outputs without overwriting files created during publication. (#109139) Thanks @Alix-007.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ Docs: https://docs.openclaw.ai
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.
-- **Gateway TLS certificate generation:** bound automatic OpenSSL generation and stage, validate, and publish key/certificate outputs without overwriting files created during publication. (#109139) Thanks @Alix-007.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -225,6 +225,31 @@ describe("loadGatewayTlsRuntime", () => {
     }
   });
 
+  it("fails closed when atomic hard-link publication is unsupported", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const linkSpy = vi
+      .spyOn(fs, "link")
+      .mockRejectedValue(Object.assign(new Error("hard links unsupported"), { code: "ENOTSUP" }));
+
+    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    try {
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    } finally {
+      linkSpy.mockRestore();
+    }
+
+    expect(result?.enabled).toBe(false);
+    expect(result?.error).toContain("publication failed");
+    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readdir(dir)).resolves.toEqual([]);
+  });
+
   it("preserves a file replaced during publication", async () => {
     const dir = await createTempDir();
     const certPath = path.join(dir, "gateway-cert.pem");
@@ -260,6 +285,130 @@ describe("loadGatewayTlsRuntime", () => {
       "gateway-cert.pem",
       "gateway-key.pem",
     ]);
+  });
+
+  it("preserves a published file modified in place during publication", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const realLink = fs.link.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      if (path.resolve(String(newPath)) === keyPath) {
+        await fs.writeFile(certPath, "operator-owned-cert\n");
+        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+
+    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    try {
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    } finally {
+      linkSpy.mockRestore();
+    }
+
+    expect(result?.enabled).toBe(false);
+    expect(result?.error).toContain("concurrent output backup preserved under");
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe("operator-owned-cert\n");
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
+    const entries = await fs.readdir(dir);
+    const recoveryDir = requireSingleRecoveryDir(entries);
+    await expect(fs.readFile(path.join(dir, recoveryDir, "cert.pem"), "utf8")).resolves.toBe(
+      "operator-owned-cert\n",
+    );
+  });
+
+  it("contains output-inspection close failures during rollback", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const realLink = fs.link.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      if (path.resolve(String(newPath)) === keyPath) {
+        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+    const realOpen = fs.open.bind(fs);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await realOpen(filePath, flags, mode);
+      if (path.resolve(String(filePath)) === certPath && typeof flags === "number") {
+        vi.spyOn(handle, "close").mockRejectedValueOnce(
+          Object.assign(new Error("close failed"), { code: "EIO" }),
+        );
+      }
+      return handle;
+    });
+
+    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    try {
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    } finally {
+      openSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+
+    expect(result?.enabled).toBe(false);
+    expect(result?.error).toContain("concurrent output backup preserved under");
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
+    expect(requireSingleRecoveryDir(await fs.readdir(dir))).toContain("gateway-tls-cert");
+  });
+
+  it("preserves writes through an open descriptor after rollback inspection", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const realOpen = fs.open.bind(fs);
+    let writerHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await realOpen(filePath, flags, mode);
+      if (path.basename(String(filePath)).startsWith("published-gateway-cert")) {
+        const realClose = handle.close.bind(handle);
+        vi.spyOn(handle, "close").mockImplementationOnce(async () => {
+          await realClose();
+          await writerHandle?.truncate(0);
+          await writerHandle?.writeFile("operator-after-check\n");
+          await writerHandle?.sync();
+        });
+      }
+      return handle;
+    });
+    const realLink = fs.link.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      if (path.resolve(String(newPath)) === keyPath) {
+        writerHandle = await fs.open(certPath, "r+");
+        throw Object.assign(new Error("key publication failed"), { code: "EEXIST" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+
+    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    try {
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    } finally {
+      await writerHandle?.close();
+      linkSpy.mockRestore();
+      openSpy.mockRestore();
+    }
+
+    expect(result?.enabled).toBe(false);
+    expect(result?.error).toContain("concurrent output backup preserved under");
+    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
+    const recoveryDir = requireSingleRecoveryDir(await fs.readdir(dir));
+    await expect(
+      fs.readFile(path.join(dir, recoveryDir, "published-gateway-cert.pem"), "utf8"),
+    ).resolves.toBe("operator-after-check\n");
   });
 
   it("restores a protected file replaced after the rollback ownership check", async () => {
@@ -417,9 +566,13 @@ describe("loadGatewayTlsRuntime", () => {
     expect(linkCount).toBe(4);
     expect(failedResult.enabled).toBe(false);
     expect(failedResult.error).toContain("publication failed");
+    expect(failedResult.error).toContain("concurrent output backup preserved under");
     await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fs.readdir(dir)).resolves.toEqual([]);
+    const recoveryDir = requireSingleRecoveryDir(await fs.readdir(dir));
+    await expect(
+      fs.readdir(path.join(dir, recoveryDir)).then((items) => items.toSorted()),
+    ).resolves.toEqual(["cert.pem", "published-gateway-cert.pem"]);
 
     const retryResult = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
 

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -1,7 +1,7 @@
 // Covers gateway TLS loading, fingerprint reporting, generated certificate
 // paths, and error handling for missing or invalid material.
 import { X509Certificate } from "node:crypto";
-import { writeFile } from "node:fs/promises";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
@@ -23,6 +23,21 @@ import { loadGatewayTlsRuntime } from "./gateway.js";
 
 const tempDirs = createTrackedTempDirs();
 const createTempDir = () => tempDirs.make("openclaw-gateway-tls-test-");
+
+function resolveOpenSslOutput(args: string[], flag: "-keyout" | "-out"): string {
+  const outputPath = args.at(args.indexOf(flag) + 1);
+  if (!outputPath) {
+    throw new Error(`missing ${flag} output path`);
+  }
+  return outputPath;
+}
+
+async function writeGeneratedTlsPair(args: string[]): Promise<void> {
+  await Promise.all([
+    fs.writeFile(resolveOpenSslOutput(args, "-out"), CERT_PEM, "utf8"),
+    fs.writeFile(resolveOpenSslOutput(args, "-keyout"), KEY_PEM, "utf8"),
+  ]);
+}
 
 const KEY_PEM = [
   "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret
@@ -98,9 +113,9 @@ describe("loadGatewayTlsRuntime", () => {
     const certPath = path.join(dir, "gateway-cert.pem");
     const keyPath = path.join(dir, "gateway-key.pem");
     const caPath = path.join(dir, "gateway-ca.pem");
-    await writeFile(certPath, CERT_PEM, "utf8");
-    await writeFile(keyPath, KEY_PEM, "utf8");
-    await writeFile(caPath, CERT_PEM, "utf8");
+    await fs.writeFile(certPath, CERT_PEM, "utf8");
+    await fs.writeFile(keyPath, KEY_PEM, "utf8");
+    await fs.writeFile(caPath, CERT_PEM, "utf8");
 
     const result = await loadGatewayTlsRuntime({
       enabled: true,
@@ -144,34 +159,96 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.error).toBe("gateway tls: cert/key missing");
   });
 
-  it("bounds self-signed certificate generation", async () => {
+  it.each(["key", "cert"] as const)(
+    "bounds generation and cleans a partial staged %s",
+    async (partialOutput) => {
+      const dir = await createTempDir();
+      const certPath = path.join(dir, "gateway-cert.pem");
+      const keyPath = path.join(dir, "gateway-key.pem");
+      runExecMock.mockImplementationOnce(async (_command: string, args: string[]) => {
+        const outputPath = resolveOpenSslOutput(args, partialOutput === "key" ? "-keyout" : "-out");
+        await fs.writeFile(outputPath, partialOutput === "key" ? KEY_PEM : CERT_PEM, "utf8");
+        throw new Error("openssl timed out");
+      });
+
+      const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+
+      expect(runExecMock).toHaveBeenCalledOnce();
+      const [command, args, options] = runExecMock.mock.calls[0] as [
+        string,
+        string[],
+        { logOutput: boolean; timeoutMs: number },
+      ];
+      expect(command).toBe("/usr/bin/openssl");
+      expect(resolveOpenSslOutput(args, "-keyout")).not.toBe(keyPath);
+      expect(resolveOpenSslOutput(args, "-out")).not.toBe(certPath);
+      expect(options).toEqual({ logOutput: false, timeoutMs: 30_000 });
+      expect(result).toMatchObject({ enabled: false, required: true, certPath, keyPath });
+      expect(result.error).toContain("openssl timed out");
+      await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readdir(dir)).resolves.toEqual([]);
+    },
+  );
+
+  it("validates and publishes a generated pair with private modes", async () => {
     const dir = await createTempDir();
     const certPath = path.join(dir, "gateway-cert.pem");
     const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockRejectedValueOnce(new Error("openssl timed out"));
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
 
     const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
 
-    expect(runExecMock).toHaveBeenCalledWith(
-      "/usr/bin/openssl",
-      expect.arrayContaining(["req", "-x509", "-keyout", keyPath, "-out", certPath]),
-      { logOutput: false, timeoutMs: 30_000 },
-    );
-    expect(result).toMatchObject({
-      enabled: false,
-      required: true,
-      certPath,
-      keyPath,
+    expect(result.enabled).toBe(true);
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe(KEY_PEM);
+    await expect(fs.readdir(dir).then((entries) => entries.toSorted())).resolves.toEqual([
+      "gateway-cert.pem",
+      "gateway-key.pem",
+    ]);
+    if (process.platform !== "win32") {
+      expect((await fs.stat(certPath)).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(keyPath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("does not overwrite a file created during publication", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
     });
-    expect(result.error).toContain("openssl timed out");
+    const realLink = fs.link.bind(fs);
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      if (path.resolve(String(newPath)) === keyPath) {
+        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+
+    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    try {
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    } finally {
+      linkSpy.mockRestore();
+    }
+
+    expect(result?.enabled).toBe(false);
+    expect(result?.error).toContain("EEXIST");
+    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
+    await expect(fs.readdir(dir)).resolves.toEqual(["gateway-key.pem"]);
   });
 
   it("reports load failures for invalid pem files", async () => {
     const dir = await createTempDir();
     const certPath = path.join(dir, "gateway-cert.pem");
     const keyPath = path.join(dir, "gateway-key.pem");
-    await writeFile(certPath, "not a certificate\n", "utf8");
-    await writeFile(keyPath, KEY_PEM, "utf8");
+    await fs.writeFile(certPath, "not a certificate\n", "utf8");
+    await fs.writeFile(keyPath, KEY_PEM, "utf8");
 
     const result = await loadGatewayTlsRuntime({
       enabled: true,

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -3,9 +3,22 @@
 import { X509Certificate } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { normalizeFingerprint } from "./fingerprint.js";
+
+const { resolveSystemBinMock, runExecMock } = vi.hoisted(() => ({
+  resolveSystemBinMock: vi.fn(() => "/usr/bin/openssl"),
+  runExecMock: vi.fn(),
+}));
+
+vi.mock("../../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/exec.js")>()),
+  runExec: runExecMock,
+}));
+
+vi.mock("../resolve-system-bin.js", () => ({ resolveSystemBin: resolveSystemBinMock }));
+
 import { loadGatewayTlsRuntime } from "./gateway.js";
 
 const tempDirs = createTrackedTempDirs();
@@ -63,6 +76,8 @@ r1USnb+wUdA7Zoj/mQ==
 -----END CERTIFICATE-----`;
 
 afterEach(async () => {
+  resolveSystemBinMock.mockClear();
+  runExecMock.mockReset();
   await tempDirs.cleanup();
 });
 
@@ -127,6 +142,28 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.certPath).toBe(certPath);
     expect(result.keyPath).toBe(keyPath);
     expect(result.error).toBe("gateway tls: cert/key missing");
+  });
+
+  it("bounds self-signed certificate generation", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockRejectedValueOnce(new Error("openssl timed out"));
+
+    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+
+    expect(runExecMock).toHaveBeenCalledWith(
+      "/usr/bin/openssl",
+      expect.arrayContaining(["req", "-x509", "-keyout", keyPath, "-out", certPath]),
+      { logOutput: false, timeoutMs: 30_000 },
+    );
+    expect(result).toMatchObject({
+      enabled: false,
+      required: true,
+      certPath,
+      keyPath,
+    });
+    expect(result.error).toContain("openssl timed out");
   });
 
   it("reports load failures for invalid pem files", async () => {

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -214,7 +214,7 @@ describe("loadGatewayTlsRuntime", () => {
     }
   });
 
-  it("does not overwrite a file created during publication", async () => {
+  it("preserves a file replaced during publication", async () => {
     const dir = await createTempDir();
     const certPath = path.join(dir, "gateway-cert.pem");
     const keyPath = path.join(dir, "gateway-key.pem");
@@ -222,8 +222,12 @@ describe("loadGatewayTlsRuntime", () => {
       await writeGeneratedTlsPair(args);
     });
     const realLink = fs.link.bind(fs);
+    let linkCount = 0;
     const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      linkCount += 1;
       if (path.resolve(String(newPath)) === keyPath) {
+        await fs.unlink(certPath);
+        await fs.writeFile(certPath, "operator-owned-cert\n", { flag: "wx" });
         await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
       }
       return await realLink(existingPath, newPath);
@@ -236,11 +240,185 @@ describe("loadGatewayTlsRuntime", () => {
       linkSpy.mockRestore();
     }
 
+    expect(linkCount).toBe(2);
     expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("EEXIST");
-    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(result?.error).toContain("publication failed");
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe("operator-owned-cert\n");
     await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
-    await expect(fs.readdir(dir)).resolves.toEqual(["gateway-key.pem"]);
+    await expect(fs.readdir(dir).then((entries) => entries.toSorted())).resolves.toEqual([
+      "gateway-cert.pem",
+      "gateway-key.pem",
+    ]);
+  });
+
+  it("restores a protected file replaced after the rollback ownership check", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const realLink = fs.link.bind(fs);
+    const realRename = fs.rename.bind(fs);
+    let linkCount = 0;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      linkCount += 1;
+      if (
+        path.resolve(String(newPath)) === certPath &&
+        path.basename(String(existingPath)).startsWith("published-")
+      ) {
+        throw Object.assign(new Error("protected hard link"), { code: "EPERM" });
+      }
+      if (path.resolve(String(newPath)) === keyPath) {
+        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (oldPath, newPath) => {
+      if (path.resolve(String(oldPath)) === certPath) {
+        await fs.unlink(certPath);
+        await fs.writeFile(certPath, "operator-owned-cert\n", { flag: "wx" });
+      }
+      return await realRename(oldPath, newPath);
+    });
+
+    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    try {
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    } finally {
+      renameSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+
+    expect(linkCount).toBe(3);
+    expect(result?.enabled).toBe(false);
+    expect(result?.error).toContain("publication failed");
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe("operator-owned-cert\n");
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
+    const entries = await fs.readdir(dir);
+    const recoveryDirs = entries.filter((entry) => entry.startsWith(".openclaw-gateway-tls-"));
+    expect(recoveryDirs).toHaveLength(1);
+    expect(recoveryDirs[0]).toMatch(/^\.openclaw-gateway-tls-cert-/);
+    await expect(
+      fs.readdir(path.join(dir, recoveryDirs[0])).then((items) => items.toSorted()),
+    ).resolves.toEqual(["cert.pem", "published-gateway-cert.pem"]);
+  });
+
+  it("restores a directory replaced after the rollback ownership check", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const realLink = fs.link.bind(fs);
+    const realRename = fs.rename.bind(fs);
+    let linkCount = 0;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      linkCount += 1;
+      if (path.resolve(String(newPath)) === keyPath) {
+        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (oldPath, newPath) => {
+      if (path.resolve(String(oldPath)) === certPath) {
+        await fs.unlink(certPath);
+        await fs.mkdir(certPath);
+        await fs.writeFile(path.join(certPath, "operator-owned.txt"), "operator directory\n");
+      }
+      return await realRename(oldPath, newPath);
+    });
+
+    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    try {
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    } finally {
+      renameSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+
+    expect(linkCount).toBe(2);
+    expect(result?.enabled).toBe(false);
+    expect(result?.error).toContain("publication failed");
+    await expect(fs.readFile(path.join(certPath, "operator-owned.txt"), "utf8")).resolves.toBe(
+      "operator directory\n",
+    );
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
+    const entries = await fs.readdir(dir);
+    const recoveryDirs = entries.filter((entry) => entry.startsWith(".openclaw-gateway-tls-"));
+    expect(recoveryDirs).toHaveLength(1);
+    expect(recoveryDirs[0]).toMatch(/^\.openclaw-gateway-tls-cert-/);
+    await expect(
+      fs.readFile(
+        path.join(dir, recoveryDirs[0], "published-gateway-cert.pem", "operator-owned.txt"),
+        "utf8",
+      ),
+    ).resolves.toBe("operator directory\n");
+  });
+
+  it("retries a transient second-link failure", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const realLink = fs.link.bind(fs);
+    let linkCount = 0;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      linkCount += 1;
+      if (linkCount === 2) {
+        throw Object.assign(new Error("transient link failure"), { code: "EIO" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+
+    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    linkSpy.mockRestore();
+
+    expect(linkCount).toBe(3);
+    expect(result.enabled).toBe(true);
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe(KEY_PEM);
+    await expect(fs.readdir(dir).then((entries) => entries.toSorted())).resolves.toEqual([
+      "gateway-cert.pem",
+      "gateway-key.pem",
+    ]);
+  });
+
+  it("rolls back a generated output after transient link retries are exhausted", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+      await writeGeneratedTlsPair(args);
+    });
+    const realLink = fs.link.bind(fs);
+    let linkCount = 0;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
+      linkCount += 1;
+      if (linkCount >= 2 && linkCount <= 4) {
+        throw Object.assign(new Error("persistent link failure"), { code: "EIO" });
+      }
+      return await realLink(existingPath, newPath);
+    });
+
+    const failedResult = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    linkSpy.mockRestore();
+
+    expect(linkCount).toBe(4);
+    expect(failedResult.enabled).toBe(false);
+    expect(failedResult.error).toContain("publication failed");
+    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readdir(dir)).resolves.toEqual([]);
+
+    const retryResult = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+
+    expect(retryResult.enabled).toBe(true);
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
+    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe(KEY_PEM);
   });
 
   it("reports load failures for invalid pem files", async () => {

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -39,6 +39,17 @@ async function writeGeneratedTlsPair(args: string[]): Promise<void> {
   ]);
 }
 
+function requireSingleRecoveryDir(entries: string[]): string {
+  const recoveryDirs = entries.filter((entry) => entry.startsWith(".openclaw-gateway-tls-"));
+  expect(recoveryDirs).toHaveLength(1);
+  const recoveryDir = recoveryDirs[0];
+  if (!recoveryDir) {
+    throw new Error("missing gateway TLS recovery directory");
+  }
+  expect(recoveryDir).toMatch(/^\.openclaw-gateway-tls-cert-/);
+  return recoveryDir;
+}
+
 const KEY_PEM = [
   "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret
   "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDrur5CWp4psMMb",
@@ -296,11 +307,9 @@ describe("loadGatewayTlsRuntime", () => {
     await expect(fs.readFile(certPath, "utf8")).resolves.toBe("operator-owned-cert\n");
     await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
     const entries = await fs.readdir(dir);
-    const recoveryDirs = entries.filter((entry) => entry.startsWith(".openclaw-gateway-tls-"));
-    expect(recoveryDirs).toHaveLength(1);
-    expect(recoveryDirs[0]).toMatch(/^\.openclaw-gateway-tls-cert-/);
+    const recoveryDir = requireSingleRecoveryDir(entries);
     await expect(
-      fs.readdir(path.join(dir, recoveryDirs[0])).then((items) => items.toSorted()),
+      fs.readdir(path.join(dir, recoveryDir)).then((items) => items.toSorted()),
     ).resolves.toEqual(["cert.pem", "published-gateway-cert.pem"]);
   });
 
@@ -346,12 +355,10 @@ describe("loadGatewayTlsRuntime", () => {
     );
     await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
     const entries = await fs.readdir(dir);
-    const recoveryDirs = entries.filter((entry) => entry.startsWith(".openclaw-gateway-tls-"));
-    expect(recoveryDirs).toHaveLength(1);
-    expect(recoveryDirs[0]).toMatch(/^\.openclaw-gateway-tls-cert-/);
+    const recoveryDir = requireSingleRecoveryDir(entries);
     await expect(
       fs.readFile(
-        path.join(dir, recoveryDirs[0], "published-gateway-cert.pem", "operator-owned.txt"),
+        path.join(dir, recoveryDir, "published-gateway-cert.pem", "operator-owned.txt"),
         "utf8",
       ),
     ).resolves.toBe("operator directory\n");

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -39,17 +39,6 @@ async function writeGeneratedTlsPair(args: string[]): Promise<void> {
   ]);
 }
 
-function requireSingleRecoveryDir(entries: string[]): string {
-  const recoveryDirs = entries.filter((entry) => entry.startsWith(".openclaw-gateway-tls-"));
-  expect(recoveryDirs).toHaveLength(1);
-  const recoveryDir = recoveryDirs[0];
-  if (!recoveryDir) {
-    throw new Error("missing gateway TLS recovery directory");
-  }
-  expect(recoveryDir).toMatch(/^\.openclaw-gateway-tls-cert-/);
-  return recoveryDir;
-}
-
 const KEY_PEM = [
   "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret
   "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDrur5CWp4psMMb",
@@ -225,10 +214,11 @@ describe("loadGatewayTlsRuntime", () => {
     }
   });
 
-  it("fails closed when atomic hard-link publication is unsupported", async () => {
+  it("publishes best-effort and warns once when hard links are unavailable", async () => {
     const dir = await createTempDir();
     const certPath = path.join(dir, "gateway-cert.pem");
     const keyPath = path.join(dir, "gateway-key.pem");
+    const warn = vi.fn();
     runExecMock.mockImplementation(async (_command: string, args: string[]) => {
       await writeGeneratedTlsPair(args);
     });
@@ -238,347 +228,30 @@ describe("loadGatewayTlsRuntime", () => {
 
     let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
     try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath }, { warn });
     } finally {
       linkSpy.mockRestore();
     }
 
-    expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("publication failed");
-    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fs.readdir(dir)).resolves.toEqual([]);
-  });
-
-  it("preserves a file replaced during publication", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
+    expect(result?.enabled).toBe(true);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[GATEWAY_TLS_DEGRADED]"), {
+      event: "gateway.tls.degraded",
+      ownerKind: "gateway",
+      ownerId: "tls",
+      reason: "atomic hard-link publication unavailable",
+      state: "best-effort",
     });
-    const realLink = fs.link.bind(fs);
-    let linkCount = 0;
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      linkCount += 1;
-      if (path.resolve(String(newPath)) === keyPath) {
-        await fs.unlink(certPath);
-        await fs.writeFile(certPath, "operator-owned-cert\n", { flag: "wx" });
-        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-
-    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
-    try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    } finally {
-      linkSpy.mockRestore();
-    }
-
-    expect(linkCount).toBe(2);
-    expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("publication failed");
-    await expect(fs.readFile(certPath, "utf8")).resolves.toBe("operator-owned-cert\n");
-    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
-    await expect(fs.readdir(dir).then((entries) => entries.toSorted())).resolves.toEqual([
-      "gateway-cert.pem",
-      "gateway-key.pem",
-    ]);
-  });
-
-  it("preserves a published file modified in place during publication", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
-    });
-    const realLink = fs.link.bind(fs);
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      if (path.resolve(String(newPath)) === keyPath) {
-        await fs.writeFile(certPath, "operator-owned-cert\n");
-        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-
-    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
-    try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    } finally {
-      linkSpy.mockRestore();
-    }
-
-    expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("concurrent output backup preserved under");
-    await expect(fs.readFile(certPath, "utf8")).resolves.toBe("operator-owned-cert\n");
-    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
-    const entries = await fs.readdir(dir);
-    const recoveryDir = requireSingleRecoveryDir(entries);
-    await expect(fs.readFile(path.join(dir, recoveryDir, "cert.pem"), "utf8")).resolves.toBe(
-      "operator-owned-cert\n",
-    );
-  });
-
-  it("contains output-inspection close failures during rollback", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
-    });
-    const realLink = fs.link.bind(fs);
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      if (path.resolve(String(newPath)) === keyPath) {
-        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-    const realOpen = fs.open.bind(fs);
-    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      const handle = await realOpen(filePath, flags, mode);
-      if (path.resolve(String(filePath)) === certPath && typeof flags === "number") {
-        vi.spyOn(handle, "close").mockRejectedValueOnce(
-          Object.assign(new Error("close failed"), { code: "EIO" }),
-        );
-      }
-      return handle;
-    });
-
-    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
-    try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    } finally {
-      openSpy.mockRestore();
-      linkSpy.mockRestore();
-    }
-
-    expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("concurrent output backup preserved under");
-    await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
-    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
-    expect(requireSingleRecoveryDir(await fs.readdir(dir))).toContain("gateway-tls-cert");
-  });
-
-  it("preserves writes through an open descriptor after rollback inspection", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
-    });
-    const realOpen = fs.open.bind(fs);
-    let writerHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
-    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      const handle = await realOpen(filePath, flags, mode);
-      if (path.basename(String(filePath)).startsWith("published-gateway-cert")) {
-        const realClose = handle.close.bind(handle);
-        vi.spyOn(handle, "close").mockImplementationOnce(async () => {
-          await realClose();
-          await writerHandle?.truncate(0);
-          await writerHandle?.writeFile("operator-after-check\n");
-          await writerHandle?.sync();
-        });
-      }
-      return handle;
-    });
-    const realLink = fs.link.bind(fs);
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      if (path.resolve(String(newPath)) === keyPath) {
-        writerHandle = await fs.open(certPath, "r+");
-        throw Object.assign(new Error("key publication failed"), { code: "EEXIST" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-
-    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
-    try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    } finally {
-      await writerHandle?.close();
-      linkSpy.mockRestore();
-      openSpy.mockRestore();
-    }
-
-    expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("concurrent output backup preserved under");
-    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
-    const recoveryDir = requireSingleRecoveryDir(await fs.readdir(dir));
-    await expect(
-      fs.readFile(path.join(dir, recoveryDir, "published-gateway-cert.pem"), "utf8"),
-    ).resolves.toBe("operator-after-check\n");
-  });
-
-  it("restores a protected file replaced after the rollback ownership check", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
-    });
-    const realLink = fs.link.bind(fs);
-    const realRename = fs.rename.bind(fs);
-    let linkCount = 0;
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      linkCount += 1;
-      if (
-        path.resolve(String(newPath)) === certPath &&
-        path.basename(String(existingPath)).startsWith("published-")
-      ) {
-        throw Object.assign(new Error("protected hard link"), { code: "EPERM" });
-      }
-      if (path.resolve(String(newPath)) === keyPath) {
-        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (oldPath, newPath) => {
-      if (path.resolve(String(oldPath)) === certPath) {
-        await fs.unlink(certPath);
-        await fs.writeFile(certPath, "operator-owned-cert\n", { flag: "wx" });
-      }
-      return await realRename(oldPath, newPath);
-    });
-
-    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
-    try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    } finally {
-      renameSpy.mockRestore();
-      linkSpy.mockRestore();
-    }
-
-    expect(linkCount).toBe(3);
-    expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("publication failed");
-    await expect(fs.readFile(certPath, "utf8")).resolves.toBe("operator-owned-cert\n");
-    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
-    const entries = await fs.readdir(dir);
-    const recoveryDir = requireSingleRecoveryDir(entries);
-    await expect(
-      fs.readdir(path.join(dir, recoveryDir)).then((items) => items.toSorted()),
-    ).resolves.toEqual(["cert.pem", "published-gateway-cert.pem"]);
-  });
-
-  it("restores a directory replaced after the rollback ownership check", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
-    });
-    const realLink = fs.link.bind(fs);
-    const realRename = fs.rename.bind(fs);
-    let linkCount = 0;
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      linkCount += 1;
-      if (path.resolve(String(newPath)) === keyPath) {
-        await fs.writeFile(keyPath, "operator-owned-key\n", { flag: "wx" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (oldPath, newPath) => {
-      if (path.resolve(String(oldPath)) === certPath) {
-        await fs.unlink(certPath);
-        await fs.mkdir(certPath);
-        await fs.writeFile(path.join(certPath, "operator-owned.txt"), "operator directory\n");
-      }
-      return await realRename(oldPath, newPath);
-    });
-
-    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
-    try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    } finally {
-      renameSpy.mockRestore();
-      linkSpy.mockRestore();
-    }
-
-    expect(linkCount).toBe(2);
-    expect(result?.enabled).toBe(false);
-    expect(result?.error).toContain("publication failed");
-    await expect(fs.readFile(path.join(certPath, "operator-owned.txt"), "utf8")).resolves.toBe(
-      "operator directory\n",
-    );
-    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe("operator-owned-key\n");
-    const entries = await fs.readdir(dir);
-    const recoveryDir = requireSingleRecoveryDir(entries);
-    await expect(
-      fs.readFile(
-        path.join(dir, recoveryDir, "published-gateway-cert.pem", "operator-owned.txt"),
-        "utf8",
-      ),
-    ).resolves.toBe("operator directory\n");
-  });
-
-  it("retries a transient second-link failure", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
-    });
-    const realLink = fs.link.bind(fs);
-    let linkCount = 0;
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      linkCount += 1;
-      if (linkCount === 2) {
-        throw Object.assign(new Error("transient link failure"), { code: "EIO" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-
-    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    linkSpy.mockRestore();
-
-    expect(linkCount).toBe(3);
-    expect(result.enabled).toBe(true);
     await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
     await expect(fs.readFile(keyPath, "utf8")).resolves.toBe(KEY_PEM);
     await expect(fs.readdir(dir).then((entries) => entries.toSorted())).resolves.toEqual([
       "gateway-cert.pem",
       "gateway-key.pem",
     ]);
-  });
-
-  it("rolls back a generated output after transient link retries are exhausted", async () => {
-    const dir = await createTempDir();
-    const certPath = path.join(dir, "gateway-cert.pem");
-    const keyPath = path.join(dir, "gateway-key.pem");
-    runExecMock.mockImplementation(async (_command: string, args: string[]) => {
-      await writeGeneratedTlsPair(args);
-    });
-    const realLink = fs.link.bind(fs);
-    let linkCount = 0;
-    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (existingPath, newPath) => {
-      linkCount += 1;
-      if (linkCount >= 2 && linkCount <= 4) {
-        throw Object.assign(new Error("persistent link failure"), { code: "EIO" });
-      }
-      return await realLink(existingPath, newPath);
-    });
-
-    const failedResult = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-    linkSpy.mockRestore();
-
-    expect(linkCount).toBe(4);
-    expect(failedResult.enabled).toBe(false);
-    expect(failedResult.error).toContain("publication failed");
-    expect(failedResult.error).toContain("concurrent output backup preserved under");
-    await expect(fs.access(certPath)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fs.access(keyPath)).rejects.toMatchObject({ code: "ENOENT" });
-    const recoveryDir = requireSingleRecoveryDir(await fs.readdir(dir));
-    await expect(
-      fs.readdir(path.join(dir, recoveryDir)).then((items) => items.toSorted()),
-    ).resolves.toEqual(["cert.pem", "published-gateway-cert.pem"]);
-
-    const retryResult = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
-
-    expect(retryResult.enabled).toBe(true);
-    await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
-    await expect(fs.readFile(keyPath, "utf8")).resolves.toBe(KEY_PEM);
+    if (process.platform !== "win32") {
+      expect((await fs.stat(certPath)).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(keyPath)).mode & 0o777).toBe(0o600);
+    }
   });
 
   it("reports load failures for invalid pem files", async () => {

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -1,222 +1,69 @@
 // Gateway TLS runtime loads configured certificates or generates a local
 // self-signed pair, returning server-ready options plus client fingerprint.
-import { createHash, X509Certificate } from "node:crypto";
-import { constants as fsConstants, type Stats } from "node:fs";
+import { X509Certificate } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { setTimeout as delay } from "node:timers/promises";
 import tls from "node:tls";
 import type { GatewayTlsConfig } from "../../config/types.gateway.js";
 import { runExec } from "../../process/exec.js";
 import { CONFIG_DIR, ensureDir, resolveUserPath, shortenHomeInString } from "../../utils.js";
-import { sameFileIdentity } from "../fs-safe-advanced.js";
 import { pathExists } from "../fs-safe.js";
 import { resolveSystemBin } from "../resolve-system-bin.js";
 import { normalizeFingerprint } from "./fingerprint.js";
 
 const GATEWAY_TLS_CERT_GENERATION_TIMEOUT_MS = 30_000;
-const GATEWAY_TLS_LINK_ATTEMPTS = 3;
-const GATEWAY_TLS_LINK_RETRY_DELAY_MS = 25;
-const TRANSIENT_LINK_ERROR_CODES = new Set(["EBUSY", "EINTR", "EIO"]);
 
-type GeneratedTlsOutput = {
-  contentDigest: string;
-  finalPath: string;
-  identity: Stats;
-  published: boolean;
-  stageDir: string;
-  stagedPath: string;
+type GatewayTlsLog = {
+  info?: (message: string) => void;
+  warn?: (message: string, meta?: Record<string, unknown>) => void;
 };
 
-type GeneratedTlsRecovery = {
-  error?: unknown;
-  preserveStageDir: boolean;
+type GatewayTlsDegradation = {
+  event: "gateway.tls.degraded";
+  ownerKind: "gateway";
+  ownerId: "tls";
+  reason: "atomic hard-link publication unavailable";
+  state: "best-effort";
 };
 
-type GeneratedTlsOutputState = "changed" | "generated" | "missing" | "replaced";
+const GATEWAY_TLS_DEGRADATION: GatewayTlsDegradation = {
+  event: "gateway.tls.degraded",
+  ownerKind: "gateway",
+  ownerId: "tls",
+  reason: "atomic hard-link publication unavailable",
+  state: "best-effort",
+};
 
-class TlsPublicationError extends Error {
-  readonly preserveStageDirs: ReadonlySet<string>;
-
-  constructor(
-    message: string,
-    options: { cause: unknown; preserveStageDirs: ReadonlySet<string> },
-  ) {
-    super(message, { cause: options.cause });
-    this.name = "TlsPublicationError";
-    this.preserveStageDirs = options.preserveStageDirs;
-  }
+function isHardLinkUnsupportedError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EPERM";
 }
 
-function digestTlsContent(content: Buffer): string {
-  return createHash("sha256").update(content).digest("hex");
-}
-
-async function publishGeneratedTlsOutput(output: GeneratedTlsOutput): Promise<void> {
-  // Hard links provide atomic no-replace publication without exposing partial key bytes.
-  // Filesystems without that guarantee fail closed instead of using a writable fallback.
-  for (let attempt = 1; attempt <= GATEWAY_TLS_LINK_ATTEMPTS; attempt += 1) {
-    try {
-      await fs.link(output.stagedPath, output.finalPath);
-      output.published = true;
-      return;
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (attempt === GATEWAY_TLS_LINK_ATTEMPTS || !TRANSIENT_LINK_ERROR_CODES.has(code ?? "")) {
-        throw error;
-      }
-      await delay(GATEWAY_TLS_LINK_RETRY_DELAY_MS);
-    }
-  }
-}
-
-async function inspectGeneratedTlsOutput(
-  output: GeneratedTlsOutput,
-  filePath: string,
-): Promise<GeneratedTlsOutputState> {
-  let currentIdentity: Stats;
-  try {
-    currentIdentity = await fs.lstat(filePath);
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "changed";
-  }
-  if (!currentIdentity.isFile() || !sameFileIdentity(output.identity, currentIdentity)) {
-    return "replaced";
-  }
-
-  let handle: Awaited<ReturnType<typeof fs.open>>;
-  try {
-    handle = await fs.open(filePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    return code === "ENOENT" || code === "ELOOP" ? "replaced" : "changed";
-  }
-  let state: GeneratedTlsOutputState;
-  try {
-    const openedIdentity = await handle.stat();
-    if (!sameFileIdentity(output.identity, openedIdentity)) {
-      state = "replaced";
-    } else {
-      const contents = await handle.readFile();
-      state = digestTlsContent(contents) === output.contentDigest ? "generated" : "changed";
-    }
-  } catch {
-    state = "changed";
-  }
-  try {
-    await handle.close();
-  } catch {
-    return "changed";
-  }
-  return state;
-}
-
-async function restoreRecoveredOutput(
-  recoveryPath: string,
+async function publishGeneratedTlsOutput(
+  stagedPath: string,
   finalPath: string,
-  identity: Stats,
-): Promise<void> {
-  if (identity.isDirectory()) {
-    await fs.cp(recoveryPath, finalPath, {
-      errorOnExist: true,
-      force: false,
-      preserveTimestamps: true,
-      recursive: true,
-      verbatimSymlinks: true,
-    });
-    return;
-  }
-  if (identity.isSymbolicLink()) {
-    await fs.symlink(await fs.readlink(recoveryPath), finalPath);
-    return;
-  }
+  contents: string,
+): Promise<boolean> {
   try {
-    await fs.link(recoveryPath, finalPath);
-  } catch {
-    try {
-      await fs.copyFile(recoveryPath, finalPath, fsConstants.COPYFILE_EXCL);
-    } catch (copyError) {
-      throw new Error("failed to restore recovered tls output after hard-link failure", {
-        cause: copyError,
-      });
+    await fs.link(stagedPath, finalPath);
+    return false;
+  } catch (error) {
+    if (!isHardLinkUnsupportedError(error)) {
+      throw error;
     }
   }
-}
 
-async function recoverPublishedTlsOutput(
-  output: GeneratedTlsOutput,
-): Promise<GeneratedTlsRecovery> {
-  if (!output.published) {
-    return { preserveStageDir: false };
-  }
-  const recoveryPath = path.join(output.stageDir, `published-${path.basename(output.finalPath)}`);
-  const currentState = await inspectGeneratedTlsOutput(output, output.finalPath);
-  if (currentState === "missing" || currentState === "replaced") {
-    return { preserveStageDir: false };
-  }
-  // Identity alone cannot detect in-place writes to a hard-linked output.
-  // Keep both paths when content changed so rollback never deletes operator data.
-  if (currentState === "changed") {
-    return { preserveStageDir: true };
-  }
+  // Some supported filesystems cannot publish with hard links. An exclusive handle keeps
+  // no-overwrite semantics without pathname cleanup that could delete concurrent output;
+  // a failed best-effort write may leave this attempt's partial file for operator cleanup.
+  const handle = await fs.open(finalPath, "wx", 0o600);
   try {
-    await fs.rename(output.finalPath, recoveryPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { preserveStageDir: false };
-    }
-    return { error, preserveStageDir: true };
+    await handle.writeFile(contents, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
   }
-
-  const recoveredState = await inspectGeneratedTlsOutput(output, recoveryPath);
-  if (recoveredState === "generated") {
-    // An already-open writer can still mutate this inode after the final check.
-    // Keep the recovery pathname so rollback never discards those late writes.
-    return { preserveStageDir: true };
-  }
-
-  let recoveredIdentity: Stats;
-  try {
-    recoveredIdentity = await fs.lstat(recoveryPath);
-  } catch (error) {
-    return { error, preserveStageDir: true };
-  }
-  try {
-    await restoreRecoveredOutput(recoveryPath, output.finalPath, recoveredIdentity);
-    return { preserveStageDir: true };
-  } catch (error) {
-    return { error, preserveStageDir: true };
-  }
-}
-
-async function publishGeneratedTlsOutputs(outputs: GeneratedTlsOutput[]): Promise<void> {
-  try {
-    for (const output of outputs) {
-      await publishGeneratedTlsOutput(output);
-    }
-  } catch (error) {
-    const preserveStageDirs = new Set<string>();
-    const recoveryErrors: unknown[] = [];
-    for (const output of outputs.toReversed()) {
-      const recovery = await recoverPublishedTlsOutput(output);
-      if (recovery.preserveStageDir) {
-        preserveStageDirs.add(output.stageDir);
-      }
-      if (recovery.error) {
-        recoveryErrors.push(recovery.error);
-      }
-    }
-    const recoveryNotice = preserveStageDirs.size
-      ? `; concurrent output backup preserved under ${[...preserveStageDirs].join(", ")}`
-      : "";
-    throw new TlsPublicationError(
-      `gateway tls: generated pair publication failed${recoveryNotice}`,
-      {
-        cause: new AggregateError([error, ...recoveryErrors]),
-        preserveStageDirs,
-      },
-    );
-  }
+  return true;
 }
 
 // Gateway TLS runtime carries loaded cert material plus the normalized SHA-256
@@ -235,7 +82,7 @@ export type GatewayTlsRuntime = {
 async function generateSelfSignedCert(params: {
   certPath: string;
   keyPath: string;
-  log?: { info?: (msg: string) => void };
+  log?: GatewayTlsLog;
 }): Promise<void> {
   const certDir = path.dirname(params.certPath);
   const keyDir = path.dirname(params.keyPath);
@@ -252,7 +99,6 @@ async function generateSelfSignedCert(params: {
   const certStageDir = await fs.mkdtemp(path.join(certDir, ".openclaw-gateway-tls-cert-"));
   const stagedCertPath = path.join(certStageDir, "cert.pem");
   let keyStageDir: string | undefined;
-  let preserveStageDirs: ReadonlySet<string> = new Set();
   try {
     keyStageDir = await fs.mkdtemp(path.join(keyDir, ".openclaw-gateway-tls-key-"));
     const stagedKeyPath = path.join(keyStageDir, "key.pem");
@@ -283,44 +129,32 @@ async function generateSelfSignedCert(params: {
       },
     );
     await Promise.all([fs.chmod(stagedKeyPath, 0o600), fs.chmod(stagedCertPath, 0o600)]);
-    const [cert, key, certIdentity, keyIdentity] = await Promise.all([
+    const [cert, key] = await Promise.all([
       fs.readFile(stagedCertPath, "utf8"),
       fs.readFile(stagedKeyPath, "utf8"),
-      fs.lstat(stagedCertPath),
-      fs.lstat(stagedKeyPath),
     ]);
     tls.createSecureContext({ cert, key, minVersion: "TLSv1.3" });
-    await publishGeneratedTlsOutputs([
-      {
-        contentDigest: digestTlsContent(Buffer.from(cert, "utf8")),
-        finalPath: params.certPath,
-        identity: certIdentity,
-        published: false,
-        stageDir: certStageDir,
-        stagedPath: stagedCertPath,
-      },
-      {
-        contentDigest: digestTlsContent(Buffer.from(key, "utf8")),
-        finalPath: params.keyPath,
-        identity: keyIdentity,
-        published: false,
-        stageDir: keyStageDir,
-        stagedPath: stagedKeyPath,
-      },
-    ]);
+    let usedBestEffortPublication = await publishGeneratedTlsOutput(
+      stagedCertPath,
+      params.certPath,
+      cert,
+    );
+    usedBestEffortPublication =
+      (await publishGeneratedTlsOutput(stagedKeyPath, params.keyPath, key)) ||
+      usedBestEffortPublication;
+    if (usedBestEffortPublication) {
+      params.log?.warn?.(
+        `[GATEWAY_TLS_DEGRADED] best-effort gateway:tls: ${GATEWAY_TLS_DEGRADATION.reason}.`,
+        GATEWAY_TLS_DEGRADATION,
+      );
+    }
     params.log?.info?.(
       `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
     );
-  } catch (error) {
-    if (error instanceof TlsPublicationError) {
-      preserveStageDirs = error.preserveStageDirs;
-    }
-    throw error;
   } finally {
     await Promise.allSettled(
       [certStageDir, keyStageDir]
         .filter((dir): dir is string => Boolean(dir))
-        .filter((dir) => !preserveStageDirs.has(dir))
         .map((dir) => fs.rm(dir, { force: true, recursive: true })),
     );
   }
@@ -329,7 +163,7 @@ async function generateSelfSignedCert(params: {
 /** Load or generate gateway TLS material and return server-ready TLS options. */
 export async function loadGatewayTlsRuntime(
   cfg: GatewayTlsConfig | undefined,
-  log?: { info?: (msg: string) => void; warn?: (msg: string) => void },
+  log?: GatewayTlsLog,
 ): Promise<GatewayTlsRuntime> {
   if (!cfg || cfg.enabled !== true) {
     return { enabled: false, required: false };

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -1,9 +1,10 @@
 // Gateway TLS runtime loads configured certificates or generates a local
 // self-signed pair, returning server-ready options plus client fingerprint.
 import { X509Certificate } from "node:crypto";
-import fsSync, { type Stats } from "node:fs";
+import { constants as fsConstants, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import tls from "node:tls";
 import type { GatewayTlsConfig } from "../../config/types.gateway.js";
 import { runExec } from "../../process/exec.js";
@@ -14,41 +15,154 @@ import { resolveSystemBin } from "../resolve-system-bin.js";
 import { normalizeFingerprint } from "./fingerprint.js";
 
 const GATEWAY_TLS_CERT_GENERATION_TIMEOUT_MS = 30_000;
+const GATEWAY_TLS_LINK_ATTEMPTS = 3;
+const GATEWAY_TLS_LINK_RETRY_DELAY_MS = 25;
+const TRANSIENT_LINK_ERROR_CODES = new Set(["EBUSY", "EINTR", "EIO"]);
 
 type GeneratedTlsOutput = {
   finalPath: string;
   identity: Stats;
   published: boolean;
+  stageDir: string;
   stagedPath: string;
 };
 
-function removePublishedOutputIfOwned(output: GeneratedTlsOutput): void {
-  if (!output.published) {
+type GeneratedTlsRecovery = {
+  error?: unknown;
+  preserveStageDir: boolean;
+};
+
+class TlsPublicationError extends Error {
+  readonly preserveStageDirs: ReadonlySet<string>;
+
+  constructor(
+    message: string,
+    options: { cause: unknown; preserveStageDirs: ReadonlySet<string> },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "TlsPublicationError";
+    this.preserveStageDirs = options.preserveStageDirs;
+  }
+}
+
+async function linkGeneratedTlsOutput(output: GeneratedTlsOutput): Promise<void> {
+  for (let attempt = 1; attempt <= GATEWAY_TLS_LINK_ATTEMPTS; attempt += 1) {
+    try {
+      await fs.link(output.stagedPath, output.finalPath);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (attempt === GATEWAY_TLS_LINK_ATTEMPTS || !TRANSIENT_LINK_ERROR_CODES.has(code ?? "")) {
+        throw error;
+      }
+      await delay(GATEWAY_TLS_LINK_RETRY_DELAY_MS);
+    }
+  }
+}
+
+async function restoreRecoveredOutput(
+  recoveryPath: string,
+  finalPath: string,
+  identity: Stats,
+): Promise<void> {
+  if (identity.isDirectory()) {
+    await fs.cp(recoveryPath, finalPath, {
+      errorOnExist: true,
+      force: false,
+      preserveTimestamps: true,
+      recursive: true,
+      verbatimSymlinks: true,
+    });
+    return;
+  }
+  if (identity.isSymbolicLink()) {
+    await fs.symlink(await fs.readlink(recoveryPath), finalPath);
     return;
   }
   try {
-    const current = fsSync.lstatSync(output.finalPath);
-    if (sameFileIdentity(output.identity, current)) {
-      fsSync.unlinkSync(output.finalPath);
+    await fs.link(recoveryPath, finalPath);
+  } catch (linkError) {
+    try {
+      await fs.copyFile(recoveryPath, finalPath, fsConstants.COPYFILE_EXCL);
+    } catch (copyError) {
+      throw new AggregateError([linkError, copyError], "failed to restore recovered tls output");
     }
+  }
+}
+
+async function recoverPublishedTlsOutput(
+  output: GeneratedTlsOutput,
+): Promise<GeneratedTlsRecovery> {
+  if (!output.published) {
+    return { preserveStageDir: false };
+  }
+  const recoveryPath = path.join(output.stageDir, `published-${path.basename(output.finalPath)}`);
+  let currentIdentity: Stats;
+  try {
+    currentIdentity = await fs.lstat(output.finalPath);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { preserveStageDir: false };
     }
+    return { error, preserveStageDir: false };
+  }
+  if (!sameFileIdentity(output.identity, currentIdentity)) {
+    return { preserveStageDir: false };
+  }
+  try {
+    await fs.rename(output.finalPath, recoveryPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { preserveStageDir: false };
+    }
+    return { error, preserveStageDir: true };
+  }
+
+  let recoveredIdentity: Stats;
+  try {
+    recoveredIdentity = await fs.lstat(recoveryPath);
+  } catch (error) {
+    return { error, preserveStageDir: true };
+  }
+  if (sameFileIdentity(output.identity, recoveredIdentity)) {
+    return { preserveStageDir: false };
+  }
+  try {
+    await restoreRecoveredOutput(recoveryPath, output.finalPath, recoveredIdentity);
+    return { preserveStageDir: true };
+  } catch (error) {
+    return { error, preserveStageDir: true };
   }
 }
 
 async function publishGeneratedTlsOutputs(outputs: GeneratedTlsOutput[]): Promise<void> {
   try {
     for (const output of outputs) {
-      await fs.link(output.stagedPath, output.finalPath);
+      await linkGeneratedTlsOutput(output);
       output.published = true;
     }
   } catch (error) {
+    const preserveStageDirs = new Set<string>();
+    const recoveryErrors: unknown[] = [];
     for (const output of outputs.toReversed()) {
-      removePublishedOutputIfOwned(output);
+      const recovery = await recoverPublishedTlsOutput(output);
+      if (recovery.preserveStageDir) {
+        preserveStageDirs.add(output.stageDir);
+      }
+      if (recovery.error) {
+        recoveryErrors.push(recovery.error);
+      }
     }
-    throw error;
+    const recoveryNotice = preserveStageDirs.size
+      ? `; concurrent output backup preserved under ${[...preserveStageDirs].join(", ")}`
+      : "";
+    throw new TlsPublicationError(
+      `gateway tls: generated pair publication failed${recoveryNotice}`,
+      {
+        cause: new AggregateError([error, ...recoveryErrors]),
+        preserveStageDirs,
+      },
+    );
   }
 }
 
@@ -85,6 +199,7 @@ async function generateSelfSignedCert(params: {
   const certStageDir = await fs.mkdtemp(path.join(certDir, ".openclaw-gateway-tls-cert-"));
   const stagedCertPath = path.join(certStageDir, "cert.pem");
   let keyStageDir: string | undefined;
+  let preserveStageDirs: ReadonlySet<string> = new Set();
   try {
     keyStageDir = await fs.mkdtemp(path.join(keyDir, ".openclaw-gateway-tls-key-"));
     const stagedKeyPath = path.join(keyStageDir, "key.pem");
@@ -127,22 +242,30 @@ async function generateSelfSignedCert(params: {
         finalPath: params.certPath,
         identity: certIdentity,
         published: false,
+        stageDir: certStageDir,
         stagedPath: stagedCertPath,
       },
       {
         finalPath: params.keyPath,
         identity: keyIdentity,
         published: false,
+        stageDir: keyStageDir,
         stagedPath: stagedKeyPath,
       },
     ]);
     params.log?.info?.(
       `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
     );
+  } catch (error) {
+    if (error instanceof TlsPublicationError) {
+      preserveStageDirs = error.preserveStageDirs;
+    }
+    throw error;
   } finally {
     await Promise.allSettled(
       [certStageDir, keyStageDir]
         .filter((dir): dir is string => Boolean(dir))
+        .filter((dir) => !preserveStageDirs.has(dir))
         .map((dir) => fs.rm(dir, { force: true, recursive: true })),
     );
   }

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -11,6 +11,8 @@ import { pathExists } from "../fs-safe.js";
 import { resolveSystemBin } from "../resolve-system-bin.js";
 import { normalizeFingerprint } from "./fingerprint.js";
 
+const GATEWAY_TLS_CERT_GENERATION_TIMEOUT_MS = 30_000;
+
 // Gateway TLS runtime carries loaded cert material plus the normalized SHA-256
 // fingerprint advertised to clients.
 export type GatewayTlsRuntime = {
@@ -61,7 +63,10 @@ async function generateSelfSignedCert(params: {
       "-subj",
       "/CN=openclaw-gateway",
     ],
-    { logOutput: false },
+    {
+      logOutput: false,
+      timeoutMs: GATEWAY_TLS_CERT_GENERATION_TIMEOUT_MS,
+    },
   );
   await fs.chmod(params.keyPath, 0o600).catch(() => {});
   await fs.chmod(params.certPath, 0o600).catch(() => {});

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -1,17 +1,56 @@
 // Gateway TLS runtime loads configured certificates or generates a local
 // self-signed pair, returning server-ready options plus client fingerprint.
 import { X509Certificate } from "node:crypto";
+import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import tls from "node:tls";
 import type { GatewayTlsConfig } from "../../config/types.gateway.js";
 import { runExec } from "../../process/exec.js";
 import { CONFIG_DIR, ensureDir, resolveUserPath, shortenHomeInString } from "../../utils.js";
+import { sameFileIdentity } from "../fs-safe-advanced.js";
 import { pathExists } from "../fs-safe.js";
 import { resolveSystemBin } from "../resolve-system-bin.js";
 import { normalizeFingerprint } from "./fingerprint.js";
 
 const GATEWAY_TLS_CERT_GENERATION_TIMEOUT_MS = 30_000;
+
+type GeneratedTlsOutput = {
+  finalPath: string;
+  identity: Stats;
+  published: boolean;
+  stagedPath: string;
+};
+
+function removePublishedOutputIfOwned(output: GeneratedTlsOutput): void {
+  if (!output.published) {
+    return;
+  }
+  try {
+    const current = fsSync.lstatSync(output.finalPath);
+    if (sameFileIdentity(output.identity, current)) {
+      fsSync.unlinkSync(output.finalPath);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function publishGeneratedTlsOutputs(outputs: GeneratedTlsOutput[]): Promise<void> {
+  try {
+    for (const output of outputs) {
+      await fs.link(output.stagedPath, output.finalPath);
+      output.published = true;
+    }
+  } catch (error) {
+    for (const output of outputs.toReversed()) {
+      removePublishedOutputIfOwned(output);
+    }
+    throw error;
+  }
+}
 
 // Gateway TLS runtime carries loaded cert material plus the normalized SHA-256
 // fingerprint advertised to clients.
@@ -43,36 +82,70 @@ async function generateSelfSignedCert(params: {
       "openssl not found in trusted system directories. Install it in an OS-managed location.",
     );
   }
-  // Use argv execution with a trusted system binary; certificate paths are arguments,
-  // not shell text.
-  await runExec(
-    opensslBin,
-    [
-      "req",
-      "-x509",
-      "-newkey",
-      "rsa:2048",
-      "-sha256",
-      "-days",
-      "3650",
-      "-nodes",
-      "-keyout",
-      params.keyPath,
-      "-out",
-      params.certPath,
-      "-subj",
-      "/CN=openclaw-gateway",
-    ],
-    {
-      logOutput: false,
-      timeoutMs: GATEWAY_TLS_CERT_GENERATION_TIMEOUT_MS,
-    },
-  );
-  await fs.chmod(params.keyPath, 0o600).catch(() => {});
-  await fs.chmod(params.certPath, 0o600).catch(() => {});
-  params.log?.info?.(
-    `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
-  );
+  const certStageDir = await fs.mkdtemp(path.join(certDir, ".openclaw-gateway-tls-cert-"));
+  const stagedCertPath = path.join(certStageDir, "cert.pem");
+  let keyStageDir: string | undefined;
+  try {
+    keyStageDir = await fs.mkdtemp(path.join(keyDir, ".openclaw-gateway-tls-key-"));
+    const stagedKeyPath = path.join(keyStageDir, "key.pem");
+    await Promise.all([fs.chmod(certStageDir, 0o700), fs.chmod(keyStageDir, 0o700)]);
+    // OpenSSL never sees the configured final paths, so timeout and generation
+    // failures cannot strand a half-written certificate pair there.
+    await runExec(
+      opensslBin,
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-sha256",
+        "-days",
+        "3650",
+        "-nodes",
+        "-keyout",
+        stagedKeyPath,
+        "-out",
+        stagedCertPath,
+        "-subj",
+        "/CN=openclaw-gateway",
+      ],
+      {
+        logOutput: false,
+        timeoutMs: GATEWAY_TLS_CERT_GENERATION_TIMEOUT_MS,
+      },
+    );
+    await Promise.all([fs.chmod(stagedKeyPath, 0o600), fs.chmod(stagedCertPath, 0o600)]);
+    const [cert, key, certIdentity, keyIdentity] = await Promise.all([
+      fs.readFile(stagedCertPath, "utf8"),
+      fs.readFile(stagedKeyPath, "utf8"),
+      fs.lstat(stagedCertPath),
+      fs.lstat(stagedKeyPath),
+    ]);
+    tls.createSecureContext({ cert, key, minVersion: "TLSv1.3" });
+    await publishGeneratedTlsOutputs([
+      {
+        finalPath: params.certPath,
+        identity: certIdentity,
+        published: false,
+        stagedPath: stagedCertPath,
+      },
+      {
+        finalPath: params.keyPath,
+        identity: keyIdentity,
+        published: false,
+        stagedPath: stagedKeyPath,
+      },
+    ]);
+    params.log?.info?.(
+      `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
+    );
+  } finally {
+    await Promise.allSettled(
+      [certStageDir, keyStageDir]
+        .filter((dir): dir is string => Boolean(dir))
+        .map((dir) => fs.rm(dir, { force: true, recursive: true })),
+    );
+  }
 }
 
 /** Load or generate gateway TLS material and return server-ready TLS options. */

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -1,6 +1,6 @@
 // Gateway TLS runtime loads configured certificates or generates a local
 // self-signed pair, returning server-ready options plus client fingerprint.
-import { X509Certificate } from "node:crypto";
+import { createHash, X509Certificate } from "node:crypto";
 import { constants as fsConstants, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -20,6 +20,7 @@ const GATEWAY_TLS_LINK_RETRY_DELAY_MS = 25;
 const TRANSIENT_LINK_ERROR_CODES = new Set(["EBUSY", "EINTR", "EIO"]);
 
 type GeneratedTlsOutput = {
+  contentDigest: string;
   finalPath: string;
   identity: Stats;
   published: boolean;
@@ -31,6 +32,8 @@ type GeneratedTlsRecovery = {
   error?: unknown;
   preserveStageDir: boolean;
 };
+
+type GeneratedTlsOutputState = "changed" | "generated" | "missing" | "replaced";
 
 class TlsPublicationError extends Error {
   readonly preserveStageDirs: ReadonlySet<string>;
@@ -45,10 +48,17 @@ class TlsPublicationError extends Error {
   }
 }
 
-async function linkGeneratedTlsOutput(output: GeneratedTlsOutput): Promise<void> {
+function digestTlsContent(content: Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function publishGeneratedTlsOutput(output: GeneratedTlsOutput): Promise<void> {
+  // Hard links provide atomic no-replace publication without exposing partial key bytes.
+  // Filesystems without that guarantee fail closed instead of using a writable fallback.
   for (let attempt = 1; attempt <= GATEWAY_TLS_LINK_ATTEMPTS; attempt += 1) {
     try {
       await fs.link(output.stagedPath, output.finalPath);
+      output.published = true;
       return;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
@@ -58,6 +68,47 @@ async function linkGeneratedTlsOutput(output: GeneratedTlsOutput): Promise<void>
       await delay(GATEWAY_TLS_LINK_RETRY_DELAY_MS);
     }
   }
+}
+
+async function inspectGeneratedTlsOutput(
+  output: GeneratedTlsOutput,
+  filePath: string,
+): Promise<GeneratedTlsOutputState> {
+  let currentIdentity: Stats;
+  try {
+    currentIdentity = await fs.lstat(filePath);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "changed";
+  }
+  if (!currentIdentity.isFile() || !sameFileIdentity(output.identity, currentIdentity)) {
+    return "replaced";
+  }
+
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(filePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ELOOP" ? "replaced" : "changed";
+  }
+  let state: GeneratedTlsOutputState;
+  try {
+    const openedIdentity = await handle.stat();
+    if (!sameFileIdentity(output.identity, openedIdentity)) {
+      state = "replaced";
+    } else {
+      const contents = await handle.readFile();
+      state = digestTlsContent(contents) === output.contentDigest ? "generated" : "changed";
+    }
+  } catch {
+    state = "changed";
+  }
+  try {
+    await handle.close();
+  } catch {
+    return "changed";
+  }
+  return state;
 }
 
 async function restoreRecoveredOutput(
@@ -81,11 +132,13 @@ async function restoreRecoveredOutput(
   }
   try {
     await fs.link(recoveryPath, finalPath);
-  } catch (linkError) {
+  } catch {
     try {
       await fs.copyFile(recoveryPath, finalPath, fsConstants.COPYFILE_EXCL);
     } catch (copyError) {
-      throw new AggregateError([linkError, copyError], "failed to restore recovered tls output");
+      throw new Error("failed to restore recovered tls output after hard-link failure", {
+        cause: copyError,
+      });
     }
   }
 }
@@ -97,17 +150,14 @@ async function recoverPublishedTlsOutput(
     return { preserveStageDir: false };
   }
   const recoveryPath = path.join(output.stageDir, `published-${path.basename(output.finalPath)}`);
-  let currentIdentity: Stats;
-  try {
-    currentIdentity = await fs.lstat(output.finalPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { preserveStageDir: false };
-    }
-    return { error, preserveStageDir: false };
-  }
-  if (!sameFileIdentity(output.identity, currentIdentity)) {
+  const currentState = await inspectGeneratedTlsOutput(output, output.finalPath);
+  if (currentState === "missing" || currentState === "replaced") {
     return { preserveStageDir: false };
+  }
+  // Identity alone cannot detect in-place writes to a hard-linked output.
+  // Keep both paths when content changed so rollback never deletes operator data.
+  if (currentState === "changed") {
+    return { preserveStageDir: true };
   }
   try {
     await fs.rename(output.finalPath, recoveryPath);
@@ -118,14 +168,18 @@ async function recoverPublishedTlsOutput(
     return { error, preserveStageDir: true };
   }
 
+  const recoveredState = await inspectGeneratedTlsOutput(output, recoveryPath);
+  if (recoveredState === "generated") {
+    // An already-open writer can still mutate this inode after the final check.
+    // Keep the recovery pathname so rollback never discards those late writes.
+    return { preserveStageDir: true };
+  }
+
   let recoveredIdentity: Stats;
   try {
     recoveredIdentity = await fs.lstat(recoveryPath);
   } catch (error) {
     return { error, preserveStageDir: true };
-  }
-  if (sameFileIdentity(output.identity, recoveredIdentity)) {
-    return { preserveStageDir: false };
   }
   try {
     await restoreRecoveredOutput(recoveryPath, output.finalPath, recoveredIdentity);
@@ -138,8 +192,7 @@ async function recoverPublishedTlsOutput(
 async function publishGeneratedTlsOutputs(outputs: GeneratedTlsOutput[]): Promise<void> {
   try {
     for (const output of outputs) {
-      await linkGeneratedTlsOutput(output);
-      output.published = true;
+      await publishGeneratedTlsOutput(output);
     }
   } catch (error) {
     const preserveStageDirs = new Set<string>();
@@ -239,6 +292,7 @@ async function generateSelfSignedCert(params: {
     tls.createSecureContext({ cert, key, minVersion: "TLSv1.3" });
     await publishGeneratedTlsOutputs([
       {
+        contentDigest: digestTlsContent(Buffer.from(cert, "utf8")),
         finalPath: params.certPath,
         identity: certIdentity,
         published: false,
@@ -246,6 +300,7 @@ async function generateSelfSignedCert(params: {
         stagedPath: stagedCertPath,
       },
       {
+        contentDigest: digestTlsContent(Buffer.from(key, "utf8")),
         finalPath: params.keyPath,
         identity: keyIdentity,
         published: false,


### PR DESCRIPTION
## What Problem This Solves

Automatic Gateway TLS setup runs `openssl req` when no certificate/key exists. The old path had no timeout and wrote directly to configured final paths, so a stalled or interrupted process could block startup indefinitely or leave partial certificate material.

## Why This Change Was Made

This branch now implements the maintainer-decided best-effort policy:

- bound OpenSSL generation to 30 seconds through the existing `runExec` lifecycle;
- generate and validate the certificate/key pair in private staging directories;
- publish with atomic no-overwrite hard links when the filesystem supports them;
- when hard links are unsupported (`ENOTSUP`, `EOPNOTSUPP`, or `EPERM`), publish through exclusive `wx` file handles instead of blocking startup;
- emit one typed `[GATEWAY_TLS_DEGRADED]` warning with `gateway:tls` owner metadata when best-effort publication is used.

There is no new config, environment variable, dependency, migration, protocol, or schema surface. `CHANGELOG.md` is unchanged.

## User Impact

A stalled OpenSSL process no longer hangs Gateway startup or writes into configured final paths. Filesystems without hard-link support continue startup with the generated TLS pair and one structured degradation warning.

The non-atomic fallback deliberately does not delete final pathnames on failure because another process may replace them. A failed best-effort write can therefore leave an attempt-owned partial file for operator cleanup; this is the explicit availability-over-atomicity tradeoff selected for this path.

Release-note context: Gateway self-signed TLS generation is now bounded and staged, and unsupported hard-link filesystems use a warned best-effort fallback. Original fix by @Alix-007.

## Evidence

- Exact current head: `5d3ca4adc51e657f0255d5fdce09c694dce0e17a`, rebased onto current `main` before push.
- `mise exec node@24.18.0 -- node scripts/run-vitest.mjs src/infra/tls/gateway.test.ts`: 11/11 passed on the exact rebased tree.
- Source-blind contract probe for `publishes best-effort and warns once when hard links are unavailable`: 1/1 passed; the harness asserts enabled TLS, private final files, and exactly one typed diagnostic for `ENOTSUP`.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 node scripts/check-changed.mjs -- src/infra/tls/gateway.ts src/infra/tls/gateway.test.ts` under Node 24.18.0: core and core-test typechecks, targeted lint/format, import cycles, dependency/patch guards, and repository guards passed.
- Blacksmith Testbox warmup timed out three times before allocation. AWS Crabbox `run_e694396eb80f` / `cbx_c81aecb18d7d` reached the check command but the raw synced workspace intentionally had no `.git`, so its conflict-marker guard could not run; the lease stopped cleanly. The trusted-source local fallback above supplied the complete changed gate.
- AutoReview secret scanning is clean. Two deletion/rollback findings were accepted as real risks but consciously rejected as contrary to the maintainer-decided best-effort policy; the fallback uses an exclusive handle and performs no pathname cleanup that could delete concurrent operator material.
- Dependency contracts checked against Node 24 `fs` documentation (`wx`/exclusive creation and copy cleanup behavior), Execa 9.6.1 timeout semantics, OpenClaw `runExec`, and the sibling backup publication patterns.

AI-assisted: yes. Final implementation and evidence were maintainer-reviewed.
