### PR TITLE
fix(cli): --container no longer hangs when runtime inspection stalls

### DIFF
--- a/src/cli/container-target.test.ts
+++ b/src/cli/container-target.test.ts
@@ -406,7 +406,7 @@ describe("maybeRunCliInContainer", () => {
       1,
       "podman",
       ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       3,
@@ -459,7 +459,7 @@ describe("maybeRunCliInContainer", () => {
       2,
       "docker",
       ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       3,
@@ -516,13 +516,13 @@ describe("maybeRunCliInContainer", () => {
       1,
       "podman",
       ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       2,
       "docker",
       ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       3,
@@ -570,13 +570,13 @@ describe("maybeRunCliInContainer", () => {
       1,
       "podman",
       ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       2,
       "docker",
       ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
   });
 
@@ -681,7 +681,7 @@ describe("maybeRunCliInContainer", () => {
       1,
       "podman",
       ["inspect", "--format", "{{.State.Running}}", "flag-demo"],
-      { encoding: "utf8" },
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
     );
   });
 

--- a/src/cli/container-target.ts
+++ b/src/cli/container-target.ts
@@ -30,6 +30,7 @@ type ContainerRuntimeExec = {
 };
 
 const CONTAINER_ALLOW_LOOPBACK_PROXY_URL_ENV = "OPENCLAW_CONTAINER_ALLOW_LOOPBACK_PROXY_URL";
+const CONTAINER_RUNTIME_PROBE_TIMEOUT_MS = 10_000;
 
 export function parseCliContainerArgs(argv: string[]): CliContainerParseResult {
   let container: string | null = null;
@@ -74,8 +75,17 @@ function isContainerRunning(params: {
     params.exec.command,
     [...params.exec.argsPrefix, "inspect", "--format", "{{.State.Running}}", params.containerName],
     params.exec.command === "sudo"
-      ? { encoding: "utf8", stdio: ["inherit", "pipe", "inherit"] }
-      : { encoding: "utf8" },
+      ? {
+          encoding: "utf8",
+          killSignal: "SIGKILL",
+          stdio: ["inherit", "pipe", "inherit"],
+          timeout: CONTAINER_RUNTIME_PROBE_TIMEOUT_MS,
+        }
+      : {
+          encoding: "utf8",
+          killSignal: "SIGKILL",
+          timeout: CONTAINER_RUNTIME_PROBE_TIMEOUT_MS,
+        },
   );
   return result.status === 0 && result.stdout.trim() === "true";
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running an OpenClaw CLI command with `--container` could wait indefinitely when Podman or Docker stopped responding while checking the named container.

## Why This Change Was Made

Container discovery now gives each runtime inspection 10 seconds and force-stops a stalled probe. The timeout applies only to `inspect`; the selected container command itself remains unrestricted so legitimate long-running operations keep working.

## User Impact

Container-targeted CLI commands now fall through to the next runtime or return the existing no-match error instead of hanging forever. Normal Podman and Docker execution behavior is unchanged.

## Evidence

- Regression test before the fix: 5 timeout-option assertions failed while 27 tests passed.
- Focused test after the fix and after rebasing onto current main: `src/cli/container-target.test.ts` passed 32/32.
- Real CLI E2E proof on current main `8bf4d388b`: `src/entry.ts --container demo status` with a test Podman executable that ignored `SIGTERM` was still blocked when a 15-second external watchdog stopped it. The exact patched head `548f5a302` force-stopped the same probe, attempted the real Docker fallback, and returned the existing no-match error in 11.95 seconds.
- `oxfmt`, `oxlint`, and `git diff --check` passed for the changed files.
- Local `codex review --base origin/main` found no confirmed regression.
