### PR TITLE
refactor(feishu): remove comment retry test seam

### DIFF
--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -742,7 +742,7 @@ describe("resolveDriveCommentEventTurn", () => {
   });
 
   it("retries comment reply lookup when the requested reply is not immediately visible", async () => {
-    const waitMs = vi.fn(async () => true);
+    vi.useFakeTimers();
     const client = makeOpenApiClient({
       includeTargetReplyInBatch: false,
       repliesSequence: [
@@ -770,7 +770,7 @@ describe("resolveDriveCommentEventTurn", () => {
       ],
     });
 
-    const turn = await resolveDriveCommentEventTurn({
+    const turnPromise = resolveDriveCommentEventTurn({
       cfg: buildMonitorConfig(),
       accountId: "default",
       event: makeDriveCommentEvent({
@@ -782,14 +782,17 @@ describe("resolveDriveCommentEventTurn", () => {
       }),
       botOpenId: "ou_bot",
       createClient: () => client as never,
-      waitMs,
     });
+
+    await vi.waitFor(() => {
+      expect(vi.getTimerCount()).toBe(1);
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    const turn = await turnPromise;
 
     expect(turn?.targetReplyText).toBe("Insert a sentence below this paragraph");
     expect(turn?.prompt).toContain("Insert a sentence below this paragraph");
-    expect(waitMs).toHaveBeenCalledTimes(2);
-    expect(waitMs).toHaveBeenNthCalledWith(1, 1000, undefined);
-    expect(waitMs).toHaveBeenNthCalledWith(2, 1000, undefined);
+    expect(vi.getTimerCount()).toBe(0);
     expect(
       client.request.mock.calls.filter(
         ([request]: [{ method: string; url: string }]) =>

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -61,7 +61,6 @@ type ResolveDriveCommentEventParams = {
   verificationTimeoutMs?: number;
   logger?: (message: string) => void;
   abortSignal?: AbortSignal;
-  waitMs?: (ms: number, abortSignal?: AbortSignal) => Promise<boolean>;
 };
 
 type ResolvedDriveCommentEventTurn = {
@@ -729,7 +728,6 @@ async function fetchDriveCommentContext(params: {
   logger?: (message: string) => void;
   accountId: string;
   abortSignal?: AbortSignal;
-  waitMs: (ms: number, abortSignal?: AbortSignal) => Promise<boolean>;
 }): Promise<{
   documentTitle?: string;
   documentUrl?: string;
@@ -832,7 +830,7 @@ async function fetchDriveCommentContext(params: {
             `requested_reply=${params.replyId} attempt=${attempt}/${FEISHU_COMMENT_REPLY_MISS_RETRY_LIMIT} ` +
             `delay_ms=${FEISHU_COMMENT_REPLY_MISS_RETRY_DELAY_MS}`,
         );
-        const delayElapsed = await params.waitMs(
+        const delayElapsed = await waitForAbortableDelay(
           FEISHU_COMMENT_REPLY_MISS_RETRY_DELAY_MS,
           params.abortSignal,
         );
@@ -1238,7 +1236,6 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     verificationTimeoutMs = FEISHU_COMMENT_VERIFY_TIMEOUT_MS,
     logger,
     abortSignal,
-    waitMs = waitForAbortableDelay,
   } = params;
   const eventId = event.event_id?.trim();
   const commentId = event.comment_id?.trim();
@@ -1288,7 +1285,6 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     logger,
     accountId,
     abortSignal,
-    waitMs,
   });
   return {
     eventId,


### PR DESCRIPTION
Related: #108408

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The Feishu comment retry resolver retained an injectable delay callback used only by tests after #108408 moved production behavior onto the shared abortable-delay helper. That test seam made internal production parameters broader than the runtime contract required.

## Why This Change Was Made

Call the established Feishu abortable-delay helper directly and exercise the real success path with fake timers. This deletes the test-only production hook while preserving normal retry timing, account-abort behavior, and the existing mocked-client coverage.

This is the bounded behavior-neutral follow-up refactor explicitly requested as part of the maintainer landing pass for #108408.

## User Impact

No user-visible behavior change. Feishu comment reply polling retains the same one-second delay, retry limit, and abort semantics with a smaller internal surface.

## Evidence

- `node scripts/run-vitest.mjs extensions/feishu/src/monitor.comment.test.ts` — 17 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- extensions/feishu/src/monitor.comment.ts extensions/feishu/src/monitor.comment.test.ts` — hosted formatting, SDK surface, plugin boundaries, extension and extension-test typechecks, lint, storage guards, and import-cycle checks passed: https://github.com/openclaw/openclaw/actions/runs/29514652096
- `git diff --check origin/main...HEAD` — passed.
- Fresh autoreview — clean, patch correct, confidence 0.93.
- Diff: 10 additions, 11 deletions.

## AI assistance

AI-assisted with Codex. I reviewed the final implementation and understand the behavior.
