### PR TITLE
fix(gateway): bound optional model catalog slow-load log cache

### DIFF
--- a/src/gateway/server-methods/optional-model-catalog.test.ts
+++ b/src/gateway/server-methods/optional-model-catalog.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayRequestContext } from "./types.js";
+
+describe("optional-model-catalog slow-load log cache", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  async function loadCatalog() {
+    const mod = await import("./optional-model-catalog.js");
+    return mod.loadOptionalServerMethodModelCatalog;
+  }
+
+  function makeContext(): GatewayRequestContext {
+    return {
+      logGateway: { debug: vi.fn() },
+    } as unknown as GatewayRequestContext;
+  }
+
+  it("caps the dedupe cache at 256 entries and re-logs evicted keys", async () => {
+    const loadOptionalServerMethodModelCatalog = await loadCatalog();
+    const context = makeContext();
+    const surface = "test-surface";
+    const neverResolvingLoad = { promise: new Promise<never>(() => {}) };
+
+    for (let i = 0; i < 256; i++) {
+      await loadOptionalServerMethodModelCatalog(context, surface, {
+        logOnceKey: `key-${i}`,
+        timeoutMs: 0,
+        startedLoad: neverResolvingLoad,
+      });
+    }
+    expect(context.logGateway.debug).toHaveBeenCalledTimes(256);
+
+    await loadOptionalServerMethodModelCatalog(context, surface, {
+      logOnceKey: "key-0",
+      timeoutMs: 0,
+      startedLoad: neverResolvingLoad,
+    });
+    expect(context.logGateway.debug).toHaveBeenCalledTimes(256);
+
+    for (let i = 256; i < 512; i++) {
+      await loadOptionalServerMethodModelCatalog(context, surface, {
+        logOnceKey: `key-${i}`,
+        timeoutMs: 0,
+        startedLoad: neverResolvingLoad,
+      });
+    }
+
+    await loadOptionalServerMethodModelCatalog(context, surface, {
+      logOnceKey: "key-0",
+      timeoutMs: 0,
+      startedLoad: neverResolvingLoad,
+    });
+    expect(context.logGateway.debug).toHaveBeenCalledTimes(513);
+  });
+});

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -1,6 +1,7 @@
 // Optional model-catalog loading gives session/tool methods metadata when fast
 // while never blocking their primary response path on catalog discovery.
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import type { GatewayRequestContext } from "./types.js";
 
 /**
@@ -9,7 +10,7 @@ import type { GatewayRequestContext } from "./types.js";
  */
 const DEFAULT_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 750;
 
-const loggedSlowCatalogKeys = new Set<string>();
+const loggedSlowCatalogKeys = createDedupeCache({ ttlMs: 0, maxSize: 256 });
 
 type OptionalServerMethodModelCatalogLoad<T> = {
   promise: Promise<T | undefined>;
@@ -86,8 +87,7 @@ async function loadOptionalServerMethodModelCatalogValue<T>(
     const result = await Promise.race([catalogLoad.promise, timeoutPromise]);
     if (result === timedOut) {
       const logOnceKey = options?.logOnceKey ?? "session-metadata";
-      if (!loggedSlowCatalogKeys.has(logOnceKey)) {
-        loggedSlowCatalogKeys.add(logOnceKey);
+      if (!loggedSlowCatalogKeys.check(logOnceKey)) {
         context.logGateway.debug(
           `${surface} continuing without model catalog after ${timeoutMs}ms`,
         );


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/server-methods/optional-model-catalog.ts` keeps a module-level `Set<string>` (`loggedSlowCatalogKeys`) to log "continuing without model catalog after timeout" only once per key. The set grows without bound over process lifetime.

## Why This Change Was Made

Replaced the raw `Set` with `createDedupeCache({ ttlMs: 0, maxSize: 256 })` from `src/infra/dedupe.js`. The cache auto-evicts the oldest entry when it overflows.

## User Impact

No behavior change under normal load; evicted slow-catalog messages will be re-logged if the same key times out again after overflow.

## Evidence

- Guard test in `src/gateway/server-methods/optional-model-catalog.test.ts` asserts the cache caps at 256 entries and re-logs evicted keys.
- `node scripts/run-vitest.mjs src/gateway/server-methods/optional-model-catalog.test.ts` passes.
