### PR TITLE
feat: add native inline widget support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
-- **Native inline widgets:** render capability-gated Canvas widgets inside iOS, Android, and macOS chat with isolated web views, strict URL validation, and expired-capability refresh; Web and Linux browser support remains unchanged.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
+- **Native inline widgets:** render capability-gated Canvas widgets inside iOS, Android, and macOS chat with isolated web views, strict URL validation, and expired-capability refresh; Web and Linux browser support remains unchanged.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 280,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 400,
+      "line": 401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 414,
+      "line": 415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -691,7 +691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 159,
+      "line": 161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -699,7 +699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 161,
+      "line": 163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -707,7 +707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 163,
+      "line": 165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 165,
+      "line": 167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 167,
+      "line": 169,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 184,
+      "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 184,
+      "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 191,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 200,
+      "line": 202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 382,
+      "line": 384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 383,
+      "line": 385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 385,
+      "line": 387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 393,
+      "line": 395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1805,
+      "line": 1807,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1835,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1835,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1848,
+      "line": 1850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1879,
+      "line": 1881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1879,
+      "line": 1881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1901,
+      "line": 1903,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1907,
+      "line": 1909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1922,
+      "line": 1924,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2127,
+      "line": 2129,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2138,
+      "line": 2140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2159,
+      "line": 2161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2170,
+      "line": 2172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3066,
+      "line": 3068,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3094,
+      "line": 3096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3103,
+      "line": 3105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3787,
+      "line": 3789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3791,
+      "line": 3793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3795,
+      "line": 3797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 3839,
+      "line": 3841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4020,
+      "line": 4022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4697,
+      "line": 4714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4728,
+      "line": 4745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4730,
+      "line": 4747,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4746,
+      "line": 4763,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4833,
+      "line": 4850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4919,
+      "line": 4936,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4929,
+      "line": 4946,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4933,
+      "line": 4950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4945,
+      "line": 4962,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4976,
+      "line": 4993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4993,
+      "line": 5010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5002,
+      "line": 5019,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5014,
+      "line": 5031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5061,
+      "line": 5078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5188,
+      "line": 5205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5223,
+      "line": 5240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5236,
+      "line": 5253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5240,
+      "line": 5257,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5255,
+      "line": 5272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5255,
+      "line": 5272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5273,
+      "line": 5290,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5319,
+      "line": 5336,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5332,
+      "line": 5349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5365,
+      "line": 5382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5381,
+      "line": 5398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5397,
+      "line": 5414,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5413,
+      "line": 5430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5503,
+      "line": 5520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5510,
+      "line": 5527,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5550,
+      "line": 5567,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5590,
+      "line": 5607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5610,
+      "line": 5627,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5662,
+      "line": 5679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5682,
+      "line": 5699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5687,
+      "line": 5704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 5846,
+      "line": 5863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5872,
+      "line": 5889,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6530,
+      "line": 6547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6560,
+      "line": 6577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6597,
+      "line": 6614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7054,
+      "line": 7071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7063,
+      "line": 7080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7064,
+      "line": 7081,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7072,
+      "line": 7089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7073,
+      "line": 7090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7074,
+      "line": 7091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7075,
+      "line": 7092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7091,
+      "line": 7108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7108,
+      "line": 7125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7116,
+      "line": 7133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7117,
+      "line": 7134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7119,
+      "line": 7136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7123,
+      "line": 7140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7126,
+      "line": 7143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7131,
+      "line": 7148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7132,
+      "line": 7149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7134,
+      "line": 7151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7138,
+      "line": 7155,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7141,
+      "line": 7158,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7146,
+      "line": 7163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7147,
+      "line": 7164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7149,
+      "line": 7166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7153,
+      "line": 7170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7156,
+      "line": 7173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7188,
+      "line": 7205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7203,
+      "line": 7220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7204,
+      "line": 7221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7205,
+      "line": 7222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7764,
+      "line": 7781,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1481,
+      "line": 1507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1481,
+      "line": 1507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -11379,7 +11379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 113,
+      "line": 133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
       "source": "Widget unavailable",
       "surface": "android",
@@ -11747,7 +11747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 232,
+      "line": 233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -11755,7 +11755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 287,
+      "line": 288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -11763,7 +11763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 396,
+      "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -11771,7 +11771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -11779,7 +11779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 682,
+      "line": 683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -11787,7 +11787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 683,
+      "line": 684,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -11795,7 +11795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 684,
+      "line": 685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -11803,7 +11803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 697,
+      "line": 698,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -11811,7 +11811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 702,
+      "line": 703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -11819,7 +11819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 710,
+      "line": 711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -11827,7 +11827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 731,
+      "line": 732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -11835,7 +11835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 884,
+      "line": 885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -11843,7 +11843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 911,
+      "line": 912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -11851,7 +11851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 937,
+      "line": 938,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -11859,7 +11859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 941,
+      "line": 942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -11867,7 +11867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 943,
+      "line": 944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -11875,7 +11875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 945,
+      "line": 946,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -11883,7 +11883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 968,
+      "line": 969,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -11891,7 +11891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 969,
+      "line": 970,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -11899,7 +11899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1028,
+      "line": 1029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -11907,7 +11907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1029,
+      "line": 1030,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent sessions and next steps.",
       "surface": "android",
@@ -11915,7 +11915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1030,
+      "line": 1031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
       "surface": "android",
@@ -11923,7 +11923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1034,
+      "line": 1035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -11931,7 +11931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1035,
+      "line": 1036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -11939,7 +11939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1036,
+      "line": 1037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -11947,7 +11947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1040,
+      "line": 1041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -11955,7 +11955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1041,
+      "line": 1042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -11963,7 +11963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1042,
+      "line": 1043,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -11971,7 +11971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1107,
+      "line": 1108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -11979,7 +11979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1108,
+      "line": 1109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -11987,7 +11987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1109,
+      "line": 1110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -11995,7 +11995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1110,
+      "line": 1111,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12003,7 +12003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1130,
+      "line": 1131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12011,7 +12011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1183,
+      "line": 1184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12019,7 +12019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1183,
+      "line": 1184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12027,7 +12027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1204,
+      "line": 1205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12035,7 +12035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1206,
+      "line": 1207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12043,7 +12043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1209,
+      "line": 1210,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12051,7 +12051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1219,
+      "line": 1220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -12059,7 +12059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1220,
+      "line": 1221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -12067,7 +12067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1285,
+      "line": 1286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -12075,7 +12075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1292,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -12083,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1292,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -12091,7 +12091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1414,
+      "line": 1415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -12099,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1515,
+      "line": 1516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -12107,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1613,
+      "line": 1614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -12115,7 +12115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1679,
+      "line": 1680,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -12123,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1679,
+      "line": 1680,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -12131,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1696,
+      "line": 1697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -12139,7 +12139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1738,
+      "line": 1739,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -12147,7 +12147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1758,
+      "line": 1759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -12155,7 +12155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1804,
+      "line": 1805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -12163,7 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1804,
+      "line": 1805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -12171,7 +12171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1864,
+      "line": 1865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -12179,7 +12179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1899,
+      "line": 1900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12187,7 +12187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1915,
+      "line": 1916,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
@@ -12195,7 +12195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1955,
+      "line": 1956,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12203,7 +12203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1964,
+      "line": 1965,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12211,7 +12211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1976,
+      "line": 1977,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12219,7 +12219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1985,
+      "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12227,7 +12227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1986,
+      "line": 1987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12235,7 +12235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1993,
+      "line": 1994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12243,7 +12243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2052,
+      "line": 2053,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12251,7 +12251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2063,
+      "line": 2064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12259,7 +12259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2064,
+      "line": 2065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12267,7 +12267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2065,
+      "line": 2066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12275,7 +12275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2084,
+      "line": 2085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12283,7 +12283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2085,
+      "line": 2086,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12291,7 +12291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2086,
+      "line": 2087,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -12299,7 +12299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2125,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -12307,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2126,
+      "line": 2127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -12315,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2127,
+      "line": 2128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -12323,7 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2128,
+      "line": 2129,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -12331,7 +12331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2129,
+      "line": 2130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -12339,7 +12339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2130,
+      "line": 2131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -12347,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2131,
+      "line": 2132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -12355,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2132,
+      "line": 2133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -36195,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 255,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
       "source": "Widget unavailable",
       "surface": "apple",
@@ -36227,7 +36227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 353,
+      "line": 357,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.title)",
       "surface": "apple",
@@ -36235,7 +36235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 367,
+      "line": 371,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
@@ -36243,7 +36243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 540,
+      "line": 544,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
@@ -36251,7 +36251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 626,
+      "line": 630,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show full output",
       "surface": "apple",
@@ -36259,7 +36259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 626,
+      "line": 630,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show less",
       "surface": "apple",
@@ -36267,7 +36267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 685,
+      "line": 689,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -36275,7 +36275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 711,
+      "line": 715,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -36283,7 +36283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 714,
+      "line": 718,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -36291,7 +36291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 722,
+      "line": 726,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -36299,7 +36299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 723,
+      "line": 727,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -36307,7 +36307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 892,
+      "line": 896,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11379,7 +11379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 133,
+      "line": 150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
       "source": "Widget unavailable",
       "surface": "android",
@@ -36195,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 229,
+      "line": 230,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
       "source": "Widget unavailable",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1507,
+      "line": 1510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1507,
+      "line": 1510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -36195,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 229,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
       "source": "Widget unavailable",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4714,
+      "line": 4722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4745,
+      "line": 4753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4747,
+      "line": 4755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4763,
+      "line": 4771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4850,
+      "line": 4858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4936,
+      "line": 4944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4946,
+      "line": 4954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4950,
+      "line": 4958,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4962,
+      "line": 4970,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4993,
+      "line": 5001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5010,
+      "line": 5018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5019,
+      "line": 5027,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5031,
+      "line": 5039,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5078,
+      "line": 5086,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5205,
+      "line": 5213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5240,
+      "line": 5248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5253,
+      "line": 5261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5257,
+      "line": 5265,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5272,
+      "line": 5280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5272,
+      "line": 5280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5290,
+      "line": 5298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5336,
+      "line": 5344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5349,
+      "line": 5357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5382,
+      "line": 5390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5398,
+      "line": 5406,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5414,
+      "line": 5422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5430,
+      "line": 5438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5520,
+      "line": 5528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5527,
+      "line": 5535,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5567,
+      "line": 5575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5607,
+      "line": 5615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5627,
+      "line": 5635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5679,
+      "line": 5687,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5699,
+      "line": 5707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5704,
+      "line": 5712,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 5863,
+      "line": 5871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5889,
+      "line": 5897,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6547,
+      "line": 6555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6577,
+      "line": 6585,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6614,
+      "line": 6622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7071,
+      "line": 7079,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7080,
+      "line": 7088,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7081,
+      "line": 7089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7089,
+      "line": 7097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7090,
+      "line": 7098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7091,
+      "line": 7099,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7092,
+      "line": 7100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7108,
+      "line": 7116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7125,
+      "line": 7133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7133,
+      "line": 7141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7134,
+      "line": 7142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7136,
+      "line": 7144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7140,
+      "line": 7148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7143,
+      "line": 7151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7148,
+      "line": 7156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7149,
+      "line": 7157,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7151,
+      "line": 7159,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7155,
+      "line": 7163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7158,
+      "line": 7166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7163,
+      "line": 7171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7164,
+      "line": 7172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7166,
+      "line": 7174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7170,
+      "line": 7178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7173,
+      "line": 7181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7205,
+      "line": 7213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7220,
+      "line": 7228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7221,
+      "line": 7229,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7222,
+      "line": 7230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7781,
+      "line": 7789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1510,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1510,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -11379,7 +11379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 150,
+      "line": 151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
       "source": "Widget unavailable",
       "surface": "android",
@@ -36195,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 230,
+      "line": 328,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
       "source": "Widget unavailable",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -691,7 +691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 156,
+      "line": 158,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -699,7 +699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 158,
+      "line": 160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -707,7 +707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 160,
+      "line": 162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 162,
+      "line": 164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 164,
+      "line": 166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 179,
+      "line": 181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 179,
+      "line": 181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 188,
+      "line": 190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 189,
+      "line": 191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 197,
+      "line": 199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 379,
+      "line": 381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 380,
+      "line": 382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 382,
+      "line": 384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 390,
+      "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1800,
+      "line": 1804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1830,
+      "line": 1834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1830,
+      "line": 1834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1843,
+      "line": 1847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1874,
+      "line": 1878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1874,
+      "line": 1878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1896,
+      "line": 1900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1902,
+      "line": 1906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1917,
+      "line": 1921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2122,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2133,
+      "line": 2137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2154,
+      "line": 2158,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2165,
+      "line": 2169,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3061,
+      "line": 3065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3089,
+      "line": 3093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3098,
+      "line": 3102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3782,
+      "line": 3786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3786,
+      "line": 3790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3790,
+      "line": 3794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 3834,
+      "line": 3838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4015,
+      "line": 4019,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4669,
+      "line": 4698,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4700,
+      "line": 4729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4702,
+      "line": 4731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4718,
+      "line": 4747,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4805,
+      "line": 4834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4891,
+      "line": 4920,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4901,
+      "line": 4930,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4905,
+      "line": 4934,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4917,
+      "line": 4946,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4948,
+      "line": 4977,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4965,
+      "line": 4994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4974,
+      "line": 5003,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4986,
+      "line": 5015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5033,
+      "line": 5062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5160,
+      "line": 5189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5195,
+      "line": 5224,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5208,
+      "line": 5237,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5212,
+      "line": 5241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5227,
+      "line": 5256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5227,
+      "line": 5256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5245,
+      "line": 5274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5291,
+      "line": 5320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5304,
+      "line": 5333,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5337,
+      "line": 5366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5353,
+      "line": 5382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5369,
+      "line": 5398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5385,
+      "line": 5414,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5475,
+      "line": 5504,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5482,
+      "line": 5511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5522,
+      "line": 5551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5562,
+      "line": 5591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5582,
+      "line": 5611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5634,
+      "line": 5663,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5654,
+      "line": 5683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5659,
+      "line": 5688,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 5818,
+      "line": 5847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5844,
+      "line": 5873,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6502,
+      "line": 6531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6532,
+      "line": 6561,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6569,
+      "line": 6598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7026,
+      "line": 7055,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7035,
+      "line": 7064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7036,
+      "line": 7065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7044,
+      "line": 7073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7045,
+      "line": 7074,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7046,
+      "line": 7075,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7047,
+      "line": 7076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7063,
+      "line": 7092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7080,
+      "line": 7109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7088,
+      "line": 7117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7089,
+      "line": 7118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7091,
+      "line": 7120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7095,
+      "line": 7124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7098,
+      "line": 7127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7103,
+      "line": 7132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7104,
+      "line": 7133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7106,
+      "line": 7135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7110,
+      "line": 7139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7113,
+      "line": 7142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7118,
+      "line": 7147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7119,
+      "line": 7148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7121,
+      "line": 7150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7125,
+      "line": 7154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7128,
+      "line": 7157,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7160,
+      "line": 7189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7175,
+      "line": 7204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7176,
+      "line": 7205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7177,
+      "line": 7206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7736,
+      "line": 7765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1404,
+      "line": 1481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1404,
+      "line": 1481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -11378,6 +11378,14 @@
       "id": "native.android.6384b9802cfdacfe"
     },
     {
+      "kind": "ui-call",
+      "line": 113,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
+      "source": "Widget unavailable",
+      "surface": "android",
+      "id": "native.android.d1712183ebf86197"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 328,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
@@ -11763,7 +11771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 599,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -11771,7 +11779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 681,
+      "line": 682,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -11779,7 +11787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 682,
+      "line": 683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -11787,7 +11795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 683,
+      "line": 684,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -11795,7 +11803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 696,
+      "line": 697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -11803,7 +11811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 701,
+      "line": 702,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -11811,7 +11819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 709,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -11819,7 +11827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 730,
+      "line": 731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -11827,7 +11835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 878,
+      "line": 884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -11835,7 +11843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 905,
+      "line": 911,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -11843,7 +11851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 931,
+      "line": 937,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -11851,7 +11859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 935,
+      "line": 941,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -11859,7 +11867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 937,
+      "line": 943,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -11867,7 +11875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 939,
+      "line": 945,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -11875,7 +11883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 962,
+      "line": 968,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -11883,7 +11891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 963,
+      "line": 969,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -11891,7 +11899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1022,
+      "line": 1028,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -11899,7 +11907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1023,
+      "line": 1029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent sessions and next steps.",
       "surface": "android",
@@ -11907,7 +11915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1024,
+      "line": 1030,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
       "surface": "android",
@@ -11915,7 +11923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1028,
+      "line": 1034,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -11923,7 +11931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1029,
+      "line": 1035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -11931,7 +11939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1030,
+      "line": 1036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -11939,7 +11947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1034,
+      "line": 1040,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -11947,7 +11955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1035,
+      "line": 1041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -11955,7 +11963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1036,
+      "line": 1042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -11963,7 +11971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 1107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -11971,7 +11979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1099,
+      "line": 1108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -11979,7 +11987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1100,
+      "line": 1109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -11987,7 +11995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1101,
+      "line": 1110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -11995,7 +12003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1115,
+      "line": 1130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12003,7 +12011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12011,7 +12019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12019,7 +12027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1189,
+      "line": 1204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12027,7 +12035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1191,
+      "line": 1206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12035,7 +12043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1194,
+      "line": 1209,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12043,7 +12051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1204,
+      "line": 1219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -12051,7 +12059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1205,
+      "line": 1220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -12059,7 +12067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1270,
+      "line": 1285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -12067,7 +12075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1277,
+      "line": 1292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -12075,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1277,
+      "line": 1292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -12083,7 +12091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1399,
+      "line": 1414,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -12091,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1500,
+      "line": 1515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -12099,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1598,
+      "line": 1613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -12107,7 +12115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1664,
+      "line": 1679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -12115,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1664,
+      "line": 1679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -12123,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1681,
+      "line": 1696,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -12131,7 +12139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1723,
+      "line": 1738,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -12139,7 +12147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1743,
+      "line": 1758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -12147,7 +12155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1789,
+      "line": 1804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -12155,7 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1789,
+      "line": 1804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -12163,7 +12171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1849,
+      "line": 1864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -12171,7 +12179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1884,
+      "line": 1899,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12179,7 +12187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1900,
+      "line": 1915,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
@@ -12187,7 +12195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1940,
+      "line": 1955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12195,7 +12203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1949,
+      "line": 1964,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12203,7 +12211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1961,
+      "line": 1976,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12211,7 +12219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1970,
+      "line": 1985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12219,7 +12227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1971,
+      "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12227,7 +12235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1978,
+      "line": 1993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12235,7 +12243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2037,
+      "line": 2052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12243,7 +12251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2048,
+      "line": 2063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12251,7 +12259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2049,
+      "line": 2064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12259,7 +12267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2050,
+      "line": 2065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12267,7 +12275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2069,
+      "line": 2084,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12275,7 +12283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2070,
+      "line": 2085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12283,7 +12291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2071,
+      "line": 2086,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -12291,7 +12299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2110,
+      "line": 2125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -12299,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2111,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -12307,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2112,
+      "line": 2127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -12315,7 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2113,
+      "line": 2128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -12323,7 +12331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2114,
+      "line": 2129,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -12331,7 +12339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2115,
+      "line": 2130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -12339,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2116,
+      "line": 2131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -12347,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2117,
+      "line": 2132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -23227,7 +23235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3863,
+      "line": 3864,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23235,7 +23243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3864,
+      "line": 3865,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -23243,7 +23251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4563,
+      "line": 4564,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23251,7 +23259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4564,
+      "line": 4565,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23259,7 +23267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4908,
+      "line": 4909,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -23267,7 +23275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4908,
+      "line": 4909,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -23275,7 +23283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6074,
+      "line": 6075,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -23283,7 +23291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6273,
+      "line": 6274,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23291,7 +23299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6273,
+      "line": 6274,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -23299,7 +23307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8682,
+      "line": 8683,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -23307,7 +23315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8682,
+      "line": 8683,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -23315,7 +23323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8688,
+      "line": 8689,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -23323,7 +23331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8689,
+      "line": 8690,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -23331,7 +23339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10027,
+      "line": 10028,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",
@@ -36186,6 +36194,14 @@
       "id": "native.apple.9243b96b3d4d590f"
     },
     {
+      "kind": "ui-call",
+      "line": 141,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "Widget unavailable",
+      "surface": "apple",
+      "id": "native.apple.2c865ac4a69645d3"
+    },
+    {
       "kind": "conditional-branch",
       "line": 548,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift",
@@ -36211,7 +36227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 340,
+      "line": 353,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.title)",
       "surface": "apple",
@@ -36219,7 +36235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 354,
+      "line": 367,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
@@ -36227,7 +36243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 516,
+      "line": 540,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
@@ -36235,7 +36251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 602,
+      "line": 626,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show full output",
       "surface": "apple",
@@ -36243,7 +36259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 602,
+      "line": 626,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show less",
       "surface": "apple",
@@ -36251,7 +36267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 661,
+      "line": 685,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -36259,7 +36275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 687,
+      "line": 711,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -36267,7 +36283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 690,
+      "line": 714,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -36275,7 +36291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 698,
+      "line": 722,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -36283,7 +36299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 699,
+      "line": 723,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -36291,7 +36307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 868,
+      "line": 892,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",
@@ -36491,7 +36507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 458,
+      "line": 462,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -36499,7 +36515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 472,
+      "line": 476,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -36507,7 +36523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 503,
+      "line": 507,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -36515,7 +36531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 506,
+      "line": 510,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -36523,7 +36539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 553,
+      "line": 557,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -36531,7 +36547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 612,
+      "line": 616,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -36539,7 +36555,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 623,
+      "line": 627,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -36547,7 +36563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 643,
+      "line": 647,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36555,7 +36571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1069,
+      "line": 1073,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -36563,7 +36579,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1149,
+      "line": 1153,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -691,7 +691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 158,
+      "line": 159,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -699,7 +699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 160,
+      "line": 161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -707,7 +707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 162,
+      "line": 163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 164,
+      "line": 165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 166,
+      "line": 167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 190,
+      "line": 191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 191,
+      "line": 192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 199,
+      "line": 200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 381,
+      "line": 382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 382,
+      "line": 383,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 384,
+      "line": 385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 392,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1804,
+      "line": 1805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1834,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1834,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1847,
+      "line": 1848,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1878,
+      "line": 1879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1878,
+      "line": 1879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1900,
+      "line": 1901,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1906,
+      "line": 1907,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1921,
+      "line": 1922,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2126,
+      "line": 2127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2137,
+      "line": 2138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2158,
+      "line": 2159,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2169,
+      "line": 2170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3065,
+      "line": 3066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3093,
+      "line": 3094,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3102,
+      "line": 3103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3786,
+      "line": 3787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3790,
+      "line": 3791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3794,
+      "line": 3795,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 3838,
+      "line": 3839,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4019,
+      "line": 4020,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4698,
+      "line": 4697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4729,
+      "line": 4728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4731,
+      "line": 4730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4747,
+      "line": 4746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4834,
+      "line": 4833,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4920,
+      "line": 4919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4930,
+      "line": 4929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4934,
+      "line": 4933,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4946,
+      "line": 4945,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4977,
+      "line": 4976,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4994,
+      "line": 4993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5003,
+      "line": 5002,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5015,
+      "line": 5014,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5062,
+      "line": 5061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5189,
+      "line": 5188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5224,
+      "line": 5223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5237,
+      "line": 5236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5241,
+      "line": 5240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5256,
+      "line": 5255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5256,
+      "line": 5255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5274,
+      "line": 5273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5320,
+      "line": 5319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5333,
+      "line": 5332,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5366,
+      "line": 5365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5382,
+      "line": 5381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5398,
+      "line": 5397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5414,
+      "line": 5413,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5504,
+      "line": 5503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5511,
+      "line": 5510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5551,
+      "line": 5550,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5591,
+      "line": 5590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5611,
+      "line": 5610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5663,
+      "line": 5662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5683,
+      "line": 5682,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5688,
+      "line": 5687,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 5847,
+      "line": 5846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5873,
+      "line": 5872,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6531,
+      "line": 6530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6561,
+      "line": 6560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6598,
+      "line": 6597,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7055,
+      "line": 7054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7064,
+      "line": 7063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7065,
+      "line": 7064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7073,
+      "line": 7072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7074,
+      "line": 7073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7075,
+      "line": 7074,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7076,
+      "line": 7075,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7092,
+      "line": 7091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7109,
+      "line": 7108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7117,
+      "line": 7116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7118,
+      "line": 7117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7120,
+      "line": 7119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7124,
+      "line": 7123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7127,
+      "line": 7126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7132,
+      "line": 7131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7133,
+      "line": 7132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7135,
+      "line": 7134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7139,
+      "line": 7138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7142,
+      "line": 7141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7147,
+      "line": 7146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7148,
+      "line": 7147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7150,
+      "line": 7149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7154,
+      "line": 7153,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7157,
+      "line": 7156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7189,
+      "line": 7188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7204,
+      "line": 7203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7205,
+      "line": 7204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7206,
+      "line": 7205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7765,
+      "line": 7764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -36195,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 141,
+      "line": 183,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
       "source": "Widget unavailable",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "الأداة غير متاحة"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "تم استخدام %@ من الرموز"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "الأداة غير متاحة"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget nicht verfügbar"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ Token verwendet"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget nicht verfügbar"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget no disponible"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ tokens utilizados"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget no disponible"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "ویجت در دسترس نیست"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ توکن استفاده شده است"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "ویجت در دسترس نیست"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget indisponible"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ jetons utilisés"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget indisponible"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "विजेट उपलब्ध नहीं है"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ टोकन उपयोग किए गए"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "विजेट उपलब्ध नहीं है"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget tidak tersedia"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ token telah digunakan"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget tidak tersedia"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget non disponibile"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ token utilizzati"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget non disponibile"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "ウィジェットを利用できません"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@トークンを使用"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "ウィジェットを利用できません"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "위젯을 사용할 수 없음"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@개 토큰 사용됨"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "위젯을 사용할 수 없음"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget niet beschikbaar"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ tokens gebruikt"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget niet beschikbaar"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widżet niedostępny"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "Wykorzystano %@ tokenów"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widżet niedostępny"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget indisponível"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ tokens usados"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget indisponível"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Виджет недоступен"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "Использовано токенов: %@"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Виджет недоступен"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widgeten är inte tillgänglig"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ token används"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widgeten är inte tillgänglig"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "วิดเจ็ตไม่พร้อมใช้งาน"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "ใช้โทเค็นไป %@ รายการ"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "วิดเจ็ตไม่พร้อมใช้งาน"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Widget kullanılamıyor"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "%@ token kullanıldı"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Widget kullanılamıyor"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Віджет недоступний"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "Використано токенів: %@"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Віджет недоступний"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "Tiện ích không khả dụng"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "Đã sử dụng %@ token"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "Tiện ích không khả dụng"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "小组件不可用"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "已使用 %@ 个 token"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "小组件不可用"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -7114,6 +7114,11 @@
       "translated": "$text "
     },
     {
+      "id": "native.android.d1712183ebf86197",
+      "source": "Widget unavailable",
+      "translated": "小工具無法使用"
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -22617,6 +22622,11 @@
       "id": "native.apple.9243b96b3d4d590f",
       "source": "%@ tokens used",
       "translated": "已使用 %@ 個權杖"
+    },
+    {
+      "id": "native.apple.2c865ac4a69645d3",
+      "source": "Widget unavailable",
+      "translated": "小工具無法使用"
     },
     {
       "id": "native.apple.769b7dcea4708c40",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -8,6 +8,7 @@ import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatPlanStep
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatThinkingLevelSelection
+import ai.openclaw.app.chat.ChatWidgetResource
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.chat.defaultChatThinkingLevelSelection
@@ -895,10 +896,10 @@ class MainViewModel private constructor(
 
   fun isTrustedCanvasActionUrl(rawUrl: String?): Boolean = ensureRuntime().isTrustedCanvasActionUrl(rawUrl)
 
-  suspend fun resolveInlineWidgetUrl(
+  internal suspend fun resolveInlineWidgetResource(
     path: String,
-    failedUrl: String?,
-  ): String? = ensureRuntime().resolveInlineWidgetUrl(path, failedUrl)
+    failedResource: ChatWidgetResource?,
+  ) = ensureRuntime().resolveInlineWidgetResource(path, failedResource)
 
   fun requestCanvasRehydrate(source: String = "screen_tab") {
     ensureRuntime().requestCanvasRehydrate(source = source, force = true)

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -895,6 +895,11 @@ class MainViewModel private constructor(
 
   fun isTrustedCanvasActionUrl(rawUrl: String?): Boolean = ensureRuntime().isTrustedCanvasActionUrl(rawUrl)
 
+  suspend fun resolveInlineWidgetUrl(
+    path: String,
+    failedUrl: String?,
+  ): String? = ensureRuntime().resolveInlineWidgetUrl(path, failedUrl)
+
   fun requestCanvasRehydrate(source: String = "screen_tab") {
     ensureRuntime().requestCanvasRehydrate(source = source, force = true)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -13,6 +13,7 @@ import ai.openclaw.app.chat.ChatPlanStep
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.ChatWidgetUrlResolver
 import ai.openclaw.app.chat.MainSessionBinding
 import ai.openclaw.app.chat.MessageSpeechClient
 import ai.openclaw.app.chat.MessageSpeechController
@@ -105,6 +106,7 @@ import android.os.SystemClock
 import android.util.Base64
 import android.util.Log
 import androidx.core.content.ContextCompat
+import androidx.webkit.WebViewFeature
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -467,6 +469,7 @@ class NodeRuntime private constructor(
   @Volatile private var connectingEndpointStableId: String? = null
   private val gatewayDataScopeLock = Any()
   private val gatewaySwitchMutex = Mutex()
+  private val inlineWidgetRefreshMutex = Mutex()
   private val gatewayLifecycleIntentLock = Any()
   private val gatewayLifecycleIntentSeq = AtomicLong()
   private var gatewayDataGeneration = 0L
@@ -720,6 +723,7 @@ class NodeRuntime private constructor(
           hasRecordAudioPermission() &&
           isVoiceWakeWordsReadyForCurrentGateway()
       },
+      inlineWidgetsAvailable = { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) },
       manualTls = { endpoint ->
         prefs.gatewayRegistry.entries.value
           .firstOrNull { it.stableId == endpoint.stableId }
@@ -4105,6 +4109,31 @@ class NodeRuntime private constructor(
   }
 
   fun isTrustedCanvasActionUrl(rawUrl: String?): Boolean = a2uiHandler.isTrustedCanvasActionUrl(rawUrl)
+
+  suspend fun resolveInlineWidgetUrl(
+    path: String,
+    failedUrl: String?,
+  ): String? {
+    fun currentResolution(): Pair<String?, String?> {
+      val nodeSurfaceUrl = nodeSession.currentCanvasHostUrl()
+      val resolved =
+        ChatWidgetUrlResolver.resolve(nodeSurfaceUrl, path)
+          ?: ChatWidgetUrlResolver.resolve(operatorSession.currentCanvasHostUrl(), path)
+      return nodeSurfaceUrl to resolved
+    }
+
+    val current = currentResolution().second
+    if (failedUrl == null || (current != null && current != failedUrl)) return current
+    return inlineWidgetRefreshMutex.withLock {
+      // Rotation is node-role only; a second rotation would also invalidate a sibling's token.
+      val (observedNodeSurfaceUrl, latest) = currentResolution()
+      latest?.takeIf { it != failedUrl }
+        ?: ChatWidgetUrlResolver.resolve(
+          nodeSession.refreshCanvasHostUrlIfCurrent(observedNodeSurfaceUrl),
+          path,
+        )
+    }
+  }
 
   fun loadChat(sessionKey: String) {
     val key = sessionKey.trim().ifEmpty { resolveMainSessionKey() }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -4131,8 +4131,8 @@ class NodeRuntime private constructor(
         operator = operatorSession.currentWidgetSurface(),
       )
 
-    val current = ChatWidgetUrlResolver.resolvePreferred(currentSurfaceUrls(), path, excluding = failedResource)
-    if (failedResource == null || current != null) return current
+    // Initial loads may use the operator fallback; failures refresh the node under the mutex.
+    if (failedResource == null) return ChatWidgetUrlResolver.resolvePreferred(currentSurfaceUrls(), path, excluding = null)
     return inlineWidgetRefreshMutex.withLock {
       // Rotation is node-role only; a second rotation would also invalidate a sibling's token.
       ChatWidgetUrlResolver.resolveAfterFailure(

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -13,6 +13,7 @@ import ai.openclaw.app.chat.ChatPlanStep
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.ChatWidgetSurfaceUrls
 import ai.openclaw.app.chat.ChatWidgetUrlResolver
 import ai.openclaw.app.chat.MainSessionBinding
 import ai.openclaw.app.chat.MessageSpeechClient
@@ -4114,24 +4115,22 @@ class NodeRuntime private constructor(
     path: String,
     failedUrl: String?,
   ): String? {
-    fun currentResolution(): Pair<String?, String?> {
-      val nodeSurfaceUrl = nodeSession.currentCanvasHostUrl()
-      val resolved =
-        ChatWidgetUrlResolver.resolve(nodeSurfaceUrl, path)
-          ?: ChatWidgetUrlResolver.resolve(operatorSession.currentCanvasHostUrl(), path)
-      return nodeSurfaceUrl to resolved
-    }
+    fun currentSurfaceUrls(): ChatWidgetSurfaceUrls =
+      ChatWidgetSurfaceUrls(
+        node = nodeSession.currentCanvasHostUrl(),
+        operator = operatorSession.currentCanvasHostUrl(),
+      )
 
-    val current = currentResolution().second
-    if (failedUrl == null || (current != null && current != failedUrl)) return current
+    val current = ChatWidgetUrlResolver.resolvePreferred(currentSurfaceUrls(), path, excluding = failedUrl)
+    if (failedUrl == null || current != null) return current
     return inlineWidgetRefreshMutex.withLock {
       // Rotation is node-role only; a second rotation would also invalidate a sibling's token.
-      val (observedNodeSurfaceUrl, latest) = currentResolution()
-      latest?.takeIf { it != failedUrl }
-        ?: ChatWidgetUrlResolver.resolve(
-          nodeSession.refreshCanvasHostUrlIfCurrent(observedNodeSurfaceUrl),
-          path,
-        )
+      ChatWidgetUrlResolver.resolveAfterFailure(
+        target = path,
+        failedUrl = failedUrl,
+        currentSurfaceUrls = ::currentSurfaceUrls,
+        refreshNodeSurfaceUrl = nodeSession::refreshCanvasHostUrlIfCurrent,
+      )
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -4131,16 +4131,24 @@ class NodeRuntime private constructor(
         operator = operatorSession.currentWidgetSurface(),
       )
 
-    // Initial loads may use the operator fallback; failures refresh the node under the mutex.
+    // Initial loads may use the operator fallback; failures rotate the preferred live route.
     if (failedResource == null) return ChatWidgetUrlResolver.resolvePreferred(currentSurfaceUrls(), path, excluding = null)
     return inlineWidgetRefreshMutex.withLock {
-      // Rotation is node-role only; a second rotation would also invalidate a sibling's token.
+      // Serialize both role sessions so sibling widgets cannot invalidate each other's new token.
       ChatWidgetUrlResolver.resolveAfterFailure(
         target = path,
         failedResource = failedResource,
         currentSurfaceUrls = ::currentSurfaceUrls,
         refreshNodeSurface = { observedUrl ->
           nodeSession.refreshCanvasHostRouteIfCurrent(observedUrl)?.let { route ->
+            ChatWidgetSurface(
+              url = route.url,
+              tlsFingerprintSha256 = route.tlsFingerprintSha256,
+            )
+          }
+        },
+        refreshOperatorSurface = { observedUrl ->
+          operatorSession.refreshCanvasHostRouteIfCurrent(observedUrl)?.let { route ->
             ChatWidgetSurface(
               url = route.url,
               tlsFingerprintSha256 = route.tlsFingerprintSha256,

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -13,6 +13,8 @@ import ai.openclaw.app.chat.ChatPlanStep
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.ChatWidgetResource
+import ai.openclaw.app.chat.ChatWidgetSurface
 import ai.openclaw.app.chat.ChatWidgetSurfaceUrls
 import ai.openclaw.app.chat.ChatWidgetUrlResolver
 import ai.openclaw.app.chat.MainSessionBinding
@@ -4111,25 +4113,40 @@ class NodeRuntime private constructor(
 
   fun isTrustedCanvasActionUrl(rawUrl: String?): Boolean = a2uiHandler.isTrustedCanvasActionUrl(rawUrl)
 
-  suspend fun resolveInlineWidgetUrl(
+  internal suspend fun resolveInlineWidgetResource(
     path: String,
-    failedUrl: String?,
-  ): String? {
+    failedResource: ChatWidgetResource?,
+  ): ChatWidgetResource? {
+    fun GatewaySession.currentWidgetSurface(): ChatWidgetSurface? =
+      currentCanvasHostRoute()?.let { route ->
+        ChatWidgetSurface(
+          url = route.url,
+          tlsFingerprintSha256 = route.tlsFingerprintSha256,
+        )
+      }
+
     fun currentSurfaceUrls(): ChatWidgetSurfaceUrls =
       ChatWidgetSurfaceUrls(
-        node = nodeSession.currentCanvasHostUrl(),
-        operator = operatorSession.currentCanvasHostUrl(),
+        node = nodeSession.currentWidgetSurface(),
+        operator = operatorSession.currentWidgetSurface(),
       )
 
-    val current = ChatWidgetUrlResolver.resolvePreferred(currentSurfaceUrls(), path, excluding = failedUrl)
-    if (failedUrl == null || current != null) return current
+    val current = ChatWidgetUrlResolver.resolvePreferred(currentSurfaceUrls(), path, excluding = failedResource)
+    if (failedResource == null || current != null) return current
     return inlineWidgetRefreshMutex.withLock {
       // Rotation is node-role only; a second rotation would also invalidate a sibling's token.
       ChatWidgetUrlResolver.resolveAfterFailure(
         target = path,
-        failedUrl = failedUrl,
+        failedResource = failedResource,
         currentSurfaceUrls = ::currentSurfaceUrls,
-        refreshNodeSurfaceUrl = nodeSession::refreshCanvasHostUrlIfCurrent,
+        refreshNodeSurface = { observedUrl ->
+          nodeSession.refreshCanvasHostRouteIfCurrent(observedUrl)?.let { route ->
+            ChatWidgetSurface(
+              url = route.url,
+              tlsFingerprintSha256 = route.tlsFingerprintSha256,
+            )
+          }
+        },
       )
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -3787,6 +3787,30 @@ internal fun parseChatMessageContent(el: JsonElement): ChatMessageContent? {
       )
     }
 
+    "canvas" -> {
+      val preview = obj["preview"].asObjectOrNull() ?: return null
+      val sandbox = preview["sandbox"].asStringOrNull() ?: return null
+      if (preview["kind"].asStringOrNull() != "canvas" ||
+        preview["surface"].asStringOrNull() != "assistant_message" ||
+        preview["render"].asStringOrNull() != "url" ||
+        (sandbox != "scripts" && sandbox != "strict")
+      ) {
+        return null
+      }
+      val path = preview["url"].asStringOrNull()?.trim()?.takeIf(String::isNotEmpty) ?: return null
+      if (!ChatWidgetUrlResolver.supportsTarget(path)) return null
+      ChatMessageContent(
+        type = "canvas",
+        widget =
+          ChatWidgetPreview(
+            title = preview["title"].asStringOrNull(),
+            path = path,
+            preferredHeight = preview["preferredHeight"].asLongOrNull()?.coerceIn(160, 1200)?.toInt(),
+            sandbox = sandbox,
+          ),
+      )
+    }
+
     else -> null
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -36,7 +36,18 @@ data class ChatMessageContent(
   val fileName: String? = null,
   val base64: String? = null,
   val durationMs: Long? = null,
+  val widget: ChatWidgetPreview? = null,
 )
+
+data class ChatWidgetPreview(
+  val title: String?,
+  val path: String,
+  val preferredHeight: Int?,
+  val sandbox: String,
+) {
+  val height: Int
+    get() = (preferredHeight ?: 320).coerceIn(160, 1200)
+}
 
 /**
  * Tool call placeholder shown while a gateway run is still streaming.

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
@@ -51,7 +51,10 @@ internal object ChatWidgetUrlResolver {
     refreshNodeSurface: suspend (String?) -> ChatWidgetSurface?,
   ): ChatWidgetResource? {
     val observed = currentSurfaceUrls()
-    resolvePreferred(observed, target, excluding = failedResource)?.let { return it }
+    observed.node
+      ?.let { resolve(it, target) }
+      ?.takeIf { isReplacement(it, failedResource) }
+      ?.let { return it }
     val refreshed = refreshNodeSurface(observed.node?.url)?.let { resolve(it, target) }
     if (refreshed != null && isReplacement(refreshed, failedResource)) return refreshed
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
@@ -27,6 +27,31 @@ internal object ChatWidgetUrlResolver {
 
   fun supportsTarget(target: String): Boolean = parseRelativeTarget(target) != null
 
+  fun resolvePreferred(
+    surfaces: ChatWidgetSurfaceUrls,
+    target: String,
+    excluding: String?,
+  ): String? =
+    sequenceOf(surfaces.node, surfaces.operator)
+      .mapNotNull { resolve(it, target) }
+      .firstOrNull { it != excluding }
+
+  suspend fun resolveAfterFailure(
+    target: String,
+    failedUrl: String,
+    currentSurfaceUrls: () -> ChatWidgetSurfaceUrls,
+    refreshNodeSurfaceUrl: suspend (String?) -> String?,
+  ): String? {
+    val observed = currentSurfaceUrls()
+    resolvePreferred(observed, target, excluding = failedUrl)?.let { return it }
+    val refreshed = resolve(refreshNodeSurfaceUrl(observed.node), target)
+    if (refreshed != null && refreshed != failedUrl) return refreshed
+
+    // A nil refresh can mean its route lease lost a reconnect race. Re-read
+    // both roles so a replacement connection wins over the stale observation.
+    return resolvePreferred(currentSurfaceUrls(), target, excluding = failedUrl)
+  }
+
   private fun parseCapabilitySurface(raw: String?): URI? {
     val parsed = raw?.trim()?.takeIf(String::isNotEmpty)?.let { runCatching { URI(it) }.getOrNull() } ?: return null
     val scheme = parsed.scheme?.lowercase()
@@ -70,3 +95,8 @@ internal object ChatWidgetUrlResolver {
     return null
   }
 }
+
+internal data class ChatWidgetSurfaceUrls(
+  val node: String?,
+  val operator: String?,
+)

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
@@ -1,0 +1,72 @@
+package ai.openclaw.app.chat
+
+import java.net.URI
+import java.net.URLDecoder
+
+internal object ChatWidgetUrlResolver {
+  private const val DOCUMENTS_PATH = "/__openclaw__/canvas/documents"
+
+  fun resolve(
+    surfaceUrl: String?,
+    target: String,
+  ): String? {
+    val surface = parseCapabilitySurface(surfaceUrl) ?: return null
+    val relative = parseRelativeTarget(target) ?: return null
+    val joined =
+      buildString {
+        append(surface.scheme.lowercase())
+        append("://")
+        append(surface.rawAuthority)
+        append(surface.rawPath.trimEnd('/'))
+        append(relative.rawPath)
+        relative.rawQuery?.let { append('?').append(it) }
+        relative.rawFragment?.let { append('#').append(it) }
+      }
+    return runCatching { URI(joined) }.getOrNull()?.toASCIIString()
+  }
+
+  fun supportsTarget(target: String): Boolean = parseRelativeTarget(target) != null
+
+  private fun parseCapabilitySurface(raw: String?): URI? {
+    val parsed = raw?.trim()?.takeIf(String::isNotEmpty)?.let { runCatching { URI(it) }.getOrNull() } ?: return null
+    val scheme = parsed.scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") return null
+    if (parsed.host.isNullOrBlank() || parsed.rawUserInfo != null || parsed.rawQuery != null || parsed.rawFragment != null) return null
+    val segments = parsed.rawPath.split('/').filter(String::isNotEmpty)
+    if (segments.size < 3 || segments[segments.lastIndex - 2] != "__openclaw__" || segments[segments.lastIndex - 1] != "cap") return null
+    if (decodeRepeatedly(segments.last())?.isEmpty() != false) return null
+    return parsed
+  }
+
+  private fun parseRelativeTarget(raw: String): URI? {
+    val target = raw.trim()
+    if (!target.startsWith('/')) return null
+    val parsed = runCatching { URI(target) }.getOrNull() ?: return null
+    if (parsed.isAbsolute || parsed.rawAuthority != null || !isCanonicalPath(parsed.rawPath)) return null
+    if (!parsed.rawPath.startsWith("$DOCUMENTS_PATH/")) return null
+    return parsed
+  }
+
+  private fun isCanonicalPath(path: String): Boolean {
+    val segments = path.split('/')
+    if (segments.firstOrNull()?.isNotEmpty() == true) return false
+    return segments.drop(1).all { encoded ->
+      if (encoded.isEmpty()) return@all false
+      val decoded = decodeRepeatedly(encoded) ?: return@all false
+      decoded != "." && decoded != ".." && !decoded.contains('/') && !decoded.contains('\\')
+    }
+  }
+
+  private fun decodeRepeatedly(raw: String): String? {
+    var value = raw
+    repeat(8) {
+      val decoded =
+        runCatching {
+          URLDecoder.decode(value.replace("+", "%2B"), Charsets.UTF_8.name())
+        }.getOrNull() ?: return null
+      if (decoded == value) return decoded
+      value = decoded
+    }
+    return null
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
@@ -49,6 +49,7 @@ internal object ChatWidgetUrlResolver {
     failedResource: ChatWidgetResource,
     currentSurfaceUrls: () -> ChatWidgetSurfaceUrls,
     refreshNodeSurface: suspend (String?) -> ChatWidgetSurface?,
+    refreshOperatorSurface: suspend (String?) -> ChatWidgetSurface?,
   ): ChatWidgetResource? {
     val observed = currentSurfaceUrls()
     observed.node
@@ -60,6 +61,12 @@ internal object ChatWidgetUrlResolver {
 
     // A nil refresh can mean its route lease lost a reconnect race. Re-read
     // both roles so a replacement connection wins over the stale observation.
+    val afterNodeRefresh = currentSurfaceUrls()
+    resolvePreferred(afterNodeRefresh, target, excluding = failedResource)?.let { return it }
+
+    val refreshedOperator = refreshOperatorSurface(afterNodeRefresh.operator?.url)?.let { resolve(it, target) }
+    if (refreshedOperator != null && isReplacement(refreshedOperator, failedResource)) return refreshedOperator
+
     return resolvePreferred(currentSurfaceUrls(), target, excluding = failedResource)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
@@ -30,18 +30,30 @@ internal object ChatWidgetUrlResolver {
   private fun resolve(
     surface: ChatWidgetSurface,
     target: String,
+    role: ChatWidgetSurfaceRole,
+    attemptedRoles: Set<ChatWidgetSurfaceRole>,
   ): ChatWidgetResource? =
     resolve(surface.url, target)?.let { url ->
-      ChatWidgetResource(url = url, tlsFingerprintSha256 = surface.tlsFingerprintSha256)
+      ChatWidgetResource(
+        url = url,
+        tlsFingerprintSha256 = surface.tlsFingerprintSha256,
+        surfaceRole = role,
+        attemptedSurfaceRoles = attemptedRoles,
+      )
     }
 
   fun resolvePreferred(
     surfaces: ChatWidgetSurfaceUrls,
     target: String,
     excluding: ChatWidgetResource?,
+    blockedRoles: Set<ChatWidgetSurfaceRole> = emptySet(),
+    attemptedRoles: Set<ChatWidgetSurfaceRole> = emptySet(),
   ): ChatWidgetResource? =
-    sequenceOf(surfaces.node, surfaces.operator)
-      .mapNotNull { it?.let { surface -> resolve(surface, target) } }
+    sequenceOf(
+      ChatWidgetSurfaceRole.NODE to surfaces.node,
+      ChatWidgetSurfaceRole.OPERATOR to surfaces.operator,
+    ).filter { (role) -> role !in blockedRoles }
+      .mapNotNull { (role, surface) -> surface?.let { resolve(it, target, role, attemptedRoles) } }
       .firstOrNull { isReplacement(it, excluding) }
 
   suspend fun resolveAfterFailure(
@@ -52,22 +64,49 @@ internal object ChatWidgetUrlResolver {
     refreshOperatorSurface: suspend (String?) -> ChatWidgetSurface?,
   ): ChatWidgetResource? {
     val observed = currentSurfaceUrls()
-    observed.node
-      ?.let { resolve(it, target) }
-      ?.takeIf { isReplacement(it, failedResource) }
-      ?.let { return it }
-    val refreshed = refreshNodeSurface(observed.node?.url)?.let { resolve(it, target) }
-    if (refreshed != null && isReplacement(refreshed, failedResource)) return refreshed
+    val blockedRoles = failedResource.attemptedSurfaceRoles
+    if (failedResource.surfaceRole == ChatWidgetSurfaceRole.LEGACY && ChatWidgetSurfaceRole.LEGACY in blockedRoles) {
+      return null
+    }
+    val attemptedRoles = blockedRoles + failedResource.surfaceRole
+    if (ChatWidgetSurfaceRole.NODE !in blockedRoles) {
+      observed.node
+        ?.let { resolve(it, target, ChatWidgetSurfaceRole.NODE, attemptedRoles) }
+        ?.takeIf { isReplacement(it, failedResource) }
+        ?.let { return it }
+      val refreshed =
+        refreshNodeSurface(observed.node?.url)?.let {
+          resolve(it, target, ChatWidgetSurfaceRole.NODE, attemptedRoles)
+        }
+      if (refreshed != null && isReplacement(refreshed, failedResource)) return refreshed
+    }
 
     // A nil refresh can mean its route lease lost a reconnect race. Re-read
     // both roles so a replacement connection wins over the stale observation.
     val afterNodeRefresh = currentSurfaceUrls()
-    resolvePreferred(afterNodeRefresh, target, excluding = failedResource)?.let { return it }
+    resolvePreferred(
+      afterNodeRefresh,
+      target,
+      excluding = failedResource,
+      blockedRoles = blockedRoles,
+      attemptedRoles = attemptedRoles,
+    )?.let { return it }
 
-    val refreshedOperator = refreshOperatorSurface(afterNodeRefresh.operator?.url)?.let { resolve(it, target) }
-    if (refreshedOperator != null && isReplacement(refreshedOperator, failedResource)) return refreshedOperator
+    if (ChatWidgetSurfaceRole.OPERATOR !in blockedRoles) {
+      val refreshedOperator =
+        refreshOperatorSurface(afterNodeRefresh.operator?.url)?.let {
+          resolve(it, target, ChatWidgetSurfaceRole.OPERATOR, attemptedRoles)
+        }
+      if (refreshedOperator != null && isReplacement(refreshedOperator, failedResource)) return refreshedOperator
+    }
 
-    return resolvePreferred(currentSurfaceUrls(), target, excluding = failedResource)
+    return resolvePreferred(
+      currentSurfaceUrls(),
+      target,
+      excluding = failedResource,
+      blockedRoles = blockedRoles,
+      attemptedRoles = attemptedRoles,
+    )
   }
 
   private fun isReplacement(
@@ -75,10 +114,14 @@ internal object ChatWidgetUrlResolver {
     failedResource: ChatWidgetResource?,
   ): Boolean {
     if (failedResource == null) return true
-    return if (failedResource.tlsFingerprintSha256 == null) {
+    return if (
+      failedResource.surfaceRole == ChatWidgetSurfaceRole.LEGACY &&
+      failedResource.tlsFingerprintSha256 == null
+    ) {
       candidate.url != failedResource.url
     } else {
-      candidate != failedResource
+      candidate.url != failedResource.url ||
+        candidate.tlsFingerprintSha256 != failedResource.tlsFingerprintSha256
     }
   }
 
@@ -136,7 +179,15 @@ internal data class ChatWidgetSurface(
   val tlsFingerprintSha256: String?,
 )
 
+internal enum class ChatWidgetSurfaceRole {
+  NODE,
+  OPERATOR,
+  LEGACY,
+}
+
 internal data class ChatWidgetResource(
   val url: String,
   val tlsFingerprintSha256: String?,
+  val surfaceRole: ChatWidgetSurfaceRole = ChatWidgetSurfaceRole.LEGACY,
+  val attemptedSurfaceRoles: Set<ChatWidgetSurfaceRole> = emptySet(),
 )

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatWidgetUrlResolver.kt
@@ -27,29 +27,49 @@ internal object ChatWidgetUrlResolver {
 
   fun supportsTarget(target: String): Boolean = parseRelativeTarget(target) != null
 
+  private fun resolve(
+    surface: ChatWidgetSurface,
+    target: String,
+  ): ChatWidgetResource? =
+    resolve(surface.url, target)?.let { url ->
+      ChatWidgetResource(url = url, tlsFingerprintSha256 = surface.tlsFingerprintSha256)
+    }
+
   fun resolvePreferred(
     surfaces: ChatWidgetSurfaceUrls,
     target: String,
-    excluding: String?,
-  ): String? =
+    excluding: ChatWidgetResource?,
+  ): ChatWidgetResource? =
     sequenceOf(surfaces.node, surfaces.operator)
-      .mapNotNull { resolve(it, target) }
-      .firstOrNull { it != excluding }
+      .mapNotNull { it?.let { surface -> resolve(surface, target) } }
+      .firstOrNull { isReplacement(it, excluding) }
 
   suspend fun resolveAfterFailure(
     target: String,
-    failedUrl: String,
+    failedResource: ChatWidgetResource,
     currentSurfaceUrls: () -> ChatWidgetSurfaceUrls,
-    refreshNodeSurfaceUrl: suspend (String?) -> String?,
-  ): String? {
+    refreshNodeSurface: suspend (String?) -> ChatWidgetSurface?,
+  ): ChatWidgetResource? {
     val observed = currentSurfaceUrls()
-    resolvePreferred(observed, target, excluding = failedUrl)?.let { return it }
-    val refreshed = resolve(refreshNodeSurfaceUrl(observed.node), target)
-    if (refreshed != null && refreshed != failedUrl) return refreshed
+    resolvePreferred(observed, target, excluding = failedResource)?.let { return it }
+    val refreshed = refreshNodeSurface(observed.node?.url)?.let { resolve(it, target) }
+    if (refreshed != null && isReplacement(refreshed, failedResource)) return refreshed
 
     // A nil refresh can mean its route lease lost a reconnect race. Re-read
     // both roles so a replacement connection wins over the stale observation.
-    return resolvePreferred(currentSurfaceUrls(), target, excluding = failedUrl)
+    return resolvePreferred(currentSurfaceUrls(), target, excluding = failedResource)
+  }
+
+  private fun isReplacement(
+    candidate: ChatWidgetResource,
+    failedResource: ChatWidgetResource?,
+  ): Boolean {
+    if (failedResource == null) return true
+    return if (failedResource.tlsFingerprintSha256 == null) {
+      candidate.url != failedResource.url
+    } else {
+      candidate != failedResource
+    }
   }
 
   private fun parseCapabilitySurface(raw: String?): URI? {
@@ -97,6 +117,16 @@ internal object ChatWidgetUrlResolver {
 }
 
 internal data class ChatWidgetSurfaceUrls(
-  val node: String?,
-  val operator: String?,
+  val node: ChatWidgetSurface?,
+  val operator: ChatWidgetSurface?,
+)
+
+internal data class ChatWidgetSurface(
+  val url: String,
+  val tlsFingerprintSha256: String?,
+)
+
+internal data class ChatWidgetResource(
+  val url: String,
+  val tlsFingerprintSha256: String?,
 )

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -282,7 +282,6 @@ enum class GatewayMethod(
   NodeRename("node.rename"),
   NodeList("node.list"),
   NodeDescribe("node.describe"),
-  PluginSurfaceRefresh("plugin.surface.refresh"),
   NodePluginSurfaceRefresh("node.pluginSurface.refresh"),
   NodePluginToolsUpdate("node.pluginTools.update"),
   NodeSkillsUpdate("node.skills.update"),
@@ -380,6 +379,7 @@ enum class GatewayMethod(
   MigrationsMemoryApply("migrations.memory.apply"),
   UiCommand("ui.command"),
   ApprovalHistory("approval.history"),
+  PluginSurfaceRefresh("plugin.surface.refresh"),
 }
 
 enum class GatewayEvent(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -282,6 +282,7 @@ enum class GatewayMethod(
   NodeRename("node.rename"),
   NodeList("node.list"),
   NodeDescribe("node.describe"),
+  PluginSurfaceRefresh("plugin.surface.refresh"),
   NodePluginSurfaceRefresh("node.pluginSurface.refresh"),
   NodePluginToolsUpdate("node.pluginTools.update"),
   NodeSkillsUpdate("node.skills.update"),

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -224,8 +224,19 @@ class GatewaySession(
   /** One ready physical WebSocket captured before queued work starts waiting. */
   internal class RequestLease internal constructor(
     val endpointStableId: String,
+    private val isCurrentImpl: () -> Boolean = { true },
+    private val commitIfCurrentImpl: ((block: () -> Unit) -> Boolean)? = null,
     private val requestImpl: suspend (method: String, paramsJson: String?, timeoutMs: Long) -> String,
   ) {
+    fun isCurrent(): Boolean = isCurrentImpl()
+
+    fun commitIfCurrent(block: () -> Unit): Boolean {
+      commitIfCurrentImpl?.let { return it(block) }
+      if (!isCurrentImpl()) return false
+      block()
+      return true
+    }
+
     suspend fun request(
       method: String,
       paramsJson: String?,
@@ -377,6 +388,58 @@ class GatewaySession(
 
   internal fun isReady(): Boolean = readyConnection() != null
 
+  internal fun currentCanvasHostUrl(): String? = pluginSurfaceUrls["canvas"]
+
+  internal suspend fun refreshCanvasHostUrl(): String? = refreshCanvasHostUrl(observedSurfaceUrl = null, requireObservedMatch = false)
+
+  internal suspend fun refreshCanvasHostUrlIfCurrent(observedSurfaceUrl: String?): String? = refreshCanvasHostUrl(observedSurfaceUrl = observedSurfaceUrl, requireObservedMatch = true)
+
+  private suspend fun refreshCanvasHostUrl(
+    observedSurfaceUrl: String?,
+    requireObservedMatch: Boolean,
+  ): String? {
+    val (lease, target) =
+      synchronized(lifecycleLock) {
+        val current = pluginSurfaceUrls["canvas"]
+        if (requireObservedMatch && current != observedSurfaceUrl) return current
+        val capturedLease = captureRequestLease() ?: return null
+        val capturedTarget =
+          desired
+            ?.takeIf { it.endpoint.stableId == capturedLease.endpointStableId }
+            ?: return null
+        capturedLease to capturedTarget
+      }
+    val response =
+      runCatching {
+        lease.request(
+          GatewayMethod.NodePluginSurfaceRefresh.rawValue,
+          buildJsonObject { put("surface", JsonPrimitive("canvas")) }.toString(),
+          timeoutMs = 8_000,
+        )
+      }.getOrNull() ?: return null
+    val raw =
+      parseJsonOrNull(response)
+        .asObjectOrNull()
+        ?.get("pluginSurfaceUrls")
+        .asObjectOrNull()
+        ?.get("canvas")
+        .asStringOrNull()
+    val refreshed = normalizeCanvasHostUrl(raw, target.endpoint, isTlsConnection = target.tls != null) ?: return null
+    var result: String? = null
+    val committed =
+      lease.commitIfCurrent {
+        val current = pluginSurfaceUrls["canvas"]
+        result =
+          if (requireObservedMatch && current != observedSurfaceUrl) {
+            current
+          } else {
+            pluginSurfaceUrls = pluginSurfaceUrls + ("canvas" to refreshed)
+            refreshed
+          }
+      }
+    return if (committed) result else null
+  }
+
   /** Current physical connection identity, including events sent during connect publication. */
   internal fun currentEndpointStableId(): String? = currentConnection?.endpoint?.stableId
 
@@ -490,16 +553,30 @@ class GatewaySession(
   }
 
   /** Captures the current physical connection; requests never resolve a replacement socket. */
-  internal fun captureRequestLease(expectedEndpointStableId: String? = null): RequestLease? {
-    val conn = readyConnection(expectedEndpointStableId) ?: return null
-    return RequestLease(endpointStableId = conn.endpoint.stableId) { method, paramsJson, timeoutMs ->
-      val res = requestDetailed(conn, method, paramsJson, timeoutMs)
-      if (!res.ok) {
-        throw GatewayRequestRejected(res.error ?: ErrorShape("UNAVAILABLE", "request failed"))
+  internal fun captureRequestLease(expectedEndpointStableId: String? = null): RequestLease? =
+    synchronized(lifecycleLock) {
+      val conn = readyConnection(expectedEndpointStableId) ?: return@synchronized null
+      RequestLease(
+        endpointStableId = conn.endpoint.stableId,
+        isCurrentImpl = { currentConnection === conn && conn.isReady() },
+        commitIfCurrentImpl = { block ->
+          synchronized(lifecycleLock) {
+            if (currentConnection !== conn || !conn.isReady()) {
+              false
+            } else {
+              block()
+              true
+            }
+          }
+        },
+      ) { method, paramsJson, timeoutMs ->
+        val res = requestDetailed(conn, method, paramsJson, timeoutMs)
+        if (!res.ok) {
+          throw GatewayRequestRejected(res.error ?: ErrorShape("UNAVAILABLE", "request failed"))
+        }
+        res.payloadJson ?: ""
       }
-      res.payloadJson ?: ""
     }
-  }
 
   /** Sends an RPC request and returns the structured success/error payload. */
   suspend fun requestDetailed(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -439,7 +439,7 @@ class GatewaySession(
       when (
         target.options.role
           .trim()
-          .lowercase(Locale.ROOT),
+          .lowercase(Locale.ROOT)
       ) {
         "node" -> GatewayMethod.NodePluginSurfaceRefresh
         "operator" -> GatewayMethod.PluginSurfaceRefresh

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -424,7 +424,7 @@ class GatewaySession(
     observedSurfaceUrl: String?,
     requireObservedMatch: Boolean,
   ): String? {
-    val (lease, target) =
+    val (lease, target, requestObservedSurfaceUrl) =
       synchronized(lifecycleLock) {
         val current = pluginSurfaceUrls["canvas"]
         if (requireObservedMatch && current != observedSurfaceUrl) return current
@@ -433,13 +433,16 @@ class GatewaySession(
           desired
             ?.takeIf { it.endpoint.stableId == capturedLease.endpointStableId }
             ?: return null
-        capturedLease to capturedTarget
+        Triple(capturedLease, capturedTarget, current)
       }
     val response =
       runCatching {
         lease.request(
           GatewayMethod.NodePluginSurfaceRefresh.rawValue,
-          buildJsonObject { put("surface", JsonPrimitive("canvas")) }.toString(),
+          buildJsonObject {
+            put("surface", JsonPrimitive("canvas"))
+            requestObservedSurfaceUrl?.let { put("observedUrl", JsonPrimitive(it)) }
+          }.toString(),
           timeoutMs = 8_000,
         )
       }.getOrNull() ?: return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -160,6 +160,11 @@ internal enum class NodeEventSendOutcome {
   FAILED,
 }
 
+internal data class GatewayCanvasHostRoute(
+  val url: String,
+  val tlsFingerprintSha256: String?,
+)
+
 /**
  * WebSocket RPC session that maintains gateway connection lifecycle, auth, events, and node invokes.
  */
@@ -390,9 +395,30 @@ class GatewaySession(
 
   internal fun currentCanvasHostUrl(): String? = pluginSurfaceUrls["canvas"]
 
+  internal fun currentCanvasHostRoute(): GatewayCanvasHostRoute? =
+    synchronized(lifecycleLock) {
+      val connection = readyConnection() ?: return@synchronized null
+      val url = pluginSurfaceUrls["canvas"] ?: return@synchronized null
+      // TOFU can learn the certificate during the WebSocket handshake. Read
+      // the live TLS config so the widget document inherits that exact trust.
+      val fingerprint =
+        connection.tlsConfig
+          ?.effectiveFingerprintSha256
+          ?.let(::normalizeGatewayTlsFingerprint)
+          ?.takeIf { it.length == 64 }
+      GatewayCanvasHostRoute(url = url, tlsFingerprintSha256 = fingerprint)
+    }
+
   internal suspend fun refreshCanvasHostUrl(): String? = refreshCanvasHostUrl(observedSurfaceUrl = null, requireObservedMatch = false)
 
   internal suspend fun refreshCanvasHostUrlIfCurrent(observedSurfaceUrl: String?): String? = refreshCanvasHostUrl(observedSurfaceUrl = observedSurfaceUrl, requireObservedMatch = true)
+
+  internal suspend fun refreshCanvasHostRouteIfCurrent(observedSurfaceUrl: String?): GatewayCanvasHostRoute? {
+    refreshCanvasHostUrlIfCurrent(observedSurfaceUrl)
+    // Pair the URL with the currently installed connection after suspension;
+    // a reconnect can replace both the capability and its certificate pin.
+    return currentCanvasHostRoute()
+  }
 
   private suspend fun refreshCanvasHostUrl(
     observedSurfaceUrl: String?,
@@ -693,6 +719,10 @@ class GatewaySession(
 
     @Volatile
     private var connectRequestId: String? = null
+    val tlsConfig: GatewayTlsConfig? =
+      buildGatewayTlsConfig(tls) { fingerprint ->
+        onTlsFingerprint?.invoke(tls?.stableId ?: endpoint.stableId, fingerprint)
+      }
     private val client: OkHttpClient = buildClient()
     private val listener = Listener()
     private var socket: WebSocket? = null
@@ -897,10 +927,6 @@ class GatewaySession(
           .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
           .readTimeout(0, java.util.concurrent.TimeUnit.SECONDS)
           .pingInterval(30, java.util.concurrent.TimeUnit.SECONDS)
-      val tlsConfig =
-        buildGatewayTlsConfig(tls) { fingerprint ->
-          onTlsFingerprint?.invoke(tls?.stableId ?: endpoint.stableId, fingerprint)
-        }
       if (tlsConfig != null) {
         builder.sslSocketFactory(tlsConfig.sslSocketFactory, tlsConfig.trustManager)
         builder.hostnameVerifier(tlsConfig.hostnameVerifier)

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -436,7 +436,11 @@ class GatewaySession(
         Triple(capturedLease, capturedTarget, current)
       }
     val refreshMethod =
-      when (target.options.role.trim().lowercase(Locale.ROOT)) {
+      when (
+        target.options.role
+          .trim()
+          .lowercase(Locale.ROOT),
+      ) {
         "node" -> GatewayMethod.NodePluginSurfaceRefresh
         "operator" -> GatewayMethod.PluginSurfaceRefresh
         else -> return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -406,7 +406,16 @@ class GatewaySession(
           ?.effectiveFingerprintSha256
           ?.let(::normalizeGatewayTlsFingerprint)
           ?.takeIf { it.length == 64 }
-      GatewayCanvasHostRoute(url = url, tlsFingerprintSha256 = fingerprint)
+      GatewayCanvasHostRoute(
+        url = url,
+        tlsFingerprintSha256 =
+          gatewayTlsFingerprintForCanvasSurface(
+            fingerprint = fingerprint,
+            surfaceUrl = url,
+            endpoint = connection.endpoint,
+            isTlsConnection = connection.tlsConfig != null,
+          ),
+      )
     }
 
   internal suspend fun refreshCanvasHostUrl(): String? = refreshCanvasHostUrl(observedSurfaceUrl = null, requireObservedMatch = false)
@@ -1817,6 +1826,23 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
 }
 
 /** Builds the gateway WebSocket URL from endpoint authority and TLS policy. */
+internal fun gatewayTlsFingerprintForCanvasSurface(
+  fingerprint: String?,
+  surfaceUrl: String,
+  endpoint: GatewayEndpoint,
+  isTlsConnection: Boolean,
+): String? {
+  if (!isTlsConnection || fingerprint == null) return null
+  val surface = runCatching { java.net.URI(surfaceUrl) }.getOrNull() ?: return null
+  if (!surface.scheme.equals("https", ignoreCase = true)) return null
+  val surfaceHost = surface.host?.trim()?.trimEnd('.') ?: return null
+  val gatewayHost = endpoint.host.trim().trimEnd('.')
+  val surfacePort = surface.port.takeIf { it > 0 } ?: 443
+  return fingerprint.takeIf {
+    surfaceHost.equals(gatewayHost, ignoreCase = true) && surfacePort == endpoint.port
+  }
+}
+
 internal fun buildGatewayWebSocketUrl(
   host: String,
   port: Int,

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -435,10 +435,16 @@ class GatewaySession(
             ?: return null
         Triple(capturedLease, capturedTarget, current)
       }
+    val refreshMethod =
+      when (target.options.role.trim().lowercase(Locale.ROOT)) {
+        "node" -> GatewayMethod.NodePluginSurfaceRefresh
+        "operator" -> GatewayMethod.PluginSurfaceRefresh
+        else -> return null
+      }
     val response =
       runCatching {
         lease.request(
-          GatewayMethod.NodePluginSurfaceRefresh.rawValue,
+          refreshMethod.rawValue,
           buildJsonObject {
             put("surface", JsonPrimitive("canvas"))
             requestObservedSurfaceUrl?.let { put("observedUrl", JsonPrimitive(it)) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
@@ -37,12 +37,16 @@ data class GatewayTlsParams(
   val stableId: String,
 )
 
-/** SSL primitives installed into OkHttp when a gateway needs TLS pinning/TOFU. */
-data class GatewayTlsConfig(
+/** SSL primitives and accepted route trust installed into OkHttp. */
+class GatewayTlsConfig internal constructor(
   val sslSocketFactory: SSLSocketFactory,
   val trustManager: X509TrustManager,
   val hostnameVerifier: HostnameVerifier,
-)
+  private val effectiveFingerprint: AtomicReference<String?>,
+) {
+  val effectiveFingerprintSha256: String?
+    get() = effectiveFingerprint.get()
+}
 
 /** Distinguishes non-TLS endpoints from unreachable endpoints during probing. */
 enum class GatewayTlsProbeFailure {
@@ -82,7 +86,13 @@ internal fun buildGatewayTlsConfig(
     params.expectedFingerprint
       ?.let(::normalizeGatewayTlsFingerprint)
       ?.takeIf { it.isNotBlank() }
+  val effectiveFingerprint = AtomicReference(expected)
   val usesPlatformTrust = expected == null && !params.allowTOFU
+
+  fun recordAcceptedFingerprint(chain: Array<X509Certificate>) {
+    val certificate = chain.firstOrNull() ?: return
+    effectiveFingerprint.set(sha256Hex(certificate.encoded))
+  }
 
   @SuppressLint("CustomX509TrustManager")
   val trustManager =
@@ -128,6 +138,7 @@ internal fun buildGatewayTlsConfig(
           if (fingerprint != expected) {
             throw CertificateException("gateway TLS fingerprint mismatch")
           }
+          effectiveFingerprint.set(fingerprint)
           return
         }
         if (params.allowTOFU) {
@@ -135,9 +146,11 @@ internal fun buildGatewayTlsConfig(
           // caller persists the fingerprint against the endpoint's stable id,
           // and later connects must come back through the pinned branch above.
           onStore?.invoke(fingerprint)
+          effectiveFingerprint.set(fingerprint)
           return
         }
         defaultTrust.checkServerTrusted(chain, authType)
+        effectiveFingerprint.set(fingerprint)
       }
 
       override fun checkServerTrusted(
@@ -148,6 +161,7 @@ internal fun buildGatewayTlsConfig(
         if (usesPlatformTrust && defaultTrust is X509ExtendedTrustManager) {
           // Preserve the connected hostname for Android's domain-aware platform trust manager.
           defaultTrust.checkServerTrusted(chain, authType, socket)
+          recordAcceptedFingerprint(chain)
         } else {
           checkServerTrusted(chain, authType)
         }
@@ -160,6 +174,7 @@ internal fun buildGatewayTlsConfig(
       ) {
         if (usesPlatformTrust && defaultTrust is X509ExtendedTrustManager) {
           defaultTrust.checkServerTrusted(chain, authType, engine)
+          recordAcceptedFingerprint(chain)
         } else {
           checkServerTrusted(chain, authType)
         }
@@ -181,6 +196,7 @@ internal fun buildGatewayTlsConfig(
     sslSocketFactory = context.socketFactory,
     trustManager = trustManager,
     hostnameVerifier = verifier,
+    effectiveFingerprint = effectiveFingerprint,
   )
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/i18n/NativeStringResources.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/i18n/NativeStringResources.kt
@@ -1327,6 +1327,7 @@ internal val nativeStringResourceIds: Map<String, Int> =
     "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session." to R.string.native_1dbf9d5979606697,
     "Where do I get a setup code?" to R.string.native_c34dd5eb8b0af56e,
     "While Using" to R.string.native_44173ba2044fb22f,
+    "Widget unavailable" to R.string.native_41659b48f2dc4c36,
     "Working" to R.string.native_a92f0449a9f7235b,
     "Working directory" to R.string.native_865e85c6fbf9d3b2,
     "Working · \$pendingRunCount active runs" to R.string.native_75c4bbf668b72cbf,

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -27,6 +27,7 @@ class ConnectionManager(
   private val photosAvailable: () -> Boolean,
   private val installedAppsSharingEnabled: () -> Boolean,
   private val voiceWakeAvailable: () -> Boolean,
+  private val inlineWidgetsAvailable: () -> Boolean,
   private val manualTls: (GatewayEndpoint) -> Boolean,
 ) {
   companion object {
@@ -47,6 +48,8 @@ class ConnectionManager(
         "operator.talk.secrets",
         "operator.write",
       )
+
+    internal const val INLINE_WIDGETS_CLIENT_CAPABILITY = "inline-widgets"
 
     internal fun operatorScopesForStoredDeviceToken(storedScopes: List<String>): List<String> {
       val normalized =
@@ -218,7 +221,7 @@ class ConnectionManager(
     GatewayConnectOptions(
       role = "operator",
       scopes = scopes,
-      caps = emptyList(),
+      caps = if (inlineWidgetsAvailable()) listOf(INLINE_WIDGETS_CLIENT_CAPABILITY) else emptyList(),
       commands = emptyList(),
       permissions = emptyMap(),
       client = buildClientInfo(clientId = "openclaw-android", clientMode = "ui"),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
@@ -10,6 +10,7 @@ import ai.openclaw.app.ui.design.ClawTheme
 import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
+import android.view.ViewGroup
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -68,10 +69,46 @@ internal fun ChatInlineWidget(
   var unavailable by remember(preview.path) { mutableStateOf(false) }
   var didRefresh by remember(preview.path) { mutableStateOf(false) }
   var refreshInFlight by remember(preview.path) { mutableStateOf(false) }
+  var refreshRequestId by remember(preview.path) { mutableStateOf<UUID?>(null) }
   val scope = rememberCoroutineScope()
   val isolatedProfileSupported = remember { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) }
 
+  fun handleFailure(
+    resource: ChatWidgetResource,
+    rendererGone: Boolean,
+  ) {
+    if (resolvedResource != resource) return
+    if (rendererGone) {
+      // onRenderProcessGone destroys the unusable WebView immediately. Drop
+      // Compose's resource reference even when its replacement is in flight.
+      resolvedResource = null
+      unavailable = false
+    }
+    if (refreshInFlight) return
+    if (didRefresh) {
+      refreshRequestId = null
+      resolvedResource = null
+      unavailable = true
+      return
+    }
+
+    didRefresh = true
+    refreshInFlight = true
+    val requestId = UUID.randomUUID()
+    refreshRequestId = requestId
+    scope.launch {
+      val replacement = resolveResource(preview.path, resource)
+      if (refreshRequestId != requestId) return@launch
+      refreshRequestId = null
+      resolvedResource = replacement
+      unavailable = replacement == null
+      refreshInFlight = false
+    }
+  }
+
   LaunchedEffect(preview.path, resolverReady) {
+    refreshRequestId = null
+    refreshInFlight = false
     if (!resolverReady) return@LaunchedEffect
     resolvedResource = resolveResource(preview.path, null)
     unavailable = resolvedResource == null
@@ -91,6 +128,7 @@ internal fun ChatInlineWidget(
       resolvedResource != null && isolatedProfileSupported -> {
         val resource = checkNotNull(resolvedResource)
         val allowsScripts = preview.sandbox == "scripts"
+        // Resource identity owns the WebView, isolated profile, and cleanup handle together.
         key(resource, allowsScripts) {
           Surface(
             modifier = Modifier.fillMaxWidth().height(preview.height.dp),
@@ -101,29 +139,8 @@ internal fun ChatInlineWidget(
             InlineWidgetWebView(
               resource = resource,
               allowsScripts = allowsScripts,
-              onFailure = {
-                // A released WebView can deliver one final failure callback. It
-                // must not discard the replacement route installed by its retry.
-                if (resolvedResource == resource && !refreshInFlight) {
-                  if (!didRefresh) {
-                    didRefresh = true
-                    refreshInFlight = true
-                    scope.launch {
-                      val replacement = resolveResource(preview.path, resource)
-                      if (resolvedResource != resource) {
-                        refreshInFlight = false
-                        return@launch
-                      }
-                      resolvedResource = replacement
-                      unavailable = replacement == null
-                      refreshInFlight = false
-                    }
-                  } else {
-                    resolvedResource = null
-                    unavailable = true
-                  }
-                }
-              },
+              onFailure = { handleFailure(resource, rendererGone = false) },
+              onRendererGone = { handleFailure(resource, rendererGone = true) },
             )
           }
         }
@@ -149,8 +166,10 @@ private fun InlineWidgetWebView(
   resource: ChatWidgetResource,
   allowsScripts: Boolean,
   onFailure: () -> Unit,
+  onRendererGone: () -> Unit,
 ) {
   val profileName = remember(resource, allowsScripts) { "$INLINE_WIDGET_PROFILE_PREFIX${UUID.randomUUID()}" }
+  val handle = remember(profileName) { InlineWidgetWebViewHandle() }
   AndroidView(
     modifier = Modifier.fillMaxWidth(),
     factory = { context ->
@@ -161,6 +180,13 @@ private fun InlineWidgetWebView(
       } else {
         error("isolated WebView profiles are unavailable")
       }
+      val client =
+        InlineWidgetWebViewClient(
+          resource = resource,
+          onFailure = onFailure,
+          onRendererGone = onRendererGone,
+        )
+      handle.bind(client)
       webView.apply {
         settings.setAllowContentAccess(false)
         settings.setAllowFileAccess(false)
@@ -174,19 +200,28 @@ private fun InlineWidgetWebView(
         settings.javaScriptCanOpenWindowsAutomatically = false
         settings.setSupportMultipleWindows(false)
         isHorizontalScrollBarEnabled = false
-        webViewClient = InlineWidgetWebViewClient(resource = resource, onFailure = onFailure)
+        webViewClient = client
         loadUrl(resource.url)
       }
     },
     onRelease = { webView ->
-      webView.stopLoading()
-      (webView.webViewClient as? InlineWidgetWebViewClient)?.close()
-      webView.webViewClient = WebViewClient()
-      webView.removeAllViews()
-      webView.destroy()
+      handle.release(webView)
       deleteInlineWidgetProfile(profileName)
     },
   )
+}
+
+private class InlineWidgetWebViewHandle {
+  private var client: InlineWidgetWebViewClient? = null
+
+  fun bind(client: InlineWidgetWebViewClient) {
+    this.client = client
+  }
+
+  fun release(view: WebView) {
+    client?.release(view)
+    client = null
+  }
 }
 
 private fun pruneStaleInlineWidgetProfiles() {
@@ -214,10 +249,33 @@ private fun deleteInlineWidgetProfile(profileName: String) {
 private class InlineWidgetWebViewClient(
   private val resource: ChatWidgetResource,
   private val onFailure: () -> Unit,
+  private val onRendererGone: () -> Unit,
 ) : WebViewClient() {
   private val pinnedClient = resource.tlsFingerprintSha256?.let(::buildPinnedWidgetClient)
+  private var released = false
 
-  fun close() {
+  fun release(view: WebView) {
+    if (released) return
+    released = true
+    view.stopLoading()
+    closePinnedClient()
+    view.webViewClient = WebViewClient()
+    view.removeAllViews()
+    view.destroy()
+  }
+
+  private fun releaseAfterRendererGone(view: WebView): Boolean {
+    if (released) return false
+    released = true
+    // A renderer-less WebView is unusable. Remove and destroy it before
+    // starting asynchronous route recovery; onRelease becomes a no-op.
+    (view.parent as? ViewGroup)?.removeView(view)
+    closePinnedClient()
+    view.destroy()
+    return true
+  }
+
+  private fun closePinnedClient() {
     pinnedClient?.dispatcher?.cancelAll()
     pinnedClient?.connectionPool?.evictAll()
   }
@@ -274,7 +332,7 @@ private class InlineWidgetWebViewClient(
     view: WebView,
     detail: RenderProcessGoneDetail,
   ): Boolean {
-    onFailure()
+    if (releaseAfterRendererGone(view)) onRendererGone()
     return true
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatWidgetPreview
 import ai.openclaw.app.chat.ChatWidgetResource
+import ai.openclaw.app.chat.ChatWidgetSurfaceRole
 import ai.openclaw.app.gateway.GatewayTlsParams
 import ai.openclaw.app.gateway.buildGatewayTlsConfig
 import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprint
@@ -67,7 +68,7 @@ internal fun ChatInlineWidget(
 ) {
   var resolvedResource by remember(preview.path) { mutableStateOf<ChatWidgetResource?>(null) }
   var unavailable by remember(preview.path) { mutableStateOf(false) }
-  var didRefresh by remember(preview.path) { mutableStateOf(false) }
+  var recoveryAttempts by remember(preview.path) { mutableStateOf(0) }
   var refreshInFlight by remember(preview.path) { mutableStateOf(false) }
   var refreshRequestId by remember(preview.path) { mutableStateOf<UUID?>(null) }
   val scope = rememberCoroutineScope()
@@ -85,14 +86,14 @@ internal fun ChatInlineWidget(
       unavailable = false
     }
     if (refreshInFlight) return
-    if (didRefresh) {
+    if (recoveryAttempts >= ChatWidgetSurfaceRole.entries.size) {
       refreshRequestId = null
       resolvedResource = null
       unavailable = true
       return
     }
 
-    didRefresh = true
+    recoveryAttempts += 1
     refreshInFlight = true
     val requestId = UUID.randomUUID()
     refreshRequestId = requestId
@@ -112,7 +113,7 @@ internal fun ChatInlineWidget(
     if (!resolverReady) return@LaunchedEffect
     resolvedResource = resolveResource(preview.path, null)
     unavailable = resolvedResource == null
-    didRefresh = false
+    recoveryAttempts = 0
   }
 
   Column(modifier = Modifier.fillMaxWidth()) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
@@ -1,0 +1,271 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.chat.ChatWidgetPreview
+import ai.openclaw.app.i18n.nativeString
+import ai.openclaw.app.ui.design.ClawTheme
+import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.ProfileStore
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import kotlinx.coroutines.launch
+import java.io.ByteArrayInputStream
+import java.net.URI
+import java.util.UUID
+
+private const val INLINE_WIDGET_PROFILE_PREFIX = "openclaw-inline-widget-"
+
+@Composable
+internal fun ChatInlineWidget(
+  preview: ChatWidgetPreview,
+  resolverReady: Boolean,
+  resolveUrl: suspend (String, String?) -> String?,
+) {
+  var resolvedUrl by remember(preview.path) { mutableStateOf<String?>(null) }
+  var unavailable by remember(preview.path) { mutableStateOf(false) }
+  var didRefresh by remember(preview.path) { mutableStateOf(false) }
+  var refreshInFlight by remember(preview.path) { mutableStateOf(false) }
+  val scope = rememberCoroutineScope()
+  val isolatedProfileSupported = remember { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) }
+
+  LaunchedEffect(preview.path, resolverReady) {
+    if (!resolverReady) return@LaunchedEffect
+    resolvedUrl = resolveUrl(preview.path, null)
+    unavailable = resolvedUrl == null
+    didRefresh = false
+  }
+
+  Column(modifier = Modifier.fillMaxWidth()) {
+    preview.title?.trim()?.takeIf(String::isNotEmpty)?.let { title ->
+      Text(
+        text = title,
+        style = ClawTheme.type.caption,
+        color = ClawTheme.colors.textMuted,
+        modifier = Modifier.padding(bottom = 6.dp),
+      )
+    }
+    when {
+      resolvedUrl != null && isolatedProfileSupported -> {
+        val url = checkNotNull(resolvedUrl)
+        val allowsScripts = preview.sandbox == "scripts"
+        key(url, allowsScripts) {
+          Surface(
+            modifier = Modifier.fillMaxWidth().height(preview.height.dp),
+            shape = RoundedCornerShape(10.dp),
+            border = BorderStroke(1.dp, ClawTheme.colors.border),
+            color = ClawTheme.colors.surface,
+          ) {
+            InlineWidgetWebView(
+              url = url,
+              allowsScripts = allowsScripts,
+              onFailure = {
+                if (!refreshInFlight) {
+                  if (!didRefresh) {
+                    didRefresh = true
+                    refreshInFlight = true
+                    scope.launch {
+                      resolvedUrl = resolveUrl(preview.path, url)
+                      unavailable = resolvedUrl == null
+                      refreshInFlight = false
+                    }
+                  } else {
+                    resolvedUrl = null
+                    unavailable = true
+                  }
+                }
+              },
+            )
+          }
+        }
+      }
+      unavailable || resolvedUrl != null ->
+        Text(
+          text = nativeString("Widget unavailable"),
+          style = ClawTheme.type.caption,
+          color = ClawTheme.colors.textMuted,
+        )
+      else ->
+        Box(modifier = Modifier.fillMaxWidth().height(44.dp), contentAlignment = Alignment.Center) {
+          CircularProgressIndicator(color = ClawTheme.colors.textMuted)
+        }
+    }
+  }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Suppress("DEPRECATION")
+@Composable
+private fun InlineWidgetWebView(
+  url: String,
+  allowsScripts: Boolean,
+  onFailure: () -> Unit,
+) {
+  val profileName = remember(url, allowsScripts) { "$INLINE_WIDGET_PROFILE_PREFIX${UUID.randomUUID()}" }
+  AndroidView(
+    modifier = Modifier.fillMaxWidth(),
+    factory = { context ->
+      pruneStaleInlineWidgetProfiles()
+      val webView = WebView(context)
+      if (WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) {
+        WebViewCompat.setProfile(webView, profileName)
+      } else {
+        error("isolated WebView profiles are unavailable")
+      }
+      webView.apply {
+        settings.setAllowContentAccess(false)
+        settings.setAllowFileAccess(false)
+        settings.setAllowFileAccessFromFileURLs(false)
+        settings.setAllowUniversalAccessFromFileURLs(false)
+        settings.setSafeBrowsingEnabled(true)
+        settings.javaScriptEnabled = allowsScripts
+        settings.domStorageEnabled = false
+        settings.cacheMode = WebSettings.LOAD_NO_CACHE
+        settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+        settings.javaScriptCanOpenWindowsAutomatically = false
+        settings.setSupportMultipleWindows(false)
+        isHorizontalScrollBarEnabled = false
+        webViewClient = InlineWidgetWebViewClient(expectedUrl = url, onFailure = onFailure)
+        loadUrl(url)
+      }
+    },
+    onRelease = { webView ->
+      webView.stopLoading()
+      webView.webViewClient = WebViewClient()
+      webView.removeAllViews()
+      webView.destroy()
+      deleteInlineWidgetProfile(profileName)
+    },
+  )
+}
+
+private fun pruneStaleInlineWidgetProfiles() {
+  if (!WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) return
+  val store = ProfileStore.getInstance()
+  store.allProfileNames
+    .asSequence()
+    .filter { it.startsWith(INLINE_WIDGET_PROFILE_PREFIX) }
+    .forEach { profileName -> runCatching { store.deleteProfile(profileName) } }
+}
+
+private fun deleteInlineWidgetProfile(profileName: String) {
+  if (!WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) return
+  val store = ProfileStore.getInstance()
+  val deleted = runCatching { store.deleteProfile(profileName) }.getOrDefault(false)
+  if (!deleted) {
+    Handler(Looper.getMainLooper()).post {
+      if (WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)) {
+        runCatching { ProfileStore.getInstance().deleteProfile(profileName) }
+      }
+    }
+  }
+}
+
+private class InlineWidgetWebViewClient(
+  private val expectedUrl: String,
+  private val onFailure: () -> Unit,
+) : WebViewClient() {
+  override fun onPageCommitVisible(
+    view: WebView,
+    url: String,
+  ) {
+    // Compose can retain the pre-navigation WebView layer until the first damage event.
+    // Invalidate once committed so the initial widget frame paints without user input.
+    view.postInvalidateOnAnimation()
+  }
+
+  override fun shouldOverrideUrlLoading(
+    view: WebView,
+    request: WebResourceRequest,
+  ): Boolean =
+    request.isForMainFrame &&
+      (!request.method.equals("GET", ignoreCase = true) || !sameDocument(expectedUrl, request.url.toString()))
+
+  override fun shouldInterceptRequest(
+    view: WebView,
+    request: WebResourceRequest,
+  ): WebResourceResponse? {
+    val scheme = request.url.scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") return null
+    val allowed =
+      request.isForMainFrame &&
+        request.method.equals("GET", ignoreCase = true) &&
+        sameDocument(expectedUrl, request.url.toString())
+    return if (allowed) null else blockedWidgetResponse()
+  }
+
+  override fun onReceivedError(
+    view: WebView,
+    request: WebResourceRequest,
+    error: WebResourceError,
+  ) {
+    if (request.isForMainFrame) onFailure()
+  }
+
+  override fun onReceivedHttpError(
+    view: WebView,
+    request: WebResourceRequest,
+    errorResponse: WebResourceResponse,
+  ) {
+    if (request.isForMainFrame && errorResponse.statusCode >= 400) onFailure()
+  }
+
+  override fun onRenderProcessGone(
+    view: WebView,
+    detail: RenderProcessGoneDetail,
+  ): Boolean {
+    onFailure()
+    return true
+  }
+}
+
+private fun sameDocument(
+  expected: String,
+  candidate: String,
+): Boolean {
+  val expectedUri = runCatching { URI(expected) }.getOrNull() ?: return false
+  val candidateUri = runCatching { URI(candidate) }.getOrNull() ?: return false
+  return expectedUri.scheme == candidateUri.scheme &&
+    expectedUri.rawAuthority == candidateUri.rawAuthority &&
+    expectedUri.rawPath == candidateUri.rawPath &&
+    expectedUri.rawQuery == candidateUri.rawQuery
+}
+
+private fun blockedWidgetResponse(): WebResourceResponse =
+  WebResourceResponse(
+    "text/plain",
+    "UTF-8",
+    403,
+    "Blocked",
+    mapOf("Cache-Control" to "no-store"),
+    ByteArrayInputStream(ByteArray(0)),
+  )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
@@ -1,6 +1,10 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatWidgetPreview
+import ai.openclaw.app.chat.ChatWidgetResource
+import ai.openclaw.app.gateway.GatewayTlsParams
+import ai.openclaw.app.gateway.buildGatewayTlsConfig
+import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprint
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.ui.design.ClawTheme
 import android.annotation.SuppressLint
@@ -39,19 +43,28 @@ import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.BufferedSource
 import java.io.ByteArrayInputStream
 import java.net.URI
+import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 private const val INLINE_WIDGET_PROFILE_PREFIX = "openclaw-inline-widget-"
+private const val INLINE_WIDGET_DOCUMENT_MAX_BYTES = 2L * 1024 * 1024
+private const val INLINE_WIDGET_FETCH_TIMEOUT_SECONDS = 8L
+private const val HTTP_HEADER_ACCEPT = "Accept"
+private const val HTTP_HEADER_CACHE_CONTROL = "Cache-Control"
 
 @Composable
 internal fun ChatInlineWidget(
   preview: ChatWidgetPreview,
   resolverReady: Boolean,
-  resolveUrl: suspend (String, String?) -> String?,
+  resolveResource: suspend (String, ChatWidgetResource?) -> ChatWidgetResource?,
 ) {
-  var resolvedUrl by remember(preview.path) { mutableStateOf<String?>(null) }
+  var resolvedResource by remember(preview.path) { mutableStateOf<ChatWidgetResource?>(null) }
   var unavailable by remember(preview.path) { mutableStateOf(false) }
   var didRefresh by remember(preview.path) { mutableStateOf(false) }
   var refreshInFlight by remember(preview.path) { mutableStateOf(false) }
@@ -60,8 +73,8 @@ internal fun ChatInlineWidget(
 
   LaunchedEffect(preview.path, resolverReady) {
     if (!resolverReady) return@LaunchedEffect
-    resolvedUrl = resolveUrl(preview.path, null)
-    unavailable = resolvedUrl == null
+    resolvedResource = resolveResource(preview.path, null)
+    unavailable = resolvedResource == null
     didRefresh = false
   }
 
@@ -75,10 +88,10 @@ internal fun ChatInlineWidget(
       )
     }
     when {
-      resolvedUrl != null && isolatedProfileSupported -> {
-        val url = checkNotNull(resolvedUrl)
+      resolvedResource != null && isolatedProfileSupported -> {
+        val resource = checkNotNull(resolvedResource)
         val allowsScripts = preview.sandbox == "scripts"
-        key(url, allowsScripts) {
+        key(resource, allowsScripts) {
           Surface(
             modifier = Modifier.fillMaxWidth().height(preview.height.dp),
             shape = RoundedCornerShape(10.dp),
@@ -86,20 +99,27 @@ internal fun ChatInlineWidget(
             color = ClawTheme.colors.surface,
           ) {
             InlineWidgetWebView(
-              url = url,
+              resource = resource,
               allowsScripts = allowsScripts,
               onFailure = {
-                if (!refreshInFlight) {
+                // A released WebView can deliver one final failure callback. It
+                // must not discard the replacement route installed by its retry.
+                if (resolvedResource == resource && !refreshInFlight) {
                   if (!didRefresh) {
                     didRefresh = true
                     refreshInFlight = true
                     scope.launch {
-                      resolvedUrl = resolveUrl(preview.path, url)
-                      unavailable = resolvedUrl == null
+                      val replacement = resolveResource(preview.path, resource)
+                      if (resolvedResource != resource) {
+                        refreshInFlight = false
+                        return@launch
+                      }
+                      resolvedResource = replacement
+                      unavailable = replacement == null
                       refreshInFlight = false
                     }
                   } else {
-                    resolvedUrl = null
+                    resolvedResource = null
                     unavailable = true
                   }
                 }
@@ -108,7 +128,7 @@ internal fun ChatInlineWidget(
           }
         }
       }
-      unavailable || resolvedUrl != null ->
+      unavailable || resolvedResource != null ->
         Text(
           text = nativeString("Widget unavailable"),
           style = ClawTheme.type.caption,
@@ -126,11 +146,11 @@ internal fun ChatInlineWidget(
 @Suppress("DEPRECATION")
 @Composable
 private fun InlineWidgetWebView(
-  url: String,
+  resource: ChatWidgetResource,
   allowsScripts: Boolean,
   onFailure: () -> Unit,
 ) {
-  val profileName = remember(url, allowsScripts) { "$INLINE_WIDGET_PROFILE_PREFIX${UUID.randomUUID()}" }
+  val profileName = remember(resource, allowsScripts) { "$INLINE_WIDGET_PROFILE_PREFIX${UUID.randomUUID()}" }
   AndroidView(
     modifier = Modifier.fillMaxWidth(),
     factory = { context ->
@@ -154,12 +174,13 @@ private fun InlineWidgetWebView(
         settings.javaScriptCanOpenWindowsAutomatically = false
         settings.setSupportMultipleWindows(false)
         isHorizontalScrollBarEnabled = false
-        webViewClient = InlineWidgetWebViewClient(expectedUrl = url, onFailure = onFailure)
-        loadUrl(url)
+        webViewClient = InlineWidgetWebViewClient(resource = resource, onFailure = onFailure)
+        loadUrl(resource.url)
       }
     },
     onRelease = { webView ->
       webView.stopLoading()
+      (webView.webViewClient as? InlineWidgetWebViewClient)?.close()
       webView.webViewClient = WebViewClient()
       webView.removeAllViews()
       webView.destroy()
@@ -191,9 +212,16 @@ private fun deleteInlineWidgetProfile(profileName: String) {
 }
 
 private class InlineWidgetWebViewClient(
-  private val expectedUrl: String,
+  private val resource: ChatWidgetResource,
   private val onFailure: () -> Unit,
 ) : WebViewClient() {
+  private val pinnedClient = resource.tlsFingerprintSha256?.let(::buildPinnedWidgetClient)
+
+  fun close() {
+    pinnedClient?.dispatcher?.cancelAll()
+    pinnedClient?.connectionPool?.evictAll()
+  }
+
   override fun onPageCommitVisible(
     view: WebView,
     url: String,
@@ -208,7 +236,7 @@ private class InlineWidgetWebViewClient(
     request: WebResourceRequest,
   ): Boolean =
     request.isForMainFrame &&
-      (!request.method.equals("GET", ignoreCase = true) || !sameDocument(expectedUrl, request.url.toString()))
+      (!request.method.equals("GET", ignoreCase = true) || !sameDocument(resource.url, request.url.toString()))
 
   override fun shouldInterceptRequest(
     view: WebView,
@@ -219,8 +247,11 @@ private class InlineWidgetWebViewClient(
     val allowed =
       request.isForMainFrame &&
         request.method.equals("GET", ignoreCase = true) &&
-        sameDocument(expectedUrl, request.url.toString())
-    return if (allowed) null else blockedWidgetResponse()
+        sameDocument(resource.url, request.url.toString())
+    if (!allowed) return blockedWidgetResponse()
+    if (resource.tlsFingerprintSha256 == null) return null
+    if (scheme != "https" || pinnedClient == null) return failedWidgetResponse()
+    return fetchPinnedWidgetDocument(client = pinnedClient, url = request.url.toString())
   }
 
   override fun onReceivedError(
@@ -248,6 +279,94 @@ private class InlineWidgetWebViewClient(
   }
 }
 
+private fun buildPinnedWidgetClient(rawFingerprint: String): OkHttpClient? {
+  val fingerprint = normalizeGatewayTlsFingerprint(rawFingerprint)
+  if (fingerprint.length != 64) return null
+  val tls =
+    buildGatewayTlsConfig(
+      GatewayTlsParams(
+        required = true,
+        expectedFingerprint = fingerprint,
+        allowTOFU = false,
+        stableId = "inline-widget",
+      ),
+    ) ?: return null
+  return OkHttpClient
+    .Builder()
+    .sslSocketFactory(tls.sslSocketFactory, tls.trustManager)
+    .hostnameVerifier(tls.hostnameVerifier)
+    .followRedirects(false)
+    .followSslRedirects(false)
+    .retryOnConnectionFailure(false)
+    .cache(null)
+    .callTimeout(INLINE_WIDGET_FETCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    .build()
+}
+
+private fun fetchPinnedWidgetDocument(
+  client: OkHttpClient,
+  url: String,
+): WebResourceResponse =
+  try {
+    val request =
+      Request
+        .Builder()
+        .url(url)
+        .header(HTTP_HEADER_ACCEPT, "text/html")
+        .header(HTTP_HEADER_CACHE_CONTROL, "no-cache")
+        .get()
+        .build()
+    client.newCall(request).execute().use { response ->
+      if (!response.isSuccessful) return failedWidgetResponse()
+      val body = response.body
+      val contentType = body.contentType() ?: return failedWidgetResponse()
+      val mimeType = "${contentType.type}/${contentType.subtype}".lowercase(Locale.US)
+      if (mimeType != "text/html") return failedWidgetResponse()
+      val contentLength = body.contentLength()
+      if (contentLength > INLINE_WIDGET_DOCUMENT_MAX_BYTES) return failedWidgetResponse()
+      val bytes =
+        readBoundedWidgetDocument(
+          source = body.source(),
+          maxBytes = INLINE_WIDGET_DOCUMENT_MAX_BYTES.toInt(),
+        ) ?: return failedWidgetResponse()
+      val responseHeaders =
+        listOf(
+          "Cache-Control",
+          "Content-Security-Policy",
+          "Permissions-Policy",
+          "Referrer-Policy",
+          "X-Content-Type-Options",
+        ).mapNotNull { name -> response.header(name)?.let { name to it } }.toMap()
+      WebResourceResponse(
+        mimeType,
+        contentType.charset(Charsets.UTF_8)?.name() ?: Charsets.UTF_8.name(),
+        response.code,
+        response.message.ifBlank { "OK" },
+        responseHeaders,
+        ByteArrayInputStream(bytes),
+      )
+    }
+  } catch (_: Exception) {
+    failedWidgetResponse()
+  }
+
+internal fun readBoundedWidgetDocument(
+  source: BufferedSource,
+  maxBytes: Int,
+): ByteArray? {
+  require(maxBytes in 0 until Int.MAX_VALUE)
+  val buffer = ByteArray(maxBytes + 1)
+  var offset = 0
+  while (offset < buffer.size) {
+    val read = source.read(buffer, offset, buffer.size - offset)
+    if (read == -1) break
+    if (read == 0) return null
+    offset += read
+  }
+  if (offset > maxBytes) return null
+  return buffer.copyOf(offset)
+}
+
 private fun sameDocument(
   expected: String,
   candidate: String,
@@ -266,6 +385,16 @@ private fun blockedWidgetResponse(): WebResourceResponse =
     "UTF-8",
     403,
     "Blocked",
+    mapOf("Cache-Control" to "no-store"),
+    ByteArrayInputStream(ByteArray(0)),
+  )
+
+private fun failedWidgetResponse(): WebResourceResponse =
+  WebResourceResponse(
+    "text/plain",
+    "UTF-8",
+    502,
+    "Widget unavailable",
     mapOf("Cache-Control" to "no-store"),
     ByteArrayInputStream(ByteArray(0)),
   )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -14,6 +14,7 @@ import ai.openclaw.app.chat.ChatPlanStepStatus
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatThinkingLevelOption
 import ai.openclaw.app.chat.ChatThinkingLevelSelection
+import ai.openclaw.app.chat.ChatWidgetResource
 import ai.openclaw.app.chat.MessageSpeechPhase
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.VoiceNoteRecorderState
@@ -420,7 +421,7 @@ fun ChatScreen(
       onReplyMessage = viewModel::setChatReplyDraft,
       speechState = messageSpeechState,
       onToggleListen = viewModel::toggleChatMessageSpeech,
-      resolveInlineWidgetUrl = viewModel::resolveInlineWidgetUrl,
+      resolveInlineWidgetResource = viewModel::resolveInlineWidgetResource,
       modifier = Modifier.weight(1f),
     )
 
@@ -811,7 +812,7 @@ private fun ChatMessageList(
   onReplyMessage: (String) -> Unit,
   speechState: MessageSpeechState?,
   onToggleListen: (String, String) -> Unit,
-  resolveInlineWidgetUrl: suspend (String, String?) -> String?,
+  resolveInlineWidgetResource: suspend (String, ChatWidgetResource?) -> ChatWidgetResource?,
   modifier: Modifier = Modifier,
 ) {
   val timeline =
@@ -852,7 +853,7 @@ private fun ChatMessageList(
               speechState = speechState,
               onToggleListen = onToggleListen,
               inlineWidgetResolverReady = healthOk,
-              resolveInlineWidgetUrl = resolveInlineWidgetUrl,
+              resolveInlineWidgetResource = resolveInlineWidgetResource,
             )
           is ChatTimelineItem.OutboxCommand ->
             ChatOutboxBubble(
@@ -872,7 +873,7 @@ private fun ChatMessageList(
               speechState = null,
               onToggleListen = onToggleListen,
               inlineWidgetResolverReady = healthOk,
-              resolveInlineWidgetUrl = resolveInlineWidgetUrl,
+              resolveInlineWidgetResource = resolveInlineWidgetResource,
             )
           ChatTimelineItem.Thinking -> ChatThinkingBubble()
         }
@@ -1054,7 +1055,7 @@ private fun ChatBubble(
   speechState: MessageSpeechState?,
   onToggleListen: (String, String) -> Unit,
   inlineWidgetResolverReady: Boolean,
-  resolveInlineWidgetUrl: suspend (String, String?) -> String?,
+  resolveInlineWidgetResource: suspend (String, ChatWidgetResource?) -> ChatWidgetResource?,
 ) {
   val normalizedRole = role.trim().lowercase(Locale.US)
   val isUser = normalizedRole == "user"
@@ -1125,7 +1126,7 @@ private fun ChatBubble(
                 ChatInlineWidget(
                   preview = checkNotNull(part.widget),
                   resolverReady = inlineWidgetResolverReady,
-                  resolveUrl = resolveInlineWidgetUrl,
+                  resolveResource = resolveInlineWidgetResource,
                 )
               else -> Text(text = part.fileName ?: nativeString("Attachment"), style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
             }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -420,6 +420,7 @@ fun ChatScreen(
       onReplyMessage = viewModel::setChatReplyDraft,
       speechState = messageSpeechState,
       onToggleListen = viewModel::toggleChatMessageSpeech,
+      resolveInlineWidgetUrl = viewModel::resolveInlineWidgetUrl,
       modifier = Modifier.weight(1f),
     )
 
@@ -810,6 +811,7 @@ private fun ChatMessageList(
   onReplyMessage: (String) -> Unit,
   speechState: MessageSpeechState?,
   onToggleListen: (String, String) -> Unit,
+  resolveInlineWidgetUrl: suspend (String, String?) -> String?,
   modifier: Modifier = Modifier,
 ) {
   val timeline =
@@ -849,6 +851,8 @@ private fun ChatMessageList(
               onReplyMessage = onReplyMessage,
               speechState = speechState,
               onToggleListen = onToggleListen,
+              inlineWidgetResolverReady = healthOk,
+              resolveInlineWidgetUrl = resolveInlineWidgetUrl,
             )
           is ChatTimelineItem.OutboxCommand ->
             ChatOutboxBubble(
@@ -867,6 +871,8 @@ private fun ChatMessageList(
               onReplyMessage = onReplyMessage,
               speechState = null,
               onToggleListen = onToggleListen,
+              inlineWidgetResolverReady = healthOk,
+              resolveInlineWidgetUrl = resolveInlineWidgetUrl,
             )
           ChatTimelineItem.Thinking -> ChatThinkingBubble()
         }
@@ -1047,6 +1053,8 @@ private fun ChatBubble(
   onReplyMessage: (String) -> Unit,
   speechState: MessageSpeechState?,
   onToggleListen: (String, String) -> Unit,
+  inlineWidgetResolverReady: Boolean,
+  resolveInlineWidgetUrl: suspend (String, String?) -> String?,
 ) {
   val normalizedRole = role.trim().lowercase(Locale.US)
   val isUser = normalizedRole == "user"
@@ -1055,6 +1063,7 @@ private fun ChatBubble(
       when (part.type) {
         "text" -> !part.text.isNullOrBlank()
         "image" -> !part.base64.isNullOrBlank()
+        "canvas" -> normalizedRole == "assistant" && part.widget != null
         else -> part.isAudioAttachment()
       }
     }
@@ -1111,6 +1120,12 @@ private fun ChatBubble(
                 ChatBase64Image(
                   base64 = checkNotNull(part.base64),
                   mimeType = part.mimeType,
+                )
+              part.type == "canvas" && normalizedRole == "assistant" ->
+                ChatInlineWidget(
+                  preview = checkNotNull(part.widget),
+                  resolverReady = inlineWidgetResolverReady,
+                  resolveUrl = resolveInlineWidgetUrl,
                 )
               else -> Text(text = part.fileName ?: nativeString("Attachment"), style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
             }

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ميزة التعرّف على الكلام على الجهاز غير متاحة."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المرفقات كبيرة جدًا بحيث لا يمكن وضعها في قائمة الانتظار ضمن رسالة واحدة؛ أزل بعضها وحاول مجددًا."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يوجد نموذج واحد مُعدّ. حدّث لإعادة التحقق من التوفر."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الأداة غير متاحة"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يلزم اتصال آمن لهذا المضيف."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد عمليات أتمتة مطابقة."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يمكن للهاتف الوصول إلى Gateway"</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Die Spracherkennung auf dem Gerät ist nicht verfügbar."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Die Anhänge sind zu groß, um sie für eine einzelne Nachricht in die Warteschlange zu stellen. Entfernen Sie einige und versuchen Sie es erneut."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 Modell konfiguriert. Aktualisieren Sie, um die Verfügbarkeit erneut zu prüfen."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget nicht verfügbar"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Für diesen Host ist eine sichere Verbindung erforderlich."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Keine passenden Automatisierungen."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Smartphone kann die Gateway erreichen"</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"El reconocimiento de voz en el dispositivo no está disponible."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Los archivos adjuntos son demasiado grandes para ponerlos en cola en un solo mensaje; elimina algunos e inténtalo de nuevo."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 modelo configurado. Actualiza para volver a comprobar la disponibilidad."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget no disponible"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Se requiere una conexión segura para este host."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No hay automatizaciones coincidentes."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"El teléfono puede acceder al Gateway"</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تشخیص گفتار روی دستگاه در دسترس نیست."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیوست‌ها برای قرار گرفتن در صف یک پیام بیش از حد بزرگ هستند؛ تعدادی را حذف و دوباره تلاش کنید."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"۱ مدل پیکربندی شده است. برای بررسی دوباره موجود بودن، تازه‌سازی کنید."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ویجت در دسترس نیست"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای این میزبان، اتصال امن الزامی است."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خودکارسازی منطبقی یافت نشد."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلفن می‌تواند به Gateway دسترسی داشته باشد"</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"La reconnaissance vocale sur l’appareil n’est pas disponible."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les pièces jointes sont trop volumineuses pour être mises en file d’attente dans un seul message ; supprimez-en certaines et réessayez."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 modèle configuré. Actualisez pour vérifier à nouveau la disponibilité."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget indisponible"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Une connexion sécurisée est requise pour cet hôte."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucune automatisation correspondante."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le téléphone peut joindre la Gateway"</string>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस पर स्पीच रिकग्निशन उपलब्ध नहीं है।"</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"एक संदेश के लिए अटैचमेंट कतार में लगाने हेतु बहुत बड़े हैं; कुछ हटाकर फिर से कोशिश करें।"</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 मॉडल कॉन्फ़िगर किया गया है। उपलब्धता दोबारा जाँचने के लिए रीफ़्रेश करें।"</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विजेट उपलब्ध नहीं है"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस होस्ट के लिए सुरक्षित कनेक्शन आवश्यक है।"</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई मेल खाता ऑटोमेशन नहीं मिला।"</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"फ़ोन Gateway तक पहुँच सकता है"</string>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pengenalan ucapan di perangkat tidak tersedia."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lampiran terlalu besar untuk dimasukkan ke antrean dalam satu pesan; hapus beberapa lampiran lalu coba lagi."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 model dikonfigurasi. Segarkan untuk memeriksa kembali ketersediaan."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget tidak tersedia"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koneksi aman diperlukan untuk host ini."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidak ada otomatisasi yang cocok."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ponsel dapat menjangkau Gateway"</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il riconoscimento vocale sul dispositivo non è disponibile."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gli allegati sono troppo grandi per essere messi in coda in un solo messaggio; rimuovine alcuni e riprova."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 modello configurato. Aggiorna per verificare nuovamente la disponibilità."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget non disponibile"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Per questo host è necessaria una connessione sicura."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna automazione corrispondente."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il telefono può raggiungere il Gateway"</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"デバイス上の音声認識は利用できません。"</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"添付ファイルが大きすぎるため、1件のメッセージとしてキューに追加できません。一部を削除して、もう一度お試しください。"</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"設定済みのモデルが1件あります。更新して利用可能か再確認してください。"</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ウィジェットを利用できません"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"このホストには安全な接続が必要です。"</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"一致する自動化はありません。"</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スマートフォンが Gateway に到達できること"</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"기기 내 음성 인식을 사용할 수 없습니다."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"첨부 파일이 너무 커서 하나의 메시지로 대기열에 추가할 수 없습니다. 일부를 제거한 후 다시 시도하세요."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"구성된 모델이 1개 있습니다. 새로 고쳐 사용 가능 여부를 다시 확인하세요."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"위젯을 사용할 수 없음"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"이 호스트에는 보안 연결이 필요합니다."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"일치하는 자동화가 없습니다."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"휴대폰에서 Gateway에 연결할 수 있음"</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spraakherkenning op het apparaat is niet beschikbaar."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De bijlagen zijn te groot om voor één bericht in de wachtrij te plaatsen; verwijder er enkele en probeer het opnieuw."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 geconfigureerd model. Vernieuw om de beschikbaarheid opnieuw te controleren."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget niet beschikbaar"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voor deze host is een beveiligde verbinding vereist."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen overeenkomende automatiseringen."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefoon kan de Gateway bereiken"</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozpoznawanie mowy na urządzeniu jest niedostępne."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Załączniki są zbyt duże, aby dodać je do kolejki w jednej wiadomości; usuń część z nich i spróbuj ponownie."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skonfigurowano 1 model. Odśwież, aby ponownie sprawdzić dostępność."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widżet niedostępny"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ten host wymaga bezpiecznego połączenia."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak pasujących automatyzacji."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefon może połączyć się z Gateway"</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"O reconhecimento de fala no dispositivo não está disponível."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Os anexos são grandes demais para serem colocados na fila em uma única mensagem; remova alguns e tente novamente."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 modelo configurado. Atualize para verificar novamente a disponibilidade."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget indisponível"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"É necessária uma conexão segura para este host."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nenhuma automação correspondente."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"O telefone pode acessar o Gateway"</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Распознавание речи на устройстве недоступно."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вложения слишком велики, чтобы поставить их в очередь в одном сообщении; удалите некоторые из них и попробуйте ещё раз."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Настроена 1 модель. Обновите, чтобы повторно проверить доступность."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виджет недоступен"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Для этого хоста требуется защищённое соединение."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подходящие автоматизации не найдены."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Телефон может подключиться к Gateway"</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Taligenkänning på enheten är inte tillgänglig."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bilagorna är för stora för att köas i ett enda meddelande. Ta bort några och försök igen."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 konfigurerad modell. Uppdatera för att kontrollera tillgängligheten igen."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgeten är inte tillgänglig"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En säker anslutning krävs för den här värden."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga matchande automatiseringar."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefonen kan nå Gateway"</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การรู้จำเสียงพูดบนอุปกรณ์ไม่พร้อมใช้งาน"</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไฟล์แนบมีขนาดใหญ่เกินกว่าจะเพิ่มลงในคิวสำหรับข้อความเดียวได้ โปรดนำบางไฟล์ออกแล้วลองอีกครั้ง"</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มีโมเดลที่กำหนดค่าไว้ 1 รายการ รีเฟรชเพื่อตรวจสอบความพร้อมใช้งานอีกครั้ง"</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วิดเจ็ตไม่พร้อมใช้งาน"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฮสต์นี้ต้องใช้การเชื่อมต่อที่ปลอดภัย"</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบระบบอัตโนมัติที่ตรงกัน"</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทรศัพท์สามารถเข้าถึง Gateway ได้"</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz üzerinde konuşma tanıma kullanılamıyor."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ekler tek bir mesaj için kuyruğa alınamayacak kadar büyük; bazılarını kaldırıp tekrar deneyin."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 yapılandırılmış model var. Kullanılabilirliği yeniden kontrol etmek için yenileyin."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget kullanılamıyor"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu ana makine için güvenli bağlantı gereklidir."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleşen otomasyon yok."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefon Gateway\'ye erişebiliyor"</string>

--- a/apps/android/app/src/main/res/values-uk/strings.xml
+++ b/apps/android/app/src/main/res/values-uk/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Розпізнавання мовлення на пристрої недоступне."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вкладення завеликі, щоб додати їх до черги в одному повідомленні; видаліть деякі з них і спробуйте ще раз."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Налаштовано 1 модель. Оновіть, щоб повторно перевірити доступність."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Віджет недоступний"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Для цього хоста потрібне захищене з’єднання."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відповідних автоматизацій не знайдено."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Телефон може підключитися до Gateway"</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tính năng nhận dạng giọng nói trên thiết bị không khả dụng."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Các tệp đính kèm quá lớn để đưa vào hàng đợi trong một tin nhắn; hãy xóa bớt rồi thử lại."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 mô hình đã được cấu hình. Làm mới để kiểm tra lại tính khả dụng."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tiện ích không khả dụng"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Máy chủ này yêu cầu kết nối bảo mật."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có tác vụ tự động nào phù hợp."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Điện thoại có thể truy cập Gateway"</string>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设备端语音识别不可用。"</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"附件过大，无法加入单条消息的队列；请移除部分附件后重试。"</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已配置 1 个模型。刷新以重新检查可用性。"</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小组件不可用"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此主机需要安全连接。"</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的自动化。"</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手机可以连接到 Gateway"</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法使用裝置端語音辨識。"</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"附件過大，無法加入單則訊息的佇列；請移除部分附件後再試一次。"</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已設定 1 個模型。請重新整理以再次檢查可用性。"</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小工具無法使用"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此主機需要安全連線。"</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有相符的自動化。"</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手機可以連線到 Gateway"</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -375,6 +375,7 @@
     <string name="native_40d04f6fb9437ff3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"On-device speech recognition is unavailable."</string>
     <string name="native_4122a5c9825224af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attachments are too large to queue for one message; remove some and try again."</string>
     <string name="native_4135d64f3bde1a92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 configured model. Refresh to recheck availability."</string>
+    <string name="native_41659b48f2dc4c36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget unavailable"</string>
     <string name="native_4186107d2194d09a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Secure connection is required for this host."</string>
     <string name="native_41cb8a2ca2cf1e36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching automations."</string>
     <string name="native_41df9f586511e084" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Phone can reach the Gateway"</string>

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -108,6 +108,21 @@ class ChatMessageContentParsingTest {
   }
 
   @Test
+  fun initialResolutionUsesOperatorFallbackWhenNodeUnavailable() {
+    val target = "/__openclaw__/canvas/documents/widget-1/index.html"
+    val fallbackSurface = "https://operator.example/__openclaw__/cap/fallback"
+    val surfaces =
+      ChatWidgetSurfaceUrls(
+        node = null,
+        operator = ChatWidgetSurface(url = fallbackSurface, tlsFingerprintSha256 = null),
+      )
+
+    val resolved = ChatWidgetUrlResolver.resolvePreferred(surfaces, target, excluding = null)
+
+    assertEquals(ChatWidgetUrlResolver.resolve(fallbackSurface, target), resolved?.url)
+  }
+
+  @Test
   fun usesReplacementRouteAfterCapabilityRefreshLosesItsLease() =
     runTest {
       val target = "/__openclaw__/canvas/documents/widget-1/index.html"
@@ -174,6 +189,38 @@ class ChatMessageContentParsingTest {
 
       assertEquals(url, resolved?.url)
       assertEquals(newPin, resolved?.tlsFingerprintSha256)
+    }
+
+  @Test
+  fun refreshesNodeBeforeTryingOperatorFallback() =
+    runTest {
+      val target = "/__openclaw__/canvas/documents/widget-1/index.html"
+      val oldSurface = "https://gateway.example/__openclaw__/cap/old"
+      val newSurface = "https://gateway.example/__openclaw__/cap/new"
+      val fallbackSurface = "https://operator.example/__openclaw__/cap/fallback"
+      val failedUrl = requireNotNull(ChatWidgetUrlResolver.resolve(oldSurface, target))
+      val failedResource = ChatWidgetResource(url = failedUrl, tlsFingerprintSha256 = null)
+      var refreshCount = 0
+      var current =
+        ChatWidgetSurfaceUrls(
+          node = ChatWidgetSurface(url = oldSurface, tlsFingerprintSha256 = null),
+          operator = ChatWidgetSurface(url = fallbackSurface, tlsFingerprintSha256 = null),
+        )
+
+      val resolved =
+        ChatWidgetUrlResolver.resolveAfterFailure(
+          target = target,
+          failedResource = failedResource,
+          currentSurfaceUrls = { current },
+          refreshNodeSurface = {
+            refreshCount += 1
+            current = current.copy(node = ChatWidgetSurface(url = newSurface, tlsFingerprintSha256 = null))
+            null
+          },
+        )
+
+      assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved?.url)
+      assertEquals(1, refreshCount)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -194,25 +194,24 @@ class ChatMessageContentParsingTest {
     }
 
   @Test
-  fun refreshesNodeBeforeTryingOperatorFallback() =
+  fun refreshesNodeOnceBeforeTryingOperatorFallback() =
     runTest {
       val target = "/__openclaw__/canvas/documents/widget-1/index.html"
       val oldSurface = "https://gateway.example/__openclaw__/cap/old"
       val newSurface = "https://gateway.example/__openclaw__/cap/new"
       val fallbackSurface = "https://operator.example/__openclaw__/cap/fallback"
-      val failedUrl = requireNotNull(ChatWidgetUrlResolver.resolve(oldSurface, target))
-      val failedResource = ChatWidgetResource(url = failedUrl, tlsFingerprintSha256 = null)
       var refreshCount = 0
       var current =
         ChatWidgetSurfaceUrls(
           node = ChatWidgetSurface(url = oldSurface, tlsFingerprintSha256 = null),
           operator = ChatWidgetSurface(url = fallbackSurface, tlsFingerprintSha256 = null),
         )
+      val initialNode = ChatWidgetUrlResolver.resolvePreferred(current, target, excluding = null)
 
-      val resolved =
+      val refreshedNode =
         ChatWidgetUrlResolver.resolveAfterFailure(
           target = target,
-          failedResource = failedResource,
+          failedResource = requireNotNull(initialNode),
           currentSurfaceUrls = { current },
           refreshNodeSurface = {
             refreshCount += 1
@@ -222,7 +221,21 @@ class ChatMessageContentParsingTest {
           refreshOperatorSurface = { null },
         )
 
-      assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved?.url)
+      assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), refreshedNode?.url)
+
+      val fallback =
+        ChatWidgetUrlResolver.resolveAfterFailure(
+          target = target,
+          failedResource = requireNotNull(refreshedNode),
+          currentSurfaceUrls = { current },
+          refreshNodeSurface = {
+            refreshCount += 1
+            null
+          },
+          refreshOperatorSurface = { null },
+        )
+
+      assertEquals(ChatWidgetUrlResolver.resolve(fallbackSurface, target), fallback?.url)
       assertEquals(1, refreshCount)
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -1,13 +1,29 @@
 package ai.openclaw.app.chat
 
+import ai.openclaw.app.ui.chat.readBoundedWidgetDocument
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
+import okio.Buffer
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ChatMessageContentParsingTest {
+  @Test
+  fun boundedWidgetDocumentReadAcceptsAtMostLimitAndRejectsOverflow() {
+    assertArrayEquals(
+      byteArrayOf(1, 2),
+      readBoundedWidgetDocument(Buffer().write(byteArrayOf(1, 2)), maxBytes = 3),
+    )
+    assertArrayEquals(
+      byteArrayOf(1, 2, 3),
+      readBoundedWidgetDocument(Buffer().write(byteArrayOf(1, 2, 3)), maxBytes = 3),
+    )
+    assertNull(readBoundedWidgetDocument(Buffer().write(byteArrayOf(1, 2, 3, 4)), maxBytes = 3))
+  }
+
   @Test
   fun dropsInternalToolBlocksFromDisplayHistory() {
     val content =
@@ -97,21 +113,67 @@ class ChatMessageContentParsingTest {
       val target = "/__openclaw__/canvas/documents/widget-1/index.html"
       val oldSurface = "https://gateway.example/__openclaw__/cap/old"
       val newSurface = "https://gateway.example/__openclaw__/cap/new"
+      val oldPin = "aa".repeat(32)
+      val newPin = "bb".repeat(32)
       val failedUrl = ChatWidgetUrlResolver.resolve(oldSurface, target)
-      var current = ChatWidgetSurfaceUrls(node = oldSurface, operator = null)
+      val failedResource = ChatWidgetResource(url = requireNotNull(failedUrl), tlsFingerprintSha256 = oldPin)
+      var current =
+        ChatWidgetSurfaceUrls(
+          node = ChatWidgetSurface(url = oldSurface, tlsFingerprintSha256 = oldPin),
+          operator = null,
+        )
 
       val resolved =
         ChatWidgetUrlResolver.resolveAfterFailure(
           target = target,
-          failedUrl = requireNotNull(failedUrl),
+          failedResource = failedResource,
           currentSurfaceUrls = { current },
-          refreshNodeSurfaceUrl = {
-            current = ChatWidgetSurfaceUrls(node = newSurface, operator = null)
+          refreshNodeSurface = {
+            current =
+              ChatWidgetSurfaceUrls(
+                node = ChatWidgetSurface(url = newSurface, tlsFingerprintSha256 = newPin),
+                operator = null,
+              )
             null
           },
         )
 
-      assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved)
+      assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved?.url)
+      assertEquals(newPin, resolved?.tlsFingerprintSha256)
+    }
+
+  @Test
+  fun acceptsSameUrlReplacementWhenTlsPinChanged() =
+    runTest {
+      val target = "/__openclaw__/canvas/documents/widget-1/index.html"
+      val surface = "https://gateway.example/__openclaw__/cap/token"
+      val oldPin = "aa".repeat(32)
+      val newPin = "bb".repeat(32)
+      val url = requireNotNull(ChatWidgetUrlResolver.resolve(surface, target))
+      val failedResource = ChatWidgetResource(url = url, tlsFingerprintSha256 = oldPin)
+      var current =
+        ChatWidgetSurfaceUrls(
+          node = ChatWidgetSurface(url = surface, tlsFingerprintSha256 = oldPin),
+          operator = null,
+        )
+
+      val resolved =
+        ChatWidgetUrlResolver.resolveAfterFailure(
+          target = target,
+          failedResource = failedResource,
+          currentSurfaceUrls = { current },
+          refreshNodeSurface = {
+            current =
+              ChatWidgetSurfaceUrls(
+                node = ChatWidgetSurface(url = surface, tlsFingerprintSha256 = newPin),
+                operator = null,
+              )
+            null
+          },
+        )
+
+      assertEquals(url, resolved?.url)
+      assertEquals(newPin, resolved?.tlsFingerprintSha256)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -28,6 +28,69 @@ class ChatMessageContentParsingTest {
   }
 
   @Test
+  fun parsesCapabilityGatedCanvasWidgets() {
+    val content =
+      Json.parseToJsonElement(
+        """{"type":"canvas","preview":{"kind":"canvas","surface":"assistant_message","render":"url","title":"Status","preferredHeight":240,"url":"/__openclaw__/canvas/documents/widget-1/index.html","sandbox":"scripts"}}""",
+      )
+
+    assertEquals(
+      ChatMessageContent(
+        type = "canvas",
+        widget =
+          ChatWidgetPreview(
+            title = "Status",
+            path = "/__openclaw__/canvas/documents/widget-1/index.html",
+            preferredHeight = 240,
+            sandbox = "scripts",
+          ),
+      ),
+      parseChatMessageContent(content),
+    )
+  }
+
+  @Test
+  fun dropsCanvasBlocksWithoutWidgetSandbox() {
+    val content =
+      Json.parseToJsonElement(
+        """{"type":"canvas","preview":{"kind":"canvas","surface":"assistant_message","render":"url","url":"/__openclaw__/canvas/documents/widget-1/index.html"}}""",
+      )
+
+    assertNull(parseChatMessageContent(content))
+  }
+
+  @Test
+  fun dropsCanvasBlocksWithUntrustedWidgetTargets() {
+    val content =
+      Json.parseToJsonElement(
+        """{"type":"canvas","preview":{"kind":"canvas","surface":"assistant_message","render":"url","url":"https://attacker.example/widget.html","sandbox":"scripts"}}""",
+      )
+
+    assertNull(parseChatMessageContent(content))
+  }
+
+  @Test
+  fun resolvesOnlyCapabilityScopedWidgetDocuments() {
+    val surface = "https://gateway.example/__openclaw__/cap/token"
+
+    assertEquals(
+      "https://gateway.example/__openclaw__/cap/token/__openclaw__/canvas/documents/widget-1/index.html",
+      ChatWidgetUrlResolver.resolve(surface, "/__openclaw__/canvas/documents/widget-1/index.html"),
+    )
+    assertEquals(
+      "https://gateway.example/__openclaw__/cap/token/__openclaw__/canvas/documents/widget-1/index.html",
+      ChatWidgetUrlResolver.resolve(
+        "HTTPS://gateway.example/__openclaw__/cap/token",
+        "/__openclaw__/canvas/documents/widget-1/index.html",
+      ),
+    )
+    assertNull(ChatWidgetUrlResolver.resolve("https://gateway.example", "/__openclaw__/canvas/documents/widget-1/index.html"))
+    assertNull(ChatWidgetUrlResolver.resolve(surface, "https://attacker.example/widget.html"))
+    assertNull(ChatWidgetUrlResolver.resolve(surface, "/__openclaw__/a2ui/index.html"))
+    assertNull(ChatWidgetUrlResolver.resolve(surface, "/__openclaw__/canvas/documents/%252e%252e/index.html"))
+  }
+
+  @Test
   fun parsesImageBlocksOnlyWhenInlineContentExists() {
     val image =
       Json.parseToJsonElement(

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -151,6 +151,7 @@ class ChatMessageContentParsingTest {
               )
             null
           },
+          refreshOperatorSurface = { null },
         )
 
       assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved?.url)
@@ -185,6 +186,7 @@ class ChatMessageContentParsingTest {
               )
             null
           },
+          refreshOperatorSurface = { null },
         )
 
       assertEquals(url, resolved?.url)
@@ -217,10 +219,47 @@ class ChatMessageContentParsingTest {
             current = current.copy(node = ChatWidgetSurface(url = newSurface, tlsFingerprintSha256 = null))
             null
           },
+          refreshOperatorSurface = { null },
         )
 
       assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved?.url)
       assertEquals(1, refreshCount)
+    }
+
+  @Test
+  fun refreshesOperatorCapabilityWhenNodeUnavailable() =
+    runTest {
+      val target = "/__openclaw__/canvas/documents/widget-1/index.html"
+      val oldSurface = "https://operator.example/__openclaw__/cap/old"
+      val newSurface = "https://operator.example/__openclaw__/cap/new"
+      val failedResource =
+        ChatWidgetResource(
+          url = requireNotNull(ChatWidgetUrlResolver.resolve(oldSurface, target)),
+          tlsFingerprintSha256 = null,
+        )
+      var operatorRefreshCount = 0
+      var current =
+        ChatWidgetSurfaceUrls(
+          node = null,
+          operator = ChatWidgetSurface(url = oldSurface, tlsFingerprintSha256 = null),
+        )
+
+      val resolved =
+        ChatWidgetUrlResolver.resolveAfterFailure(
+          target = target,
+          failedResource = failedResource,
+          currentSurfaceUrls = { current },
+          refreshNodeSurface = { null },
+          refreshOperatorSurface = {
+            operatorRefreshCount += 1
+            ChatWidgetSurface(url = newSurface, tlsFingerprintSha256 = null).also {
+              current = current.copy(operator = it)
+            }
+          },
+        )
+
+      assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved?.url)
+      assertEquals(1, operatorRefreshCount)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.chat
 
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
@@ -89,6 +90,29 @@ class ChatMessageContentParsingTest {
     assertNull(ChatWidgetUrlResolver.resolve(surface, "/__openclaw__/a2ui/index.html"))
     assertNull(ChatWidgetUrlResolver.resolve(surface, "/__openclaw__/canvas/documents/%252e%252e/index.html"))
   }
+
+  @Test
+  fun usesReplacementRouteAfterCapabilityRefreshLosesItsLease() =
+    runTest {
+      val target = "/__openclaw__/canvas/documents/widget-1/index.html"
+      val oldSurface = "https://gateway.example/__openclaw__/cap/old"
+      val newSurface = "https://gateway.example/__openclaw__/cap/new"
+      val failedUrl = ChatWidgetUrlResolver.resolve(oldSurface, target)
+      var current = ChatWidgetSurfaceUrls(node = oldSurface, operator = null)
+
+      val resolved =
+        ChatWidgetUrlResolver.resolveAfterFailure(
+          target = target,
+          failedUrl = requireNotNull(failedUrl),
+          currentSurfaceUrls = { current },
+          refreshNodeSurfaceUrl = {
+            current = ChatWidgetSurfaceUrls(node = newSurface, operator = null)
+            null
+          },
+        )
+
+      assertEquals(ChatWidgetUrlResolver.resolve(newSurface, target), resolved)
+    }
 
   @Test
   fun parsesImageBlocksOnlyWhenInlineContentExists() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -93,6 +93,63 @@ private data class InvokeScenarioResult(
 @Config(sdk = [34])
 class GatewaySessionInvokeTest {
   @Test
+  fun refreshCanvasHostUrl_replacesAdvertisedCapabilityUrl() =
+    runBlocking {
+      val json = testJson()
+      val connected = CompletableDeferred<Unit>()
+      val lastDisconnect = AtomicReference("")
+      val refreshRequests = AtomicInteger()
+      val server =
+        startGatewayServer(json) { webSocket, id, method, frame ->
+          when (method) {
+            "connect" ->
+              webSocket.send(
+                connectResponseFrame(
+                  id,
+                  pluginSurfaceUrls =
+                    mapOf("canvas" to "http://127.0.0.1:18789/__openclaw__/cap/old-token"),
+                ),
+              )
+            "node.pluginSurface.refresh" -> {
+              refreshRequests.incrementAndGet()
+              assertEquals(
+                "canvas",
+                frame["params"]
+                  ?.jsonObject
+                  ?.get("surface")
+                  ?.jsonPrimitive
+                  ?.content,
+              )
+              webSocket.send(
+                """{"type":"res","id":"$id","ok":true,"payload":{"surface":"canvas","pluginSurfaceUrls":{"canvas":"http://127.0.0.1:18789/__openclaw__/cap/new-token"}}}""",
+              )
+            }
+          }
+        }
+      val harness =
+        createNodeHarness(connected = connected, lastDisconnect = lastDisconnect) {
+          GatewaySession.InvokeResult.ok("""{"handled":true}""")
+        }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        awaitConnectedOrThrow(connected, lastDisconnect, server)
+        val oldUrl = requireNotNull(harness.session.currentCanvasHostUrl())
+        assertTrue(oldUrl.endsWith("/old-token"))
+
+        val refreshed = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
+        val lagging = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
+
+        assertTrue(refreshed?.endsWith("/new-token") == true)
+        assertEquals(refreshed, harness.session.currentCanvasHostUrl())
+        assertEquals(refreshed, lagging)
+        assertEquals(1, refreshRequests.get())
+      } finally {
+        shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
   fun connect_advertisesCompatibleProtocolRange() =
     runBlocking {
       val json = testJson()

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -93,6 +93,38 @@ private data class InvokeScenarioResult(
 @Config(sdk = [34])
 class GatewaySessionInvokeTest {
   @Test
+  fun canvasRoutePinsOnlyTheConnectedTlsEndpoint() {
+    val fingerprint = "ab".repeat(32)
+    val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 7443)
+
+    assertEquals(
+      fingerprint,
+      gatewayTlsFingerprintForCanvasSurface(
+        fingerprint = fingerprint,
+        surfaceUrl = "https://gateway.example:7443/__openclaw__/cap/token",
+        endpoint = endpoint,
+        isTlsConnection = true,
+      ),
+    )
+    assertNull(
+      gatewayTlsFingerprintForCanvasSurface(
+        fingerprint = fingerprint,
+        surfaceUrl = "https://canvas.example:7443/__openclaw__/cap/token",
+        endpoint = endpoint,
+        isTlsConnection = true,
+      ),
+    )
+    assertNull(
+      gatewayTlsFingerprintForCanvasSurface(
+        fingerprint = fingerprint,
+        surfaceUrl = "https://gateway.example:9443/__openclaw__/cap/token",
+        endpoint = endpoint,
+        isTlsConnection = true,
+      ),
+    )
+  }
+
+  @Test
   fun refreshCanvasHostUrl_usesNodeRefreshMethod() =
     runBlocking {
       assertCanvasHostRefreshMethod(role = "node", expectedMethod = "node.pluginSurface.refresh")

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -120,6 +120,14 @@ class GatewaySessionInvokeTest {
                   ?.jsonPrimitive
                   ?.content,
               )
+              assertTrue(
+                frame["params"]
+                  ?.jsonObject
+                  ?.get("observedUrl")
+                  ?.jsonPrimitive
+                  ?.content
+                  ?.endsWith("/old-token") == true,
+              )
               webSocket.send(
                 """{"type":"res","id":"$id","ok":true,"payload":{"surface":"canvas","pluginSurfaceUrls":{"canvas":"http://127.0.0.1:18789/__openclaw__/cap/new-token"}}}""",
               )

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -93,69 +93,87 @@ private data class InvokeScenarioResult(
 @Config(sdk = [34])
 class GatewaySessionInvokeTest {
   @Test
-  fun refreshCanvasHostUrl_replacesAdvertisedCapabilityUrl() =
+  fun refreshCanvasHostUrl_usesNodeRefreshMethod() =
     runBlocking {
-      val json = testJson()
-      val connected = CompletableDeferred<Unit>()
-      val lastDisconnect = AtomicReference("")
-      val refreshRequests = AtomicInteger()
-      val server =
-        startGatewayServer(json) { webSocket, id, method, frame ->
-          when (method) {
-            "connect" ->
-              webSocket.send(
-                connectResponseFrame(
-                  id,
-                  pluginSurfaceUrls =
-                    mapOf("canvas" to "http://127.0.0.1:18789/__openclaw__/cap/old-token"),
-                ),
-              )
-            "node.pluginSurface.refresh" -> {
-              refreshRequests.incrementAndGet()
-              assertEquals(
-                "canvas",
-                frame["params"]
-                  ?.jsonObject
-                  ?.get("surface")
-                  ?.jsonPrimitive
-                  ?.content,
-              )
-              assertTrue(
-                frame["params"]
-                  ?.jsonObject
-                  ?.get("observedUrl")
-                  ?.jsonPrimitive
-                  ?.content
-                  ?.endsWith("/old-token") == true,
-              )
-              webSocket.send(
-                """{"type":"res","id":"$id","ok":true,"payload":{"surface":"canvas","pluginSurfaceUrls":{"canvas":"http://127.0.0.1:18789/__openclaw__/cap/new-token"}}}""",
-              )
-            }
+      assertCanvasHostRefreshMethod(role = "node", expectedMethod = "node.pluginSurface.refresh")
+    }
+
+  @Test
+  fun refreshCanvasHostUrl_usesOperatorRefreshMethod() =
+    runBlocking {
+      assertCanvasHostRefreshMethod(role = "operator", expectedMethod = "plugin.surface.refresh")
+    }
+
+  private suspend fun assertCanvasHostRefreshMethod(
+    role: String,
+    expectedMethod: String,
+  ) {
+    val json = testJson()
+    val connected = CompletableDeferred<Unit>()
+    val lastDisconnect = AtomicReference("")
+    val refreshRequests = AtomicInteger()
+    val server =
+      startGatewayServer(json) { webSocket, id, method, frame ->
+        when (method) {
+          "connect" ->
+            webSocket.send(
+              connectResponseFrame(
+                id,
+                pluginSurfaceUrls =
+                  mapOf("canvas" to "http://127.0.0.1:18789/__openclaw__/cap/old-token"),
+              ),
+            )
+          expectedMethod -> {
+            refreshRequests.incrementAndGet()
+            assertEquals(
+              "canvas",
+              frame["params"]
+                ?.jsonObject
+                ?.get("surface")
+                ?.jsonPrimitive
+                ?.content,
+            )
+            assertTrue(
+              frame["params"]
+                ?.jsonObject
+                ?.get("observedUrl")
+                ?.jsonPrimitive
+                ?.content
+                ?.endsWith("/old-token") == true,
+            )
+            webSocket.send(
+              """{"type":"res","id":"$id","ok":true,"payload":{"surface":"canvas","pluginSurfaceUrls":{"canvas":"http://127.0.0.1:18789/__openclaw__/cap/new-token"}}}""",
+            )
           }
         }
-      val harness =
-        createNodeHarness(connected = connected, lastDisconnect = lastDisconnect) {
-          GatewaySession.InvokeResult.ok("""{"handled":true}""")
-        }
-
-      try {
-        connectNodeSession(harness.session, server.port)
-        awaitConnectedOrThrow(connected, lastDisconnect, server)
-        val oldUrl = requireNotNull(harness.session.currentCanvasHostUrl())
-        assertTrue(oldUrl.endsWith("/old-token"))
-
-        val refreshed = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
-        val lagging = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
-
-        assertTrue(refreshed?.endsWith("/new-token") == true)
-        assertEquals(refreshed, harness.session.currentCanvasHostUrl())
-        assertEquals(refreshed, lagging)
-        assertEquals(1, refreshRequests.get())
-      } finally {
-        shutdownHarness(harness, server)
       }
+    val harness =
+      createNodeHarness(connected = connected, lastDisconnect = lastDisconnect) {
+        GatewaySession.InvokeResult.ok("""{"handled":true}""")
+      }
+
+    try {
+      connectNodeSession(
+        session = harness.session,
+        port = server.port,
+        role = role,
+        scopes = if (role == "operator") listOf("operator.read") else listOf("node:invoke"),
+      )
+      awaitConnectedOrThrow(connected, lastDisconnect, server)
+      val oldUrl = requireNotNull(harness.session.currentCanvasHostUrl())
+      assertTrue(oldUrl.endsWith("/old-token"))
+
+      val refreshed = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
+      val lagging = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
+
+      assertTrue(refreshed?.endsWith("/new-token") == true)
+      assertEquals(refreshed, harness.session.currentCanvasHostUrl())
+      assertEquals(refreshed, lagging)
+      assertEquals(1, refreshRequests.get())
+    } finally {
+      shutdownHarness(harness, server)
     }
+  }
 
   @Test
   fun connect_advertisesCompatibleProtocolRange() =

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -189,8 +189,13 @@ class GatewaySessionReconnectTest {
           requireNotNull(
             harness.session.captureRequestLease("manual|127.0.0.1|${server.port}"),
           )
+        assertTrue(lease.isCurrent())
         harness.session.reconnect()
         withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { reconnected.await() }
+        assertFalse(lease.isCurrent())
+        var committed = false
+        assertFalse(lease.commitIfCurrent { committed = true })
+        assertFalse(committed)
         val result =
           runCatching {
             lease.request(

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
@@ -15,6 +15,24 @@ import kotlin.concurrent.thread
 
 class GatewayTlsTest {
   @Test
+  fun buildGatewayTlsConfig_exposesNormalizedExpectedRouteFingerprint() {
+    val expected = "ab".repeat(32)
+    val config: GatewayTlsConfig =
+      buildGatewayTlsConfig(
+        params =
+          GatewayTlsParams(
+            required = true,
+            expectedFingerprint = "SHA-256: $expected",
+            allowTOFU = false,
+            stableId = "gateway-1",
+          ),
+        defaultTrust = RecordingExtendedTrustManager(),
+      )
+
+    assertEquals(expected, config.effectiveFingerprintSha256)
+  }
+
+  @Test
   fun buildGatewayTlsConfig_forwardsPlatformTrustWithSocketAndEngineContext() {
     val defaultTrust = RecordingExtendedTrustManager()
     val config =

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -439,6 +439,14 @@ class ConnectionManagerTest {
       ),
       options.scopes,
     )
+    assertEquals(listOf(ConnectionManager.INLINE_WIDGETS_CLIENT_CAPABILITY), options.caps)
+  }
+
+  @Test
+  fun buildOperatorConnectOptions_omitsInlineWidgetsWithoutIsolatedWebViews() {
+    val options = newManager(inlineWidgetsAvailable = false).buildOperatorConnectOptions()
+
+    assertTrue(options.caps.isEmpty())
   }
 
   @Test
@@ -619,6 +627,7 @@ class ConnectionManagerTest {
     installedAppsSharingEnabled: Boolean = false,
     voiceWakeEnabled: Boolean = false,
     voiceWakeAvailable: Boolean = true,
+    inlineWidgetsAvailable: Boolean = true,
   ): ConnectionManager {
     val context = RuntimeEnvironment.getApplication()
     context
@@ -646,6 +655,7 @@ class ConnectionManagerTest {
       photosAvailable = { photosAvailable },
       installedAppsSharingEnabled = { installedAppsSharingEnabled },
       voiceWakeAvailable = { voiceWakeAvailable },
+      inlineWidgetsAvailable = { inlineWidgetsAvailable },
       manualTls = { false },
     )
   }

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -300,19 +300,20 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
     }
 
     func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
-        let nodeSurfaceURL = await self.widgetGateway?.currentCanvasHostUrl()
-        let operatorSurfaceURL = await self.gateway.currentCanvasHostUrl()
-        let current = OpenClawChatWidgetURLResolver.resolve(surfaceURL: nodeSurfaceURL, target: path)
-            ?? OpenClawChatWidgetURLResolver.resolve(surfaceURL: operatorSurfaceURL, target: path)
-        guard let failedURL else { return current }
-        if let current, current != failedURL {
-            return current
-        }
-        // Only node-role sessions may rotate plugin-surface capabilities. The operator
-        // URL remains a useful initial fallback but cannot own expired-token recovery.
-        guard let widgetGateway = self.widgetGateway else { return nil }
-        let refreshed = await widgetGateway.refreshCanvasHostUrl(replacing: nodeSurfaceURL)
-        return OpenClawChatWidgetURLResolver.resolve(surfaceURL: refreshed, target: path)
+        let gateway = self.gateway
+        let widgetGateway = self.widgetGateway
+        return await OpenClawChatWidgetURLResolver.resolve(
+            target: path,
+            replacing: failedURL,
+            currentSurfaceURLs: {
+                let node = await widgetGateway?.currentCanvasHostUrl()
+                let operatorSurface = await gateway.currentCanvasHostUrl()
+                return (node: node, operatorSurface: operatorSurface)
+            },
+            // Only node-role sessions may rotate plugin-surface capabilities.
+            refreshNodeSurfaceURL: { observed in
+                await widgetGateway?.refreshCanvasHostUrl(replacing: observed)
+            })
     }
 
     func requestHistory(

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -299,21 +299,30 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         try await self.requestHistory(sessionKey: sessionKey, agentID: nil, ifCurrentRoute: nil)
     }
 
-    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
+    func resolveInlineWidgetResource(
+        path: String,
+        replacing failedResource: OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
+    {
         let gateway = self.gateway
         let widgetGateway = self.widgetGateway
-        return await OpenClawChatWidgetURLResolver.resolve(
+        return await OpenClawChatWidgetURLResolver.resolveResource(
             target: path,
-            replacing: failedURL,
-            currentSurfaceURLs: {
-                let node = await widgetGateway?.currentCanvasHostUrl()
-                let operatorSurface = await gateway.currentCanvasHostUrl()
+            replacing: failedResource,
+            currentSurfaceRoutes: {
+                let node = await widgetGateway?.currentCanvasHostRoute()
+                let operatorSurface = await gateway.currentCanvasHostRoute()
                 return (node: node, operatorSurface: operatorSurface)
             },
             // Only node-role sessions may rotate plugin-surface capabilities.
-            refreshNodeSurfaceURL: { observed in
-                await widgetGateway?.refreshCanvasHostUrl(replacing: observed)
+            refreshNodeSurfaceRoute: { observed in
+                await widgetGateway?.refreshCanvasHostRoute(replacing: observed?.url)
             })
+    }
+
+    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
+        await self.resolveInlineWidgetResource(
+            path: path,
+            replacing: failedURL.map { OpenClawChatWidgetResource(url: $0) })?.url
     }
 
     func requestHistory(

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -7,6 +7,7 @@ import OSLog
 struct IOSGatewayChatTransport: OpenClawChatTransport {
     static let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "ios.chat.transport")
     private let gateway: GatewayNodeSession
+    private let widgetGateway: GatewayNodeSession?
     private let globalAgentId: String?
     private let outboxGatewayID: String?
     private let sessionMutationRequest: (@Sendable (OpenClawChatGatewayRequest) async throws -> Data)?
@@ -17,11 +18,13 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
 
     init(
         gateway: GatewayNodeSession,
+        widgetGateway: GatewayNodeSession? = nil,
         globalAgentId: String? = nil,
         outboxGatewayID: String? = nil,
         sessionMutationRequest: (@Sendable (OpenClawChatGatewayRequest) async throws -> Data)? = nil)
     {
         self.gateway = gateway
+        self.widgetGateway = widgetGateway
         let normalized = globalAgentId?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         self.globalAgentId = normalized?.isEmpty == false ? normalized : nil
         let normalizedGatewayID = outboxGatewayID?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -294,6 +297,22 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
 
     func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
         try await self.requestHistory(sessionKey: sessionKey, agentID: nil, ifCurrentRoute: nil)
+    }
+
+    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
+        let nodeSurfaceURL = await self.widgetGateway?.currentCanvasHostUrl()
+        let operatorSurfaceURL = await self.gateway.currentCanvasHostUrl()
+        let current = OpenClawChatWidgetURLResolver.resolve(surfaceURL: nodeSurfaceURL, target: path)
+            ?? OpenClawChatWidgetURLResolver.resolve(surfaceURL: operatorSurfaceURL, target: path)
+        guard let failedURL else { return current }
+        if let current, current != failedURL {
+            return current
+        }
+        // Only node-role sessions may rotate plugin-surface capabilities. The operator
+        // URL remains a useful initial fallback but cannot own expired-token recovery.
+        guard let widgetGateway = self.widgetGateway else { return nil }
+        let refreshed = await widgetGateway.refreshCanvasHostUrl(replacing: nodeSurfaceURL)
+        return OpenClawChatWidgetURLResolver.resolve(surfaceURL: refreshed, target: path)
     }
 
     func requestHistory(

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -313,9 +313,13 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
                 let operatorSurface = await gateway.currentCanvasHostRoute()
                 return (node: node, operatorSurface: operatorSurface)
             },
-            // Only node-role sessions may rotate plugin-surface capabilities.
+            // Prefer the device's node route; operator rotation covers clients
+            // whose node role is unavailable or intentionally disabled.
             refreshNodeSurfaceRoute: { observed in
                 await widgetGateway?.refreshCanvasHostRoute(replacing: observed?.url)
+            },
+            refreshOperatorSurfaceRoute: { observed in
+                await gateway.refreshCanvasHostRoute(replacing: observed?.url)
             })
     }
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
@@ -110,6 +110,7 @@ extension GatewayConnectionController {
         var caps = [
             OpenClawCapability.canvas.rawValue,
             OpenClawCapability.screen.rawValue,
+            OpenClawGatewayClientCapability.inlineWidgets,
         ]
 
         // Default-on: if the key doesn't exist yet, treat it as enabled.

--- a/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
@@ -110,7 +110,6 @@ extension GatewayConnectionController {
         var caps = [
             OpenClawCapability.canvas.rawValue,
             OpenClawCapability.screen.rawValue,
-            OpenClawGatewayClientCapability.inlineWidgets,
         ]
 
         // Default-on: if the key doesn't exist yet, treat it as enabled.

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -641,6 +641,7 @@ final class NodeAppModel {
         }
         return IOSGatewayChatTransport(
             gateway: self.operatorSession,
+            widgetGateway: self.nodeGateway,
             globalAgentId: self.chatDeliveryAgentId,
             outboxGatewayID: outboxGatewayID)
     }
@@ -4877,7 +4878,7 @@ extension NodeAppModel {
             role: "operator",
             scopes: scopes,
             scopesAreExplicit: forceExplicitScopes,
-            caps: [],
+            caps: [OpenClawGatewayClientCapability.inlineWidgets],
             commands: [],
             permissions: [:],
             clientId: clientId,

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -231,7 +231,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
 
             #expect(caps.contains(OpenClawCapability.canvas.rawValue))
             #expect(caps.contains(OpenClawCapability.screen.rawValue))
-            #expect(caps.contains(OpenClawGatewayClientCapability.inlineWidgets))
+            #expect(!caps.contains(OpenClawGatewayClientCapability.inlineWidgets))
             #expect(caps.contains(OpenClawCapability.camera.rawValue))
             #expect(caps.contains(OpenClawCapability.location.rawValue))
             #expect(caps.contains(OpenClawCapability.voiceWake.rawValue))

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -231,6 +231,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
 
             #expect(caps.contains(OpenClawCapability.canvas.rawValue))
             #expect(caps.contains(OpenClawCapability.screen.rawValue))
+            #expect(caps.contains(OpenClawGatewayClientCapability.inlineWidgets))
             #expect(caps.contains(OpenClawCapability.camera.rawValue))
             #expect(caps.contains(OpenClawCapability.location.rawValue))
             #expect(caps.contains(OpenClawCapability.voiceWake.rawValue))
@@ -322,6 +323,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         #expect(!withoutApprovalScope.scopes.contains("operator.approvals"))
         #expect(withoutApprovalScope.scopes.contains("operator.talk.secrets"))
         #expect(!withoutApprovalScope.scopesAreExplicit)
+        #expect(withoutApprovalScope.caps == [OpenClawGatewayClientCapability.inlineWidgets])
 
         #expect(withApprovalScope.scopes.contains("operator.approvals"))
         #expect(withAdminScope.scopes.contains("operator.admin"))

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -253,7 +253,7 @@ struct SwiftUIRenderSmokeTests {
                 isClean: false,
                 contextWindowTokens: 1_000_000,
                 inlineWidgetResolverReady: true,
-                inlineWidgetURLResolver: { _, _ in nil })
+                inlineWidgetResourceResolver: { _, _ in nil })
                 .environment(\.dynamicTypeSize, typeSize)
 
             _ = Self.host(root, size: CGSize(width: 320, height: 280))

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -251,7 +251,9 @@ struct SwiftUIRenderSmokeTests {
                 assistantAvatarTint: nil,
                 showsAssistantAvatar: true,
                 isClean: false,
-                contextWindowTokens: 1_000_000)
+                contextWindowTokens: 1_000_000,
+                inlineWidgetResolverReady: true,
+                inlineWidgetURLResolver: { _, _ in nil })
                 .environment(\.dynamicTypeSize, typeSize)
 
             _ = Self.host(root, size: CGSize(width: 320, height: 280))

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+Inference.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+Inference.swift
@@ -1,0 +1,27 @@
+import Foundation
+import OpenClawChatUI
+import OpenClawProtocol
+
+extension GatewayConnection {
+    func configuredInferenceModel(
+        ifCurrentRoute route: Route,
+        timeoutMs: Double = 15000) async throws -> String?
+    {
+        let data = try await request(
+            OpenClawChatGatewayRequests.agentsList(timeoutMs: timeoutMs),
+            ifCurrentRoute: route)
+        guard await self.isCurrentRoute(route) else {
+            throw CancellationError()
+        }
+        return try Self.decodeConfiguredInferenceModel(data)
+    }
+
+    static func decodeConfiguredInferenceModel(_ data: Data) throws -> String? {
+        let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
+        let primary = result.agents
+            .first(where: { $0.id == result.defaultid })?
+            .model?["primary"]?.value as? String
+        let trimmed = primary?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+WidgetSurface.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+WidgetSurface.swift
@@ -72,7 +72,10 @@ extension GatewayConnection {
                 return self.currentCanvasPluginSurfaceRoute()
             }
             let raw = response.pluginSurfaceUrls?["canvas"]?.value as? String
-            guard let refreshed = Self.normalizePluginSurfaceURL(raw) else { return nil }
+            guard let refreshed = GatewayPluginSurfaceURL.canonicalize(
+                raw: raw,
+                against: self.configuredGatewayURL())
+            else { return nil }
             self.canvasPluginSurfaceURL = refreshed
             return self.currentCanvasPluginSurfaceRoute()
         } catch {
@@ -92,17 +95,14 @@ extension GatewayConnection {
     func installCanvasPluginSurfaceURL(from snapshot: HelloOk) {
         let raw = snapshot.pluginsurfaceurls?["canvas"]?.value as? String
         self.resetCanvasPluginSurfaceState()
-        self.canvasPluginSurfaceURL = Self.normalizePluginSurfaceURL(raw)
+        self.canvasPluginSurfaceURL = GatewayPluginSurfaceURL.canonicalize(
+            raw: raw,
+            against: self.configuredGatewayURL())
     }
 
     func resetCanvasPluginSurfaceState() {
         self.canvasPluginSurfaceRefresh?.task.cancel()
         self.canvasPluginSurfaceRefresh = nil
         self.canvasPluginSurfaceURL = nil
-    }
-
-    private static func normalizePluginSurfaceURL(_ raw: String?) -> String? {
-        let trimmed = raw?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+WidgetSurface.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+WidgetSurface.swift
@@ -1,0 +1,10 @@
+import OpenClawKit
+
+extension GatewayConnection {
+    func canvasPluginSurfaceRoute() async -> GatewayCanvasHostRoute? {
+        guard let url = await self.canvasPluginSurfaceUrl() else { return nil }
+        // The operator channel uses platform trust. Pinned remote routes belong
+        // to MacNodeModeCoordinator and arrive through its node session.
+        return GatewayCanvasHostRoute(url: url, tlsFingerprintSHA256: nil)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+WidgetSurface.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+WidgetSurface.swift
@@ -1,10 +1,108 @@
+import Foundation
 import OpenClawKit
+import OpenClawProtocol
+import OSLog
+
+private let gatewayWidgetSurfaceLogger = Logger(subsystem: "ai.openclaw", category: "gateway.widget-surface")
+
+private struct PluginSurfaceRefreshResponse: Decodable {
+    let pluginSurfaceUrls: [String: AnyCodable]?
+}
 
 extension GatewayConnection {
+    func canvasPluginSurfaceUrl() async -> String? {
+        self.canvasPluginSurfaceURL
+    }
+
     func canvasPluginSurfaceRoute() async -> GatewayCanvasHostRoute? {
-        guard let url = await self.canvasPluginSurfaceUrl() else { return nil }
+        self.currentCanvasPluginSurfaceRoute()
+    }
+
+    func refreshCanvasPluginSurfaceRoute(replacing observedURL: String?) async -> GatewayCanvasHostRoute? {
+        if self.canvasPluginSurfaceURL != observedURL {
+            return self.currentCanvasPluginSurfaceRoute()
+        }
+        if let activeRefresh = self.canvasPluginSurfaceRefresh {
+            return await activeRefresh.task.value
+        }
+        guard let lease = await self.captureServerLease(), !Task.isCancelled else { return nil }
+        // Capturing the physical connection before spawning prevents a canceled
+        // refresh from adopting a replacement connection when its task starts.
+        if self.canvasPluginSurfaceURL != observedURL {
+            return self.currentCanvasPluginSurfaceRoute()
+        }
+        if let activeRefresh = self.canvasPluginSurfaceRefresh {
+            return await activeRefresh.task.value
+        }
+        let id = UUID()
+        let task = Task<GatewayCanvasHostRoute?, Never> { [weak self] in
+            guard let self, !Task.isCancelled else { return nil }
+            return await self.requestCanvasPluginSurfaceRefresh(
+                replacing: observedURL,
+                ifCurrentServerLease: lease)
+        }
+        // Install before the task's first suspension so sibling widgets share
+        // one rotation instead of invalidating each other's new capability.
+        self.canvasPluginSurfaceRefresh = CanvasPluginSurfaceRefresh(id: id, task: task)
+        let route = await task.value
+        if self.canvasPluginSurfaceRefresh?.id == id {
+            self.canvasPluginSurfaceRefresh = nil
+        }
+        return route
+    }
+
+    private func requestCanvasPluginSurfaceRefresh(
+        replacing observedURL: String?,
+        ifCurrentServerLease lease: ServerLease) async -> GatewayCanvasHostRoute?
+    {
+        guard !Task.isCancelled else { return nil }
+        var params = ["surface": AnyCodable("canvas")]
+        if let observedURL {
+            params["observedUrl"] = AnyCodable(observedURL)
+        }
+        do {
+            let data = try await self.request(
+                method: "plugin.surface.refresh",
+                params: params,
+                timeoutMs: 8000,
+                ifCurrentServerLease: lease)
+            let response = try JSONDecoder().decode(PluginSurfaceRefreshResponse.self, from: data)
+            guard !Task.isCancelled, await self.isCurrentServerLease(lease) else { return nil }
+            if self.canvasPluginSurfaceURL != observedURL {
+                return self.currentCanvasPluginSurfaceRoute()
+            }
+            let raw = response.pluginSurfaceUrls?["canvas"]?.value as? String
+            guard let refreshed = Self.normalizePluginSurfaceURL(raw) else { return nil }
+            self.canvasPluginSurfaceURL = refreshed
+            return self.currentCanvasPluginSurfaceRoute()
+        } catch {
+            gatewayWidgetSurfaceLogger.debug(
+                "plugin.surface.refresh failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    private func currentCanvasPluginSurfaceRoute() -> GatewayCanvasHostRoute? {
+        guard let url = self.canvasPluginSurfaceURL else { return nil }
         // The operator channel uses platform trust. Pinned remote routes belong
         // to MacNodeModeCoordinator and arrive through its node session.
         return GatewayCanvasHostRoute(url: url, tlsFingerprintSHA256: nil)
+    }
+
+    func installCanvasPluginSurfaceURL(from snapshot: HelloOk) {
+        let raw = snapshot.pluginsurfaceurls?["canvas"]?.value as? String
+        self.resetCanvasPluginSurfaceState()
+        self.canvasPluginSurfaceURL = Self.normalizePluginSurfaceURL(raw)
+    }
+
+    func resetCanvasPluginSurfaceState() {
+        self.canvasPluginSurfaceRefresh?.task.cancel()
+        self.canvasPluginSurfaceRefresh = nil
+        self.canvasPluginSurfaceURL = nil
+    }
+
+    private static func normalizePluginSurfaceURL(_ raw: String?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -207,6 +207,14 @@ actor GatewayConnection {
 
     private var subscribers: [UUID: AsyncStream<GatewayPush>.Continuation] = [:]
     private var lastSnapshot: HelloOk?
+    var canvasPluginSurfaceURL: String?
+
+    struct CanvasPluginSurfaceRefresh {
+        let id: UUID
+        let task: Task<GatewayCanvasHostRoute?, Never>
+    }
+
+    var canvasPluginSurfaceRefresh: CanvasPluginSurfaceRefresh?
 
     private struct LossyDecodable<Value: Decodable>: Decodable {
         let value: Value?
@@ -861,6 +869,7 @@ extension GatewayConnection {
         self.routeGeneration &+= 1
         resetSocketGeneration()
         self.lastSnapshot = nil
+        self.resetCanvasPluginSurfaceState()
         let client = client
         self.client = nil
         self.configuredURL = nil
@@ -899,6 +908,7 @@ extension GatewayConnection {
         self.routeGeneration &+= 1
         resetSocketGeneration()
         self.lastSnapshot = nil
+        self.resetCanvasPluginSurfaceState()
         let configuredRouteGeneration = self.routeGeneration
         let previousClient = client
         client = nil
@@ -1018,6 +1028,7 @@ extension GatewayConnection {
               admitSocketGeneration(socketGeneration)
         else { return }
         self.lastSnapshot = snapshot
+        self.installCanvasPluginSurfaceURL(from: snapshot)
     }
 
     private func handleDisconnect(routeGeneration: UInt64, socketGeneration: UInt64) {
@@ -1025,6 +1036,7 @@ extension GatewayConnection {
               retireSocketGeneration(socketGeneration)
         else { return }
         self.lastSnapshot = nil
+        self.resetCanvasPluginSurfaceState()
     }
 }
 
@@ -1139,13 +1151,6 @@ extension GatewayConnection {
 // MARK: - Snapshot cache and subscriptions
 
 extension GatewayConnection {
-    func canvasPluginSurfaceUrl() async -> String? {
-        guard let snapshot = lastSnapshot else { return nil }
-        let raw = snapshot.pluginsurfaceurls?["canvas"]?.value as? String
-        let trimmed = raw?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
     func controlUiAutoAuthToken(config: Config) async -> String? {
         guard let endpoint = try? await currentEndpoint(),
               endpoint.config.url == config.url,
@@ -1271,6 +1276,9 @@ extension GatewayConnection {
     private func broadcast(_ push: GatewayPush) {
         if case let .snapshot(snapshot) = push {
             self.lastSnapshot = snapshot
+            if self.canvasPluginSurfaceURL == nil {
+                self.installCanvasPluginSurfaceURL(from: snapshot)
+            }
             if let mainSessionKey = cachedMainSessionKey() {
                 Task { @MainActor in
                     WorkActivityStore.shared.setMainSessionKey(mainSessionKey)

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -837,26 +837,8 @@ extension GatewayConnection {
         return try OpenClawChatGatewayPayloadCodec.decodeSessionRoutingIdentity(data)
     }
 
-    func configuredInferenceModel(
-        ifCurrentRoute route: Route,
-        timeoutMs: Double = 15000) async throws -> String?
-    {
-        let data = try await request(
-            OpenClawChatGatewayRequests.agentsList(timeoutMs: timeoutMs),
-            ifCurrentRoute: route)
-        guard await self.isCurrentRoute(route) else {
-            throw CancellationError()
-        }
-        return try Self.decodeConfiguredInferenceModel(data)
-    }
-
-    static func decodeConfiguredInferenceModel(_ data: Data) throws -> String? {
-        let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
-        let primary = result.agents
-            .first(where: { $0.id == result.defaultid })?
-            .model?["primary"]?.value as? String
-        let trimmed = primary?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
+    func configuredGatewayURL() -> URL? {
+        self.configuredURL
     }
 
     func authSource() async -> GatewayAuthSource? {

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -77,6 +77,7 @@ private enum GatewayActivationBindingKeyStore {
 actor GatewayConnection {
     static let shared = GatewayConnection(
         endpointProvider: GatewayConnection.defaultEndpointProvider)
+    nonisolated static let operatorClientCaps = [OpenClawGatewayClientCapability.inlineWidgets]
 
     typealias Config = (url: URL, token: String?, password: String?)
 
@@ -947,7 +948,7 @@ extension GatewayConnection {
             connectOptions: GatewayConnectOptions(
                 role: "operator",
                 scopes: GatewayChannelActor.defaultOperatorConnectScopes,
-                caps: [],
+                caps: Self.operatorClientCaps,
                 commands: [],
                 permissions: [:],
                 clientId: "openclaw-macos",

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1146,6 +1146,13 @@ extension GatewayConnection {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    func canvasPluginSurfaceRoute() async -> GatewayCanvasHostRoute? {
+        guard let url = await canvasPluginSurfaceUrl() else { return nil }
+        // The macOS operator channel uses platform trust. Pinned remote routes
+        // are owned by MacNodeModeCoordinator and arrive through its node session.
+        return GatewayCanvasHostRoute(url: url, tlsFingerprintSHA256: nil)
+    }
+
     func controlUiAutoAuthToken(config: Config) async -> String? {
         guard let endpoint = try? await currentEndpoint(),
               endpoint.config.url == config.url,

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1146,13 +1146,6 @@ extension GatewayConnection {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    func canvasPluginSurfaceRoute() async -> GatewayCanvasHostRoute? {
-        guard let url = await canvasPluginSurfaceUrl() else { return nil }
-        // The macOS operator channel uses platform trust. Pinned remote routes
-        // are owned by MacNodeModeCoordinator and arrive through its node session.
-        return GatewayCanvasHostRoute(url: url, tlsFingerprintSHA256: nil)
-    }
-
     func controlUiAutoAuthToken(config: Config) async -> String? {
         guard let endpoint = try? await currentEndpoint(),
               endpoint.config.url == config.url,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCanvasHostedSurfaceResolver.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCanvasHostedSurfaceResolver.swift
@@ -2,37 +2,36 @@ import Foundation
 
 struct MacNodeCanvasHostedSurfaceResolver: Sendable {
     private let currentSurfaceURL: @Sendable () async -> String?
-    private let refreshSurfaceURL: @Sendable () async -> String?
+    private let refreshSurfaceURL: @Sendable (String?) async -> String?
 
     init(
         currentSurfaceURL: @escaping @Sendable () async -> String?,
-        refreshSurfaceURL: @escaping @Sendable () async -> String?)
+        refreshSurfaceURL: @escaping @Sendable (String?) async -> String?)
     {
         self.currentSurfaceURL = currentSurfaceURL
         self.refreshSurfaceURL = refreshSurfaceURL
     }
 
     func resolveA2UIURL(forceRefresh: Bool = false) async -> String? {
+        let observedSurface = await currentSurfaceURL()
         if !forceRefresh,
-           let currentSurface = await currentSurfaceURL(),
-           let current = CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: currentSurface)
+           let current = CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: observedSurface)
         {
             return current
         }
-        let refreshedSurface = await refreshSurfaceURL()
+        let refreshedSurface = await refreshSurfaceURL(observedSurface)
         return CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: refreshedSurface)
     }
 
     func resolveTarget(_ target: String?) async throws -> CanvasHostedTarget? {
         guard let target, CanvasHostedURLResolver.isHostedTarget(target) else { return nil }
-        if let refreshedSurface = await refreshSurfaceURL(),
+        let observedSurface = await currentSurfaceURL()
+        if let refreshedSurface = await refreshSurfaceURL(observedSurface),
            let resolved = CanvasHostedURLResolver.resolve(surfaceURL: refreshedSurface, target: target)
         {
             return resolved
         }
-        if let currentSurface = await currentSurfaceURL(),
-           let resolved = CanvasHostedURLResolver.resolve(surfaceURL: currentSurface, target: target)
-        {
+        if let resolved = CanvasHostedURLResolver.resolve(surfaceURL: observedSurface, target: target) {
             return resolved
         }
         throw NSError(domain: "Canvas", code: 32, userInfo: [

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCanvasHostedSurfaceResolver.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCanvasHostedSurfaceResolver.swift
@@ -31,7 +31,10 @@ struct MacNodeCanvasHostedSurfaceResolver: Sendable {
         {
             return resolved
         }
-        if let resolved = CanvasHostedURLResolver.resolve(surfaceURL: observedSurface, target: target) {
+        // A failed refresh can mean the route changed while it was in flight.
+        // Re-read so the replacement gateway's capability wins over the stale observation.
+        let currentSurface = await currentSurfaceURL()
+        if let resolved = CanvasHostedURLResolver.resolve(surfaceURL: currentSurface, target: target) {
             return resolved
         }
         throw NSError(domain: "Canvas", code: 32, userInfo: [

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -269,8 +269,16 @@ final class MacNodeModeCoordinator: NSObject {
         await self.session.currentCanvasHostUrl()
     }
 
+    func currentCanvasPluginSurfaceRoute() async -> GatewayCanvasHostRoute? {
+        await self.session.currentCanvasHostRoute()
+    }
+
     func refreshCanvasPluginSurfaceURL(replacing observedURL: String?) async -> String? {
         await self.session.refreshCanvasHostUrl(replacing: observedURL)
+    }
+
+    func refreshCanvasPluginSurfaceRoute(replacing observedURL: String?) async -> GatewayCanvasHostRoute? {
+        await self.session.refreshCanvasHostRoute(replacing: observedURL)
     }
 
     private func refresh(isPaused: Bool, computerControlEnabled: Bool) {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -123,7 +123,9 @@ final class MacNodeModeCoordinator: NSObject {
             runtime: MacNodeRuntime(
                 nodeHostWorker: nodeHostWorker,
                 canvasSurfaceUrl: { await session.currentCanvasHostUrl() },
-                refreshCanvasSurfaceUrl: { await session.refreshCanvasHostUrl() }),
+                refreshCanvasSurfaceUrl: { observedURL in
+                    await session.refreshCanvasHostUrl(replacing: observedURL)
+                }),
             nodeHostWorker: nodeHostWorker,
             presenceReporter: MacNodePresenceReporter(),
             observeNotifications: true,
@@ -261,6 +263,14 @@ final class MacNodeModeCoordinator: NSObject {
             isPaused: UserDefaults.standard.bool(forKey: pauseDefaultsKey),
             computerControlEnabled: UserDefaults.standard.object(
                 forKey: computerControlEnabledKey) as? Bool ?? false)
+    }
+
+    func currentCanvasPluginSurfaceURL() async -> String? {
+        await self.session.currentCanvasHostUrl()
+    }
+
+    func refreshCanvasPluginSurfaceURL(replacing observedURL: String?) async -> String? {
+        await self.session.refreshCanvasHostUrl(replacing: observedURL)
     }
 
     private func refresh(isPaused: Bool, computerControlEnabled: Bool) {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -265,16 +265,8 @@ final class MacNodeModeCoordinator: NSObject {
                 forKey: computerControlEnabledKey) as? Bool ?? false)
     }
 
-    func currentCanvasPluginSurfaceURL() async -> String? {
-        await self.session.currentCanvasHostUrl()
-    }
-
     func currentCanvasPluginSurfaceRoute() async -> GatewayCanvasHostRoute? {
         await self.session.currentCanvasHostRoute()
-    }
-
-    func refreshCanvasPluginSurfaceURL(replacing observedURL: String?) async -> String? {
-        await self.session.refreshCanvasHostUrl(replacing: observedURL)
     }
 
     func refreshCanvasPluginSurfaceRoute(replacing observedURL: String?) async -> GatewayCanvasHostRoute? {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -38,7 +38,7 @@ actor MacNodeRuntime {
         canvasSurfaceUrl: @escaping @Sendable () async -> String? = {
             await GatewayConnection.shared.canvasPluginSurfaceUrl()
         },
-        refreshCanvasSurfaceUrl: @escaping @Sendable () async -> String? = { nil },
+        refreshCanvasSurfaceUrl: @escaping @Sendable (String?) async -> String? = { _ in nil },
         codexThreadCatalogEnabled: @escaping @Sendable () -> Bool = {
             MacNodeCodexThreadCatalog.shouldAdvertise()
         },

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -89,19 +89,28 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             agentID: target.agentID)
     }
 
-    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
-        await OpenClawChatWidgetURLResolver.resolve(
+    func resolveInlineWidgetResource(
+        path: String,
+        replacing failedResource: OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
+    {
+        await OpenClawChatWidgetURLResolver.resolveResource(
             target: path,
-            replacing: failedURL,
-            currentSurfaceURLs: {
-                let node = await MacNodeModeCoordinator.shared.currentCanvasPluginSurfaceURL()
-                let operatorSurface = await GatewayConnection.shared.canvasPluginSurfaceUrl()
+            replacing: failedResource,
+            currentSurfaceRoutes: {
+                let node = await MacNodeModeCoordinator.shared.currentCanvasPluginSurfaceRoute()
+                let operatorSurface = await GatewayConnection.shared.canvasPluginSurfaceRoute()
                 return (node: node, operatorSurface: operatorSurface)
             },
             // Gateway policy restricts capability rotation to the node session.
-            refreshNodeSurfaceURL: { observed in
-                await MacNodeModeCoordinator.shared.refreshCanvasPluginSurfaceURL(replacing: observed)
+            refreshNodeSurfaceRoute: { observed in
+                await MacNodeModeCoordinator.shared.refreshCanvasPluginSurfaceRoute(replacing: observed?.url)
             })
+    }
+
+    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
+        await self.resolveInlineWidgetResource(
+            path: path,
+            replacing: failedURL.map { OpenClawChatWidgetResource(url: $0) })?.url
     }
 
     func listModels() async throws -> [OpenClawChatModelChoice] {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -101,9 +101,13 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
                 let operatorSurface = await GatewayConnection.shared.canvasPluginSurfaceRoute()
                 return (node: node, operatorSurface: operatorSurface)
             },
-            // Gateway policy restricts capability rotation to the node session.
+            // Prefer the local node route; operator rotation keeps chat usable
+            // while macOS node mode is disabled or reconnecting.
             refreshNodeSurfaceRoute: { observed in
                 await MacNodeModeCoordinator.shared.refreshCanvasPluginSurfaceRoute(replacing: observed?.url)
+            },
+            refreshOperatorSurfaceRoute: { observed in
+                await GatewayConnection.shared.refreshCanvasPluginSurfaceRoute(replacing: observed?.url)
             })
     }
 

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -90,18 +90,18 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
-        let nodeSurfaceURL = await MacNodeModeCoordinator.shared.currentCanvasPluginSurfaceURL()
-        let operatorSurfaceURL = await GatewayConnection.shared.canvasPluginSurfaceUrl()
-        let current = OpenClawChatWidgetURLResolver.resolve(surfaceURL: nodeSurfaceURL, target: path)
-            ?? OpenClawChatWidgetURLResolver.resolve(surfaceURL: operatorSurfaceURL, target: path)
-        guard let failedURL else { return current }
-        if let current, current != failedURL {
-            return current
-        }
-        // Gateway policy restricts capability rotation to the node session.
-        let refreshed = await MacNodeModeCoordinator.shared.refreshCanvasPluginSurfaceURL(
-            replacing: nodeSurfaceURL)
-        return OpenClawChatWidgetURLResolver.resolve(surfaceURL: refreshed, target: path)
+        await OpenClawChatWidgetURLResolver.resolve(
+            target: path,
+            replacing: failedURL,
+            currentSurfaceURLs: {
+                let node = await MacNodeModeCoordinator.shared.currentCanvasPluginSurfaceURL()
+                let operatorSurface = await GatewayConnection.shared.canvasPluginSurfaceUrl()
+                return (node: node, operatorSurface: operatorSurface)
+            },
+            // Gateway policy restricts capability rotation to the node session.
+            refreshNodeSurfaceURL: { observed in
+                await MacNodeModeCoordinator.shared.refreshCanvasPluginSurfaceURL(replacing: observed)
+            })
     }
 
     func listModels() async throws -> [OpenClawChatModelChoice] {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -89,6 +89,21 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             agentID: target.agentID)
     }
 
+    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
+        let nodeSurfaceURL = await MacNodeModeCoordinator.shared.currentCanvasPluginSurfaceURL()
+        let operatorSurfaceURL = await GatewayConnection.shared.canvasPluginSurfaceUrl()
+        let current = OpenClawChatWidgetURLResolver.resolve(surfaceURL: nodeSurfaceURL, target: path)
+            ?? OpenClawChatWidgetURLResolver.resolve(surfaceURL: operatorSurfaceURL, target: path)
+        guard let failedURL else { return current }
+        if let current, current != failedURL {
+            return current
+        }
+        // Gateway policy restricts capability rotation to the node session.
+        let refreshed = await MacNodeModeCoordinator.shared.refreshCanvasPluginSurfaceURL(
+            replacing: nodeSurfaceURL)
+        return OpenClawChatWidgetURLResolver.resolve(surfaceURL: refreshed, target: path)
+    }
+
     func listModels() async throws -> [OpenClawChatModelChoice] {
         do {
             let data = try await GatewayConnection.shared.request(OpenClawChatGatewayRequests.modelsList())

--- a/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
@@ -167,12 +167,13 @@ struct AsyncTimeoutTests {
         }
     }
 
-    @Test func `caller cancellation returns before operation finishes`() async {
+    @Test(arguments: [0.0, 60.0])
+    func `caller cancellation returns before operation finishes`(seconds: Double) async {
         let operation = CancellationIgnoringOperation()
         let cancellation = CancellationProbe()
         let task = Task {
             try await AsyncTimeout.withTimeout(
-                seconds: 60,
+                seconds: seconds,
                 onTimeout: { ExpectedTimeout() },
                 operation: {
                     await withTaskCancellationHandler {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -235,6 +235,67 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
 }
 
 @Suite(.serialized) struct GatewayConnectionControlTests {
+    @Test func `operator widget capability refresh is shared and retained`() async throws {
+        let oldSurface = "http://127.0.0.1:18789/__openclaw__/cap/old-token"
+        let newSurface = "http://127.0.0.1:18789/__openclaw__/cap/new-token"
+        let recorder = WebSocketMessageRecorder()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(
+                sendHook: { task, message, sendIndex in
+                    recorder.append(message)
+                    guard sendIndex > 0,
+                          let data = Self.messageData(message),
+                          let frame = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                          let method = frame["method"] as? String,
+                          let id = frame["id"] as? String
+                    else { return }
+                    if method == "plugin.surface.refresh" {
+                        task.emitReceiveSuccess(.data(Data(
+                            #"{"type":"res","id":"\#(id)","ok":true,"payload":{"surface":"canvas","pluginSurfaceUrls":{"canvas":"\#(newSurface)"}}}"#
+                                .utf8)))
+                    } else {
+                        task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                    }
+                },
+                receiveHook: { task, receiveIndex in
+                    if receiveIndex == 0 {
+                        return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                    }
+                    let id = task.snapshotConnectRequestID() ?? "connect"
+                    return .data(GatewayWebSocketTestSupport.connectOkData(
+                        id: id,
+                        canvasPluginSurfaceURL: oldSurface))
+                })
+        })
+        let connection = GatewayConnection(
+            configProvider: {
+                (
+                    url: URL(string: "ws://127.0.0.1:1")!,
+                    token: "test-token-placeholder",
+                    password: nil)
+            },
+            sessionBox: WebSocketSessionBox(session: session))
+
+        try await connection.refresh()
+        _ = try await connection.acquireServerLease()
+        #expect(await connection.canvasPluginSurfaceUrl() == oldSurface)
+        async let first = connection.refreshCanvasPluginSurfaceRoute(replacing: oldSurface)
+        async let second = connection.refreshCanvasPluginSurfaceRoute(replacing: oldSurface)
+        let routes = await (first, second)
+
+        #expect(routes.0?.url == newSurface)
+        #expect(routes.1?.url == newSurface)
+        #expect(await connection.canvasPluginSurfaceUrl() == newSurface)
+        let refreshCount = recorder.snapshot().count { message in
+            guard let data = Self.messageData(message),
+                  let frame = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return false }
+            return frame["method"] as? String == "plugin.surface.refresh"
+        }
+        #expect(refreshCount == 1)
+        await connection.shutdown()
+    }
+
     @Test func `wizard not found means cancellation already reached a terminal session`() {
         let notFound = GatewayResponseError(
             method: "wizard.cancel",

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -236,8 +236,10 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
 
 @Suite(.serialized) struct GatewayConnectionControlTests {
     @Test func `operator widget capability refresh is shared and retained`() async throws {
-        let oldSurface = "http://127.0.0.1:18789/__openclaw__/cap/old-token"
-        let newSurface = "http://127.0.0.1:18789/__openclaw__/cap/new-token"
+        let rawOldSurface = "http://127.0.0.1:18789/__openclaw__/cap/old-token"
+        let rawNewSurface = "http://127.0.0.1:18789/__openclaw__/cap/new-token"
+        let oldSurface = "https://gateway.example.invalid:9443/__openclaw__/cap/old-token"
+        let newSurface = "https://gateway.example.invalid:9443/__openclaw__/cap/new-token"
         let recorder = WebSocketMessageRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(
@@ -250,9 +252,18 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
                           let id = frame["id"] as? String
                     else { return }
                     if method == "plugin.surface.refresh" {
-                        task.emitReceiveSuccess(.data(Data(
-                            #"{"type":"res","id":"\#(id)","ok":true,"payload":{"surface":"canvas","pluginSurfaceUrls":{"canvas":"\#(newSurface)"}}}"#
-                                .utf8)))
+                        let response = """
+                        {
+                          "type": "res",
+                          "id": "\(id)",
+                          "ok": true,
+                          "payload": {
+                            "surface": "canvas",
+                            "pluginSurfaceUrls": { "canvas": "\(rawNewSurface)" }
+                          }
+                        }
+                        """
+                        task.emitReceiveSuccess(.data(Data(response.utf8)))
                     } else {
                         task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
                     }
@@ -264,13 +275,13 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
                     let id = task.snapshotConnectRequestID() ?? "connect"
                     return .data(GatewayWebSocketTestSupport.connectOkData(
                         id: id,
-                        canvasPluginSurfaceURL: oldSurface))
+                        canvasPluginSurfaceURL: rawOldSurface))
                 })
         })
         let connection = GatewayConnection(
             configProvider: {
                 (
-                    url: URL(string: "ws://127.0.0.1:1")!,
+                    url: URL(string: "wss://gateway.example.invalid:9443")!,
                     token: "test-token-placeholder",
                     password: nil)
             },

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -48,9 +48,13 @@ enum GatewayWebSocketTestSupport {
     static func connectOkData(
         id: String,
         tickIntervalMs: Int = 30000,
-        deviceToken: String? = nil) -> Data
+        deviceToken: String? = nil,
+        canvasPluginSurfaceURL: String? = nil) -> Data
     {
         let deviceTokenField = deviceToken.map { #", "deviceToken": "\#($0)""# } ?? ""
+        let pluginSurfaceField = canvasPluginSurfaceURL.map {
+            #", "pluginSurfaceUrls": { "canvas": "\#($0)" }"#
+        } ?? ""
         let json = """
         {
           "type": "res",
@@ -60,7 +64,7 @@ enum GatewayWebSocketTestSupport {
             "type": "hello-ok",
             "protocol": 2,
             "server": { "version": "test", "connId": "test" },
-            "features": { "methods": [], "events": [] },
+            "features": { "methods": [], "events": [] }\(pluginSurfaceField),
             "snapshot": {
               "presence": [ { "ts": 1 } ],
               "health": {},
@@ -150,7 +154,8 @@ enum GatewayWebSocketTestSupport {
 extension NSLock {
     @inline(__always)
     fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
-        self.lock(); defer { self.unlock() }
+        self.lock()
+        defer { self.unlock() }
         return try body()
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
@@ -1,9 +1,14 @@
 import OpenClawChatUI
+import OpenClawKit
 import OpenClawProtocol
 import Testing
 @testable import OpenClaw
 
 struct MacGatewayChatTransportMappingTests {
+    @Test func `mac chat advertises inline widgets`() {
+        #expect(GatewayConnection.operatorClientCaps == [OpenClawGatewayClientCapability.inlineWidgets])
+    }
+
     @Test func `bare global session target carries normalized selected agent`() {
         let transport = MacGatewayChatTransport(defaultGlobalAgentID: "  Agent-A  ")
 

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -61,6 +61,19 @@ struct MacNodeRuntimeTests {
         }
     }
 
+    actor CanvasReconnectProbe {
+        private var surfaceURL = "http://127.0.0.1:18789/__openclaw__/cap/old-token"
+
+        func current() -> String? {
+            self.surfaceURL
+        }
+
+        func reconnectDuringRefresh() -> String? {
+            self.surfaceURL = "http://127.0.0.1:18789/__openclaw__/cap/new-token"
+            return nil
+        }
+    }
+
     @MainActor
     final class ScreenSnapshotProbeServices: MacNodeRuntimeMainActorServices, @unchecked Sendable {
         var snapshotCallCount = 0
@@ -280,6 +293,18 @@ struct MacNodeRuntimeTests {
         let external = try await resolver.resolveTarget("https://example.com/")
         #expect(external == nil)
         #expect(await probe.calls == 1)
+    }
+
+    @Test func `hosted Canvas commands use replacement route after refresh fails`() async throws {
+        let probe = CanvasReconnectProbe()
+        let resolver = MacNodeCanvasHostedSurfaceResolver(
+            currentSurfaceURL: { await probe.current() },
+            refreshSurfaceURL: { _ in await probe.reconnectDuringRefresh() })
+
+        let resolved = try await resolver.resolveTarget("/__openclaw__/canvas/demo.html")
+
+        #expect(resolved?.url.absoluteString ==
+            "http://127.0.0.1:18789/__openclaw__/cap/new-token/__openclaw__/canvas/demo.html")
     }
 
     @Test func `handle invoke rejects empty notification`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -251,7 +251,7 @@ struct MacNodeRuntimeTests {
         let probe = CanvasRefreshProbe()
         let resolver = MacNodeCanvasHostedSurfaceResolver(
             currentSurfaceURL: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
-            refreshSurfaceURL: { await probe.refresh() })
+            refreshSurfaceURL: { _ in await probe.refresh() })
 
         let current = await resolver.resolveA2UIURL()
         #expect(current ==
@@ -268,7 +268,7 @@ struct MacNodeRuntimeTests {
         let probe = CanvasRefreshProbe()
         let resolver = MacNodeCanvasHostedSurfaceResolver(
             currentSurfaceURL: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
-            refreshSurfaceURL: { await probe.refresh() })
+            refreshSurfaceURL: { _ in await probe.refresh() })
 
         let resolved = try await resolver.resolveTarget(
             "/__openclaw__/canvas/demo%20page.html?mode=proof#result")
@@ -979,5 +979,4 @@ struct MacNodeRuntimeTests {
             nodeId: controlHeavyNodeId)
         #expect(controlHeavyProjection > 25 * 1024 * 1024)
     }
-
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -8,13 +8,39 @@ import Security
 import WebKit
 #endif
 
+enum OpenClawChatWidgetSurfaceRole: Sendable, Hashable {
+    case node
+    case operatorSurface
+    case legacy
+}
+
 public struct OpenClawChatWidgetResource: Sendable, Equatable {
     public let url: URL
     public let tlsFingerprintSHA256: String?
+    let surfaceRole: OpenClawChatWidgetSurfaceRole
+    let attemptedSurfaceRoles: Set<OpenClawChatWidgetSurfaceRole>
 
     public init(url: URL, tlsFingerprintSHA256: String? = nil) {
         self.url = url
         self.tlsFingerprintSHA256 = tlsFingerprintSHA256
+        self.surfaceRole = .legacy
+        self.attemptedSurfaceRoles = []
+    }
+
+    init(
+        url: URL,
+        tlsFingerprintSHA256: String?,
+        surfaceRole: OpenClawChatWidgetSurfaceRole,
+        attemptedSurfaceRoles: Set<OpenClawChatWidgetSurfaceRole>)
+    {
+        self.url = url
+        self.tlsFingerprintSHA256 = tlsFingerprintSHA256
+        self.surfaceRole = surfaceRole
+        self.attemptedSurfaceRoles = attemptedSurfaceRoles
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.url == rhs.url && lhs.tlsFingerprintSHA256 == rhs.tlsFingerprintSHA256
     }
 }
 
@@ -52,17 +78,39 @@ public enum OpenClawChatWidgetURLResolver {
     {
         let observed = await currentSurfaceRoutes()
         guard let failedResource else {
-            return self.resolvePreferred(surfaces: observed, target: target, excluding: nil)
+            return self.resolvePreferred(
+                surfaces: observed,
+                target: target,
+                excluding: nil,
+                blockedRoles: [],
+                attemptedRoles: [])
         }
-        if let nodeSurface = observed.node,
-           let currentNode = self.resolve(surface: nodeSurface, target: target),
+        let blockedRoles = failedResource.attemptedSurfaceRoles
+        if failedResource.surfaceRole == .legacy,
+           blockedRoles.contains(.legacy)
+        {
+            return nil
+        }
+        let attemptedRoles = blockedRoles.union([failedResource.surfaceRole])
+        if !blockedRoles.contains(.node),
+           let nodeSurface = observed.node,
+           let currentNode = self.resolve(
+               surface: nodeSurface,
+               role: .node,
+               target: target,
+               attemptedRoles: attemptedRoles),
            self.isReplacement(currentNode, for: failedResource)
         {
             return currentNode
         }
 
-        if let refreshedSurface = await refreshNodeSurfaceRoute(observed.node),
-           let refreshed = resolve(surface: refreshedSurface, target: target),
+        if !blockedRoles.contains(.node),
+           let refreshedSurface = await refreshNodeSurfaceRoute(observed.node),
+           let refreshed = resolve(
+               surface: refreshedSurface,
+               role: .node,
+               target: target,
+               attemptedRoles: attemptedRoles),
            self.isReplacement(refreshed, for: failedResource)
         {
             return refreshed
@@ -74,13 +122,20 @@ public enum OpenClawChatWidgetURLResolver {
         if let replacement = self.resolvePreferred(
             surfaces: afterNodeRefresh,
             target: target,
-            excluding: failedResource)
+            excluding: failedResource,
+            blockedRoles: blockedRoles,
+            attemptedRoles: attemptedRoles)
         {
             return replacement
         }
 
-        if let refreshedSurface = await refreshOperatorSurfaceRoute(afterNodeRefresh.operatorSurface),
-           let refreshed = resolve(surface: refreshedSurface, target: target),
+        if !blockedRoles.contains(.operatorSurface),
+           let refreshedSurface = await refreshOperatorSurfaceRoute(afterNodeRefresh.operatorSurface),
+           let refreshed = resolve(
+               surface: refreshedSurface,
+               role: .operatorSurface,
+               target: target,
+               attemptedRoles: attemptedRoles),
            self.isReplacement(refreshed, for: failedResource)
         {
             return refreshed
@@ -89,7 +144,9 @@ public enum OpenClawChatWidgetURLResolver {
         return await self.resolvePreferred(
             surfaces: currentSurfaceRoutes(),
             target: target,
-            excluding: failedResource)
+            excluding: failedResource,
+            blockedRoles: blockedRoles,
+            attemptedRoles: attemptedRoles)
     }
 
     private static func relativeWidgetTarget(_ rawTarget: String) -> URLComponents? {
@@ -129,23 +186,41 @@ public enum OpenClawChatWidgetURLResolver {
 
     private static func resolve(
         surface: GatewayCanvasHostRoute,
-        target: String) -> OpenClawChatWidgetResource?
+        role: OpenClawChatWidgetSurfaceRole,
+        target: String,
+        attemptedRoles: Set<OpenClawChatWidgetSurfaceRole>) -> OpenClawChatWidgetResource?
     {
         guard let url = resolve(surfaceURL: surface.url, target: target) else { return nil }
         let resource = OpenClawChatWidgetResource(
             url: url,
-            tlsFingerprintSHA256: surface.tlsFingerprintSHA256)
+            tlsFingerprintSHA256: surface.tlsFingerprintSHA256,
+            surfaceRole: role,
+            attemptedSurfaceRoles: attemptedRoles)
         return resource.hasValidTLSBinding ? resource : nil
     }
 
     private static func resolvePreferred(
         surfaces: (node: GatewayCanvasHostRoute?, operatorSurface: GatewayCanvasHostRoute?),
         target: String,
-        excluding failedResource: OpenClawChatWidgetResource?) -> OpenClawChatWidgetResource?
+        excluding failedResource: OpenClawChatWidgetResource?,
+        blockedRoles: Set<OpenClawChatWidgetSurfaceRole>,
+        attemptedRoles: Set<OpenClawChatWidgetSurfaceRole>) -> OpenClawChatWidgetResource?
     {
-        [surfaces.node, surfaces.operatorSurface]
+        [
+            (role: OpenClawChatWidgetSurfaceRole.node, surface: surfaces.node),
+            (role: OpenClawChatWidgetSurfaceRole.operatorSurface, surface: surfaces.operatorSurface),
+        ]
             .lazy
-            .compactMap { $0.flatMap { self.resolve(surface: $0, target: target) } }
+            .filter { !blockedRoles.contains($0.role) }
+            .compactMap { candidate in
+                candidate.surface.flatMap {
+                    self.resolve(
+                        surface: $0,
+                        role: candidate.role,
+                        target: target,
+                        attemptedRoles: attemptedRoles)
+                }
+            }
             .first { self.isReplacement($0, for: failedResource) }
     }
 
@@ -156,10 +231,13 @@ public enum OpenClawChatWidgetURLResolver {
         guard let failedResource else { return true }
         // Legacy URL-only callers cannot express trust identity, so retain
         // their URL-only exclusion while resource-aware callers compare both.
-        if failedResource.tlsFingerprintSHA256 == nil {
+        if failedResource.surfaceRole == .legacy,
+           failedResource.tlsFingerprintSHA256 == nil
+        {
             return candidate.url != failedResource.url
         }
-        return candidate != failedResource
+        return candidate.url != failedResource.url ||
+            candidate.tlsFingerprintSHA256 != failedResource.tlsFingerprintSHA256
     }
 
     private static func isWebURL(_ components: URLComponents) -> Bool {
@@ -203,7 +281,7 @@ struct ChatInlineWidgetView: View {
         OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
 
     @State private var resolvedResource: OpenClawChatWidgetResource?
-    @State private var didRefresh = false
+    @State private var recoveryAttempts = 0
     @State private var refreshInFlight = false
     @State private var unavailable = false
     @State private var activePath: String?
@@ -276,7 +354,7 @@ struct ChatInlineWidgetView: View {
         self.loadGeneration = UUID()
         self.activePath = path
         self.resolvedResource = nil
-        self.didRefresh = false
+        self.recoveryAttempts = 0
         self.refreshInFlight = false
         self.unavailable = false
     }
@@ -301,12 +379,12 @@ struct ChatInlineWidgetView: View {
               let path = self.activePath,
               !self.refreshInFlight
         else { return }
-        guard !self.didRefresh else {
+        guard self.recoveryAttempts < 3 else {
             self.resolvedResource = nil
             self.unavailable = true
             return
         }
-        self.didRefresh = true
+        self.recoveryAttempts += 1
         self.refreshInFlight = true
         let generation = self.loadGeneration
         Task { @MainActor in

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -1,9 +1,22 @@
+import CryptoKit
 import Foundation
+import OpenClawKit
 import SwiftUI
 
 #if canImport(WebKit) && (os(iOS) || os(macOS))
+import Security
 import WebKit
 #endif
+
+public struct OpenClawChatWidgetResource: Sendable, Equatable {
+    public let url: URL
+    public let tlsFingerprintSHA256: String?
+
+    public init(url: URL, tlsFingerprintSHA256: String? = nil) {
+        self.url = url
+        self.tlsFingerprintSHA256 = tlsFingerprintSHA256
+    }
+}
 
 public enum OpenClawChatWidgetURLResolver {
     private static let documentsPath = "/__openclaw__/canvas/documents"
@@ -33,29 +46,58 @@ public enum OpenClawChatWidgetURLResolver {
         currentSurfaceURLs: @Sendable () async -> (node: String?, operatorSurface: String?),
         refreshNodeSurfaceURL: @Sendable (String?) async -> String?) async -> URL?
     {
-        let observed = await currentSurfaceURLs()
-        if let current = self.resolvePreferred(
+        await self.resolveResource(
+            target: target,
+            replacing: failedURL.map { OpenClawChatWidgetResource(url: $0) },
+            currentSurfaceRoutes: {
+                let surfaces = await currentSurfaceURLs()
+                return (
+                    node: surfaces.node.map {
+                        GatewayCanvasHostRoute(url: $0, tlsFingerprintSHA256: nil)
+                    },
+                    operatorSurface: surfaces.operatorSurface.map {
+                        GatewayCanvasHostRoute(url: $0, tlsFingerprintSHA256: nil)
+                    })
+            },
+            refreshNodeSurfaceRoute: { observed in
+                await refreshNodeSurfaceURL(observed?.url).map {
+                    GatewayCanvasHostRoute(url: $0, tlsFingerprintSHA256: observed?.tlsFingerprintSHA256)
+                }
+            })?.url
+    }
+
+    public static func resolveResource(
+        target: String,
+        replacing failedResource: OpenClawChatWidgetResource?,
+        currentSurfaceRoutes: @Sendable () async -> (
+            node: GatewayCanvasHostRoute?,
+            operatorSurface: GatewayCanvasHostRoute?),
+        refreshNodeSurfaceRoute: @Sendable (GatewayCanvasHostRoute?) async -> GatewayCanvasHostRoute?) async
+        -> OpenClawChatWidgetResource?
+    {
+        let observed = await currentSurfaceRoutes()
+        if let current = resolvePreferred(
             surfaces: observed,
             target: target,
-            excluding: failedURL)
+            excluding: failedResource)
         {
             return current
         }
-        guard let failedURL else { return nil }
+        guard failedResource != nil else { return nil }
 
-        if let refreshedSurface = await refreshNodeSurfaceURL(observed.node),
-           let refreshed = self.resolve(surfaceURL: refreshedSurface, target: target),
-           refreshed != failedURL
+        if let refreshedSurface = await refreshNodeSurfaceRoute(observed.node),
+           let refreshed = resolve(surface: refreshedSurface, target: target),
+           self.isReplacement(refreshed, for: failedResource)
         {
             return refreshed
         }
 
         // A nil refresh can mean its route lease lost a reconnect race. Re-read
-        // both roles so a replacement connection wins over the stale observation.
+        // both roles so a replacement connection and its TLS pin win together.
         return await self.resolvePreferred(
-            surfaces: currentSurfaceURLs(),
+            surfaces: currentSurfaceRoutes(),
             target: target,
-            excluding: failedURL)
+            excluding: failedResource)
     }
 
     private static func relativeWidgetTarget(_ rawTarget: String) -> URLComponents? {
@@ -93,15 +135,39 @@ public enum OpenClawChatWidgetURLResolver {
         return components
     }
 
+    private static func resolve(
+        surface: GatewayCanvasHostRoute,
+        target: String) -> OpenClawChatWidgetResource?
+    {
+        guard let url = resolve(surfaceURL: surface.url, target: target) else { return nil }
+        let resource = OpenClawChatWidgetResource(
+            url: url,
+            tlsFingerprintSHA256: surface.tlsFingerprintSHA256)
+        return resource.hasValidTLSBinding ? resource : nil
+    }
+
     private static func resolvePreferred(
-        surfaces: (node: String?, operatorSurface: String?),
+        surfaces: (node: GatewayCanvasHostRoute?, operatorSurface: GatewayCanvasHostRoute?),
         target: String,
-        excluding failedURL: URL?) -> URL?
+        excluding failedResource: OpenClawChatWidgetResource?) -> OpenClawChatWidgetResource?
     {
         [surfaces.node, surfaces.operatorSurface]
             .lazy
-            .compactMap { self.resolve(surfaceURL: $0, target: target) }
-            .first { $0 != failedURL }
+            .compactMap { $0.flatMap { self.resolve(surface: $0, target: target) } }
+            .first { self.isReplacement($0, for: failedResource) }
+    }
+
+    private static func isReplacement(
+        _ candidate: OpenClawChatWidgetResource,
+        for failedResource: OpenClawChatWidgetResource?) -> Bool
+    {
+        guard let failedResource else { return true }
+        // Legacy URL-only callers cannot express trust identity, so retain
+        // their URL-only exclusion while resource-aware callers compare both.
+        if failedResource.tlsFingerprintSHA256 == nil {
+            return candidate.url != failedResource.url
+        }
+        return candidate != failedResource
     }
 
     private static func isWebURL(_ components: URLComponents) -> Bool {
@@ -140,9 +206,11 @@ public enum OpenClawChatWidgetURLResolver {
 struct ChatInlineWidgetView: View {
     let preview: OpenClawChatCanvasPreview
     let resolverReady: Bool
-    let resolveURL: @MainActor @Sendable (String, URL?) async -> URL?
+    let resolveResource: @MainActor @Sendable (
+        String,
+        OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
 
-    @State private var resolvedURL: URL?
+    @State private var resolvedResource: OpenClawChatWidgetResource?
     @State private var didRefresh = false
     @State private var refreshInFlight = false
     @State private var unavailable = false
@@ -158,12 +226,16 @@ struct ChatInlineWidgetView: View {
             }
 
             #if canImport(WebKit) && (os(iOS) || os(macOS))
-            if let resolvedURL {
+            if let resolvedResource {
                 ChatInlineWidgetWebView(
-                    url: resolvedURL,
+                    resource: resolvedResource,
                     allowsScripts: self.preview.sandbox == "scripts",
-                    onFailure: { self.handleLoadFailure(url: resolvedURL) })
-                    .id("\(resolvedURL.absoluteString)\u{0}\(self.preview.sandbox ?? "")")
+                    onFailure: { self.handleLoadFailure(resource: resolvedResource) })
+                    .id([
+                        resolvedResource.url.absoluteString,
+                        resolvedResource.tlsFingerprintSHA256 ?? "",
+                        self.preview.sandbox ?? "",
+                    ].joined(separator: "\u{0}"))
                     .frame(height: self.preview.inlineWidgetHeight)
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     .overlay {
@@ -207,40 +279,70 @@ struct ChatInlineWidgetView: View {
 
     private func reset(path: String?) {
         self.activePath = path
-        self.resolvedURL = nil
+        self.resolvedResource = nil
         self.didRefresh = false
         self.refreshInFlight = false
         self.unavailable = false
     }
 
-    private func load(path: String, replacing failedURL: URL?) async {
-        let url = await self.resolveURL(path, failedURL)
+    private func load(path: String, replacing failedResource: OpenClawChatWidgetResource?) async {
+        let candidate = await self.resolveResource(path, failedResource)
         guard !Task.isCancelled, self.activePath == path else { return }
-        self.resolvedURL = url
-        self.unavailable = url == nil
+        let resource = candidate?.hasValidTLSBinding == true ? candidate : nil
+        self.resolvedResource = resource
+        self.unavailable = resource == nil
     }
 
-    private func handleLoadFailure(url: URL) {
-        guard self.resolvedURL == url,
+    private func handleLoadFailure(resource: OpenClawChatWidgetResource) {
+        guard self.resolvedResource == resource,
               let path = self.activePath,
               !self.refreshInFlight
         else { return }
         guard !self.didRefresh else {
-            self.resolvedURL = nil
+            self.resolvedResource = nil
             self.unavailable = true
             return
         }
         self.didRefresh = true
         self.refreshInFlight = true
         Task { @MainActor in
-            await self.load(path: path, replacing: url)
+            await self.load(path: path, replacing: resource)
             guard self.activePath == path else { return }
             self.refreshInFlight = false
         }
     }
 }
 
+extension OpenClawChatWidgetResource {
+    fileprivate var hasValidTLSBinding: Bool {
+        self.tlsFingerprintSHA256 == nil || self.url.scheme?.lowercased() == "https"
+    }
+}
+
 #if canImport(WebKit) && (os(iOS) || os(macOS))
+enum ChatInlineWidgetTLSPin {
+    static func normalize(_ raw: String) -> String? {
+        let stripped = raw.replacingOccurrences(
+            of: #"(?i)^sha-?256\s*:?\s*"#,
+            with: "",
+            options: .regularExpression)
+        let normalized = stripped.lowercased().filter(\.isHexDigit)
+        return normalized.count == 64 ? normalized : nil
+    }
+
+    static func fingerprint(certificateData: Data) -> String {
+        SHA256.hash(data: certificateData).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func matches(_ expected: String, trust: SecTrust) -> Bool {
+        guard let expected = normalize(expected),
+              let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+              let certificate = chain.first
+        else { return false }
+        return self.fingerprint(certificateData: SecCertificateCopyData(certificate) as Data) == expected
+    }
+}
+
 struct ChatInlineWidgetContentProcessRecovery {
     enum Action: Equatable {
         case reload
@@ -262,9 +364,9 @@ struct ChatInlineWidgetContentProcessRecovery {
 
 @MainActor
 private final class ChatInlineWidgetNavigationDelegate: NSObject, WKNavigationDelegate {
-    var expectedURL: URL {
+    var resource: OpenClawChatWidgetResource {
         didSet {
-            if self.expectedURL != oldValue {
+            if self.resource != oldValue {
                 self.contentProcessRecovery.reset()
             }
         }
@@ -273,8 +375,8 @@ private final class ChatInlineWidgetNavigationDelegate: NSObject, WKNavigationDe
     let onFailure: @MainActor @Sendable () -> Void
     private var contentProcessRecovery = ChatInlineWidgetContentProcessRecovery()
 
-    init(expectedURL: URL, onFailure: @escaping @MainActor @Sendable () -> Void) {
-        self.expectedURL = expectedURL
+    init(resource: OpenClawChatWidgetResource, onFailure: @escaping @MainActor @Sendable () -> Void) {
+        self.resource = resource
         self.onFailure = onFailure
     }
 
@@ -321,30 +423,62 @@ private final class ChatInlineWidgetNavigationDelegate: NSObject, WKNavigationDe
         self.onFailure()
     }
 
+    func webView(
+        _: WKWebView,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping @MainActor @Sendable (
+            URLSession.AuthChallengeDisposition,
+            URLCredential?) -> Void)
+    {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let expectedFingerprint = resource.tlsFingerprintSHA256
+        else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        guard self.matchesExpectedProtectionSpace(challenge.protectionSpace),
+              let trust = challenge.protectionSpace.serverTrust,
+              ChatInlineWidgetTLSPin.matches(expectedFingerprint, trust: trust)
+        else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            self.onFailure()
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         // One same-document recovery handles incidental process loss. A second
         // termination enters the view's bounded capability-refresh/failure path.
         switch self.contentProcessRecovery.nextAction() {
         case .reload:
-            webView.load(URLRequest(url: self.expectedURL, cachePolicy: .reloadIgnoringLocalCacheData))
+            webView.load(URLRequest(url: self.resource.url, cachePolicy: .reloadIgnoringLocalCacheData))
         case .fail:
             self.onFailure()
         }
     }
 
     private func matchesExpectedDocument(_ candidate: URL) -> Bool {
-        guard var expected = URLComponents(url: self.expectedURL, resolvingAgainstBaseURL: false),
+        guard var expected = URLComponents(url: self.resource.url, resolvingAgainstBaseURL: false),
               var candidate = URLComponents(url: candidate, resolvingAgainstBaseURL: false)
         else { return false }
         expected.fragment = nil
         candidate.fragment = nil
         return expected == candidate
     }
+
+    private func matchesExpectedProtectionSpace(_ protectionSpace: URLProtectionSpace) -> Bool {
+        guard let expectedHost = self.resource.url.host,
+              protectionSpace.host.caseInsensitiveCompare(expectedHost) == .orderedSame
+        else { return false }
+        let expectedPort = self.resource.url.port ?? (self.resource.url.scheme?.lowercased() == "https" ? 443 : 80)
+        return protectionSpace.port == expectedPort
+    }
 }
 
 @MainActor
 private func makeChatInlineWidgetWebView(
-    url: URL,
+    resource: OpenClawChatWidgetResource,
     allowsScripts: Bool,
     coordinator: ChatInlineWidgetNavigationDelegate) -> WKWebView
 {
@@ -355,31 +489,31 @@ private func makeChatInlineWidgetWebView(
     let webView = WKWebView(frame: .zero, configuration: configuration)
     webView.navigationDelegate = coordinator
     webView.allowsLinkPreview = false
-    webView.load(URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData))
+    webView.load(URLRequest(url: resource.url, cachePolicy: .reloadIgnoringLocalCacheData))
     return webView
 }
 
 #if os(iOS)
 private struct ChatInlineWidgetWebView: UIViewRepresentable {
-    let url: URL
+    let resource: OpenClawChatWidgetResource
     let allowsScripts: Bool
     let onFailure: @MainActor @Sendable () -> Void
 
     func makeCoordinator() -> ChatInlineWidgetNavigationDelegate {
-        ChatInlineWidgetNavigationDelegate(expectedURL: self.url, onFailure: self.onFailure)
+        ChatInlineWidgetNavigationDelegate(resource: self.resource, onFailure: self.onFailure)
     }
 
     func makeUIView(context: Context) -> WKWebView {
         makeChatInlineWidgetWebView(
-            url: self.url,
+            resource: self.resource,
             allowsScripts: self.allowsScripts,
             coordinator: context.coordinator)
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {
-        guard context.coordinator.expectedURL != self.url else { return }
-        context.coordinator.expectedURL = self.url
-        webView.load(URLRequest(url: self.url, cachePolicy: .reloadIgnoringLocalCacheData))
+        guard context.coordinator.resource != self.resource else { return }
+        context.coordinator.resource = self.resource
+        webView.load(URLRequest(url: self.resource.url, cachePolicy: .reloadIgnoringLocalCacheData))
     }
 
     static func dismantleUIView(_ webView: WKWebView, coordinator: ChatInlineWidgetNavigationDelegate) {
@@ -389,25 +523,25 @@ private struct ChatInlineWidgetWebView: UIViewRepresentable {
 }
 #elseif os(macOS)
 private struct ChatInlineWidgetWebView: NSViewRepresentable {
-    let url: URL
+    let resource: OpenClawChatWidgetResource
     let allowsScripts: Bool
     let onFailure: @MainActor @Sendable () -> Void
 
     func makeCoordinator() -> ChatInlineWidgetNavigationDelegate {
-        ChatInlineWidgetNavigationDelegate(expectedURL: self.url, onFailure: self.onFailure)
+        ChatInlineWidgetNavigationDelegate(resource: self.resource, onFailure: self.onFailure)
     }
 
     func makeNSView(context: Context) -> WKWebView {
         makeChatInlineWidgetWebView(
-            url: self.url,
+            resource: self.resource,
             allowsScripts: self.allowsScripts,
             coordinator: context.coordinator)
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
-        guard context.coordinator.expectedURL != self.url else { return }
-        context.coordinator.expectedURL = self.url
-        webView.load(URLRequest(url: self.url, cachePolicy: .reloadIgnoringLocalCacheData))
+        guard context.coordinator.resource != self.resource else { return }
+        context.coordinator.resource = self.resource
+        webView.load(URLRequest(url: self.resource.url, cachePolicy: .reloadIgnoringLocalCacheData))
     }
 
     static func dismantleNSView(_ webView: WKWebView, coordinator: ChatInlineWidgetNavigationDelegate) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -27,6 +27,37 @@ public enum OpenClawChatWidgetURLResolver {
         self.relativeWidgetTarget(rawTarget) != nil
     }
 
+    public static func resolve(
+        target: String,
+        replacing failedURL: URL?,
+        currentSurfaceURLs: @Sendable () async -> (node: String?, operatorSurface: String?),
+        refreshNodeSurfaceURL: @Sendable (String?) async -> String?) async -> URL?
+    {
+        let observed = await currentSurfaceURLs()
+        if let current = self.resolvePreferred(
+            surfaces: observed,
+            target: target,
+            excluding: failedURL)
+        {
+            return current
+        }
+        guard let failedURL else { return nil }
+
+        if let refreshedSurface = await refreshNodeSurfaceURL(observed.node),
+           let refreshed = self.resolve(surfaceURL: refreshedSurface, target: target),
+           refreshed != failedURL
+        {
+            return refreshed
+        }
+
+        // A nil refresh can mean its route lease lost a reconnect race. Re-read
+        // both roles so a replacement connection wins over the stale observation.
+        return await self.resolvePreferred(
+            surfaces: currentSurfaceURLs(),
+            target: target,
+            excluding: failedURL)
+    }
+
     private static func relativeWidgetTarget(_ rawTarget: String) -> URLComponents? {
         let target = rawTarget.trimmingCharacters(in: .whitespacesAndNewlines)
         guard target.hasPrefix("/"),
@@ -60,6 +91,17 @@ public enum OpenClawChatWidgetURLResolver {
               !capability.isEmpty
         else { return nil }
         return components
+    }
+
+    private static func resolvePreferred(
+        surfaces: (node: String?, operatorSurface: String?),
+        target: String,
+        excluding failedURL: URL?) -> URL?
+    {
+        [surfaces.node, surfaces.operatorSurface]
+            .lazy
+            .compactMap { self.resolve(surfaceURL: $0, target: target) }
+            .first { $0 != failedURL }
     }
 
     private static func isWebURL(_ components: URLComponents) -> Bool {
@@ -199,10 +241,37 @@ struct ChatInlineWidgetView: View {
 }
 
 #if canImport(WebKit) && (os(iOS) || os(macOS))
+struct ChatInlineWidgetContentProcessRecovery {
+    enum Action: Equatable {
+        case reload
+        case fail
+    }
+
+    private var didReload = false
+
+    mutating func nextAction() -> Action {
+        guard !self.didReload else { return .fail }
+        self.didReload = true
+        return .reload
+    }
+
+    mutating func reset() {
+        self.didReload = false
+    }
+}
+
 @MainActor
 private final class ChatInlineWidgetNavigationDelegate: NSObject, WKNavigationDelegate {
-    var expectedURL: URL
+    var expectedURL: URL {
+        didSet {
+            if self.expectedURL != oldValue {
+                self.contentProcessRecovery.reset()
+            }
+        }
+    }
+
     let onFailure: @MainActor @Sendable () -> Void
+    private var contentProcessRecovery = ChatInlineWidgetContentProcessRecovery()
 
     init(expectedURL: URL, onFailure: @escaping @MainActor @Sendable () -> Void) {
         self.expectedURL = expectedURL
@@ -253,9 +322,14 @@ private final class ChatInlineWidgetNavigationDelegate: NSObject, WKNavigationDe
     }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        // Process loss does not prove the capability expired. Reload the same
-        // document; normal navigation failures own the one allowed token refresh.
-        webView.load(URLRequest(url: self.expectedURL, cachePolicy: .reloadIgnoringLocalCacheData))
+        // One same-document recovery handles incidental process loss. A second
+        // termination enters the view's bounded capability-refresh/failure path.
+        switch self.contentProcessRecovery.nextAction() {
+        case .reload:
+            webView.load(URLRequest(url: self.expectedURL, cachePolicy: .reloadIgnoringLocalCacheData))
+        case .fail:
+            self.onFailure()
+        }
     }
 
     private func matchesExpectedDocument(_ candidate: URL) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -50,14 +50,15 @@ public enum OpenClawChatWidgetURLResolver {
         -> OpenClawChatWidgetResource?
     {
         let observed = await currentSurfaceRoutes()
-        if let current = resolvePreferred(
-            surfaces: observed,
-            target: target,
-            excluding: failedResource)
-        {
-            return current
+        guard let failedResource else {
+            return self.resolvePreferred(surfaces: observed, target: target, excluding: nil)
         }
-        guard failedResource != nil else { return nil }
+        if let nodeSurface = observed.node,
+           let currentNode = self.resolve(surface: nodeSurface, target: target),
+           self.isReplacement(currentNode, for: failedResource)
+        {
+            return currentNode
+        }
 
         if let refreshedSurface = await refreshNodeSurfaceRoute(observed.node),
            let refreshed = resolve(surface: refreshedSurface, target: target),

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -1,0 +1,339 @@
+import Foundation
+import SwiftUI
+
+#if canImport(WebKit) && (os(iOS) || os(macOS))
+import WebKit
+#endif
+
+public enum OpenClawChatWidgetURLResolver {
+    private static let documentsPath = "/__openclaw__/canvas/documents"
+
+    public static func resolve(surfaceURL rawSurfaceURL: String?, target rawTarget: String) -> URL? {
+        guard let target = self.relativeWidgetTarget(rawTarget),
+              var surface = self.capabilitySurface(rawSurfaceURL)
+        else { return nil }
+
+        var surfacePath = surface.percentEncodedPath
+        while surfacePath.hasSuffix("/") {
+            surfacePath.removeLast()
+        }
+        surface.percentEncodedPath = surfacePath + target.percentEncodedPath
+        surface.percentEncodedQuery = target.percentEncodedQuery
+        surface.fragment = target.fragment
+        return surface.url
+    }
+
+    public static func supportsTarget(_ rawTarget: String) -> Bool {
+        self.relativeWidgetTarget(rawTarget) != nil
+    }
+
+    private static func relativeWidgetTarget(_ rawTarget: String) -> URLComponents? {
+        let target = rawTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard target.hasPrefix("/"),
+              let components = URLComponents(string: target),
+              components.scheme == nil,
+              components.host == nil,
+              components.user == nil,
+              components.password == nil,
+              self.isCanonicalPath(components.percentEncodedPath),
+              components.percentEncodedPath.hasPrefix("\(self.documentsPath)/")
+        else { return nil }
+        return components
+    }
+
+    private static func capabilitySurface(_ rawSurfaceURL: String?) -> URLComponents? {
+        let raw = rawSurfaceURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !raw.isEmpty,
+              let components = URLComponents(string: raw),
+              self.isWebURL(components),
+              components.user == nil,
+              components.password == nil,
+              components.percentEncodedQuery == nil,
+              components.fragment == nil
+        else { return nil }
+
+        let segments = components.percentEncodedPath.split(separator: "/", omittingEmptySubsequences: true)
+        guard segments.count >= 3,
+              segments[segments.count - 3] == "__openclaw__",
+              segments[segments.count - 2] == "cap",
+              let capability = String(segments[segments.count - 1]).removingPercentEncoding,
+              !capability.isEmpty
+        else { return nil }
+        return components
+    }
+
+    private static func isWebURL(_ components: URLComponents) -> Bool {
+        let scheme = components.scheme?.lowercased()
+        return (scheme == "http" || scheme == "https") && components.host?.isEmpty == false
+    }
+
+    private static func isCanonicalPath(_ path: String) -> Bool {
+        let segments = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard segments.first?.isEmpty == true else { return false }
+        for (index, encodedSegment) in segments.enumerated() {
+            if index == 0 || (index == segments.count - 1 && encodedSegment.isEmpty) {
+                continue
+            }
+            guard !encodedSegment.isEmpty else { return false }
+            guard let segment = self.decodeRepeatedly(String(encodedSegment)) else { return false }
+            if segment == "." || segment == ".." || segment.contains("/") || segment.contains("\\") {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func decodeRepeatedly(_ encoded: String) -> String? {
+        var value = encoded
+        for _ in 0..<8 {
+            guard let decoded = value.removingPercentEncoding else { return nil }
+            if decoded == value { return decoded }
+            value = decoded
+        }
+        return nil
+    }
+}
+
+@MainActor
+struct ChatInlineWidgetView: View {
+    let preview: OpenClawChatCanvasPreview
+    let resolverReady: Bool
+    let resolveURL: @MainActor @Sendable (String, URL?) async -> URL?
+
+    @State private var resolvedURL: URL?
+    @State private var didRefresh = false
+    @State private var refreshInFlight = false
+    @State private var unavailable = false
+    @State private var activePath: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let title = self.preview.title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
+                Text(title)
+                    .font(OpenClawChatTypography.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(OpenClawChatTheme.muted)
+            }
+
+            #if canImport(WebKit) && (os(iOS) || os(macOS))
+            if let resolvedURL {
+                ChatInlineWidgetWebView(
+                    url: resolvedURL,
+                    allowsScripts: self.preview.sandbox == "scripts",
+                    onFailure: { self.handleLoadFailure(url: resolvedURL) })
+                    .id("\(resolvedURL.absoluteString)\u{0}\(self.preview.sandbox ?? "")")
+                    .frame(height: self.preview.inlineWidgetHeight)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(OpenClawChatTheme.muted.opacity(0.24), lineWidth: 1)
+                    }
+            } else if self.unavailable {
+                Text("Widget unavailable")
+                    .font(OpenClawChatTypography.footnote)
+                    .foregroundStyle(OpenClawChatTheme.muted)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            #else
+            Text("Widget unavailable")
+                .font(OpenClawChatTypography.footnote)
+                .foregroundStyle(OpenClawChatTheme.muted)
+            #endif
+        }
+        .task(id: LoadID(path: self.preview.inlineWidgetPath, resolverReady: self.resolverReady)) {
+            let path = self.preview.inlineWidgetPath
+            if self.activePath != path {
+                self.reset(path: path)
+            }
+            guard self.resolverReady else { return }
+            self.reset(path: path)
+            guard let path else {
+                self.unavailable = true
+                return
+            }
+            await self.load(path: path, replacing: nil)
+        }
+    }
+
+    private struct LoadID: Hashable {
+        let path: String?
+        let resolverReady: Bool
+    }
+
+    private func reset(path: String?) {
+        self.activePath = path
+        self.resolvedURL = nil
+        self.didRefresh = false
+        self.refreshInFlight = false
+        self.unavailable = false
+    }
+
+    private func load(path: String, replacing failedURL: URL?) async {
+        let url = await self.resolveURL(path, failedURL)
+        guard !Task.isCancelled, self.activePath == path else { return }
+        self.resolvedURL = url
+        self.unavailable = url == nil
+    }
+
+    private func handleLoadFailure(url: URL) {
+        guard self.resolvedURL == url,
+              let path = self.activePath,
+              !self.refreshInFlight
+        else { return }
+        guard !self.didRefresh else {
+            self.resolvedURL = nil
+            self.unavailable = true
+            return
+        }
+        self.didRefresh = true
+        self.refreshInFlight = true
+        Task { @MainActor in
+            await self.load(path: path, replacing: url)
+            guard self.activePath == path else { return }
+            self.refreshInFlight = false
+        }
+    }
+}
+
+#if canImport(WebKit) && (os(iOS) || os(macOS))
+@MainActor
+private final class ChatInlineWidgetNavigationDelegate: NSObject, WKNavigationDelegate {
+    var expectedURL: URL
+    let onFailure: @MainActor @Sendable () -> Void
+
+    init(expectedURL: URL, onFailure: @escaping @MainActor @Sendable () -> Void) {
+        self.expectedURL = expectedURL
+        self.onFailure = onFailure
+    }
+
+    func webView(
+        _: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void)
+    {
+        if navigationAction.targetFrame?.isMainFrame == false {
+            decisionHandler(.cancel)
+            return
+        }
+        guard navigationAction.request.httpMethod?.caseInsensitiveCompare("GET") == .orderedSame,
+              let url = navigationAction.request.url,
+              self.matchesExpectedDocument(url)
+        else {
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(
+        _: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationResponsePolicy) -> Void)
+    {
+        if navigationResponse.isForMainFrame,
+           let response = navigationResponse.response as? HTTPURLResponse,
+           response.statusCode >= 400
+        {
+            self.onFailure()
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation?, withError _: any Error) {
+        self.onFailure()
+    }
+
+    func webView(_: WKWebView, didFail _: WKNavigation?, withError _: any Error) {
+        self.onFailure()
+    }
+
+    private func matchesExpectedDocument(_ candidate: URL) -> Bool {
+        guard var expected = URLComponents(url: self.expectedURL, resolvingAgainstBaseURL: false),
+              var candidate = URLComponents(url: candidate, resolvingAgainstBaseURL: false)
+        else { return false }
+        expected.fragment = nil
+        candidate.fragment = nil
+        return expected == candidate
+    }
+}
+
+@MainActor
+private func makeChatInlineWidgetWebView(
+    url: URL,
+    allowsScripts: Bool,
+    coordinator: ChatInlineWidgetNavigationDelegate) -> WKWebView
+{
+    let configuration = WKWebViewConfiguration()
+    configuration.websiteDataStore = .nonPersistent()
+    configuration.defaultWebpagePreferences.allowsContentJavaScript = allowsScripts
+    configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
+    let webView = WKWebView(frame: .zero, configuration: configuration)
+    webView.navigationDelegate = coordinator
+    webView.allowsLinkPreview = false
+    webView.load(URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData))
+    return webView
+}
+
+#if os(iOS)
+private struct ChatInlineWidgetWebView: UIViewRepresentable {
+    let url: URL
+    let allowsScripts: Bool
+    let onFailure: @MainActor @Sendable () -> Void
+
+    func makeCoordinator() -> ChatInlineWidgetNavigationDelegate {
+        ChatInlineWidgetNavigationDelegate(expectedURL: self.url, onFailure: self.onFailure)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        makeChatInlineWidgetWebView(
+            url: self.url,
+            allowsScripts: self.allowsScripts,
+            coordinator: context.coordinator)
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard context.coordinator.expectedURL != self.url else { return }
+        context.coordinator.expectedURL = self.url
+        webView.load(URLRequest(url: self.url, cachePolicy: .reloadIgnoringLocalCacheData))
+    }
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: ChatInlineWidgetNavigationDelegate) {
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+    }
+}
+#elseif os(macOS)
+private struct ChatInlineWidgetWebView: NSViewRepresentable {
+    let url: URL
+    let allowsScripts: Bool
+    let onFailure: @MainActor @Sendable () -> Void
+
+    func makeCoordinator() -> ChatInlineWidgetNavigationDelegate {
+        ChatInlineWidgetNavigationDelegate(expectedURL: self.url, onFailure: self.onFailure)
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        makeChatInlineWidgetWebView(
+            url: self.url,
+            allowsScripts: self.allowsScripts,
+            coordinator: context.coordinator)
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        guard context.coordinator.expectedURL != self.url else { return }
+        context.coordinator.expectedURL = self.url
+        webView.load(URLRequest(url: self.url, cachePolicy: .reloadIgnoringLocalCacheData))
+    }
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: ChatInlineWidgetNavigationDelegate) {
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+    }
+}
+#endif
+#endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -252,6 +252,12 @@ private final class ChatInlineWidgetNavigationDelegate: NSObject, WKNavigationDe
         self.onFailure()
     }
 
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        // Process loss does not prove the capability expired. Reload the same
+        // document; normal navigation failures own the one allowed token refresh.
+        webView.load(URLRequest(url: self.expectedURL, cachePolicy: .reloadIgnoringLocalCacheData))
+    }
+
     private func matchesExpectedDocument(_ candidate: URL) -> Bool {
         guard var expected = URLComponents(url: self.expectedURL, resolvingAgainstBaseURL: false),
               var candidate = URLComponents(url: candidate, resolvingAgainstBaseURL: false)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -46,7 +46,8 @@ public enum OpenClawChatWidgetURLResolver {
         currentSurfaceRoutes: @Sendable () async -> (
             node: GatewayCanvasHostRoute?,
             operatorSurface: GatewayCanvasHostRoute?),
-        refreshNodeSurfaceRoute: @Sendable (GatewayCanvasHostRoute?) async -> GatewayCanvasHostRoute?) async
+        refreshNodeSurfaceRoute: @Sendable (GatewayCanvasHostRoute?) async -> GatewayCanvasHostRoute?,
+        refreshOperatorSurfaceRoute: @Sendable (GatewayCanvasHostRoute?) async -> GatewayCanvasHostRoute?) async
         -> OpenClawChatWidgetResource?
     {
         let observed = await currentSurfaceRoutes()
@@ -69,6 +70,22 @@ public enum OpenClawChatWidgetURLResolver {
 
         // A nil refresh can mean its route lease lost a reconnect race. Re-read
         // both roles so a replacement connection and its TLS pin win together.
+        let afterNodeRefresh = await currentSurfaceRoutes()
+        if let replacement = self.resolvePreferred(
+            surfaces: afterNodeRefresh,
+            target: target,
+            excluding: failedResource)
+        {
+            return replacement
+        }
+
+        if let refreshedSurface = await refreshOperatorSurfaceRoute(afterNodeRefresh.operatorSurface),
+           let refreshed = resolve(surface: refreshedSurface, target: target),
+           self.isReplacement(refreshed, for: failedResource)
+        {
+            return refreshed
+        }
+
         return await self.resolvePreferred(
             surfaces: currentSurfaceRoutes(),
             target: target,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -207,6 +207,9 @@ struct ChatInlineWidgetView: View {
     @State private var refreshInFlight = false
     @State private var unavailable = false
     @State private var activePath: String?
+    /// A reset can keep the same path while installing a new connection route.
+    /// Its generation prevents older resolver completions from restoring stale trust state.
+    @State private var loadGeneration = UUID()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -260,7 +263,7 @@ struct ChatInlineWidgetView: View {
                 self.unavailable = true
                 return
             }
-            await self.load(path: path, replacing: nil)
+            await self.load(path: path, replacing: nil, generation: self.loadGeneration)
         }
     }
 
@@ -270,6 +273,7 @@ struct ChatInlineWidgetView: View {
     }
 
     private func reset(path: String?) {
+        self.loadGeneration = UUID()
         self.activePath = path
         self.resolvedResource = nil
         self.didRefresh = false
@@ -277,9 +281,16 @@ struct ChatInlineWidgetView: View {
         self.unavailable = false
     }
 
-    private func load(path: String, replacing failedResource: OpenClawChatWidgetResource?) async {
+    private func load(
+        path: String,
+        replacing failedResource: OpenClawChatWidgetResource?,
+        generation: UUID) async
+    {
         let candidate = await self.resolveResource(path, failedResource)
-        guard !Task.isCancelled, self.activePath == path else { return }
+        guard !Task.isCancelled,
+              self.activePath == path,
+              self.loadGeneration == generation
+        else { return }
         let resource = candidate?.hasValidTLSBinding == true ? candidate : nil
         self.resolvedResource = resource
         self.unavailable = resource == nil
@@ -297,9 +308,10 @@ struct ChatInlineWidgetView: View {
         }
         self.didRefresh = true
         self.refreshInFlight = true
+        let generation = self.loadGeneration
         Task { @MainActor in
-            await self.load(path: path, replacing: resource)
-            guard self.activePath == path else { return }
+            await self.load(path: path, replacing: resource, generation: generation)
+            guard self.activePath == path, self.loadGeneration == generation else { return }
             self.refreshInFlight = false
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift
@@ -40,32 +40,6 @@ public enum OpenClawChatWidgetURLResolver {
         self.relativeWidgetTarget(rawTarget) != nil
     }
 
-    public static func resolve(
-        target: String,
-        replacing failedURL: URL?,
-        currentSurfaceURLs: @Sendable () async -> (node: String?, operatorSurface: String?),
-        refreshNodeSurfaceURL: @Sendable (String?) async -> String?) async -> URL?
-    {
-        await self.resolveResource(
-            target: target,
-            replacing: failedURL.map { OpenClawChatWidgetResource(url: $0) },
-            currentSurfaceRoutes: {
-                let surfaces = await currentSurfaceURLs()
-                return (
-                    node: surfaces.node.map {
-                        GatewayCanvasHostRoute(url: $0, tlsFingerprintSHA256: nil)
-                    },
-                    operatorSurface: surfaces.operatorSurface.map {
-                        GatewayCanvasHostRoute(url: $0, tlsFingerprintSHA256: nil)
-                    })
-            },
-            refreshNodeSurfaceRoute: { observed in
-                await refreshNodeSurfaceURL(observed?.url).map {
-                    GatewayCanvasHostRoute(url: $0, tlsFingerprintSHA256: observed?.tlsFingerprintSHA256)
-                }
-            })?.url
-    }
-
     public static func resolveResource(
         target: String,
         replacing failedResource: OpenClawChatWidgetResource?,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -213,6 +213,8 @@ struct ChatMessageBubble: View {
     let showsAssistantAvatar: Bool
     let isClean: Bool
     let contextWindowTokens: Int?
+    let inlineWidgetResolverReady: Bool
+    let inlineWidgetURLResolver: @MainActor @Sendable (String, URL?) async -> URL?
 
     var body: some View {
         if self.isUser {
@@ -251,7 +253,9 @@ struct ChatMessageBubble: View {
             userAccent: self.userAccent,
             showsAssistantTrace: self.showsAssistantTrace,
             isClean: self.isClean,
-            contextWindowTokens: self.contextWindowTokens)
+            contextWindowTokens: self.contextWindowTokens,
+            inlineWidgetResolverReady: self.inlineWidgetResolverReady,
+            inlineWidgetURLResolver: self.inlineWidgetURLResolver)
     }
 }
 
@@ -266,6 +270,8 @@ private struct ChatMessageBody: View {
     let showsAssistantTrace: Bool
     let isClean: Bool
     let contextWindowTokens: Int?
+    let inlineWidgetResolverReady: Bool
+    let inlineWidgetURLResolver: @MainActor @Sendable (String, URL?) async -> URL?
 
     var body: some View {
         let text = self.primaryText
@@ -323,6 +329,13 @@ private struct ChatMessageBody: View {
                 ForEach(self.inlineAttachments.indices, id: \.self) { idx in
                     AttachmentRow(att: self.inlineAttachments[idx], isUser: self.isUser)
                 }
+            }
+
+            ForEach(self.inlineWidgets.indices, id: \.self) { idx in
+                ChatInlineWidgetView(
+                    preview: self.inlineWidgets[idx],
+                    resolverReady: self.inlineWidgetResolverReady,
+                    resolveURL: self.inlineWidgetURLResolver)
             }
 
             if self.showsAssistantTrace, !self.toolCalls.isEmpty {
@@ -391,6 +404,17 @@ private struct ChatMessageBody: View {
             default:
                 false
             }
+        }
+    }
+
+    private var inlineWidgets: [OpenClawChatCanvasPreview] {
+        guard self.message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "assistant"
+        else { return [] }
+        return self.message.content.compactMap { content in
+            guard (content.type ?? "").lowercased() == "canvas",
+                  content.preview?.inlineWidgetPath != nil
+            else { return nil }
+            return content.preview
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -214,7 +214,9 @@ struct ChatMessageBubble: View {
     let isClean: Bool
     let contextWindowTokens: Int?
     let inlineWidgetResolverReady: Bool
-    let inlineWidgetURLResolver: @MainActor @Sendable (String, URL?) async -> URL?
+    let inlineWidgetResourceResolver: @MainActor @Sendable (
+        String,
+        OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
 
     var body: some View {
         if self.isUser {
@@ -255,7 +257,7 @@ struct ChatMessageBubble: View {
             isClean: self.isClean,
             contextWindowTokens: self.contextWindowTokens,
             inlineWidgetResolverReady: self.inlineWidgetResolverReady,
-            inlineWidgetURLResolver: self.inlineWidgetURLResolver)
+            inlineWidgetResourceResolver: self.inlineWidgetResourceResolver)
     }
 }
 
@@ -271,7 +273,9 @@ private struct ChatMessageBody: View {
     let isClean: Bool
     let contextWindowTokens: Int?
     let inlineWidgetResolverReady: Bool
-    let inlineWidgetURLResolver: @MainActor @Sendable (String, URL?) async -> URL?
+    let inlineWidgetResourceResolver: @MainActor @Sendable (
+        String,
+        OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
 
     var body: some View {
         let text = self.primaryText
@@ -335,7 +339,7 @@ private struct ChatMessageBody: View {
                 ChatInlineWidgetView(
                     preview: self.inlineWidgets[idx],
                     resolverReady: self.inlineWidgetResolverReady,
-                    resolveURL: self.inlineWidgetURLResolver)
+                    resolveResource: self.inlineWidgetResourceResolver)
             }
 
             if self.showsAssistantTrace, !self.toolCalls.isEmpty {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -202,26 +202,6 @@ public struct OpenClawChatCanvasPreview: Codable, Hashable, Sendable {
     public let viewId: String?
     public let sandbox: String?
 
-    public init(
-        kind: String?,
-        surface: String?,
-        render: String?,
-        title: String?,
-        preferredHeight: Double?,
-        url: String?,
-        viewId: String?,
-        sandbox: String?)
-    {
-        self.kind = kind
-        self.surface = surface
-        self.render = render
-        self.title = title
-        self.preferredHeight = preferredHeight
-        self.url = url
-        self.viewId = viewId
-        self.sandbox = sandbox
-    }
-
     public var inlineWidgetPath: String? {
         guard self.kind == "canvas",
               self.surface == "assistant_message",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -118,6 +118,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
     public let fileName: String?
     public let durationSeconds: Double?
     public let content: AnyCodable?
+    public let preview: OpenClawChatCanvasPreview?
 
     // Tool-call fields (when `type == "toolCall"` or similar)
     public let id: String?
@@ -133,6 +134,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         fileName: String?,
         durationSeconds: Double? = nil,
         content: AnyCodable?,
+        preview: OpenClawChatCanvasPreview? = nil,
         id: String? = nil,
         name: String? = nil,
         arguments: AnyCodable? = nil)
@@ -145,6 +147,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         self.fileName = fileName
         self.durationSeconds = durationSeconds
         self.content = content
+        self.preview = preview
         self.id = id
         self.name = name
         self.arguments = arguments
@@ -159,6 +162,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         case fileName
         case durationSeconds
         case content
+        case preview
         case id
         case name
         case arguments
@@ -176,6 +180,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         self.id = try container.decodeIfPresent(String.self, forKey: .id)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
         self.arguments = try container.decodeIfPresent(AnyCodable.self, forKey: .arguments)
+        self.preview = try container.decodeIfPresent(OpenClawChatCanvasPreview.self, forKey: .preview)
 
         if let any = try container.decodeIfPresent(AnyCodable.self, forKey: .content) {
             self.content = any
@@ -184,6 +189,52 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         } else {
             self.content = nil
         }
+    }
+}
+
+public struct OpenClawChatCanvasPreview: Codable, Hashable, Sendable {
+    public let kind: String?
+    public let surface: String?
+    public let render: String?
+    public let title: String?
+    public let preferredHeight: Double?
+    public let url: String?
+    public let viewId: String?
+    public let sandbox: String?
+
+    public init(
+        kind: String?,
+        surface: String?,
+        render: String?,
+        title: String?,
+        preferredHeight: Double?,
+        url: String?,
+        viewId: String?,
+        sandbox: String?)
+    {
+        self.kind = kind
+        self.surface = surface
+        self.render = render
+        self.title = title
+        self.preferredHeight = preferredHeight
+        self.url = url
+        self.viewId = viewId
+        self.sandbox = sandbox
+    }
+
+    public var inlineWidgetPath: String? {
+        guard self.kind == "canvas",
+              self.surface == "assistant_message",
+              self.render == "url",
+              self.sandbox == "scripts" || self.sandbox == "strict",
+              let url = self.url?.trimmingCharacters(in: .whitespacesAndNewlines),
+              OpenClawChatWidgetURLResolver.supportsTarget(url)
+        else { return nil }
+        return url
+    }
+
+    public var inlineWidgetHeight: Double {
+        min(max(self.preferredHeight ?? 320, 160), 1200)
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -290,6 +290,7 @@ public protocol OpenClawChatTransport: Sendable {
     func requestHealth(timeoutMs: Int) async throws -> Bool
     func waitForRunCompletion(runId: String, timeoutMs: Int) async -> OpenClawChatRunObservation
     func events() -> AsyncStream<OpenClawChatTransportEvent>
+    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL?
 
     func setActiveSessionKey(_ sessionKey: String) async throws
     func resetSession(sessionKey: String) async throws
@@ -297,6 +298,10 @@ public protocol OpenClawChatTransport: Sendable {
 }
 
 extension OpenClawChatTransport {
+    public func resolveInlineWidgetURL(path _: String, replacing _: URL?) async -> URL? {
+        nil
+    }
+
     public var outboxRequiresSessionRoutingContract: Bool {
         false
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -290,6 +290,9 @@ public protocol OpenClawChatTransport: Sendable {
     func requestHealth(timeoutMs: Int) async throws -> Bool
     func waitForRunCompletion(runId: String, timeoutMs: Int) async -> OpenClawChatRunObservation
     func events() -> AsyncStream<OpenClawChatTransportEvent>
+    func resolveInlineWidgetResource(
+        path: String,
+        replacing failedResource: OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
     func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL?
 
     func setActiveSessionKey(_ sessionKey: String) async throws
@@ -298,6 +301,14 @@ public protocol OpenClawChatTransport: Sendable {
 }
 
 extension OpenClawChatTransport {
+    public func resolveInlineWidgetResource(
+        path: String,
+        replacing failedResource: OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
+    {
+        guard let url = await resolveInlineWidgetURL(path: path, replacing: failedResource?.url) else { return nil }
+        return OpenClawChatWidgetResource(url: url)
+    }
+
     public func resolveInlineWidgetURL(path _: String, replacing _: URL?) async -> URL? {
         nil
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -437,8 +437,8 @@ public struct OpenClawChatView: View {
             isClean: self.composerChrome == .clean,
             contextWindowTokens: contextWindowTokens,
             inlineWidgetResolverReady: self.viewModel.healthOK,
-            inlineWidgetURLResolver: { [weak viewModel] path, failedURL in
-                await viewModel?.resolveInlineWidgetURL(path: path, replacing: failedURL)
+            inlineWidgetResourceResolver: { [weak viewModel] path, failedResource in
+                await viewModel?.resolveInlineWidgetResource(path: path, replacing: failedResource)
             })
             .frame(
                 maxWidth: .infinity,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -435,7 +435,11 @@ public struct OpenClawChatView: View {
             assistantAvatarTint: self.assistantAvatarTint,
             showsAssistantAvatar: self.showsAssistantAvatars,
             isClean: self.composerChrome == .clean,
-            contextWindowTokens: contextWindowTokens)
+            contextWindowTokens: contextWindowTokens,
+            inlineWidgetResolverReady: self.viewModel.healthOK,
+            inlineWidgetURLResolver: { [weak viewModel] path, failedURL in
+                await viewModel?.resolveInlineWidgetURL(path: path, replacing: failedURL)
+            })
             .frame(
                 maxWidth: .infinity,
                 alignment: msg.role.lowercased() == "user" ? .trailing : .leading)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -14,6 +14,10 @@ private final class PendingRunOwnerReference {
 }
 
 extension OpenClawChatViewModel {
+    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
+        await self.transport.resolveInlineWidgetURL(path: path, replacing: failedURL)
+    }
+
     func handleTransportEvent(_ evt: OpenClawChatTransportEvent) {
         switch evt {
         case let .health(ok):

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -14,8 +14,11 @@ private final class PendingRunOwnerReference {
 }
 
 extension OpenClawChatViewModel {
-    func resolveInlineWidgetURL(path: String, replacing failedURL: URL?) async -> URL? {
-        await self.transport.resolveInlineWidgetURL(path: path, replacing: failedURL)
+    func resolveInlineWidgetResource(
+        path: String,
+        replacing failedResource: OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
+    {
+        await self.transport.resolveInlineWidgetResource(path: path, replacing: failedResource)
     }
 
     func handleTransportEvent(_ evt: OpenClawChatTransportEvent) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/AsyncTimeout.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/AsyncTimeout.swift
@@ -66,12 +66,8 @@ public enum AsyncTimeout {
         operation: @escaping @Sendable () async throws -> T) async throws -> T
     {
         let clamped = max(0, seconds)
-        if clamped == 0 {
-            return try await operation()
-        }
-
         // Unstructured racers let the caller return without awaiting a cancellation-ignoring loser.
-        // The actor resumes once and cancels both tasks; noncooperative work may still finish later,
+        // The actor resumes once and cancels every racer; noncooperative work may still finish later,
         // so callers must own resource cleanup and stale-result safety.
         let race = AsyncTimeoutRace<T>()
         return try await withTaskCancellationHandler {
@@ -85,22 +81,25 @@ public enum AsyncTimeout {
                     await race.resolveFailure(error)
                 }
             }
-            let timeoutTask = Task {
-                do {
-                    try await Task.sleep(nanoseconds: UInt64(clamped * 1_000_000_000))
-                    await race.resolveFailure(onTimeout())
-                } catch is CancellationError {
-                    // The operation or caller resolved the race first.
-                } catch {
-                    await race.resolveFailure(error)
+            var tasks = [operationTask]
+            if clamped > 0 {
+                let timeoutTask = Task {
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(clamped * 1_000_000_000))
+                        await race.resolveFailure(onTimeout())
+                    } catch is CancellationError {
+                        // The operation or caller resolved the race first.
+                    } catch {
+                        await race.resolveFailure(error)
+                    }
                 }
+                tasks.append(timeoutTask)
             }
             if Task.isCancelled {
-                operationTask.cancel()
-                timeoutTask.cancel()
+                tasks.forEach { $0.cancel() }
                 throw CancellationError()
             }
-            return try await race.wait(for: [operationTask, timeoutTask])
+            return try await race.wait(for: tasks)
         } onCancel: {
             Task { await race.resolveFailure(CancellationError()) }
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
@@ -1,3 +1,7 @@
+public enum OpenClawGatewayClientCapability {
+    public static let inlineWidgets = "inline-widgets"
+}
+
 public struct GatewayConnectOptions: Sendable {
     public var role: String
     public var scopes: [String]

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -286,6 +286,7 @@ public actor GatewayNodeSession {
         let id: UUID
         let channelGeneration: UInt64
         let admissionGeneration: UInt64
+        let timeoutMs: Double
         let task: Task<String?, Never>
     }
 
@@ -630,6 +631,27 @@ public actor GatewayNodeSession {
         surface: String,
         replacing observedURL: String?) async -> String?
     {
+        await self.refreshPluginSurfaceUrl(
+            surface: surface,
+            observedURL: observedURL,
+            timeoutMs: Self.pluginSurfaceRefreshTimeoutMs)
+    }
+
+    @discardableResult
+    public func refreshPluginSurfaceUrl(surface: String, timeoutSeconds: Int = 8) async -> String? {
+        let trimmedSurface = surface.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSurface.isEmpty else { return nil }
+        return await self.refreshPluginSurfaceUrl(
+            surface: trimmedSurface,
+            observedURL: self.pluginSurfaceUrls[trimmedSurface],
+            timeoutMs: Double(timeoutSeconds) * 1000)
+    }
+
+    private func refreshPluginSurfaceUrl(
+        surface: String,
+        observedURL: String?,
+        timeoutMs: Double) async -> String?
+    {
         guard let channel else { return nil }
         let trimmedSurface = surface.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSurface.isEmpty else { return nil }
@@ -640,7 +662,8 @@ public actor GatewayNodeSession {
         let admissionGeneration = self.admissionGeneration
         if let refresh = self.pluginSurfaceRefreshes[trimmedSurface],
            refresh.channelGeneration == channelGeneration,
-           refresh.admissionGeneration == admissionGeneration
+           refresh.admissionGeneration == admissionGeneration,
+           refresh.timeoutMs == timeoutMs
         {
             return await refresh.task.value
         }
@@ -653,12 +676,14 @@ public actor GatewayNodeSession {
                 channelGeneration: channelGeneration,
                 admissionGeneration: admissionGeneration,
                 surface: trimmedSurface,
-                observedURL: observedURL)
+                observedURL: observedURL,
+                timeoutMs: timeoutMs)
         }
         self.pluginSurfaceRefreshes[trimmedSurface] = PluginSurfaceRefresh(
             id: id,
             channelGeneration: channelGeneration,
             admissionGeneration: admissionGeneration,
+            timeoutMs: timeoutMs,
             task: task)
         let refreshed = await task.value
         if self.pluginSurfaceRefreshes[trimmedSurface]?.id == id {
@@ -672,6 +697,11 @@ public actor GatewayNodeSession {
         replacing observedURL: String?) async -> String?
     {
         await self.refreshPluginSurfaceUrl(surface: "canvas", replacing: observedURL)
+    }
+
+    @discardableResult
+    public func refreshCanvasHostUrl(timeoutSeconds: Int = 8) async -> String? {
+        await self.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: timeoutSeconds)
     }
 
     public func currentRemoteAddress() -> String? {
@@ -1019,14 +1049,15 @@ extension GatewayNodeSession {
         channelGeneration: UInt64,
         admissionGeneration: UInt64,
         surface: String,
-        observedURL: String?) async -> String?
+        observedURL: String?,
+        timeoutMs: Double) async -> String?
     {
         let method = "node.pluginSurface.refresh"
         do {
             let data = try await channel.request(
                 method: method,
                 params: ["surface": AnyCodable(surface)],
-                timeoutMs: Self.pluginSurfaceRefreshTimeoutMs)
+                timeoutMs: timeoutMs)
             let decoded = try decoder.decode(PluginSurfaceRefreshResponse.self, from: data)
             let urls = self.normalizePluginSurfaceUrls(decoded.pluginSurfaceUrls)
             guard let refreshed = urls[surface] else { return nil }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -55,6 +55,17 @@ public struct GatewayNodeSessionRoute: Sendable, Equatable {
     fileprivate let socketGeneration: UInt64
 }
 
+/// One capability-scoped Canvas URL and the transport trust bound to its route.
+public struct GatewayCanvasHostRoute: Sendable, Equatable {
+    public let url: String
+    public let tlsFingerprintSHA256: String?
+
+    public init(url: String, tlsFingerprintSHA256: String?) {
+        self.url = url
+        self.tlsFingerprintSHA256 = tlsFingerprintSHA256
+    }
+}
+
 /// A route lease became stale before its request touched the channel. Unlike
 /// a socket cancellation, this proves the payload was never dispatched.
 public enum GatewayNodeSessionRequestError: Error, Sendable {
@@ -158,6 +169,7 @@ public actor GatewayNodeSession {
     private var activeSessionIdentity: ObjectIdentifier?
     private var channelGeneration: UInt64 = 0
     private var admissionGeneration: UInt64 = 0
+    private var activeTLSRouteMetadataProvider: GatewayTLSRouteMetadataProviding?
     // A delayed push keeps its physical socket epoch. Once disconnect cleanup
     // retires that epoch, it cannot adopt the replacement route's admission.
     private var activeSocketGeneration: UInt64?
@@ -360,6 +372,7 @@ public actor GatewayNodeSession {
     {
         let nextOptionsKey = self.connectOptionsKey(connectOptions)
         let nextSessionIdentity = sessionBox.map { ObjectIdentifier($0.session) }
+        let nextTLSRouteMetadataProvider = sessionBox?.session as? GatewayTLSRouteMetadataProviding
         let shouldReconnect = self.activeURL != url ||
             self.activeCredentials != credentials ||
             self.activeConnectOptionsKey != nextOptionsKey ||
@@ -432,6 +445,7 @@ public actor GatewayNodeSession {
             self.activeCredentials = credentials
             self.activeConnectOptionsKey = nextOptionsKey
             self.activeSessionIdentity = nextSessionIdentity
+            self.activeTLSRouteMetadataProvider = nextTLSRouteMetadataProvider
         } else {
             channelGeneration = self.channelGeneration
             self.connectOptions = connectOptions
@@ -532,6 +546,7 @@ public actor GatewayNodeSession {
         self.activeCredentials = nil
         self.activeConnectOptionsKey = nil
         self.activeSessionIdentity = nil
+        self.activeTLSRouteMetadataProvider = nil
         self.connectOptions = nil
         self.onConnected = nil
         self.onDisconnected = nil
@@ -624,6 +639,21 @@ public actor GatewayNodeSession {
 
     public func currentCanvasHostUrl() -> String? {
         self.pluginSurfaceUrls["canvas"]
+    }
+
+    public func currentCanvasHostRoute() -> GatewayCanvasHostRoute? {
+        guard let url = currentCanvasHostUrl() else { return nil }
+        return GatewayCanvasHostRoute(
+            url: url,
+            tlsFingerprintSHA256: self.activeTLSRouteMetadataProvider?.effectiveTLSFingerprintSHA256)
+    }
+
+    @discardableResult
+    public func refreshCanvasHostRoute(replacing observedURL: String?) async -> GatewayCanvasHostRoute? {
+        _ = await self.refreshCanvasHostUrl(replacing: observedURL)
+        // Re-read after the refresh suspension. A reconnect may have installed
+        // both a replacement capability and a different certificate pin.
+        return self.currentCanvasHostRoute()
     }
 
     @discardableResult

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -614,7 +614,10 @@ public actor GatewayNodeSession {
         guard let url = currentCanvasHostUrl() else { return nil }
         return GatewayCanvasHostRoute(
             url: url,
-            tlsFingerprintSHA256: self.activeTLSRouteMetadataProvider?.effectiveTLSFingerprintSHA256)
+            tlsFingerprintSHA256: GatewayPluginSurfaceURL.tlsFingerprintForSurface(
+                self.activeTLSRouteMetadataProvider?.effectiveTLSFingerprintSHA256,
+                surfaceURL: url,
+                gatewayURL: self.activeURL))
     }
 
     @discardableResult

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -286,13 +286,13 @@ public actor GatewayNodeSession {
         let id: UUID
         let channelGeneration: UInt64
         let admissionGeneration: UInt64
-        let timeoutMs: Double
         let task: Task<String?, Never>
     }
 
     /// Surface tokens belong to the shared session. A second rotation can invalidate
     /// the URL returned to another chat before its web view has loaded it.
     private var pluginSurfaceRefreshes: [String: PluginSurfaceRefresh] = [:]
+    private var pluginSurfaceRefreshOperationTimeoutMs = GatewayNodeSession.pluginSurfaceRefreshTimeoutMs
 
     private struct PluginSurfaceRefreshResponse: Decodable {
         let pluginSurfaceUrls: [String: AnyCodable]?
@@ -662,34 +662,51 @@ public actor GatewayNodeSession {
         let admissionGeneration = self.admissionGeneration
         if let refresh = self.pluginSurfaceRefreshes[trimmedSurface],
            refresh.channelGeneration == channelGeneration,
-           refresh.admissionGeneration == admissionGeneration,
-           refresh.timeoutMs == timeoutMs
+           refresh.admissionGeneration == admissionGeneration
         {
-            return await refresh.task.value
+            return await self.awaitPluginSurfaceRefresh(refresh.task, timeoutMs: timeoutMs)
         }
 
         let id = UUID()
         let task = Task<String?, Never> { [weak self] in
             guard let self else { return nil }
-            return await self.requestPluginSurfaceRefresh(
+            let refreshed = await self.requestPluginSurfaceRefresh(
                 channel: channel,
                 channelGeneration: channelGeneration,
                 admissionGeneration: admissionGeneration,
                 surface: trimmedSurface,
-                observedURL: observedURL,
-                timeoutMs: timeoutMs)
+                observedURL: observedURL)
+            await self.finishPluginSurfaceRefresh(surface: trimmedSurface, id: id)
+            return refreshed
         }
         self.pluginSurfaceRefreshes[trimmedSurface] = PluginSurfaceRefresh(
             id: id,
             channelGeneration: channelGeneration,
             admissionGeneration: admissionGeneration,
-            timeoutMs: timeoutMs,
             task: task)
-        let refreshed = await task.value
-        if self.pluginSurfaceRefreshes[trimmedSurface]?.id == id {
-            self.pluginSurfaceRefreshes[trimmedSurface] = nil
+        return await self.awaitPluginSurfaceRefresh(task, timeoutMs: timeoutMs)
+    }
+
+    private func awaitPluginSurfaceRefresh(_ task: Task<String?, Never>, timeoutMs: Double) async -> String? {
+        do {
+            return try await AsyncTimeout.withTimeout(
+                seconds: max(0, timeoutMs) / 1000,
+                onTimeout: {
+                    NSError(
+                        domain: "Gateway",
+                        code: 8,
+                        userInfo: [NSLocalizedDescriptionKey: "plugin surface refresh timed out"])
+                },
+                operation: { await task.value })
+        } catch {
+            return nil
         }
-        return refreshed
+    }
+
+    private func finishPluginSurfaceRefresh(surface: String, id: UUID) {
+        if self.pluginSurfaceRefreshes[surface]?.id == id {
+            self.pluginSurfaceRefreshes[surface] = nil
+        }
     }
 
     @discardableResult
@@ -1049,15 +1066,18 @@ extension GatewayNodeSession {
         channelGeneration: UInt64,
         admissionGeneration: UInt64,
         surface: String,
-        observedURL: String?,
-        timeoutMs: Double) async -> String?
+        observedURL: String?) async -> String?
     {
         let method = "node.pluginSurface.refresh"
         do {
+            // One server-side rotation owns the surface until it responds or the
+            // canonical operation deadline expires. Callers keep independent,
+            // shorter deadlines without issuing a second rotation that could
+            // invalidate the first result.
             let data = try await channel.request(
                 method: method,
                 params: ["surface": AnyCodable(surface)],
-                timeoutMs: timeoutMs)
+                timeoutMs: self.pluginSurfaceRefreshOperationTimeoutMs)
             let decoded = try decoder.decode(PluginSurfaceRefreshResponse.self, from: data)
             let urls = self.normalizePluginSurfaceUrls(decoded.pluginSurfaceUrls)
             guard let refreshed = urls[surface] else { return nil }
@@ -1294,6 +1314,11 @@ extension GatewayNodeSession {
     // periphery:ignore - package tests verify event stream filtering without a live gateway.
     func _test_broadcastServerEvent(_ event: EventFrame) {
         self.broadcastServerEvent(event)
+    }
+
+    // periphery:ignore - package tests prove a stalled surface rotation releases for retry.
+    func _test_setPluginSurfaceRefreshOperationTimeoutMs(_ timeoutMs: Double) {
+        self.pluginSurfaceRefreshOperationTimeoutMs = max(1, timeoutMs)
     }
     #endif
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -1081,7 +1081,7 @@ extension GatewayNodeSession {
     }
 
     private func normalizeCanvasHostUrl(_ raw: String?) -> String? {
-        canonicalizeCanvasHostUrl(raw: raw, activeURL: self.activeURL)
+        GatewayPluginSurfaceURL.canonicalize(raw: raw, against: self.activeURL)
     }
 
     private func normalizePluginSurfaceUrls(_ raw: [String: AnyCodable]?) -> [String: String] {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -16,37 +16,6 @@ private struct NodeInvokeCancelPayload: Codable {
     var invokeId: String
 }
 
-func canonicalizeCanvasHostUrl(raw: String?, activeURL: URL?) -> String? {
-    let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    guard !trimmed.isEmpty else { return nil }
-    guard var parsed = URLComponents(string: trimmed) else { return trimmed }
-
-    let parsedHost = parsed.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    let parsedIsLoopback = !parsedHost.isEmpty && LoopbackHost.isLoopback(parsedHost)
-
-    if !parsedHost.isEmpty, !parsedIsLoopback {
-        guard let activeURL else { return trimmed }
-        let isTLS = activeURL.scheme?.lowercased() == "wss"
-        guard isTLS else { return trimmed }
-        parsed.scheme = "https"
-        if parsed.port == nil {
-            let tlsPort = activeURL.port ?? 443
-            parsed.port = (tlsPort == 443) ? nil : tlsPort
-        }
-        return parsed.string ?? trimmed
-    }
-
-    guard let activeURL, let fallbackHost = activeURL.host, !LoopbackHost.isLoopback(fallbackHost) else {
-        return trimmed
-    }
-    let isTLS = activeURL.scheme?.lowercased() == "wss"
-    parsed.scheme = isTLS ? "https" : "http"
-    parsed.host = fallbackHost
-    let fallbackPort = activeURL.port ?? (isTLS ? 443 : 80)
-    parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
-    return parsed.string ?? trimmed
-}
-
 /// Binds suspended work to one installed gateway channel generation.
 /// Callers use this lease so an actor hop cannot retarget a payload to a replacement gateway.
 public struct GatewayNodeSessionRoute: Sendable, Equatable {
@@ -684,6 +653,7 @@ public actor GatewayNodeSession {
         timeoutMs: Double) async -> String?
     {
         guard let channel else { return nil }
+        guard let method = self.pluginSurfaceRefreshMethod() else { return nil }
         let trimmedSurface = surface.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSurface.isEmpty else { return nil }
         if self.pluginSurfaceUrls[trimmedSurface] != observedURL {
@@ -711,6 +681,7 @@ public actor GatewayNodeSession {
                     channel: channel,
                     channelGeneration: channelGeneration,
                     admissionGeneration: admissionGeneration,
+                    method: method,
                     surface: trimmedSurface,
                     observedURL: observedURL)
             }
@@ -1123,14 +1094,22 @@ extension GatewayNodeSession {
         return normalized
     }
 
+    private func pluginSurfaceRefreshMethod() -> String? {
+        switch self.connectOptions?.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "node": "node.pluginSurface.refresh"
+        case "operator": "plugin.surface.refresh"
+        default: nil
+        }
+    }
+
     private func requestPluginSurfaceRefresh(
         channel: GatewayChannelActor,
         channelGeneration: UInt64,
         admissionGeneration: UInt64,
+        method: String,
         surface: String,
         observedURL: String?) async -> String?
     {
-        let method = "node.pluginSurface.refresh"
         do {
             // Waiters own independent deadlines around this shared request. Zero
             // leaves its lifetime unbounded; the last waiter cancels channel work.

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -98,6 +98,7 @@ public struct GatewayNodeSessionCredentials: Sendable, Equatable {
 
 public actor GatewayNodeSession {
     @TaskLocal private static var executingLifecycleCallbackID: UUID?
+    private static let pluginSurfaceRefreshTimeoutMs = 8000.0
 
     private static let staleRouteInvokeMessage = "UNAVAILABLE: node route changed before dispatch"
     private enum ComputerInvokeReceiptState {
@@ -280,6 +281,17 @@ public actor GatewayNodeSession {
 
     private var serverEventSubscribers: [UUID: ServerEventSubscriber] = [:]
     private var pluginSurfaceUrls: [String: String] = [:]
+
+    private struct PluginSurfaceRefresh {
+        let id: UUID
+        let channelGeneration: UInt64
+        let admissionGeneration: UInt64
+        let task: Task<String?, Never>
+    }
+
+    /// Surface tokens belong to the shared session. A second rotation can invalidate
+    /// the URL returned to another chat before its web view has loaded it.
+    private var pluginSurfaceRefreshes: [String: PluginSurfaceRefresh] = [:]
 
     private struct PluginSurfaceRefreshResponse: Decodable {
         let pluginSurfaceUrls: [String: AnyCodable]?
@@ -614,22 +626,55 @@ public actor GatewayNodeSession {
     }
 
     @discardableResult
-    public func refreshPluginSurfaceUrl(surface: String, timeoutSeconds: Int = 8) async -> String? {
+    public func refreshPluginSurfaceUrl(
+        surface: String,
+        replacing observedURL: String?) async -> String?
+    {
         guard let channel else { return nil }
         let trimmedSurface = surface.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSurface.isEmpty else { return nil }
+        if self.pluginSurfaceUrls[trimmedSurface] != observedURL {
+            return self.pluginSurfaceUrls[trimmedSurface]
+        }
+        let channelGeneration = self.channelGeneration
+        let admissionGeneration = self.admissionGeneration
+        if let refresh = self.pluginSurfaceRefreshes[trimmedSurface],
+           refresh.channelGeneration == channelGeneration,
+           refresh.admissionGeneration == admissionGeneration
+        {
+            return await refresh.task.value
+        }
 
-        return await self.requestPluginSurfaceRefresh(
-            channel: channel,
-            method: "node.pluginSurface.refresh",
-            params: ["surface": AnyCodable(trimmedSurface)],
-            surface: trimmedSurface,
-            timeoutSeconds: timeoutSeconds)
+        let id = UUID()
+        let task = Task<String?, Never> { [weak self] in
+            guard let self else { return nil }
+            return await self.requestPluginSurfaceRefresh(
+                channel: channel,
+                channelGeneration: channelGeneration,
+                admissionGeneration: admissionGeneration,
+                method: "node.pluginSurface.refresh",
+                params: ["surface": AnyCodable(trimmedSurface)],
+                surface: trimmedSurface,
+                observedURL: observedURL,
+                timeoutMs: Self.pluginSurfaceRefreshTimeoutMs)
+        }
+        self.pluginSurfaceRefreshes[trimmedSurface] = PluginSurfaceRefresh(
+            id: id,
+            channelGeneration: channelGeneration,
+            admissionGeneration: admissionGeneration,
+            task: task)
+        let refreshed = await task.value
+        if self.pluginSurfaceRefreshes[trimmedSurface]?.id == id {
+            self.pluginSurfaceRefreshes[trimmedSurface] = nil
+        }
+        return refreshed
     }
 
     @discardableResult
-    public func refreshCanvasHostUrl(timeoutSeconds: Int = 8) async -> String? {
-        await self.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: timeoutSeconds)
+    public func refreshCanvasHostUrl(
+        replacing observedURL: String?) async -> String?
+    {
+        await self.refreshPluginSurfaceUrl(surface: "canvas", replacing: observedURL)
     }
 
     public func currentRemoteAddress() -> String? {
@@ -974,19 +1019,29 @@ extension GatewayNodeSession {
 
     private func requestPluginSurfaceRefresh(
         channel: GatewayChannelActor,
+        channelGeneration: UInt64,
+        admissionGeneration: UInt64,
         method: String,
         params: [String: AnyCodable]?,
         surface: String,
-        timeoutSeconds: Int) async -> String?
+        observedURL: String?,
+        timeoutMs: Double) async -> String?
     {
         do {
             let data = try await channel.request(
                 method: method,
                 params: params,
-                timeoutMs: Double(timeoutSeconds * 1000))
+                timeoutMs: timeoutMs)
             let decoded = try decoder.decode(PluginSurfaceRefreshResponse.self, from: data)
             let urls = self.normalizePluginSurfaceUrls(decoded.pluginSurfaceUrls)
             guard let refreshed = urls[surface] else { return nil }
+            guard self.channel === channel,
+                  self.channelGeneration == channelGeneration,
+                  self.admissionGeneration == admissionGeneration
+            else { return nil }
+            if self.pluginSurfaceUrls[surface] != observedURL {
+                return self.pluginSurfaceUrls[surface]
+            }
             self.pluginSurfaceUrls[surface] = refreshed
             return refreshed
         } catch {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -668,6 +668,7 @@ public actor GatewayNodeSession {
     }
 
     @discardableResult
+    // periphery:ignore - Shipped public refresh API; keep until a breaking OpenClawKit window.
     public func refreshPluginSurfaceUrl(surface: String, timeoutSeconds: Int = 8) async -> String? {
         let trimmedSurface = surface.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSurface.isEmpty else { return nil }
@@ -747,6 +748,7 @@ public actor GatewayNodeSession {
     }
 
     @discardableResult
+    // periphery:ignore - Shipped public refresh API; keep until a breaking OpenClawKit window.
     public func refreshCanvasHostUrl(timeoutSeconds: Int = 8) async -> String? {
         await self.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: timeoutSeconds)
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -299,12 +299,12 @@ public actor GatewayNodeSession {
         let channelGeneration: UInt64
         let admissionGeneration: UInt64
         let task: Task<String?, Never>
+        var waiterIDs: Set<UUID>
     }
 
     /// Surface tokens belong to the shared session. A second rotation can invalidate
     /// the URL returned to another chat before its web view has loaded it.
     private var pluginSurfaceRefreshes: [String: PluginSurfaceRefresh] = [:]
-    private var pluginSurfaceRefreshOperationTimeoutMs = GatewayNodeSession.pluginSurfaceRefreshTimeoutMs
 
     private struct PluginSurfaceRefreshResponse: Decodable {
         let pluginSurfaceUrls: [String: AnyCodable]?
@@ -667,8 +667,8 @@ public actor GatewayNodeSession {
             timeoutMs: Self.pluginSurfaceRefreshTimeoutMs)
     }
 
-    @discardableResult
     // periphery:ignore - Shipped public refresh API; keep until a breaking OpenClawKit window.
+    @discardableResult
     public func refreshPluginSurfaceUrl(surface: String, timeoutSeconds: Int = 8) async -> String? {
         let trimmedSurface = surface.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSurface.isEmpty else { return nil }
@@ -691,31 +691,53 @@ public actor GatewayNodeSession {
         }
         let channelGeneration = self.channelGeneration
         let admissionGeneration = self.admissionGeneration
-        if let refresh = self.pluginSurfaceRefreshes[trimmedSurface],
-           refresh.channelGeneration == channelGeneration,
-           refresh.admissionGeneration == admissionGeneration
+        let waiterID = UUID()
+        let refresh: PluginSurfaceRefresh
+        if var activeRefresh = self.pluginSurfaceRefreshes[trimmedSurface],
+           activeRefresh.channelGeneration == channelGeneration,
+           activeRefresh.admissionGeneration == admissionGeneration
         {
-            return await self.awaitPluginSurfaceRefresh(refresh.task, timeoutMs: timeoutMs)
-        }
-
-        let id = UUID()
-        let task = Task<String?, Never> { [weak self] in
-            guard let self else { return nil }
-            let refreshed = await self.requestPluginSurfaceRefresh(
-                channel: channel,
+            activeRefresh.waiterIDs.insert(waiterID)
+            self.pluginSurfaceRefreshes[trimmedSurface] = activeRefresh
+            refresh = activeRefresh
+        } else {
+            // A reconnect retires the old channel owner. Do not leave its
+            // deadline-free request alive after installing the new generation.
+            self.pluginSurfaceRefreshes.removeValue(forKey: trimmedSurface)?.task.cancel()
+            let id = UUID()
+            let task = Task<String?, Never> { [weak self] in
+                guard let self else { return nil }
+                return await self.requestPluginSurfaceRefresh(
+                    channel: channel,
+                    channelGeneration: channelGeneration,
+                    admissionGeneration: admissionGeneration,
+                    surface: trimmedSurface,
+                    observedURL: observedURL)
+            }
+            refresh = PluginSurfaceRefresh(
+                id: id,
                 channelGeneration: channelGeneration,
                 admissionGeneration: admissionGeneration,
-                surface: trimmedSurface,
-                observedURL: observedURL)
-            await self.finishPluginSurfaceRefresh(surface: trimmedSurface, id: id)
-            return refreshed
+                task: task,
+                waiterIDs: [waiterID])
+            self.pluginSurfaceRefreshes[trimmedSurface] = refresh
         }
-        self.pluginSurfaceRefreshes[trimmedSurface] = PluginSurfaceRefresh(
-            id: id,
-            channelGeneration: channelGeneration,
-            admissionGeneration: admissionGeneration,
-            task: task)
-        return await self.awaitPluginSurfaceRefresh(task, timeoutMs: timeoutMs)
+
+        let value = await withTaskCancellationHandler {
+            await self.awaitPluginSurfaceRefresh(refresh.task, timeoutMs: timeoutMs)
+        } onCancel: {
+            Task {
+                await self.releasePluginSurfaceRefreshWaiter(
+                    surface: trimmedSurface,
+                    refreshID: refresh.id,
+                    waiterID: waiterID)
+            }
+        }
+        self.releasePluginSurfaceRefreshWaiter(
+            surface: trimmedSurface,
+            refreshID: refresh.id,
+            waiterID: waiterID)
+        return value
     }
 
     private func awaitPluginSurfaceRefresh(_ task: Task<String?, Never>, timeoutMs: Double) async -> String? {
@@ -734,9 +756,17 @@ public actor GatewayNodeSession {
         }
     }
 
-    private func finishPluginSurfaceRefresh(surface: String, id: UUID) {
-        if self.pluginSurfaceRefreshes[surface]?.id == id {
+    private func releasePluginSurfaceRefreshWaiter(surface: String, refreshID: UUID, waiterID: UUID) {
+        guard var refresh = self.pluginSurfaceRefreshes[surface], refresh.id == refreshID else { return }
+        guard refresh.waiterIDs.remove(waiterID) != nil else { return }
+        if refresh.waiterIDs.isEmpty {
+            // The request itself has no deadline because callers may select different
+            // timeouts. The last waiter cancels locally; observedUrl makes any retry
+            // reuse an on-wire predecessor's rotation instead of invalidating it.
             self.pluginSurfaceRefreshes[surface] = nil
+            refresh.task.cancel()
+        } else {
+            self.pluginSurfaceRefreshes[surface] = refresh
         }
     }
 
@@ -747,8 +777,8 @@ public actor GatewayNodeSession {
         await self.refreshPluginSurfaceUrl(surface: "canvas", replacing: observedURL)
     }
 
-    @discardableResult
     // periphery:ignore - Shipped public refresh API; keep until a breaking OpenClawKit window.
+    @discardableResult
     public func refreshCanvasHostUrl(timeoutSeconds: Int = 8) async -> String? {
         await self.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: timeoutSeconds)
     }
@@ -1102,14 +1132,18 @@ extension GatewayNodeSession {
     {
         let method = "node.pluginSurface.refresh"
         do {
-            // One server-side rotation owns the surface until it responds or the
-            // canonical operation deadline expires. Callers keep independent,
-            // shorter deadlines without issuing a second rotation that could
-            // invalidate the first result.
+            // Waiters own independent deadlines around this shared request. Zero
+            // leaves its lifetime unbounded; the last waiter cancels channel work.
+            var params = ["surface": AnyCodable(surface)]
+            if let observedURL {
+                // The gateway compares capability tokens, not hosts, because
+                // native clients rewrite loopback surface URLs for remote access.
+                params["observedUrl"] = AnyCodable(observedURL)
+            }
             let data = try await channel.request(
                 method: method,
-                params: ["surface": AnyCodable(surface)],
-                timeoutMs: self.pluginSurfaceRefreshOperationTimeoutMs)
+                params: params,
+                timeoutMs: 0)
             let decoded = try decoder.decode(PluginSurfaceRefreshResponse.self, from: data)
             let urls = self.normalizePluginSurfaceUrls(decoded.pluginSurfaceUrls)
             guard let refreshed = urls[surface] else { return nil }
@@ -1348,10 +1382,6 @@ extension GatewayNodeSession {
         self.broadcastServerEvent(event)
     }
 
-    // periphery:ignore - package tests prove a stalled surface rotation releases for retry.
-    func _test_setPluginSurfaceRefreshOperationTimeoutMs(_ timeoutMs: Double) {
-        self.pluginSurfaceRefreshOperationTimeoutMs = max(1, timeoutMs)
-    }
     #endif
 
     private func cancelActiveInvokes(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -652,11 +652,8 @@ public actor GatewayNodeSession {
                 channel: channel,
                 channelGeneration: channelGeneration,
                 admissionGeneration: admissionGeneration,
-                method: "node.pluginSurface.refresh",
-                params: ["surface": AnyCodable(trimmedSurface)],
                 surface: trimmedSurface,
-                observedURL: observedURL,
-                timeoutMs: Self.pluginSurfaceRefreshTimeoutMs)
+                observedURL: observedURL)
         }
         self.pluginSurfaceRefreshes[trimmedSurface] = PluginSurfaceRefresh(
             id: id,
@@ -1021,17 +1018,15 @@ extension GatewayNodeSession {
         channel: GatewayChannelActor,
         channelGeneration: UInt64,
         admissionGeneration: UInt64,
-        method: String,
-        params: [String: AnyCodable]?,
         surface: String,
-        observedURL: String?,
-        timeoutMs: Double) async -> String?
+        observedURL: String?) async -> String?
     {
+        let method = "node.pluginSurface.refresh"
         do {
             let data = try await channel.request(
                 method: method,
-                params: params,
-                timeoutMs: timeoutMs)
+                params: ["surface": AnyCodable(surface)],
+                timeoutMs: Self.pluginSurfaceRefreshTimeoutMs)
             let decoded = try decoder.decode(PluginSurfaceRefreshResponse.self, from: data)
             let urls = self.normalizePluginSurfaceUrls(decoded.pluginSurfaceUrls)
             guard let refreshed = urls[surface] else { return nil }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPluginSurfaceSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPluginSurfaceSupport.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+func canonicalizeCanvasHostUrl(raw: String?, activeURL: URL?) -> String? {
+    let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !trimmed.isEmpty else { return nil }
+    guard var parsed = URLComponents(string: trimmed) else { return trimmed }
+
+    let parsedHost = parsed.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let parsedIsLoopback = !parsedHost.isEmpty && LoopbackHost.isLoopback(parsedHost)
+
+    if !parsedHost.isEmpty, !parsedIsLoopback {
+        guard let activeURL else { return trimmed }
+        let isTLS = activeURL.scheme?.lowercased() == "wss"
+        guard isTLS else { return trimmed }
+        parsed.scheme = "https"
+        if parsed.port == nil {
+            let tlsPort = activeURL.port ?? 443
+            parsed.port = (tlsPort == 443) ? nil : tlsPort
+        }
+        return parsed.string ?? trimmed
+    }
+
+    guard let activeURL, let fallbackHost = activeURL.host, !LoopbackHost.isLoopback(fallbackHost) else {
+        return trimmed
+    }
+    let isTLS = activeURL.scheme?.lowercased() == "wss"
+    parsed.scheme = isTLS ? "https" : "http"
+    parsed.host = fallbackHost
+    let fallbackPort = activeURL.port ?? (isTLS ? 443 : 80)
+    parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
+    return parsed.string ?? trimmed
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPluginSurfaceSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPluginSurfaceSupport.swift
@@ -1,32 +1,35 @@
 import Foundation
 
-func canonicalizeCanvasHostUrl(raw: String?, activeURL: URL?) -> String? {
-    let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    guard !trimmed.isEmpty else { return nil }
-    guard var parsed = URLComponents(string: trimmed) else { return trimmed }
+public enum GatewayPluginSurfaceURL {
+    public static func canonicalize(raw: String?, against activeGatewayURL: URL?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        guard var parsed = URLComponents(string: trimmed) else { return trimmed }
 
-    let parsedHost = parsed.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    let parsedIsLoopback = !parsedHost.isEmpty && LoopbackHost.isLoopback(parsedHost)
+        let parsedHost = parsed.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let parsedIsLoopback = !parsedHost.isEmpty && LoopbackHost.isLoopback(parsedHost)
 
-    if !parsedHost.isEmpty, !parsedIsLoopback {
-        guard let activeURL else { return trimmed }
-        let isTLS = activeURL.scheme?.lowercased() == "wss"
-        guard isTLS else { return trimmed }
-        parsed.scheme = "https"
-        if parsed.port == nil {
-            let tlsPort = activeURL.port ?? 443
-            parsed.port = (tlsPort == 443) ? nil : tlsPort
+        if !parsedHost.isEmpty, !parsedIsLoopback {
+            guard let activeGatewayURL else { return trimmed }
+            let isTLS = activeGatewayURL.scheme?.lowercased() == "wss"
+            guard isTLS else { return trimmed }
+            parsed.scheme = "https"
+            if parsed.port == nil {
+                let tlsPort = activeGatewayURL.port ?? 443
+                parsed.port = (tlsPort == 443) ? nil : tlsPort
+            }
+            return parsed.string ?? trimmed
         }
+
+        guard let activeGatewayURL,
+              let fallbackHost = activeGatewayURL.host,
+              !LoopbackHost.isLoopback(fallbackHost)
+        else { return trimmed }
+        let isTLS = activeGatewayURL.scheme?.lowercased() == "wss"
+        parsed.scheme = isTLS ? "https" : "http"
+        parsed.host = fallbackHost
+        let fallbackPort = activeGatewayURL.port ?? (isTLS ? 443 : 80)
+        parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
         return parsed.string ?? trimmed
     }
-
-    guard let activeURL, let fallbackHost = activeURL.host, !LoopbackHost.isLoopback(fallbackHost) else {
-        return trimmed
-    }
-    let isTLS = activeURL.scheme?.lowercased() == "wss"
-    parsed.scheme = isTLS ? "https" : "http"
-    parsed.host = fallbackHost
-    let fallbackPort = activeURL.port ?? (isTLS ? 443 : 80)
-    parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
-    return parsed.string ?? trimmed
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPluginSurfaceSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPluginSurfaceSupport.swift
@@ -32,4 +32,26 @@ public enum GatewayPluginSurfaceURL {
         parsed.port = ((isTLS && fallbackPort == 443) || (!isTLS && fallbackPort == 80)) ? nil : fallbackPort
         return parsed.string ?? trimmed
     }
+
+    static func tlsFingerprintForSurface(
+        _ fingerprint: String?,
+        surfaceURL: String,
+        gatewayURL: URL?) -> String?
+    {
+        guard let fingerprint,
+              let gatewayURL,
+              gatewayURL.scheme?.lowercased() == "wss",
+              let surface = URLComponents(string: surfaceURL),
+              surface.scheme?.lowercased() == "https",
+              self.normalizedEndpointHost(surface.host) == self.normalizedEndpointHost(gatewayURL.host),
+              (surface.port ?? 443) == (gatewayURL.port ?? 443)
+        else { return nil }
+        return fingerprint
+    }
+
+    private static func normalizedEndpointHost(_ raw: String?) -> String? {
+        let host = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        let normalized = host.hasSuffix(".") ? String(host.dropLast()) : host
+        return normalized.isEmpty ? nil : normalized
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
@@ -214,11 +214,18 @@ public enum GatewayTLSStore {
     }
 }
 
+protocol GatewayTLSRouteMetadataProviding: AnyObject {
+    var effectiveTLSFingerprintSHA256: String? { get }
+}
+
 public final class GatewayTLSPinningSession: NSObject, WebSocketSessioning, URLSessionDelegate,
-GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Sendable {
+    GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, GatewayTLSRouteMetadataProviding,
+    @unchecked Sendable
+{
     private let params: GatewayTLSParams
     private let failureLock = NSLock()
     private var lastTLSFailure: GatewayTLSValidationFailure?
+    private var acceptedTLSFingerprintSHA256: String?
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.default
         config.waitsForConnectivity = true
@@ -227,11 +234,20 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
 
     public init(params: GatewayTLSParams) {
         self.params = params
+        self.acceptedTLSFingerprintSHA256 = params.expectedFingerprint
+            .map(normalizeFingerprint)
+            .flatMap { $0.count == 64 ? $0 : nil }
         super.init()
     }
 
     public var allowsDeviceTokenRetryAuth: Bool {
         self.params.expectedFingerprint?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    }
+
+    var effectiveTLSFingerprintSHA256: String? {
+        self.failureLock.lock()
+        defer { self.failureLock.unlock() }
+        return self.acceptedTLSFingerprintSHA256
     }
 
     public func consumeLastTLSFailure() -> GatewayTLSValidationFailure? {
@@ -248,9 +264,12 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
         self.failureLock.unlock()
     }
 
-    private func clearTLSFailure() {
+    private func recordTLSAcceptance(_ fingerprint: String?) {
         self.failureLock.lock()
         self.lastTLSFailure = nil
+        if let fingerprint {
+            self.acceptedTLSFingerprintSHA256 = fingerprint
+        }
         self.failureLock.unlock()
     }
 
@@ -283,7 +302,7 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
         if let fingerprint {
             if let expected {
                 if fingerprint == expected {
-                    self.clearTLSFailure()
+                    self.recordTLSAcceptance(fingerprint)
                     completionHandler(.useCredential, URLCredential(trust: trust))
                 } else {
                     self.recordTLSFailure(GatewayTLSValidationFailure(
@@ -302,7 +321,7 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
                     if let storeKey = params.storeKey {
                         GatewayTLSStore.saveFingerprint(fingerprint, stableID: storeKey)
                     }
-                    self.clearTLSFailure()
+                    self.recordTLSAcceptance(fingerprint)
                     completionHandler(.useCredential, URLCredential(trust: trust))
                     return
                 }
@@ -310,7 +329,7 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
         }
 
         if systemTrustOk || !self.params.required {
-            self.clearTLSFailure()
+            self.recordTLSAcceptance(fingerprint)
             completionHandler(.useCredential, URLCredential(trust: trust))
         } else {
             self.recordTLSFailure(GatewayTLSValidationFailure(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
@@ -47,4 +47,57 @@ struct ChatInlineWidgetTests {
             surfaceURL: surface,
             target: "/__openclaw__/canvas/documents/%2525252525252525252525252525252525/index.html") == nil)
     }
+
+    @Test func `uses replacement route after capability refresh loses its lease`() async throws {
+        let target = "/__openclaw__/canvas/documents/widget-1/index.html"
+        let oldSurface = "https://gateway.example/__openclaw__/cap/old"
+        let newSurface = "https://gateway.example/__openclaw__/cap/new"
+        let failedURL = try #require(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: oldSurface,
+            target: target))
+        let probe = ChatWidgetReconnectProbe(surfaceURL: oldSurface, replacementURL: newSurface)
+
+        let resolved = await OpenClawChatWidgetURLResolver.resolve(
+            target: target,
+            replacing: failedURL,
+            currentSurfaceURLs: { await probe.current() },
+            refreshNodeSurfaceURL: { observed in await probe.reconnect(observed: observed) })
+
+        #expect(resolved == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
+        #expect(await probe.refreshCount == 1)
+    }
+
+    #if canImport(WebKit) && (os(iOS) || os(macOS))
+    @Test func `bounds WebKit content process recovery per document`() {
+        var recovery = ChatInlineWidgetContentProcessRecovery()
+
+        #expect(recovery.nextAction() == .reload)
+        #expect(recovery.nextAction() == .fail)
+        #expect(recovery.nextAction() == .fail)
+
+        recovery.reset()
+        #expect(recovery.nextAction() == .reload)
+    }
+    #endif
+}
+
+private actor ChatWidgetReconnectProbe {
+    private var surfaceURL: String?
+    private let replacementURL: String
+    private(set) var refreshCount = 0
+
+    init(surfaceURL: String, replacementURL: String) {
+        self.surfaceURL = surfaceURL
+        self.replacementURL = replacementURL
+    }
+
+    func current() -> (node: String?, operatorSurface: String?) {
+        (node: self.surfaceURL, operatorSurface: nil)
+    }
+
+    func reconnect(observed _: String?) -> String? {
+        self.refreshCount += 1
+        self.surfaceURL = self.replacementURL
+        return nil
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
@@ -56,15 +56,18 @@ struct ChatInlineWidgetTests {
         let failedURL = try #require(OpenClawChatWidgetURLResolver.resolve(
             surfaceURL: oldSurface,
             target: target))
-        let probe = ChatWidgetReconnectProbe(surfaceURL: oldSurface, replacementURL: newSurface)
+        let failedResource = OpenClawChatWidgetResource(url: failedURL)
+        let probe = ChatWidgetRouteReconnectProbe(
+            route: GatewayCanvasHostRoute(url: oldSurface, tlsFingerprintSHA256: nil),
+            replacement: GatewayCanvasHostRoute(url: newSurface, tlsFingerprintSHA256: nil))
 
-        let resolved = await OpenClawChatWidgetURLResolver.resolve(
+        let resolved = await OpenClawChatWidgetURLResolver.resolveResource(
             target: target,
-            replacing: failedURL,
-            currentSurfaceURLs: { await probe.current() },
-            refreshNodeSurfaceURL: { observed in await probe.reconnect(observed: observed) })
+            replacing: failedResource,
+            currentSurfaceRoutes: { await probe.current() },
+            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) })
 
-        #expect(resolved == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
+        #expect(resolved?.url == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
         #expect(await probe.refreshCount == 1)
     }
 
@@ -146,27 +149,6 @@ private actor ChatWidgetRouteReconnectProbe {
     func reconnect(observed _: GatewayCanvasHostRoute?) -> GatewayCanvasHostRoute? {
         self.refreshCount += 1
         self.route = self.replacement
-        return nil
-    }
-}
-
-private actor ChatWidgetReconnectProbe {
-    private var surfaceURL: String?
-    private let replacementURL: String
-    private(set) var refreshCount = 0
-
-    init(surfaceURL: String, replacementURL: String) {
-        self.surfaceURL = surfaceURL
-        self.replacementURL = replacementURL
-    }
-
-    func current() -> (node: String?, operatorSurface: String?) {
-        (node: self.surfaceURL, operatorSurface: nil)
-    }
-
-    func reconnect(observed _: String?) -> String? {
-        self.refreshCount += 1
-        self.surfaceURL = self.replacementURL
         return nil
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
@@ -65,7 +65,8 @@ struct ChatInlineWidgetTests {
             target: target,
             replacing: failedResource,
             currentSurfaceRoutes: { await probe.current() },
-            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) })
+            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) },
+            refreshOperatorSurfaceRoute: { _ in nil })
 
         #expect(resolved?.url == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
         #expect(await probe.refreshCount == 1)
@@ -88,7 +89,8 @@ struct ChatInlineWidgetTests {
             target: target,
             replacing: failedResource,
             currentSurfaceRoutes: { await probe.current() },
-            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) })
+            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) },
+            refreshOperatorSurfaceRoute: { _ in nil })
 
         #expect(resolved?.url == failedURL)
         #expect(resolved?.tlsFingerprintSHA256 == newPin)
@@ -113,7 +115,31 @@ struct ChatInlineWidgetTests {
             target: target,
             replacing: failedResource,
             currentSurfaceRoutes: { await probe.current() },
-            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) })
+            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) },
+            refreshOperatorSurfaceRoute: { _ in nil })
+
+        #expect(resolved?.url == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
+        #expect(await probe.refreshCount == 1)
+    }
+
+    @Test func `refreshes the operator capability when the node route is unavailable`() async throws {
+        let target = "/__openclaw__/canvas/documents/widget-1/index.html"
+        let oldSurface = "https://operator.example/__openclaw__/cap/old"
+        let newSurface = "https://operator.example/__openclaw__/cap/new"
+        let failedURL = try #require(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: oldSurface,
+            target: target))
+        let failedResource = OpenClawChatWidgetResource(url: failedURL)
+        let probe = ChatWidgetOperatorRouteRefreshProbe(
+            route: GatewayCanvasHostRoute(url: oldSurface, tlsFingerprintSHA256: nil),
+            replacement: GatewayCanvasHostRoute(url: newSurface, tlsFingerprintSHA256: nil))
+
+        let resolved = await OpenClawChatWidgetURLResolver.resolveResource(
+            target: target,
+            replacing: failedResource,
+            currentSurfaceRoutes: { await probe.current() },
+            refreshNodeSurfaceRoute: { _ in nil },
+            refreshOperatorSurfaceRoute: { observed in await probe.refresh(observed: observed) })
 
         #expect(resolved?.url == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
         #expect(await probe.refreshCount == 1)
@@ -129,7 +155,8 @@ struct ChatInlineWidgetTests {
             target: target,
             replacing: nil,
             currentSurfaceRoutes: { (node: route, operatorSurface: nil) },
-            refreshNodeSurfaceRoute: { _ in nil })
+            refreshNodeSurfaceRoute: { _ in nil },
+            refreshOperatorSurfaceRoute: { _ in nil })
 
         #expect(resolved == nil)
     }
@@ -154,6 +181,27 @@ struct ChatInlineWidgetTests {
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     }
     #endif
+}
+
+private actor ChatWidgetOperatorRouteRefreshProbe {
+    private var route: GatewayCanvasHostRoute
+    private let replacement: GatewayCanvasHostRoute
+    private(set) var refreshCount = 0
+
+    init(route: GatewayCanvasHostRoute, replacement: GatewayCanvasHostRoute) {
+        self.route = route
+        self.replacement = replacement
+    }
+
+    func current() -> (node: GatewayCanvasHostRoute?, operatorSurface: GatewayCanvasHostRoute?) {
+        (node: nil, operatorSurface: self.route)
+    }
+
+    func refresh(observed _: GatewayCanvasHostRoute?) -> GatewayCanvasHostRoute? {
+        self.refreshCount += 1
+        self.route = self.replacement
+        return self.replacement
+    }
 }
 
 private actor ChatWidgetRouteReconnectProbe {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatInlineWidgetTests {
+    @Test func `decodes projected canvas widget block`() throws {
+        let data = Data(
+            #"{"role":"assistant","content":[{"type":"text","text":"Done"},{"type":"canvas","preview":{"kind":"canvas","surface":"assistant_message","render":"url","title":"Status","preferredHeight":240,"url":"/__openclaw__/canvas/documents/widget-1/index.html","sandbox":"scripts"}}]}"#
+                .utf8)
+
+        let message = try JSONDecoder().decode(OpenClawChatMessage.self, from: data)
+        let preview = try #require(message.content.last?.preview)
+        #expect(preview.inlineWidgetPath == "/__openclaw__/canvas/documents/widget-1/index.html")
+        #expect(preview.inlineWidgetHeight == 240)
+
+        let unsafe = OpenClawChatCanvasPreview(
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            title: nil,
+            preferredHeight: nil,
+            url: "https://attacker.example/widget.html",
+            viewId: nil,
+            sandbox: "scripts")
+        #expect(unsafe.inlineWidgetPath == nil)
+    }
+
+    @Test func `resolves only capability scoped widget documents`() {
+        let surface = "https://gateway.example/__openclaw__/cap/token"
+        let target = "/__openclaw__/canvas/documents/widget-1/index.html"
+
+        #expect(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: surface,
+            target: target)?.absoluteString ==
+            "https://gateway.example/__openclaw__/cap/token/__openclaw__/canvas/documents/widget-1/index.html")
+        #expect(OpenClawChatWidgetURLResolver.resolve(surfaceURL: "https://gateway.example", target: target) == nil)
+        #expect(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: surface,
+            target: "https://attacker.example/widget.html") == nil)
+        #expect(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/a2ui/index.html") == nil)
+        #expect(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/canvas/documents/%252e%252e/index.html") == nil)
+        #expect(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/canvas/documents/%2525252525252525252525252525252525/index.html") == nil)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
@@ -49,6 +49,18 @@ struct ChatInlineWidgetTests {
             target: "/__openclaw__/canvas/documents/%2525252525252525252525252525252525/index.html") == nil)
     }
 
+    @Test func `resource equality ignores internal recovery metadata`() throws {
+        let url = try #require(URL(string: "https://gateway.example/widget"))
+        let publicResource = OpenClawChatWidgetResource(url: url)
+        let trackedResource = OpenClawChatWidgetResource(
+            url: url,
+            tlsFingerprintSHA256: nil,
+            surfaceRole: .node,
+            attemptedSurfaceRoles: [.node])
+
+        #expect(publicResource == trackedResource)
+    }
+
     @Test func `uses replacement route after capability refresh loses its lease`() async throws {
         let target = "/__openclaw__/canvas/documents/widget-1/index.html"
         let oldSurface = "https://gateway.example/__openclaw__/cap/old"
@@ -72,22 +84,26 @@ struct ChatInlineWidgetTests {
         #expect(await probe.refreshCount == 1)
     }
 
-    @Test func `accepts a same URL widget route when its TLS pin changed`() async throws {
+    @Test func `accepts a same URL widget route when it acquires a TLS pin`() async throws {
         let target = "/__openclaw__/canvas/documents/widget-1/index.html"
         let surface = "https://gateway.example/__openclaw__/cap/token"
-        let oldPin = String(repeating: "aa", count: 32)
         let newPin = String(repeating: "bb", count: 32)
         let failedURL = try #require(OpenClawChatWidgetURLResolver.resolve(
             surfaceURL: surface,
             target: target))
-        let failedResource = OpenClawChatWidgetResource(url: failedURL, tlsFingerprintSHA256: oldPin)
         let probe = ChatWidgetRouteReconnectProbe(
-            route: GatewayCanvasHostRoute(url: surface, tlsFingerprintSHA256: oldPin),
+            route: GatewayCanvasHostRoute(url: surface, tlsFingerprintSHA256: nil),
             replacement: GatewayCanvasHostRoute(url: surface, tlsFingerprintSHA256: newPin))
+        let initialResource = await OpenClawChatWidgetURLResolver.resolveResource(
+            target: target,
+            replacing: nil,
+            currentSurfaceRoutes: { await probe.current() },
+            refreshNodeSurfaceRoute: { _ in nil },
+            refreshOperatorSurfaceRoute: { _ in nil })
 
         let resolved = await OpenClawChatWidgetURLResolver.resolveResource(
             target: target,
-            replacing: failedResource,
+            replacing: initialResource,
             currentSurfaceRoutes: { await probe.current() },
             refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) },
             refreshOperatorSurfaceRoute: { _ in nil })
@@ -97,28 +113,41 @@ struct ChatInlineWidgetTests {
         #expect(await probe.refreshCount == 1)
     }
 
-    @Test func `refreshes node before trying the operator fallback`() async throws {
+    @Test func `refreshes node once before trying the operator fallback`() async {
         let target = "/__openclaw__/canvas/documents/widget-1/index.html"
         let oldSurface = "https://gateway.example/__openclaw__/cap/old"
         let newSurface = "https://gateway.example/__openclaw__/cap/new"
         let fallbackSurface = "https://operator.example/__openclaw__/cap/fallback"
-        let failedURL = try #require(OpenClawChatWidgetURLResolver.resolve(
-            surfaceURL: oldSurface,
-            target: target))
-        let failedResource = OpenClawChatWidgetResource(url: failedURL)
         let probe = ChatWidgetRouteReconnectProbe(
             route: GatewayCanvasHostRoute(url: oldSurface, tlsFingerprintSHA256: nil),
             replacement: GatewayCanvasHostRoute(url: newSurface, tlsFingerprintSHA256: nil),
             operatorRoute: GatewayCanvasHostRoute(url: fallbackSurface, tlsFingerprintSHA256: nil))
-
-        let resolved = await OpenClawChatWidgetURLResolver.resolveResource(
+        let initialNode = await OpenClawChatWidgetURLResolver.resolveResource(
             target: target,
-            replacing: failedResource,
+            replacing: nil,
+            currentSurfaceRoutes: { await probe.current() },
+            refreshNodeSurfaceRoute: { _ in nil },
+            refreshOperatorSurfaceRoute: { _ in nil })
+
+        let refreshedNode = await OpenClawChatWidgetURLResolver.resolveResource(
+            target: target,
+            replacing: initialNode,
             currentSurfaceRoutes: { await probe.current() },
             refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) },
             refreshOperatorSurfaceRoute: { _ in nil })
 
-        #expect(resolved?.url == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
+        #expect(refreshedNode?.url == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
+
+        let fallback = await OpenClawChatWidgetURLResolver.resolveResource(
+            target: target,
+            replacing: refreshedNode,
+            currentSurfaceRoutes: { await probe.current() },
+            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) },
+            refreshOperatorSurfaceRoute: { _ in nil })
+
+        #expect(fallback?.url == OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: fallbackSurface,
+            target: target))
         #expect(await probe.refreshCount == 1)
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClawChatUI
 
@@ -67,6 +68,45 @@ struct ChatInlineWidgetTests {
         #expect(await probe.refreshCount == 1)
     }
 
+    @Test func `accepts a same URL widget route when its TLS pin changed`() async throws {
+        let target = "/__openclaw__/canvas/documents/widget-1/index.html"
+        let surface = "https://gateway.example/__openclaw__/cap/token"
+        let oldPin = String(repeating: "aa", count: 32)
+        let newPin = String(repeating: "bb", count: 32)
+        let failedURL = try #require(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: surface,
+            target: target))
+        let failedResource = OpenClawChatWidgetResource(url: failedURL, tlsFingerprintSHA256: oldPin)
+        let probe = ChatWidgetRouteReconnectProbe(
+            route: GatewayCanvasHostRoute(url: surface, tlsFingerprintSHA256: oldPin),
+            replacement: GatewayCanvasHostRoute(url: surface, tlsFingerprintSHA256: newPin))
+
+        let resolved = await OpenClawChatWidgetURLResolver.resolveResource(
+            target: target,
+            replacing: failedResource,
+            currentSurfaceRoutes: { await probe.current() },
+            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) })
+
+        #expect(resolved?.url == failedURL)
+        #expect(resolved?.tlsFingerprintSHA256 == newPin)
+        #expect(await probe.refreshCount == 1)
+    }
+
+    @Test func `rejects a TLS pin on a cleartext widget route`() async {
+        let target = "/__openclaw__/canvas/documents/widget-1/index.html"
+        let route = GatewayCanvasHostRoute(
+            url: "http://gateway.example/__openclaw__/cap/token",
+            tlsFingerprintSHA256: String(repeating: "aa", count: 32))
+
+        let resolved = await OpenClawChatWidgetURLResolver.resolveResource(
+            target: target,
+            replacing: nil,
+            currentSurfaceRoutes: { (node: route, operatorSurface: nil) },
+            refreshNodeSurfaceRoute: { _ in nil })
+
+        #expect(resolved == nil)
+    }
+
     #if canImport(WebKit) && (os(iOS) || os(macOS))
     @Test func `bounds WebKit content process recovery per document`() {
         var recovery = ChatInlineWidgetContentProcessRecovery()
@@ -78,7 +118,36 @@ struct ChatInlineWidgetTests {
         recovery.reset()
         #expect(recovery.nextAction() == .reload)
     }
+
+    @Test func `normalizes exact SHA-256 widget certificate pins`() {
+        let fingerprint = String(repeating: "aB", count: 32)
+        #expect(ChatInlineWidgetTLSPin.normalize("SHA-256: \(fingerprint)") == fingerprint.lowercased())
+        #expect(ChatInlineWidgetTLSPin.normalize("abc") == nil)
+        #expect(ChatInlineWidgetTLSPin.fingerprint(certificateData: Data("abc".utf8)) ==
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+    }
     #endif
+}
+
+private actor ChatWidgetRouteReconnectProbe {
+    private var route: GatewayCanvasHostRoute?
+    private let replacement: GatewayCanvasHostRoute
+    private(set) var refreshCount = 0
+
+    init(route: GatewayCanvasHostRoute, replacement: GatewayCanvasHostRoute) {
+        self.route = route
+        self.replacement = replacement
+    }
+
+    func current() -> (node: GatewayCanvasHostRoute?, operatorSurface: GatewayCanvasHostRoute?) {
+        (node: self.route, operatorSurface: nil)
+    }
+
+    func reconnect(observed _: GatewayCanvasHostRoute?) -> GatewayCanvasHostRoute? {
+        self.refreshCount += 1
+        self.route = self.replacement
+        return nil
+    }
 }
 
 private actor ChatWidgetReconnectProbe {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineWidgetTests.swift
@@ -95,6 +95,30 @@ struct ChatInlineWidgetTests {
         #expect(await probe.refreshCount == 1)
     }
 
+    @Test func `refreshes node before trying the operator fallback`() async throws {
+        let target = "/__openclaw__/canvas/documents/widget-1/index.html"
+        let oldSurface = "https://gateway.example/__openclaw__/cap/old"
+        let newSurface = "https://gateway.example/__openclaw__/cap/new"
+        let fallbackSurface = "https://operator.example/__openclaw__/cap/fallback"
+        let failedURL = try #require(OpenClawChatWidgetURLResolver.resolve(
+            surfaceURL: oldSurface,
+            target: target))
+        let failedResource = OpenClawChatWidgetResource(url: failedURL)
+        let probe = ChatWidgetRouteReconnectProbe(
+            route: GatewayCanvasHostRoute(url: oldSurface, tlsFingerprintSHA256: nil),
+            replacement: GatewayCanvasHostRoute(url: newSurface, tlsFingerprintSHA256: nil),
+            operatorRoute: GatewayCanvasHostRoute(url: fallbackSurface, tlsFingerprintSHA256: nil))
+
+        let resolved = await OpenClawChatWidgetURLResolver.resolveResource(
+            target: target,
+            replacing: failedResource,
+            currentSurfaceRoutes: { await probe.current() },
+            refreshNodeSurfaceRoute: { observed in await probe.reconnect(observed: observed) })
+
+        #expect(resolved?.url == OpenClawChatWidgetURLResolver.resolve(surfaceURL: newSurface, target: target))
+        #expect(await probe.refreshCount == 1)
+    }
+
     @Test func `rejects a TLS pin on a cleartext widget route`() async {
         let target = "/__openclaw__/canvas/documents/widget-1/index.html"
         let route = GatewayCanvasHostRoute(
@@ -135,15 +159,21 @@ struct ChatInlineWidgetTests {
 private actor ChatWidgetRouteReconnectProbe {
     private var route: GatewayCanvasHostRoute?
     private let replacement: GatewayCanvasHostRoute
+    private let operatorRoute: GatewayCanvasHostRoute?
     private(set) var refreshCount = 0
 
-    init(route: GatewayCanvasHostRoute, replacement: GatewayCanvasHostRoute) {
+    init(
+        route: GatewayCanvasHostRoute,
+        replacement: GatewayCanvasHostRoute,
+        operatorRoute: GatewayCanvasHostRoute? = nil)
+    {
         self.route = route
         self.replacement = replacement
+        self.operatorRoute = operatorRoute
     }
 
     func current() -> (node: GatewayCanvasHostRoute?, operatorSurface: GatewayCanvasHostRoute?) {
-        (node: self.route, operatorSurface: nil)
+        (node: self.route, operatorSurface: self.operatorRoute)
     }
 
     func reconnect(observed _: GatewayCanvasHostRoute?) -> GatewayCanvasHostRoute? {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -685,7 +685,7 @@ struct GatewayNodeSessionTests {
             includeDeviceIdentity: false)
 
         try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
+            url: #require(URL(string: "wss://gateway.example.invalid")),
             connectOptions: options,
             sessionBox: WebSocketSessionBox(session: session),
             onConnected: {},
@@ -3373,6 +3373,25 @@ struct GatewayNodeSessionTests {
             against: URL(string: "wss://gateway.example.com:7443"))
 
         #expect(normalized == "https://gateway.example.com:7443/__openclaw__/cap/token")
+    }
+
+    @Test
+    func `gateway TLS pin applies only to the same canvas endpoint`() {
+        let fingerprint = String(repeating: "ab", count: 32)
+        let gateway = URL(string: "wss://gateway.example.com:7443")
+
+        #expect(GatewayPluginSurfaceURL.tlsFingerprintForSurface(
+            fingerprint,
+            surfaceURL: "https://gateway.example.com:7443/__openclaw__/cap/token",
+            gatewayURL: gateway) == fingerprint)
+        #expect(GatewayPluginSurfaceURL.tlsFingerprintForSurface(
+            fingerprint,
+            surfaceURL: "https://canvas.example.com:7443/__openclaw__/cap/token",
+            gatewayURL: gateway) == nil)
+        #expect(GatewayPluginSurfaceURL.tlsFingerprintForSurface(
+            fingerprint,
+            surfaceURL: "https://gateway.example.com:9443/__openclaw__/cap/token",
+            gatewayURL: gateway) == nil)
     }
 
     @Test

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -679,7 +679,7 @@ struct GatewayNodeSessionTests {
         await gateway.disconnect()
     }
 
-    @Test func `timed out surface caller does not start another rotation`() async throws {
+    @Test func `timed out surface caller does not cancel rotation with longer waiter`() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()
         let options = GatewayConnectOptions(
@@ -701,11 +701,11 @@ struct GatewayNodeSessionTests {
             onDisconnected: { _ in },
             onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
 
-        async let longWait = gateway.refreshCanvasHostUrl(replacing: nil)
         async let shortWait = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
         try await waitUntil("single surface refresh sent") {
             session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
         }
+        async let longWait = gateway.refreshCanvasHostUrl(replacing: nil)
         let shortValue = await shortWait
         #expect(shortValue == nil)
 
@@ -729,10 +729,9 @@ struct GatewayNodeSessionTests {
         await gateway.disconnect()
     }
 
-    @Test func `stalled surface rotation releases for retry after operation timeout`() async throws {
+    @Test func `last timed out surface waiter releases stalled rotation for retry`() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()
-        await gateway._test_setPluginSurfaceRefreshOperationTimeoutMs(200)
         let options = GatewayConnectOptions(
             role: "node",
             scopes: [],
@@ -754,6 +753,55 @@ struct GatewayNodeSessionTests {
 
         let first = await gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
         #expect(first == nil)
+
+        async let retry = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
+        let task = try #require(session.latestTask())
+        try await waitUntil("second surface refresh sent") {
+            task.sentRequestCount(method: "node.pluginSurface.refresh") == 2
+        }
+        let request = try #require(task.sentRequests(method: "node.pluginSurface.refresh").last)
+        try task.emitResponse(
+            id: #require(request["id"] as? String),
+            payload: [
+                "surface": "canvas",
+                "pluginSurfaceUrls": [
+                    "canvas": "http://gateway.example.invalid/__openclaw__/cap/retry-token",
+                ],
+            ])
+
+        let retryValue = await retry
+        #expect(retryValue?.hasSuffix("/retry-token") == true)
+        await gateway.disconnect()
+    }
+
+    @Test func `cancelled unbounded surface waiter releases stalled rotation for retry`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["canvas"],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+
+        let stalled = Task { await gateway.refreshCanvasHostUrl(timeoutSeconds: 0) }
+        try await waitUntil("first surface refresh sent") {
+            session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
+        }
+        stalled.cancel()
+        #expect(await stalled.value == nil)
 
         async let retry = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
         let task = try #require(session.latestTask())
@@ -818,6 +866,8 @@ struct GatewayNodeSessionTests {
             task.sentRequestCount(method: "node.pluginSurface.refresh") == 2
         }
         let rotateRequest = try #require(task.sentRequests(method: "node.pluginSurface.refresh").last)
+        let rotateParams = try #require(rotateRequest["params"] as? [String: Any])
+        #expect(rotateParams["observedUrl"] as? String == oldURL)
         try task.emitResponse(
             id: #require(rotateRequest["id"] as? String),
             payload: [

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -419,7 +419,9 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     }
 }
 
-private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked Sendable {
+private final class FakeGatewayWebSocketSession: WebSocketSessioning, GatewayTLSRouteMetadataProviding,
+    @unchecked Sendable
+{
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
     private let helloMethods: [String]
@@ -427,6 +429,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
     private let helloDelayNanoseconds: UInt64
     private let connectError: [String: Any]?
     private let cancelGate: FirstCancelGate?
+    let effectiveTLSFingerprintSHA256: String?
     private var tasks: [FakeGatewayWebSocketTask] = []
     private var requests: [URLRequest] = []
     private var makeCount = 0
@@ -437,7 +440,8 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
         helloSessionDefaults: [String: Any]? = nil,
         helloDelayNanoseconds: UInt64 = 0,
         connectError: [String: Any]? = nil,
-        cancelGate: FirstCancelGate? = nil)
+        cancelGate: FirstCancelGate? = nil,
+        effectiveTLSFingerprintSHA256: String? = nil)
     {
         self.helloAuth = helloAuth
         self.helloMethods = helloMethods
@@ -445,6 +449,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
         self.helloDelayNanoseconds = helloDelayNanoseconds
         self.connectError = connectError
         self.cancelGate = cancelGate
+        self.effectiveTLSFingerprintSHA256 = effectiveTLSFingerprintSHA256
     }
 
     func snapshotMakeCount() -> Int {
@@ -623,7 +628,8 @@ private func nodeInvokePush(id: String, command: String) -> GatewayPush {
 @Suite(.serialized)
 struct GatewayNodeSessionTests {
     @Test func `canvas surface refresh is shared across callers with different timeouts`() async throws {
-        let session = FakeGatewayWebSocketSession()
+        let expectedFingerprint = String(repeating: "ab", count: 32)
+        let session = FakeGatewayWebSocketSession(effectiveTLSFingerprintSHA256: expectedFingerprint)
         let gateway = GatewayNodeSession()
         let options = GatewayConnectOptions(
             role: "node",
@@ -667,6 +673,9 @@ struct GatewayNodeSessionTests {
         #expect(values.0 == values.2)
         #expect(values.0?.hasSuffix("/new-token") == true)
         #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
+        let route = try #require(await gateway.currentCanvasHostRoute())
+        #expect(route.url == values.0)
+        #expect(route.tlsFingerprintSHA256 == expectedFingerprint)
         await gateway.disconnect()
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -622,7 +622,7 @@ private func nodeInvokePush(id: String, command: String) -> GatewayPush {
 
 @Suite(.serialized)
 struct GatewayNodeSessionTests {
-    @Test func `canvas surface refresh is shared across concurrent callers`() async throws {
+    @Test func `canvas surface refresh is shared across callers with different timeouts`() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()
         let options = GatewayConnectOptions(
@@ -645,8 +645,8 @@ struct GatewayNodeSessionTests {
             onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
 
         async let first = gateway.refreshCanvasHostUrl(replacing: nil)
-        async let second = gateway.refreshCanvasHostUrl(timeoutSeconds: 8)
-        async let third = gateway.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: 8)
+        async let second = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
+        async let third = gateway.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: 2)
         try await waitUntil("single surface refresh sent") {
             session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
         }
@@ -667,6 +667,102 @@ struct GatewayNodeSessionTests {
         #expect(values.0 == values.2)
         #expect(values.0?.hasSuffix("/new-token") == true)
         #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
+        await gateway.disconnect()
+    }
+
+    @Test func `timed out surface caller does not start another rotation`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["canvas"],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+
+        async let longWait = gateway.refreshCanvasHostUrl(replacing: nil)
+        async let shortWait = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
+        try await waitUntil("single surface refresh sent") {
+            session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
+        }
+        let shortValue = await shortWait
+        #expect(shortValue == nil)
+
+        async let joinedWait = gateway.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: 8)
+        let task = try #require(session.latestTask())
+        #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
+        let request = try #require(task.sentRequests(method: "node.pluginSurface.refresh").first)
+        try task.emitResponse(
+            id: #require(request["id"] as? String),
+            payload: [
+                "surface": "canvas",
+                "pluginSurfaceUrls": [
+                    "canvas": "http://gateway.example.invalid/__openclaw__/cap/new-token",
+                ],
+            ])
+
+        let values = await (longWait, joinedWait)
+        #expect(values.0 == values.1)
+        #expect(values.0?.hasSuffix("/new-token") == true)
+        #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
+        await gateway.disconnect()
+    }
+
+    @Test func `stalled surface rotation releases for retry after operation timeout`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        await gateway._test_setPluginSurfaceRefreshOperationTimeoutMs(200)
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["canvas"],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+
+        let first = await gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
+        #expect(first == nil)
+
+        async let retry = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
+        let task = try #require(session.latestTask())
+        try await waitUntil("second surface refresh sent") {
+            task.sentRequestCount(method: "node.pluginSurface.refresh") == 2
+        }
+        let request = try #require(task.sentRequests(method: "node.pluginSurface.refresh").last)
+        try task.emitResponse(
+            id: #require(request["id"] as? String),
+            payload: [
+                "surface": "canvas",
+                "pluginSurfaceUrls": [
+                    "canvas": "http://gateway.example.invalid/__openclaw__/cap/retry-token",
+                ],
+            ])
+
+        let retryValue = await retry
+        #expect(retryValue?.hasSuffix("/retry-token") == true)
         await gateway.disconnect()
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -301,6 +301,24 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
             idempotencyKey: idempotencyKey))))
     }
 
+    func emitResponse(id: String, payload: [String: Any]) {
+        let handler = self.lock.withLock { () -> (@Sendable (Result<
+            URLSessionWebSocketTask.Message,
+            Error,
+        >) -> Void)? in
+            defer { self.pendingReceiveHandler = nil }
+            return self.pendingReceiveHandler
+        }
+        let frame: [String: Any] = [
+            "type": "res",
+            "id": id,
+            "ok": true,
+            "payload": payload,
+        ]
+        let data = (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
+        handler?(.success(.data(data)))
+    }
+
     private static func connectChallengeData(nonce: String) -> Data {
         let frame: [String: Any] = [
             "type": "event",
@@ -604,6 +622,112 @@ private func nodeInvokePush(id: String, command: String) -> GatewayPush {
 
 @Suite(.serialized)
 struct GatewayNodeSessionTests {
+    @Test func `canvas surface refresh is shared across concurrent callers`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["canvas"],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+
+        async let first = gateway.refreshCanvasHostUrl(replacing: nil)
+        async let second = gateway.refreshCanvasHostUrl(replacing: nil)
+        try await waitUntil("single surface refresh sent") {
+            session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
+        }
+        let task = try #require(session.latestTask())
+        let request = try #require(task.sentRequests(method: "node.pluginSurface.refresh").first)
+        let requestID = try #require(request["id"] as? String)
+        task.emitResponse(
+            id: requestID,
+            payload: [
+                "surface": "canvas",
+                "pluginSurfaceUrls": [
+                    "canvas": "http://gateway.example.invalid/__openclaw__/cap/new-token",
+                ],
+            ])
+
+        let values = await (first, second)
+        #expect(values.0 == values.1)
+        #expect(values.0?.hasSuffix("/new-token") == true)
+        #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
+        await gateway.disconnect()
+    }
+
+    @Test func `lagging canvas refresh reuses the rotated capability`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["canvas"],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+
+        async let seeded = gateway.refreshCanvasHostUrl(replacing: nil)
+        try await waitUntil("seed surface refresh sent") {
+            session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
+        }
+        let task = try #require(session.latestTask())
+        let seedRequest = try #require(task.sentRequests(method: "node.pluginSurface.refresh").first)
+        try task.emitResponse(
+            id: #require(seedRequest["id"] as? String),
+            payload: [
+                "surface": "canvas",
+                "pluginSurfaceUrls": [
+                    "canvas": "http://gateway.example.invalid/__openclaw__/cap/old-token",
+                ],
+            ])
+        let oldURL = try #require(await seeded)
+
+        async let rotated = gateway.refreshCanvasHostUrl(replacing: oldURL)
+        try await waitUntil("rotating surface refresh sent") {
+            task.sentRequestCount(method: "node.pluginSurface.refresh") == 2
+        }
+        let rotateRequest = try #require(task.sentRequests(method: "node.pluginSurface.refresh").last)
+        try task.emitResponse(
+            id: #require(rotateRequest["id"] as? String),
+            payload: [
+                "surface": "canvas",
+                "pluginSurfaceUrls": [
+                    "canvas": "http://gateway.example.invalid/__openclaw__/cap/new-token",
+                ],
+            ])
+        let newURL = try #require(await rotated)
+
+        let laggingURL = await gateway.refreshCanvasHostUrl(replacing: oldURL)
+
+        #expect(laggingURL == newURL)
+        #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 2)
+        await gateway.disconnect()
+    }
+
     @Test func `node requests preserve numeric JSON params`() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -645,7 +645,8 @@ struct GatewayNodeSessionTests {
             onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
 
         async let first = gateway.refreshCanvasHostUrl(replacing: nil)
-        async let second = gateway.refreshCanvasHostUrl(replacing: nil)
+        async let second = gateway.refreshCanvasHostUrl(timeoutSeconds: 8)
+        async let third = gateway.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: 8)
         try await waitUntil("single surface refresh sent") {
             session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
         }
@@ -661,8 +662,9 @@ struct GatewayNodeSessionTests {
                 ],
             ])
 
-        let values = await (first, second)
+        let values = await (first, second, third)
         #expect(values.0 == values.1)
+        #expect(values.0 == values.2)
         #expect(values.0?.hasSuffix("/new-token") == true)
         #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
         await gateway.disconnect()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -3359,18 +3359,18 @@ struct GatewayNodeSessionTests {
 
     @Test
     func `normalize canvas host url preserves explicit secure canvas port`() {
-        let normalized = canonicalizeCanvasHostUrl(
+        let normalized = GatewayPluginSurfaceURL.canonicalize(
             raw: "https://canvas.example.com:9443/__openclaw__/cap/token",
-            activeURL: URL(string: "wss://gateway.example.com"))
+            against: URL(string: "wss://gateway.example.com"))
 
         #expect(normalized == "https://canvas.example.com:9443/__openclaw__/cap/token")
     }
 
     @Test
     func `normalize canvas host url backfills gateway host for loopback canvas`() {
-        let normalized = canonicalizeCanvasHostUrl(
+        let normalized = GatewayPluginSurfaceURL.canonicalize(
             raw: "http://127.0.0.1:18789/__openclaw__/cap/token",
-            activeURL: URL(string: "wss://gateway.example.com:7443"))
+            against: URL(string: "wss://gateway.example.com:7443"))
 
         #expect(normalized == "https://gateway.example.com:7443/__openclaw__/cap/token")
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -627,6 +627,48 @@ private func nodeInvokePush(id: String, command: String) -> GatewayPush {
 
 @Suite(.serialized)
 struct GatewayNodeSessionTests {
+    @Test func `operator canvas refresh uses the operator surface method`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "operator",
+            scopes: ["operator.read"],
+            caps: [OpenClawGatewayClientCapability.inlineWidgets],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios",
+            clientMode: "ui",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+
+        async let refreshed = gateway.refreshCanvasHostUrl(replacing: nil)
+        try await waitUntil("operator surface refresh sent") {
+            session.latestTask()?.sentRequestCount(method: "plugin.surface.refresh") == 1
+        }
+        let task = try #require(session.latestTask())
+        let request = try #require(task.sentRequests(method: "plugin.surface.refresh").first)
+        try task.emitResponse(
+            id: #require(request["id"] as? String),
+            payload: [
+                "surface": "canvas",
+                "pluginSurfaceUrls": [
+                    "canvas": "http://gateway.example.invalid/__openclaw__/cap/operator-token",
+                ],
+            ])
+
+        #expect(await refreshed?.hasSuffix("/operator-token") == true)
+        #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 0)
+        await gateway.disconnect()
+    }
+
     @Test func `canvas surface refresh is shared across callers with different timeouts`() async throws {
         let expectedFingerprint = String(repeating: "ab", count: 32)
         let session = FakeGatewayWebSocketSession(effectiveTLSFingerprintSHA256: expectedFingerprint)

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -109,7 +109,7 @@ for contract details.
 Common plugin-provided tools include:
 
 - [Diffs](/tools/diffs) for rendering file and markdown diffs
-- [Show widget](/tools/show-widget) for self-contained inline SVG and HTML in web chat
+- [Show widget](/tools/show-widget) for self-contained inline SVG and HTML in supported chat clients
 - [LLM Task](/tools/llm-task) for JSON-only workflow steps
 - [Lobster](/tools/lobster) for typed workflows with resumable approvals
 - [Tokenjuice](/tools/tokenjuice) for compacting noisy `exec` and `bash` tool

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -1,27 +1,27 @@
 ---
-summary: "Show self-contained HTML widgets on the current chat surface"
+summary: "Show self-contained HTML widgets on supported chat surfaces"
 title: "Show widget"
 sidebarTitle: "Show widget"
 read_when:
-  - You want an agent to render an interactive result in web chat or Discord
+  - You want an agent to render an interactive result in web chat, a native app, or Discord
   - You want widget buttons to send follow-up prompts into the chat
   - You need the show_widget input, security, or retention contract
 ---
 
-`show_widget` shows a self-contained HTML widget on the user's current surface. In the Control UI, the Canvas plugin renders it inline in the chat transcript. In a Discord session with [Activities](/channels/discord-activities) enabled, the Discord plugin posts an **Open widget** button that launches it as an Activity.
+`show_widget` shows a self-contained HTML widget on the user's current surface. The Canvas plugin renders it inline in the Control UI, iOS, Android, and macOS chat transcripts; Linux uses the browser Control UI. In a Discord session with [Activities](/channels/discord-activities) enabled, the Discord plugin posts an **Open widget** button that launches it as an Activity.
 
 ## How widgets work
 
-When the agent calls `show_widget`, the Canvas plugin wraps `widget_code` in a minimal HTML document, stores it as a Canvas document, and returns a preview handle. Web chat renders that handle as a sandboxed iframe directly under the tool call and restores it after history reload.
+When the agent calls `show_widget`, the Canvas plugin wraps `widget_code` in a minimal HTML document, stores it as a Canvas document, and returns a preview handle. The Control UI renders that handle as a sandboxed iframe directly under the tool call, while native apps use an isolated web view. Both restore the widget after history reload.
 
-The wrapper document injects two small host bridges around the widget code:
+For browser embedding, the wrapper document injects two small host bridges around the widget code:
 
 - A size reporter posts the rendered content height to the embedding chat, which clamps it and fits the iframe (160 to 1200 pixels).
 - A prompt bridge defines a global `sendPrompt(text)` function that widget scripts can call to submit a follow-up message into the chat. The bridge creates a private message channel and offers one endpoint to the chat before any widget code runs; the chat adopts only that first offer. See [Interactive widgets](#interactive-widgets).
 
 Everything else stays inside the frame: the document runs in an opaque origin with a strict Content Security Policy, so widget scripts cannot reach the Control UI, the Gateway, or the network.
 
-The Canvas implementation is available only when the originating Gateway client declares the `inline-widgets` capability. The Control UI declares this capability automatically. The Discord implementation is available only in Discord sessions with Activities configured. Other channel runs do not receive `show_widget`.
+The Canvas implementation is available only when the originating Gateway client declares the `inline-widgets` capability. The Control UI and supported native apps declare this capability automatically. The Discord implementation is available only in Discord sessions with Activities configured. Other channel runs do not receive `show_widget`.
 
 Capability transport covers embedded, Codex app-server, and CLI-backed model backends. Grant-authenticated MCP callers and direct HTTP tool-invoke callers remain fail closed because they do not declare client capabilities.
 
@@ -34,18 +34,18 @@ Both implementations use the same required fields:
 </ParamField>
 
 <ParamField path="widget_code" type="string" required>
-  Self-contained HTML or SVG. In the Control UI, input beginning with `<svg` after trimming is rendered in SVG mode; maximum length is 262,144 characters. Discord accepts a complete HTML document or body fragment up to 48 KiB.
+  Self-contained HTML or SVG. For Canvas-backed clients, input beginning with `<svg` after trimming is rendered in SVG mode; maximum length is 262,144 characters. Discord accepts a complete HTML document or body fragment up to 48 KiB.
 </ParamField>
 
 Discord also accepts optional `button_label` text for the Activity launch button. The Canvas schema intentionally omits this Discord-only field.
 
-The Control UI result includes a Canvas preview handle, so web chat renders the widget directly from the tool call and restores it after history reload. Discord returns the stored widget and posted-message identifiers.
+The Canvas result includes a preview handle, so the Control UI and supported native apps render the widget directly from the tool call and restore it after history reload. Discord returns the stored widget and posted-message identifiers.
 
 `discord_widget` remains registered as a deprecated alias for one release. New agent calls should use `show_widget`.
 
 ## Interactive widgets
 
-Widget scripts can drive the conversation. The wrapper document defines a global `sendPrompt(text)` function; calling it submits `text` to the chat as if the user had typed and sent the message. Wire it to buttons or other controls to build interactive flows such as pickers, quizzes, or drill-down dashboards:
+In the Control UI, widget scripts can drive the conversation. The wrapper document defines a global `sendPrompt(text)` function; calling it submits `text` to the chat as if the user had typed and sent the message. Wire it to buttons or other controls to build interactive flows such as pickers, quizzes, or drill-down dashboards. Native apps render interactive widget code but do not expose this chat prompt bridge.
 
 ```html
 <button onclick="sendPrompt('Show the failing tests in detail')">Failing tests</button>
@@ -66,7 +66,7 @@ Accepted prompts appear in the transcript as regular user messages and start a n
 
 Widget documents use restrictive Content Security Policies. Inline style and script are allowed, while external fetches and resource loads are blocked. Keep all markup, styles, scripts, and image data inside `widget_code`.
 
-The iframe always omits `allow-same-origin`, even when the Control UI's global embed mode is `trusted`, so widget scripts cannot read the parent application origin. The Canvas host also serves widget documents with a `Content-Security-Policy: sandbox allow-scripts` response header, so opening the hosted URL directly still runs the widget in an opaque origin instead of the Control UI origin. Browser sandboxing does not prevent a script from navigating its own iframe; only render widget code you are willing to execute in that isolated frame.
+The Control UI iframe always omits `allow-same-origin`, even when the global embed mode is `trusted`, so widget scripts cannot read the parent application origin. Native clients use isolated, nonpersistent web views and block navigation away from the hosted widget. The Canvas host also serves widget documents with a `Content-Security-Policy: sandbox allow-scripts` response header, so direct rendering still runs the widget in an opaque origin instead of an application origin. Only render widget code you are willing to execute in that isolated frame.
 
 The iframe also follows [`gateway.controlUi.embedSandbox`](/web/control-ui#hosted-embeds). The default `scripts` tier supports interactive widgets while preserving origin isolation.
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -463,7 +463,7 @@ Web Push is independent of the iOS APNS relay path (see [Configuration](/gateway
 
 Assistant messages can render hosted web content inline with the `[embed ...]` shortcode. The iframe sandbox policy is controlled by `gateway.controlUi.embedSandbox`:
 
-The bundled Canvas plugin provides [`show_widget`](/tools/show-widget) to render self-contained SVG or HTML directly from a tool call. The browser advertises the `inline-widgets` Gateway capability, and the resulting Canvas document remains available when chat history reloads. Discord Activities provide the same tool name on Discord; other channel-originated runs do not receive it.
+The bundled Canvas plugin provides [`show_widget`](/tools/show-widget) to render self-contained SVG or HTML directly from a tool call. The browser and supported native chat clients advertise the `inline-widgets` Gateway capability, and the resulting Canvas document remains available when chat history reloads. Discord Activities provide the same tool name on Discord; other channel-originated runs do not receive it.
 
 <Tabs>
   <Tab title="strict">

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -65,7 +65,7 @@ function createLazyShowWidgetTool(params: {
     label: "Show Widget",
     name: "show_widget",
     description:
-      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data. A global sendPrompt(text) function submits text to the chat as if the user typed it — wire it to buttons or controls to build interactive widgets. It only works after the user clicks inside the widget (plain conversational text only; slash commands are rejected), so never call it automatically.",
+      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data. In web chat, a global sendPrompt(text) function submits text to the chat as if the user typed it — wire it to buttons or controls to build interactive widgets. It only works after the user clicks inside the widget (plain conversational text only; slash commands are rejected), so never call it automatically.",
     parameters: ShowWidgetToolSchema,
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>

--- a/extensions/canvas/src/tool-schema.ts
+++ b/extensions/canvas/src/tool-schema.ts
@@ -26,7 +26,7 @@ const CANVAS_SNAPSHOT_FORMATS = ["png", "jpg", "jpeg"] as const;
 /** Gateway capability required for inline transcript widgets. */
 export const SHOW_WIDGET_REQUIRED_CLIENT_CAPS = ["inline-widgets"];
 
-/** TypeBox schema for inline web chat widgets. */
+/** TypeBox schema for inline chat widgets. */
 export const ShowWidgetToolSchema = Type.Object({
   title: Type.String(),
   widget_code: Type.String(),

--- a/extensions/canvas/src/widget-tool.ts
+++ b/extensions/canvas/src/widget-tool.ts
@@ -1,4 +1,4 @@
-/** Agent-facing inline web chat widget tool. */
+/** Agent-facing inline chat widget tool. */
 import { createHash } from "node:crypto";
 import { jsonResult, readStringParam } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -76,7 +76,7 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
     label: "Show Widget",
     name: "show_widget",
     description:
-      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data. A global sendPrompt(text) function submits text to the chat as if the user typed it — wire it to buttons or controls to build interactive widgets. It only works after the user clicks inside the widget (plain conversational text only; slash commands are rejected), so never call it automatically.",
+      "Show an interactive, self-contained HTML or SVG widget to the user on their current surface. Inline all required code and data. In web chat, a global sendPrompt(text) function submits text to the chat as if the user typed it — wire it to buttons or controls to build interactive widgets. It only works after the user clicks inside the widget (plain conversational text only; slash commands are rejected), so never call it automatically.",
     parameters: ShowWidgetToolSchema,
     requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS,
     execute: async (_toolCallId, args) => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -227,6 +227,7 @@ const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.rename", scope: "operator.pairing" },
   { name: "node.list", scope: "operator.read" },
   { name: "node.describe", scope: "operator.read" },
+  { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "node.pluginTools.update", scope: "node" },
   { name: "node.skills.update", scope: "node" },
   { name: "node.pending.drain", scope: "node" },
@@ -366,7 +367,6 @@ const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "migrations.memory.apply", scope: "operator.admin", controlPlaneWrite: true },
   { name: "ui.command", scope: "operator.write" },
   { name: "approval.history", scope: "operator.approvals" },
-  { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "plugin.surface.refresh", scope: "operator.read" },
 ] as const;
 

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -227,7 +227,6 @@ const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.rename", scope: "operator.pairing" },
   { name: "node.list", scope: "operator.read" },
   { name: "node.describe", scope: "operator.read" },
-  { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "node.pluginTools.update", scope: "node" },
   { name: "node.skills.update", scope: "node" },
   { name: "node.pending.drain", scope: "node" },
@@ -367,6 +366,8 @@ const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "migrations.memory.apply", scope: "operator.admin", controlPlaneWrite: true },
   { name: "ui.command", scope: "operator.write" },
   { name: "approval.history", scope: "operator.approvals" },
+  { name: "node.pluginSurface.refresh", scope: "node" },
+  { name: "plugin.surface.refresh", scope: "operator.read" },
 ] as const;
 
 const CORE_GATEWAY_METHOD_SPEC_BY_NAME: ReadonlyMap<string, CoreGatewayMethodSpec> = new Map(

--- a/src/gateway/plugin-node-capability.test.ts
+++ b/src/gateway/plugin-node-capability.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "vitest";
 import {
   buildPluginNodeCapabilityScopedHostUrl,
+  hasAuthorizedClientPluginNodeCapabilityUrl,
   hasAuthorizedPluginNodeCapability,
   indexPluginNodeCapabilitySurfaces,
   normalizePluginNodeCapabilityScopedUrl,
@@ -70,6 +71,42 @@ describe("plugin node capability helpers", () => {
       ),
     ).toBe(true);
     expect(pluginNodeCapabilityScopedHostUrlsConflict("not-a-url", "also-not-a-url")).toBe(false);
+  });
+
+  test("validates a current scoped URL without extending its authorization", () => {
+    const client = makeClient({
+      pluginNodeCapabilities: {
+        canvas: { capability: "current-token", expiresAtMs: 1_500 },
+      },
+    });
+    const params = {
+      client,
+      surface: { surface: "canvas" },
+      url: "https://gateway.example/__openclaw__/cap/current-token",
+      nowMs: 1_000,
+    };
+
+    expect(hasAuthorizedClientPluginNodeCapabilityUrl(params)).toBe(true);
+    expect(client.pluginNodeCapabilities?.canvas?.expiresAtMs).toBe(1_500);
+    expect(
+      hasAuthorizedClientPluginNodeCapabilityUrl({
+        ...params,
+        url: "https://gateway.example/__openclaw__/cap/other-token",
+      }),
+    ).toBe(false);
+    expect(hasAuthorizedClientPluginNodeCapabilityUrl({ ...params, nowMs: 1_500 })).toBe(false);
+    expect(
+      hasAuthorizedClientPluginNodeCapabilityUrl({
+        ...params,
+        client: makeClient(),
+      }),
+    ).toBe(false);
+    expect(
+      hasAuthorizedClientPluginNodeCapabilityUrl({
+        ...params,
+        surface: { surface: "canvas", scopeKey: "other-plugin:canvas" },
+      }),
+    ).toBe(false);
   });
 
   test("treats the scoped path capability as authoritative over a stale query", () => {

--- a/src/gateway/plugin-node-capability.test.ts
+++ b/src/gateway/plugin-node-capability.test.ts
@@ -6,6 +6,7 @@ import {
   hasAuthorizedPluginNodeCapability,
   indexPluginNodeCapabilitySurfaces,
   normalizePluginNodeCapabilityScopedUrl,
+  pluginNodeCapabilityScopedHostUrlsConflict,
   refreshClientPluginNodeCapability,
   setClientPluginNodeCapability,
 } from "./plugin-node-capability.js";
@@ -53,6 +54,22 @@ describe("plugin node capability helpers", () => {
       scopedPath: true,
       malformedScopedPath: false,
     });
+  });
+
+  test("detects conflicting scoped host capabilities across rewritten hosts", () => {
+    expect(
+      pluginNodeCapabilityScopedHostUrlsConflict(
+        "http://127.0.0.1:18789/__openclaw__/cap/token%20value",
+        "https://gateway.example:7443/__openclaw__/cap/token%20value",
+      ),
+    ).toBe(false);
+    expect(
+      pluginNodeCapabilityScopedHostUrlsConflict(
+        "https://gateway.example/__openclaw__/cap/old-token",
+        "https://gateway.example/__openclaw__/cap/new-token",
+      ),
+    ).toBe(true);
+    expect(pluginNodeCapabilityScopedHostUrlsConflict("not-a-url", "also-not-a-url")).toBe(false);
   });
 
   test("treats the scoped path capability as authoritative over a stale query", () => {

--- a/src/gateway/plugin-node-capability.ts
+++ b/src/gateway/plugin-node-capability.ts
@@ -181,6 +181,27 @@ export function pluginNodeCapabilityScopedHostUrlsConflict(first: string, second
   );
 }
 
+/** Check whether a client's current scoped surface URL still has live authorization. */
+export function hasAuthorizedClientPluginNodeCapabilityUrl(params: {
+  client: PluginNodeCapabilityClient;
+  surface: PluginNodeCapabilitySurface;
+  url: string;
+  nowMs?: number;
+}): boolean {
+  const storageKey = resolvePluginNodeCapabilityStorageKey(params.surface);
+  const capability = pluginNodeCapabilityFromScopedHostUrl(params.url);
+  if (!storageKey || !capability) {
+    return false;
+  }
+  const entry = params.client.pluginNodeCapabilities?.[storageKey];
+  const nowMs = params.nowMs ?? Date.now();
+  return Boolean(
+    entry &&
+    isFutureDateTimestampMs(entry.expiresAtMs, { nowMs }) &&
+    safeEqualSecret(entry.capability, capability),
+  );
+}
+
 /** Parse and rewrite scoped capability URLs into canonical paths plus query tokens. */
 export function normalizePluginNodeCapabilityScopedUrl(
   rawUrl: string,

--- a/src/gateway/plugin-node-capability.ts
+++ b/src/gateway/plugin-node-capability.ts
@@ -152,6 +152,35 @@ function replacePluginNodeCapabilityInScopedHostUrl(
   }
 }
 
+function pluginNodeCapabilityFromScopedHostUrl(rawUrl: string): string | undefined {
+  try {
+    const pathname = new URL(rawUrl).pathname;
+    const prefix = `${PLUGIN_NODE_CAPABILITY_PATH_PREFIX}/`;
+    const markerStart = pathname.indexOf(prefix);
+    if (markerStart < 0) {
+      return undefined;
+    }
+    const capabilityStart = markerStart + prefix.length;
+    const nextSlashIndex = pathname.indexOf("/", capabilityStart);
+    const capabilityEnd = nextSlashIndex >= 0 ? nextSlashIndex : pathname.length;
+    if (capabilityEnd <= capabilityStart) {
+      return undefined;
+    }
+    return normalizeCapability(decodeURIComponent(pathname.slice(capabilityStart, capabilityEnd)));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Detect conflicting scoped capabilities while allowing transport host rewriting. */
+export function pluginNodeCapabilityScopedHostUrlsConflict(first: string, second: string): boolean {
+  const firstCapability = pluginNodeCapabilityFromScopedHostUrl(first);
+  const secondCapability = pluginNodeCapabilityFromScopedHostUrl(second);
+  return Boolean(
+    firstCapability && secondCapability && !safeEqualSecret(firstCapability, secondCapability),
+  );
+}
+
 /** Parse and rewrite scoped capability URLs into canonical paths plus query tokens. */
 export function normalizePluginNodeCapabilityScopedUrl(
   rawUrl: string,

--- a/src/gateway/role-policy.test.ts
+++ b/src/gateway/role-policy.test.ts
@@ -25,6 +25,7 @@ describe("gateway role policy", () => {
   test("authorizes roles against node vs operator methods", () => {
     expect(isRoleAuthorizedForMethod("node", "node.event")).toBe(true);
     expect(isRoleAuthorizedForMethod("node", "node.pluginSurface.refresh")).toBe(true);
+    expect(isRoleAuthorizedForMethod("node", "plugin.surface.refresh")).toBe(false);
     expect(isRoleAuthorizedForMethod("node", "node.pluginTools.update")).toBe(true);
     expect(isRoleAuthorizedForMethod("node", "node.skills.update")).toBe(true);
     expect(isRoleAuthorizedForMethod("node", "node.pending.drain")).toBe(true);
@@ -32,6 +33,7 @@ describe("gateway role policy", () => {
     expect(isRoleAuthorizedForMethod("node", "status")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "status")).toBe(true);
     expect(isRoleAuthorizedForMethod("operator", "system-event")).toBe(true);
+    expect(isRoleAuthorizedForMethod("operator", "plugin.surface.refresh")).toBe(true);
     expect(isRoleAuthorizedForMethod("operator", "node.pluginSurface.refresh")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "node.pluginTools.update")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "node.skills.update")).toBe(false);

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -25,6 +25,7 @@ describe("GATEWAY_EVENTS", () => {
 
 describe("listGatewayMethods", () => {
   it("advertises plugin surface refresh for capability rotation", () => {
+    expect(listGatewayMethods()).toContain("plugin.surface.refresh");
     expect(listGatewayMethods()).toContain("node.pluginSurface.refresh");
   });
 
@@ -43,12 +44,14 @@ describe("listGatewayMethods", () => {
   });
 
   it("appends new methods after model probing without shifting older method indices", () => {
-    expect(listGatewayMethods().slice(-5)).toEqual([
+    expect(listGatewayMethods().slice(-7)).toEqual([
       "models.probe",
       "migrations.memory.plan",
       "migrations.memory.apply",
       "ui.command",
       "approval.history",
+      "node.pluginSurface.refresh",
+      "plugin.surface.refresh",
     ]);
   });
 
@@ -97,7 +100,7 @@ describe("listGatewayMethods", () => {
       "exec.approval.get",
     ]);
     expect(methods).toContain("tts.speak");
-    expect(coreMethods.slice(-12)).toEqual([
+    expect(coreMethods.slice(-14)).toEqual([
       "sessions.catalog.continue",
       "sessions.catalog.archive",
       "approval.get",
@@ -110,6 +113,8 @@ describe("listGatewayMethods", () => {
       "migrations.memory.apply",
       "ui.command",
       "approval.history",
+      "node.pluginSurface.refresh",
+      "plugin.surface.refresh",
     ]);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));
     expect(methods.indexOf("approval.resolve")).toBe(methods.indexOf("approval.get") + 1);

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -44,15 +44,21 @@ describe("listGatewayMethods", () => {
   });
 
   it("appends new methods after model probing without shifting older method indices", () => {
-    expect(listGatewayMethods().slice(-7)).toEqual([
+    expect(listGatewayMethods().slice(-6)).toEqual([
       "models.probe",
       "migrations.memory.plan",
       "migrations.memory.apply",
       "ui.command",
       "approval.history",
-      "node.pluginSurface.refresh",
       "plugin.surface.refresh",
     ]);
+    const methods = listGatewayMethods();
+    expect(methods.indexOf("node.pluginSurface.refresh")).toBe(
+      methods.indexOf("node.describe") + 1,
+    );
+    expect(methods.indexOf("node.pluginTools.update")).toBe(
+      methods.indexOf("node.pluginSurface.refresh") + 1,
+    );
   });
 
   it("advertises ClawHub skill trust methods", () => {
@@ -100,7 +106,7 @@ describe("listGatewayMethods", () => {
       "exec.approval.get",
     ]);
     expect(methods).toContain("tts.speak");
-    expect(coreMethods.slice(-14)).toEqual([
+    expect(coreMethods.slice(-13)).toEqual([
       "sessions.catalog.continue",
       "sessions.catalog.archive",
       "approval.get",
@@ -113,7 +119,6 @@ describe("listGatewayMethods", () => {
       "migrations.memory.apply",
       "ui.command",
       "approval.history",
-      "node.pluginSurface.refresh",
       "plugin.surface.refresh",
     ]);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -677,6 +677,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "node.rename",
       "node.list",
       "node.describe",
+      "plugin.surface.refresh",
       "node.pluginSurface.refresh",
       "node.pluginTools.update",
       "node.skills.update",

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -483,7 +483,10 @@ describe("node plugin surface refresh", () => {
       'nodeHandlers["node.pluginSurface.refresh"] test invariant',
     )({
       req: { type: "req", id: "r1", method: "node.pluginSurface.refresh", params: {} },
-      params: { surface: "canvas" },
+      params: {
+        surface: "canvas",
+        observedUrl: "https://gateway.example/__openclaw__/cap/old-token",
+      },
       client: client as never,
       isWebchatConnect: () => false,
       respond,
@@ -506,6 +509,45 @@ describe("node plugin surface refresh", () => {
     expect(capabilityToken.length).toBeGreaterThan(0);
     expect(capabilityToken).not.toBe("old-token");
     expect(client.pluginSurfaceUrls.canvas).toBe(canvasUrl);
+  });
+
+  it("reuses a capability rotated after the caller observed its surface", async () => {
+    const respond = vi.fn();
+    const currentUrl = "http://127.0.0.1:18789/__openclaw__/cap/current-token";
+    const client = {
+      connect: {
+        client: { id: "node-1", mode: "node" },
+      },
+      pluginSurfaceUrls: { canvas: currentUrl },
+      pluginNodeCapabilitySurfaces: {
+        canvas: { surface: "canvas", ttlMs: 100 },
+      },
+    };
+
+    await expectDefined(
+      nodeHandlers["node.pluginSurface.refresh"],
+      'nodeHandlers["node.pluginSurface.refresh"] test invariant',
+    )({
+      req: { type: "req", id: "r2", method: "node.pluginSurface.refresh", params: {} },
+      params: {
+        surface: "canvas",
+        observedUrl: "https://gateway.example/__openclaw__/cap/old-token",
+      },
+      client: client as never,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const call = firstRespondCall(respond);
+    expect(call[0]).toBe(true);
+    expect(call[1]).toEqual({
+      surface: "canvas",
+      pluginSurfaceUrls: { canvas: currentUrl },
+    });
+    expect(client.pluginSurfaceUrls.canvas).toBe(currentUrl);
+    expect(client).not.toHaveProperty("pluginNodeCapabilities");
   });
 });
 

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -461,7 +461,7 @@ async function ackPending(nodeId: string, ids: string[], commands?: string[]) {
   return respond;
 }
 
-describe("node plugin surface refresh", () => {
+describe("plugin surface refresh", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -512,6 +512,45 @@ describe("node plugin surface refresh", () => {
     const capabilityToken = parsedCanvasUrl.pathname.slice("/__openclaw__/cap/".length);
     expect(capabilityToken.length).toBeGreaterThan(0);
     expect(capabilityToken).not.toBe("old-token");
+    expect(client.pluginSurfaceUrls.canvas).toBe(canvasUrl);
+  });
+
+  it("refreshes the calling operator's own surface capability", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const respond = vi.fn();
+    const client = {
+      connect: {
+        role: "operator",
+        scopes: ["operator.read"],
+        client: { id: "operator-1", mode: "ui" },
+      },
+      pluginSurfaceUrls: {
+        canvas: "http://127.0.0.1:18789/__openclaw__/cap/old-token",
+      },
+      pluginNodeCapabilitySurfaces: {
+        canvas: { surface: "canvas", ttlMs: 100 },
+      },
+    };
+
+    await expectDefined(
+      nodeHandlers["plugin.surface.refresh"],
+      'nodeHandlers["plugin.surface.refresh"] test invariant',
+    )({
+      req: { type: "req", id: "operator-r1", method: "plugin.surface.refresh", params: {} },
+      params: { surface: "canvas" },
+      client: client as never,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    const call = firstRespondCall(respond);
+    expect(call[0]).toBe(true);
+    const payload = requireRecord(call[1], "operator refresh payload");
+    const pluginSurfaceUrls = requireRecord(payload.pluginSurfaceUrls, "operator surface urls");
+    const canvasUrl = requireString(pluginSurfaceUrls.canvas, "operator canvas url");
+    expect(canvasUrl).not.toContain("old-token");
     expect(client.pluginSurfaceUrls.canvas).toBe(canvasUrl);
   });
 

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -462,6 +462,10 @@ async function ackPending(nodeId: string, ids: string[], commands?: string[]) {
 }
 
 describe("node plugin surface refresh", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("refreshes generic plugin surface capability urls", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
@@ -512,6 +516,8 @@ describe("node plugin surface refresh", () => {
   });
 
   it("reuses a capability rotated after the caller observed its surface", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
     const respond = vi.fn();
     const currentUrl = "http://127.0.0.1:18789/__openclaw__/cap/current-token";
     const client = {
@@ -521,6 +527,9 @@ describe("node plugin surface refresh", () => {
       pluginSurfaceUrls: { canvas: currentUrl },
       pluginNodeCapabilitySurfaces: {
         canvas: { surface: "canvas", ttlMs: 100 },
+      },
+      pluginNodeCapabilities: {
+        canvas: { capability: "current-token", expiresAtMs: 1_100 },
       },
     };
 
@@ -547,7 +556,55 @@ describe("node plugin surface refresh", () => {
       pluginSurfaceUrls: { canvas: currentUrl },
     });
     expect(client.pluginSurfaceUrls.canvas).toBe(currentUrl);
-    expect(client).not.toHaveProperty("pluginNodeCapabilities");
+    expect(client.pluginNodeCapabilities.canvas).toEqual({
+      capability: "current-token",
+      expiresAtMs: 1_100,
+    });
+  });
+
+  it("rotates a conflicting current URL after its authorization expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const respond = vi.fn();
+    const currentUrl = "http://127.0.0.1:18789/__openclaw__/cap/current-token";
+    const client = {
+      connect: {
+        client: { id: "node-1", mode: "node" },
+      },
+      pluginSurfaceUrls: { canvas: currentUrl },
+      pluginNodeCapabilitySurfaces: {
+        canvas: { surface: "canvas", ttlMs: 100 },
+      },
+      pluginNodeCapabilities: {
+        canvas: { capability: "current-token", expiresAtMs: 999 },
+      },
+    };
+
+    await expectDefined(
+      nodeHandlers["node.pluginSurface.refresh"],
+      'nodeHandlers["node.pluginSurface.refresh"] test invariant',
+    )({
+      req: { type: "req", id: "r3", method: "node.pluginSurface.refresh", params: {} },
+      params: {
+        surface: "canvas",
+        observedUrl: "https://gateway.example/__openclaw__/cap/old-token",
+      },
+      client: client as never,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    const call = firstRespondCall(respond);
+    expect(call[0]).toBe(true);
+    const payload = requireRecord(call[1], "refresh payload");
+    expect(payload.expiresAtMs).toBe(1_100);
+    const pluginSurfaceUrls = requireRecord(payload.pluginSurfaceUrls, "refresh surface urls");
+    const canvasUrl = requireString(pluginSurfaceUrls.canvas, "refresh canvas url");
+    expect(canvasUrl).not.toBe(currentUrl);
+    expect(client.pluginSurfaceUrls.canvas).toBe(canvasUrl);
+    expect(client.pluginNodeCapabilities.canvas.capability).not.toBe("current-token");
+    expect(client.pluginNodeCapabilities.canvas.expiresAtMs).toBe(1_100);
   });
 });
 

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -103,7 +103,7 @@ import {
   safeParseJson,
 } from "./nodes.helpers.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./shared-types.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestHandler, GatewayRequestHandlers } from "./types.js";
 
 export {
   clearNodeWakeState,
@@ -262,6 +262,20 @@ function respondRefreshedPluginSurface(params: {
     undefined,
   );
 }
+
+const handlePluginSurfaceRefresh: GatewayRequestHandler = ({ params, respond, client }) => {
+  const parsed = normalizePluginSurfaceRefreshParams(params);
+  if (!parsed) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "surface required"));
+    return;
+  }
+  respondRefreshedPluginSurface({
+    surface: parsed.surface,
+    observedUrl: parsed.observedUrl,
+    client,
+    respond,
+  });
+};
 
 async function resolveDirectNodePushConfig() {
   const auth = await resolveApnsAuthConfigFromEnv(process.env);
@@ -1251,19 +1265,8 @@ export const nodeHandlers: GatewayRequestHandlers = {
       );
     });
   },
-  "node.pluginSurface.refresh": async ({ params, respond, client }) => {
-    const parsed = normalizePluginSurfaceRefreshParams(params);
-    if (!parsed) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "surface required"));
-      return;
-    }
-    respondRefreshedPluginSurface({
-      surface: parsed.surface,
-      observedUrl: parsed.observedUrl,
-      client,
-      respond,
-    });
-  },
+  "plugin.surface.refresh": handlePluginSurfaceRefresh,
+  "node.pluginSurface.refresh": handlePluginSurfaceRefresh,
   "node.pluginTools.update": async ({ params, respond, client, context }) => {
     if (!validateNodePluginToolsUpdateParams(params)) {
       respondInvalidParams({

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -69,7 +69,10 @@ import { applyPluginNodeInvokePolicy } from "../node-invoke-plugin-policy.js";
 import { sanitizeNodeInvokeParamsForForwarding } from "../node-invoke-sanitize.js";
 import type { NodeSession } from "../node-registry.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
-import { refreshClientPluginNodeCapability } from "../plugin-node-capability.js";
+import {
+  pluginNodeCapabilityScopedHostUrlsConflict,
+  refreshClientPluginNodeCapability,
+} from "../plugin-node-capability.js";
 import type { NodeEventContext } from "../server-node-events-types.js";
 import {
   deniesCrossDeviceManagement,
@@ -187,7 +190,9 @@ function listNodesForClient(params: {
   return nodes.map((node) => safeNodeReadProjection(node, ownDeviceId)).filter(isVisibleNode);
 }
 
-function normalizePluginSurfaceRefreshParams(params: unknown): { surface: string } | undefined {
+function normalizePluginSurfaceRefreshParams(
+  params: unknown,
+): { surface: string; observedUrl?: string } | undefined {
   if (!params || typeof params !== "object") {
     return undefined;
   }
@@ -195,14 +200,34 @@ function normalizePluginSurfaceRefreshParams(params: unknown): { surface: string
   if (!surface) {
     return undefined;
   }
-  return { surface };
+  const observedUrl = normalizeOptionalString((params as { observedUrl?: unknown }).observedUrl);
+  return { surface, ...(observedUrl ? { observedUrl } : {}) };
 }
 
 function respondRefreshedPluginSurface(params: {
   surface: string;
+  observedUrl?: string;
   client: GatewayClient | null;
   respond: RespondFn;
 }) {
+  const currentUrl = params.client?.pluginSurfaceUrls?.[params.surface];
+  if (
+    currentUrl &&
+    params.observedUrl &&
+    pluginNodeCapabilityScopedHostUrlsConflict(currentUrl, params.observedUrl)
+  ) {
+    // A prior in-flight request already rotated this capability. Return its
+    // result instead of invalidating it with a second rotation.
+    params.respond(
+      true,
+      {
+        surface: params.surface,
+        pluginSurfaceUrls: { [params.surface]: currentUrl },
+      },
+      undefined,
+    );
+    return;
+  }
   const refreshed = params.client
     ? refreshClientPluginNodeCapability({
         client: params.client,
@@ -1226,6 +1251,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
     }
     respondRefreshedPluginSurface({
       surface: parsed.surface,
+      observedUrl: parsed.observedUrl,
       client,
       respond,
     });

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -70,6 +70,7 @@ import { sanitizeNodeInvokeParamsForForwarding } from "../node-invoke-sanitize.j
 import type { NodeSession } from "../node-registry.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import {
+  hasAuthorizedClientPluginNodeCapabilityUrl,
   pluginNodeCapabilityScopedHostUrlsConflict,
   refreshClientPluginNodeCapability,
 } from "../plugin-node-capability.js";
@@ -211,10 +212,19 @@ function respondRefreshedPluginSurface(params: {
   respond: RespondFn;
 }) {
   const currentUrl = params.client?.pluginSurfaceUrls?.[params.surface];
+  const capabilitySurface = params.client?.pluginNodeCapabilitySurfaces?.[params.surface] ?? {
+    surface: params.surface,
+  };
   if (
+    params.client &&
     currentUrl &&
     params.observedUrl &&
-    pluginNodeCapabilityScopedHostUrlsConflict(currentUrl, params.observedUrl)
+    pluginNodeCapabilityScopedHostUrlsConflict(currentUrl, params.observedUrl) &&
+    hasAuthorizedClientPluginNodeCapabilityUrl({
+      client: params.client,
+      surface: capabilitySurface,
+      url: currentUrl,
+    })
   ) {
     // A prior in-flight request already rotated this capability. Return its
     // result instead of invalidating it with a second rotation.
@@ -231,9 +241,7 @@ function respondRefreshedPluginSurface(params: {
   const refreshed = params.client
     ? refreshClientPluginNodeCapability({
         client: params.client,
-        surface: params.client.pluginNodeCapabilitySurfaces?.[params.surface] ?? {
-          surface: params.surface,
-        },
+        surface: capabilitySurface,
       })
     : undefined;
   if (!refreshed) {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3619,7 +3619,6 @@ describe("package artifact reuse", () => {
   });
 
   it("accepts tag-matched frozen release branches in OpenClaw npm preflight", () => {
-    const workflow = readWorkflow(OPENCLAW_NPM_RELEASE_WORKFLOW);
     const preflight = workflowJob(OPENCLAW_NPM_RELEASE_WORKFLOW, "preflight_openclaw_npm");
     const metadata = workflowStep(preflight, "Validate release metadata");
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `show_widget` results rendered interactively in the Control UI but appeared only as transcript text in the native iOS, Android, and macOS chats.

## Why This Change Was Made

Adds one portable inline-widget path across the native clients while keeping Linux on the existing Control UI path. Native chat operator connections advertise the capability only when the device can resolve the Canvas surface; node-role connections retain device capabilities and do not require reapproval for a chat rendering feature. Assistant-authored widget calls render in isolated WebViews, navigation stays constrained to the minted capability URL, and an expired capability gets one refresh attempt. Android requires WebView multi-profile support and fails closed when isolation is unavailable.

The follow-up refactor centralizes capability refresh around a conditional URL snapshot, coalesces native callers while preserving each caller's selected deadline, cancels stalled work when its last waiter departs, and makes overlapping on-wire retries idempotent only while the replacement token still has live authorization. Failed native loads refresh the node route before using an operator fallback. It also re-reads the active macOS surface after reconnect races, preserves the shipped Swift refresh API, bounds WebKit content-process recovery, and immediately removes and destroys renderer-dead Android WebViews before recreating their keyed view/profile/cleanup subtree.

Native widget delivery remains bound to the gateway's effective TLS identity. Apple WebViews verify the exact leaf fingerprint. Android fetches a bounded HTML main document through the pinned gateway client, keeps WebView SSL failures fail-closed, and rejects redirects, oversized responses, non-HTML documents, mismatched pins, and pin-bearing cleartext URLs. TOFU connections propagate the accepted fingerprint into widget routes.

## User Impact

Users can now ask a model to create an interactive widget and use it inline from Web, iOS, Android, macOS, and Linux (through the Control UI). Native clients avoid exposing widgets from user-authored transcript content, do not reuse authenticated WebView state between widgets, and preserve the gateway trust boundary while loading widget content.

## Evidence

Live end-to-end proof used real OpenAI model sessions where `openai/gpt-5.6-luna` chose and called `show_widget`:

- Web: widget rendered, button changed the visible count from 18 to 19, and the session completed with `WEB_DONE`.
- iOS: model-created widget rendered in the native app; native XCUITest tapped Increment and observed 0 to 1; 13.905 seconds, 0 failures.
- Android: model-created widget rendered in the native app; isolated WebView inspection and a native tap observed 0 to 1.

Cross-platform focused proof:

- TypeScript Canvas widget tests: 12 passed.
- Gateway capability and conditional-refresh tests: 61 passed across 4 files.
- Swift shared widget tests: 10 passed; gateway-node session tests: 66 passed.
- Shared timeout tests passed zero-deadline and finite-deadline cancellation cases.
- macOS node runtime tests: 28 passed; chat transport mapping tests: 11 passed; full package compiled.
- iOS gateway connection tests: 71 passed; app, watch, and extension targets built successfully.
- Android bounded-document, TLS-route, and node-before-operator recovery tests passed. Exact head also passed two focused unit-test classes, ktlintCheck, lintPlayDebug, and assemblePlayDebug on Blacksmith Testbox in 6m03s.
- Native localization tests: 43 passed; Android and Apple artifacts synchronized across 21 locales.
- Exact-head full changed-surface gate passed on Blacksmith Testbox in 22m11s: formatting, SDK baseline, dependency and plugin boundaries, all relevant typechecks/lint, macOS CI tests, architecture guards, and import-cycle checks.
- Final follow-ups regenerated the Kotlin gateway enum into canonical protocol order and removed one unused current-main test local that broke test-type CI. `pnpm protocol:check`, the exact root test-type command, the focused workflow test, and fresh uncommitted autoreviews pass; widget behavior and protocol strings are unchanged.
- Post-CI cleanup removed six unshipped dead symbols, retained two shipped refresh APIs with explicit compatibility annotations, preserved caller-selected refresh deadlines with cancellation-safe waiter ownership, required live authorization for retry deduplication, hardened native retry ordering and Android renderer recovery, synchronized the 4,640-entry native i18n inventory, and passed canonical macOS SwiftLint/SwiftFormat.
- Fresh whole-branch autoreview has no accepted/actionable findings. Its sole report claimed profiles must be created before `WebViewCompat.setProfile`; AndroidX WebKit 1.16 explicitly creates missing profiles in `setProfile`, retaining a `Profile` through `getOrCreateProfile` would prevent cleanup, and the live Android run confirms the current path. Source-blind behavior validation passed Web, iOS, and Android.

### Live visual proof

| iOS before interaction | iOS after interaction |
| --- | --- |
| <img width="260" alt="iOS widget before interaction" src="https://github.com/user-attachments/assets/04cd795b-bc81-41f8-a1f0-2841809d0a63" /> | <img width="260" alt="iOS widget after interaction" src="https://github.com/user-attachments/assets/23e2b753-7d1d-419b-b21c-a3a48b508609" /> |

**Web after interaction**

<img width="760" alt="Web widget after interaction" src="https://github.com/user-attachments/assets/325748d4-7253-4129-973b-6e9885eb3c4e" />

**Android after interaction**

<img width="280" alt="Android widget after interaction" src="https://github.com/user-attachments/assets/4727a288-d576-42bb-af2f-7147f38036fc" />
