### PR TITLE
fix(auto-reply): stop minting channel source-turn ids for internal-origin turns

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -184,6 +184,7 @@ import {
   buildChannelSourceTurnId,
   readChannelSourceTurnId,
   setChannelSourceTurnId,
+  shouldMintChannelSourceTurnId,
 } from "./source-turn-id.js";
 import { stageRemoteInboundMediaIfNeeded } from "./stage-remote-inbound-media.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -982,16 +983,18 @@ async function dispatchReplyFromConfigInner(
 
   const durableSourceTurnId =
     readChannelSourceTurnId(ctx) ??
-    buildChannelSourceTurnId({
-      provider: resolveOriginMessageProvider({
-        originatingChannel: replyRoute.channel,
-        provider: ctx.Provider ?? ctx.Surface,
-      }),
-      accountId: replyRoute.accountId,
-      conversationId: replyRoute.to,
-      messageId:
-        normalizeOptionalString(ctx.MessageSidFull) ?? normalizeOptionalString(ctx.MessageSid),
-    });
+    (shouldMintChannelSourceTurnId(ctx.Provider ?? ctx.Surface)
+      ? buildChannelSourceTurnId({
+          provider: resolveOriginMessageProvider({
+            originatingChannel: replyRoute.channel,
+            provider: ctx.Provider ?? ctx.Surface,
+          }),
+          accountId: replyRoute.accountId,
+          conversationId: replyRoute.to,
+          messageId:
+            normalizeOptionalString(ctx.MessageSidFull) ?? normalizeOptionalString(ctx.MessageSid),
+        })
+      : undefined);
   // Compute once before hooks. The prepared agent turn reuses this exact route-scoped id.
   setChannelSourceTurnId(ctx, durableSourceTurnId);
   if (isDuplicateRestartRecoverySource(sessionStoreEntry.entry, durableSourceTurnId)) {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -132,6 +132,7 @@ import {
   buildChannelSourceTurnId,
   readChannelSourceTurnId,
   setChannelSourceTurnId,
+  shouldMintChannelSourceTurnId,
 } from "./source-turn-id.js";
 import { buildSessionStartupContextPrelude, shouldApplyStartupContext } from "./startup-context.js";
 import { resolveTypingMode } from "./typing-mode.js";
@@ -1446,12 +1447,14 @@ export async function runPreparedReply(
     normalizeOptionalString(sessionCtx.MessageSid);
   const sourceTurnId =
     readChannelSourceTurnId(sessionCtx) ??
-    buildChannelSourceTurnId({
-      provider: messageProvider,
-      accountId: replyRoute.accountId,
-      conversationId: replyRoute.to,
-      messageId: sourceMessageId,
-    });
+    (shouldMintChannelSourceTurnId(ctx.Provider ?? ctx.Surface ?? promptSessionCtx.Provider)
+      ? buildChannelSourceTurnId({
+          provider: messageProvider,
+          accountId: replyRoute.accountId,
+          conversationId: replyRoute.to,
+          messageId: sourceMessageId,
+        })
+      : undefined);
   setChannelSourceTurnId(sessionCtx, sourceTurnId);
   const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
   const userTurnMediaForPersistence = buildPersistedUserTurnMediaInputsFromFields(ctx);

--- a/src/auto-reply/reply/source-turn-id.test.ts
+++ b/src/auto-reply/reply/source-turn-id.test.ts
@@ -5,6 +5,7 @@ import {
   readChannelSourceTurnSameThreadRequired,
   setChannelSourceTurnId,
   setChannelSourceTurnSameThreadRequired,
+  shouldMintChannelSourceTurnId,
 } from "./source-turn-id.js";
 
 describe("buildChannelSourceTurnId", () => {
@@ -67,5 +68,13 @@ describe("buildChannelSourceTurnId", () => {
     expect(readChannelSourceTurnId({ ...context })).toBe("channel-user:v1:source-7");
     expect(readChannelSourceTurnSameThreadRequired({ ...context })).toBe(true);
     expect(JSON.stringify(context)).toBe('{"MessageSid":"7"}');
+  });
+  it("does not mint channel source-turn ids for internal-origin ingress", () => {
+    // Gateway chat.send stamps the internal channel as the ingress provider and
+    // keys the persisted user turn by run id; minting a channel id there would
+    // trip the source-keyed admission guard (live regression via #108283).
+    expect(shouldMintChannelSourceTurnId("webchat")).toBe(false);
+    expect(shouldMintChannelSourceTurnId("telegram")).toBe(true);
+    expect(shouldMintChannelSourceTurnId(undefined)).toBe(true);
   });
 });

--- a/src/auto-reply/reply/source-turn-id.ts
+++ b/src/auto-reply/reply/source-turn-id.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAccountId } from "../../routing/account-id.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
 
 const CHANNEL_SOURCE_TURN_ID_PREFIX = "channel-user:v1:";
 const CHANNEL_SOURCE_TURN_ID = Symbol("openclaw.channelSourceTurnId");
@@ -15,6 +16,16 @@ type ChannelSourceTurnContext = object & {
   [CHANNEL_SOURCE_TURN_ID]?: string;
   [CHANNEL_SOURCE_TURN_SAME_THREAD_REQUIRED]?: true;
 };
+
+/**
+ * Internal-origin turns (gateway chat.send stamps the internal channel as the
+ * ingress provider) carry run ids, not provider message ids. Minting a channel
+ * source-turn id from them breaks the run-keyed user-turn admission guard;
+ * gateway turns own restart via fingerprint admission and client retries.
+ */
+export function shouldMintChannelSourceTurnId(ingressProvider: string | undefined): boolean {
+  return !isInternalMessageChannel(ingressProvider);
+}
 
 /**
  * Identifies one inbound channel turn across shared sessions.

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -550,7 +550,7 @@ async function waitForChatAgentRunOk(client: GatewayClient, runId: string): Prom
     },
   );
   if (result?.status !== "ok") {
-    throw new Error(`agent.wait failed for ${runId}: status=${String(result?.status)}`);
+    throw new Error(`agent.wait failed for ${runId}: ${JSON.stringify(result)}`);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Every gateway `chat.send` turn carrying `originatingChannel`/`originatingTo` overrides dies with `Error: channel restart recovery requires source-keyed user-turn admission` on current main. Reproduced live twice on a Blacksmith Testbox (codex harness chat-image probe, real OpenAI key); text-only turns fail identically. Affected surfaces: qa-lab suite runtime dispatch, ACP-bridge flows (`gateway-acp-bind` / `gateway-codex-bind`), and any relay integration using admin-scope chat.send with originating-route fields. Real channel ingress (Telegram/Discord/…) and plain webchat/Control-UI chat.send are unaffected.

## Why This Change Was Made

Regression from PR #108283: it started minting a durable channel source-turn id (`channel-user:v1:<sha256>`) for these turns by hashing the gateway `clientRunId` as if it were a provider message id, while the gateway's pre-created user-turn recorder still keys the persisted turn by run id (`idem-<run>:user`). The same PR's admission guard (`restart-recovery-claim.ts`) then throws on exactly that mismatch. CI missed it because the existing chat.send+originating tests mock dispatch and never drive real admission.

The semantic bug is identity conflation: channel source-turn ids exist to deduplicate provider redelivery after restart, and gateway-owned turns have no provider message — they already own restart via fingerprint-based admission (`chat-restart-recovery.ts`) plus client-side idempotent retries. Fix at the owning seam: `shouldMintChannelSourceTurnId` skips the mint when the actual ingress provider is the internal message channel, applied at both derivation sites (`dispatch-from-config.ts`, `get-reply-run.ts`). Admission then takes the existing source-less `persistUserTurnOnly` branch — pre-#108283 behavior for internal turns — while real channel ingress keeps the new source-keyed recovery unchanged. The rejected alternative (rekeying the gateway recorder by the minted hash) would grant gateway turns channel-style restart replay on top of client retries — double ownership with no shipped demand.

Also surfaces the full `agent.wait` result in the codex harness live test's error message (this is how the regression was diagnosed).

## User Impact

Admin-scope chat.send with originating-route fields works again: qa-lab scenario dispatch, ACP bridge sessions, and relay integrations complete turns instead of erroring at admission. Channel restart recovery for real provider ingress is untouched.

## Evidence

- Live before/after on a Blacksmith Testbox with a real OpenAI key against the codex app-server harness: `verifyCodexChatImageProbe` failed twice on main with the admission error; with this fix the same run is admitted and executes (turn completes; the probe's remaining OCR assertion is a separate pre-existing media-path question, tracked separately).
- New unit regression: internal ingress never mints (`webchat` → false), external (`telegram`) and undefined ingress unchanged.
- Focused suites green: source-turn-id (5), agent-runner.runreplyagent e2e (23), dispatch-from-config pending-final, agent-runner-utils (111).
- Autoreview (gpt-5.6-sol, xhigh): clean.
