### PR TITLE
test(scripts): fix pid-write race in tsc-boundary SIGTERM test

### DIFF
--- a/test/scripts/check-extension-package-tsc-boundary.test.ts
+++ b/test/scripts/check-extension-package-tsc-boundary.test.ts
@@ -696,7 +696,12 @@ describe("check-extension-package-tsc-boundary", () => {
       const childScript = [
         "const fs = require('node:fs');",
         "process.on('SIGTERM', () => {});",
-        `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+        // Write the pid atomically: writeFileSync makes the file visible at open() (0 bytes)
+        // before the content lands, so an existsSync-then-read poller can catch an empty file
+        // and parse NaN. Rename only publishes the path once the pid is fully written.
+        `const pidPath = ${JSON.stringify(childPidPath)};`,
+        "fs.writeFileSync(pidPath + '.tmp', String(process.pid));",
+        "fs.renameSync(pidPath + '.tmp', pidPath);",
         "setInterval(() => {}, 1000);",
       ].join("");
       const parentScript = [


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/check-extension-package-tsc-boundary.test.ts > cleans active async node step descendants before forwarding parent SIGTERM` flakes on CI (observed in the `checks-node-compact-small-6` shard). It fails at the pre-kill liveness assertion `expect(isProcessAlive(childPid)).toBe(true)` with `expected false to be true`.

Root cause: the spawned child records its pid with `fs.writeFileSync(childPidPath, String(process.pid))`. `writeFileSync` makes the file visible at `open()` (0 bytes) before the content is written. The test's `waitForFile` gate only checks `fs.existsSync`, so under load the reader can observe the file in that empty window, `readFileSync` returns `""`, `Number.parseInt("")` yields `NaN`, and `isProcessAlive(NaN)` returns false — even though the child is alive.

## Why This Change Was Made

Publish the pid file atomically: write to a `.tmp` sibling, then `renameSync` it into place. `rename` is atomic, so the pid path only becomes visible once it holds the full pid. This closes the empty-read window at the source rather than papering over it with reader retries.

## User Impact

None — test-only. Removes an intermittent CI failure.

## Evidence

- Ran the focused test 3× locally after the fix: `node scripts/run-vitest.mjs test/scripts/check-extension-package-tsc-boundary.test.ts -t "cleans active async node step descendants"` — 1 passed each run.
- Failure provenance: run 29509427146, job `checks-node-compact-small-6`, `test/scripts/check-extension-package-tsc-boundary.test.ts:725:42`.
