### PR TITLE
fix(trajectory): clean runtime files after short reads

### DIFF
--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -1,7 +1,8 @@
 // Trajectory cleanup tests cover retention pruning of trajectory artifacts.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
@@ -131,14 +132,31 @@ describe("trajectory cleanup", () => {
 
       const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
       await fs.writeFile(pointerPath, pointerFile(sessionId, safeExternalRuntime), "utf8");
-      await removeSessionTrajectoryArtifacts({
-        sessionId,
-        sessionFile,
-        storePath,
-        restrictToStoreDir: true,
-      });
+      const realReadSync = fsSync.readSync.bind(fsSync);
+      let shortReadCalls = 0;
+      const readSpy = vi.spyOn(fsSync, "readSync").mockImplementation(((
+        fd: number,
+        buffer: NodeJS.ArrayBufferView,
+        offset: number,
+        length: number,
+        position: fsSync.ReadPosition | null,
+      ) => {
+        shortReadCalls += 1;
+        return realReadSync(fd, buffer, offset, Math.min(length, 16), position);
+      }) as typeof fsSync.readSync);
+      try {
+        await removeSessionTrajectoryArtifacts({
+          sessionId,
+          sessionFile,
+          storePath,
+          restrictToStoreDir: true,
+        });
+      } finally {
+        readSpy.mockRestore();
+      }
 
       await expectPathMissing(safeExternalRuntime);
+      expect(shortReadCalls).toBeGreaterThan(1);
       await expectPathMissing(pointerPath);
 
       await fs.writeFile(pointerPath, pointerFile(sessionId, unsafeExternalRuntime), "utf8");

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
+import { readFileWindowFullySync } from "../infra/file-read.js";
 import { isPathInside } from "../infra/path-guards.js";
 import {
   resolveTrajectoryFilePath,
@@ -79,7 +80,7 @@ function readFirstNonEmptyLine(filePath: string): string | null {
   try {
     fd = fs.openSync(filePath, "r");
     const buffer = Buffer.alloc(64 * 1024);
-    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    const bytesRead = readFileWindowFullySync(fd, buffer, 0);
     if (bytesRead <= 0) {
       return null;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where trajectory cleanup could leave an external runtime JSONL file behind when the filesystem returned a permitted short positional read. The pointer was removed, but the truncated ownership header could not prove that the matching runtime file belonged to the deleted session.

## Why This Change Was Made

The bounded 64 KiB ownership-header read now uses the existing fill-until-EOF helper before applying the same schema, source, session-id, basename, and path checks. The main risk is deleting an unrelated external file; those ownership checks are unchanged, and the regression still verifies that an unsafe non-matching target remains untouched.

## User Impact

Deleted sessions no longer leave proven trajectory runtime files behind on network-backed or otherwise short-reading filesystems, while unrelated external files remain protected by the existing cleanup guards.

## Evidence

Node documents that `fs.read()` may return fewer bytes than requested, including on slow network filesystems, and `fs.readSync()` follows that contract: https://nodejs.org/api/fs.html#fsreadsyncfd-buffer-offset-length-position

Real filesystem behavior proof on Linux/Node 24 used an `LD_PRELOAD` shim that capped `pread` to 16 bytes only for the external runtime JSONL file, while calling the production `removeSessionTrajectoryArtifacts` function.

Latest `upstream/main` (`b3301e32127de6b5ca9ca6b7c0defe0f9c80434a`):

```text
{"removed":["pointer"],"runtimeExists":true}
```

Patched head (`60df0b8db55b7b1fc00b37d92f76b8bbc8fc84b2`), same harness and target:

```text
{"removed":["pointer","runtime"],"runtimeExists":false}
```

Focused regression:

```text
node scripts/run-vitest.mjs src/trajectory/cleanup.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)
```

Reverting only the production read made the short-read case fail before the external runtime could be removed; restoring the helper passed all four tests. `CI=1 node scripts/check-changed.mjs --base upstream/main --head HEAD -- src/trajectory/cleanup.ts src/trajectory/cleanup.test.ts` passed formatting, core and core-test typechecks, targeted lint, Plugin SDK baseline, boundary, database-first, sidecar, import-cycle, webhook, and pairing guards.

`.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` reported no accepted or actionable findings (`patch is correct`, 0.93 confidence).

AI-assisted: Codex identified the adoption gap, implemented the bounded read, and ran the focused, changed-gate, negative-control, and real-process proof manually.
