### PR TITLE
fix(agents): bound deprecated approval timeout warning cache

### DIFF
--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -863,17 +863,20 @@ function warnDeprecatedApprovalTimeoutBehavior(approval: PluginApprovalRequest):
   );
 }
 
-/** Test-only seam to reset the deprecation warning cache. */
-export function resetDeprecatedTimeoutBehaviorWarningsForTest(): void {
-  warnedDeprecatedTimeoutBehaviorPluginIds.clear();
-}
-
-/** Test-only seam to trigger the deprecation warning for a plugin id. */
-export function warnDeprecatedApprovalTimeoutBehaviorForTest(pluginId: string): void {
-  warnDeprecatedApprovalTimeoutBehavior({
-    pluginId,
-    timeoutBehavior: "allow",
-  } as PluginApprovalRequest);
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.warnDeprecatedApprovalTimeoutBehaviorTestApi")
+  ] = {
+    reset(): void {
+      warnedDeprecatedTimeoutBehaviorPluginIds.clear();
+    },
+    warn(pluginId: string): void {
+      warnDeprecatedApprovalTimeoutBehavior({
+        pluginId,
+        timeoutBehavior: "allow",
+      } as PluginApprovalRequest);
+    },
+  };
 }
 
 function notifyPluginApprovalResolution(

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -9,6 +9,7 @@ import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coer
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
+import { createDedupeCache } from "../infra/dedupe.js";
 import {
   diagnosticErrorCategory,
   diagnosticHttpStatusCode,
@@ -842,22 +843,37 @@ function emitToolBlockedSecurityEvent(params: {
   });
 }
 
-// Once-per-plugin-per-process deprecation signal; the field is ignored at
-// runtime because unresolved approvals always fail closed on timeout.
-const warnedDeprecatedTimeoutBehaviorPluginIds = new Set<string>();
+// Bounded once-per-plugin deprecation signal; the field is ignored at runtime
+// because unresolved approvals always fail closed on timeout.
+const warnedDeprecatedTimeoutBehaviorPluginIds = createDedupeCache({
+  ttlMs: 0,
+  maxSize: 1024,
+});
 
 function warnDeprecatedApprovalTimeoutBehavior(approval: PluginApprovalRequest): void {
   if (approval.timeoutBehavior !== "allow") {
     return;
   }
   const pluginId = approval.pluginId ?? "unknown-plugin";
-  if (warnedDeprecatedTimeoutBehaviorPluginIds.has(pluginId)) {
+  if (warnedDeprecatedTimeoutBehaviorPluginIds.check(pluginId)) {
     return;
   }
-  warnedDeprecatedTimeoutBehaviorPluginIds.add(pluginId);
   log.warn(
     `plugin '${pluginId}' sets deprecated requireApproval.timeoutBehavior:"allow"; the field is ignored and approvals fail closed on timeout (see docs/plugins/plugin-permission-requests.md)`,
   );
+}
+
+/** Test-only seam to reset the deprecation warning cache. */
+export function resetDeprecatedTimeoutBehaviorWarningsForTest(): void {
+  warnedDeprecatedTimeoutBehaviorPluginIds.clear();
+}
+
+/** Test-only seam to trigger the deprecation warning for a plugin id. */
+export function warnDeprecatedApprovalTimeoutBehaviorForTest(pluginId: string): void {
+  warnDeprecatedApprovalTimeoutBehavior({
+    pluginId,
+    timeoutBehavior: "allow",
+  } as PluginApprovalRequest);
 }
 
 function notifyPluginApprovalResolution(

--- a/src/agents/agent-tools.before-tool-call.warning-cache.test.ts
+++ b/src/agents/agent-tools.before-tool-call.warning-cache.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const warnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    subsystem: "agents/tools",
+    isEnabled: vi.fn(() => false),
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(() => ({ warn: vi.fn() })),
+  })),
+}));
+
+import {
+  resetDeprecatedTimeoutBehaviorWarningsForTest,
+  warnDeprecatedApprovalTimeoutBehaviorForTest,
+} from "./agent-tools.before-tool-call.js";
+
+describe("deprecated approval timeout behavior warning cache", () => {
+  beforeEach(() => {
+    resetDeprecatedTimeoutBehaviorWarningsForTest();
+    warnMock.mockClear();
+  });
+
+  it("deduplicates warnings for the same plugin id", () => {
+    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-a");
+    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-a");
+    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-a");
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("plugin 'plugin-a' sets deprecated requireApproval.timeoutBehavior"),
+    );
+  });
+
+  it("caps the cache at 1024 entries and re-warns evicted plugin ids", () => {
+    // Fill the cache to exactly its max size.
+    for (let i = 0; i < 1024; i += 1) {
+      warnDeprecatedApprovalTimeoutBehaviorForTest(`plugin-${i}`);
+    }
+    expect(warnMock).toHaveBeenCalledTimes(1024);
+
+    // A recent plugin should still be deduplicated.
+    warnMock.mockClear();
+    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-1023");
+    expect(warnMock).not.toHaveBeenCalled();
+
+    // Overflow the cache by one entry, evicting the oldest plugin.
+    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-1024");
+    expect(warnMock).toHaveBeenCalledTimes(1);
+
+    // The oldest plugin should now be warned again.
+    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-0");
+    expect(warnMock).toHaveBeenCalledTimes(2);
+    expect(warnMock).toHaveBeenLastCalledWith(
+      expect.stringContaining("plugin 'plugin-0' sets deprecated requireApproval.timeoutBehavior"),
+    );
+  });
+});

--- a/src/agents/agent-tools.before-tool-call.warning-cache.test.ts
+++ b/src/agents/agent-tools.before-tool-call.warning-cache.test.ts
@@ -17,21 +17,31 @@ vi.mock("../logging/subsystem.js", () => ({
   })),
 }));
 
-import {
-  resetDeprecatedTimeoutBehaviorWarningsForTest,
-  warnDeprecatedApprovalTimeoutBehaviorForTest,
-} from "./agent-tools.before-tool-call.js";
+type DeprecatedTimeoutBehaviorTestApi = {
+  reset: () => void;
+  warn: (pluginId: string) => void;
+};
+
+async function loadTestApi(): Promise<DeprecatedTimeoutBehaviorTestApi> {
+  await import("./agent-tools.before-tool-call.js");
+  const api = (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.warnDeprecatedApprovalTimeoutBehaviorTestApi")
+  ];
+  return api as DeprecatedTimeoutBehaviorTestApi;
+}
 
 describe("deprecated approval timeout behavior warning cache", () => {
   beforeEach(() => {
-    resetDeprecatedTimeoutBehaviorWarningsForTest();
+    vi.resetModules();
     warnMock.mockClear();
   });
 
-  it("deduplicates warnings for the same plugin id", () => {
-    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-a");
-    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-a");
-    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-a");
+  it("deduplicates warnings for the same plugin id", async () => {
+    const api = await loadTestApi();
+    api.reset();
+    api.warn("plugin-a");
+    api.warn("plugin-a");
+    api.warn("plugin-a");
 
     expect(warnMock).toHaveBeenCalledTimes(1);
     expect(warnMock).toHaveBeenCalledWith(
@@ -39,24 +49,27 @@ describe("deprecated approval timeout behavior warning cache", () => {
     );
   });
 
-  it("caps the cache at 1024 entries and re-warns evicted plugin ids", () => {
+  it("caps the cache at 1024 entries and re-warns evicted plugin ids", async () => {
+    const api = await loadTestApi();
+    api.reset();
+
     // Fill the cache to exactly its max size.
     for (let i = 0; i < 1024; i += 1) {
-      warnDeprecatedApprovalTimeoutBehaviorForTest(`plugin-${i}`);
+      api.warn(`plugin-${i}`);
     }
     expect(warnMock).toHaveBeenCalledTimes(1024);
 
     // A recent plugin should still be deduplicated.
     warnMock.mockClear();
-    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-1023");
+    api.warn("plugin-1023");
     expect(warnMock).not.toHaveBeenCalled();
 
     // Overflow the cache by one entry, evicting the oldest plugin.
-    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-1024");
+    api.warn("plugin-1024");
     expect(warnMock).toHaveBeenCalledTimes(1);
 
     // The oldest plugin should now be warned again.
-    warnDeprecatedApprovalTimeoutBehaviorForTest("plugin-0");
+    api.warn("plugin-0");
     expect(warnMock).toHaveBeenCalledTimes(2);
     expect(warnMock).toHaveBeenLastCalledWith(
       expect.stringContaining("plugin 'plugin-0' sets deprecated requireApproval.timeoutBehavior"),


### PR DESCRIPTION
## What Problem This Solves

`src/agents/agent-tools.before-tool-call.ts` keeps a module-level `Set<string>` (`warnedDeprecatedTimeoutBehaviorPluginIds`) to warn only once per plugin about deprecated `requireApproval.timeoutBehavior: "allow"`. The set grows without bound over process lifetime.

## Why This Change Was Made

Replaced the raw `Set` with `createDedupeCache({ ttlMs: 0, maxSize: 1024 })` from `src/infra/dedupe.js`. The cache auto-evicts the oldest entry when it overflows.

## User Impact

No behavior change under normal load; evicted plugin warnings will be re-logged if the same plugin triggers the deprecated path again after overflow.

## Evidence

- Guard test in `src/agents/agent-tools.before-tool-call.warning-cache.test.ts` asserts the cache caps at 1024 entries and re-warns evicted plugin IDs.
- `node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.warning-cache.test.ts` passes.
