### PR TITLE
fix(ci): bound docs-sync publish repo git clone

### DIFF
--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -56,7 +56,7 @@ jobs:
           set -euo pipefail
           for attempt in 1 2 3 4 5; do
             rm -rf publish
-            if git clone \
+            if timeout --signal=TERM --kill-after=10s 120s git clone \
               "https://x-access-token:${OPENCLAW_DOCS_SYNC_TOKEN}@github.com/openclaw/docs.git" \
               publish; then
               exit 0


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `docs-sync-publish` workflow could remain stuck in the `git clone` step until the job timeout when the Git transport to `openclaw/docs.git` stalls. This blocks the entire documentation publish pipeline and wastes runner time.

## Why This Change Was Made

The `git clone` command now runs through the repository's bounded process pattern: a 120-second deadline, followed by a 10-second termination grace period. This matches the pattern already applied to Mantis Crabbox workflows in #108940 (commit 16c2bbb). Ref selection, shallow checkout, build, warmup, and sync behavior are unchanged.

## User Impact

Maintainers get a prompt, actionable checkout failure instead of losing a docs-publish runner for the full job timeout before the sync begins.

## Evidence

- Regression: `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts --run --testNamePattern="bounds docs-sync publish repo git clone"` ??1 passed.

- Controlled runtime proof extracted the production workflow step, scaled the production deadline to one second, and injected a Git transport that stalls until `TERM`. The step returned 124 in about 1.03 seconds, the Git fixture observed `TERM`, and did not reach the five-second outer watchdog. The identical pattern was proven for all five Mantis Crabbox workflows in #108940.

- `pnpm exec oxfmt --check` passed for the changed file; `git diff --check` passed.

- The complete test suite was also attempted: 72 tests passed, while unrelated environment-dependent cases failed because the isolated host lacked GitHub CLI authentication/clean login-shell state. The affected focused regression is green.