### PR TITLE
fix(acpx): prevent process cleanup from hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/extensions/acpx/src/process-reaper.test.ts
+++ b/extensions/acpx/src/process-reaper.test.ts
@@ -1,7 +1,15 @@
 // ACPX tests cover process reaper plugin behavior.
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
+
+const runExecMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>()),
+  runExec: runExecMock,
+}));
+
 import {
   cleanupOpenClawOwnedAcpxProcessTree,
   isOpenClawLeaseAwareAcpxProcessCommand,
@@ -53,6 +61,35 @@ function collectMatching<T, U>(
 }
 
 describe("process reaper", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runExecMock.mockReset();
+  });
+
+  it("bounds process inspection and fails closed on timeout", async () => {
+    runExecMock.mockRejectedValueOnce(new Error("process listing timed out"));
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    const killSpy = vi.spyOn(process, "kill");
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 200,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      wrapperRoot: WRAPPER_ROOT,
+    });
+
+    expect(runExecMock).toHaveBeenCalledWith("ps", ["-axo", "pid=,ppid=,command="], {
+      logOutput: false,
+      maxBuffer: 8 * 1024 * 1024,
+      timeoutMs: 2_000,
+    });
+    expect(result).toEqual({
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "unverified-root",
+    });
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
   it("only treats generated wrappers as launch-lease aware", () => {
     expect(
       isOpenClawLeaseAwareAcpxProcessCommand({

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -15,6 +15,7 @@ const GENERATED_WRAPPER_BASENAMES = new Set([
   "claude-agent-acp-wrapper.mjs",
 ]);
 const OPENCLAW_PLUGIN_DEPS_MARKER = "/plugin-runtime-deps/";
+const ACPX_PROCESS_LIST_TIMEOUT_MS = 2_000;
 const OWNED_ACP_PACKAGE_NAMES = [
   "@zed-industries/codex-acp",
   "@zed-industries/codex-acp-darwin-arm64",
@@ -219,6 +220,7 @@ async function listPlatformProcesses(): Promise<AcpxProcessInfo[]> {
   const { stdout } = await runExec("ps", ["-axo", "pid=,ppid=,command="], {
     logOutput: false,
     maxBuffer: 8 * 1024 * 1024,
+    timeoutMs: ACPX_PROCESS_LIST_TIMEOUT_MS,
   });
   return parseProcessList(stdout);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with the ACPX plugin enabled could have gateway startup or stale-session cleanup hang indefinitely when the host process-table command stopped responding.

## Why This Change Was Made

The ACPX-owned reaper now gives its one-shot `ps -axo pid=,ppid=,command=` inspection a two-second deadline through the existing process-runtime contract. A timeout keeps the current fail-closed behavior: cleanup skips the unverified tree and sends no process signal. This is the same command and deadline already validated in #109091, applied at ACPX's separate startup and session-cleanup owner boundary. This PR is AI-assisted and was independently reviewed.

## User Impact

ACPX gateway startup and cleanup can recover from a stalled process listing instead of waiting forever. If inspection times out, a stale ACPX process may remain for a later cleanup attempt, but no process is terminated without a complete ownership snapshot.

## Evidence

- `node scripts/run-vitest.mjs extensions/acpx/src/process-reaper.test.ts --run` - 13 tests passed on Node 24.15.0 after rebasing onto current `main`.
- The focused timeout test verifies the exact two-second `runExec` option, the existing `unverified-root` result, and that `process.kill` is not called.
- Real shared-runtime hang proof: `{"pass":true,"elapsedMs":129,"timedOut":true,"signal":"SIGTERM"}` for a child kept alive with `setInterval`, using a 100 ms deadline.
- Type-aware extensions `oxlint`, `oxfmt --check`, and `git diff --check origin/main...HEAD` passed for the touched files.
- Directly inspected `src/process/exec.ts:33-65`, `src/plugin-sdk/process-runtime.ts:1-12`, and Execa 9.6.1 timeout/termination behavior in `node_modules/execa/lib/terminate/timeout.js:11-20` and `node_modules/execa/lib/terminate/kill.js:70-92`.
