### PR TITLE
fix(codex): show Atlas and ChatGPT sessions in catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex interactive session discovery:** include Atlas and ChatGPT-origin sessions in the Gateway and paired-node catalogs so they appear in the Control UI with transcript, continuation, archive, and terminal actions. Fixes #109099.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Codex interactive session discovery:** include Atlas and ChatGPT-origin sessions in the Gateway and paired-node catalogs so they appear in the Control UI with transcript, continuation, archive, and terminal actions. Fixes #109099.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -84,10 +84,10 @@ every later turn remains on that connection with native auth and provider
 configuration. Disabled supervision or binding/connection drift fails closed
 rather than switching to the ordinary agent-home harness.
 
-The original CLI or VS Code source remains eligible for both catalogs. The
-canonical branch is a native Codex thread, but its source kind is `appServer`;
-native clients may filter that source kind, so its appearance in Codex Desktop
-is not guaranteed.
+The original CLI, VS Code, Atlas, or ChatGPT source remains eligible for both
+catalogs. The canonical branch is a native Codex thread, but its source kind is
+`appServer`; native clients may filter that source kind, so its appearance in
+Codex Desktop is not guaranteed.
 
 Active sources cannot start a new branch or be archived; an existing supervised
 Chat can still be opened. `notLoaded` means activity is unknown, not idle;

--- a/docs/plugins/codex-supervision.md
+++ b/docs/plugins/codex-supervision.md
@@ -9,8 +9,9 @@ read_when:
 ---
 
 Codex supervision is an opt-in capability of the official `codex` plugin. It
-shows non-archived Codex Desktop and CLI source sessions from the Gateway
-computer and opted-in paired computers in the normal sessions sidebar and Chat pane.
+shows non-archived Codex CLI, VS Code, Atlas, and ChatGPT source sessions from
+the Gateway computer and opted-in paired computers in the normal sessions
+sidebar and Chat pane.
 
 The initial release deliberately keeps ownership narrow:
 
@@ -264,11 +265,11 @@ the source thread or displaying the pending Chat. Starting a distinct canonical
 harness thread on the first turn lets another Codex process keep owning the
 source without creating competing rollout writers.
 
-The original CLI or VS Code source remains visible to native clients and the
-OpenClaw catalog. The canonical branch is stored as a native Codex thread, but
-its source kind is `appServer`; Codex Desktop or another native client may filter
-that source kind, so the branch itself is not guaranteed to appear in every
-native history view.
+The original CLI, VS Code, Atlas, or ChatGPT source remains visible to native
+clients and the OpenClaw catalog. The canonical branch is stored as a native
+Codex thread, but its source kind is `appServer`; Codex Desktop or another
+native client may filter that source kind, so the branch itself is not guaranteed
+to appear in every native history view.
 
 An active row reported by OpenClaw's App Server cannot start a new branch. Wait
 for the current turn to finish and refresh the catalog. Codex App Server

--- a/docs/specs/codex-supervision.md
+++ b/docs/specs/codex-supervision.md
@@ -113,8 +113,9 @@ or assume that daemon implicitly.
 ## Catalog flow
 
 The generic Gateway method `sessions.catalog.list` dispatches to the `codex`
-catalog provider, which always requests `archived: false` and
-the interactive `cli` and `vscode` source kinds. It combines:
+catalog provider, which always requests `archived: false` and lets App Server
+apply its interactive-source default: `cli`, `vscode`, Atlas, and ChatGPT. It
+combines:
 
 1. Gateway-local `thread/list` results from the supervision App Server,
    which defaults to managed user-home stdio.
@@ -264,11 +265,11 @@ snapshot; it is not the durable continuation thread. Starting a distinct
 canonical harness thread on the first turn prevents OpenClaw from becoming a
 competing source writer merely because process-local status failed to see a
 Desktop-owned turn. The visible-history mirror and pinned snapshot may omit work
-that has not yet completed in an active source. The original CLI or VS Code
-source remains eligible for both native and OpenClaw catalogs. The canonical
-branch remains a native Codex thread in the supervision store, but native clients
-may filter its `appServer` source kind, so Codex Desktop visibility is not a
-contract.
+that has not yet completed in an active source. The original CLI, VS Code,
+Atlas, or ChatGPT source remains eligible for both native and OpenClaw catalogs.
+The canonical branch remains a native Codex thread in the supervision store,
+but native clients may filter its `appServer` source kind, so Codex Desktop
+visibility is not a contract.
 
 ## Archive behavior
 

--- a/extensions/codex/README.md
+++ b/extensions/codex/README.md
@@ -8,7 +8,7 @@ Install from OpenClaw:
 openclaw plugins install @openclaw/codex
 ```
 
-Use this plugin when you want OpenClaw to run Codex-backed model turns, media understanding, and prompt overlays through the Codex app-server harness, or to browse non-archived Codex Desktop and CLI sessions and paginated transcripts across paired computers.
+Use this plugin when you want OpenClaw to run Codex-backed model turns, media understanding, and prompt overlays through the Codex app-server harness, or to browse non-archived Codex CLI, VS Code, Atlas, and ChatGPT sessions and paginated transcripts across paired computers.
 
 Guided onboarding attempts to install and enable supervision after it detects a native Codex installation and the selected inference backend passes its live check; Codex does not need to be the primary backend. Supervision activates when that opportunistic plugin setup succeeds. App Server availability is checked when supervision connects. An explicit Codex plugin disable, plugin-policy block, or `supervision.enabled: false` prevents opportunistic enablement. Manual setups enable `plugins.entries.codex.config.supervision.enabled`. Without explicit App Server connection settings, supervision uses a managed user-home stdio connection; explicit `appServer` settings are honored.
 

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -180,6 +180,7 @@ export type CodexThreadForkParams = JsonObject & {
 export type CodexThreadForkResponse = CodexThreadStartResponse;
 
 export const CODEX_INTERACTIVE_THREAD_SOURCE_KINDS = ["cli", "vscode"] as const;
+export const CODEX_INTERACTIVE_CUSTOM_THREAD_SOURCES = ["atlas", "chatgpt"] as const;
 
 type CodexThreadSourceKind =
   | (typeof CODEX_INTERACTIVE_THREAD_SOURCE_KINDS)[number]

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -188,12 +188,10 @@ function requireContinuableNodeRecord(record: CodexSessionCatalogSession): void 
     throw new CatalogParamsError("Codex session is archived on the paired node");
   }
   if (!isInteractiveThreadSource(record.source)) {
-    throw new CatalogParamsError(
-      "Codex session is not a non-archived interactive CLI or VS Code session",
-    );
+    throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
   }
   if (record.status === "idle" || record.status === "notLoaded") {
-    // The node App Server is a passive catalog reader, so stored CLI/VS Code
+    // The node App Server is a passive catalog reader, so stored native Codex
     // sessions normally report notLoaded. Node resume serializes OpenClaw turns.
     return;
   }

--- a/extensions/codex/src/session-catalog-parsing.ts
+++ b/extensions/codex/src/session-catalog-parsing.ts
@@ -1,7 +1,10 @@
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { CodexThread, CodexThreadTurnsListResponse } from "./app-server/protocol.js";
-import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
+import {
+  CODEX_INTERACTIVE_CUSTOM_THREAD_SOURCES,
+  CODEX_INTERACTIVE_THREAD_SOURCE_KINDS,
+} from "./app-server/protocol.js";
 import type {
   CodexSessionCatalogError,
   CodexSessionCatalogPage,
@@ -65,20 +68,40 @@ export function boundedCatalogString(
   return overflow === "truncate" ? truncateUtf16Safe(normalized, maxLength) : undefined;
 }
 
-type CodexInteractiveThreadSourceKind = (typeof CODEX_INTERACTIVE_THREAD_SOURCE_KINDS)[number];
+type CodexInteractiveThreadSource =
+  | (typeof CODEX_INTERACTIVE_THREAD_SOURCE_KINDS)[number]
+  | (typeof CODEX_INTERACTIVE_CUSTOM_THREAD_SOURCES)[number];
 
-export function isInteractiveThreadSource(
+function normalizeInteractiveThreadSource(
   source: unknown,
-): source is CodexInteractiveThreadSourceKind {
-  return CODEX_INTERACTIVE_THREAD_SOURCE_KINDS.some((kind) => kind === source);
+): CodexInteractiveThreadSource | undefined {
+  if (
+    CODEX_INTERACTIVE_THREAD_SOURCE_KINDS.some((kind) => kind === source) ||
+    CODEX_INTERACTIVE_CUSTOM_THREAD_SOURCES.some((kind) => kind === source)
+  ) {
+    return source as CodexInteractiveThreadSource;
+  }
+  if (
+    isRecord(source) &&
+    CODEX_INTERACTIVE_CUSTOM_THREAD_SOURCES.some((kind) => kind === source.custom)
+  ) {
+    return source.custom as (typeof CODEX_INTERACTIVE_CUSTOM_THREAD_SOURCES)[number];
+  }
+  return undefined;
+}
+
+export function isInteractiveThreadSource(source: unknown): boolean {
+  return normalizeInteractiveThreadSource(source) !== undefined;
 }
 
 export function toCatalogSession(
   thread: CodexThread,
   archived: boolean,
 ): CodexSessionCatalogSession | undefined {
-  const source = thread.source;
-  if (!isInteractiveThreadSource(source)) {
+  // Codex models Atlas and ChatGPT as custom sources but includes both in its
+  // interactive default. Normalize those objects for the string-only catalog.
+  const source = normalizeInteractiveThreadSource(thread.source);
+  if (!source) {
     return undefined;
   }
   const record = thread as CodexThread & Record<string, unknown>;

--- a/extensions/codex/src/session-catalog-terminal.ts
+++ b/extensions/codex/src/session-catalog-terminal.ts
@@ -67,18 +67,14 @@ export async function requireCatalogEligibleThread(
     });
     const candidate = page.sessions.find((session) => session.threadId === threadId);
     if (candidate) {
-      if (candidate.source === "cli" || candidate.source === "vscode") {
+      if (isInteractiveThreadSource(candidate.source)) {
         return candidate;
       }
-      throw new CatalogParamsError(
-        "Codex session is not a non-archived interactive CLI or VS Code session",
-      );
+      throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
     }
     const nextCursor = page.nextCursor?.trim();
     if (!nextCursor) {
-      throw new CatalogParamsError(
-        "Codex session is not a non-archived interactive CLI or VS Code session",
-      );
+      throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
     }
     if (seenCursors.has(nextCursor)) {
       throw new CatalogParamsError("Codex session eligibility could not be verified");
@@ -177,9 +173,7 @@ async function resolveNodeCatalogEligibleThread(params: {
     seenCursors.add(nextCursor);
     cursor = nextCursor;
   }
-  throw new CatalogParamsError(
-    "Codex session is not a non-archived interactive CLI or VS Code session",
-  );
+  throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
 }
 
 export async function openCodexCatalogTerminal(params: {

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -449,7 +449,6 @@ describe("Codex supervision catalog", () => {
         modelProviders: [],
         sortKey: "recency_at",
         sortDirection: "desc",
-        sourceKinds: ["cli", "vscode"],
         cwd: "/workspace/one",
       },
       {
@@ -643,11 +642,13 @@ describe("Codex supervision catalog", () => {
     },
   );
 
-  it("omits noninteractive sources when App Server ignores the requested source kinds", async () => {
+  it("keeps every Codex interactive source while omitting other custom sources", async () => {
     commandRpcMocks.codexControlRequest.mockResolvedValue({
       data: [
         idleThread({ id: "cli", source: "cli" }),
         idleThread({ id: "vscode", source: "vscode" }),
+        idleThread({ id: "atlas", source: { custom: "atlas" } }),
+        idleThread({ id: "chatgpt", source: { custom: "chatgpt" } }),
         idleThread({ id: "exec", source: "exec" }),
         idleThread({ id: "app-server", source: "appServer" }),
         idleThread({ id: "subagent", source: { subAgent: "review" } }),
@@ -663,8 +664,18 @@ describe("Codex supervision catalog", () => {
 
     const page = await control.listPage({});
 
-    expect(page.sessions.map((session) => session.threadId)).toEqual(["cli", "vscode"]);
-    expect(page.sessions.map((session) => session.source)).toEqual(["cli", "vscode"]);
+    expect(page.sessions.map((session) => session.threadId)).toEqual([
+      "cli",
+      "vscode",
+      "atlas",
+      "chatgpt",
+    ]);
+    expect(page.sessions.map((session) => session.source)).toEqual([
+      "cli",
+      "vscode",
+      "atlas",
+      "chatgpt",
+    ]);
   });
 
   it("keeps takeover forking out of the passive catalog control", async () => {
@@ -1057,7 +1068,7 @@ describe("Codex supervision catalog", () => {
             {
               threadId,
               status: "idle",
-              source: "cli",
+              source: "atlas",
               cwd: "/node/catalog/cwd",
               archived: false,
             },
@@ -2415,9 +2426,9 @@ describe("Codex supervision actions", () => {
         control,
         threadId: "thread-1",
       }),
-    ).rejects.toThrow("not a non-archived interactive CLI or VS Code session");
+    ).rejects.toThrow("not a non-archived interactive Codex session");
     await expect(archiveTestSession({ control })).rejects.toThrow(
-      "not a non-archived interactive CLI or VS Code session",
+      "not a non-archived interactive Codex session",
     );
     expect(control.readThread).not.toHaveBeenCalled();
     expect(createSessionEntry).not.toHaveBeenCalled();
@@ -2448,9 +2459,9 @@ describe("Codex supervision actions", () => {
         control,
         threadId: "thread-1",
       }),
-    ).rejects.toThrow("not a non-archived interactive CLI or VS Code session");
+    ).rejects.toThrow("not a non-archived interactive Codex session");
     await expect(archiveTestSession({ control })).rejects.toThrow(
-      "not a non-archived interactive CLI or VS Code session",
+      "not a non-archived interactive Codex session",
     );
     expect(control.readThread).not.toHaveBeenCalled();
   });
@@ -2841,6 +2852,7 @@ describe("Codex supervision actions", () => {
     const sourceByNode = new Map([
       ["ready-cli", { status: "idle", source: "cli" }],
       ["ready-vscode", { status: "notLoaded", source: "vscode" }],
+      ["ready-atlas", { status: "notLoaded", source: "atlas" }],
       ["missing-run", { status: "idle", source: "cli" }],
       ["active", { status: "active", source: "cli" }],
       ["noninteractive", { status: "idle", source: "exec" }],
@@ -2895,6 +2907,10 @@ describe("Codex supervision actions", () => {
       canArchive: false,
     });
     expect(sessionByHost.get("node:ready-vscode")).toMatchObject({
+      canContinue: true,
+      canArchive: false,
+    });
+    expect(sessionByHost.get("node:ready-atlas")).toMatchObject({
       canContinue: true,
       canArchive: false,
     });

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -23,7 +23,6 @@ import type {
   CodexThreadTurnsListParams,
   CodexThreadTurnsListResponse,
 } from "./app-server/protocol.js";
-import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
 import { requestCodexAppServerClientJson } from "./app-server/request.js";
 import {
   reclaimCurrentCodexSessionGeneration,
@@ -167,7 +166,6 @@ function createCodexSessionCatalogControlFromRequests(params: {
             modelProviders: [],
             sortKey: "recency_at",
             sortDirection: "desc",
-            sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
             ...(cwd ? { cwd } : {}),
             ...(cursor ? { cursor } : {}),
           },


### PR DESCRIPTION
Closes #109099

## What Problem This Solves

Fixes an issue where users with Atlas- or ChatGPT-origin Codex sessions could not see those sessions in the Control UI or paired-node catalog, so their transcript and continuation actions were unreachable.

## Why This Change Was Made

Codex App Server defines CLI, VS Code, Atlas, and ChatGPT as its interactive session set when `sourceKinds` is omitted. The catalog now uses that dependency-owned default, normalizes the two object-shaped custom origins to stable strings, and still rejects unrelated custom or noninteractive sources.

## User Impact

Atlas and ChatGPT-origin sessions now appear beside CLI and VS Code sessions on the Gateway and opted-in paired nodes. They expose the same eligible transcript, branch, archive, and terminal actions. Arbitrary custom integrations remain hidden.

## Evidence

- Live pre-fix dependency proof with Codex App Server 0.144.5: an unfiltered `thread/list` returned Atlas and VS Code fixtures; `sourceKinds: ["cli", "vscode"]` returned only VS Code.
- Live post-fix isolated Gateway proof: CLI, VS Code, Atlas, and ChatGPT fixtures appeared; an unrelated custom integration fixture stayed absent; Atlas and ChatGPT sources were normalized strings; every row was actionable; a repeat list was stable; Atlas continuation created an OpenClaw Chat branch.
- `node scripts/run-vitest.mjs extensions/codex/src/session-catalog.test.ts` — 84 tests passed on the rebased head.
- Blacksmith Testbox: focused Codex suite, `pnpm docs:check-mdx`, `pnpm check:changed`, and `pnpm build` all passed.
- Fresh structured autoreview: clean, no accepted/actionable findings.

No UI layout changed; the live operator CLI proof exercises the same Gateway catalog provider consumed by the Control UI.
