### PR TITLE
refactor(discord): deprecate abort signal helper

### DIFF
--- a/extensions/discord/src/monitor/timeouts.test.ts
+++ b/extensions/discord/src/monitor/timeouts.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover timeouts plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { mergeAbortSignals as publicApiMergeAbortSignals } from "../../api.js";
 import {
   isAbortError as runtimeApiIsAbortError,
   mergeAbortSignals as runtimeApiMergeAbortSignals,
@@ -26,7 +27,8 @@ afterEach(() => {
 });
 
 describe("discord monitor timeouts", () => {
-  it("keeps deprecated timeout helpers on the runtime api compatibility surface", () => {
+  it("keeps deprecated timeout helpers on shipped compatibility surfaces", () => {
+    expect(publicApiMergeAbortSignals).toBe(mergeAbortSignals);
     expect(runtimeApiIsAbortError).toBe(isAbortError);
     expect(runtimeApiMergeAbortSignals).toBe(mergeAbortSignals);
     expect(runtimeApiNormalizeDiscordInboundWorkerTimeoutMs).toBe(

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -38,6 +38,7 @@ export function isAbortError(error: unknown): boolean {
   return "name" in error && String((error as { name?: unknown }).name) === "AbortError";
 }
 
+/** @deprecated Use native `AbortSignal.any` after filtering optional signals at the call site. */
 export function mergeAbortSignals(
   signals: Array<AbortSignal | undefined>,
 ): AbortSignal | undefined {


### PR DESCRIPTION
## What Problem This Solves

Discord still exposes `mergeAbortSignals` after all internal production callers moved to native `AbortSignal.any`. The helper looked like removable duplicate code, but it is part of the shipped `@openclaw/discord` compatibility surface.

## Why This Change Was Made

- Mark `mergeAbortSignals` deprecated and point callers to native `AbortSignal.any`.
- Keep the `api.js` and runtime-sidecar exports intact because `v2026.7.2-beta.1` and `@openclaw/discord@2026.7.2-beta.1` shipped them. PR #105947 also explicitly preserved this runtime export as a compatibility wrapper.
- Extend the Discord timeout contract test to prove both shipped public surfaces still resolve to the compatibility helper.
- Leave the runtime API guardrail export list unchanged intentionally; removing the name there would encode a breaking removal.

No Discord production caller remains. Internal abort composition already uses `AbortSignal.any` directly.

## User Impact

Plugin developers receive a deprecation warning and a native replacement path. Existing imports continue to work with no runtime behavior change.

## Evidence

- Blacksmith Testbox `tbx_01kxnsztp5ewf3cvq1drkbv42e`: `pnpm test extensions/discord` — 185 files and 2,178 tests passed.
- Same Testbox: `pnpm test src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts` — 6 tests passed.
- Same Testbox: `pnpm check:changed` — formatting, Plugin SDK baseline, extension typechecks, lint, boundary guards, and import-cycle checks passed.
- Fresh autoreview on the final patch: no accepted or actionable findings; confidence 0.96.
- Published-contract proof: Git tag/release `v2026.7.2-beta.1` and the npm package both contain `mergeAbortSignals` in the Discord public/runtime barrels.

AI-assisted: Codex. I reviewed the implementation, compatibility history, published artifact, and validation results.
