### PR TITLE
fix(github-copilot): redact credential-shaped text in embedding API errors

### DIFF
--- a/extensions/github-copilot/embeddings.transport.test.ts
+++ b/extensions/github-copilot/embeddings.transport.test.ts
@@ -1,0 +1,231 @@
+// Real-transport regression proof for GitHub Copilot embedding error redaction.
+// Drives the production discovery + embeddings paths against a loopback HTTP
+// server with NO ssrf-runtime or global fetch mocks, so redactSensitiveText is
+// exercised end to end over real sockets rather than synthetic stubs.
+import fs from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveFirstGithubTokenMock = vi.hoisted(() => vi.fn());
+const resolveCopilotApiTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./auth.js", () => ({
+  resolveFirstGithubToken: resolveFirstGithubTokenMock,
+}));
+
+vi.mock("./token.js", () => ({
+  DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",
+  resolveCopilotApiToken: resolveCopilotApiTokenMock,
+}));
+
+// Intentionally NOT mocked: openclaw/plugin-sdk/ssrf-runtime, global fetch, and
+// openclaw/plugin-sdk/logging-core (redactSensitiveText is the unit under proof).
+import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
+
+type CopilotServer = {
+  baseUrl: string;
+  requests: Array<{ method: string | undefined; url: string | undefined }>;
+};
+
+const servers: Array<{ close: () => Promise<void> }> = [];
+
+const DISCOVERY_MODELS_BODY = JSON.stringify({
+  data: [{ id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] }],
+});
+
+async function startCopilotServer(handle: {
+  models: { status: number; body: string };
+  embeddings?: { status: number; body: string };
+}): Promise<CopilotServer> {
+  const requests: CopilotServer["requests"] = [];
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void (async () => {
+      // Drain the request body so keep-alive sockets close cleanly.
+      await new Promise<void>((resolve) => {
+        req.resume();
+        req.on("end", resolve);
+      });
+      requests.push({ method: req.method, url: req.url });
+      const isEmbeddings = req.method === "POST" && req.url === "/embeddings";
+      const route = isEmbeddings && handle.embeddings ? handle.embeddings : handle.models;
+      res.writeHead(route.status, { "content-type": "application/json" });
+      res.end(route.body);
+    })();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+
+  const address = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${address.port}`, requests };
+}
+
+function pointTokenAt(baseUrl: string): void {
+  resolveCopilotApiTokenMock.mockResolvedValue({
+    token: "copilot_test_token_abc",
+    expiresAt: Date.now() + 3_600_000,
+    source: "test",
+    baseUrl,
+  });
+}
+
+function defaultCreateOptions() {
+  return {
+    config: {} as Record<string, unknown>,
+    agentDir: "/tmp/test-agent",
+    model: "",
+  };
+}
+
+// Points the global logging-config reader at an on-disk config with sensitive
+// redaction turned off, so the test proves the error paths force masking rather
+// than inheriting the operator's `logging.redactSensitive` preference.
+function withRedactionDisabledConfig(): () => void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-redact-off-"));
+  const configPath = path.join(dir, "openclaw.json");
+  fs.writeFileSync(configPath, JSON.stringify({ logging: { redactSensitive: "off" } }));
+  const previous = process.env.OPENCLAW_CONFIG_PATH;
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  return () => {
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previous;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+}
+
+describe("githubCopilotMemoryEmbeddingProviderAdapter real transport", () => {
+  beforeEach(() => {
+    resolveFirstGithubTokenMock.mockResolvedValue({
+      githubToken: "gh_test_token_123",
+      hasProfile: false,
+    });
+  });
+
+  afterEach(async () => {
+    const pending = servers.splice(0);
+    await Promise.all(pending.map((server) => server.close()));
+    resolveFirstGithubTokenMock.mockReset();
+    resolveCopilotApiTokenMock.mockReset();
+  });
+
+  it("redacts credential-shaped text in model discovery errors over real transport", async () => {
+    const server = await startCopilotServer({
+      models: {
+        status: 401,
+        body: '{"error":{"message":"authentication failed"},"access_token":"ghu_AAAAUNIQUESECRETXXXX111122223333"}',
+      },
+    });
+    pointTokenAt(server.baseUrl);
+
+    let caught: Error | undefined;
+    try {
+      await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    expect(server.requests).toEqual([{ method: "GET", url: "/models" }]);
+    expect(caught?.message).toContain("GitHub Copilot model discovery HTTP 401");
+    expect(caught?.message).toContain("authentication failed");
+    expect(caught?.message).not.toContain("ghu_AAAAUNIQUESECRETXXXX111122223333");
+    expect(caught?.message).not.toContain("UNIQUESECRET");
+  });
+
+  it("redacts credential-shaped text in embeddings errors over real transport", async () => {
+    const server = await startCopilotServer({
+      models: { status: 200, body: DISCOVERY_MODELS_BODY },
+      embeddings: {
+        status: 429,
+        body: '{"error":{"message":"rate limit exceeded"},"access_token":"gho_BBBBUNIQUEEMBSECRETYYYY444455556666"}',
+      },
+    });
+    pointTokenAt(server.baseUrl);
+
+    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+    let caught: Error | undefined;
+    try {
+      await result.provider?.embedQuery("hello");
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    expect(server.requests).toEqual([
+      { method: "GET", url: "/models" },
+      { method: "POST", url: "/embeddings" },
+    ]);
+    expect(caught?.message).toContain("GitHub Copilot embeddings HTTP 429");
+    expect(caught?.message).toContain("rate limit exceeded");
+    expect(caught?.message).not.toContain("gho_BBBBUNIQUEEMBSECRETYYYY444455556666");
+    expect(caught?.message).not.toContain("UNIQUEEMBSECRET");
+  });
+
+  it("still redacts when logging.redactSensitive is off", async () => {
+    const restoreConfig = withRedactionDisabledConfig();
+    try {
+      const server = await startCopilotServer({
+        models: {
+          status: 403,
+          body: '{"error":{"message":"forbidden"},"access_token":"ghu_CCCCUNIQUEOFFSECRETZZZZ777788889999"}',
+        },
+      });
+      pointTokenAt(server.baseUrl);
+
+      let caught: Error | undefined;
+      try {
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+      } catch (error) {
+        caught = error as Error;
+      }
+
+      expect(caught?.message).toContain("GitHub Copilot model discovery HTTP 403");
+      expect(caught?.message).toContain("forbidden");
+      // Forced `tools` mode must mask the token even though on-disk config
+      // disables general log redaction; a config-honoring call would leak it.
+      expect(caught?.message).not.toContain("ghu_CCCCUNIQUEOFFSECRETZZZZ777788889999");
+      expect(caught?.message).not.toContain("UNIQUEOFFSECRET");
+    } finally {
+      restoreConfig();
+    }
+  });
+
+  it("returns embedding vectors on a successful response over real transport", async () => {
+    const server = await startCopilotServer({
+      models: { status: 200, body: DISCOVERY_MODELS_BODY },
+      embeddings: {
+        status: 200,
+        body: JSON.stringify({ data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }] }),
+      },
+    });
+    pointTokenAt(server.baseUrl);
+
+    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+    const vector = await result.provider?.embedQuery("hello");
+
+    expect(server.requests).toEqual([
+      { method: "GET", url: "/models" },
+      { method: "POST", url: "/embeddings" },
+    ]);
+    expect(Array.isArray(vector)).toBe(true);
+    expect(vector).toHaveLength(3);
+    expect(vector?.every((value) => typeof value === "number")).toBe(true);
+  });
+});

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -1,4 +1,5 @@
 // Github Copilot plugin module implements embeddings behavior.
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   buildRemoteBaseUrlPolicy,
   sanitizeAndNormalizeEmbedding,
@@ -104,7 +105,11 @@ async function discoverEmbeddingModels(params: {
   });
   try {
     if (!response.ok) {
-      const detail = await readResponseTextLimited(response, COPILOT_ERROR_BODY_LIMIT_BYTES);
+      // Copilot requests carry a bearer token, so reflected upstream text must
+      // be sanitized independently of the operator's log-redaction setting.
+      const detail = redactToolPayloadText(
+        await readResponseTextLimited(response, COPILOT_ERROR_BODY_LIMIT_BYTES),
+      );
       throw new Error(`GitHub Copilot model discovery HTTP ${response.status}: ${detail}`);
     }
     const payload = await readProviderJsonResponse(response, "github-copilot.model-discovery");
@@ -246,7 +251,9 @@ async function createGitHubCopilotEmbeddingProvider(
       },
       onResponse: async (response) => {
         if (!response.ok) {
-          const detail = await readResponseTextLimited(response, COPILOT_ERROR_BODY_LIMIT_BYTES);
+          const detail = redactToolPayloadText(
+            await readResponseTextLimited(response, COPILOT_ERROR_BODY_LIMIT_BYTES),
+          );
           throw new Error(`GitHub Copilot embeddings HTTP ${response.status}: ${detail}`);
         }
 


### PR DESCRIPTION
## What Problem This Solves

The GitHub Copilot embeddings integration echoes credential-shaped text into user-visible error diagnostics. Both non-2xx paths — model discovery (`discoverEmbeddingModels`) and the embeddings call itself (`createGitHubCopilotEmbeddingProvider`) — send a Copilot bearer token to a configurable base URL, then interpolate the bounded upstream response body verbatim into the thrown `Error`. If an upstream or proxy response reflected token-shaped or credential-shaped data, that content surfaced unredacted in error messages, logs, and any operator-facing diagnostics for the Copilot embeddings provider.

## Why This Change Was Made

Both error paths now pass the bounded response body through `redactToolPayloadText` from `openclaw/plugin-sdk/logging-core` before interpolation. This is the canonical unconditional UI/error-surface sanitizer: it forces tools-mode masking regardless of `logging.redactSensitive` while merging operator-defined redaction patterns with the built-in defaults.

This reuses the established in-boundary SDK redaction helper (already used elsewhere in the tree) and the existing `readResponseTextLimited` reader, so no new dependency, abstraction, or boundary crossing is introduced. The existing 8 KiB streaming read bound (`COPILOT_ERROR_BODY_LIMIT_BYTES`) is preserved, and the exact error message prefixes are unchanged (`GitHub Copilot model discovery HTTP <status>:` and `GitHub Copilot embeddings HTTP <status>:`). Preserving those prefixes matters because `isCopilotSetupError` matches on them for auto-selection fallback. Only the interpolated body segment is redacted; status codes and safe reason text are retained.

This addresses the ClawSweeper P1 finding "Force redaction independently of logging settings" and its recommended maintainer option "Force boundary redaction before merge".

## User Impact

- Before: with a reflected credential in an upstream/proxy body, a Copilot embeddings failure could surface the raw token in the thrown error and logs. With `logging.redactSensitive: off`, even the prior redaction attempt would have passed the raw body through unchanged.
- After: the reflected body segment is masked at both error boundaries regardless of `logging.redactSensitive`, while the HTTP status and human-readable failure reason are preserved. No change to success paths, error message prefixes, Copilot setup detection, or auto-selection fallback.

## Evidence

**Scope:** 2 files.
- `extensions/github-copilot/embeddings.ts` (+11/-2): force-redaction at both non-2xx error boundaries.
- `extensions/github-copilot/embeddings.transport.test.ts` (+231, new): real-transport regression proof.

### Regression test

`extensions/github-copilot/embeddings.transport.test.ts` drives the production adapter (`githubCopilotMemoryEmbeddingProviderAdapter`) against a loopback `node:http` server on `127.0.0.1:0`. It does **not** mock `fetch`, `openclaw/plugin-sdk/ssrf-runtime`, or `openclaw/plugin-sdk/logging-core` (`redactToolPayloadText` is exercised end to end). Only auth/token resolution uses synthetic fixtures. Four cases:

1. **Model discovery error (401)** — server body contains `ghu_...`; asserts the thrown error keeps `HTTP 401` and `authentication failed` but does NOT contain the full token or its `UNIQUESECRET` component.
2. **Embeddings error (429)** — server body contains `gho_...`; asserts `HTTP 429` and `rate limit exceeded` preserved, token and `UNIQUEEMBSECRET` component absent.
3. **Redaction disabled in config (403)** — writes an on-disk config with `logging.redactSensitive: "off"` (via `OPENCLAW_CONFIG_PATH`), then asserts the `ghu_...` token is still masked. This is the guard for the forced-`tools`-mode boundary: a config-honoring call would leak the token here.
4. **Success path (200)** — asserts a valid embeddings response still returns a numeric vector of the expected length, proving no behavior change on the happy path.

### Pre-submit checks: ✅ PASSED on Linux

All checks validated on Linux checkout:

```bash
$ oxfmt --check extensions/github-copilot/embeddings.ts extensions/github-copilot/embeddings.transport.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 80ms on 2 files using 8 threads.

$ node scripts/run-oxlint.mjs --tsconfig tsconfig.json extensions/github-copilot/embeddings.ts extensions/github-copilot/embeddings.transport.test.ts
# No errors, passed cleanly

$ pnpm test extensions/github-copilot/embeddings.transport.test.ts
 RUN  v4.1.10 /home/0668001344/Desktop/openclaw
 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  19:01:36
   Duration  5.63s
[test] passed 1 Vitest shard in 10.84s

$ pnpm test extensions/github-copilot/embeddings.test.ts
 RUN  v4.1.10 /home/0668001344/Desktop/openclaw
 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  19:02:21
   Duration  5.34s
[test] passed 1 Vitest shard in 10.24s

$ $autoreview
# No findings, exit code 0
```

### Notes

- Verified against live `openclaw/openclaw` `main`: both error paths still read the response body raw with no redaction, so this change is not superseded.
- Branch rebased onto latest `main`; `extensions/github-copilot/embeddings.test.ts` is unchanged from `main` (the earlier oxfmt failure on that file no longer applies).
- All pre-submit checks passed on Linux checkout. Ready for merge.

