### PR TITLE
fix(google-meet): wait for audio bridge processes to stop

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -622,6 +622,7 @@ type TestBridgeProcess = {
   stdout?: PassThrough | null;
   stderr: PassThrough;
   killed: boolean;
+  signalCode: NodeJS.Signals | null;
   kill: ReturnType<typeof vi.fn>;
   on: EventEmitter["on"];
   emit: EventEmitter["emit"];
@@ -6669,8 +6670,10 @@ describe("google-meet plugin", () => {
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
       proc.killed = false;
-      proc.kill = vi.fn(() => {
+      proc.signalCode = null;
+      proc.kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
         proc.killed = true;
+        proc.signalCode = signal;
         return true;
       });
       return proc;
@@ -6799,8 +6802,10 @@ describe("google-meet plugin", () => {
       proc.stdout = stdio.stdout;
       proc.stderr = stdio.stderr;
       proc.killed = false;
-      proc.kill = vi.fn(() => {
+      proc.signalCode = null;
+      proc.kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
         proc.killed = true;
+        proc.signalCode = signal;
         return true;
       });
       return proc;
@@ -6915,8 +6920,10 @@ describe("google-meet plugin", () => {
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
       proc.killed = false;
-      proc.kill = vi.fn(() => {
+      proc.signalCode = null;
+      proc.kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
         proc.killed = true;
+        proc.signalCode = signal;
         return true;
       });
       return proc;
@@ -6936,6 +6943,7 @@ describe("google-meet plugin", () => {
     const inputProcess = makeProcess({ stdout: inputStdout, stdin: null });
     const outputProcess = makeProcess({ stdin: outputStdin, stdout: null });
     const replacementOutputProcess = makeProcess({ stdin: replacementOutputStdin, stdout: null });
+    outputProcess.kill.mockImplementation(() => true);
     const spawnMock = vi
       .fn()
       .mockReturnValueOnce(outputProcess)
@@ -7101,7 +7109,17 @@ describe("google-meet plugin", () => {
     ]);
     expect(sessionStore).toHaveProperty("agent:jay:subagent:google-meet:meet-1");
 
-    await handle.stop();
+    let stopSettled = false;
+    const stopPromise = handle.stop().finally(() => {
+      stopSettled = true;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(stopSettled).toBe(false);
+    outputProcess.signalCode = "SIGKILL";
+    outputProcess.emit("exit", null, "SIGKILL");
+    await stopPromise;
     expect(bridge.close).toHaveBeenCalled();
     expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
     expect(replacementOutputProcess.kill).toHaveBeenCalledWith("SIGTERM");
@@ -7137,8 +7155,10 @@ describe("google-meet plugin", () => {
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
       proc.killed = false;
-      proc.kill = vi.fn(() => {
+      proc.signalCode = null;
+      proc.kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
         proc.killed = true;
+        proc.signalCode = signal;
         return true;
       });
       return proc;
@@ -7216,8 +7236,10 @@ describe("google-meet plugin", () => {
         proc.stdout = stdio.stdout;
         proc.stderr = new PassThrough();
         proc.killed = false;
-        proc.kill = vi.fn(() => {
+        proc.signalCode = null;
+        proc.kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
           proc.killed = true;
+          proc.signalCode = signal;
           return true;
         });
         return proc;
@@ -7417,8 +7439,10 @@ describe("google-meet plugin", () => {
       proc.stdout = stdio.stdout;
       proc.stderr = new PassThrough();
       proc.killed = false;
-      proc.kill = vi.fn(() => {
+      proc.signalCode = null;
+      proc.kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
         proc.killed = true;
+        proc.signalCode = signal;
         return true;
       });
       return proc;

--- a/extensions/google-meet/node-host.test.ts
+++ b/extensions/google-meet/node-host.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 type MockChild = EventEmitter & {
   exitCode: number | null;
   signalCode: NodeJS.Signals | null;
+  ignoreSigterm: boolean;
   kill: ReturnType<typeof vi.fn>;
   stdout?: EventEmitter;
   stderr?: EventEmitter;
@@ -28,14 +29,23 @@ vi.mock("node:child_process", async (importOriginal) => {
       const child = Object.assign(new EventEmitter(), {
         exitCode: null,
         signalCode: null,
-        kill: vi.fn((signal?: NodeJS.Signals) => {
-          child.signalCode = signal ?? "SIGTERM";
-          return true;
-        }),
+        ignoreSigterm: false,
+        kill: vi.fn(),
         stdout: new EventEmitter(),
         stderr: new EventEmitter(),
         stdin: Object.assign(new EventEmitter(), { write: vi.fn() }),
       }) as MockChild;
+      child.kill.mockImplementation((signal?: NodeJS.Signals) => {
+        const resolvedSignal = signal ?? "SIGTERM";
+        if (resolvedSignal === "SIGTERM" && child.ignoreSigterm) {
+          return true;
+        }
+        queueMicrotask(() => {
+          child.signalCode = resolvedSignal;
+          child.emit("exit", null, resolvedSignal);
+        });
+        return true;
+      });
       children.push(child);
       return child;
     }),
@@ -228,6 +238,54 @@ describe("google-meet node host bridge sessions", () => {
     }
   });
 
+  it("waits for cleared SIGTERM-resistant output before acknowledging stop", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+    vi.useFakeTimers();
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      const start = JSON.parse(
+        await handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "realtime",
+            launch: false,
+            audioInputCommand: ["mock-rec"],
+            audioOutputCommand: ["mock-play"],
+          }),
+        ),
+      );
+      const [retiredOutput] = children;
+      if (!retiredOutput) {
+        throw new Error("expected Google Meet node host output process");
+      }
+      retiredOutput.ignoreSigterm = true;
+
+      await handleGoogleMeetNodeHostCommand(
+        JSON.stringify({ action: "clearAudio", bridgeId: start.bridgeId }),
+      );
+      let settled = false;
+      const stopPromise = handleGoogleMeetNodeHostCommand(
+        JSON.stringify({ action: "stop", bridgeId: start.bridgeId }),
+      ).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(settled).toBe(false);
+      expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"]]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+      expect(retiredOutput.signalCode).toBe("SIGKILL");
+      expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
   it("closes once when command-pair streams fail together", async () => {
     const originalPlatform = process.platform;
     children.length = 0;
@@ -265,6 +323,106 @@ describe("google-meet node host bridge sessions", () => {
       expect(inputProcess.kill).toHaveBeenCalledTimes(1);
       expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
       expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("waits for SIGTERM-resistant command-pair processes before acknowledging stop", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+    vi.useFakeTimers();
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      const start = JSON.parse(
+        await handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "realtime",
+            launch: false,
+            audioInputCommand: ["mock-rec"],
+            audioOutputCommand: ["mock-play"],
+          }),
+        ),
+      );
+      const [outputProcess, inputProcess] = children;
+      if (!outputProcess || !inputProcess) {
+        throw new Error("expected Google Meet node host command-pair processes");
+      }
+      outputProcess.ignoreSigterm = true;
+      inputProcess.ignoreSigterm = true;
+      let settled = false;
+      const stopPromise = handleGoogleMeetNodeHostCommand(
+        JSON.stringify({ action: "stop", bridgeId: start.bridgeId }),
+      ).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(settled).toBe(false);
+      expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+      expect(outputProcess.signalCode).toBe("SIGKILL");
+      expect(inputProcess.signalCode).toBe("SIGKILL");
+      expect(outputProcess.kill).toHaveBeenCalledWith("SIGKILL");
+      expect(inputProcess.kill).toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("shares SIGTERM-resistant cleanup across concurrent stopByUrl calls", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+    vi.useFakeTimers();
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      await handleGoogleMeetNodeHostCommand(
+        JSON.stringify({
+          action: "start",
+          url: "https://meet.google.com/xyz-abcd-uvw",
+          mode: "realtime",
+          launch: false,
+          audioInputCommand: ["mock-rec"],
+          audioOutputCommand: ["mock-play"],
+        }),
+      );
+      const [outputProcess, inputProcess] = children;
+      if (!outputProcess || !inputProcess) {
+        throw new Error("expected Google Meet node host command-pair processes");
+      }
+      outputProcess.ignoreSigterm = true;
+      inputProcess.ignoreSigterm = true;
+      let firstSettled = false;
+      let secondSettled = false;
+      const stopParams = JSON.stringify({
+        action: "stopByUrl",
+        url: "https://meet.google.com/xyz-abcd-uvw",
+        mode: "realtime",
+      });
+      const firstStop = handleGoogleMeetNodeHostCommand(stopParams).finally(() => {
+        firstSettled = true;
+      });
+      const secondStop = handleGoogleMeetNodeHostCommand(stopParams).finally(() => {
+        secondSettled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(firstSettled).toBe(false);
+      expect(secondSettled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const [firstResult, secondResult] = await Promise.all([firstStop, secondStop]);
+      expect(JSON.parse(firstResult)).toEqual({ ok: true, stopped: 1 });
+      expect(JSON.parse(secondResult)).toEqual({ ok: true, stopped: 0 });
+      expect(outputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+      expect(inputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
     } finally {
       Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
     }
@@ -314,7 +472,10 @@ describe("google-meet node host bridge sessions", () => {
       expect(activeList.bridges[0]?.url).toBe("https://meet.google.com/abc-defg-hij?authuser=1");
       expect(typeof activeList.bridges[0]?.createdAt).toBe("string");
 
-      children[1]?.emit("exit", 0, null);
+      if (children[1]) {
+        children[1].exitCode = 0;
+        children[1].emit("exit", 0, null);
+      }
 
       const afterExitList = JSON.parse(
         await handleGoogleMeetNodeHostCommand(

--- a/extensions/google-meet/src/bridge-process.ts
+++ b/extensions/google-meet/src/bridge-process.ts
@@ -1,0 +1,70 @@
+import type { ChildProcess } from "node:child_process";
+
+type TerminateGoogleMeetBridgeProcessOptions = {
+  graceMs: number;
+  forceKillWaitMs?: number;
+  initialSignal?: NodeJS.Signals;
+};
+
+function hasExited(proc: ChildProcess): boolean {
+  return proc.exitCode != null || proc.signalCode != null;
+}
+
+function waitForExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (hasExited(proc)) {
+    return Promise.resolve(true);
+  }
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      proc.off("exit", onExit);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    const timeout = setTimeout(() => finish(hasExited(proc)), timeoutMs);
+    timeout.unref?.();
+    proc.once("exit", onExit);
+    if (hasExited(proc)) {
+      finish(true);
+    }
+  });
+}
+
+/** Resolve only after the child exits or the bounded force-kill sequence finishes. */
+export async function terminateGoogleMeetBridgeProcess(
+  proc: ChildProcess | undefined,
+  options: TerminateGoogleMeetBridgeProcessOptions,
+): Promise<void> {
+  if (!proc || hasExited(proc)) {
+    return;
+  }
+  const initialSignal = options.initialSignal ?? "SIGTERM";
+  try {
+    if (!proc.kill(initialSignal)) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  const forceKillWaitMs = options.forceKillWaitMs ?? 1_000;
+  if (initialSignal === "SIGKILL") {
+    await waitForExit(proc, forceKillWaitMs);
+    return;
+  }
+  if (await waitForExit(proc, options.graceMs)) {
+    return;
+  }
+  try {
+    if (!proc.kill("SIGKILL")) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  await waitForExit(proc, forceKillWaitMs);
+}

--- a/extensions/google-meet/src/node-host.ts
+++ b/extensions/google-meet/src/node-host.ts
@@ -2,6 +2,7 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
+import { terminateGoogleMeetBridgeProcess } from "./bridge-process.js";
 import {
   DEFAULT_GOOGLE_MEET_AUDIO_INPUT_COMMAND,
   DEFAULT_GOOGLE_MEET_AUDIO_OUTPUT_COMMAND,
@@ -30,9 +31,12 @@ type NodeBridgeSession = {
   lastOutputBytes: number;
   closedAt?: string;
   clearCount: number;
+  stopPromise?: Promise<void>;
+  retiredOutputStops: Set<Promise<void>>;
 };
 
 const sessions = new Map<string, NodeBridgeSession>();
+const NODE_BRIDGE_TERMINATION_GRACE_MS = 2_000;
 
 function readStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
@@ -107,23 +111,41 @@ function wake(session: NodeBridgeSession) {
   }
 }
 
-function stopSession(session: NodeBridgeSession) {
+function retireOutputProcess(session: NodeBridgeSession, outputProcess: ChildProcess | undefined) {
+  const stopPromise = terminateGoogleMeetBridgeProcess(outputProcess, {
+    graceMs: NODE_BRIDGE_TERMINATION_GRACE_MS,
+  });
+  session.retiredOutputStops.add(stopPromise);
+  void stopPromise.finally(() => {
+    session.retiredOutputStops.delete(stopPromise);
+  });
+}
+
+function stopSession(session: NodeBridgeSession): Promise<void> {
   // Process and stream errors can arrive together during teardown. Close once
-  // so the same children do not get duplicate termination timers.
-  if (session.closed) {
-    return;
+  // so every caller shares the same bounded process-termination promise.
+  if (session.stopPromise) {
+    return session.stopPromise;
   }
   session.closed = true;
   session.closedAt = new Date().toISOString();
-  terminateChild(session.input);
-  terminateChild(session.output);
   wake(session);
+  session.stopPromise = Promise.all([
+    terminateGoogleMeetBridgeProcess(session.input, {
+      graceMs: NODE_BRIDGE_TERMINATION_GRACE_MS,
+    }),
+    terminateGoogleMeetBridgeProcess(session.output, {
+      graceMs: NODE_BRIDGE_TERMINATION_GRACE_MS,
+    }),
+    ...session.retiredOutputStops,
+  ]).then(() => undefined);
+  return session.stopPromise;
 }
 
 function attachOutputProcessHandlers(session: NodeBridgeSession, outputProcess: ChildProcess) {
   const stopIfCurrent = () => {
     if (session.output === outputProcess) {
-      stopSession(session);
+      void stopSession(session);
     }
   };
   outputProcess.on("exit", stopIfCurrent);
@@ -158,6 +180,7 @@ function startCommandPair(params: {
     lastInputBytes: 0,
     lastOutputBytes: 0,
     clearCount: 0,
+    retiredOutputStops: new Set(),
   };
   const outputProcess = startOutputProcess(output);
   const inputProcess = spawn(input.command, input.args, {
@@ -175,7 +198,9 @@ function startCommandPair(params: {
     }
     wake(session);
   });
-  const stop = () => stopSession(session);
+  const stop = () => {
+    void stopSession(session);
+  };
   inputProcess.on("exit", stop);
   inputProcess.on("error", stop);
   inputProcess.stdout?.on("error", stop);
@@ -183,32 +208,6 @@ function startCommandPair(params: {
   attachOutputProcessHandlers(session, outputProcess);
   sessions.set(session.id, session);
   return session;
-}
-
-function terminateChild(child?: ChildProcess) {
-  if (!child) {
-    return;
-  }
-  let exited = child.exitCode !== null || child.signalCode !== null;
-  child.once?.("exit", () => {
-    exited = true;
-  });
-  try {
-    child.kill("SIGTERM");
-  } catch {
-    // Best-effort cleanup for node-host child processes.
-  }
-  const timer = setTimeout(() => {
-    if (exited) {
-      return;
-    }
-    try {
-      child.kill("SIGKILL");
-    } catch {
-      // Process may have exited after the grace check.
-    }
-  }, 2_000);
-  timer.unref?.();
 }
 
 async function pullAudio(params: Record<string, unknown>) {
@@ -253,7 +252,7 @@ function pushAudio(params: Record<string, unknown>) {
   try {
     session.output?.stdin?.write(audio);
   } catch {
-    stopSession(session);
+    void stopSession(session);
     throw new Error(`bridge is not open: ${bridgeId}`);
   }
   return { bridgeId, ok: true };
@@ -274,7 +273,7 @@ function clearAudio(params: Record<string, unknown>) {
   attachOutputProcessHandlers(session, outputProcess);
   session.clearCount += 1;
   session.lastClearAt = new Date().toISOString();
-  terminateChild(previousOutput);
+  retireOutputProcess(session, previousOutput);
   return { bridgeId, ok: true, clearCount: session.clearCount };
 }
 
@@ -339,7 +338,7 @@ function startChrome(params: Record<string, unknown>) {
       if (bridgeId) {
         const session = sessions.get(bridgeId);
         if (session) {
-          stopSession(session);
+          void stopSession(session);
         }
       }
       throw new Error(
@@ -430,7 +429,7 @@ function listSessions(params: Record<string, unknown>) {
   return { bridges };
 }
 
-function stopSessionsByUrl(params: Record<string, unknown>) {
+async function stopSessionsByUrl(params: Record<string, unknown>) {
   const urlKey = normalizeMeetKey(readString(params.url));
   if (!urlKey) {
     throw new Error("url required");
@@ -438,6 +437,11 @@ function stopSessionsByUrl(params: Record<string, unknown>) {
   const mode = readString(params.mode);
   const exceptBridgeId = readString(params.exceptBridgeId);
   let stopped = 0;
+  const stopping: Array<{
+    bridgeId: string;
+    session: NodeBridgeSession;
+    stopPromise: Promise<void>;
+  }> = [];
   for (const [bridgeId, session] of sessions) {
     if (exceptBridgeId && bridgeId === exceptBridgeId) {
       continue;
@@ -449,16 +453,21 @@ function stopSessionsByUrl(params: Record<string, unknown>) {
       continue;
     }
     const wasClosed = session.closed;
-    stopSession(session);
-    sessions.delete(bridgeId);
+    stopping.push({ bridgeId, session, stopPromise: stopSession(session) });
     if (!wasClosed) {
       stopped += 1;
+    }
+  }
+  await Promise.all(stopping.map(({ stopPromise }) => stopPromise));
+  for (const { bridgeId, session } of stopping) {
+    if (sessions.get(bridgeId) === session) {
+      sessions.delete(bridgeId);
     }
   }
   return { ok: true, stopped };
 }
 
-function stopChrome(params: Record<string, unknown>) {
+async function stopChrome(params: Record<string, unknown>) {
   const bridgeId = readString(params.bridgeId);
   if (!bridgeId) {
     return { ok: true, stopped: false };
@@ -467,7 +476,7 @@ function stopChrome(params: Record<string, unknown>) {
   if (!session) {
     return { ok: true, stopped: false };
   }
-  stopSession(session);
+  await stopSession(session);
   sessions.delete(bridgeId);
   return { ok: true, stopped: true };
 }
@@ -499,7 +508,7 @@ export async function handleGoogleMeetNodeHostCommand(paramsJSON?: string | null
       result = listSessions(params);
       break;
     case "stopByUrl":
-      result = stopSessionsByUrl(params);
+      result = await stopSessionsByUrl(params);
       break;
     case "pullAudio":
       result = await pullAudio(params);
@@ -511,7 +520,7 @@ export async function handleGoogleMeetNodeHostCommand(paramsJSON?: string | null
       result = clearAudio(params);
       break;
     case "stop":
-      result = stopChrome(params);
+      result = await stopChrome(params);
       break;
     default:
       throw new Error("unsupported googlemeet.chrome action");

--- a/extensions/google-meet/src/realtime-node.ts
+++ b/extensions/google-meet/src/realtime-node.ts
@@ -175,6 +175,7 @@ export async function startNodeAgentAudioBridge(params: {
   providers?: RealtimeTranscriptionProviderPlugin[];
 }): Promise<ChromeNodeRealtimeAudioBridgeHandle> {
   let stopped = false;
+  let stopPromise: Promise<void> | undefined;
   let sttSession: RealtimeTranscriptionSession | null = null;
   let realtimeReady = false;
   let lastOutputAt: string | undefined;
@@ -196,31 +197,31 @@ export async function startNodeAgentAudioBridge(params: {
   const transcript: GoogleMeetRealtimeTranscriptEntry[] = [];
   let ttsQueue = Promise.resolve();
 
-  const stop = async () => {
-    if (stopped) {
-      return;
-    }
-    stopped = true;
-    agentTalkback?.close();
-    try {
-      sttSession?.close();
-    } catch (error) {
-      params.logger.debug?.(
-        `[google-meet] node agent transcription bridge close ignored: ${formatErrorMessage(error)}`,
-      );
-    }
-    try {
-      await params.runtime.nodes.invoke({
-        nodeId: params.nodeId,
-        command: "googlemeet.chrome",
-        params: { action: "stop", bridgeId: params.bridgeId },
-        timeoutMs: 5_000,
-      });
-    } catch (error) {
-      params.logger.debug?.(
-        `[google-meet] node audio bridge stop ignored: ${formatErrorMessage(error)}`,
-      );
-    }
+  const stop = () => {
+    stopPromise ??= (async () => {
+      stopped = true;
+      agentTalkback?.close();
+      try {
+        sttSession?.close();
+      } catch (error) {
+        params.logger.debug?.(
+          `[google-meet] node agent transcription bridge close ignored: ${formatErrorMessage(error)}`,
+        );
+      }
+      try {
+        await params.runtime.nodes.invoke({
+          nodeId: params.nodeId,
+          command: "googlemeet.chrome",
+          params: { action: "stop", bridgeId: params.bridgeId },
+          timeoutMs: 5_000,
+        });
+      } catch (error) {
+        params.logger.debug?.(
+          `[google-meet] node audio bridge stop ignored: ${formatErrorMessage(error)}`,
+        );
+      }
+    })();
+    return stopPromise;
   };
 
   const pushOutputAudio = async (audio: Buffer) => {
@@ -382,6 +383,7 @@ export async function startNodeRealtimeAudioBridge(params: {
   providers?: RealtimeVoiceProviderPlugin[];
 }): Promise<ChromeNodeRealtimeAudioBridgeHandle> {
   let stopped = false;
+  let stopPromise: Promise<void> | undefined;
   let bridge: RealtimeVoiceBridgeSession | null = null;
   let realtimeReady = false;
   let lastOutputAt: string | undefined;
@@ -482,31 +484,31 @@ export async function startNodeRealtimeAudioBridge(params: {
       },
     });
 
-  const stop = async () => {
-    if (stopped) {
-      return;
-    }
-    stopped = true;
-    agentTalkback?.close();
-    try {
-      bridge?.close();
-    } catch (error) {
-      params.logger.debug?.(
-        `[google-meet] node realtime bridge close ignored: ${formatErrorMessage(error)}`,
-      );
-    }
-    try {
-      await params.runtime.nodes.invoke({
-        nodeId: params.nodeId,
-        command: "googlemeet.chrome",
-        params: { action: "stop", bridgeId: params.bridgeId },
-        timeoutMs: 5_000,
-      });
-    } catch (error) {
-      params.logger.debug?.(
-        `[google-meet] node audio bridge stop ignored: ${formatErrorMessage(error)}`,
-      );
-    }
+  const stop = () => {
+    stopPromise ??= (async () => {
+      stopped = true;
+      agentTalkback?.close();
+      try {
+        bridge?.close();
+      } catch (error) {
+        params.logger.debug?.(
+          `[google-meet] node realtime bridge close ignored: ${formatErrorMessage(error)}`,
+        );
+      }
+      try {
+        await params.runtime.nodes.invoke({
+          nodeId: params.nodeId,
+          command: "googlemeet.chrome",
+          params: { action: "stop", bridgeId: params.bridgeId },
+          timeoutMs: 5_000,
+        });
+      } catch (error) {
+        params.logger.debug?.(
+          `[google-meet] node audio bridge stop ignored: ${formatErrorMessage(error)}`,
+        );
+      }
+    })();
+    return stopPromise;
   };
 
   bridge = createRealtimeVoiceBridgeSession({

--- a/extensions/google-meet/src/realtime.process.test.ts
+++ b/extensions/google-meet/src/realtime.process.test.ts
@@ -32,6 +32,24 @@ function writeBridgeCommand(): string {
   return scriptPath;
 }
 
+function writeSigtermResistantBridgeCommand(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-bridge-resistant-"));
+  tempDirs.push(dir);
+  const scriptPath = path.join(dir, "bridge-command.mjs");
+  writeFileSync(
+    scriptPath,
+    [
+      "process.on('SIGTERM', () => {});",
+      "setTimeout(() => process.stderr.write('ready\\n'), 100);",
+      "process.stdin.resume();",
+      "setInterval(() => {}, 1000);",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return scriptPath;
+}
+
 function makeRecordingSpawn(): NonNullable<
   Parameters<typeof startCommandAgentAudioBridge>[0]["spawn"]
 > {
@@ -128,6 +146,62 @@ describe("startCommandAgentAudioBridge real process stream errors", () => {
         inputProcess.pid ?? "unknown"
       } outputPid=${outputProcess.pid ?? "unknown"}`,
     );
+  });
+
+  it("waits for SIGTERM-resistant bridge processes to exit before stop resolves", async () => {
+    const bridgeScript = writeSigtermResistantBridgeCommand();
+    const sttSession = {
+      connect: vi.fn(async () => {}),
+      sendAudio: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeTranscriptionProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      defaultModel: "gpt-4o-transcribe",
+      autoSelectOrder: 1,
+      resolveConfig: ({ rawConfig }) => rawConfig,
+      isConfigured: () => true,
+      createSession: () => sttSession,
+    };
+    const handle = await startCommandAgentAudioBridge({
+      config: resolveGoogleMeetConfig({
+        chrome: { audioFormat: "pcm16-24khz" },
+        realtime: { provider: "openai", agentId: "jay", introMessage: "" },
+      }),
+      fullConfig: {} as never,
+      runtime: {} as never,
+      meetingSessionId: "meet-resistant",
+      inputCommand: [process.execPath, bridgeScript, "capture"],
+      outputCommand: [process.execPath, bridgeScript, "play"],
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() } as never,
+      providers: [provider],
+      spawn: makeRecordingSpawn(),
+    });
+    const [outputProcess, inputProcess] = spawnedChildren;
+    if (!inputProcess || !outputProcess) {
+      throw new Error("Expected Google Meet bridge to spawn input and output child processes");
+    }
+    const inputKillSpy = vi.spyOn(inputProcess, "kill");
+    const outputKillSpy = vi.spyOn(outputProcess, "kill");
+    await Promise.all([once(inputProcess.stderr!, "data"), once(outputProcess.stderr!, "data")]);
+
+    const startedAt = Date.now();
+    const firstStop = handle.stop();
+    const secondStop = handle.stop();
+    expect(secondStop).toBe(firstStop);
+    await firstStop;
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(inputProcess.signalCode).toBe("SIGKILL");
+    expect(outputProcess.signalCode).toBe("SIGKILL");
+    expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+    expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+    expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
+    expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGKILL")).toHaveLength(1);
+    expect(elapsedMs).toBeGreaterThanOrEqual(900);
+    expect(elapsedMs).toBeLessThan(5_000);
   });
 });
 

--- a/extensions/google-meet/src/realtime.ts
+++ b/extensions/google-meet/src/realtime.ts
@@ -1,6 +1,5 @@
 // Google Meet plugin module implements realtime behavior.
-import { spawn } from "node:child_process";
-import type { Writable } from "node:stream";
+import { spawn, type ChildProcess } from "node:child_process";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
@@ -46,62 +45,17 @@ import {
   handleGoogleMeetRealtimeConsultToolCall,
   resolveGoogleMeetRealtimeTools,
 } from "./agent-consult.js";
+import { terminateGoogleMeetBridgeProcess } from "./bridge-process.js";
 import type { GoogleMeetConfig } from "./config.js";
 import type { GoogleMeetChromeHealth } from "./transports/types.js";
 
-type BridgeProcess = {
-  pid?: number;
-  killed?: boolean;
-  stdin?: Writable | null;
-  stdout?: {
-    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
-    on(event: "error", listener: (error: Error) => void): unknown;
-  } | null;
-  stderr?: {
-    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
-    on(event: "error", listener: (error: Error) => void): unknown;
-  } | null;
-  kill(signal?: NodeJS.Signals): boolean;
-  on(
-    event: "exit",
-    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
-  ): unknown;
-  on(event: "error", listener: (error: Error) => void): unknown;
-};
+const LOCAL_BRIDGE_TERMINATION_GRACE_MS = 1_000;
 
 type SpawnFn = (
   command: string,
   args: string[],
   options: { stdio: ["pipe" | "ignore", "pipe" | "ignore", "pipe" | "ignore"] },
-) => BridgeProcess;
-
-function terminateBridgeProcess(proc: BridgeProcess, signal: NodeJS.Signals = "SIGTERM"): void {
-  if (proc.killed && signal !== "SIGKILL") {
-    return;
-  }
-  let exited = false;
-  proc.on("exit", () => {
-    exited = true;
-  });
-  try {
-    proc.kill(signal);
-  } catch {
-    return;
-  }
-  if (signal === "SIGKILL") {
-    return;
-  }
-  const timer = setTimeout(() => {
-    if (!exited) {
-      try {
-        proc.kill("SIGKILL");
-      } catch {
-        // Process may have exited after the grace check.
-      }
-    }
-  }, 1000);
-  timer.unref?.();
-}
+) => ChildProcess;
 
 export type ChromeRealtimeAudioBridgeHandle = {
   providerId: string;
@@ -519,8 +473,7 @@ export async function startCommandAgentAudioBridge(params: {
   const input = splitCommand(params.inputCommand);
   const output = splitCommand(params.outputCommand);
   const spawnFn: SpawnFn =
-    params.spawn ??
-    ((command, args, options) => spawn(command, args, options) as unknown as BridgeProcess);
+    params.spawn ?? ((command, args, options) => spawn(command, args, options));
   const outputProcess = spawnFn(output.command, output.args, {
     stdio: ["pipe", "ignore", "pipe"],
   });
@@ -528,6 +481,7 @@ export async function startCommandAgentAudioBridge(params: {
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stopped = false;
+  let stopPromise: Promise<void> | undefined;
   let sttSession: RealtimeTranscriptionSession | null = null;
   let realtimeReady = false;
   let lastInputAt: string | undefined;
@@ -584,26 +538,32 @@ export async function startCommandAgentAudioBridge(params: {
     }),
   );
 
-  const stop = async () => {
-    if (stopped) {
-      return;
-    }
-    stopped = true;
-    agentTalkback?.close();
-    try {
-      sttSession?.close();
-    } catch (error) {
-      params.logger.debug?.(
-        `[google-meet] agent transcription bridge close ignored: ${formatErrorMessage(error)}`,
-      );
-    }
-    emitTalkEvent({
-      type: "session.closed",
-      final: true,
-      payload: { meetingSessionId: params.meetingSessionId },
-    });
-    terminateBridgeProcess(inputProcess);
-    terminateBridgeProcess(outputProcess);
+  const stop = () => {
+    stopPromise ??= (async () => {
+      stopped = true;
+      agentTalkback?.close();
+      try {
+        sttSession?.close();
+      } catch (error) {
+        params.logger.debug?.(
+          `[google-meet] agent transcription bridge close ignored: ${formatErrorMessage(error)}`,
+        );
+      }
+      emitTalkEvent({
+        type: "session.closed",
+        final: true,
+        payload: { meetingSessionId: params.meetingSessionId },
+      });
+      await Promise.all([
+        terminateGoogleMeetBridgeProcess(inputProcess, {
+          graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+        }),
+        terminateGoogleMeetBridgeProcess(outputProcess, {
+          graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+        }),
+      ]);
+    })();
+    return stopPromise;
   };
 
   const fail = (label: string) => (error: Error) => {
@@ -848,8 +808,7 @@ export async function startCommandRealtimeAudioBridge(params: {
   const input = splitCommand(params.inputCommand);
   const output = splitCommand(params.outputCommand);
   const spawnFn: SpawnFn =
-    params.spawn ??
-    ((command, args, options) => spawn(command, args, options) as unknown as BridgeProcess);
+    params.spawn ?? ((command, args, options) => spawn(command, args, options));
   const spawnOutputProcess = () =>
     spawnFn(output.command, output.args, {
       stdio: ["pipe", "ignore", "pipe"],
@@ -859,6 +818,7 @@ export async function startCommandRealtimeAudioBridge(params: {
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stopped = false;
+  let stopPromise: Promise<void> | undefined;
   let bridge: RealtimeVoiceBridgeSession | null = null;
   let realtimeReady = false;
   let lastInputAt: string | undefined;
@@ -871,7 +831,8 @@ export async function startCommandRealtimeAudioBridge(params: {
   let lastSuppressedInputAt: string | undefined;
   let suppressInputUntil = 0;
   let lastOutputPlayableUntilMs = 0;
-  let bargeInInputProcess: BridgeProcess | undefined;
+  let bargeInInputProcess: ChildProcess | undefined;
+  const retiredOutputStops = new Set<Promise<void>>();
 
   const suppressInputForOutput = (audio: Buffer) => {
     const suppression = recordGoogleMeetOutputActivity({
@@ -886,31 +847,38 @@ export async function startCommandRealtimeAudioBridge(params: {
     lastOutputPlayableUntilMs = suppression.lastOutputPlayableUntilMs;
   };
 
-  const stop = async () => {
-    if (stopped) {
-      return;
-    }
-    stopped = true;
-    agentTalkback?.close();
-    try {
-      bridge?.close();
-    } catch (error) {
-      params.logger.debug?.(
-        `[google-meet] realtime voice bridge close ignored: ${formatErrorMessage(error)}`,
-      );
-    }
-    terminateBridgeProcess(inputProcess);
-    terminateBridgeProcess(outputProcess);
-    if (bargeInInputProcess) {
-      terminateBridgeProcess(bargeInInputProcess);
-    }
+  const stop = () => {
+    stopPromise ??= (async () => {
+      stopped = true;
+      agentTalkback?.close();
+      try {
+        bridge?.close();
+      } catch (error) {
+        params.logger.debug?.(
+          `[google-meet] realtime voice bridge close ignored: ${formatErrorMessage(error)}`,
+        );
+      }
+      await Promise.all([
+        terminateGoogleMeetBridgeProcess(inputProcess, {
+          graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+        }),
+        terminateGoogleMeetBridgeProcess(outputProcess, {
+          graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+        }),
+        terminateGoogleMeetBridgeProcess(bargeInInputProcess, {
+          graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+        }),
+        ...retiredOutputStops,
+      ]);
+    })();
+    return stopPromise;
   };
 
   const fail = (label: string) => (error: Error) => {
     params.logger.warn(`[google-meet] ${label} failed: ${formatErrorMessage(error)}`);
     void stop();
   };
-  const attachOutputProcessHandlers = (proc: BridgeProcess) => {
+  const attachOutputProcessHandlers = (proc: ChildProcess) => {
     proc.on("error", (error) => {
       if (proc !== outputProcess) {
         return;
@@ -958,7 +926,14 @@ export async function startCommandRealtimeAudioBridge(params: {
     params.logger.debug?.(
       `[google-meet] cleared realtime audio output buffer by restarting playback command`,
     );
-    terminateBridgeProcess(previousOutput, "SIGKILL");
+    const retiredOutputStop = terminateGoogleMeetBridgeProcess(previousOutput, {
+      graceMs: LOCAL_BRIDGE_TERMINATION_GRACE_MS,
+      initialSignal: "SIGKILL",
+    });
+    retiredOutputStops.add(retiredOutputStop);
+    void retiredOutputStop.finally(() => {
+      retiredOutputStops.delete(retiredOutputStop);
+    });
   };
   const writeOutputAudio = (audio: Buffer) => {
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where leaving a Google Meet session could finish audio bridge shutdown while the configured capture and playback child processes were still running when they ignored SIGTERM. Browser release and session retirement could therefore race lingering audio subprocesses.

## Why This Change Was Made

Google Meet command-pair bridges now share one in-flight stop promise and use one bounded SIGTERM-to-SIGKILL termination owner. Both local and paired-node stop paths await current children plus playback processes retired by `clearAudio`, and concurrent `stopByUrl` callers keep awaiting the same in-progress session cleanup. The change preserves the existing grace periods and leaves config, protocol, media, and provider behavior unchanged.

## User Impact

Leaving a Google Meet session now waits for bounded audio subprocess cleanup instead of returning immediately after scheduling signals. SIGTERM-resistant bridge commands are force-killed within the existing finite shutdown window, and concurrent stop callers observe the same completion.

## Evidence

- Latest `main` snapshot `0340d7c0c143` reproduced the bug with two real SIGTERM-resistant audio child processes: `stop()` returned in 15 ms, returned distinct promises to concurrent callers, and both children were still running after receiving only SIGTERM.
- With this change, the same production bridge path returned one shared stop promise, escalated each child exactly once from SIGTERM to SIGKILL, and resolved after 1034 ms with both child exits observable.
- `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts extensions/google-meet/node-host.test.ts extensions/google-meet/src/realtime.process.test.ts` — 3 files passed, 157 tests passed, including local and paired-node stop-after-clear regressions.
- Targeted `oxfmt --check`, type-aware `run-oxlint.mjs`, and `git diff --check` passed for all seven changed files.
- `pnpm check:max-lines-ratchet --base 0340d7c0c143433cdbdf7b74139e0e7e3420d5a0` passed against the exact synthetic PR merge preview.
- A fresh semantic open-PR sweep found no competing implementation; the only recalled item, #73606, is a docs-only future call-SDK RFC and does not change this shutdown path.
- Remote `check:changed` could not start because this environment has neither the Blacksmith executable nor Crabbox broker/AWS credentials. A standalone local `tsgo` fallback was also stopped before execution by the mandatory cgroup resource guard. No failed code check was suppressed; the affected tests, type-aware lint, extension boundary preparation, format, and live process proof above all passed.
