### PR TITLE
test: raise async wait ceilings that flaked under CI load

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
@@ -2,12 +2,16 @@ import Foundation
 
 struct AsyncWaitTimeoutError: Error, CustomStringConvertible {
     let label: String
-    var description: String { "Timeout waiting for: \(self.label)" }
+    var description: String {
+        "Timeout waiting for: \(self.label)"
+    }
 }
 
 func waitUntil(
     _ label: String,
-    timeoutSeconds: Double = 3.0,
+    // Polling returns as soon as the condition holds; the generous ceiling
+    // only matters under full-suite parallel load, where 3s flaked on CI.
+    timeoutSeconds: Double = 15.0,
     pollMs: UInt64 = 10,
     _ condition: @escaping @Sendable () async -> Bool) async throws
 {

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -299,7 +299,9 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       () => {
         expect(runtime.runTurn).toHaveBeenCalledTimes(1);
       },
-      { timeout: 5_000 },
+      // Import-bound dispatch startup can exceed 5s on contended CI runners
+      // (flaked on shard reruns); waitFor returns immediately once satisfied.
+      { timeout: 15_000 },
     );
     abortController.abort();
     const outcome = await raceWithTimeoutResult(


### PR DESCRIPTION
## What Problem This Solves

Two timing-sensitive tests flaked repeatedly on contended CI runners during recent landings, costing full rerun cycles: `dispatch-from-config.acp-abort.test.ts > aborts ACP dispatch promptly` (vi.waitFor at 5s expired before dispatch startup finished importing on a loaded shard) and `ChatViewModelOutboxTests > definitive live-send rejection restores draft without queueing` (the shared Swift `waitUntil` helper defaults to a 3s ceiling that lapses under 269-test parallel load). Both pass deterministically solo and locally.

## Why This Change Was Made

Both waits are polling constructs that return the moment their condition holds, so raising the ceilings (15s for the vi.waitFor, 15s default for the Swift helper) removes the flake class without slowing any healthy run. The Swift change fixes every `waitUntil` caller at once rather than the single observed test.

## User Impact

None at runtime; CI reruns caused by these two flakes disappear.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts` — 18 passed.
- `swift test --package-path apps/shared/OpenClawKit --filter ChatViewModelOutbox` — 49 passed (previously flaked under full-suite load in this exact suite).
- Flake provenance: both failures observed on PR #108675 CI (shard `auto-reply-reply-dispatch` rerun, and local full-suite Swift runs), each passing solo on identical code.
