### PR TITLE
fix(ci): restore dead-code gate on main

### DIFF
--- a/src/cli/daemon-cli/restart-lock-replacement.ts
+++ b/src/cli/daemon-cli/restart-lock-replacement.ts
@@ -5,7 +5,7 @@ import {
 } from "../../infra/gateway-lock.js";
 import { sleep } from "../../utils.js";
 
-export type GatewayLockReplacementWaitResult =
+type GatewayLockReplacementWaitResult =
   | { status: "replacement"; attemptsUsed: number }
   | { status: "timeout" };
 

--- a/src/infra/gateway-supervision.test.ts
+++ b/src/infra/gateway-supervision.test.ts
@@ -2,29 +2,26 @@ import { describe, expect, it } from "vitest";
 import {
   assertGatewayServiceMutationAllowed,
   formatExternalSupervisorUpdateRequired,
-  GATEWAY_SUPERVISOR_MODE_ENV,
   isGatewayExternallySupervised,
-  resolveGatewaySupervisorMode,
 } from "./gateway-supervision.js";
 
 describe("gateway supervision", () => {
   it.each([
-    { value: undefined, expected: "auto" },
-    { value: "", expected: "auto" },
-    { value: "auto", expected: "auto" },
-    { value: "invalid", expected: "auto" },
-    { value: " EXTERNAL ", expected: "external" },
-  ])("resolves $value as $expected", ({ value, expected }) => {
-    const env = { [GATEWAY_SUPERVISOR_MODE_ENV]: value };
+    { value: undefined, expected: false },
+    { value: "", expected: false },
+    { value: "auto", expected: false },
+    { value: "invalid", expected: false },
+    { value: " EXTERNAL ", expected: true },
+  ])("treats $value as externally supervised: $expected", ({ value, expected }) => {
+    const env = { OPENCLAW_SUPERVISOR_MODE: value };
 
-    expect(resolveGatewaySupervisorMode(env)).toBe(expected);
-    expect(isGatewayExternallySupervised(env)).toBe(expected === "external");
+    expect(isGatewayExternallySupervised(env)).toBe(expected);
   });
 
   it("blocks native service mutation with actionable guidance", () => {
     expect(() =>
       assertGatewayServiceMutationAllowed("restart the gateway", {
-        [GATEWAY_SUPERVISOR_MODE_ENV]: "external",
+        OPENCLAW_SUPERVISOR_MODE: "external",
       }),
     ).toThrow(
       "OpenClaw gateway lifecycle is managed by an external supervisor " +

--- a/src/infra/gateway-supervision.ts
+++ b/src/infra/gateway-supervision.ts
@@ -1,12 +1,10 @@
 // Defines gateway lifecycle ownership shared by service, restart, and update paths.
-export const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
+const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
 export const EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON = "external-supervisor-update-required";
 
-export type GatewaySupervisorMode = "auto" | "external";
+type GatewaySupervisorMode = "auto" | "external";
 
-export function resolveGatewaySupervisorMode(
-  env: NodeJS.ProcessEnv = process.env,
-): GatewaySupervisorMode {
+function resolveGatewaySupervisorMode(env: NodeJS.ProcessEnv = process.env): GatewaySupervisorMode {
   return env[GATEWAY_SUPERVISOR_MODE_ENV]?.trim().toLowerCase() === "external"
     ? "external"
     : "auto";

--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -14,12 +14,6 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 
-export {
-  createGatewayRestartHandoffCapabilities,
-  GATEWAY_RESTART_HANDOFF_PROTOCOL,
-  GATEWAY_RESTART_HANDOFF_PROTOCOL_VERSION,
-} from "./restart-handoff-contract.js";
-
 // Restart handoff rows let a supervisor explain a recent gateway restart after
 // the old process exits. The row is short-lived, bounded, and replaced on write.
 const GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND = "gateway-supervisor-restart-handoff";
@@ -77,7 +71,7 @@ export type GatewayRestartHandoff = {
   };
 };
 
-export type GatewayRestartHandoffConsumeResult =
+type GatewayRestartHandoffConsumeResult =
   | {
       status: "accepted";
       handoff: GatewayRestartHandoff;

--- a/src/infra/supervisor-markers.ts
+++ b/src/infra/supervisor-markers.ts
@@ -23,7 +23,7 @@ export const SUPERVISOR_HINT_ENV_VARS = [
 
 /** Supported supervisor families that can respawn the gateway after update/restart handoff. */
 export type RespawnSupervisor = "launchd" | "systemd" | "schtasks";
-export type GatewayRespawnSupervisor = RespawnSupervisor | "external";
+type GatewayRespawnSupervisor = RespawnSupervisor | "external";
 
 interface DetectRespawnSupervisorOptions {
   includeLinuxOpenClawGatewayServiceMarker?: boolean;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the dependency check on current `main` failed because internal-only declarations were still exported.

## Why This Change Was Made

Keeps the existing runtime behavior while making implementation-only constants, helpers, and result types module-private. Removes the obsolete restart-handoff re-export after its machine contract moved to the dedicated contract module. Tests now exercise the public supervision behavior instead of test-only exports.

## User Impact

No user-visible behavior change. Restores the dead-code CI gate and keeps the internal API surface smaller.

## Evidence

- `node scripts/run-vitest.mjs src/infra/gateway-supervision.test.ts src/cli/daemon-cli/restart-lock-replacement.test.ts src/infra/supervisor-markers.test.ts src/infra/restart-handoff.test.ts src/cli/gateway-cli/register-restart-handoff.test.ts` — 43 tests pass.
- Blacksmith Testbox: `corepack pnpm deadcode:full` passes at this head.
- `oxfmt --check` and `git diff --check` pass.
- Fresh autoreview: no actionable findings, 0.98 confidence.
