### PR TITLE
perf(ci): unblock parallel oxlint shards and gate the lint-lane i18n verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1837,6 +1837,7 @@ jobs:
         env:
           HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
           FORMAT_CHECK: ${{ needs.preflight.outputs.run_format_check }}
+          RUN_CONTROL_UI_I18N: ${{ needs.preflight.outputs.run_control_ui_i18n }}
           OPENCLAW_LOCAL_CHECK: "0"
           TASK: ${{ matrix.task }}
           PR_BASE_SHA: ${{ github.event_name == 'pull_request' && needs.preflight.outputs.diff_base_revision || '' }}
@@ -1875,7 +1876,14 @@ jobs:
               pnpm tsgo:prod
               ;;
             lint)
-              pnpm lint --threads=8
+              # Control-UI i18n catalogs only change with ui/ sources or the
+              # i18n tooling (manifest-gated); oxlint always runs.
+              if [ "$RUN_CONTROL_UI_I18N" = "true" ]; then
+                pnpm lint --threads=8
+              else
+                echo "[skip] changed scope cannot affect control-UI i18n catalogs"
+                node scripts/run-oxlint-shards.mjs --threads=8
+              fi
               if [ "$FORMAT_CHECK" = "true" ]; then
                 pnpm format:check
               fi

--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -19,6 +19,11 @@ const PROCESS_GROUP_EXIT_POLL_MS = 25;
 const DEFAULT_SPLIT_CORE_SHARD_CONCURRENCY = 4;
 const FAST_LOCAL_CHECK_MIN_CPUS = 12;
 const FAST_LOCAL_CHECK_MIN_MEMORY_BYTES = 48 * 1024 ** 3;
+// CI runners are dedicated: Blacksmith's 16 vCPU class carries 32GB, which the
+// local-Mac threshold above misreads as too small and forces serial shards.
+// Three concurrent oxlint shards peak well under 24GB.
+const CI_PARALLEL_MIN_CPUS = 8;
+const CI_PARALLEL_MIN_MEMORY_BYTES = 24 * 1024 ** 3;
 const EXTENSION_TS_CONFIG = "config/tsconfig/oxlint.extensions.json";
 const EXTENSIONS_DIR = "extensions";
 const OXLINT_SOURCE_FILE_PATTERN = /\.[cm]?[jt]sx?$/;
@@ -155,8 +160,8 @@ export function shouldRunOxlintShardsSerial({
   const resources = resolveHostResources(hostResources);
   if (env.CI === "true" || env.GITHUB_ACTIONS === "true") {
     return (
-      resources.totalMemoryBytes < FAST_LOCAL_CHECK_MIN_MEMORY_BYTES ||
-      resources.logicalCpuCount < FAST_LOCAL_CHECK_MIN_CPUS
+      resources.totalMemoryBytes < CI_PARALLEL_MIN_MEMORY_BYTES ||
+      resources.logicalCpuCount < CI_PARALLEL_MIN_CPUS
     );
   }
   return (

--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -278,6 +278,11 @@ export async function main(extraArgs = process.argv.slice(2), runtimeEnv = proce
         platform: process.platform,
         splitCore: shardArgs.splitCore,
       });
+      const hostResources = resolveHostResources();
+      console.log(
+        `[oxlint] shard concurrency ${Math.max(1, Math.min(shardConcurrency, selectedShards.length))} ` +
+          `(cpus=${hostResources.logicalCpuCount}, memGB=${Math.round(hostResources.totalMemoryBytes / 1024 ** 3)})`,
+      );
       const results = await runShards({
         concurrency: Math.max(1, Math.min(shardConcurrency, selectedShards.length)),
         entries: selectedShards,

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -125,6 +125,25 @@ describe("run-oxlint", () => {
     ).toBe(true);
   });
 
+  it("keeps oxlint shards parallel on dedicated CI runner classes", () => {
+    // Blacksmith's 16 vCPU class carries 32GB; the local-Mac 48GB threshold
+    // must not force CI serial (measured: serial shards cost 89s vs ~47s).
+    expect(
+      shouldRunOxlintShardsSerial({
+        env: { CI: "true" },
+        platform: "linux",
+        hostResources: { totalMemoryBytes: 32 * 1024 ** 3, logicalCpuCount: 16 },
+      }),
+    ).toBe(false);
+    expect(
+      shouldRunOxlintShardsSerial({
+        env: { CI: "true" },
+        platform: "linux",
+        hostResources: { totalMemoryBytes: 16 * 1024 ** 3, logicalCpuCount: 8 },
+      }),
+    ).toBe(true);
+  });
+
   it("keeps oxlint shards parallel for roomy CI and explicit full-speed runs", () => {
     const constrainedHost = { totalMemoryBytes: 8 * 1024 ** 3, logicalCpuCount: 4 };
     const roomyHost = { totalMemoryBytes: 64 * 1024 ** 3, logicalCpuCount: 16 };


### PR DESCRIPTION
## What Problem This Solves

A 17-run job census (838 jobs) shows `check-lint` is now the slowest static lane: median 252s, p90 277s. Log decomposition of a representative run: ~45s setup, **86s of `control-ui-i18n-verify` running unconditionally**, then **89s of oxlint shards running serially** (core 47s → extensions 37s → scripts 5s) on a 16 vCPU runner.

## Why This Change Was Made

Two independent defects:

1. `shouldRunOxlintShardsSerial` demands 48GB of memory before allowing parallel shards — a threshold calibrated for local Macs. Blacksmith's 16 vCPU class carries 32GB, so CI is *always* forced serial no matter the runner size. CI runners are dedicated machines; three concurrent oxlint shards peak far below 24GB. The CI branch now parallelizes at ≥8 cores and ≥24GB (constrained hosts still serialize).
2. The control-UI i18n verify only proves generated locale catalogs match keys extracted from `ui/` sources, but ran on every PR. The manifest already computes exactly the right gate (`run_control_ui_i18n`, used by the dedicated locale-drift job); the lint case now reuses it — unaffected diffs skip the verify with an explicit log line while oxlint always runs. Dispatch events always run; the semantics are unchanged from the existing gate.

## User Impact

None at runtime — CI-only. `check-lint` drops from ~252s to ~135s on ui-affecting PRs (parallel shards) and ~95s on everything else (parallel shards + skipped verify), removing the top static lane from the PR wall clock.

## Evidence

- Census data: check-lint median 252s / p90 277s across 17 green runs; phase timings from job 87662608451.
- `node scripts/run-vitest.mjs test/scripts/run-oxlint.test.ts test/scripts/ci-workflow-guards.test.ts` — green, including new threshold cases (32GB/16cpu CI → parallel; 16GB/8cpu CI → serial).
- YAML validated; the lint case falls back to running oxlint directly when the verify is skipped.
- This PR touches ci.yml (always-run surface for the i18n gate), so its own CI run exercises the gated lint lane — verify check-lint duration and shard overlap in its log before merge.
