### PR TITLE
refactor(core): reuse keyed promise memoization

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -44,6 +44,7 @@ import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.j
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { getOrCreatePromise } from "../../shared/lazy-promise.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { isProvenDeliveryNotSentError } from "../delivery-recovery.shared.js";
 import { diagnosticErrorCategory } from "../diagnostic-error-metadata.js";
@@ -2082,13 +2083,7 @@ async function deliverOutboundPayloadsCore(
       return Promise.resolve(baseHandler);
     }
     const key = JSON.stringify(mediaSources);
-    const cached = handlerByMediaSources.get(key);
-    if (cached) {
-      return cached;
-    }
-    const created = createHandler(mediaSources);
-    handlerByMediaSources.set(key, created);
-    return created;
+    return getOrCreatePromise(handlerByMediaSources, key, () => createHandler(mediaSources));
   };
   const handler = baseHandler;
   const configuredTextLimit = handler.chunker

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -22,6 +22,7 @@ import {
 import { runCommandWithTimeout } from "../process/exec.js";
 import { inspectPathPermissions, safeStat } from "../security/audit-fs.js";
 import { isPathInside } from "../security/scan-paths.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { resolveUserPath } from "../utils.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { readJsonPointer } from "./json-pointer.js";
@@ -338,13 +339,8 @@ async function readFileProviderPayload(params: {
 }): Promise<unknown> {
   const cacheKey = params.providerName;
   const cache = params.cache;
-  const cachedFilePayload = cache?.filePayloadByProvider?.get(cacheKey);
-  if (cachedFilePayload) {
-    return await cachedFilePayload;
-  }
-
-  const filePath = resolveUserPath(params.providerConfig.path);
-  const readPromise = (async () => {
+  const read = async () => {
+    const filePath = resolveUserPath(params.providerConfig.path);
     const timeoutMs = normalizePositiveTimerMs(
       params.providerConfig.timeoutMs,
       DEFAULT_FILE_TIMEOUT_MS,
@@ -374,15 +370,15 @@ async function readFileProviderPayload(params: {
       }
       throw error;
     }
-  })();
+  };
 
-  if (cache) {
-    // Cache the in-flight read, not just the fulfilled payload, so concurrent refs share one
-    // permission-checked file read and observe the same provider error.
-    cache.filePayloadByProvider ??= new Map();
-    cache.filePayloadByProvider.set(cacheKey, readPromise);
+  if (!cache) {
+    return await read();
   }
-  return await readPromise;
+  // Cache the in-flight read, not just the fulfilled payload, so concurrent refs share one
+  // permission-checked file read and observe the same provider error.
+  cache.filePayloadByProvider ??= new Map();
+  return await getOrCreatePromise(cache.filePayloadByProvider, cacheKey, read);
 }
 
 async function resolveEnvRefs(params: {
@@ -876,12 +872,7 @@ export async function resolveSecretRefValue(
 ): Promise<unknown> {
   const cache = options.cache;
   const key = secretRefKey(ref);
-  const cachedResolvedValue = cache?.resolvedByRefKey?.get(key);
-  if (cachedResolvedValue) {
-    return await cachedResolvedValue;
-  }
-
-  const promise = (async () => {
+  const resolve = async () => {
     const resolved = await resolveSecretRefValues([ref], options);
     if (!resolved.has(key)) {
       throw refResolutionError({
@@ -892,14 +883,14 @@ export async function resolveSecretRefValue(
       });
     }
     return resolved.get(key);
-  })();
+  };
 
-  if (cache) {
-    // Store the in-flight promise so repeated callers do not race duplicate provider work.
-    cache.resolvedByRefKey ??= new Map();
-    cache.resolvedByRefKey.set(key, promise);
+  if (!cache) {
+    return await resolve();
   }
-  return await promise;
+  // Store the in-flight promise so repeated callers do not race duplicate provider work.
+  cache.resolvedByRefKey ??= new Map();
+  return await getOrCreatePromise(cache.resolvedByRefKey, key, resolve);
 }
 
 /** Resolves one SecretRef and requires a non-empty string result. */

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -22,6 +22,7 @@ import type { OpenClawConfig, ConfigFileSnapshot } from "../config/config.js";
 import { collectIncludePathsRecursive } from "../config/includes-scan.js";
 import { resolveOAuthDir } from "../config/paths.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { createLazyRuntimeModule, createLazyRuntimeNamedExport } from "../shared/lazy-runtime.js";
 import type { SkillScanFinding } from "../skills/security/scanner.js";
 import { listInstalledPluginDirs } from "./installed-plugin-dirs.js";
@@ -155,23 +156,15 @@ async function getCodeSafetySummary(params: {
     dirPath: params.dirPath,
     includeFiles: params.includeFiles,
   });
-  const cache = params.summaryCache;
-  if (cache) {
-    const hit = cache.get(cacheKey);
-    if (hit) {
-      return (await hit) as SkillScanSummary;
-    }
+  const scan = async () => {
     const skillScanner = await loadSkillScannerModule();
-    const pending = skillScanner.scanDirectoryWithSummary(params.dirPath, {
+    return await skillScanner.scanDirectoryWithSummary(params.dirPath, {
       includeFiles: params.includeFiles,
     });
-    cache.set(cacheKey, pending);
-    return await pending;
-  }
-  const skillScanner = await loadSkillScannerModule();
-  return await skillScanner.scanDirectoryWithSummary(params.dirPath, {
-    includeFiles: params.includeFiles,
-  });
+  };
+  return params.summaryCache
+    ? ((await getOrCreatePromise(params.summaryCache, cacheKey, scan)) as SkillScanSummary)
+    : await scan();
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Related: #105956

## What Problem This Solves

The keyed promise memo helper used by media understanding remained underused: matching pure promise caches in security auditing, SecretRef resolution, and outbound delivery still open-coded the same get/create/store sequence.

## Why This Change Was Made

Current `main` already delegates the Plugin SDK `createDeferred<T>()` export to the canonical shared implementation while preserving its public generic signature, and the media pair already uses `getOrCreatePromise`. This follow-up makes that shared helper pay rent by migrating three additional pure memo consumers (four caches total). Reconcile trackers, retry-aware state, and the exec-approval queue retain their domain lifecycle and serialization logic.

## User Impact

No intended user-visible behavior or API change. Maintainers get one canonical promise-memo implementation across the matching cache sites, with 21 fewer non-test lines.

## Evidence

- Blacksmith Testbox `tbx_01kxnwdx0jnt19mqxt6j56f1zd`: `pnpm plugin-sdk:surface:check`, full `pnpm deadcode:full`, 271 focused shared/media/security/secrets/outbound/gateway tests, and full `pnpm check:changed` core production/test typecheck, lint, format, API-baseline, boundary, dependency, and guard lanes passed; exit 0; lease stopped.
- Head rebased onto current `main` after `f871b499b6cb4` removed the unrelated consumer-less gateway exports that had failed the first hosted dependency gate.
- Local focused proof: 192 tests passed across the shared helper, security audit, SecretRef resolver, and outbound delivery shards.
- `git diff --numstat origin/main...HEAD`: non-test +26/-47, net -21 lines.
- Fresh rebased-head autoreview against `origin/main`: no accepted/actionable findings; patch correct at 0.94 confidence.

AI assistance: implementation, testing, and review were performed with Codex under maintainer direction.
