### PR TITLE
fix(test): keep bounded child output UTF-8 safe

### DIFF
--- a/test/helpers/bounded-child-output.test.ts
+++ b/test/helpers/bounded-child-output.test.ts
@@ -39,4 +39,12 @@ describe("bounded child output", () => {
 
     expect(output.text()).toBe("tail");
   });
+
+  it("preserves replacement output for incomplete trailing bytes", () => {
+    const output = createBoundedChildOutput(7);
+
+    output.append(Buffer.from([0x61, 0xe2]));
+
+    expect(output.text()).toBe("a�");
+  });
 });

--- a/test/helpers/bounded-child-output.test.ts
+++ b/test/helpers/bounded-child-output.test.ts
@@ -22,4 +22,21 @@ describe("bounded child output", () => {
 
     expect(output.text()).toBe("x-recent");
   });
+
+  it("drops split UTF-8 prefixes after buffered output overflow", () => {
+    const output = createBoundedChildOutput(7);
+
+    output.append(Buffer.from("prefix 😀"));
+    output.append(Buffer.from("tail"));
+
+    expect(output.text()).toBe("tail");
+  });
+
+  it("drops split UTF-8 prefixes from single oversized chunks", () => {
+    const output = createBoundedChildOutput(7);
+
+    output.append(Buffer.from("prefix 😀tail"));
+
+    expect(output.text()).toBe("tail");
+  });
 });

--- a/test/helpers/bounded-child-output.ts
+++ b/test/helpers/bounded-child-output.ts
@@ -7,7 +7,7 @@ function decodeUtf8Tail(buffer: Buffer): string {
   while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
     start += 1;
   }
-  return new StringDecoder("utf8").write(buffer.subarray(start));
+  return new StringDecoder("utf8").end(buffer.subarray(start));
 }
 
 export function createBoundedChildOutput(maxBytes = DEFAULT_CHILD_OUTPUT_TAIL_BYTES) {

--- a/test/helpers/bounded-child-output.ts
+++ b/test/helpers/bounded-child-output.ts
@@ -1,4 +1,14 @@
+import { StringDecoder } from "node:string_decoder";
+
 export const DEFAULT_CHILD_OUTPUT_TAIL_BYTES = 128 * 1024;
+
+function decodeUtf8Tail(buffer: Buffer): string {
+  let start = 0;
+  while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
+    start += 1;
+  }
+  return new StringDecoder("utf8").write(buffer.subarray(start));
+}
 
 export function createBoundedChildOutput(maxBytes = DEFAULT_CHILD_OUTPUT_TAIL_BYTES) {
   const limit =
@@ -37,7 +47,7 @@ export function createBoundedChildOutput(maxBytes = DEFAULT_CHILD_OUTPUT_TAIL_BY
       trim();
     },
     text(): string {
-      return Buffer.concat(chunks, totalBytes).toString("utf8");
+      return decodeUtf8Tail(Buffer.concat(chunks, totalBytes));
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where shared test and E2E child-output diagnostics could render replacement characters when a byte-bounded retained tail starts inside a multibyte UTF-8 character.

## Why This Change Was Made

The shared bounded child-output helper now drops leading UTF-8 continuation bytes before decoding the retained tail with `StringDecoder`. The change stays inside the test helper owner boundary and preserves the existing byte cap behavior for subprocess stdout and stderr diagnostics.

## User Impact

Failure diagnostics from test and E2E subprocess harnesses stay readable for multibyte output while still limiting noisy child output.

## Evidence

- Current head: `75149c1b219b2e623f03edfdd586116db1c879bc` after merge-refresh onto `upstream/main` `0903ebe4fa5f4643aaf83e3d59cc5518f80db448`.
- Focused regression: `node scripts/run-vitest.mjs test/helpers/bounded-child-output.test.ts` passed, 1 file / 4 tests.
- Diff hygiene: `git diff --check upstream/main...HEAD` passed; diff is limited to `test/helpers/bounded-child-output.ts` and `test/helpers/bounded-child-output.test.ts`.
- Autoreview: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main --codex-bin C:\Users\86158\.codex\codex-pixel-autoreview.cmd` passed with `autoreview clean: no accepted/actionable findings reported`.
- Duplicate search after refresh: `gh search prs --repo openclaw/openclaw "bounded-child-output createBoundedChildOutput UTF-8"` returned only this PR.