### PR TITLE
refactor(infra): narrow restart owner exports

### DIFF
--- a/src/cli/daemon-cli/restart-lock-replacement.ts
+++ b/src/cli/daemon-cli/restart-lock-replacement.ts
@@ -5,7 +5,7 @@ import {
 } from "../../infra/gateway-lock.js";
 import { sleep } from "../../utils.js";
 
-export type GatewayLockReplacementWaitResult =
+type GatewayLockReplacementWaitResult =
   | { status: "replacement"; attemptsUsed: number }
   | { status: "timeout" };
 

--- a/src/infra/gateway-supervision.test.ts
+++ b/src/infra/gateway-supervision.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   assertGatewayServiceMutationAllowed,
   formatExternalSupervisorUpdateRequired,
-  GATEWAY_SUPERVISOR_MODE_ENV,
   isGatewayExternallySupervised,
-  resolveGatewaySupervisorMode,
 } from "./gateway-supervision.js";
 
 describe("gateway supervision", () => {
@@ -15,16 +13,15 @@ describe("gateway supervision", () => {
     { value: "invalid", expected: "auto" },
     { value: " EXTERNAL ", expected: "external" },
   ])("resolves $value as $expected", ({ value, expected }) => {
-    const env = { [GATEWAY_SUPERVISOR_MODE_ENV]: value };
+    const env = { OPENCLAW_SUPERVISOR_MODE: value };
 
-    expect(resolveGatewaySupervisorMode(env)).toBe(expected);
     expect(isGatewayExternallySupervised(env)).toBe(expected === "external");
   });
 
   it("blocks native service mutation with actionable guidance", () => {
     expect(() =>
       assertGatewayServiceMutationAllowed("restart the gateway", {
-        [GATEWAY_SUPERVISOR_MODE_ENV]: "external",
+        OPENCLAW_SUPERVISOR_MODE: "external",
       }),
     ).toThrow(
       "OpenClaw gateway lifecycle is managed by an external supervisor " +

--- a/src/infra/gateway-supervision.ts
+++ b/src/infra/gateway-supervision.ts
@@ -1,12 +1,10 @@
 // Defines gateway lifecycle ownership shared by service, restart, and update paths.
-export const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
+const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
 export const EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON = "external-supervisor-update-required";
 
-export type GatewaySupervisorMode = "auto" | "external";
+type GatewaySupervisorMode = "auto" | "external";
 
-export function resolveGatewaySupervisorMode(
-  env: NodeJS.ProcessEnv = process.env,
-): GatewaySupervisorMode {
+function resolveGatewaySupervisorMode(env: NodeJS.ProcessEnv = process.env): GatewaySupervisorMode {
   return env[GATEWAY_SUPERVISOR_MODE_ENV]?.trim().toLowerCase() === "external"
     ? "external"
     : "auto";

--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -14,12 +14,6 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 
-export {
-  createGatewayRestartHandoffCapabilities,
-  GATEWAY_RESTART_HANDOFF_PROTOCOL,
-  GATEWAY_RESTART_HANDOFF_PROTOCOL_VERSION,
-} from "./restart-handoff-contract.js";
-
 // Restart handoff rows let a supervisor explain a recent gateway restart after
 // the old process exits. The row is short-lived, bounded, and replaced on write.
 const GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND = "gateway-supervisor-restart-handoff";
@@ -77,7 +71,7 @@ export type GatewayRestartHandoff = {
   };
 };
 
-export type GatewayRestartHandoffConsumeResult =
+type GatewayRestartHandoffConsumeResult =
   | {
       status: "accepted";
       handoff: GatewayRestartHandoff;

--- a/src/infra/supervisor-markers.ts
+++ b/src/infra/supervisor-markers.ts
@@ -23,7 +23,7 @@ export const SUPERVISOR_HINT_ENV_VARS = [
 
 /** Supported supervisor families that can respawn the gateway after update/restart handoff. */
 export type RespawnSupervisor = "launchd" | "systemd" | "schtasks";
-export type GatewayRespawnSupervisor = RespawnSupervisor | "external";
+type GatewayRespawnSupervisor = RespawnSupervisor | "external";
 
 interface DetectRespawnSupervisorOptions {
   includeLinuxOpenClawGatewayServiceMarker?: boolean;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the repository dependency/dead-code CI lane fails after the restart-owner refactor because internal symbols remain exported after their production consumers moved to narrower owner modules.

## Why This Change Was Made

The stale restart-handoff re-exports are removed, internal-only result/supervisor types are no longer exported, and the gateway supervision test now exercises the public predicate instead of internal normalization helpers. Runtime behavior is unchanged.

## User Impact

No user-visible behavior change. Maintainers regain a green dependency/dead-code gate, and the internal restart ownership surface stays minimal.

## Evidence

- Before: exact-head CI run [29514196056](https://github.com/openclaw/openclaw/actions/runs/29514196056) reported the nine stale exports/types from the current main baseline.
- `node scripts/run-vitest.mjs src/infra/gateway-supervision.test.ts src/infra/restart-handoff.test.ts src/cli/daemon-cli/restart-lock-replacement.test.ts src/infra/supervisor-markers.test.ts`: 4 files, 33 tests passed across 3 shards.
- `node scripts/check-changed.mjs -- src/infra/gateway-supervision.ts src/infra/gateway-supervision.test.ts src/infra/restart-handoff.ts src/cli/daemon-cli/restart-lock-replacement.ts src/infra/supervisor-markers.ts`: hosted Blacksmith changed gate passed ([run 29515379603](https://github.com/openclaw/openclaw/actions/runs/29515379603)).
- Fresh uncommitted autoreview: clean (0.94).
