### PR TITLE
fix(wizard): treat not-directory paths as missing in migration snapshots

### DIFF
--- a/src/wizard/setup.migration-recovery.test.ts
+++ b/src/wizard/setup.migration-recovery.test.ts
@@ -433,6 +433,15 @@ describe("setup migration recovery", () => {
     await expect(buildSetupMigrationPlanSourceSnapshot(buildPlan(root))).resolves.not.toBe(initial);
   });
 
+  it("treats source paths beneath a non-directory as missing", async () => {
+    const root = await makeTempRoot();
+    const plan = buildPlan(root);
+    const missingSnapshot = await buildSetupMigrationPlanSourceSnapshot(plan);
+    await fs.writeFile(path.join(root, "hermes"), "not a directory");
+
+    await expect(buildSetupMigrationPlanSourceSnapshot(plan)).resolves.toBe(missingSnapshot);
+  });
+
   it("snapshots meaningful target changes but ignores migration reports", async () => {
     const stateDir = await makeTempRoot();
     const workspaceDir = path.join(stateDir, "workspace");
@@ -491,6 +500,21 @@ describe("setup migration recovery", () => {
     ).resolves.not.toBe(workspaceChanged);
   });
 
+  it("treats target paths beneath a non-directory as missing", async () => {
+    const stateDir = await makeTempRoot();
+    const workspaceDir = path.join(stateDir, "workspace");
+    const missingSnapshot = await buildSetupMigrationTargetSnapshot({
+      config: {},
+      stateDir,
+      workspaceDir,
+    });
+    await fs.writeFile(workspaceDir, "not a directory");
+
+    await expect(
+      buildSetupMigrationTargetSnapshot({ config: {}, stateDir, workspaceDir }),
+    ).resolves.toBe(missingSnapshot);
+  });
+
   it("fails closed when the newest recovery record is malformed", async () => {
     const stateDir = await makeTempRoot();
     const reportDir = path.join(stateDir, "migration", "hermes", "2026-07-13T10-00-00Z");
@@ -508,10 +532,8 @@ describe("setup migration recovery", () => {
   });
 
   it("treats a not-directory migration root as no recovery record", async () => {
-    // When the migration report path itself exists but is a file rather than a
-    // directory, fs.readdir returns ENOTDIR (not ENOENT). Recovery must treat
-    // that the same as a missing report dir and resolve to no record instead of
-    // surfacing the ENOTDIR as an unexpected error during onboarding.
+    // A file at the provider report path makes readdir return ENOTDIR; recovery
+    // treats that unavailable child path like a missing report directory.
     const stateDir = await makeTempRoot();
     await fs.mkdir(path.join(stateDir, "migration"), { recursive: true });
     await fs.writeFile(path.join(stateDir, "migration", "hermes"), "not a directory");

--- a/src/wizard/setup.migration-recovery.test.ts
+++ b/src/wizard/setup.migration-recovery.test.ts
@@ -506,4 +506,23 @@ describe("setup migration recovery", () => {
       }),
     ).rejects.toThrow("Invalid onboarding migration recovery record");
   });
+
+  it("treats a not-directory migration root as no recovery record", async () => {
+    // When the migration report path itself exists but is a file rather than a
+    // directory, fs.readdir returns ENOTDIR (not ENOENT). Recovery must treat
+    // that the same as a missing report dir and resolve to no record instead of
+    // surfacing the ENOTDIR as an unexpected error during onboarding.
+    const stateDir = await makeTempRoot();
+    await fs.mkdir(path.join(stateDir, "migration"), { recursive: true });
+    await fs.writeFile(path.join(stateDir, "migration", "hermes"), "not a directory");
+
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: "hermes",
+        workspaceDir: path.join(stateDir, "workspace"),
+        targetSnapshotHash: BEFORE_HASH,
+      }),
+    ).resolves.toEqual({ kind: "none" });
+  });
 });

--- a/src/wizard/setup.migration-recovery.ts
+++ b/src/wizard/setup.migration-recovery.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { readDurableJsonFile, writeJsonAtomic } from "../infra/json-files.js";
+import { isNotFoundPathError } from "../infra/path-guards.js";
 import { summarizeMigrationItems } from "../plugin-sdk/migration.js";
 import type { MigrationApplyResult, MigrationItem, MigrationPlan } from "../plugins/types.js";
 import { resolveUserPath } from "../utils.js";
@@ -153,10 +154,6 @@ function isSetupMigrationAttempt(value: unknown): value is SetupMigrationAttempt
   );
 }
 
-function isMissingPathError(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
-}
-
 export function createSetupMigrationAttempt(
   params: SetupMigrationIdentity & {
     plan: MigrationPlan;
@@ -285,7 +282,7 @@ async function findLatestSetupMigrationAttempt(params: {
   try {
     entries = await fs.readdir(providerReportRoot, { withFileTypes: true });
   } catch (error) {
-    if (isMissingPathError(error)) {
+    if (isNotFoundPathError(error)) {
       return undefined;
     }
     throw error;

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withFileLock } from "../infra/file-lock.js";
+import { isNotFoundPathError } from "../infra/path-guards.js";
 import type { MigrationPlan } from "../plugins/types.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -24,10 +25,6 @@ const MEANINGFUL_WORKSPACE_ENTRIES = [
   "skills",
 ] as const;
 const MEANINGFUL_STATE_ENTRIES = ["credentials", "sessions", "agents"] as const;
-
-function isMissingPathError(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
-}
 
 function canonicalizeJsonValue(value: unknown): unknown {
   if (Array.isArray(value)) {
@@ -149,7 +146,7 @@ async function hashTargetPath(
   try {
     stat = await fs.lstat(candidate);
   } catch (error) {
-    if (isMissingPathError(error)) {
+    if (isNotFoundPathError(error)) {
       hash.update(`missing:${snapshotPath}\0`);
       return;
     }
@@ -187,7 +184,7 @@ async function hashSourcePath(
   try {
     stat = await fs.lstat(candidate);
   } catch (error) {
-    if (isMissingPathError(error)) {
+    if (isNotFoundPathError(error)) {
       hash.update(`missing:${snapshotPath}\0`);
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

The onboarding migration snapshot (`buildSetupMigrationTargetSnapshot` / `buildSetupMigrationPlanSourceSnapshot`) and the recovery lookup (`findLatestSetupMigrationAttempt`) each had a local `isMissingPathError` helper that only matched `code === "ENOENT"`. When a path component that should be a directory is actually a file, `fs.readdir`/`fs.lstat` return **ENOTDIR**, not ENOENT. That ENOTDIR was not recognized, so:

- `findLatestSetupMigrationAttempt` re-threw ENOTDIR from `fs.readdir(providerReportRoot)` instead of resolving to "no recovery record" - an unexpected error surfaced during onboarding whenever the migration report path existed but was a file.
- `hashTargetPath`/`hashSourcePath` re-threw ENOTDIR from `fs.lstat` instead of hashing the path as `missing:`, interrupting the migration snapshot hash with an error rather than treating the not-directory path as an absent contribution.

This is the ENOENT-guard sibling of #107691 (`plugins`: migrate `error.code === "ENOENT"` to `isNotFoundPathError`). #107691 added the shared `isNotFoundPathError` export (matches `ENOENT` + `ENOTDIR`) and migrated the plugins scope; this applies the same migration to the wizard migration snapshot/recovery paths, which still had their own ENOENT-only helpers.

## Evidence

- `setup.migration-snapshot.ts` and `setup.migration-recovery.ts`: replaced each local `isMissingPathError` (ENOENT-only) with the shared `isNotFoundPathError` from `../infra/path-guards.js` (3 call sites: two `fs.lstat` catches in the snapshot hashers, one `fs.readdir` catch in the recovery lookup). Behavior for ENOENT is unchanged; ENOTDIR now takes the same graceful "missing" path instead of throwing.
- New test `treats a not-directory migration root as no recovery record`: writes `migration/hermes` as a file so `fs.readdir(migration/hermes)` returns ENOTDIR, and asserts `resolveSetupMigrationRecovery` resolves to `{ kind: "none" }` (verified the construction triggers `code: ENOTDIR` before asserting). Under the old ENOENT-only check this surfaced ENOTDIR as an unexpected error.
- Local prechecks green:
  - `vitest run src/wizard/setup.migration-recovery.test.ts` -> 7 passed, 1 skipped (existing snapshot/recovery tests unchanged).
  - `tsgo:core:test` -> exit 0, no errors.
  - `oxlint -c .oxlintrc.json` on all three files -> exit 0.
