### PR TITLE
refactor: prune redundant OpenClaw env controls

### DIFF
--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -21,14 +21,17 @@ Diagnostics flags turn on extra logging for one subsystem without raising
 
 ## Known flags
 
-| Flag             | Enables                                                   |
-| ---------------- | --------------------------------------------------------- |
-| `telegram.http`  | Telegram Bot API HTTP error logging                       |
-| `brave.http`     | Brave Search request/response/cache logging               |
-| `profiler`       | Reply-stage profiler and Codex app-server profiler (both) |
-| `reply.profiler` | Reply-stage profiler only                                 |
-| `codex.profiler` | Codex app-server profiler only                            |
-| `timeline`       | Structured JSONL timeline artifact (see below)            |
+| Flag                  | Enables                                                   |
+| --------------------- | --------------------------------------------------------- |
+| `telegram.http`       | Telegram Bot API HTTP error logging                       |
+| `brave.http`          | Brave Search request/response/cache logging               |
+| `profiler`            | Reply-stage profiler and Codex app-server profiler (both) |
+| `reply.profiler`      | Reply-stage profiler only                                 |
+| `codex.profiler`      | Codex app-server profiler only                            |
+| `health`              | Gateway health probe/account/binding debug details        |
+| `ingress.timing`      | Session load, model selection, and model catalog timings  |
+| `plugin.load-profile` | Synchronous plugin module-load timings                    |
+| `timeline`            | Structured JSONL timeline artifact (see below)            |
 
 ## Enable via config
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4115,6 +4115,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Env var substitution in config
   - H2: Secret refs vs ${ENV} strings
   - H2: Path-related env vars
+  - H2: Agent helper tool downloads
   - H2: Logging
   - H3: OPENCLAWHOME
   - H2: nvm users: webfetch TLS failures

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -35,6 +35,7 @@ Debugging helpers for streaming output, gateway iteration, and startup profiling
 ## Plugin lifecycle trace
 
 Set `OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1` for a phase-by-phase breakdown of plugin metadata, discovery, registry, runtime mirror, config mutation, and refresh work. Writes to stderr, so JSON command output stays parseable.
+Plugin load failures include their stack trace while this trace is enabled.
 
 ```bash
 OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1 openclaw plugins install tokenjuice --force
@@ -47,6 +48,12 @@ OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1 openclaw plugins install tokenjuice --force
 ```
 
 Use this before reaching for a CPU profiler. From a source checkout, measure the built runtime with `node dist/entry.js ...` after `pnpm build`; `pnpm openclaw ...` also measures source-runner overhead.
+
+For synchronous module-load timings, use the shared diagnostics surface instead of a separate plugin-only environment switch:
+
+```bash
+OPENCLAW_DIAGNOSTICS=plugin.load-profile openclaw plugins list
+```
 
 ## CLI startup and command profiling
 

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -167,6 +167,13 @@ shorthand values.
 | `OPENCLAW_CONFIG_PATH`   | Override the config file path (default `~/.openclaw/openclaw.json`).                                                                                                                                                                    |
 | `OPENCLAW_INCLUDE_ROOTS` | Path-list of directories where `$include` directives may resolve files outside the config directory (default: none - `$include` is confined to the config dir). Tilde-expanded.                                                         |
 
+## Agent helper tool downloads
+
+Set `OPENCLAW_OFFLINE=1` to prevent OpenClaw from downloading its pinned `fd`
+and `ripgrep` helper binaries. Existing helpers under the OpenClaw tools
+directory and working system binaries remain eligible; a missing helper stays
+unavailable instead of triggering a network request.
+
 ## Logging
 
 | Variable                         | Purpose                                                                                                                                                                                      |

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -11,6 +11,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { planManifestModelCatalogRows } from "../model-catalog/manifest-planner.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
@@ -132,10 +133,6 @@ const modelSuppressionLoader = createLazyImportLoader(
 const providerApiKeyResolverLoader = createLazyImportLoader(
   () => import("./models-config.providers.secrets.js"),
 );
-
-function shouldLogModelCatalogTiming(): boolean {
-  return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
-}
 
 function loadModelSuppression() {
   return modelSuppressionLoader.load();
@@ -706,7 +703,8 @@ export async function loadModelCatalogSnapshot(
   const loadCatalog = async () => {
     const models: ModelCatalogEntry[] = [];
     const routeVariants = createModelCatalogRouteVariantCollector();
-    const timingEnabled = shouldLogModelCatalogTiming();
+    const cfg = params?.config ?? getRuntimeConfig();
+    const timingEnabled = isDiagnosticFlagEnabled("ingress.timing", cfg);
     const startMs = timingEnabled ? Date.now() : 0;
     const logStage = (stage: string, extra?: string) => {
       if (!timingEnabled) {
@@ -716,7 +714,6 @@ export async function loadModelCatalogSnapshot(
       log.info(`model-catalog stage=${stage} elapsedMs=${Date.now() - startMs}${suffix}`);
     };
     try {
-      const cfg = params?.config ?? getRuntimeConfig();
       const workspaceDir = params?.workspaceDir ?? resolveModelWorkspaceDir(cfg, undefined);
       let manifestMetadataSnapshot: PluginMetadataSnapshot | undefined;
       let manifestPlugins: ProviderModelIdNormalizationOptions["manifestPlugins"];

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -38,6 +38,7 @@ import {
 } from "../../config/sessions/session-snapshot-merge.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeThinkLevel, type ThinkLevel } from "../thinking.shared.js";
@@ -107,10 +108,6 @@ export function createFastTestModelSelectionState(params: {
   };
 }
 
-function shouldLogModelSelectionTiming(): boolean {
-  return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
-}
-
 const modelCatalogRuntimeLoader = createLazyImportLoader(
   () => import("../../agents/model-catalog.runtime.js"),
 );
@@ -163,7 +160,7 @@ export async function createModelSelectionState(params: {
   hasResolvedHeartbeatModelOverride?: boolean;
   isHeartbeat?: boolean;
 }): Promise<ModelSelectionState> {
-  const timingEnabled = shouldLogModelSelectionTiming();
+  const timingEnabled = isDiagnosticFlagEnabled("ingress.timing", params.cfg);
   const startMs = timingEnabled ? Date.now() : 0;
   const logStage = (stage: string, extra?: string) => {
     if (!timingEnabled) {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -53,6 +53,7 @@ import {
   forgetActiveSessionForShutdown,
   noteActiveSessionForShutdown,
 } from "../../gateway/active-sessions-shutdown-tracker.js";
+import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -435,7 +436,7 @@ async function initSessionStateAttemptLocked(
     ? sessionCfg.resetTriggers
     : DEFAULT_RESET_TRIGGERS;
   const sessionScope = sessionCfg?.scope ?? "per-sender";
-  const ingressTimingEnabled = process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
+  const ingressTimingEnabled = isDiagnosticFlagEnabled("ingress.timing", cfg);
 
   let sessionEntry: SessionEntry;
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -40,7 +40,7 @@ import { isGatewayModelPricingEnabled } from "../gateway/model-pricing-config.js
 import type { ChannelRuntimeSnapshot } from "../gateway/server-channel-runtime.types.js";
 import { info } from "../globals.js";
 import { countFailedDeliveryQueueEntries } from "../infra/delivery-queue-sqlite.js";
-import { isTruthyEnvValue } from "../infra/env.js";
+import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationHuman } from "../infra/format-time/format-duration.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
@@ -70,8 +70,8 @@ export type { HealthSummary } from "./health.types.js";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
-const debugHealth = (...args: unknown[]) => {
-  if (isTruthyEnvValue(process.env.OPENCLAW_DEBUG_HEALTH)) {
+const debugHealth = (cfg: OpenClawConfig | undefined, ...args: unknown[]) => {
+  if (isDiagnosticFlagEnabled("health", cfg)) {
     console.warn("[health:debug]", ...args);
   }
 };
@@ -265,7 +265,7 @@ export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | 
     });
     return failed.length > 0 ? { failed } : undefined;
   } catch (error) {
-    debugHealth("delivery queue health read failed", error);
+    debugHealth(undefined, "delivery queue health read failed", error);
     return undefined;
   }
 }
@@ -585,7 +585,7 @@ export async function getHealthSnapshot(params?: {
     );
     // Probe preferred/default/bound accounts first, but include all configured
     // accounts so verbose health can explain account-specific failures.
-    debugHealth("channel", {
+    debugHealth(cfg, "channel", {
       id: plugin.id,
       accountIds,
       defaultAccountId,
@@ -603,7 +603,7 @@ export async function getHealthSnapshot(params?: {
           accountId,
         });
       if (diagnostics.length > 0) {
-        debugHealth("account.diagnostics", { channel: plugin.id, accountId, diagnostics });
+        debugHealth(cfg, "account.diagnostics", { channel: plugin.id, accountId, diagnostics });
       }
 
       let probe: unknown;
@@ -629,7 +629,7 @@ export async function getHealthSnapshot(params?: {
           ? (probeRecord.bot as { username?: string | null })
           : null;
       if (bot?.username) {
-        debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
+        debugHealth(cfg, "probe.bot", { channel: plugin.id, accountId, username: bot.username });
       }
 
       const runtimeSnapshot =
@@ -812,7 +812,7 @@ export async function healthCommand(
   if (opts.json) {
     writeRuntimeJson(runtime, summary);
   } else {
-    const debugEnabled = isTruthyEnvValue(process.env.OPENCLAW_DEBUG_HEALTH);
+    const debugEnabled = isDiagnosticFlagEnabled("health", cfg);
     const rich = isRich();
     if (opts.verbose) {
       const details = buildGatewayConnectionDetails({
@@ -1009,7 +1009,7 @@ export async function healthCommand(
           includeChannelPrefix: true,
         });
       } catch (error) {
-        debugHealth("logSelfId.failed", {
+        debugHealth(cfg, "logSelfId.failed", {
           channel: plugin.id,
           accountId,
           error: formatErrorMessage(error),

--- a/src/config/doc-baseline.ts
+++ b/src/config/doc-baseline.ts
@@ -105,12 +105,6 @@ function compareBaselineStrings(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
-function logConfigDocBaselineDebug(message: string): void {
-  if (process.env.OPENCLAW_CONFIG_DOC_BASELINE_DEBUG === "1") {
-    console.error(`[config-doc-baseline] ${message}`);
-  }
-}
-
 function resolveRepoRoot(): string {
   const fromPackage = resolveOpenClawPackageRootSync({
     cwd: path.dirname(fileURLToPath(import.meta.url)),
@@ -369,15 +363,11 @@ async function loadBundledConfigSchemaResponse(): Promise<ConfigSchemaResponse> 
     config: {},
     bundledChannelConfigCollector: runtime.collectBundledChannelConfigs,
   });
-  logConfigDocBaselineDebug(`loaded ${manifestRegistry.plugins.length} bundled plugin manifests`);
   const bundledRegistry = {
     ...manifestRegistry,
     plugins: manifestRegistry.plugins.filter((plugin) => plugin.origin === "bundled"),
   };
   const channelPlugins = runtime.collectChannelSchemaMetadata(bundledRegistry);
-  logConfigDocBaselineDebug(
-    `loaded ${channelPlugins.length} bundled channel entries from metadata`,
-  );
 
   return runtime.buildConfigSchema({
     plugins: runtime.collectPluginSchemaMetadata(bundledRegistry),
@@ -520,23 +510,15 @@ async function buildConfigDocBaseline(): Promise<ConfigDocBaseline> {
     return await cachedConfigDocBaselinePromise;
   }
   cachedConfigDocBaselinePromise = (async () => {
-    const start = Date.now();
-    logConfigDocBaselineDebug("build baseline start");
     const response = await loadBundledConfigSchemaResponse();
     const schemaRoot = asSchemaObject(response.schema);
     if (!schemaRoot) {
       throw new Error("config schema root is not an object");
     }
-    const collectStart = Date.now();
-    logConfigDocBaselineDebug("collect baseline entries start");
     const entries = dedupeConfigDocBaselineEntries(
       collectConfigDocBaselineEntries(schemaRoot, response.uiHints),
     );
     const { coreEntries, channelEntries, pluginEntries } = splitConfigDocBaselineEntries(entries);
-    logConfigDocBaselineDebug(
-      `collect baseline entries done count=${entries.length} elapsedMs=${Date.now() - collectStart}`,
-    );
-    logConfigDocBaselineDebug(`build baseline done elapsedMs=${Date.now() - start}`);
     return {
       generatedBy: GENERATED_BY,
       coreEntries,
@@ -567,8 +549,6 @@ function renderKindBaseline(
 export async function renderConfigDocBaselineArtifacts(
   baseline?: ConfigDocBaseline | Promise<ConfigDocBaseline>,
 ): Promise<ConfigDocBaselineArtifactsRender> {
-  const start = Date.now();
-  logConfigDocBaselineDebug("render artifacts start");
   const resolvedBaseline = baseline ? await baseline : await buildConfigDocBaseline();
   const json: ConfigDocBaselineArtifacts = {
     combined: `${JSON.stringify(resolvedBaseline, null, 2)}\n`,
@@ -576,7 +556,6 @@ export async function renderConfigDocBaselineArtifacts(
     channel: renderKindBaseline("channel", resolvedBaseline.channelEntries),
     plugin: renderKindBaseline("plugin", resolvedBaseline.pluginEntries),
   };
-  logConfigDocBaselineDebug(`render artifacts done elapsedMs=${Date.now() - start}`);
   return {
     json,
     baseline: resolvedBaseline,
@@ -643,22 +622,16 @@ export async function writeConfigDocBaselineArtifacts(params?: {
   hashPath?: string;
   rendered?: ConfigDocBaselineArtifactsRender | Promise<ConfigDocBaselineArtifactsRender>;
 }): Promise<ConfigDocBaselineArtifactsWriteResult> {
-  const start = Date.now();
-  logConfigDocBaselineDebug("write artifacts start");
   const repoRoot = params?.repoRoot ?? resolveRepoRoot();
   const jsonPaths = resolveBaselineArtifactPaths(repoRoot, params);
   const hashPath = path.resolve(repoRoot, params?.hashPath ?? DEFAULT_HASH_OUTPUT);
   const rendered = params?.rendered
     ? await params.rendered
     : await renderConfigDocBaselineArtifacts();
-  logConfigDocBaselineDebug(`render artifacts done elapsedMs=${Date.now() - start}`);
 
   const nextHashContent = computeConfigBaselineHashFileContent(rendered.json);
   const currentHashContent = readFileIfExists(hashPath);
   const changed = currentHashContent !== nextHashContent;
-  logConfigDocBaselineDebug(
-    `compare hashes done changed=${changed} elapsedMs=${Date.now() - start}`,
-  );
 
   if (params?.check) {
     return {

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -248,7 +248,7 @@ async function expectBuiltArtifactNodeRequireFastPath(
   scope: string,
   artifactRoot = "dist",
 ): Promise<void> {
-  vi.stubEnv("OPENCLAW_PLUGIN_LOAD_PROFILE", "1");
+  vi.stubEnv("OPENCLAW_DIAGNOSTICS", "plugin.load-profile");
   const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
   try {
@@ -346,7 +346,7 @@ function runCompiledEsmSidecarFastPathProbe(): SpawnSyncReturns<string> {
   return spawnSync(process.execPath, ["--import", "tsx", probePath], {
     cwd: process.cwd(),
     encoding: "utf8",
-    env: { ...process.env, OPENCLAW_PLUGIN_LOAD_PROFILE: "1" },
+    env: { ...process.env, OPENCLAW_DIAGNOSTICS: "plugin.load-profile" },
   });
 }
 

--- a/src/plugins/loader-records.test.ts
+++ b/src/plugins/loader-records.test.ts
@@ -1,8 +1,13 @@
 /** Verifies plugin loader records expose stable metadata for registered plugin surfaces. */
-import { describe, expect, it } from "vitest";
-import { createPluginRecord } from "./loader-records.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPluginRecord, recordPluginError } from "./loader-records.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
 
 describe("plugin loader records", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("preserves manifest-declared channel ids before runtime registration", () => {
     const record = createPluginRecord({
       id: "kitchen-sink",
@@ -69,5 +74,37 @@ describe("plugin loader records", () => {
     expect(record.webSearchProviderIds).toEqual(["kitchen-sink-web-search-provider"]);
     expect(record.migrationProviderIds).toEqual(["kitchen-sink-migration-provider"]);
     expect(record.memoryEmbeddingProviderIds).toEqual(["kitchen-sink-memory-provider"]);
+  });
+
+  it.each([
+    { diagnostics: "", expected: "Error: boom" },
+    { diagnostics: "1", expected: "Error: boom\n    at plugin-entry.ts:1:1" },
+  ])("uses lifecycle tracing for loader error stacks", ({ diagnostics, expected }) => {
+    vi.stubEnv("OPENCLAW_PLUGIN_LIFECYCLE_TRACE", diagnostics);
+    const registry = createEmptyPluginRegistry();
+    const record = createPluginRecord({
+      id: "broken-plugin",
+      source: "/tmp/broken-plugin/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const error = new Error("boom");
+    error.stack = "Error: boom\n    at plugin-entry.ts:1:1";
+
+    recordPluginError({
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      registry,
+      record,
+      seenIds: new Map(),
+      pluginId: record.id,
+      origin: record.origin,
+      phase: "load",
+      error,
+      logPrefix: "",
+      diagnosticMessagePrefix: "",
+    });
+
+    expect(record.error).toBe(expected);
   });
 });

--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -4,6 +4,7 @@ import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationState } from "./config-state.js";
 import type { PluginBundleFormat, PluginDiagnosticCode, PluginFormat } from "./manifest-types.js";
 import type { PluginManifestContracts } from "./manifest.js";
+import { isPluginLifecycleTraceEnabled } from "./plugin-lifecycle-trace.js";
 import type { PluginRecord, PluginRegistry } from "./registry.js";
 import type { PluginLogger } from "./types.js";
 
@@ -119,7 +120,7 @@ export function recordPluginError(params: {
   diagnosticCode?: PluginDiagnosticCode;
 }) {
   const errorText =
-    process.env.OPENCLAW_PLUGIN_LOADER_DEBUG_STACKS === "1" &&
+    isPluginLifecycleTraceEnabled() &&
     params.error instanceof Error &&
     typeof params.error.stack === "string"
       ? params.error.stack

--- a/src/plugins/plugin-lifecycle-trace.ts
+++ b/src/plugins/plugin-lifecycle-trace.ts
@@ -2,7 +2,7 @@
 type TraceDetails = Record<string, boolean | number | string | undefined>;
 
 /** Checks the opt-in plugin lifecycle tracing environment flag. */
-function isPluginLifecycleTraceEnabled(): boolean {
+export function isPluginLifecycleTraceEnabled(): boolean {
   const raw = process.env.OPENCLAW_PLUGIN_LIFECYCLE_TRACE?.trim().toLowerCase();
   return raw === "1" || raw === "true" || raw === "yes";
 }

--- a/src/plugins/plugin-load-profile.ts
+++ b/src/plugins/plugin-load-profile.ts
@@ -7,7 +7,7 @@
  *
  *     [plugin-load-profile] phase=<X> plugin=<Y> elapsedMs=<N> [extras…] source=<S>
  *
- * The same `OPENCLAW_PLUGIN_LOAD_PROFILE=1` env flag activates all probes.
+ * The `plugin.load-profile` diagnostics flag activates all probes.
  *
  * Tooling that scrapes these lines (e.g. PERF-STARTUP-PLAN.md profiling
  * methodology) depends on the field order being:
@@ -21,8 +21,10 @@
  * Keep this contract stable — downstream parsers rely on it.
  */
 
+import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
+
 export function shouldProfilePluginLoader(): boolean {
-  return process.env.OPENCLAW_PLUGIN_LOAD_PROFILE === "1";
+  return isDiagnosticFlagEnabled("plugin.load-profile");
 }
 
 /**

--- a/src/wizard/setup.migration-import.test.ts
+++ b/src/wizard/setup.migration-import.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { listSetupMigrationOptions } from "./setup.migration-import.js";
 import {
+  assertFreshSetupMigrationTarget,
   inspectSetupMigrationFreshness,
   preserveSetupMigrationSecurityAcknowledgement,
 } from "./setup.migration-snapshot.js";
@@ -99,6 +100,9 @@ describe("setup migration import freshness", () => {
       "workspace MEMORY.md exists",
       "state agents/ exists",
     ]);
+    expect(() => assertFreshSetupMigrationTarget(result)).toThrow(
+      "Migration import during onboarding requires a fresh OpenClaw setup.",
+    );
   });
 });
 

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -416,16 +416,14 @@ export async function runSetupMigrationImport(params: {
       stateDir,
       workspaceDir,
     });
-    const recoveryState =
-      !setupMigrationProviderSupportsRecovery(providerId) ||
-      process.env.OPENCLAW_MIGRATION_EXISTING_IMPORT === "1"
-        ? ({ kind: "none" } as const)
-        : await resolveSetupMigrationRecovery({
-            stateDir,
-            providerId,
-            workspaceDir,
-            targetSnapshotHash: initialTargetSnapshotHash,
-          });
+    const recoveryState = !setupMigrationProviderSupportsRecovery(providerId)
+      ? ({ kind: "none" } as const)
+      : await resolveSetupMigrationRecovery({
+          stateDir,
+          providerId,
+          workspaceDir,
+          targetSnapshotHash: initialTargetSnapshotHash,
+        });
     const recoveryAttempt =
       !freshness.fresh && recoveryState.kind === "recoverable" ? recoveryState.attempt : undefined;
     if (!recoveryAttempt) {

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -333,7 +333,7 @@ export function assertFreshSetupMigrationTarget(freshness: {
   fresh: boolean;
   reasons: readonly string[];
 }): void {
-  if (freshness.fresh || process.env.OPENCLAW_MIGRATION_EXISTING_IMPORT === "1") {
+  if (freshness.fresh) {
     return;
   }
   throw new Error(


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's already-large environment surface had hidden one-off debug controls and an undocumented migration safety bypass alongside its supported configuration and diagnostics seams. That made operator behavior harder to discover and let unsupported switches bypass canonical product behavior.

## Why This Change Was Made

This audits the prompt-defined `src/` census and classifies every entry before changing behavior. Six unsupported variables are removed or consolidated: three debug/profiling switches now use the shared diagnostics surface, plugin loader stacks now use the documented lifecycle trace, the config-baseline-only debug logger is deleted, and migration import always enforces freshness/recovery. No documented environment contract is removed.

No config schema is changed. Durable env/config overlaps are handed off below for the separate config-key audit.

## User Impact

Operators get fewer hidden controls and one consistent diagnostics mechanism. `OPENCLAW_OFFLINE` is now documented. Existing documented env variables remain supported. Onboarding migration imports can no longer bypass freshness and recovery with an unsupported environment switch.

Production non-test source is net **31 lines smaller**.

## Evidence

- Remote changed-surface gate: [Blacksmith run 29514691495](https://github.com/openclaw/openclaw/actions/runs/29514691495) — format, API/boundary checks, four typecheck lanes, core and extension lint, database/security/runtime policy checks; passed.
- Remote focused behavior suite: [Blacksmith run 29516523894](https://github.com/openclaw/openclaw/actions/runs/29516523894) — 327 tests across 9 Vitest shards, including full Linux plugin sidecar contract; passed.
- Local focused model/session/health/migration/plugin/config tests passed.
- `git diff --check` passed.
- Autoreview: clean; no accepted/actionable findings.

<details>
<summary>Full OPENCLAW_ classification (112 scoped variables)</summary>

# OPENCLAW_ environment-variable audit

Audit started at `c46cc1e2d458c042ea63a4ea4331ac4d120a564f` and was rebased/rechecked against `origin/main` at `fa2b38c8909deb14399121a1633871c67a4ed0a4` (2026-07-16).
Canonical environment reference found through `pnpm docs:list`: `docs/help/environment.md`.

The prompt's direct-access census returned 106 names at audit start. One later `main` refactor moved `OPENCLAW_DEBUG_MODEL_PAYLOAD` behind an injected env object without changing the surface, leaving 105 direct `process.env.OPENCLAW_*` names plus that same env-object read. The table also covers four adjacent quoted proxy reads and two adjacent constant-key reads, for 112 classified variables. Dynamic key registries outside the prompt's grep are out of scope. `INTERNAL MARKER` is separated from user-facing variables because process-to-process markers are real reads but are not operator configuration. No read was provably unreachable; the six removals below are unsupported hidden overrides or duplicate diagnostics controls, not false-positive dead code.

| Variable | Classification | Evidence / decision |
| --- | --- | --- |
| `OPENCLAW_AGENT_DIR` | DOCUMENTED + USED | Auth/model agent-directory override; documented in CLI/config-tool docs. Keep. |
| `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS` | DOCUMENTED + USED | Remote onboarding and node WebSocket override; documented security exception. Keep. |
| `OPENCLAW_ALLOW_PROJECT_LOCAL_BIN` | UNDOCUMENTED USER-FACING | Changes PATH trust behavior. No config equivalent; needs explicit security/docs decision before becoming contract. Keep for follow-up. |
| `OPENCLAW_ANTIGRAVITY_CLI` | DOCUMENTED + USED | Media-understanding CLI override. Keep. |
| `OPENCLAW_AUTH_STORE_READONLY` | INTERNAL MARKER | CLI entrypoint injects read-only auth-store mode. Keep internal. |
| `OPENCLAW_BUILD_PRIVATE_QA` | TEST/DEV/CI-ONLY | Named private QA build gate; documented and set by CI. Keep CI contract. |
| `OPENCLAW_BUNDLED_HOOKS_DIR` | TEST/DEV/CI-ONLY | Bundled hook root override used by packaging/test paths. Keep internal test seam. |
| `OPENCLAW_BUNDLED_PLUGINS_DIR` | TEST/DEV/CI-ONLY | Bundled plugin root override used heavily by tests/release QA. Keep CI contract. |
| `OPENCLAW_BUNDLED_SKILLS_DIR` | TEST/DEV/CI-ONLY | Bundled skill root override used by packaging/test paths. Keep internal test seam. |
| `OPENCLAW_BUNDLED_VERSION` | INTERNAL MARKER | Build/package version injection consumed by `src/version.ts`. Keep internal. |
| `OPENCLAW_CACHE_RETENTION` | DOCUMENTED + USED | Provider prompt-cache policy. Keep documented contract. |
| `OPENCLAW_CLAWHUB_URL` | DOCUMENTED + USED | ClawHub endpoint override documented for testing and used by plugin flows. Keep. |
| `OPENCLAW_CLI_BACKEND_LOG_OUTPUT` | TEST/DEV/CI-ONLY | Live backend probe/log marker set by CLI and live CI. Keep CI seam. |
| `OPENCLAW_CLI_PATH` | DOCUMENTED + USED | Discovery/native-hook CLI-path advertisement override. Keep. |
| `OPENCLAW_CODEX_SUPERVISOR_ALLOW_RAW_TRANSCRIPTS` | UNDOCUMENTED USER-FACING | Security-sensitive Codex supervision capability; plugin-owned config should be preferred. Keep for owner/docs decision. |
| `OPENCLAW_CODEX_SUPERVISOR_ALLOW_WRITE_CONTROLS` | UNDOCUMENTED USER-FACING | Security-sensitive Codex supervision capability; plugin-owned config should be preferred. Keep for owner/docs decision. |
| `OPENCLAW_COMMITMENTS_SAFETY_E2E` | TEST/DEV/CI-ONLY | Set only by commitments Docker E2E. Keep cross-process test seam. |
| `OPENCLAW_COMPATIBILITY_HOST_VERSION` | INTERNAL MARKER | Self-update/plugin compatibility handoff. Keep internal. |
| `OPENCLAW_CONFIG_DOC_BASELINE_DEBUG` | REMOVE / CONSOLIDATE | Hidden generator timing logger, never set in docs/tests/CI/installers. Remove bespoke switch and its unused trace code. |
| `OPENCLAW_CONFIG_PATH` | DOCUMENTED + USED | Canonical config-path override. Keep. |
| `OPENCLAW_CONTAINER` | DOCUMENTED + USED | Podman/container target selection. Keep. |
| `OPENCLAW_DEBUG_CHANNEL_CONTRACT_API` | TEST/DEV/CI-ONLY | Hidden security-surface diagnostic. Prefer `diagnostics.flags`; defer to security owner. |
| `OPENCLAW_DEBUG_HEALTH` | REMOVE / CONSOLIDATE | Hidden health diagnostics duplicate `OPENCLAW_DIAGNOSTICS`; replace with `health` flag. |
| `OPENCLAW_DEBUG_INGRESS_TIMING` | REMOVE / CONSOLIDATE | Hidden ingress timing switch duplicates `OPENCLAW_DIAGNOSTICS`; replace with `ingress.timing`. |
| `OPENCLAW_DEBUG_MODEL_PAYLOAD` | DOCUMENTED + USED | Model payload diagnostic with redaction contract. Keep. |
| `OPENCLAW_DEBUG_PROXY_ENABLED` | INTERNAL MARKER | CLI debug-proxy/capture marker, injected and restored internally. Keep internal. |
| `OPENCLAW_DIAGNOSTICS_EVENT_LOOP` | DOCUMENTED + USED | Timeline event-loop opt-in. Keep. |
| `OPENCLAW_DISABLE_BONJOUR` | DOCUMENTED + USED | Discovery override; `discovery.mdns.mode` is durable config duplicate. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_DISABLE_BUNDLED_PLUGINS` | TEST/DEV/CI-ONLY | Test/release isolation switch. Keep CI seam. |
| `OPENCLAW_DISABLE_ROUTE_FIRST` | TEST/DEV/CI-ONLY | Only route tests set it; move to injected route test seam in follow-up. |
| `OPENCLAW_ENABLE_PRIVATE_QA_CLI` | DOCUMENTED + USED | Private QA CLI build/runtime gate documented and set by CI. Keep named CI contract. |
| `OPENCLAW_FS_SAFE_PYTHON_MODE` | DOCUMENTED + USED | Secure filesystem helper mode. Keep. |
| `OPENCLAW_GATEWAY_PASSWORD` | DOCUMENTED + USED | Gateway auth override; duplicates `gateway.auth.password`/remote password config. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_GATEWAY_PORT` | DOCUMENTED + USED | Gateway port override; duplicates `gateway.port`. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_GATEWAY_RESTART_TRACE` | DOCUMENTED + USED | Restart benchmark/diagnostic trace. Keep. |
| `OPENCLAW_GATEWAY_STARTUP_TRACE` | DOCUMENTED + USED | Startup benchmark/diagnostic trace. Keep. |
| `OPENCLAW_GATEWAY_TOKEN` | DOCUMENTED + USED | Gateway auth override used by installers and deployments. Keep. |
| `OPENCLAW_GATEWAY_URL` | DOCUMENTED + USED | Remote Gateway selector; duplicates `gateway.remote.url`. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_GIT_DIR` | DOCUMENTED + USED | Dev-channel checkout override used by sibling installers. Keep. |
| `OPENCLAW_HANDSHAKE_TIMEOUT_MS` | DOCUMENTED + USED | Gateway client/server handshake timeout; config metadata also exposes it. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_HOME` | DOCUMENTED + USED | Canonical home/path override used by installers. Keep. |
| `OPENCLAW_LAUNCHD_LABEL` | DOCUMENTED + USED | macOS service label override. Keep. |
| `OPENCLAW_LIVE_CACHE_TEST` | DOCUMENTED + USED | Live cache validation gate documented in test/release docs. Keep test contract. |
| `OPENCLAW_LIVE_CLI_BACKEND_ARGS` | DOCUMENTED + USED | Live CLI backend argument injection documented in live-testing docs. Keep test contract. |
| `OPENCLAW_LIVE_CLI_BACKEND_DEBUG` | TEST/DEV/CI-ONLY | Live backend debug output set by workflow/scripts. Keep CI seam. |
| `OPENCLAW_LIVE_CLI_BACKEND_IMAGE_PROBE` | DOCUMENTED + USED | Live image probe selector. Keep test contract. |
| `OPENCLAW_LIVE_CLI_BACKEND_MCP_PROBE` | DOCUMENTED + USED | Live MCP probe selector. Keep test contract. |
| `OPENCLAW_LIVE_CLI_BACKEND_MODEL_SWITCH_PROBE` | DOCUMENTED + USED | Live model-switch probe selector. Keep test contract. |
| `OPENCLAW_LIVE_CLI_BACKEND_RESUME_ARGS` | TEST/DEV/CI-ONLY | Live resume-probe argument injection set by scripts. Keep CI seam. |
| `OPENCLAW_LIVE_HEARTBEAT_MS` | DOCUMENTED + USED | Live cache-test timing override. Keep test contract. |
| `OPENCLAW_LIVE_MODEL_TIMEOUT_MS` | TEST/DEV/CI-ONLY | Live model timeout set by workflows/scripts. Keep CI seam. |
| `OPENCLAW_LOG_LEVEL` | DOCUMENTED + USED | Logging override; duplicates `logging.level`/`consoleLevel`. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_MIGRATION_EXISTING_IMPORT` | REMOVE / CONSOLIDATE | Shipped but hidden safety bypass; no docs/tests/CI/installer setter. Remove so onboarding migration always enforces freshness/recovery. |
| `OPENCLAW_NIX_MODE` | DOCUMENTED + USED | Nix packaging/runtime contract. Keep. |
| `OPENCLAW_NODE_EXEC_FALLBACK` | DOCUMENTED + USED | Node-host execution fallback. Keep. |
| `OPENCLAW_NODE_EXEC_HOST` | DOCUMENTED + USED | Node-host execution target. Keep. |
| `OPENCLAW_NO_AUTO_UPDATE` | DOCUMENTED + USED | Startup update-check opt-out. Keep documented contract; durable config ownership is a config-audit question. |
| `OPENCLAW_NO_RESPAWN` | DOCUMENTED + USED | Container/process supervisor contract. Keep. |
| `OPENCLAW_OFFLINE` | UNDOCUMENTED USER-FACING | Disables automatic fd/ripgrep downloads. Document explicitly; no config equivalent. |
| `OPENCLAW_PACKAGE_DIR` | INTERNAL MARKER | Package root injected by launcher/build layouts. Keep internal. |
| `OPENCLAW_PATH_BOOTSTRAPPED` | INTERNAL MARKER | Prevents duplicate PATH bootstrap. Keep internal. |
| `OPENCLAW_PLUGIN_LIFECYCLE_TRACE` | DOCUMENTED + USED | Supported plugin lifecycle trace. Keep; absorb loader stack diagnostics. |
| `OPENCLAW_PLUGIN_LOADER_DEBUG_STACKS` | REMOVE / CONSOLIDATE | Hidden stack switch duplicates documented plugin lifecycle trace. Consolidate onto that trace. |
| `OPENCLAW_PLUGIN_LOAD_PROFILE` | REMOVE / CONSOLIDATE | Hidden profiler duplicates generic diagnostics flags. Replace with `OPENCLAW_DIAGNOSTICS=plugin.load-profile`. |
| `OPENCLAW_PROFILE` | DOCUMENTED + USED | Named profile selection used across services/config. Keep. |
| `OPENCLAW_PROXY_ACTIVE` | INTERNAL MARKER | Managed-proxy child-process marker. Keep internal. |
| `OPENCLAW_PROXY_CA_FILE` | INTERNAL MARKER | Managed-proxy CA handoff. Keep internal. |
| `OPENCLAW_PROXY_LOOPBACK_MODE` | INTERNAL MARKER | Managed-proxy loopback-mode handoff. Keep internal. |
| `OPENCLAW_PROXY_URL` | DOCUMENTED + USED | Managed proxy override; duplicates proxy config. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_QA_FORCE_RUNTIME` | TEST/DEV/CI-ONLY | Private QA runtime selector used by QA plugin/tests. Keep test seam. |
| `OPENCLAW_RAW_STREAM` | DOCUMENTED + USED | Raw embedded-agent stream diagnostic gate. Keep. |
| `OPENCLAW_RAW_STREAM_PATH` | DOCUMENTED + USED | Raw stream artifact path. Keep. |
| `OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS` | DOCUMENTED + USED | Provider retry wait cap. Keep. |
| `OPENCLAW_SERVICE_MARKER` | INTERNAL MARKER | Installed-service execution marker. Keep internal. |
| `OPENCLAW_SESSION_CACHE_TTL_MS` | TEST/DEV/CI-ONLY | Only tests tune the runtime cache; move to injected cache options in follow-up. |
| `OPENCLAW_SESSION_SERIALIZED_CACHE_MAX_BYTES` | TEST/DEV/CI-ONLY | Only tests reference the runtime cache cap; move to injected cache options in follow-up. |
| `OPENCLAW_SHELL` | DOCUMENTED + USED | Runtime-injected shell context marker with documented profile contract. Keep. |
| `OPENCLAW_SHOW_SECRETS` | UNDOCUMENTED USER-FACING | Controls status env preview redaction behavior; security/config owner decision needed before documenting. Keep. |
| `OPENCLAW_SKIP_BROWSER_CONTROL_SERVER` | TEST/DEV/CI-ONLY | Test/live isolation; browser config is durable operator seam. Keep CI seam; config-audit follow-up. |
| `OPENCLAW_SKIP_CANVAS_HOST` | DOCUMENTED + USED | Gateway canvas-host override; durable gateway config overlaps. Keep documented contract. |
| `OPENCLAW_SKIP_CHANNELS` | DOCUMENTED + USED | Dev/test gateway isolation. Keep documented contract. |
| `OPENCLAW_SKIP_CRON` | DOCUMENTED + USED | Cron startup override; overlaps cron config. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_SKIP_GMAIL_WATCHER` | DOCUMENTED + USED | Gmail watcher startup override; overlaps hook config. Keep documented contract; config-audit follow-up. |
| `OPENCLAW_SKIP_PROVIDERS` | TEST/DEV/CI-ONLY | Gateway provider isolation set by tests/E2E. Keep CI seam. |
| `OPENCLAW_SSH_PORT` | DOCUMENTED + USED | Discovery SSH-port advertisement override. Keep. |
| `OPENCLAW_STATE_DIR` | DOCUMENTED + USED | Canonical state root used by installers/tests/deployments. Keep. |
| `OPENCLAW_SUPPRESS_EXTENSION_API_WARNING` | DOCUMENTED + USED | External plugin migration compatibility switch. Keep. |
| `OPENCLAW_SUPPRESS_HELP_BANNER` | INTERNAL MARKER | Parent-help recursion marker. Keep internal. |
| `OPENCLAW_SUPPRESS_PLUGIN_SDK_COMPAT_WARNING` | DOCUMENTED + USED | External plugin SDK migration compatibility switch. Keep. |
| `OPENCLAW_SYSTEMD_UNIT` | DOCUMENTED + USED | Linux service unit selection. Keep. |
| `OPENCLAW_TELEMETRY` | UNDOCUMENTED USER-FACING | Overrides persisted install-telemetry settings; prefer the existing settings owner. Keep for config/settings audit. |
| `OPENCLAW_TEST_CONSOLE` | TEST/DEV/CI-ONLY | Vitest console opt-in used by live CI. Keep named test contract. |
| `OPENCLAW_TEST_FAST` | TEST/DEV/CI-ONLY | Broad cross-process test timing/isolation switch. Keep; candidate for a shared test runtime seam. |
| `OPENCLAW_TEST_FILE_LOG` | TEST/DEV/CI-ONLY | Vitest file-log opt-in. Keep named test contract. |
| `OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS` | TEST/DEV/CI-ONLY | Vitest-only handshake timeout guarded by test runtime. Keep test seam. |
| `OPENCLAW_TEST_MINIMAL_GATEWAY` | TEST/DEV/CI-ONLY | Cross-process minimal Gateway used by E2E/live tests. Keep test contract. |
| `OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE` | TEST/DEV/CI-ONLY | SQLite migration proof switch. Move to injected state-reader seam in follow-up. |
| `OPENCLAW_THEME` | DOCUMENTED + USED | TUI palette override. Keep. |
| `OPENCLAW_TRAJECTORY` | DOCUMENTED + USED | Runtime trajectory capture switch. Keep. |
| `OPENCLAW_TRAJECTORY_DIR` | UNDOCUMENTED USER-FACING | Legacy/export trajectory path override; runtime storage is now SQLite. Prefer explicit export path and retire in follow-up. |
| `OPENCLAW_TTS_PREFS` | DOCUMENTED + USED | TTS preferences path override. Keep. |
| `OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS` | DOCUMENTED + USED | TUI local-run shutdown grace documented in release notes. Keep contract; promote to stable docs in follow-up. |
| `OPENCLAW_TUI_PTY_MIRROR_PATH` | TEST/DEV/CI-ONLY | PTY watcher artifact handoff used by dev script. Keep cross-process test seam. |
| `OPENCLAW_UPDATE_DEV_TARGET_REF` | TEST/DEV/CI-ONLY | Update-channel E2E/cross-OS target override. Keep test seam. |
| `OPENCLAW_UPDATE_IN_PROGRESS` | INTERNAL MARKER | Installer/update/doctor coordination marker. Keep internal. |
| `OPENCLAW_UPDATE_PACKAGE_SPEC` | UNDOCUMENTED USER-FACING | Hidden global-install target override; explicit update targets should own this. Keep for update/config audit. |
| `OPENCLAW_VAPID_PRIVATE_KEY` | DOCUMENTED + USED | Web push key override. Keep. |
| `OPENCLAW_VAPID_PUBLIC_KEY` | DOCUMENTED + USED | Web push key override. Keep. |
| `OPENCLAW_VAPID_SUBJECT` | DOCUMENTED + USED | Web push subject override. Keep. |
| `OPENCLAW_VERBOSE` | DOCUMENTED + USED | Installer/migration verbosity contract used by sibling installer. Keep. |
| `OPENCLAW_VERSION` | DOCUMENTED + USED | Build/package version injection used by installers/plugins. Keep. |
| `OPENCLAW_WRAPPER` | DOCUMENTED + USED | Installed Gateway wrapper path used by service repair/status. Keep. |

## Config-overlap handoff

No config-schema files changed in this task. The separate config-key audit should evaluate the durable config owners for: Gateway auth/port/remote URL/handshake timeout, logging level, Bonjour/mDNS, managed proxy, startup auto-update checks, browser/canvas startup, cron, Gmail watcher, and install telemetry. Documented env variables remain intact pending those maintainer decisions.

</details>

