### PR TITLE
fix(sessions): recover start times across short transcript reads

### DIFF
--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -1,5 +1,6 @@
 // Session lifecycle timestamps prefer store metadata and fall back to transcript headers.
 import fs from "node:fs";
+import { readFileWindowFullySync } from "../../infra/file-read.js";
 import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import { canonicalizeMainSessionAlias } from "./main-session.js";
 import {
@@ -111,7 +112,7 @@ function readFirstLine(filePath: string): string | undefined {
     const fd = fs.openSync(filePath, "r");
     try {
       const buffer = Buffer.alloc(8192);
-      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+      const bytesRead = readFileWindowFullySync(fd, buffer, 0);
       if (bytesRead <= 0) {
         return undefined;
       }

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -302,16 +302,34 @@ describe("session lifecycle timestamps", () => {
         "utf8",
       );
 
-      const timestamps = resolveSessionLifecycleTimestamps({
-        storePath,
-        entry: {
-          sessionId: "legacy-session",
-          sessionFile,
-          updatedAt: Date.parse("2026-04-25T08:00:00.000Z"),
-        },
-      });
+      const realReadSync = fs.readSync.bind(fs);
+      let shortReadCalls = 0;
+      const readSpy = vi.spyOn(fs, "readSync").mockImplementation(((
+        fd: number,
+        buffer: NodeJS.ArrayBufferView,
+        offset: number,
+        length: number,
+        position: fs.ReadPosition | null,
+      ) => {
+        shortReadCalls += 1;
+        return realReadSync(fd, buffer, offset, Math.min(length, 16), position);
+      }) as typeof fs.readSync);
 
-      expect(timestamps.sessionStartedAt).toBe(Date.parse(headerTimestamp));
+      try {
+        const timestamps = resolveSessionLifecycleTimestamps({
+          storePath,
+          entry: {
+            sessionId: "legacy-session",
+            sessionFile,
+            updatedAt: Date.parse("2026-04-25T08:00:00.000Z"),
+          },
+        });
+
+        expect(timestamps.sessionStartedAt).toBe(Date.parse(headerTimestamp));
+        expect(shortReadCalls).toBeGreaterThan(1);
+      } finally {
+        readSpy.mockRestore();
+      }
     } finally {
       await fsPromises.rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where legacy sessions could lose their recovered start time when the transcript filesystem returned a permitted short positional read. Status age, reset freshness, and session recovery paths could then operate without the timestamp stored in the JSONL header.

## Why This Change Was Made

The bounded 8 KiB header read now uses the existing fill-until-EOF helper, matching the other bounded session readers without parsing or materializing the full transcript. Risk is limited to header recovery: the path checks, byte cap, header validation, and stored-metadata precedence are unchanged, and the short-read regression exercises that exact fallback.

## User Impact

Legacy session start times remain available on network-backed or otherwise short-reading filesystems, so lifecycle age and freshness decisions continue to use the original session timestamp.

## Evidence

Node documents that `fs.read()` may return fewer bytes than requested, including on slow network filesystems, and `fs.readSync()` follows that contract: https://nodejs.org/api/fs.html#fsreadsyncfd-buffer-offset-length-position

Real filesystem behavior proof on Linux/Node 24 used an `LD_PRELOAD` shim that capped `pread` to 16 bytes only for the target transcript file, while calling the production `resolveSessionLifecycleTimestamps` function.

Latest `upstream/main` (`b3301e32127de6b5ca9ca6b7c0defe0f9c80434a`):

```text
{"expected":1776659400000,"actual":null}
```

Patched head (`5e74f8ade25d76ae615eebb4234e6bb65420b890`), same harness and target:

```text
{"expected":1776659400000,"actual":1776659400000}
```

Focused regression:

```text
node scripts/run-vitest.mjs src/config/sessions/sessions.test.ts
Test Files  1 passed (1)
Tests       44 passed (44)
```

Reverting only the production read made the new focused case fail with `expected undefined to be 1776659400000`; restoring the helper passed all 44 tests. `CI=1 node scripts/check-changed.mjs --base upstream/main --head HEAD -- src/config/sessions/lifecycle.ts src/config/sessions/sessions.test.ts` passed formatting, core and core-test typechecks, targeted lint, Plugin SDK baseline, boundary, database-first, sidecar, import-cycle, webhook, and pairing guards.

`.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` reported no accepted or actionable findings (`patch is correct`, 0.93 confidence).

AI-assisted: Codex identified the adoption gap, implemented the bounded read, and ran the focused, changed-gate, negative-control, and real-process proof manually.
