### PR TITLE
fix(infra): bound accepted env option log cache

### DIFF
--- a/src/infra/env.test.ts
+++ b/src/infra/env.test.ts
@@ -1,13 +1,6 @@
 // Tests infra environment loading and variable normalization.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
-import {
-  isTruthyEnvValue,
-  logAcceptedEnvOption,
-  normalizeEnv,
-  normalizeZaiEnv,
-  resetLoggedEnvCacheForTest,
-} from "./env.js";
 
 const loggerMocks = vi.hoisted(() => ({
   info: vi.fn(),
@@ -21,32 +14,36 @@ vi.mock("../logging/subsystem.js", () => ({
 
 beforeEach(() => {
   loggerMocks.info.mockClear();
-  resetLoggedEnvCacheForTest();
+  vi.resetModules();
 });
 
 describe("normalizeZaiEnv", () => {
-  it("copies Z_AI_API_KEY to ZAI_API_KEY when missing", () => {
+  it("copies Z_AI_API_KEY to ZAI_API_KEY when missing", async () => {
+    const { normalizeZaiEnv } = await import("./env.js");
     withEnv({ ZAI_API_KEY: "", Z_AI_API_KEY: "zai-legacy" }, () => {
       normalizeZaiEnv();
       expect(process.env.ZAI_API_KEY).toBe("zai-legacy");
     });
   });
 
-  it("does not override existing ZAI_API_KEY", () => {
+  it("does not override existing ZAI_API_KEY", async () => {
+    const { normalizeZaiEnv } = await import("./env.js");
     withEnv({ ZAI_API_KEY: "zai-current", Z_AI_API_KEY: "zai-legacy" }, () => {
       normalizeZaiEnv();
       expect(process.env.ZAI_API_KEY).toBe("zai-current");
     });
   });
 
-  it("ignores blank legacy Z_AI_API_KEY values", () => {
+  it("ignores blank legacy Z_AI_API_KEY values", async () => {
+    const { normalizeZaiEnv } = await import("./env.js");
     withEnv({ ZAI_API_KEY: "", Z_AI_API_KEY: "   " }, () => {
       normalizeZaiEnv();
       expect(process.env.ZAI_API_KEY).toBe("");
     });
   });
 
-  it("does not copy when legacy Z_AI_API_KEY is unset", () => {
+  it("does not copy when legacy Z_AI_API_KEY is unset", async () => {
+    const { normalizeZaiEnv } = await import("./env.js");
     withEnv({ ZAI_API_KEY: "", Z_AI_API_KEY: undefined }, () => {
       normalizeZaiEnv();
       expect(process.env.ZAI_API_KEY).toBe("");
@@ -55,14 +52,16 @@ describe("normalizeZaiEnv", () => {
 });
 
 describe("isTruthyEnvValue", () => {
-  it("accepts common truthy values", () => {
+  it("accepts common truthy values", async () => {
+    const { isTruthyEnvValue } = await import("./env.js");
     expect(isTruthyEnvValue("1")).toBe(true);
     expect(isTruthyEnvValue("true")).toBe(true);
     expect(isTruthyEnvValue(" yes ")).toBe(true);
     expect(isTruthyEnvValue("ON")).toBe(true);
   });
 
-  it("rejects other values", () => {
+  it("rejects other values", async () => {
+    const { isTruthyEnvValue } = await import("./env.js");
     expect(isTruthyEnvValue("0")).toBe(false);
     expect(isTruthyEnvValue("false")).toBe(false);
     expect(isTruthyEnvValue("")).toBe(false);
@@ -72,6 +71,7 @@ describe("isTruthyEnvValue", () => {
 
 describe("logAcceptedEnvOption", () => {
   it("logs accepted env options once with redaction and formatting", async () => {
+    const { logAcceptedEnvOption } = await import("./env.js");
     loggerMocks.info.mockClear();
 
     withEnv(
@@ -103,6 +103,7 @@ describe("logAcceptedEnvOption", () => {
   });
 
   it("caps the dedupe cache at 256 entries and re-logs evicted keys", async () => {
+    const { logAcceptedEnvOption } = await import("./env.js");
     withEnv(
       {
         VITEST: "",
@@ -142,7 +143,8 @@ describe("logAcceptedEnvOption", () => {
     });
   });
 
-  it("skips blank values and test-mode logging", () => {
+  it("skips blank values and test-mode logging", async () => {
+    const { logAcceptedEnvOption } = await import("./env.js");
     loggerMocks.info.mockClear();
 
     withEnv(
@@ -177,6 +179,7 @@ describe("logAcceptedEnvOption", () => {
   });
 
   it("keeps bounded non-secret values UTF-16 well-formed", async () => {
+    const { logAcceptedEnvOption } = await import("./env.js");
     withEnv(
       {
         VITEST: "",
@@ -199,7 +202,8 @@ describe("logAcceptedEnvOption", () => {
 });
 
 describe("normalizeEnv", () => {
-  it("normalizes the legacy ZAI env alias", () => {
+  it("normalizes the legacy ZAI env alias", async () => {
+    const { normalizeEnv } = await import("./env.js");
     withEnv({ ZAI_API_KEY: "", Z_AI_API_KEY: "zai-legacy" }, () => {
       normalizeEnv();
       expect(process.env.ZAI_API_KEY).toBe("zai-legacy");

--- a/src/infra/env.test.ts
+++ b/src/infra/env.test.ts
@@ -1,7 +1,13 @@
 // Tests infra environment loading and variable normalization.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
-import { isTruthyEnvValue, logAcceptedEnvOption, normalizeEnv, normalizeZaiEnv } from "./env.js";
+import {
+  isTruthyEnvValue,
+  logAcceptedEnvOption,
+  normalizeEnv,
+  normalizeZaiEnv,
+  resetLoggedEnvCacheForTest,
+} from "./env.js";
 
 const loggerMocks = vi.hoisted(() => ({
   info: vi.fn(),
@@ -15,6 +21,7 @@ vi.mock("../logging/subsystem.js", () => ({
 
 beforeEach(() => {
   loggerMocks.info.mockClear();
+  resetLoggedEnvCacheForTest();
 });
 
 describe("normalizeZaiEnv", () => {
@@ -93,6 +100,46 @@ describe("logAcceptedEnvOption", () => {
     expect(loggerMocks.info).toHaveBeenCalledWith(
       "env: OPENCLAW_TEST_ENV=<redacted> (test option)",
     );
+  });
+
+  it("caps the dedupe cache at 256 entries and re-logs evicted keys", async () => {
+    withEnv(
+      {
+        VITEST: "",
+        NODE_ENV: "development",
+      },
+      () => {
+        for (let i = 0; i < 257; i++) {
+          logAcceptedEnvOption({
+            key: `OPENCLAW_CACHE_TEST_${i}`,
+            description: "cache cap test",
+            value: `value-${i}`,
+          });
+        }
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(loggerMocks.info).toHaveBeenCalledTimes(257);
+    });
+
+    withEnv(
+      {
+        VITEST: "",
+        NODE_ENV: "development",
+      },
+      () => {
+        logAcceptedEnvOption({
+          key: "OPENCLAW_CACHE_TEST_0",
+          description: "cache cap test",
+          value: "value-0",
+        });
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(loggerMocks.info).toHaveBeenCalledTimes(258);
+    });
   });
 
   it("skips blank values and test-mode logging", () => {

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
+import { createDedupeCache } from "./dedupe.js";
 
 let log: SubsystemLogger | null = null;
 const loadLog = createLazyPromise(
@@ -12,7 +13,7 @@ const loadLog = createLazyPromise(
     ),
   { cacheRejections: true },
 );
-const loggedEnv = new Set<string>();
+const loggedEnv = createDedupeCache({ ttlMs: 0, maxSize: 256 });
 const ENV_NORMALIZATION_KEY_GROUPS = [["ZAI_API_KEY", "Z_AI_API_KEY"]] as const;
 
 async function getLog(): Promise<SubsystemLogger> {
@@ -40,19 +41,23 @@ function formatEnvValue(value: string, redact?: boolean): string {
   return `${truncateUtf16Safe(singleLine, 160)}…`;
 }
 
+/** Resets the module-level accepted-env log cache for tests. */
+export function resetLoggedEnvCacheForTest(): void {
+  loggedEnv.clear();
+}
+
 /** Logs an accepted env option once, with optional redaction for sensitive values. */
 export function logAcceptedEnvOption(option: AcceptedEnvOption): void {
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return;
   }
-  if (loggedEnv.has(option.key)) {
+  if (loggedEnv.check(option.key)) {
     return;
   }
   const rawValue = option.value ?? process.env[option.key];
   if (!rawValue || !rawValue.trim()) {
     return;
   }
-  loggedEnv.add(option.key);
   void getLog()
     .then((logger) => {
       logger.info(

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -41,11 +41,6 @@ function formatEnvValue(value: string, redact?: boolean): string {
   return `${truncateUtf16Safe(singleLine, 160)}…`;
 }
 
-/** Resets the module-level accepted-env log cache for tests. */
-export function resetLoggedEnvCacheForTest(): void {
-  loggedEnv.clear();
-}
-
 /** Logs an accepted env option once, with optional redaction for sensitive values. */
 export function logAcceptedEnvOption(option: AcceptedEnvOption): void {
   if (process.env.VITEST || process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## What Problem This Solves

`src/infra/env.ts` keeps a module-level `Set<string>` (`loggedEnv`) to log accepted env options only once per key. The set grows without bound for the lifetime of the process.

## Why This Change Was Made

Replaced the raw `Set` with `createDedupeCache({ ttlMs: 0, maxSize: 256 })` from `src/infra/dedupe.js`. The cache auto-evicts the oldest entry when it overflows, so a long-running process cannot leak memory through distinct env keys.

## User Impact

No behavior change for normal use; evicted env keys will be re-logged if they are accepted again after overflow.

## Evidence

- Guard test in `src/infra/env.test.ts` asserts the cache caps at 256 entries and re-logs evicted keys.
- `node scripts/run-vitest.mjs src/infra/env.test.ts` passes.
