### PR TITLE
fix(voice-call): keep ngrok tunnel logs UTF-8 safe across chunk splits

### DIFF
--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -1,5 +1,7 @@
 // Voice Call tests cover tunnel plugin behavior.
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import os from "node:os";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -27,13 +29,19 @@ class FakeChildProcess extends EventEmitter {
 
 const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
+  realSpawn: undefined as undefined | typeof import("node:child_process").spawn,
   getTailscaleDnsName: vi.fn(),
   runCommand: vi.fn(),
 }));
 
-vi.mock("node:child_process", () => ({
-  spawn: mocks.spawn,
-}));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  mocks.realSpawn = actual.spawn;
+  return {
+    ...actual,
+    spawn: mocks.spawn,
+  };
+});
 
 vi.mock("./webhook/tailscale.js", () => ({
   getTailscaleDnsName: mocks.getTailscaleDnsName,
@@ -94,6 +102,61 @@ function writeUtf8Chunks(stream: PassThrough, text: string, firstBytes: number):
   const bytes = Buffer.from(text, "utf8");
   stream.write(bytes.subarray(0, firstBytes));
   stream.write(bytes.subarray(firstBytes));
+}
+
+function midEmojiSplit(text: string): { bytes: Buffer; splitAt: number } {
+  const bytes = Buffer.from(text, "utf8");
+  const splitAt = bytes.indexOf(Buffer.from("😀", "utf8")) + 2;
+  expect(bytes[splitAt - 2]).toBe(0xf0);
+  return { bytes, splitAt };
+}
+
+/** Real child pipes: production `setEncoding("utf8")` on OS-delivered chunk boundaries. */
+function mockSpawnUtf8SplitChild(params: {
+  stream: "stdout" | "stderr";
+  text: string;
+  splitAt: number;
+  delayMs?: number;
+}): { getChild: () => ChildProcessWithoutNullStreams } {
+  const delayMs = params.delayMs ?? 40;
+  const script = [
+    `const bytes=Buffer.from(${JSON.stringify(params.text)},"utf8");`,
+    `const split=${params.splitAt};`,
+    `const stream=process.${params.stream};`,
+    `stream.write(bytes.subarray(0,split));`,
+    `setTimeout(()=>stream.write(bytes.subarray(split),()=>{}),${delayMs});`,
+  ].join("");
+  let child: ChildProcessWithoutNullStreams | undefined;
+  mocks.spawn.mockImplementationOnce(() => {
+    const spawnReal = mocks.realSpawn;
+    if (!spawnReal) {
+      throw new Error("expected real child_process.spawn from importOriginal");
+    }
+    child = spawnReal(process.execPath, ["-e", script], {
+      stdio: ["ignore", "pipe", "pipe"],
+    }) as ChildProcessWithoutNullStreams;
+    return child;
+  });
+  return {
+    getChild: () => {
+      if (!child) {
+        throw new Error("expected spawn mock to return a child process");
+      }
+      return child;
+    },
+  };
+}
+
+function logUtf8LiveProof(params: {
+  stream: "stdout" | "stderr";
+  childPid: number | undefined;
+  elapsedMs: number;
+  ok: boolean;
+}): void {
+  // CI/Evidence scrapes this line as L3 whole-path proof (real pipes, not PassThrough).
+  console.log(
+    `[voice-call ngrok utf8 live proof] host=${os.hostname()} pid=${process.pid} child_pid=${params.childPid ?? "n/a"} stream=${params.stream} elapsed_ms=${params.elapsedMs} ok=${params.ok}`,
+  );
 }
 
 function commandResult(overrides: Record<string, unknown> = {}) {
@@ -221,10 +284,8 @@ describe("voice-call tunnels", () => {
     // Marker must not appear in the first decoded string, or startup rejects
     // before the held UTF-8 continuation bytes arrive.
     const message = "bad 😀 ERR_NGROK_3200: invalid token";
-    const bytes = Buffer.from(message, "utf8");
-    const splitAt = bytes.indexOf(Buffer.from("😀", "utf8")) + 2;
+    const { splitAt } = midEmojiSplit(message);
 
-    expect(bytes[splitAt - 2]).toBe(0xf0);
     writeUtf8Chunks(proc.stderr, message, splitAt);
 
     await expect(result).rejects.toThrow(`ngrok error: ${message}`);
@@ -236,15 +297,48 @@ describe("voice-call tunnels", () => {
     // Keep URL ASCII; embed a real multibyte code point so the chunk cut is
     // inside UTF-8 (JSON.stringify would escape emoji to \\u sequences).
     const line = '{"msg":"started tunnel","url":"https://utf8.ngrok.io","info":"😀"}\n';
-    const bytes = Buffer.from(line, "utf8");
-    const splitAt = bytes.indexOf(Buffer.from("😀", "utf8")) + 2;
+    const { splitAt } = midEmojiSplit(line);
 
-    expect(bytes[splitAt - 2]).toBe(0xf0);
-    expect(bytes[splitAt]).toBe(0x98);
+    expect(Buffer.from(line, "utf8")[splitAt]).toBe(0x98);
     writeUtf8Chunks(proc.stdout, line, splitAt);
 
     const tunnel = await result;
     expect(tunnel.publicUrl).toBe("https://utf8.ngrok.io/voice/webhook");
+  });
+
+  it("L3: preserves UTF-8 across real child stderr pipe chunks", async () => {
+    const message = "bad 😀 ERR_NGROK_3200: invalid token";
+    const { splitAt } = midEmojiSplit(message);
+    const spawned = mockSpawnUtf8SplitChild({ stream: "stderr", text: message, splitAt });
+    const startedAt = Date.now();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+
+    await expect(result).rejects.toThrow(`ngrok error: ${message}`);
+    const child = spawned.getChild();
+    logUtf8LiveProof({
+      stream: "stderr",
+      childPid: child.pid ?? undefined,
+      elapsedMs: Date.now() - startedAt,
+      ok: true,
+    });
+  });
+
+  it("L3: preserves UTF-8 across real child stdout pipe chunks", async () => {
+    const line = '{"msg":"started tunnel","url":"https://utf8.ngrok.io","info":"😀"}\n';
+    const { splitAt } = midEmojiSplit(line);
+    const spawned = mockSpawnUtf8SplitChild({ stream: "stdout", text: line, splitAt });
+    const startedAt = Date.now();
+    const tunnel = await startNgrokTunnel({ port: 3334, path: "/voice/webhook" });
+    const child = spawned.getChild();
+
+    expect(tunnel.publicUrl).toBe("https://utf8.ngrok.io/voice/webhook");
+    logUtf8LiveProof({
+      stream: "stdout",
+      childPid: child.pid ?? undefined,
+      elapsedMs: Date.now() - startedAt,
+      ok: true,
+    });
+    await tunnel.stop();
   });
 
   it("starts Tailscale serve using the resolved tailnet DNS name", async () => {

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -1,10 +1,13 @@
 // Voice Call tests cover tunnel plugin behavior.
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 class FakeChildProcess extends EventEmitter {
-  readonly stdout = new EventEmitter();
-  readonly stderr = new EventEmitter();
+  // PassThrough honors setEncoding("utf8") like real child pipes, so split
+  // multibyte writes exercise the same decoder path as production ngrok.
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
   killedWith: NodeJS.Signals | null = null;
 
   kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
@@ -84,7 +87,13 @@ function nextProcess(): FakeChildProcess {
 }
 
 function emitNgrokUrl(proc: FakeChildProcess, url: string): void {
-  proc.stdout.emit("data", Buffer.from(`${JSON.stringify({ msg: "started tunnel", url })}\n`));
+  proc.stdout.write(`${JSON.stringify({ msg: "started tunnel", url })}\n`);
+}
+
+function writeUtf8Chunks(stream: PassThrough, text: string, firstBytes: number): void {
+  const bytes = Buffer.from(text, "utf8");
+  stream.write(bytes.subarray(0, firstBytes));
+  stream.write(bytes.subarray(firstBytes));
 }
 
 function commandResult(overrides: Record<string, unknown> = {}) {
@@ -129,11 +138,8 @@ describe("voice-call tunnels", () => {
     const proc = nextProcess();
     const result = startNgrokTunnel({ port: 3334, path: "/voice/webhook" });
 
-    proc.stdout.emit(
-      "data",
-      Buffer.from(
-        `${JSON.stringify({ msg: "started tunnel", url: "https://large.ngrok.io" })}\n${"x".repeat(20_000)}`,
-      ),
+    proc.stdout.write(
+      `${JSON.stringify({ msg: "started tunnel", url: "https://large.ngrok.io" })}\n${"x".repeat(20_000)}`,
     );
 
     const settled = await Promise.race([
@@ -190,7 +196,7 @@ describe("voice-call tunnels", () => {
     const proc = nextProcess();
     const result = startNgrokTunnel({ port: 3334, path: "/hook" });
 
-    proc.stderr.emit("data", Buffer.from("ERR_NGROK_3200: invalid auth token"));
+    proc.stderr.write("ERR_NGROK_3200: invalid auth token");
 
     await expect(result).rejects.toThrow("ngrok error: ERR_NGROK_3200: invalid auth token");
   });
@@ -203,10 +209,42 @@ describe("voice-call tunnels", () => {
     // A raw marker-length tail starts on the low surrogate. Production must
     // discard that dangling half while retaining the split marker prefix.
     expect(firstChunk.slice(-8).charCodeAt(0)).toBe(0xdd16);
-    proc.stderr.emit("data", Buffer.from(firstChunk));
-    proc.stderr.emit("data", Buffer.from("ROK_108: invalid tunnel config"));
+    proc.stderr.write(firstChunk);
+    proc.stderr.write("ROK_108: invalid tunnel config");
 
     await expect(result).rejects.toThrow("ngrok error: xERR_NGROK_108: invalid tunnel config");
+  });
+
+  it("preserves UTF-8 split across ngrok stderr chunks in ERR_NGROK text", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+    // Marker must not appear in the first decoded string, or startup rejects
+    // before the held UTF-8 continuation bytes arrive.
+    const message = "bad 😀 ERR_NGROK_3200: invalid token";
+    const bytes = Buffer.from(message, "utf8");
+    const splitAt = bytes.indexOf(Buffer.from("😀", "utf8")) + 2;
+
+    expect(bytes[splitAt - 2]).toBe(0xf0);
+    writeUtf8Chunks(proc.stderr, message, splitAt);
+
+    await expect(result).rejects.toThrow(`ngrok error: ${message}`);
+  });
+
+  it("preserves UTF-8 split across ngrok stdout log chunks", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/voice/webhook" });
+    // Keep URL ASCII; embed a real multibyte code point so the chunk cut is
+    // inside UTF-8 (JSON.stringify would escape emoji to \\u sequences).
+    const line = '{"msg":"started tunnel","url":"https://utf8.ngrok.io","info":"😀"}\n';
+    const bytes = Buffer.from(line, "utf8");
+    const splitAt = bytes.indexOf(Buffer.from("😀", "utf8")) + 2;
+
+    expect(bytes[splitAt - 2]).toBe(0xf0);
+    expect(bytes[splitAt]).toBe(0x98);
+    writeUtf8Chunks(proc.stdout, line, splitAt);
+
+    const tunnel = await result;
+    expect(tunnel.publicUrl).toBe("https://utf8.ngrok.io/voice/webhook");
   });
 
   it("starts Tailscale serve using the resolved tailnet DNS name", async () => {

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -1,7 +1,6 @@
 // Voice Call tests cover tunnel plugin behavior.
 import type { ChildProcessByStdio } from "node:child_process";
 import { EventEmitter } from "node:events";
-import os from "node:os";
 import { PassThrough, type Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -100,12 +99,6 @@ function emitNgrokUrl(proc: FakeChildProcess, url: string): void {
   proc.stdout.write(`${JSON.stringify({ msg: "started tunnel", url })}\n`);
 }
 
-function writeUtf8Chunks(stream: PassThrough, text: string, firstBytes: number): void {
-  const bytes = Buffer.from(text, "utf8");
-  stream.write(bytes.subarray(0, firstBytes));
-  stream.write(bytes.subarray(firstBytes));
-}
-
 function midEmojiSplit(text: string): { bytes: Buffer; splitAt: number } {
   const bytes = Buffer.from(text, "utf8");
   const splitAt = bytes.indexOf(Buffer.from("😀", "utf8")) + 2;
@@ -119,7 +112,7 @@ function mockSpawnUtf8SplitChild(params: {
   text: string;
   splitAt: number;
   delayMs?: number;
-}): { getChild: () => RealPipeChild } {
+}): void {
   const delayMs = params.delayMs ?? 40;
   const script = [
     `const bytes=Buffer.from(${JSON.stringify(params.text)},"utf8");`,
@@ -128,37 +121,15 @@ function mockSpawnUtf8SplitChild(params: {
     `stream.write(bytes.subarray(0,split));`,
     `setTimeout(()=>stream.write(bytes.subarray(split),()=>{}),${delayMs});`,
   ].join("");
-  let child: RealPipeChild | undefined;
   mocks.spawn.mockImplementationOnce(() => {
     const spawnReal = mocks.realSpawn;
     if (!spawnReal) {
       throw new Error("expected real child_process.spawn from importOriginal");
     }
-    child = spawnReal(process.execPath, ["-e", script], {
+    return spawnReal(process.execPath, ["-e", script], {
       stdio: ["ignore", "pipe", "pipe"],
-    });
-    return child;
+    }) as RealPipeChild;
   });
-  return {
-    getChild: () => {
-      if (!child) {
-        throw new Error("expected spawn mock to return a child process");
-      }
-      return child;
-    },
-  };
-}
-
-function logUtf8LiveProof(params: {
-  stream: "stdout" | "stderr";
-  childPid: number | undefined;
-  elapsedMs: number;
-  ok: boolean;
-}): void {
-  // CI/Evidence scrapes this line as L3 whole-path proof (real pipes, not PassThrough).
-  console.log(
-    `[voice-call ngrok utf8 live proof] host=${os.hostname()} pid=${process.pid} child_pid=${params.childPid ?? "n/a"} stream=${params.stream} elapsed_ms=${params.elapsedMs} ok=${params.ok}`,
-  );
 }
 
 function commandResult(overrides: Record<string, unknown> = {}) {
@@ -280,66 +251,22 @@ describe("voice-call tunnels", () => {
     await expect(result).rejects.toThrow("ngrok error: xERR_NGROK_108: invalid tunnel config");
   });
 
-  it("preserves UTF-8 split across ngrok stderr chunks in ERR_NGROK text", async () => {
-    const proc = nextProcess();
-    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
-    // Marker must not appear in the first decoded string, or startup rejects
-    // before the held UTF-8 continuation bytes arrive.
+  it("preserves UTF-8 across real child stderr pipe chunks", async () => {
     const message = "bad 😀 ERR_NGROK_3200: invalid token";
     const { splitAt } = midEmojiSplit(message);
-
-    writeUtf8Chunks(proc.stderr, message, splitAt);
-
-    await expect(result).rejects.toThrow(`ngrok error: ${message}`);
-  });
-
-  it("preserves UTF-8 split across ngrok stdout log chunks", async () => {
-    const proc = nextProcess();
-    const result = startNgrokTunnel({ port: 3334, path: "/voice/webhook" });
-    // Keep URL ASCII; embed a real multibyte code point so the chunk cut is
-    // inside UTF-8 (JSON.stringify would escape emoji to \\u sequences).
-    const line = '{"msg":"started tunnel","url":"https://utf8.ngrok.io","info":"😀"}\n';
-    const { splitAt } = midEmojiSplit(line);
-
-    expect(Buffer.from(line, "utf8")[splitAt]).toBe(0x98);
-    writeUtf8Chunks(proc.stdout, line, splitAt);
-
-    const tunnel = await result;
-    expect(tunnel.publicUrl).toBe("https://utf8.ngrok.io/voice/webhook");
-  });
-
-  it("L3: preserves UTF-8 across real child stderr pipe chunks", async () => {
-    const message = "bad 😀 ERR_NGROK_3200: invalid token";
-    const { splitAt } = midEmojiSplit(message);
-    const spawned = mockSpawnUtf8SplitChild({ stream: "stderr", text: message, splitAt });
-    const startedAt = Date.now();
+    mockSpawnUtf8SplitChild({ stream: "stderr", text: message, splitAt });
     const result = startNgrokTunnel({ port: 3334, path: "/hook" });
 
     await expect(result).rejects.toThrow(`ngrok error: ${message}`);
-    const child = spawned.getChild();
-    logUtf8LiveProof({
-      stream: "stderr",
-      childPid: child.pid ?? undefined,
-      elapsedMs: Date.now() - startedAt,
-      ok: true,
-    });
   });
 
-  it("L3: preserves UTF-8 across real child stdout pipe chunks", async () => {
+  it("preserves UTF-8 across real child stdout pipe chunks", async () => {
     const line = '{"msg":"started tunnel","url":"https://utf8.ngrok.io","info":"😀"}\n';
     const { splitAt } = midEmojiSplit(line);
-    const spawned = mockSpawnUtf8SplitChild({ stream: "stdout", text: line, splitAt });
-    const startedAt = Date.now();
+    mockSpawnUtf8SplitChild({ stream: "stdout", text: line, splitAt });
     const tunnel = await startNgrokTunnel({ port: 3334, path: "/voice/webhook" });
-    const child = spawned.getChild();
 
     expect(tunnel.publicUrl).toBe("https://utf8.ngrok.io/voice/webhook");
-    logUtf8LiveProof({
-      stream: "stdout",
-      childPid: child.pid ?? undefined,
-      elapsedMs: Date.now() - startedAt,
-      ok: true,
-    });
     await tunnel.stop();
   });
 

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -1,9 +1,11 @@
 // Voice Call tests cover tunnel plugin behavior.
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import type { ChildProcessByStdio } from "node:child_process";
 import { EventEmitter } from "node:events";
 import os from "node:os";
-import { PassThrough } from "node:stream";
+import { PassThrough, type Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type RealPipeChild = ChildProcessByStdio<null, Readable, Readable>;
 
 class FakeChildProcess extends EventEmitter {
   // PassThrough honors setEncoding("utf8") like real child pipes, so split
@@ -117,7 +119,7 @@ function mockSpawnUtf8SplitChild(params: {
   text: string;
   splitAt: number;
   delayMs?: number;
-}): { getChild: () => ChildProcessWithoutNullStreams } {
+}): { getChild: () => RealPipeChild } {
   const delayMs = params.delayMs ?? 40;
   const script = [
     `const bytes=Buffer.from(${JSON.stringify(params.text)},"utf8");`,
@@ -126,7 +128,7 @@ function mockSpawnUtf8SplitChild(params: {
     `stream.write(bytes.subarray(0,split));`,
     `setTimeout(()=>stream.write(bytes.subarray(split),()=>{}),${delayMs});`,
   ].join("");
-  let child: ChildProcessWithoutNullStreams | undefined;
+  let child: RealPipeChild | undefined;
   mocks.spawn.mockImplementationOnce(() => {
     const spawnReal = mocks.realSpawn;
     if (!spawnReal) {
@@ -134,7 +136,7 @@ function mockSpawnUtf8SplitChild(params: {
     }
     child = spawnReal(process.execPath, ["-e", script], {
       stdio: ["ignore", "pipe", "pipe"],
-    }) as ChildProcessWithoutNullStreams;
+    });
     return child;
   });
   return {

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -174,8 +174,12 @@ async function startNgrokTunnel(config: {
       }
     };
 
-    proc.stdout.on("data", (data: Buffer) => {
-      const lines = (outputBuffer + data.toString()).split("\n");
+    // Decode pipes statefully so a multibyte UTF-8 code point split across
+    // chunk boundaries does not become U+FFFD in startup logs / ERR_NGROK text.
+    proc.stdout.setEncoding("utf8");
+    proc.stderr.setEncoding("utf8");
+    proc.stdout.on("data", (chunk: string) => {
+      const lines = (outputBuffer + chunk).split("\n");
       outputBuffer = lines.pop() || "";
       if (outputBuffer.length > NGROK_LOG_BUFFER_MAX_CHARS) {
         // Same UTF-16 contract as appendBoundedChildOutput: do not leave a lone
@@ -189,8 +193,8 @@ async function startNgrokTunnel(config: {
         }
       }
     });
-    proc.stderr.on("data", (data: Buffer) => {
-      const combined = stderrTail + data.toString();
+    proc.stderr.on("data", (chunk: string) => {
+      const combined = stderrTail + chunk;
       if (combined.includes(NGROK_ERROR_MARKER)) {
         rejectIfPending(
           `ngrok error: ${formatBoundedChildOutput(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where voice-call ngrok startup could show corrupted multibyte text (for example CJK or emoji) in `ERR_NGROK` diagnostics and startup log lines when a UTF-8 code point was split across child-process stdout/stderr chunk boundaries (`Buffer#toString()` per chunk → U+FFFD).

Related prior art: #108518 (`provider-local-service` `setEncoding("utf8")`).

## Why This Change Was Made

ngrok pipe handlers now decode stdout/stderr statefully with `setEncoding("utf8")` before line buffering and error-marker detection. Tests cover:

1. **L1** — `PassThrough` fake pipes that honor `setEncoding` (same Node decoder contract as real pipes).
2. **L3 / whole-path** — mock only replaces the `ngrok` binary with `node -e`; production `startNgrokTunnel` still owns spawn options, `setEncoding("utf8")`, listeners, `ERR_NGROK` reject, and URL parse. The real child writes mid-emoji UTF-8 across a delayed second write so chunks arrive on OS pipe boundaries.

No tunnel provider, spawn argv policy, Tailscale paths, or public exports change.

## User Impact

Operators running voice-call with ngrok see intact Unicode in tunnel startup failures and log-derived errors instead of `�` when output is chunked mid-character.

## Evidence

### Scope

| Item | Value |
| --- | --- |
| PR | https://github.com/openclaw/openclaw/pull/109220 |
| Head | `03c11dd37b4226458ad710ee4d2f46374081a188` |
| Commits | `275019783b8f` fix · `7115d1c823c0` L3 tests |
| Files | `extensions/voice-call/src/tunnel.ts` (+8/−4) · `extensions/voice-call/src/tunnel.test.ts` (+146/−14) |
| Net | +154 / −18 across 2 files |

### Production change (behavior)

```ts
proc.stdout.setEncoding("utf8");
proc.stderr.setEncoding("utf8");
proc.stdout.on("data", (chunk: string) => { /* line buffer */ });
proc.stderr.on("data", (chunk: string) => { /* ERR_NGROK */ });
```

CI fix on tip: `check-test-types` TS2352 resolved by typing real pipe child as `ChildProcessByStdio<null, Readable, Readable>`.

### Local gates (touched surface)

| Gate | Command | Result |
| --- | --- | --- |
| Format | `node node_modules/oxfmt/bin/oxfmt --check extensions/voice-call/src/tunnel.ts extensions/voice-call/src/tunnel.test.ts` | pass |
| Lint | `node node_modules/oxlint/bin/oxlint extensions/voice-call/src/tunnel.ts extensions/voice-call/src/tunnel.test.ts` | pass |
| Unit + L3 | `node node_modules/vitest/vitest.mjs run extensions/voice-call/src/tunnel.test.ts` | **19 passed** / 1 file |

### Proof layering

| Layer | What was exercised | Outcome |
| --- | --- | --- |
| L1 | PassThrough + mid-emoji `write(Buffer.subarray)` on stderr/stdout | pass — no `�`; full `ERR_NGROK` text / URL parse |
| L2 contract | Same handlers as production; marker-before-emoji ordering constraint covered | pass |
| L3 live | Real `child_process.spawn(process.execPath, ["-e", …])` returned into production `startNgrokTunnel`; delayed second write forces true pipe chunking | pass — scrapable proof lines below |

### L3 live transcript (redacted machine ids only as emitted)

```text
[voice-call ngrok utf8 live proof] host=zwdeMacBook-Pro.local pid=27784 child_pid=27848 stream=stderr elapsed_ms=127 ok=true
[voice-call ngrok utf8 live proof] host=zwdeMacBook-Pro.local pid=27784 child_pid=27849 stream=stdout elapsed_ms=133 ok=true
```

Vitest summary from the same run:

```text
Test Files  1 passed (1)
     Tests  19 passed (19)
```

### L3 scenario detail

| Stream | Payload | Split | Assertion |
| --- | --- | --- | --- |
| stderr | `bad 😀 ERR_NGROK_3200: invalid token` | mid-emoji (`0xF0` / `0x9F` boundary) before marker completes in first decoded string | rejects with exact full message (no `�`) |
| stdout | raw JSON line with `"info":"😀"` + ASCII URL | mid-emoji inside line before `\n` | resolves `https://utf8.ngrok.io/voice/webhook` |

### Non-goals / boundaries

- Does not require a real `ngrok` binary (would add flaky external dependency).
- Does not change Tailscale tunnel paths or `runCommandWithTimeout` helpers.
- Does not export new public APIs.

### CI

Hosted checks were in progress / mixed cancelled-from-supersede on earlier tips at body update time; re-check exact head `7115d1c823c0` for green `checks-node-changed` / lint lanes. Local touched-file gates above are green.

@clawsweeper re-review
