### PR TITLE
fix(onepassword): disable desktop-app integration on broker op calls

### DIFF
--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -35,6 +35,10 @@ variables or resolve OpenClaw config secrets.
   value.
 - The plugin invokes `op` once per cache miss. It does not retry rate limits or
   other failures.
+- Each `op` call runs with a minimal environment that disables 1Password
+  desktop-app integration (`OP_LOAD_DESKTOP_APP_SETTINGS=false`,
+  `OP_BIOMETRIC_UNLOCK_ENABLED=false`), so a 1Password app installed on the
+  Gateway host never triggers biometric or macOS permission dialogs.
 
 Give the service account read access only to the vaults and items registered in
 the plugin config.

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -67,7 +67,12 @@ describe("OpClient", () => {
         "--cache=false",
       ],
       {
-        env: { OP_SERVICE_ACCOUNT_TOKEN: fixtureAuth, HOME: root },
+        env: {
+          OP_SERVICE_ACCOUNT_TOKEN: fixtureAuth,
+          HOME: root,
+          OP_LOAD_DESKTOP_APP_SETTINGS: "false",
+          OP_BIOMETRIC_UNLOCK_ENABLED: "false",
+        },
         timeoutMs: 1234,
         maxBufferBytes: 1024 * 1024,
       },

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -241,6 +241,12 @@ export class OpClient {
         env: {
           OP_SERVICE_ACCOUNT_TOKEN: token,
           HOME: this.home,
+          // Force the pure service-account path. Without both overrides, op
+          // 2.35 on macOS still reads the 1Password desktop app's settings and
+          // can block on a per-PID App Data Protection dialog until a human
+          // answers, hanging the broker for timeoutMs on Mac gateway hosts.
+          OP_LOAD_DESKTOP_APP_SETTINGS: "false",
+          OP_BIOMETRIC_UNLOCK_ENABLED: "false",
         },
         timeoutMs: this.timeoutMs,
         maxBufferBytes: MAX_STDOUT_BYTES,


### PR DESCRIPTION
## What Problem This Solves

The bundled `onepassword` secrets-broker plugin invokes the 1Password CLI with only `OP_SERVICE_ACCOUNT_TOKEN` and `HOME` in the environment. On macOS with the 1Password desktop app installed on the Gateway host, `op` 2.35 still reads the desktop app's group-container settings on startup — even on the service-account path — and can block on a per-PID macOS App Data Protection dialog ("op would like to access data from other apps"). Each broker cache miss can then hang for the full `timeoutMs`, surface as a misleading `TIMEOUT` error, and spam the operator with permission dialogs.

## Why This Change Was Made

Live-verified today on macOS 26 with `op` 2.35: a service-token `op whoami` with only `OP_BIOMETRIC_UNLOCK_ENABLED=false` still prompted and hung; adding `OP_LOAD_DESKTOP_APP_SETTINGS=false` returned success with zero `SystemPolicyAppData` prompts. The broker is documented as service-account-only, so desktop-app integration should be explicitly disabled on every call. Both variables are inert on hosts without the desktop app and on Linux/Windows.

## User Impact

Operators running a Mac Gateway with the 1Password desktop app installed no longer get biometric/App Data permission dialogs or timeout hangs from broker secret reads. No config or API changes; behavior on hosts without the desktop app is unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/onepassword` — 6 files, 61 tests, all pass.
- The exact-env test assertion now locks in both overrides so a refactor cannot silently drop them.
- Known upstream repeated-dialog report: https://github.com/1Password/shell-plugins/issues/586
