### PR TITLE
fix(prompt-probe): stop hanging when upstream bodies stall

### DIFF
--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -426,6 +426,12 @@ async function startAnthropicProxy(params: {
         }
         res.end();
       } catch (error) {
+        // Once upstream headers are forwarded, a synthetic 502 is invalid.
+        // Close the downstream body so its reader fails instead of hanging.
+        if (res.headersSent) {
+          res.destroy();
+          return;
+        }
         res.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
         res.end(redactForDevToolLog(`proxy error: ${String(error)}`));
       }

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -1202,9 +1202,17 @@ describe("script-specific dev tooling hardening", () => {
     ).rejects.toThrow(`Claude usage test response body exceeded ${maxBytes} bytes`);
   });
 
-  it("aborts a stalled Anthropic proxy upstream at the configured deadline", async () => {
+  it.each([
+    { name: "before response headers", sendsHeaders: false },
+    { name: "during the response body", sendsHeaders: true },
+  ])("bounds an Anthropic upstream stall $name", async ({ sendsHeaders }) => {
     const nativeFetch = globalThis.fetch;
-    const upstream = http.createServer(() => {});
+    const upstream = http.createServer((_request, response) => {
+      if (sendsHeaders) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.flushHeaders();
+      }
+    });
     await new Promise<void>((resolve, reject) => {
       upstream.once("error", reject);
       upstream.listen(0, "127.0.0.1", () => {
@@ -1229,13 +1237,19 @@ describe("script-specific dev tooling hardening", () => {
         timeoutMs: 100,
       });
       const startedAt = Date.now();
-      const response = await nativeFetch(`http://127.0.0.1:${proxy.port}/v1/messages`, {
+      const request = nativeFetch(`http://127.0.0.1:${proxy.port}/v1/messages`, {
         method: "POST",
         body: "{}",
-      });
+      }).then(async (response) => ({ status: response.status, body: await response.text() }));
 
-      expect(response.status).toBe(502);
-      await expect(response.text()).resolves.toMatch(/TimeoutError/u);
+      if (sendsHeaders) {
+        await expect(request).rejects.toThrow();
+      } else {
+        await expect(request).resolves.toMatchObject({
+          status: 502,
+          body: expect.stringMatching(/TimeoutError/u),
+        });
+      }
       expect(Date.now() - startedAt).toBeLessThan(2_000);
       expect(fetchSpy).toHaveBeenCalledWith(
         "https://api.anthropic.com/v1/messages",
@@ -1244,6 +1258,7 @@ describe("script-specific dev tooling hardening", () => {
     } finally {
       fetchSpy.mockRestore();
       await proxy?.stop();
+      upstream.closeAllConnections();
       await new Promise<void>((resolve, reject) => {
         upstream.close((error) => (error ? reject(error) : resolve()));
       });


### PR DESCRIPTION
Follow-up to #108832.

## What Problem This Solves

Fixes an issue where developers using the Anthropic prompt capture proxy could still see a request hang when the upstream sent response headers and then stopped sending its body. The timeout aborted the upstream body, but the proxy attempted to replace already-committed headers with a 502 and left the downstream response open.

## Why This Change Was Made

Once response headers have been forwarded, the proxy now closes the downstream response so its body reader fails promptly. Before headers are committed, the existing redacted 502 response remains unchanged. The regression uses real loopback servers for both stall phases.

This PR was AI-assisted. The maintainer reviewed the complete changed module, adjacent tests, both callers, Node Fetch/Undici abort behavior, and the final patch.

## User Impact

Anthropic prompt capture requests now finish within the configured deadline whether the upstream stalls before response headers or during the response body. Developers no longer get a hung request or an unhandled `ERR_HTTP_HEADERS_SENT` rejection in the body-stall case.

## Evidence

- Before fix, a real headers-then-stall loopback diagnostic returned `{"outcome":{"timeout":true},"unhandled":["Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client"]}`.
- `node scripts/run-vitest.mjs test/scripts/dev-tooling-safety.test.ts` — 60/60 passed after the final rebase. Table-driven real-network coverage exercises stalls before headers and during the response body.
- `node scripts/check-changed.mjs -- scripts/anthropic-prompt-probe.ts test/scripts/dev-tooling-safety.test.ts` — hosted format, scripts types, root-test types, tooling lint, and guards passed: https://github.com/openclaw/openclaw/actions/runs/29514279324
- `git diff --check` — clean.
- Fresh final-head autoreview — clean, patch correct, confidence 0.97.
