### PR TITLE
fix(channels): bound message action discovery error cache

### DIFF
--- a/src/channels/plugins/message-action-discovery.test.ts
+++ b/src/channels/plugins/message-action-discovery.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelMessageToolDiscoveryAdapter } from "./message-tool-api.js";
+import type { ChannelMessageActionDiscoveryContext } from "./types.core.js";
+
+const { defaultRuntimeMock } = vi.hoisted(() => ({
+  defaultRuntimeMock: { error: vi.fn() },
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: defaultRuntimeMock,
+}));
+
+describe("message action discovery error cache", () => {
+  beforeEach(() => {
+    defaultRuntimeMock.error.mockClear();
+    vi.resetModules();
+  });
+
+  it("caps the error dedupe cache at 1024 entries and re-logs evicted errors", async () => {
+    const { resolveMessageActionDiscoveryForPlugin } =
+      await import("./message-action-discovery.js");
+
+    const describeMessageTool = vi.fn();
+    const actions = {
+      describeMessageTool,
+    } as unknown as ChannelMessageToolDiscoveryAdapter;
+    const context = { cfg: {} } as unknown as ChannelMessageActionDiscoveryContext;
+
+    for (let i = 0; i < 1024; i++) {
+      describeMessageTool.mockImplementationOnce(() => {
+        throw new Error(`error-${i}`);
+      });
+      resolveMessageActionDiscoveryForPlugin({
+        pluginId: "test-plugin",
+        actions,
+        context,
+      });
+    }
+    expect(defaultRuntimeMock.error).toHaveBeenCalledTimes(1024);
+
+    // Push the cache over its max size; the oldest entry (error-0) is evicted.
+    describeMessageTool.mockImplementationOnce(() => {
+      throw new Error("error-1024");
+    });
+    resolveMessageActionDiscoveryForPlugin({
+      pluginId: "test-plugin",
+      actions,
+      context,
+    });
+    expect(defaultRuntimeMock.error).toHaveBeenCalledTimes(1025);
+
+    // The evicted error should be logged again because it is no longer cached.
+    describeMessageTool.mockImplementationOnce(() => {
+      throw new Error("error-0");
+    });
+    resolveMessageActionDiscoveryForPlugin({
+      pluginId: "test-plugin",
+      actions,
+      context,
+    });
+    expect(defaultRuntimeMock.error).toHaveBeenCalledTimes(1026);
+  });
+});

--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { Type, type TSchema } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeAnyChannelId } from "../registry.js";
@@ -49,7 +50,7 @@ type ChannelMessageToolMediaSourceParamKeyInput = ChannelMessageActionDiscoveryP
   action?: ChannelMessageActionName;
 };
 
-const loggedMessageActionErrors = new Set<string>();
+const loggedMessageActionErrors = createDedupeCache({ ttlMs: 0, maxSize: 1024 });
 
 /**
  * Normalizes a raw channel/provider id before consulting action discovery hooks.
@@ -91,10 +92,9 @@ function logMessageActionError(params: {
   const key = `${params.pluginId}:${params.operation}:${message}`;
   // Discovery runs while building tool schemas, so log each plugin/error pair
   // once and let the agent continue with the remaining channel capabilities.
-  if (loggedMessageActionErrors.has(key)) {
+  if (loggedMessageActionErrors.check(key)) {
     return;
   }
-  loggedMessageActionErrors.add(key);
   const stack = params.error instanceof Error && params.error.stack ? params.error.stack : null;
   defaultRuntime.error?.(
     `[message-action-discovery] ${params.pluginId}.actions.${params.operation} failed: ${stack ?? message}`,


### PR DESCRIPTION
## What Problem This Solves

`src/channels/plugins/message-action-discovery.ts` keeps a module-level `Set<string>` (`loggedMessageActionErrors`) to dedupe plugin `describeMessageTool` failures per plugin/operation/error message. The set grows without bound over process lifetime.

## Why This Change Was Made

Replaced the raw `Set` with `createDedupeCache({ ttlMs: 0, maxSize: 1024 })` from `src/infra/dedupe.js`. The cache auto-evicts the oldest entry when it overflows.

## User Impact

No behavior change under normal load; evicted plugin/error combinations will be re-logged if encountered again after overflow.

## Evidence

- Guard test in `src/channels/plugins/message-action-discovery.test.ts` asserts the cache caps at 1024 entries and re-logs evicted errors.
- `node scripts/run-vitest.mjs src/channels/plugins/message-action-discovery.test.ts` passes.
