### PR TITLE
fix(qa): suites no longer hang when process sampling stalls

### DIFF
--- a/extensions/qa-lab/src/process-tree-cpu.test.ts
+++ b/extensions/qa-lab/src/process-tree-cpu.test.ts
@@ -40,7 +40,12 @@ describe("POSIX process tree metrics", () => {
     expect(readProcessTreeCpuMs(102)).toBe(62_000);
     expect(readProcessTreeCpuMs(103)).toBe(3_723_450);
     expect(readProcessTreeCpuMs(104)).toBe(93_784_500);
-    expect(spawnSyncMock.mock.calls[0]?.slice(0, 2)).toEqual(["ps", ["-eo", "pid=,ppid=,time="]]);
+    expect(spawnSyncMock).toHaveBeenCalledWith("ps", ["-eo", "pid=,ppid=,time="], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    });
   });
 
   it("rejects malformed ps CPU time strings", () => {
@@ -69,7 +74,12 @@ describe("POSIX process tree metrics", () => {
 
     expect(readProcessTreeRssBytes(100)).toBe(1_048_576);
     expect(readProcessTreeRssBytes(101)).toBe(1_536);
-    expect(spawnSyncMock.mock.calls[0]?.slice(0, 2)).toEqual(["ps", ["-eo", "pid=,ppid=,rss="]]);
+    expect(spawnSyncMock).toHaveBeenCalledWith("ps", ["-eo", "pid=,ppid=,rss="], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    });
   });
 
   it("rejects malformed ps RSS values", () => {

--- a/extensions/qa-lab/src/process-tree-cpu.ts
+++ b/extensions/qa-lab/src/process-tree-cpu.ts
@@ -9,6 +9,8 @@ type ProcessTreeSnapshot = {
   rssByPid: Map<number, number>;
 };
 
+const PROCESS_TREE_SNAPSHOT_TIMEOUT_MS = 5_000;
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -191,8 +193,10 @@ function readWindowsProcessTreeSnapshot(): ProcessTreeSnapshot | null {
     ],
     {
       encoding: "utf8",
+      killSignal: "SIGKILL",
       maxBuffer: 16 * 1024 * 1024,
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: PROCESS_TREE_SNAPSHOT_TIMEOUT_MS,
     },
   );
   if (result.status !== 0) {
@@ -213,7 +217,9 @@ export function readProcessTreeCpuMs(rootPid: number | null | undefined): number
   }
   const result = spawnSync("ps", ["-eo", "pid=,ppid=,time="], {
     encoding: "utf8",
+    killSignal: "SIGKILL",
     stdio: ["ignore", "pipe", "ignore"],
+    timeout: PROCESS_TREE_SNAPSHOT_TIMEOUT_MS,
   });
   if (result.status !== 0) {
     return null;
@@ -257,7 +263,9 @@ export function readProcessTreeRssBytes(rootPid: number | null | undefined): num
   }
   const result = spawnSync("ps", ["-eo", "pid=,ppid=,rss="], {
     encoding: "utf8",
+    killSignal: "SIGKILL",
     stdio: ["ignore", "pipe", "ignore"],
+    timeout: PROCESS_TREE_SNAPSHOT_TIMEOUT_MS,
   });
   if (result.status !== 0) {
     return null;

--- a/extensions/qa-lab/src/process-tree-cpu.windows.test.ts
+++ b/extensions/qa-lab/src/process-tree-cpu.windows.test.ts
@@ -68,6 +68,13 @@ describe("readProcessTreeCpuMs on Windows", () => {
     expect(spawnSyncMock.mock.calls[0]?.[0]).toBe(
       path.win32.join("D:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
     );
+    expect(spawnSyncMock.mock.calls[0]?.[2]).toEqual({
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    });
   });
 
   it("rejects non-decimal Windows process counters", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a QA suite could stop making progress when its optional gateway CPU or RSS sampling command stalled on POSIX or Windows.

## Why This Change Was Made

All process-tree snapshot probes now have a 5-second limit and are force-stopped when that limit expires. A failed or timed-out sample keeps the existing `null` result, so metrics remain optional and the QA scenario can continue.

## User Impact

QA runs no longer hang indefinitely while collecting process metrics. Healthy `ps` and PowerShell/CIM samples produce the same CPU and RSS values as before.

## Evidence

- Regression test before the fix: 3 timeout-option assertions failed while 6 tests passed across the POSIX and Windows files.
- Focused test after the fix and after rebasing onto current main: 2 files passed, 9/9 tests.
- Real production-path proof on current main `b3301e3212`: the QA process sampler with a test `ps` executable that ignored `SIGTERM` was still blocked when an 8-second external watchdog stopped it. The exact patched head `234dc346ac` force-stopped the same probe and returned the existing unavailable-metric result in 5.40 seconds.
- `oxfmt`, `oxlint`, and `git diff --check` passed for the changed files.
- Local `codex review --base origin/main` confirmed the probes are consistently bounded and found no regression.
