### PR TITLE
fix(agents): find and grep no longer hang on stalled tool checks

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -243,6 +243,11 @@ describe("ensureTool exit-status handling", () => {
       stdout: Buffer.alloc(0),
     });
     await expect(ensureTool("fd", true)).resolves.toBe("fd");
+    expect(spawnSyncMock).toHaveBeenCalledWith("fd", ["--version"], {
+      killSignal: "SIGKILL",
+      stdio: "pipe",
+      timeout: 5_000,
+    });
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -103,7 +103,11 @@ const TOOLS: Record<string, ToolConfig> = {
 // Check if a command exists in PATH by trying to run it
 function commandExists(cmd: string): boolean {
   try {
-    const result = spawnSync(cmd, ["--version"], { stdio: "pipe", timeout: 5_000 });
+    const result = spawnSync(cmd, ["--version"], {
+      killSignal: "SIGKILL",
+      stdio: "pipe",
+      timeout: 5_000,
+    });
     // Require a clean exit, not just a successful spawn. An installed-but-broken
     // binary (e.g. GLIBC mismatch after a system upgrade, missing shared lib)
     // spawns fine but exits non-zero; without the status check it would be


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent `find` and `grep` operations could remain blocked after their `fd` or `rg` version check timed out if the installed executable ignored the default termination signal.

## Why This Change Was Made

The existing 5-second version-check budget now uses a forceful kill signal. Tool discovery, offline behavior, download fallback, and the actual `fd` or `rg` search process are otherwise unchanged.

## User Impact

Agent file searches now continue to the install or unavailable-tool path instead of hanging indefinitely on a stalled local binary. Normal working installations are detected exactly as before.

## Evidence

- Regression test before the fix: 1 option assertion failed while 7 tests passed.
- Focused test after the fix and after rebasing onto current main: `src/agents/utils/tools-manager.test.ts` passed 8/8.
- Real agent-tool E2E proof on current main `af42fbb6f3`: the built-in `find` tool with a test `fd` executable that ignored `SIGTERM` was still blocked when a 12-second external watchdog stopped it. The exact patched head `d816dbec0c` completed the same probe in 5.025 seconds and reached the existing offline-unavailable result without making a network request.
- A direct Node contract proof showed the default timeout waited 1.556 seconds for a child that ignored `SIGTERM`, while `SIGKILL` returned in 123 ms under the same 100 ms timeout.
- `oxfmt`, `oxlint`, and `git diff --check` passed for the changed files.
- Local `codex review --base origin/main` found no behavior regression and verified Node and Bun compatibility for the option.
