### PR TITLE
fix(gateway): bound MCP loopback schema warning cache

### DIFF
--- a/src/gateway/mcp-http.schema.test.ts
+++ b/src/gateway/mcp-http.schema.test.ts
@@ -6,14 +6,19 @@ vi.mock("../logger.js", () => ({
   logWarn: logWarnMock,
 }));
 
-import { buildMcpToolSchema, testing } from "./mcp-http.schema.js";
+async function loadSchema() {
+  const { buildMcpToolSchema } = await import("./mcp-http.schema.js");
+  return { buildMcpToolSchema };
+}
 
 describe("buildMcpToolSchema", () => {
   beforeEach(() => {
     logWarnMock.mockClear();
-    testing.resetEmittedSchemaWarningsForTest();
+    vi.resetModules();
   });
-  it("keeps union schema properties named like Object prototype keys", () => {
+
+  it("keeps union schema properties named like Object prototype keys", async () => {
+    const { buildMcpToolSchema } = await loadSchema();
     const [entry] = buildMcpToolSchema([
       {
         name: "proof_tool",
@@ -42,7 +47,8 @@ describe("buildMcpToolSchema", () => {
     expect(inputSchema?.required).toEqual(["toString"]);
   });
 
-  it("serializes union schema properties named __proto__ as own keys", () => {
+  it("serializes union schema properties named __proto__ as own keys", async () => {
+    const { buildMcpToolSchema } = await loadSchema();
     const protoKey = "__proto__";
     const [entry] = buildMcpToolSchema([
       {
@@ -70,7 +76,8 @@ describe("buildMcpToolSchema", () => {
     expect(inputSchema?.required).toEqual([protoKey]);
   });
 
-  it("does not keep inherited prototype names as required schema keys", () => {
+  it("does not keep inherited prototype names as required schema keys", async () => {
+    const { buildMcpToolSchema } = await loadSchema();
     const [entry] = buildMcpToolSchema([
       {
         name: "proof_tool",
@@ -92,7 +99,8 @@ describe("buildMcpToolSchema", () => {
     expect(entry?.inputSchema.required).toEqual([]);
   });
 
-  it("bounds the schema warning cache at 4096 entries and re-warns evicted messages", () => {
+  it("bounds the schema warning cache at 4096 entries and re-warns evicted messages", async () => {
+    const { buildMcpToolSchema } = await loadSchema();
     const makeTool = (index: number) =>
       ({
         name: `tool_${index}`,

--- a/src/gateway/mcp-http.schema.test.ts
+++ b/src/gateway/mcp-http.schema.test.ts
@@ -6,12 +6,12 @@ vi.mock("../logger.js", () => ({
   logWarn: logWarnMock,
 }));
 
-import { buildMcpToolSchema, resetEmittedSchemaWarningsForTest } from "./mcp-http.schema.js";
+import { buildMcpToolSchema, testing } from "./mcp-http.schema.js";
 
 describe("buildMcpToolSchema", () => {
   beforeEach(() => {
     logWarnMock.mockClear();
-    resetEmittedSchemaWarningsForTest();
+    testing.resetEmittedSchemaWarningsForTest();
   });
   it("keeps union schema properties named like Object prototype keys", () => {
     const [entry] = buildMcpToolSchema([

--- a/src/gateway/mcp-http.schema.test.ts
+++ b/src/gateway/mcp-http.schema.test.ts
@@ -1,8 +1,18 @@
 // Gateway tests cover MCP loopback schema projection behavior.
-import { describe, expect, it } from "vitest";
-import { buildMcpToolSchema } from "./mcp-http.schema.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logWarnMock = vi.hoisted(() => vi.fn<(message: string) => void>());
+vi.mock("../logger.js", () => ({
+  logWarn: logWarnMock,
+}));
+
+import { buildMcpToolSchema, resetEmittedSchemaWarningsForTest } from "./mcp-http.schema.js";
 
 describe("buildMcpToolSchema", () => {
+  beforeEach(() => {
+    logWarnMock.mockClear();
+    resetEmittedSchemaWarningsForTest();
+  });
   it("keeps union schema properties named like Object prototype keys", () => {
     const [entry] = buildMcpToolSchema([
       {
@@ -80,5 +90,33 @@ describe("buildMcpToolSchema", () => {
     ]);
 
     expect(entry?.inputSchema.required).toEqual([]);
+  });
+
+  it("bounds the schema warning cache at 4096 entries and re-warns evicted messages", () => {
+    const makeTool = (index: number) =>
+      ({
+        name: `tool_${index}`,
+        description: "proof",
+        parameters: {
+          anyOf: [
+            {
+              type: "object",
+              properties: { [`field_${index}`]: 1 },
+            },
+          ],
+        },
+      }) as never;
+
+    const tools = Array.from({ length: 4096 }, (_, index) => makeTool(index));
+    buildMcpToolSchema(tools);
+    expect(logWarnMock).toHaveBeenCalledTimes(4096);
+
+    logWarnMock.mockClear();
+    buildMcpToolSchema([makeTool(4096)]);
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+
+    logWarnMock.mockClear();
+    buildMcpToolSchema(tools.slice(0, 1));
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -224,10 +224,11 @@ function warnSchemaOnce(message: string) {
   logWarn(message);
 }
 
-/** Resets the schema-warning dedupe cache. For tests only. */
-export function resetEmittedSchemaWarningsForTest() {
+function resetEmittedSchemaWarningsForTest() {
   emittedSchemaWarnings.clear();
 }
+
+export const testing = { resetEmittedSchemaWarningsForTest } as const;
 
 /** Builds MCP-compatible tool schemas for loopback-visible gateway tools. */
 export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry[] {

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -2,6 +2,7 @@
 // Converts gateway-scoped tools into MCP tools/list-compatible schemas.
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { createDedupeCache } from "../infra/dedupe.js";
 import { logWarn } from "../logger.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
@@ -212,16 +213,20 @@ function isPropertySchema(value: unknown): value is boolean | Record<string, unk
 // Dedupe on the full message: distinct (tool, field, reason) still each warn once,
 // but rebuilds collapse to one line. Named per tool.field so a conflict in one tool
 // no longer suppresses a genuinely different conflict on the same field name in
-// another tool. Bounded by the process-stable universe of loopback tool + field
-// names (gateway tool metadata does not change without restart or explicit reload).
-const emittedSchemaWarnings = new Set<string>();
+// another tool. Bounded to 4096 entries so the process-stable universe of loopback
+// tool + field names cannot grow without limit.
+const emittedSchemaWarnings = createDedupeCache({ ttlMs: 0, maxSize: 4096 });
 
 function warnSchemaOnce(message: string) {
-  if (emittedSchemaWarnings.has(message)) {
+  if (emittedSchemaWarnings.check(message)) {
     return;
   }
-  emittedSchemaWarnings.add(message);
   logWarn(message);
+}
+
+/** Resets the schema-warning dedupe cache. For tests only. */
+export function resetEmittedSchemaWarningsForTest() {
+  emittedSchemaWarnings.clear();
 }
 
 /** Builds MCP-compatible tool schemas for loopback-visible gateway tools. */

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -224,12 +224,6 @@ function warnSchemaOnce(message: string) {
   logWarn(message);
 }
 
-function resetEmittedSchemaWarningsForTest() {
-  emittedSchemaWarnings.clear();
-}
-
-export const testing = { resetEmittedSchemaWarningsForTest } as const;
-
 /** Builds MCP-compatible tool schemas for loopback-visible gateway tools. */
 export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry[] {
   return tools.flatMap((tool) => {


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/mcp-http.schema.ts` keeps a module-level `Set<string>` (`emittedSchemaWarnings`) to dedupe loopback MCP tool-schema field warnings. The set grows without bound over the lifetime of the gateway process.

## Why This Change Was Made

Replaced the raw `Set` with `createDedupeCache({ ttlMs: 0, maxSize: 4096 })` from `src/infra/dedupe.js`. The cache auto-evicts the oldest entry when it overflows.

## User Impact

No behavior change under normal load; evicted schema warnings will be re-emitted if the same message is encountered again after overflow.

## Evidence

- Guard test in `src/gateway/mcp-http.schema.test.ts` asserts the cache caps at 4096 entries and re-warns evicted messages.
- `node scripts/run-vitest.mjs src/gateway/mcp-http.schema.test.ts` passes.
