### PR TITLE
fix(sms): ignore blank Twilio env account fallbacks

### DIFF
--- a/extensions/sms/src/accounts.test.ts
+++ b/extensions/sms/src/accounts.test.ts
@@ -232,7 +232,7 @@ describe("SMS account config", () => {
     });
   });
 
-  it("does not discover blank env values as the implicit default account", () => {
+  it("does not discover blank credential strings as the implicit default account", () => {
     process.env.TWILIO_ACCOUNT_SID = " ";
     process.env.TWILIO_AUTH_TOKEN = "\t";
     process.env.TWILIO_PHONE_NUMBER = " ";
@@ -240,6 +240,18 @@ describe("SMS account config", () => {
     process.env.TWILIO_MESSAGING_SERVICE_SID = " ";
 
     expect(listSmsAccountIds({})).toEqual([]);
+    expect(
+      listSmsAccountIds({
+        channels: {
+          sms: {
+            accountSid: " ",
+            authToken: "\t",
+            fromNumber: "\n",
+            messagingServiceSid: " ",
+          },
+        },
+      }),
+    ).toEqual([]);
     expect(
       listSmsAccountIds({
         channels: {

--- a/extensions/sms/src/accounts.test.ts
+++ b/extensions/sms/src/accounts.test.ts
@@ -232,6 +232,31 @@ describe("SMS account config", () => {
     });
   });
 
+  it("does not discover blank env values as the implicit default account", () => {
+    process.env.TWILIO_ACCOUNT_SID = " ";
+    process.env.TWILIO_AUTH_TOKEN = "\t";
+    process.env.TWILIO_PHONE_NUMBER = " ";
+    process.env.TWILIO_SMS_FROM = "\n";
+    process.env.TWILIO_MESSAGING_SERVICE_SID = " ";
+
+    expect(listSmsAccountIds({})).toEqual([]);
+    expect(
+      listSmsAccountIds({
+        channels: {
+          sms: {
+            accounts: {
+              support: {
+                accountSid: "AC-support",
+                authToken: "support-token",
+                fromNumber: "+15551112222",
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual(["support"]);
+  });
+
   it("uses TWILIO_SMS_FROM when the legacy from-number env var is blank", () => {
     process.env.TWILIO_ACCOUNT_SID = "AC-env";
     process.env.TWILIO_AUTH_TOKEN = "env-token";

--- a/extensions/sms/src/accounts.test.ts
+++ b/extensions/sms/src/accounts.test.ts
@@ -258,9 +258,7 @@ describe("SMS account config", () => {
           sms: {
             accounts: {
               support: {
-                accountSid: "AC-support",
-                authToken: "support-token",
-                fromNumber: "+15551112222",
+                enabled: true,
               },
             },
           },

--- a/extensions/sms/src/accounts.ts
+++ b/extensions/sms/src/accounts.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   DEFAULT_ACCOUNT_ID,
+  hasConfiguredAccountValue,
   listCombinedAccountIds,
   resolveAccountEntry,
   resolveListedDefaultAccountId,
@@ -51,25 +52,19 @@ function firstNonBlankEnv(...values: Array<string | undefined>): string | undefi
   return values.find((value) => value?.trim());
 }
 
-function hasNonBlankString(...values: Array<string | undefined>): boolean {
-  return values.some((value) => Boolean(value?.trim()));
-}
-
 function hasBaseAccount(channelCfg: SmsChannelConfig | undefined): boolean {
-  return Boolean(
-    hasNonBlankString(
+  return (
+    [
       channelCfg?.accountSid,
       channelCfg?.fromNumber,
       channelCfg?.messagingServiceSid,
-    ) ||
-    hasConfiguredSecretInput(channelCfg?.authToken) ||
-    firstNonBlankEnv(
       process.env.TWILIO_ACCOUNT_SID,
       process.env.TWILIO_AUTH_TOKEN,
       process.env.TWILIO_PHONE_NUMBER,
       process.env.TWILIO_SMS_FROM,
       process.env.TWILIO_MESSAGING_SERVICE_SID,
-    ),
+    ].some((value) => hasConfiguredAccountValue(value)) ||
+    hasConfiguredSecretInput(channelCfg?.authToken)
   );
 }
 

--- a/extensions/sms/src/accounts.ts
+++ b/extensions/sms/src/accounts.ts
@@ -51,17 +51,25 @@ function firstNonBlankEnv(...values: Array<string | undefined>): string | undefi
   return values.find((value) => value?.trim());
 }
 
+function hasNonBlankString(...values: Array<string | undefined>): boolean {
+  return values.some((value) => Boolean(value?.trim()));
+}
+
 function hasBaseAccount(channelCfg: SmsChannelConfig | undefined): boolean {
   return Boolean(
-    channelCfg?.accountSid ||
+    hasNonBlankString(
+      channelCfg?.accountSid,
+      channelCfg?.fromNumber,
+      channelCfg?.messagingServiceSid,
+    ) ||
     hasConfiguredSecretInput(channelCfg?.authToken) ||
-    channelCfg?.fromNumber ||
-    channelCfg?.messagingServiceSid ||
-    process.env.TWILIO_ACCOUNT_SID ||
-    process.env.TWILIO_AUTH_TOKEN ||
-    process.env.TWILIO_PHONE_NUMBER ||
-    process.env.TWILIO_SMS_FROM ||
-    process.env.TWILIO_MESSAGING_SERVICE_SID,
+    firstNonBlankEnv(
+      process.env.TWILIO_ACCOUNT_SID,
+      process.env.TWILIO_AUTH_TOKEN,
+      process.env.TWILIO_PHONE_NUMBER,
+      process.env.TWILIO_SMS_FROM,
+      process.env.TWILIO_MESSAGING_SERVICE_SID,
+    ),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where whitespace-only SMS Twilio environment variables made OpenClaw discover an implicit default SMS account even though no usable SMS credential or sender value was configured.

## Why This Change Was Made

SMS account discovery now treats string config and Twilio env fallbacks the same way the resolver consumes them: blank strings are ignored, while SecretRefs and non-empty env credentials still count.

## User Impact

Operators no longer see or select a phantom default SMS account caused only by blank Twilio env variables.

## Evidence

- Before fix, the real `extensions/sms/src/accounts.ts` module on `origin/main` returned `["default"]` for blank-only env values.
- After fix, the same module boundary returns no default account for blank-only env values, keeps a named account list clean, and still discovers valid env-only credentials.
- `node scripts/run-vitest.mjs extensions/sms/src/accounts.test.ts`: 1 file, 12 tests passed.

```text
$ pnpm exec tsx proof-sms-blank-env.ts
# origin/main
blank-env-only=["default"]
named-with-blank-env=["default","support"]
valid-env=["default"]

# branch
blank-env-only=[]
named-with-blank-env=["support"]
valid-env=["default"]
```

<details>
<summary>proof-sms-blank-env.ts</summary>

```ts
import path from "node:path";
import { pathToFileURL } from "node:url";

const envKeys = [
  "TWILIO_ACCOUNT_SID",
  "TWILIO_AUTH_TOKEN",
  "TWILIO_PHONE_NUMBER",
  "TWILIO_SMS_FROM",
  "TWILIO_MESSAGING_SERVICE_SID",
] as const;

for (const key of envKeys) {
  process.env[key] = key === "TWILIO_AUTH_TOKEN" ? "\t" : " ";
}
process.env.TWILIO_SMS_FROM = "\n";

async function main(): Promise<void> {
  const modulePath = pathToFileURL(path.join(process.cwd(), "extensions/sms/src/accounts.ts")).href;
  const { listSmsAccountIds } = (await import(modulePath)) as typeof import(
    "./extensions/sms/src/accounts"
  );

  const namedOnlyConfig = {
    channels: {
      sms: {
        accounts: {
          support: {
            accountSid: "AC-support",
            authToken: "support-token",
            fromNumber: "+15551112222",
          },
        },
      },
    },
  };

  const blankEnvOnly = listSmsAccountIds({});
  const namedWithBlankEnv = listSmsAccountIds(namedOnlyConfig);

  for (const key of envKeys) {
    delete process.env[key];
  }
  process.env.TWILIO_ACCOUNT_SID = "AC-env";
  process.env.TWILIO_AUTH_TOKEN = "env-token";
  process.env.TWILIO_SMS_FROM = "+15550001111";

  const validEnv = listSmsAccountIds({});

  console.log(`blank-env-only=${JSON.stringify(blankEnvOnly)}`);
  console.log(`named-with-blank-env=${JSON.stringify(namedWithBlankEnv)}`);
  console.log(`valid-env=${JSON.stringify(validEnv)}`);
}

main().catch((error: unknown) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

AI-assisted: built with Codex
