### PR TITLE
fix(vydra): bound stalled generated image download body reads

### DIFF
--- a/extensions/vydra/shared.test.ts
+++ b/extensions/vydra/shared.test.ts
@@ -1,0 +1,115 @@
+// Vydra tests cover shared download timeout plugin behavior.
+import { once } from "node:events";
+import http from "node:http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { downloadVydraAsset } from "./shared.js";
+
+describe("downloadVydraAsset", () => {
+  let server: http.Server | undefined;
+  const dripTimers = new Set<ReturnType<typeof setTimeout>>();
+
+  afterEach(async () => {
+    for (const timer of dripTimers) {
+      clearTimeout(timer);
+    }
+    dripTimers.clear();
+    if (!server) {
+      return;
+    }
+    server.closeAllConnections?.();
+    server.close();
+    await once(server, "close").catch(() => undefined);
+    server = undefined;
+  });
+
+  it("bounds a dripping download body with one wall-clock deadline", async () => {
+    const timeoutMs = 250;
+    server = http.createServer((_req, res) => {
+      res.on("error", () => {});
+      res.writeHead(200, {
+        "Content-Type": "image/png",
+        "Transfer-Encoding": "chunked",
+      });
+      // Keep sending bytes so chunk idle alone would never fire.
+      const drip = () => {
+        if (res.writableEnded || res.destroyed) {
+          return;
+        }
+        res.write(Buffer.from([0x00]));
+        const timer = setTimeout(drip, 20);
+        dripTimers.add(timer);
+      };
+      drip();
+    });
+    server.on("clientError", (_err, socket) => socket.destroy());
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+
+    const startedAt = performance.now();
+    await expect(
+      downloadVydraAsset({
+        url: `http://127.0.0.1:${address.port}/generated/test.png`,
+        kind: "image",
+        timeoutMs,
+        fetchFn: fetch,
+        maxBytes: 1024 * 1024,
+      }),
+    ).rejects.toThrow(`Vydra image download timed out after ${timeoutMs}ms`);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 50);
+    expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
+  });
+
+  it("does not bound a dripping body when only chunk idle timeout is used", async () => {
+    // Negative control: chunkTimeoutMs resets on every drip, so idle alone never fires.
+    server = http.createServer((_req, res) => {
+      res.on("error", () => {});
+      res.writeHead(200, {
+        "Content-Type": "image/png",
+        "Transfer-Encoding": "chunked",
+      });
+      const drip = () => {
+        if (res.writableEnded || res.destroyed) {
+          return;
+        }
+        res.write(Buffer.from([0x00]));
+        const timer = setTimeout(drip, 20);
+        dripTimers.add(timer);
+      };
+      drip();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+    let settled = false;
+    void readResponseWithLimit(response, 1024 * 1024, {
+      chunkTimeoutMs: 100,
+      onIdleTimeout: ({ chunkTimeoutMs }) => new Error(`idle fired after ${chunkTimeoutMs}ms`),
+    })
+      .then(() => {
+        settled = true;
+      })
+      .catch(() => {
+        settled = true;
+      });
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 400);
+    });
+    expect(settled).toBe(false);
+    // Body reader is locked by readResponseWithLimit; tear down via server close in afterEach.
+  });
+});

--- a/extensions/vydra/shared.test.ts
+++ b/extensions/vydra/shared.test.ts
@@ -23,12 +23,15 @@ describe("downloadVydraAsset", () => {
     server = undefined;
   });
 
-  it("bounds a dripping download body with one wall-clock deadline", async () => {
-    const timeoutMs = 250;
+  async function listenDripServer(params: {
+    statusCode: number;
+    contentType: string;
+    chunk: Buffer | string;
+  }): Promise<number> {
     server = http.createServer((_req, res) => {
       res.on("error", () => {});
-      res.writeHead(200, {
-        "Content-Type": "image/png",
+      res.writeHead(params.statusCode, {
+        "Content-Type": params.contentType,
         "Transfer-Encoding": "chunked",
       });
       // Keep sending bytes so chunk idle alone would never fire.
@@ -36,7 +39,7 @@ describe("downloadVydraAsset", () => {
         if (res.writableEnded || res.destroyed) {
           return;
         }
-        res.write(Buffer.from([0x00]));
+        res.write(params.chunk);
         const timer = setTimeout(drip, 20);
         dripTimers.add(timer);
       };
@@ -45,16 +48,49 @@ describe("downloadVydraAsset", () => {
     server.on("clientError", (_err, socket) => socket.destroy());
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
-
     const address = server.address();
     if (!address || typeof address === "string") {
       throw new Error("expected loopback server address");
     }
+    return address.port;
+  }
+
+  it("bounds a dripping download body with one wall-clock deadline", async () => {
+    const timeoutMs = 250;
+    const port = await listenDripServer({
+      statusCode: 200,
+      contentType: "image/png",
+      chunk: Buffer.from([0x00]),
+    });
 
     const startedAt = performance.now();
     await expect(
       downloadVydraAsset({
-        url: `http://127.0.0.1:${address.port}/generated/test.png`,
+        url: `http://127.0.0.1:${port}/generated/test.png`,
+        kind: "image",
+        timeoutMs,
+        fetchFn: fetch,
+        maxBytes: 1024 * 1024,
+      }),
+    ).rejects.toThrow(`Vydra image download timed out after ${timeoutMs}ms`);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 50);
+    expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
+  });
+
+  it("bounds a dripping non-2xx error body with one wall-clock deadline", async () => {
+    const timeoutMs = 250;
+    const port = await listenDripServer({
+      statusCode: 500,
+      contentType: "text/plain",
+      chunk: "e",
+    });
+
+    const startedAt = performance.now();
+    await expect(
+      downloadVydraAsset({
+        url: `http://127.0.0.1:${port}/generated/test.png`,
         kind: "image",
         timeoutMs,
         fetchFn: fetch,

--- a/extensions/vydra/shared.test.ts
+++ b/extensions/vydra/shared.test.ts
@@ -103,6 +103,45 @@ describe("downloadVydraAsset", () => {
     expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
   });
 
+  it("preserves normalized and redacted provider errors after the bounded read", async () => {
+    const result = await downloadVydraAsset({
+      url: "https://cdn.vydra.example/generated/test.png",
+      kind: "image",
+      timeoutMs: 250,
+      fetchFn: async () =>
+        new Response(
+          JSON.stringify({ message: "Authorization: Bearer test-token", code: "asset_failed" }),
+          {
+            status: 502,
+            headers: { "x-request-id": "req-vydra-test" },
+          },
+        ),
+      maxBytes: 1024 * 1024,
+    }).catch((error: unknown) => error);
+
+    expect(result).toMatchObject({
+      name: "ProviderHttpError",
+      status: 502,
+      statusCode: 502,
+      errorCode: "asset_failed",
+      requestId: "req-vydra-test",
+    });
+    expect(result).toBeInstanceOf(Error);
+    expect(result instanceof Error ? result.message : "").not.toContain("test-token");
+  });
+
+  it("normalizes null-body HTTP errors after the bounded read", async () => {
+    const result = await downloadVydraAsset({
+      url: "https://cdn.vydra.example/generated/test.png",
+      kind: "image",
+      timeoutMs: 250,
+      fetchFn: async () => new Response(null, { status: 304 }),
+      maxBytes: 1024 * 1024,
+    }).catch((error: unknown) => error);
+
+    expect(result).toMatchObject({ name: "ProviderHttpError", status: 304, statusCode: 304 });
+  });
+
   it("does not bound a dripping body when only chunk idle timeout is used", async () => {
     // Negative control: chunkTimeoutMs resets on every drip, so idle alone never fires.
     server = http.createServer((_req, res) => {

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -4,6 +4,7 @@ import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
+  createProviderHttpError,
   createProviderOperationDeadline,
   fetchWithTimeout,
   readProviderJsonResponse,
@@ -271,10 +272,16 @@ export async function downloadVydraAsset(params: {
       16 * 1024,
       resolveVydraDownloadBodyTimeout({ kind: params.kind, timeoutMs, deadlineMs }),
     );
-    const detail = prefix.text.replace(/\s+/g, " ").trim();
-    throw new Error(
-      `Vydra ${params.kind} download failed (HTTP ${response.status})` +
-        (detail ? `: ${detail.length > 220 ? `${detail.slice(0, 219)}…` : detail}` : ""),
+    // Re-run the bounded body through the shared formatter so provider error metadata and
+    // sensitive-text redaction remain identical to the previous assertOkOrThrowHttpError path.
+    throw await createProviderHttpError(
+      new Response(prefix.text || null, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      }),
+      `Vydra ${params.kind} download failed`,
+      { statusPrefix: "HTTP " },
     );
   }
   const mimeType =

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -241,6 +241,9 @@ export async function downloadVydraAsset(params: {
   maxBytes: number;
 }): Promise<{ buffer: Buffer; mimeType: string; fileName: string }> {
   const timeoutMs = resolveVydraHttpTimeoutMs(params.timeoutMs);
+  // fetchWithTimeout clears its abort after headers land. Keep one wall-clock deadline across
+  // the body read so a slow drip cannot reset chunk idle forever past the download budget.
+  const deadlineMs = Date.now() + timeoutMs;
   const response = await fetchWithTimeout(params.url, { method: "GET" }, timeoutMs, params.fetchFn);
   await assertOkOrThrowHttpError(response, `Vydra ${params.kind} download failed`);
   const mimeType =
@@ -248,10 +251,12 @@ export async function downloadVydraAsset(params: {
     (params.kind === "image" ? "image/png" : params.kind === "audio" ? "audio/mpeg" : "video/mp4");
   const buffer = await readResponseWithLimit(response, params.maxBytes, {
     chunkTimeoutMs: timeoutMs,
+    timeoutMs: Math.max(1, deadlineMs - Date.now()),
     onOverflow: ({ maxBytes }) =>
       new Error(`Vydra ${params.kind} download exceeds ${maxBytes} bytes`),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Vydra ${params.kind} download stalled after ${chunkTimeoutMs}ms`),
+    onTimeout: () => new Error(`Vydra ${params.kind} download timed out after ${timeoutMs}ms`),
   });
   const extension = resolveVydraFileExtension(params.kind, mimeType);
   const fileStem = params.kind === "image" ? "image" : params.kind === "audio" ? "audio" : "video";

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -13,7 +13,10 @@ import {
   type ProviderOperationDeadline,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import {
+  readResponseTextPrefix,
+  readResponseWithLimit,
+} from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -233,6 +236,21 @@ export function resolveVydraGeneratedMediaMaxBytes(params: {
   return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
+function resolveVydraDownloadBodyTimeout(params: {
+  kind: VydraMediaKind;
+  timeoutMs: number;
+  deadlineMs: number;
+}) {
+  return {
+    chunkTimeoutMs: params.timeoutMs,
+    timeoutMs: Math.max(1, params.deadlineMs - Date.now()),
+    onIdleTimeout: ({ chunkTimeoutMs }: { chunkTimeoutMs: number }) =>
+      new Error(`Vydra ${params.kind} download stalled after ${chunkTimeoutMs}ms`),
+    onTimeout: () =>
+      new Error(`Vydra ${params.kind} download timed out after ${params.timeoutMs}ms`),
+  };
+}
+
 export async function downloadVydraAsset(params: {
   url: string;
   kind: VydraMediaKind;
@@ -242,21 +260,30 @@ export async function downloadVydraAsset(params: {
 }): Promise<{ buffer: Buffer; mimeType: string; fileName: string }> {
   const timeoutMs = resolveVydraHttpTimeoutMs(params.timeoutMs);
   // fetchWithTimeout clears its abort after headers land. Keep one wall-clock deadline across
-  // the body read so a slow drip cannot reset chunk idle forever past the download budget.
+  // non-2xx error-detail and successful-body reads so a slow drip cannot reset chunk idle forever.
   const deadlineMs = Date.now() + timeoutMs;
   const response = await fetchWithTimeout(params.url, { method: "GET" }, timeoutMs, params.fetchFn);
-  await assertOkOrThrowHttpError(response, `Vydra ${params.kind} download failed`);
+  if (!response.ok) {
+    // Shared assertOkOrThrowHttpError reads error detail without a wall-clock bound; a dripping
+    // non-2xx body would hang before the success-path reader runs.
+    const prefix = await readResponseTextPrefix(
+      response,
+      16 * 1024,
+      resolveVydraDownloadBodyTimeout({ kind: params.kind, timeoutMs, deadlineMs }),
+    );
+    const detail = prefix.text.replace(/\s+/g, " ").trim();
+    throw new Error(
+      `Vydra ${params.kind} download failed (HTTP ${response.status})` +
+        (detail ? `: ${detail.length > 220 ? `${detail.slice(0, 219)}…` : detail}` : ""),
+    );
+  }
   const mimeType =
     response.headers.get("content-type")?.trim() ||
     (params.kind === "image" ? "image/png" : params.kind === "audio" ? "audio/mpeg" : "video/mp4");
   const buffer = await readResponseWithLimit(response, params.maxBytes, {
-    chunkTimeoutMs: timeoutMs,
-    timeoutMs: Math.max(1, deadlineMs - Date.now()),
+    ...resolveVydraDownloadBodyTimeout({ kind: params.kind, timeoutMs, deadlineMs }),
     onOverflow: ({ maxBytes }) =>
       new Error(`Vydra ${params.kind} download exceeds ${maxBytes} bytes`),
-    onIdleTimeout: ({ chunkTimeoutMs }) =>
-      new Error(`Vydra ${params.kind} download stalled after ${chunkTimeoutMs}ms`),
-    onTimeout: () => new Error(`Vydra ${params.kind} download timed out after ${timeoutMs}ms`),
   });
   const extension = resolveVydraFileExtension(params.kind, mimeType);
   const fileStem = params.kind === "image" ? "image" : params.kind === "audio" ? "audio" : "video";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Vydra image/audio/video generation could hang forever when a CDN returned response headers and then dripped the body slowly enough to keep resetting the per-chunk idle timer. `fetchWithTimeout` clears its abort after headers land, so the download budget no longer applied to the body — including non-2xx error-detail reads.

## Why This Change Was Made

At the `downloadVydraAsset` call site only, keep one wall-clock deadline across headers + non-2xx error-detail + successful-body reads via `readResponseTextPrefix` / `readResponseWithLimit({ timeoutMs, onTimeout })`, matching Discord `probe.ts` / `readDiscordProbeGetMeJson`.

Shared `fetchWithTimeout` and `assertOkOrThrowHttpError` are intentionally unchanged (the shared assert helper has no wall-clock body budget).

Collision check: searched open/closed PRs for `downloadVydraAsset` / Vydra drip wall-clock; no competing open PR. Related hang-class siblings (Discord probe / ClawHub body deadline) are separate owners.

## User Impact

Vydra media downloads fail within the configured HTTP timeout when a remote body keeps trickling instead of completing — for both 2xx asset bodies and dripping non-2xx error bodies. Generation no longer sticks forever on a slow-drip CDN response.

## Evidence

Exact head: `59fd01cb2bc6aa8699432fe992766d26dcaf91c8`

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/vydra/shared.test.ts -- --run --reporter=verbose
```

```text
node=v22.22.0
head=59fd01cb2bc6aa8699432fe992766d26dcaf91c8

 ✓ bounds a dripping download body with one wall-clock deadline 488ms
 ✓ bounds a dripping non-2xx error body with one wall-clock deadline 258ms
 ✓ does not bound a dripping body when only chunk idle timeout is used 406ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

- Negative control: idle-only `chunkTimeoutMs` on a 20ms drip stays unsettled past 400ms.
- Patched paths (200 and 500): reject with `Vydra image download timed out after 250ms` near the wall-clock budget (`elapsed` ≈ 250–488ms).
- What was not tested: live `vydra.ai` CDN; exercised real `downloadVydraAsset` + Node `fetch` against local drip peers.

AI-assisted: yes (Cursor).