### PR TITLE
fix(autoreview): sync config token fixture

### DIFF
--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -297,6 +297,7 @@ SECRET_PLACEHOLDER_VALUES = {
     "test-token-placeholder",
     "token-oversized",
     "clawrouter-e2e-secret",
+    "config-token",
     "very-long-browser-token-0123456789",
 }
 SYNTHETIC_SECRET_PREFIXES = frozenset(

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -2956,6 +2956,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             'token: "token-oversized"',
             'API_KEY = "clawrouter-e2e-secret"',
             'token: "very-long-browser-token-0123456789"',
+            'token: "config-token"',
         ):
             with self.subTest(content=content):
                 self.assertFalse(self.helper["secret_text_risk"](content))


### PR DESCRIPTION
## Summary

- sync the complete canonical autoreview skill from openclaw/agent-skills#106
- allow the exact synthetic `config-token` fixture while retaining real-secret blocking
- unblock mandatory reviews for existing credential-adjacent tests such as #109115

## Proof

- canonical agent-skills Linux and Windows validation green
- downstream focused hardening regression: 1 passed
- real #109115 bundle: scanner passed; autoreview clean
- fresh autoreview of this sync diff: clean, 0 findings
- `git diff --check`: pass
