### PR TITLE
fix(ci): drop unused gateway supervision/restart-handoff exports breaking the knip gate on main

### DIFF
--- a/src/cli/daemon-cli/restart-lock-replacement.ts
+++ b/src/cli/daemon-cli/restart-lock-replacement.ts
@@ -5,7 +5,7 @@ import {
 } from "../../infra/gateway-lock.js";
 import { sleep } from "../../utils.js";
 
-export type GatewayLockReplacementWaitResult =
+type GatewayLockReplacementWaitResult =
   | { status: "replacement"; attemptsUsed: number }
   | { status: "timeout" };
 

--- a/src/infra/gateway-supervision.test.ts
+++ b/src/infra/gateway-supervision.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   assertGatewayServiceMutationAllowed,
   formatExternalSupervisorUpdateRequired,
-  GATEWAY_SUPERVISOR_MODE_ENV,
   isGatewayExternallySupervised,
-  resolveGatewaySupervisorMode,
 } from "./gateway-supervision.js";
+
+const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
 
 describe("gateway supervision", () => {
   it.each([
@@ -17,7 +17,6 @@ describe("gateway supervision", () => {
   ])("resolves $value as $expected", ({ value, expected }) => {
     const env = { [GATEWAY_SUPERVISOR_MODE_ENV]: value };
 
-    expect(resolveGatewaySupervisorMode(env)).toBe(expected);
     expect(isGatewayExternallySupervised(env)).toBe(expected === "external");
   });
 

--- a/src/infra/gateway-supervision.ts
+++ b/src/infra/gateway-supervision.ts
@@ -1,12 +1,10 @@
 // Defines gateway lifecycle ownership shared by service, restart, and update paths.
-export const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
+const GATEWAY_SUPERVISOR_MODE_ENV = "OPENCLAW_SUPERVISOR_MODE";
 export const EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON = "external-supervisor-update-required";
 
-export type GatewaySupervisorMode = "auto" | "external";
+type GatewaySupervisorMode = "auto" | "external";
 
-export function resolveGatewaySupervisorMode(
-  env: NodeJS.ProcessEnv = process.env,
-): GatewaySupervisorMode {
+function resolveGatewaySupervisorMode(env: NodeJS.ProcessEnv = process.env): GatewaySupervisorMode {
   return env[GATEWAY_SUPERVISOR_MODE_ENV]?.trim().toLowerCase() === "external"
     ? "external"
     : "auto";

--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -14,12 +14,6 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 
-export {
-  createGatewayRestartHandoffCapabilities,
-  GATEWAY_RESTART_HANDOFF_PROTOCOL,
-  GATEWAY_RESTART_HANDOFF_PROTOCOL_VERSION,
-} from "./restart-handoff-contract.js";
-
 // Restart handoff rows let a supervisor explain a recent gateway restart after
 // the old process exits. The row is short-lived, bounded, and replaced on write.
 const GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND = "gateway-supervisor-restart-handoff";
@@ -77,7 +71,7 @@ export type GatewayRestartHandoff = {
   };
 };
 
-export type GatewayRestartHandoffConsumeResult =
+type GatewayRestartHandoffConsumeResult =
   | {
       status: "accepted";
       handoff: GatewayRestartHandoff;

--- a/src/infra/supervisor-markers.ts
+++ b/src/infra/supervisor-markers.ts
@@ -23,7 +23,6 @@ export const SUPERVISOR_HINT_ENV_VARS = [
 
 /** Supported supervisor families that can respawn the gateway after update/restart handoff. */
 export type RespawnSupervisor = "launchd" | "systemd" | "schtasks";
-export type GatewayRespawnSupervisor = RespawnSupervisor | "external";
 
 interface DetectRespawnSupervisorOptions {
   includeLinuxOpenClawGatewayServiceMarker?: boolean;
@@ -87,7 +86,7 @@ export function detectGatewayRespawnSupervisor(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
   options: DetectRespawnSupervisorOptions = {},
-): GatewayRespawnSupervisor | null {
+): RespawnSupervisor | "external" | null {
   if (isGatewayExternallySupervised(env)) {
     return "external";
   }


### PR DESCRIPTION
## What Problem This Solves

`main` is currently failing the `check-dependencies` CI gate repo-wide: commit e123606b46b5 ("feat: support externally supervised gateway restarts") introduced exports that knip's production unused-export scan rejects, so every open PR now fails that required check.

## Why This Change Was Made

Broken-main repair, narrowest possible: remove or de-export the flagged symbols instead of widening knip modeling. All of them have no production importers — they are used only in-file or by their own colocated tests:

- `supervisor-markers.ts`: `GatewayRespawnSupervisor` alias inlined into the function signature (`RespawnSupervisor | "external" | null`), alias deleted.
- `restart-handoff.ts`: duplicate re-export block of the contract file removed (all consumers import `restart-handoff-contract.js` directly); `GatewayRestartHandoffConsumeResult` made local.
- `gateway-supervision.ts`: `resolveGatewaySupervisorMode`, `GatewaySupervisorMode`, `GATEWAY_SUPERVISOR_MODE_ENV` made local; the test now covers mode resolution through the public `isGatewayExternallySupervised`.
- `restart-lock-replacement.ts`: `GatewayLockReplacementWaitResult` made local.

No runtime behavior changes; exported function contracts keep identical signatures.

## User Impact

None directly — unblocks CI for every open PR.

## Evidence

- Before: `pnpm deadcode:exports` / `pnpm deadcode:dependencies` fail on clean main-derived branches with the five entries above (matches the failing `check-dependencies` runs on open PRs, e.g. run 29514498283).
- After: both knip gates pass with 0 entries; `pnpm deadcode:unused-files` clean.
- Focused suites green: supervisor-markers, restart-handoff, gateway-supervision, daemon-cli tests.
- Autoreview (codex, gpt-5.6-sol, xhigh): clean.
