### PR TITLE
test(agents): add native loopback regression for outer-abort SSE cancellation

### DIFF
--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -1,5 +1,7 @@
 // Runtime proxy tests cover SSE parsing, terminal error handling, and request
 // payload scrubbing before proxying model streams.
+import { once } from "node:events";
+import http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model, Usage } from "../../llm/types.js";
 import { streamProxy } from "./proxy.js";
@@ -597,5 +599,83 @@ describe("streamProxy", () => {
       stopReason: "error",
       errorMessage: "Proxy stream ended before terminal event",
     });
+  });
+});
+
+describe("streamProxy loopback /api/stream", () => {
+  let server: http.Server | undefined;
+  const dripTimers = new Set<ReturnType<typeof setTimeout>>();
+
+  afterEach(async () => {
+    for (const timer of dripTimers) {
+      clearTimeout(timer);
+    }
+    dripTimers.clear();
+    if (!server) {
+      return;
+    }
+    server.closeAllConnections?.();
+    server.close();
+    await once(server, "close").catch(() => undefined);
+    server = undefined;
+  });
+
+  async function listenDripProxy(): Promise<number> {
+    server = http.createServer((req, res) => {
+      res.on("error", () => {});
+      if (req.method !== "POST" || req.url !== "/api/stream") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Transfer-Encoding": "chunked",
+      });
+      // Keepalive-style drip resets chunk-idle; outer abort must win.
+      const drip = () => {
+        if (res.writableEnded || res.destroyed) {
+          return;
+        }
+        res.write(`data: ${JSON.stringify({ type: "start" })}\n\n`);
+        const timer = setTimeout(drip, 20);
+        dripTimers.add(timer);
+      };
+      drip();
+    });
+    server.on("clientError", (_err, socket) => socket.destroy());
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+    return address.port;
+  }
+
+  it("cancels a dripping native SSE body when the outer abort signal fires", async () => {
+    const port = await listenDripProxy();
+    const controller = new AbortController();
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: `http://127.0.0.1:${port}`,
+      // Idle well above drip cadence so only the outer abort can terminate.
+      timeoutMs: 10_000,
+      signal: controller.signal,
+    });
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 120);
+    });
+    const startedAt = performance.now();
+    controller.abort();
+    const result = await stream.result();
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result).toMatchObject({
+      stopReason: "aborted",
+      errorMessage: "Request aborted by user",
+    });
+    expect(elapsedMs).toBeLessThan(1_500);
   });
 });

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -97,12 +97,17 @@ async function resultWithinMs(
   stream: { result(): Promise<unknown> },
   timeoutMs = 25,
 ): Promise<unknown> {
-  return await Promise.race([
-    stream.result(),
-    new Promise<symbol>((resolve) => {
-      setTimeout(() => resolve(unresolved), timeoutMs);
-    }),
-  ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      stream.result(),
+      new Promise<symbol>((resolve) => {
+        timer = setTimeout(() => resolve(unresolved), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function settledResult(stream: { result(): Promise<unknown> }): Promise<unknown> {
@@ -604,19 +609,20 @@ describe("streamProxy", () => {
 
 describe("streamProxy loopback /api/stream", () => {
   let server: http.Server | undefined;
-  const dripTimers = new Set<ReturnType<typeof setTimeout>>();
+  const dripIntervals = new Set<ReturnType<typeof setInterval>>();
 
   afterEach(async () => {
-    for (const timer of dripTimers) {
-      clearTimeout(timer);
+    for (const interval of dripIntervals) {
+      clearInterval(interval);
     }
-    dripTimers.clear();
+    dripIntervals.clear();
     if (!server) {
       return;
     }
-    server.closeAllConnections?.();
+    const closed = once(server, "close");
     server.close();
-    await once(server, "close").catch(() => undefined);
+    server.closeAllConnections();
+    await closed;
     server = undefined;
   });
 
@@ -638,9 +644,13 @@ describe("streamProxy loopback /api/stream", () => {
           return;
         }
         res.write(`data: ${JSON.stringify({ type: "start" })}\n\n`);
-        const timer = setTimeout(drip, 20);
-        dripTimers.add(timer);
       };
+      const interval = setInterval(drip, 20);
+      dripIntervals.add(interval);
+      res.once("close", () => {
+        clearInterval(interval);
+        dripIntervals.delete(interval);
+      });
       drip();
     });
     server.on("clientError", (_err, socket) => socket.destroy());
@@ -664,18 +674,13 @@ describe("streamProxy loopback /api/stream", () => {
       signal: controller.signal,
     });
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 120);
-    });
-    const startedAt = performance.now();
+    const firstEvent = await stream[Symbol.asyncIterator]().next();
+    expect(firstEvent).toMatchObject({ done: false, value: { type: "start" } });
     controller.abort();
-    const result = await stream.result();
-    const elapsedMs = performance.now() - startedAt;
 
-    expect(result).toMatchObject({
+    expect(await resultWithinMs(stream, 1_500)).toMatchObject({
       stopReason: "aborted",
       errorMessage: "Request aborted by user",
     });
-    expect(elapsedMs).toBeLessThan(1_500);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Adds native loopback regression coverage proving that the existing outer `AbortSignal` cancels a keepalive-style dripping proxy SSE body in `streamProxy` (`/api/stream`). Without this coverage, a future change to the abort handler or reader cleanup path could silently break total-stream-lifetime ownership without any test catching it.

## Why This Change Was Made

`streamProxy` bounds pre-header waits and per-chunk SSE idle, but the total stream lifetime after headers is owned by the caller's `signal` / outer agent-provider abort budget. A dripping keepalive SSE body (chunks every 20ms) resets per-chunk idle forever, so only the outer abort can terminate it. This PR adds a native loopback regression proving that path works end-to-end with real Node `http` + `fetch` + `ReadableStream`.

An earlier revision proposed an opt-in `streamDeadlineMs` proxy-local wall-clock. ClawSweeper review ([P1](https://github.com/openclaw/openclaw/pull/109185#issuecomment-4995322509)) identified that no production caller needed it and the outer `signal` already owns total stream lifetime, so a second deadline source would create a competing timeout contract. This revision removes `streamDeadlineMs` entirely and narrows to the regression proof only (Maintainer option 1, recommended).

Non-goals: adding a proxy-local total-stream deadline; changing the existing outer-abort contract; live proxy provider auth.

Collision check: searched open PRs for `proxy SSE abort`, `streamDeadlineMs`, `proxy stream lifetime`; no same-file or same-problem open PR was found.

## User Impact

No user-visible behavior change. This is a test-only PR that protects the existing outer-abort SSE cancellation contract against regressions.

## Verification

- Exact head: `ece303619a791e886a15d94b9723c5a206f5624b`
- `oxfmt --check src/agents/runtime/proxy.test.ts` - passed; exit 0.
- `oxlint src/agents/runtime/proxy.test.ts` - passed; exit 0.
- `git diff --check` - passed; exit 0.

Focused tests:

```bash
node scripts/run-vitest.mjs src/agents/runtime/proxy.test.ts -- --run --reporter=verbose
```

```text
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.9 /tmp/openclaw-109185

 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > reconstructs a text signature from text_start before streamed deltas 366ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > flushes a final SSE frame without a trailing newline 6ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > forwards prompt cache affinity separately from session identity 3ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > applies timeoutMs before proxy response headers arrive 8ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > bounds non-2xx proxy JSON error reads 97ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > caps unterminated pending SSE bytes before a frame delimiter arrives 57ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > caps delimiter-terminated SSE success body bytes 46ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > re-arms the SSE idle timeout after each received chunk 4ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > does not apply the pre-header timeout as an absolute stream deadline 3ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > returns an error result when the SSE read idles 4ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > honors a longer configured SSE read idle timeout 2ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > releases the proxy response reader after a terminal stream 1ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy > returns an error result when EOF arrives without a terminal event 1ms
 ✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy loopback /api/stream > cancels a dripping native SSE body when the outer abort signal fires 147ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  09:20:33
   Duration  3.38s

[test] passed 1 Vitest shard in 10.64s
```

Mutation check: temporarily commented out `reader.cancel()` in the `abortHandler` (`src/agents/runtime/proxy.ts:287`) -> loopback test fails (1 failed | 13 passed) -> restored -> 14 passed. Proves the regression test catches abort-handler breakage.

## Real behavior proof

Behavior addressed: a dripping keepalive SSE body (20ms cadence) that resets per-chunk idle is canceled by the outer `AbortSignal` within 1.5s, not by per-chunk idle (which never fires because drip resets it).

Real environment tested: Linux, Node 22, real `http.createServer` loopback on `127.0.0.1`, real `fetch` / `ReadableStream` (no mocked reader or fetch).

Exact commands run:

```bash
node scripts/run-vitest.mjs src/agents/runtime/proxy.test.ts -- --run --reporter=verbose
```

Observed output:

```text
✓ |agents| src/agents/runtime/proxy.test.ts > streamProxy loopback /api/stream > cancels a dripping native SSE body when the outer abort signal fires 147ms

Tests  14 passed (14)
```

Evidence:
- Drip cadence: 20ms (resets per-chunk idle every 20ms; idle timeout 10s never fires)
- Outer abort latency: < 1,500ms (asserted; observed 147ms)
- Cancellation result: `stopReason: "aborted"`, `errorMessage: "Request aborted by user"`
- All 14 tests pass including 13 existing proxy tests (no regression)
- Mutation check: removing `reader.cancel()` from abort handler -> test fails -> restored -> passes

What was not tested: live remote proxy provider outage with provider credentials; non-HTTP/1.1 transports; proxy auth flows.

## Risk / Compatibility

Low. Test-only change; no production code modified. No new API surface, config, or behavior contract. The regression test uses native Node `http` + `fetch` on loopback, matching the production `streamProxy` code path.
