### PR TITLE
improve: speed up stuck-session recovery tests

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -15,10 +15,20 @@ import {
   recoverStuckDiagnosticSession,
 } from "./diagnostic-stuck-session-recovery.runtime.js";
 
-function delay(ms: number): Promise<"blocked"> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve("blocked"), ms);
+async function expectPendingAfterEventLoopTurn(promise: Promise<unknown>): Promise<void> {
+  let settled = false;
+  void promise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
   });
+  expect(settled).toBe(false);
 }
 
 describe("stuck session recovery integration", () => {
@@ -55,7 +65,7 @@ describe("stuck session recovery integration", () => {
       queueDepth: 1,
     });
 
-    await expect(Promise.race([queued, delay(100)])).resolves.toBe("blocked");
+    await expectPendingAfterEventLoopTurn(queued);
     expect(getQueueSize(lane)).toBe(2);
 
     operation.complete();
@@ -99,7 +109,7 @@ describe("stuck session recovery integration", () => {
       reason: "active_embedded_run",
       activeSessionId,
     });
-    await expect(Promise.race([queued, delay(100)])).resolves.toBe("blocked");
+    await expectPendingAfterEventLoopTurn(queued);
     expect(getQueueSize(lane)).toBe(2);
 
     clearActiveEmbeddedRun(activeSessionId, handle, activeSessionKey, sessionFile);
@@ -196,7 +206,7 @@ describe("stuck session recovery integration", () => {
     const queued = enqueueCommandInLane(lane, async () => "drained", {
       warnAfterMs: Number.MAX_SAFE_INTEGER,
     });
-    await expect(Promise.race([queued, delay(100)])).resolves.toBe("drained");
+    await expect(queued).resolves.toBe("drained");
   });
 
   it("does not reset a lane that unwedged and started a queued turn during the abort (#91700)", async () => {
@@ -259,7 +269,8 @@ describe("stuck session recovery integration", () => {
     const third = enqueueCommandInLane(lane, async () => "third", {
       warnAfterMs: Number.MAX_SAFE_INTEGER,
     });
-    await expect(Promise.race([third, delay(100)])).resolves.toBe("blocked");
+    await expectPendingAfterEventLoopTurn(third);
+    expect(getQueueSize(lane)).toBe(2);
     releaseFreshTurn("done");
     await expect(freshTurn).resolves.toBe("done");
     await expect(third).resolves.toBe("third");
@@ -286,7 +297,7 @@ describe("stuck session recovery integration", () => {
       queueDepth: 1,
     });
 
-    await expect(Promise.race([queued, delay(100)])).resolves.toBe("blocked");
+    await expectPendingAfterEventLoopTurn(queued);
     expect(getQueueSize(lane)).toBe(2);
 
     expect(resetCommandLane(lane)).toBe(1);


### PR DESCRIPTION
## What Problem This Solves

The stuck-session recovery integration suite spent four fixed 100 ms waits checking that queued commands remained blocked, making six behavior tests take about half a second even when the queue state was already correct.

## Why This Change Was Made

Replace fixed wall-clock waits with a deterministic pending-promise check after one event-loop turn, while retaining exact active-plus-queued depth assertions and awaiting commands that should drain. Production code and CI configuration are unchanged.

## User Impact

No user-visible behavior change. The integration coverage completes faster while continuing to verify that recovery does not release or overwrite active lane work.

## Evidence

- Controlled Blacksmith Testbox `tbx_01kxntwejvd6pbnyy7cr054br0`, same box and command, three runs each:
  - Before test body: 556 ms, 441 ms, 443 ms; average 480.0 ms.
  - After test body: 29 ms, 34 ms, 35 ms; average 32.7 ms.
  - Improvement: 93.2%.
  - All 6 tests passed in every run before and after.
- Fresh post-rebase Testbox `tbx_01kxnvrc97f624e638b2qseg4g`:
  - Focused test passed, 6/6.
  - `pnpm check:changed` passed: formatting, guards, core-test typecheck, and Oxlint.
- Exact-head autoreview: clean, no accepted or actionable findings.
