### PR TITLE
fix(crabbox): make signal-cleanup proof deterministic

### DIFF
--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -56,9 +56,14 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
 
   if (process.platform !== "win32") {
     const signalIgnoringDescendantScript = [
+      "import fs from 'node:fs';",
       "process.on('SIGHUP', () => {});",
       "process.on('SIGINT', () => {});",
       "process.on('SIGTERM', () => {});",
+      "const pidPath = process.env.OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH;",
+      "const pidTmpPath = `${pidPath}.tmp.${process.pid}`;",
+      "fs.writeFileSync(pidTmpPath, String(process.pid));",
+      "fs.renameSync(pidTmpPath, pidPath);",
       "setInterval(() => {}, 1000);",
     ].join("");
     const script = [
@@ -145,12 +150,9 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
       '  cd "$deleted_cwd" || exit 1',
       "fi",
       'if [ -n "${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH:-}" ]; then',
+      // The descendant publishes its own PID only after its signal handlers exist.
+      // Atomic rename makes path existence a complete readiness handshake.
       `  ${shellSingleQuote(process.execPath)} --input-type=module --eval ${shellSingleQuote(signalIgnoringDescendantScript)} &`,
-      // Publish readiness only after the PID is complete; redirection exposes
-      // an empty destination before printf runs under scheduler pressure.
-      '  descendant_pid_tmp="${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH}.tmp.$$"',
-      '  printf "%s" "$!" > "$descendant_pid_tmp"',
-      '  mv "$descendant_pid_tmp" "$OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH"',
       '  trap "exit 0" INT TERM HUP',
       "  while :; do sleep 1; done",
       "fi",

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -146,7 +146,11 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
       "fi",
       'if [ -n "${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH:-}" ]; then',
       `  ${shellSingleQuote(process.execPath)} --input-type=module --eval ${shellSingleQuote(signalIgnoringDescendantScript)} &`,
-      '  printf "%s" "$!" > "$OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH"',
+      // Publish readiness only after the PID is complete; redirection exposes
+      // an empty destination before printf runs under scheduler pressure.
+      '  descendant_pid_tmp="${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH}.tmp.$$"',
+      '  printf "%s" "$!" > "$descendant_pid_tmp"',
+      '  mv "$descendant_pid_tmp" "$OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH"',
       '  trap "exit 0" INT TERM HUP',
       "  while :; do sleep 1; done",
       "fi",
@@ -640,7 +644,9 @@ async function runSignalCleanupProof(sendSignals: (pid: number) => Promise<void>
     const runnerExit = waitForProcessExit(runner);
     await sendSignals(runner.pid!);
     await expect(runnerExit).resolves.toEqual({ status: 143, signal: null });
-    await waitForCondition(() => !isProcessAlive(descendantPid));
+    // The wrapper waits for the detached process group to disappear before exit.
+    // A live PID here would expose the cleanup-ordering regression this proves.
+    expect(isProcessAlive(descendantPid)).toBe(false);
   } finally {
     if (runner.pid && isProcessAlive(runner.pid)) {
       runner.kill("SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Crabbox wrapper signal-cleanup proof could fail unrelated pull requests under Linux scheduler pressure by reading its descendant PID marker while the file was still empty.

## Why This Change Was Made

The fake descendant now installs its signal handlers, writes its own PID to a same-directory temporary file, and atomically renames it into place. Observing the destination is therefore a complete readiness handshake: valid PID plus active signal handlers. The proof also checks immediately after wrapper exit that the descendant is already gone, matching the wrapper contract that cleanup completes before parent signal exit.

## User Impact

No user-visible runtime change. Maintainers get deterministic CI coverage for Crabbox descendant cleanup without unrelated signal-test flakes.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/29513282166/attempts/1?check_suite_focus=true, job `checks-node-compact-small-3`, Node 24.18.0. The assertion parsed an empty PID before any signal was sent.
- Baseline Linux Node 24 bounded loop: 200/200 passes, confirming the race is rare and load-dependent.
- Final Linux Node 24 bounded loop: 200/200 passes on Blacksmith Testbox `tbx_01kxnyej51ka8179acqjgb56ww`.
- `test/scripts/crabbox-wrapper.test.ts`: 195/195 passes.
- Changed checks pass for `testRoot, tooling`, including format, root-test typecheck, and script lint.
- Fresh autoreview after the readiness-handshake fix: clean, no actionable findings.
- Exact-head hosted CI will be required again before merge.

AI-assisted: yes. The change and process-tree ordering were manually verified against the wrapper implementation and Node 24 signal behavior.
