### PR TITLE
fix(skills): bound skill command debug dedupe cache

### DIFF
--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -1,8 +1,11 @@
 // Command spec tests cover skill-provided command metadata and filtering.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createFixtureSkillEntry } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
-import { buildWorkspaceSkillCommandSpecs } from "./command-specs.js";
+import {
+  buildWorkspaceSkillCommandSpecs,
+  resetSkillCommandDebugCacheForTest,
+} from "./command-specs.js";
 
 const bundleCommandState = vi.hoisted(() => ({
   entries: [] as Array<{
@@ -14,6 +17,15 @@ const bundleCommandState = vi.hoisted(() => ({
   }>,
 }));
 
+const skillsLoggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  trace: vi.fn(),
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => skillsLoggerMock,
+}));
+
 vi.mock("../../plugins/bundle-commands.js", () => ({
   loadEnabledClaudeBundleCommands: () => bundleCommandState.entries,
 }));
@@ -22,6 +34,12 @@ vi.mock("../loading/workspace.js", () => ({
   filterWorkspaceSkillEntriesWithOptions: (entries: SkillEntry[]) => entries,
   loadVisibleWorkspaceSkillEntries: () => [],
 }));
+
+beforeEach(() => {
+  resetSkillCommandDebugCacheForTest();
+  skillsLoggerMock.debug.mockClear();
+  skillsLoggerMock.trace.mockClear();
+});
 
 afterEach(() => {
   bundleCommandState.entries = [];
@@ -86,5 +104,26 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
       description,
       promptTemplate: "Run the bundled command.",
     });
+  });
+
+  it("bounds the skill command debug cache and re-logs evicted keys", () => {
+    const entries = [];
+    for (let index = 0; index < 1025; index += 1) {
+      entries.push({
+        pluginId: "bundle-plugin",
+        rawName: `raw ${index}`,
+        description: "Run the bundled command.",
+        promptTemplate: "Run the bundled command.",
+        sourceFilePath: `/plugins/bundle-plugin/commands/raw-${index}.md`,
+      });
+    }
+
+    bundleCommandState.entries = entries;
+    buildWorkspaceSkillCommandSpecs("/workspace", { entries: [] });
+    expect(skillsLoggerMock.debug).toHaveBeenCalledTimes(1025);
+
+    bundleCommandState.entries = [entries[0]];
+    buildWorkspaceSkillCommandSpecs("/workspace", { entries: [] });
+    expect(skillsLoggerMock.debug).toHaveBeenCalledTimes(1026);
   });
 });

--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createFixtureSkillEntry } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
-import { buildWorkspaceSkillCommandSpecs, testing } from "./command-specs.js";
 
 const bundleCommandState = vi.hoisted(() => ({
   entries: [] as Array<{
@@ -33,7 +32,8 @@ vi.mock("../loading/workspace.js", () => ({
 }));
 
 beforeEach(() => {
-  testing.resetSkillCommandDebugCacheForTest();
+  vi.resetModules();
+  bundleCommandState.entries = [];
   skillsLoggerMock.debug.mockClear();
   skillsLoggerMock.trace.mockClear();
 });
@@ -43,7 +43,8 @@ afterEach(() => {
 });
 
 describe("buildWorkspaceSkillCommandSpecs", () => {
-  it("uses shared user-invocable skill exposure policy", () => {
+  it("uses shared user-invocable skill exposure policy", async () => {
+    const { buildWorkspaceSkillCommandSpecs } = await import("./command-specs.js");
     const specs = buildWorkspaceSkillCommandSpecs("/workspace", {
       entries: [
         createFixtureSkillEntry("visible"),
@@ -66,7 +67,8 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     expect(specs.map((spec) => spec.skillName)).toEqual(["visible"]);
   });
 
-  it("preserves workspace skill descriptions for provider-specific limits", () => {
+  it("preserves workspace skill descriptions for provider-specific limits", async () => {
+    const { buildWorkspaceSkillCommandSpecs } = await import("./command-specs.js");
     const prefix = "a".repeat(98);
     const entry = createFixtureSkillEntry("emoji-skill");
     entry.skill.description = `${prefix}😀 extra text beyond the limit`;
@@ -79,7 +81,8 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     expect(specs[0]?.skillFile).toBe(entry.skill.filePath);
   });
 
-  it("preserves bundle command descriptions for provider-specific limits", () => {
+  it("preserves bundle command descriptions for provider-specific limits", async () => {
+    const { buildWorkspaceSkillCommandSpecs } = await import("./command-specs.js");
     const prefix = "a".repeat(98);
     const description = `${prefix}😀 extra text beyond the limit`;
     bundleCommandState.entries = [
@@ -103,7 +106,8 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     });
   });
 
-  it("bounds the skill command debug cache and re-logs evicted keys", () => {
+  it("bounds the skill command debug cache and re-logs evicted keys", async () => {
+    const { buildWorkspaceSkillCommandSpecs } = await import("./command-specs.js");
     const entries = [];
     for (let index = 0; index < 1025; index += 1) {
       entries.push({

--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -2,10 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createFixtureSkillEntry } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
-import {
-  buildWorkspaceSkillCommandSpecs,
-  resetSkillCommandDebugCacheForTest,
-} from "./command-specs.js";
+import { buildWorkspaceSkillCommandSpecs, testing } from "./command-specs.js";
 
 const bundleCommandState = vi.hoisted(() => ({
   entries: [] as Array<{
@@ -36,7 +33,7 @@ vi.mock("../loading/workspace.js", () => ({
 }));
 
 beforeEach(() => {
-  resetSkillCommandDebugCacheForTest();
+  testing.resetSkillCommandDebugCacheForTest();
   skillsLoggerMock.debug.mockClear();
   skillsLoggerMock.trace.mockClear();
 });
@@ -122,7 +119,7 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     buildWorkspaceSkillCommandSpecs("/workspace", { entries: [] });
     expect(skillsLoggerMock.debug).toHaveBeenCalledTimes(1025);
 
-    bundleCommandState.entries = [entries[0]];
+    bundleCommandState.entries = [entries[0]!];
     buildWorkspaceSkillCommandSpecs("/workspace", { entries: [] });
     expect(skillsLoggerMock.debug).toHaveBeenCalledTimes(1026);
   });

--- a/src/skills/discovery/command-specs.ts
+++ b/src/skills/discovery/command-specs.ts
@@ -45,10 +45,11 @@ function traceSkillCommandOnce(
   skillsLogger.trace(message, meta);
 }
 
-/** Test-only: resets the skill command debug dedupe cache. */
-export function resetSkillCommandDebugCacheForTest() {
+function resetSkillCommandDebugCacheForTest(): void {
   skillCommandDebugOnce.clear();
 }
+
+export const testing = { resetSkillCommandDebugCacheForTest } as const;
 
 function sanitizeSkillCommandName(raw: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(raw)

--- a/src/skills/discovery/command-specs.ts
+++ b/src/skills/discovery/command-specs.ts
@@ -45,12 +45,6 @@ function traceSkillCommandOnce(
   skillsLogger.trace(message, meta);
 }
 
-function resetSkillCommandDebugCacheForTest(): void {
-  skillCommandDebugOnce.clear();
-}
-
-export const testing = { resetSkillCommandDebugCacheForTest } as const;
-
 function sanitizeSkillCommandName(raw: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(raw)
     .replace(/[^a-z0-9_]+/g, "_")

--- a/src/skills/discovery/command-specs.ts
+++ b/src/skills/discovery/command-specs.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { loadEnabledClaudeBundleCommands } from "../../plugins/bundle-commands.js";
 import { resolveSkillTelemetrySource } from "../loading/source.js";
@@ -17,7 +18,7 @@ import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
 import { filterUserInvocableSkillEntries } from "./skill-index.js";
 
 const skillsLogger = createSubsystemLogger("skills");
-const skillCommandDebugOnce = new Set<string>();
+const skillCommandDebugOnce = createDedupeCache({ ttlMs: 0, maxSize: 1024 });
 const SKILL_COMMAND_MAX_LENGTH = 32;
 const SKILL_COMMAND_FALLBACK = "skill";
 
@@ -27,10 +28,9 @@ function debugSkillCommandOnce(
   message: string,
   meta?: Record<string, unknown>,
 ) {
-  if (skillCommandDebugOnce.has(messageKey)) {
+  if (skillCommandDebugOnce.check(messageKey)) {
     return;
   }
-  skillCommandDebugOnce.add(messageKey);
   skillsLogger.debug(message, meta);
 }
 
@@ -39,11 +39,15 @@ function traceSkillCommandOnce(
   message: string,
   meta?: Record<string, unknown>,
 ) {
-  if (skillCommandDebugOnce.has(messageKey)) {
+  if (skillCommandDebugOnce.check(messageKey)) {
     return;
   }
-  skillCommandDebugOnce.add(messageKey);
   skillsLogger.trace(message, meta);
+}
+
+/** Test-only: resets the skill command debug dedupe cache. */
+export function resetSkillCommandDebugCacheForTest() {
+  skillCommandDebugOnce.clear();
 }
 
 function sanitizeSkillCommandName(raw: string): string {


### PR DESCRIPTION
## What Problem This Solves

`src/skills/discovery/command-specs.ts` keeps a module-level `Set<string>` (`skillCommandDebugOnce`) to dedupe skill-command debug/trace diagnostics across workspace scans. The set grows without bound for the lifetime of the process.

## Why This Change Was Made

Replaced the raw `Set` with `createDedupeCache({ ttlMs: 0, maxSize: 1024 })` from `src/infra/dedupe.js`. The cache auto-evicts the oldest entry when it overflows.

## User Impact

No behavior change under normal load; evicted skill-command diagnostics will be re-logged if the same message key is encountered again after overflow.

## Evidence

- Guard test in `src/skills/discovery/command-specs.test.ts` asserts the cache caps at 1024 entries and re-logs evicted keys.
- `node scripts/run-vitest.mjs src/skills/discovery/command-specs.test.ts` passes.
