### PR TITLE
fix(doctor): bound launchctl service teardown probes

### DIFF
--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -107,8 +107,14 @@ const EXECSTART_REPAIR_CODES = new Set<string>([
   SERVICE_AUDIT_CODES.gatewayCommandMissing,
   SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
 ]);
+// Bound the teardown probes so a stuck launchd cannot hang doctor/repair
+// indefinitely; the failures are already ignored below (matches #109115).
+const LAUNCHCTL_TEARDOWN_TIMEOUT_MS = 5_000;
 const runLaunchctlQuietly = (args: string[]) =>
-  runExec("launchctl", args, { logOutput: false }).catch(() => undefined);
+  runExec("launchctl", args, {
+    logOutput: false,
+    timeoutMs: LAUNCHCTL_TEARDOWN_TIMEOUT_MS,
+  }).catch(() => undefined);
 const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
 
 function detectGatewayRuntime(programArguments: string[] | undefined): GatewayDaemonRuntime {


### PR DESCRIPTION
Related: #109115

## What Problem This Solves

The macOS doctor gateway-services repair path tears down the existing launchd service before reinstalling it. Both teardown calls (`launchctl bootout` and `launchctl unload`) go through `runLaunchctlQuietly`, which called `runExec` with no `timeoutMs`. A stuck or unresponsive `launchd` therefore leaves the repair waiting indefinitely — the same "doctor could wait indefinitely" class of hang that #109115 fixed for the launchctl `getenv` probes in `doctor-platform-notes.ts`.

## Why This Change Was Made

This adds a five-second deadline to the two launchctl teardown probes via a local `LAUNCHCTL_TEARDOWN_TIMEOUT_MS` constant.

The change is deliberately behavior-preserving on the failure side: `runLaunchctlQuietly` already ends in `.catch(() => undefined)`, so bootout/unload failures are swallowed and the repair proceeds regardless. A timeout just turns an *indefinite* hang into the same already-ignored failure, rather than blocking the whole doctor run. This is the same contract #109115 relied on, applied to the one remaining unbounded launchctl call site. The other doctor subprocess probes (`docker version`, `unshare`, `crontab -l`) already carry a `timeoutMs`; this closes the last unbounded one in the family.

## User Impact

`openclaw doctor` (and the gateway-services repair it drives) no longer hangs indefinitely when `launchd` is wedged during service teardown; it now bounds each teardown probe at five seconds and continues, exactly as it already does when the teardown command errors.

## Evidence

Static analysis: on `main`, `src/commands/doctor-gateway-services.ts:111` passed `runExec("launchctl", args, { logOutput: false })` with no `timeoutMs`, while every sibling doctor probe is bounded — `doctor-platform-notes.ts` (`DOCTOR_LAUNCHCTL_TIMEOUT_MS`, #109115), `doctor-sandbox.ts` (`timeoutMs: 5_000`), and `doctor/cron/warnings.ts` (`CRONTAB_READ_TIMEOUT_MS`). `timeoutMs` is an existing `runExec` option used by all of those, so this typechecks. Formatting verified with `oxfmt`.

Proof gap (stated plainly): I did not add a unit test. The teardown path isn't mock-covered in the current `doctor-gateway-services.test.ts` (it doesn't mock `../process/exec.js`), and I can't run the suite from a fork, so a timeout-assertion test would need new mock scaffolding — happy to add it if a maintainer prefers. The change itself is a one-option addition mirroring the merged #109115 pattern.
