### PR TITLE
fix(line): bound inbound media download body reads

### DIFF
--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -298,7 +298,7 @@ describe("downloadLineMedia", () => {
     expect(saveMediaStreamMock).not.toHaveBeenCalled();
   });
 
-  it("aborts a hung content request at the total readiness deadline", async () => {
+  it("aborts a hung content request at the readiness deadline", async () => {
     let requestSignal: AbortSignal | undefined;
     fetchMock.mockImplementation(
       async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -320,6 +320,67 @@ describe("downloadLineMedia", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(requestSignal?.aborted).toBe(true);
     expect(saveMediaStreamMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts a dripping content body after headers within the body deadline", async () => {
+    vi.useFakeTimers();
+    let dripTimer: ReturnType<typeof setInterval> | undefined;
+    let requestSignal: AbortSignal | undefined;
+    fetchMock.mockImplementation(async (_input, init?: RequestInit) => {
+      requestSignal = init?.signal ?? undefined;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            dripTimer = setInterval(() => controller.enqueue(new Uint8Array([0x78])), 40);
+          },
+          cancel() {
+            if (dripTimer !== undefined) clearInterval(dripTimer);
+          },
+        }),
+        { status: 200 },
+      );
+    });
+    const pending = downloadLineMedia("mid-drip", "token", 10 * 1024 * 1024, {
+      bodyTimeoutMs: 1_000,
+    });
+    const rejection = expect(pending).rejects.toThrow(
+      /body for message mid-drip timed out after 1 seconds/i,
+    );
+    await vi.waitFor(() => expect(saveMediaStreamMock).toHaveBeenCalledTimes(1));
+    expect(requestSignal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+  });
+
+  it("keeps a fresh body deadline after late readiness", async () => {
+    vi.useFakeTimers();
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+    const first = cancellableResponse(202);
+    fetchMock
+      .mockImplementationOnce(async (_input, init?: RequestInit) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 14_000);
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(new Error("fetch aborted"));
+            },
+            { once: true },
+          );
+        });
+        return first.response;
+      })
+      .mockResolvedValueOnce(
+        new Response(jpeg, { status: 200, headers: { "content-type": "image/jpeg" } }),
+      );
+    const pending = downloadLineMedia("mid-late-ready", "token", 10 * 1024 * 1024, {
+      bodyTimeoutMs: 2_000,
+    });
+    await vi.advanceTimersByTimeAsync(14_000);
+    const result = await pending;
+    expect(first.cancel).toHaveBeenCalledTimes(1);
+    expect(result.size).toBe(jpeg.length);
   });
 
   it("wraps an ordinary network failure for durable retry", async () => {

--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -334,7 +334,9 @@ describe("downloadLineMedia", () => {
             dripTimer = setInterval(() => controller.enqueue(new Uint8Array([0x78])), 40);
           },
           cancel() {
-            if (dripTimer !== undefined) clearInterval(dripTimer);
+            if (dripTimer !== undefined) {
+              clearInterval(dripTimer);
+            }
           },
         }),
         { status: 200 },

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -1,4 +1,7 @@
 // Line plugin module implements download behavior.
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { setTimeout as delay } from "node:timers/promises";
 import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaStream } from "openclaw/plugin-sdk/media-store";
@@ -16,7 +19,10 @@ interface DownloadResult {
 const CONTENT_READY_MAX_ATTEMPTS = 6;
 const CONTENT_READY_BASE_DELAY_MS = 500;
 const CONTENT_READY_MAX_DELAY_MS = 4000;
+// Readiness polls only (202 → retry); body transfer uses a separate wall-clock.
 const CONTENT_READY_TIMEOUT_MS = 15_000;
+// After HTTP 200; aligned with Slack/Feishu inbound media totals (default 10MB).
+const LINE_MEDIA_BODY_TIMEOUT_MS = 120_000;
 const LINE_CONTENT_BASE_URL = "https://api-data.line.me/v2/bot/message";
 
 class RetryableLineMediaFetchError extends MediaFetchError {
@@ -30,48 +36,33 @@ function contentBackoffDelayMs(attempt: number): number {
   return Math.min(CONTENT_READY_BASE_DELAY_MS * 2 ** attempt, CONTENT_READY_MAX_DELAY_MS);
 }
 
+function resolvePositiveTimeoutMs(timeoutMs: number | undefined, fallbackMs: number): number {
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? Math.floor(timeoutMs)
+    : fallbackMs;
+}
+
 function lineContentUrl(messageId: string): string {
   return `${LINE_CONTENT_BASE_URL}/${encodeURIComponent(messageId)}/content`;
 }
 
-async function* lineResponseBodyChunks(
-  response: Response,
+// Stream errors are retryable; consumer errors (e.g. size limits) pass through.
+async function* autoRetryStreamErrors(
+  source: Readable,
   messageId: string,
 ): AsyncIterable<Uint8Array> {
-  const body = response.body;
-  if (!body) {
-    throw new RetryableLineMediaFetchError(
-      `LINE media response for message ${messageId} had no body`,
-    );
-  }
-  const reader = body.getReader();
-  let completed = false;
   try {
-    while (true) {
-      let chunk: ReadableStreamReadResult<Uint8Array>;
-      try {
-        chunk = await reader.read();
-      } catch (err) {
-        throw new RetryableLineMediaFetchError(
-          `LINE media response stream failed for message ${messageId}`,
-          { cause: err },
-        );
-      }
-      if (chunk.done) {
-        completed = true;
-        return;
-      }
-      if (chunk.value.byteLength > 0) {
-        yield chunk.value;
-      }
+    for await (const chunk of source) {
+      yield chunk;
     }
-  } finally {
-    if (!completed) {
-      await reader.cancel().catch(() => undefined);
+  } catch (err) {
+    if (err instanceof MediaFetchError) {
+      throw err;
     }
-    try {
-      reader.releaseLock();
-    } catch {}
+    throw new RetryableLineMediaFetchError(
+      `LINE media response stream failed for message ${messageId}`,
+      { cause: err },
+    );
   }
 }
 
@@ -160,27 +151,72 @@ export async function downloadLineMedia(
   messageId: string,
   channelAccessToken: string,
   maxBytes = 10 * 1024 * 1024,
-  options?: { originalFilename?: string },
+  options?: {
+    originalFilename?: string;
+    bodyTimeoutMs?: number;
+  },
 ): Promise<DownloadResult> {
-  const response = await fetchLineContentWhenReady(messageId, channelAccessToken);
-  let saved: Awaited<ReturnType<typeof saveMediaStream>>;
-  try {
-    saved = await saveMediaStream(
-      lineResponseBodyChunks(response, messageId),
-      response.headers.get("content-type") ?? undefined,
-      "inbound",
-      maxBytes,
-      options?.originalFilename,
-    );
-  } catch (err) {
-    await response.body?.cancel().catch(() => undefined);
-    throw err;
-  }
-  logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
+  const bodyTimeoutMs = resolvePositiveTimeoutMs(
+    options?.bodyTimeoutMs,
+    LINE_MEDIA_BODY_TIMEOUT_MS,
+  );
 
-  return {
-    path: saved.path,
-    contentType: saved.contentType,
-    size: saved.size,
-  };
+  const response = await fetchLineContentWhenReady(messageId, channelAccessToken);
+
+  const bodyController = new AbortController();
+  const bodyDeadline = setTimeout(() => bodyController.abort(), bodyTimeoutMs);
+  bodyDeadline.unref();
+
+  let content: Readable | undefined;
+  try {
+    content = Readable.fromWeb(response.body as NodeReadableStream<Uint8Array>);
+
+    const onAbort = () => {
+      content?.destroy(
+        new RetryableLineMediaFetchError(
+          `LINE media body for message ${messageId} timed out after ${bodyTimeoutMs / 1000} seconds`,
+        ),
+      );
+    };
+
+    if (bodyController.signal.aborted) {
+      onAbort();
+    } else {
+      bodyController.signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    let saved: Awaited<ReturnType<typeof saveMediaStream>>;
+    try {
+      saved = await saveMediaStream(
+        autoRetryStreamErrors(content, messageId),
+        response.headers.get("content-type") ?? undefined,
+        "inbound",
+        maxBytes,
+        options?.originalFilename,
+      );
+    } finally {
+      bodyController.signal.removeEventListener("abort", onAbort);
+    }
+
+    logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
+    return {
+      path: saved.path,
+      contentType: saved.contentType,
+      size: saved.size,
+    };
+  } catch (err) {
+    if (bodyController.signal.aborted) {
+      throw new RetryableLineMediaFetchError(
+        `LINE media body for message ${messageId} timed out after ${bodyTimeoutMs / 1000} seconds`,
+        { cause: err },
+      );
+    }
+    if (content) {
+      content.destroy();
+      await finished(content).catch(() => undefined);
+    }
+    throw err;
+  } finally {
+    clearTimeout(bodyDeadline);
+  }
 }

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -19,10 +19,8 @@ interface DownloadResult {
 const CONTENT_READY_MAX_ATTEMPTS = 6;
 const CONTENT_READY_BASE_DELAY_MS = 500;
 const CONTENT_READY_MAX_DELAY_MS = 4000;
-// Readiness polls only (202 → retry); body transfer uses a separate wall-clock.
-const CONTENT_READY_TIMEOUT_MS = 15_000;
-// After HTTP 200; aligned with Slack/Feishu inbound media totals (default 10MB).
-const LINE_MEDIA_BODY_TIMEOUT_MS = 120_000;
+const CONTENT_READY_TIMEOUT_MS = 15_000; // readiness polls only
+const LINE_MEDIA_BODY_TIMEOUT_MS = 120_000; // post-200 body wall-clock
 const LINE_CONTENT_BASE_URL = "https://api-data.line.me/v2/bot/message";
 
 class RetryableLineMediaFetchError extends MediaFetchError {
@@ -37,16 +35,14 @@ function contentBackoffDelayMs(attempt: number): number {
 }
 
 function resolvePositiveTimeoutMs(timeoutMs: number | undefined, fallbackMs: number): number {
-  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
-    ? Math.floor(timeoutMs)
-    : fallbackMs;
+  const ok = typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0;
+  return ok ? Math.floor(timeoutMs) : fallbackMs;
 }
 
 function lineContentUrl(messageId: string): string {
   return `${LINE_CONTENT_BASE_URL}/${encodeURIComponent(messageId)}/content`;
 }
 
-// Stream errors are retryable; consumer errors (e.g. size limits) pass through.
 async function* autoRetryStreamErrors(
   source: Readable,
   messageId: string,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LINE inbound media download could hang forever after the content endpoint returned HTTP 200, when the response body kept dripping bytes slowly. `fetchLineContentWhenReady` cleared its 15s `AbortController` after headers returned `Readable.fromWeb(response.body)`, leaving no wall-clock bound on the Node stream consumed by `saveMediaStream` — a slow-drip CDN body would keep inbound media handling alive indefinitely.

## Why This Change Was Made

On current `main`, readiness owns a 15s `AbortController` inside `fetchLineContentWhenReady` and clears that timer as soon as headers return. After headers, only the Node stream remains — with no wall-clock — so a slow drip can keep `saveMediaStream` alive indefinitely.

This keeps the existing **15s readiness** contract for 202→retry polling, and adds a separate **120s body** wall-clock after HTTP 200 that aborts and destroys the Node stream via a fresh `AbortController`. Body budget matches Slack/Feishu inbound media totals (`SLACK_MEDIA_TOTAL_TIMEOUT_MS` / Feishu `120_000`) so late readiness still gets a full transfer window for the default 10MB cap. LINE documents `api-data.line.me` as the large-data content endpoint where video/audio may spend time preparing before binary retrieval.

The current `main` branch already uses `fetchWithRuntimeDispatcherOrMockedGlobal` (custom fetch + 202 polling) for LINE content download — this was introduced in #108351. This PR layers the body deadline on top of that existing path; no SDK ownership boundary is being crossed.

Non-goals: changing shared `saveMediaStream`, LINE send/API surfaces, or collapsing readiness+body into one shared 15s budget.

Collision check: no open PR on `extensions/line/src/download.ts`.

## User Impact

- Wedged or dripping LINE content bodies fail closed at the **body** deadline instead of hanging inbound media handling.
- Healthy media that becomes ready late still gets a full body transfer budget (no longer starved by a shared 15s total).
- Readiness-only behavior for hung pre-header / endless 202 polling stays at 15s.

## Evidence (refreshed 2026-07-21)

Exact head: `751fbf24bd2f548af739ad6fd921536c305318a3`

CI fix: removed `download.deadline.loopback.test.ts` — it passed `contentBaseUrl` but production never wired it, so CI hit real `api-data.line.me` → HTTP 404. Fake-timer drip + late-readiness cases in `download.test.ts` cover the body wall-clock invariant.

```bash
node scripts/run-vitest.mjs extensions/line/src/download.test.ts
```

```
Test Files  1 passed (1)
Tests  21 passed (21)
[test] passed 1 Vitest shard in 7.44s
```

Size:S after dropping the broken loopback harness.

## Verification

- Exact head: `751fbf24bd2f548af739ad6fd921536c305318a3`
- Focused: `node scripts/run-vitest.mjs extensions/line/src/download.test.ts` → 21/21 pass
- Size:S; removed broken loopback harness that caused CI HTTP 404
- Rebuilt as single commit on current `origin/main`

## Risk / Compatibility

- Med: 120s post-header body deadline fails closed into existing LINE download-error path; owner should confirm budget for large media
