### PR TITLE
fix(plugin-sdk): bound rejected copilot domain warning cache

### DIFF
--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -987,8 +987,7 @@ describe("Copilot data-residency domain resolution", () => {
       return { ...actual, logWarn };
     });
 
-    const { testing, resolveCopilotApiToken } = await import("./provider-auth.js");
-    testing.resetRejectedConfigDomainWarningsForTest();
+    const { resolveCopilotApiToken } = await import("./provider-auth.js");
 
     const fetchImpl = vi.fn(
       async () =>

--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -978,6 +978,60 @@ describe("Copilot data-residency domain resolution", () => {
     vi.doUnmock("../logger.js");
   });
 
+  it("bounds the rejected-domain warning cache and re-warns evicted domains", async () => {
+    vi.resetModules();
+
+    const logWarn = vi.fn();
+    vi.doMock("../logger.js", async () => {
+      const actual = await vi.importActual<typeof import("../logger.js")>("../logger.js");
+      return { ...actual, logWarn };
+    });
+
+    const { resetRejectedConfigDomainWarningsForTest, resolveCopilotApiToken } =
+      await import("./provider-auth.js");
+    resetRejectedConfigDomainWarningsForTest();
+
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ token: "tok", expires_at: "+2000000000" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const withDomain = (githubDomain: string) =>
+      ({
+        models: { providers: { "github-copilot": { params: { githubDomain } } } },
+      }) as never;
+    const resolveWithConfigDomain = (githubDomain: string) =>
+      resolveCopilotApiToken({
+        githubToken: "github-token",
+        env: {},
+        config: withDomain(githubDomain),
+        fetchImpl,
+        cachePath: "/tmp/copilot-token-bound.json",
+        loadJsonFileImpl: () => undefined,
+        saveJsonFileImpl: () => {},
+      });
+
+    const domains: string[] = [];
+    for (let i = 0; i < 256; i += 1) {
+      domains.push(`tenant-${i}.ghe.co`);
+    }
+
+    for (const domain of domains) {
+      await resolveWithConfigDomain(domain);
+    }
+    expect(logWarn).toHaveBeenCalledTimes(256);
+
+    await resolveWithConfigDomain("tenant-256.ghe.co");
+    expect(logWarn).toHaveBeenCalledTimes(257);
+
+    await resolveWithConfigDomain(domains[0]);
+    expect(logWarn).toHaveBeenCalledTimes(258);
+
+    vi.doUnmock("../logger.js");
+  });
+
   it("rejects unsafe hostnames and falls back to github.com", async () => {
     vi.resetModules();
     const { normalizeGithubCopilotDomain } = await import("./provider-auth.js");

--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -987,9 +987,8 @@ describe("Copilot data-residency domain resolution", () => {
       return { ...actual, logWarn };
     });
 
-    const { resetRejectedConfigDomainWarningsForTest, resolveCopilotApiToken } =
-      await import("./provider-auth.js");
-    resetRejectedConfigDomainWarningsForTest();
+    const { testing, resolveCopilotApiToken } = await import("./provider-auth.js");
+    testing.resetRejectedConfigDomainWarningsForTest();
 
     const fetchImpl = vi.fn(
       async () =>
@@ -1026,7 +1025,7 @@ describe("Copilot data-residency domain resolution", () => {
     await resolveWithConfigDomain("tenant-256.ghe.co");
     expect(logWarn).toHaveBeenCalledTimes(257);
 
-    await resolveWithConfigDomain(domains[0]);
+    await resolveWithConfigDomain(domains[0]!);
     expect(logWarn).toHaveBeenCalledTimes(258);
 
     vi.doUnmock("../logger.js");

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -23,6 +23,7 @@ import {
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createDedupeCache } from "../infra/dedupe.js";
 import { logWarn } from "../logger.js";
 import {
   DEFAULT_GITHUB_COPILOT_DOMAIN,
@@ -167,7 +168,7 @@ function readGithubCopilotDomainFromConfig(config?: OpenClawConfig): string | un
 // github.com (fail-closed for the token). That silent fallback turns a typo like
 // `acme.ghe.co` into an opaque 401 (tenant token vs public endpoint), so warn the
 // user loudly — once per distinct bad value — that their config was ignored.
-const warnedRejectedConfigDomains = new Set<string>();
+const warnedRejectedConfigDomains = createDedupeCache({ ttlMs: 0, maxSize: 256 });
 function warnOnceOnRejectedConfigDomain(configured: string): void {
   const lowered = configured.toLowerCase();
   if (lowered === DEFAULT_GITHUB_COPILOT_DOMAIN) {
@@ -176,13 +177,17 @@ function warnOnceOnRejectedConfigDomain(configured: string): void {
   if (normalizeGithubCopilotDomain(configured) !== DEFAULT_GITHUB_COPILOT_DOMAIN) {
     return;
   }
-  if (warnedRejectedConfigDomains.has(lowered)) {
+  if (warnedRejectedConfigDomains.check(lowered)) {
     return;
   }
-  warnedRejectedConfigDomains.add(lowered);
   logWarn(
     `Ignoring configured GitHub Copilot domain "${configured}": only github.com and *.ghe.com tenants are accepted. Falling back to github.com.`,
   );
+}
+
+/** Resets the rejected-domain warning cache. Exported for tests only. */
+export function resetRejectedConfigDomainWarningsForTest(): void {
+  warnedRejectedConfigDomains.clear();
 }
 
 // Provider-internal host resolver (env > explicit caller value > persisted

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -185,10 +185,11 @@ function warnOnceOnRejectedConfigDomain(configured: string): void {
   );
 }
 
-/** Resets the rejected-domain warning cache. Exported for tests only. */
-export function resetRejectedConfigDomainWarningsForTest(): void {
+function resetRejectedConfigDomainWarningsForTest(): void {
   warnedRejectedConfigDomains.clear();
 }
+
+export const testing = { resetRejectedConfigDomainWarningsForTest } as const;
 
 // Provider-internal host resolver (env > explicit caller value > persisted
 // config), always passed through the fail-closed allowlist. Not exported: the

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -185,12 +185,6 @@ function warnOnceOnRejectedConfigDomain(configured: string): void {
   );
 }
 
-function resetRejectedConfigDomainWarningsForTest(): void {
-  warnedRejectedConfigDomains.clear();
-}
-
-export const testing = { resetRejectedConfigDomainWarningsForTest } as const;
-
 // Provider-internal host resolver (env > explicit caller value > persisted
 // config), always passed through the fail-closed allowlist. Not exported: the
 // provider extension owns its own copy so the SDK surface stays minimal.


### PR DESCRIPTION
## What Problem This Solves

`src/plugin-sdk/provider-auth.ts` keeps a module-level `Set<string>` (`warnedRejectedConfigDomains`) to warn only once per rejected GitHub Copilot `githubDomain` value. The set grows without bound over process lifetime.

## Why This Change Was Made

Replaced the raw `Set` with `createDedupeCache({ ttlMs: 0, maxSize: 256 })` from `src/infra/dedupe.js`. The cache auto-evicts the oldest entry when it overflows.

## User Impact

No behavior change under normal load; evicted rejected-domain warnings will be re-logged if the same domain is encountered again after overflow.

## Evidence

- Guard test in `src/plugin-sdk/provider-auth.test.ts` asserts the cache caps at 256 entries and re-warns evicted domains.
- `node scripts/run-vitest.mjs src/plugin-sdk/provider-auth.test.ts` passes.
