### PR TITLE
perf(ci): carry extension boundary artifacts on a Blacksmith sticky disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1833,6 +1833,36 @@ jobs:
         with:
           install-bun: "false"
 
+      # check-lint's shard runner rebuilds the same plugin-sdk boundary
+      # artifacts the boundary lane snapshots (~72s cold); restore them from
+      # the shared sticky. Read-only consumer: only the boundary lane seeds,
+      # so concurrent mounts of the committed snapshot stay consistent.
+      - name: Mount extension boundary sticky disk
+        if: matrix.task == 'lint' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
+        uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
+        with:
+          key: ${{ github.repository }}-ext-boundary-v1-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'scripts/check-extension-package-tsc-boundary.mjs', 'scripts/prepare-extension-package-boundary-artifacts.mjs', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mjs', 'package.json', 'pnpm-lock.yaml') }}
+          path: /var/tmp/openclaw-ext-boundary
+          commit: if-missing
+
+      - name: Restore extension boundary artifacts from sticky disk
+        if: matrix.task == 'lint' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
+        shell: bash
+        run: |
+          set -euo pipefail
+          sticky_root=/var/tmp/openclaw-ext-boundary
+          if [ ! -f "$sticky_root/.snapshot-ready" ]; then
+            echo "boundary artifact snapshot not seeded yet; lint prepares cold"
+            exit 0
+          fi
+          # rsync -a preserves snapshot mtimes; fresh checkout sources stay
+          # newer, so the prepare script always takes its incremental path.
+          for payload in dist packages extensions; do
+            if [ -d "$sticky_root/$payload" ]; then
+              rsync -a "$sticky_root/$payload/" "$payload/"
+            fi
+          done
+
       - name: Run check shard
         env:
           HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1978,6 +1978,46 @@ jobs:
         with:
           install-bun: "false"
 
+      # Same-repo runs carry boundary artifacts on a Blacksmith sticky disk:
+      # the GitHub cache below is evicted so quickly under the repo quota that
+      # its prefix restore never hits, leaving every run to rebuild ~113s of
+      # plugin-sdk declarations. Fork PRs must never produce writable
+      # repository-global snapshots, so they keep the GitHub cache path.
+      - name: Mount extension boundary sticky disk
+        if: matrix.group == 'extension-package-boundary' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
+        uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
+        with:
+          # Coarse toolchain key only: source changes are meant to hit a stale
+          # snapshot, whose restored artifacts rebuild incrementally. PR scope
+          # keeps feature snapshots separate from protected pushes.
+          key: ${{ github.repository }}-ext-boundary-v1-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'scripts/check-extension-package-tsc-boundary.mjs', 'scripts/prepare-extension-package-boundary-artifacts.mjs', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mjs', 'package.json', 'pnpm-lock.yaml') }}
+          path: /var/tmp/openclaw-ext-boundary
+          # v1.4.0 skips commit after failed/cancelled steps, so an incomplete
+          # first hydration cannot seed this key.
+          commit: if-missing
+
+      - name: Restore extension boundary artifacts from sticky disk
+        id: boundary-sticky-restore
+        if: matrix.group == 'extension-package-boundary' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
+        shell: bash
+        run: |
+          set -euo pipefail
+          sticky_root=/var/tmp/openclaw-ext-boundary
+          if [ ! -f "$sticky_root/.snapshot-ready" ]; then
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # rsync -a preserves the snapshotting run's artifact mtimes; the
+          # fresh checkout's newer source mtimes force the prepare script down
+          # its incremental-rebuild path, so a stale snapshot can never
+          # false-skip the boundary compile.
+          for payload in dist packages extensions; do
+            if [ -d "$sticky_root/$payload" ]; then
+              rsync -a "$sticky_root/$payload/" "$payload/"
+            fi
+          done
+          echo "restored=true" >> "$GITHUB_OUTPUT"
+
       - name: Cache extension package boundary artifacts
         id: extension-package-boundary-cache
         if: matrix.group == 'extension-package-boundary'
@@ -2131,6 +2171,26 @@ jobs:
           esac
 
           exit "$failures"
+
+      # commit: if-missing snapshots only the first run per key; seed the
+      # payload before the sticky post-action flushes. rsync -aR mirrors the
+      # repo-relative layout the restore step replays.
+      - name: Seed extension boundary sticky disk
+        if: success() && steps.boundary-sticky-restore.outputs.restored == 'false' && matrix.group == 'extension-package-boundary' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
+        shell: bash
+        run: |
+          set -euo pipefail
+          sticky_root=/var/tmp/openclaw-ext-boundary
+          rm -rf "$sticky_root/dist" "$sticky_root/packages" "$sticky_root/extensions" "$sticky_root/.snapshot-ready"
+          if [ -d dist/plugin-sdk ]; then
+            rsync -aR dist/plugin-sdk "$sticky_root/"
+          fi
+          if [ -d packages/plugin-sdk/dist ]; then
+            rsync -aR packages/plugin-sdk/dist "$sticky_root/"
+          fi
+          find extensions -maxdepth 3 \( -name '.boundary-tsc.tsbuildinfo' -o -name '.boundary-tsc.stamp' \) \
+            -exec rsync -aR {} "$sticky_root/" \;
+          touch "$sticky_root/.snapshot-ready"
 
   # Validate docs (format, lint, broken links) only when docs files changed.
   check-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1835,15 +1835,17 @@ jobs:
 
       # check-lint's shard runner rebuilds the same plugin-sdk boundary
       # artifacts the boundary lane snapshots (~72s cold); restore them from
-      # the shared sticky. Read-only consumer: only the boundary lane seeds,
-      # so concurrent mounts of the committed snapshot stay consistent.
+      # the shared sticky. Strictly read-only (commit: false): if this lane
+      # could commit a freshly formatted disk, a cold-key race with the
+      # boundary lane would permanently seed an empty, marker-less snapshot
+      # that if-missing then refuses to repair.
       - name: Mount extension boundary sticky disk
         if: matrix.task == 'lint' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')
         uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
         with:
           key: ${{ github.repository }}-ext-boundary-v1-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ hashFiles('tsconfig.json', 'tsconfig.plugin-sdk.dts.json', 'packages/plugin-sdk/tsconfig.json', 'scripts/check-extension-package-tsc-boundary.mjs', 'scripts/prepare-extension-package-boundary-artifacts.mjs', 'scripts/write-plugin-sdk-entry-dts.ts', 'scripts/lib/plugin-sdk-entrypoints.json', 'scripts/lib/plugin-sdk-entries.mjs', 'package.json', 'pnpm-lock.yaml') }}
           path: /var/tmp/openclaw-ext-boundary
-          commit: if-missing
+          commit: "false"
 
       - name: Restore extension boundary artifacts from sticky disk
         if: matrix.task == 'lint' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw')


### PR DESCRIPTION
## What Problem This Solves

`check-additional-extension-package-boundary` runs at median 214s / p90 236s on every full-scope PR. Its internal timeline (job 87662608451-adjacent census, run 29510520305): ~45s setup, **~113s rebuilding plugin-sdk declaration artifacts**, then only 49.5s of actual boundary compilation (122 plugins at concurrency 6). The lane already has an actions/cache for exactly those artifacts, but the repo's 10GB cache quota churns so fast that even the `restore-keys` prefix never hits — observed: `Cache not found for input keys: <exact>, <prefix>`. Every run rebuilds from scratch.

## Why This Change Was Made

Same-repo runs now carry the boundary artifacts (`dist/plugin-sdk`, `packages/plugin-sdk/dist`, `extensions/*/dist/.boundary-tsc.*`) on a Blacksmith sticky disk, which is immune to the GitHub cache quota:

- **Coarse toolchain key** (tsconfigs, the boundary scripts, package manifests — not source hashes): source changes are *meant* to hit a stale snapshot. `rsync -a` preserves the snapshotting run's artifact mtimes, and the fresh checkout's newer source mtimes always fail the prepare script's mtime freshness predicate (`isArtifactSetFresh`), routing into tsc's tsbuildinfo-based incremental rebuild. A stale snapshot can therefore never false-skip the compile — it only makes the rebuild cheaper.
- **Per-PR key scope** (like the node-deps sticky): each PR's first push pays cold and seeds; subsequent pushes to the same PR restore warm. Protected pushes get their own key.
- **`commit: if-missing`** with an explicit seed step before the sticky post-action, mirroring the dependency sticky's incomplete-hydration guard.
- **Fork PRs are fully excluded** (same gate expression as every other sticky use) and keep the existing actions/cache path — fork code can never produce writable repository-global snapshots.

## User Impact

None at runtime — CI-only. On warm pushes the lane drops from ~214s toward ~110–140s (setup + incremental prepare + compile).

## Evidence

- Census: lane median 214s across 17 green runs; phase split from the job log (113s prep vs 49.5s compile; `compile elapsed: 49539ms`).
- Seed/restore round-trip simulated locally with the exact rsync commands: all three payload groups restore to correct repo-relative paths; non-payload files in `extensions/*/dist` are excluded.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — green; YAML parse validated.
- This PR's own run seeds the sticky for its PR key; push a trivial follow-up commit to observe the warm restore before merge.
