### PR TITLE
fix(ci): bound openclaw-npm-release git fetch operations with timeout

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -122,7 +122,7 @@ jobs:
             exit 1
           fi
           alpha_branch="${WORKFLOW_REF#refs/heads/}"
-          git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
+          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
           if ! git merge-base --is-ancestor HEAD "refs/remotes/origin/${alpha_branch}"; then
             echo "Alpha preflight target must be reachable from ${alpha_branch}." >&2
             exit 1
@@ -263,7 +263,7 @@ jobs:
           else
             # Tagged release validation still proves the commit is contained in
             # the workflow branch selected by the operator.
-            git fetch --no-tags origin "+refs/heads/${WORKFLOW_REF_NAME}:refs/remotes/origin/${WORKFLOW_REF_NAME}"
+            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${WORKFLOW_REF_NAME}:refs/remotes/origin/${WORKFLOW_REF_NAME}"
             RELEASE_TAG="${RELEASE_REF}"
             export RELEASE_TAG
           fi
@@ -730,7 +730,7 @@ jobs:
             exit 1
           fi
           alpha_branch="${WORKFLOW_REF#refs/heads/}"
-          git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
+          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
           if ! git merge-base --is-ancestor HEAD "refs/remotes/origin/${alpha_branch}"; then
             echo "Alpha publish tag must be reachable from ${alpha_branch}." >&2
             exit 1
@@ -891,7 +891,7 @@ jobs:
           export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
           # Fetch the workflow branch so merge-base ancestry checks keep working
           # for older tagged commits contained in a release branch.
-          git fetch --no-tags origin "+refs/heads/${WORKFLOW_REF_NAME}:refs/remotes/origin/${WORKFLOW_REF_NAME}"
+          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${WORKFLOW_REF_NAME}:refs/remotes/origin/${WORKFLOW_REF_NAME}"
           pnpm release:openclaw:npm:check
 
       - name: Verify prepared tarball provenance


### PR DESCRIPTION
## Summary
- Problem: Multiple `git fetch` commands in `openclaw-npm-release.yml` had no timeout bound, risking indefinite CI hangs on network stalls. Same pattern already fixed for Mantis Crabbox workflows in #108940.
- Solution: Add `timeout --signal=TERM --kill-after=10s 120s` before all 4 `git fetch` commands.
- What changed: Wrapped all `git fetch --no-tags origin` commands with timeout (4 locations).
- What did NOT change: All release logic and merge-base checks remain unchanged.

## Real behavior proof
- **Behavior addressed:** CI npm-release could hang during git fetch at 4 separate points.
- **Evidence:** Same timeout pattern as merged Crabbox fix (#108940 / 16c2bbb).
- **Change:** All `git fetch --no-tags origin` commands now prefixed with `timeout --signal=TERM --kill-after=10s 120s`.

## Root Cause
- The git fetch commands were added before the timeout-bounding pattern was standardized across CI workflows.