### PR TITLE
fix(acpx): avoid startup hangs during process inspection

### DIFF
--- a/extensions/acpx/src/process-reaper.test.ts
+++ b/extensions/acpx/src/process-reaper.test.ts
@@ -2,6 +2,11 @@
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
+
+const runExecMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({ runExec: runExecMock }));
+
 import {
   cleanupOpenClawOwnedAcpxProcessTree,
   isOpenClawLeaseAwareAcpxProcessCommand,
@@ -61,6 +66,23 @@ function collectMatching<T, U>(
 }
 
 describe("process reaper", () => {
+  it("bounds startup process listing and fails closed when it times out", async () => {
+    runExecMock.mockRejectedValueOnce(new Error("process listing timed out"));
+
+    const result = await reapStaleOpenClawOwnedAcpxOrphans({ wrapperRoot: WRAPPER_ROOT });
+
+    expect(runExecMock).toHaveBeenCalledWith("ps", ["-axo", "pid=,ppid=,command="], {
+      logOutput: false,
+      maxBuffer: 8 * 1024 * 1024,
+      timeoutMs: 2_000,
+    });
+    expect(result).toEqual({
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "process-list-unavailable",
+    });
+  });
+
   it("only treats generated wrappers as launch-lease aware", () => {
     expect(
       isOpenClawLeaseAwareAcpxProcessCommand({

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -11,6 +11,7 @@ import { resolveAcpxPluginRoot } from "./config.js";
 import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
 
 const requireFromHere = createRequire(import.meta.url);
+const ACPX_PROCESS_LIST_TIMEOUT_MS = 2_000;
 const GENERATED_WRAPPER_BASENAMES = new Set([
   "codex-acp-wrapper.mjs",
   "claude-agent-acp-wrapper.mjs",
@@ -235,6 +236,7 @@ async function listPlatformProcesses(): Promise<AcpxProcessInfo[]> {
   const { stdout } = await runExec("ps", ["-axo", "pid=,ppid=,command="], {
     logOutput: false,
     maxBuffer: 8 * 1024 * 1024,
+    timeoutMs: ACPX_PROCESS_LIST_TIMEOUT_MS,
   });
   return parseProcessList(stdout);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ACPX startup and stale-lease cleanup could wait indefinitely when the host process-list command stopped responding.

## Why This Change Was Made

The ACPX-owned process scan now uses a two-second deadline through the existing process runtime. Timeout failures keep the existing fail-closed behavior: the reaper reports that the process list is unavailable and does not terminate any process without a verified snapshot.

## User Impact

Gateway startup and ACPX lease cleanup can recover from a stuck process-table probe instead of hanging indefinitely.

## Evidence

- Baseline checked against `upstream/main` `5f4f249d880cea7e9564f895ffa05f86361be3d5`; the target files had no drift after the proof was captured.
- Real local process proof used an executable `ps` fixture on `PATH` that slept for 30 seconds and invoked the public `reapStaleOpenClawOwnedAcpxOrphans` entry point:
  - Before (the production timeout line temporarily removed to match `main`), an outer five-second guard expired: `before_exit=124 elapsed_bound=5s`.
  - After, the same real child process was terminated by the production deadline and the public entry point returned without killing anything: `{"elapsedMs":2682,"result":{"inspectedPids":[],"terminatedPids":[],"skippedReason":"process-list-unavailable"}}`.
- Mutation proof: removing only `timeoutMs` made the new focused test fail on the missing option; restoring it returned the suite to green.
- `node scripts/run-vitest.mjs extensions/acpx/src/process-reaper.test.ts` — 14 tests passed.
- `./node_modules/.bin/oxfmt --check extensions/acpx/src/process-reaper.ts extensions/acpx/src/process-reaper.test.ts` — passed.
- `./node_modules/.bin/oxlint --type-aware --tsconfig config/tsconfig/oxlint.extensions.json --report-unused-disable-directives-severity error extensions/acpx/src/process-reaper.ts extensions/acpx/src/process-reaper.test.ts` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.
- Full repository checks were left to GitHub Actions.

AI-assisted with Codex; I reviewed the production path and ran the behavior proof manually.
