### PR TITLE
refactor(codex): deduplicate sandbox HTTP test setup [AI]

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
@@ -24,6 +24,15 @@ function testExecEnv(): NodeJS.ProcessEnv {
   };
 }
 
+async function openSandboxHttpSocket(sandbox: ReturnType<typeof createSandboxContext>) {
+  const client = createClient();
+  await ensureCodexSandboxExecServerEnvironment({
+    client: client as never,
+    sandbox,
+  });
+  return openSocket(execServerUrlFromClient(client));
+}
+
 function splitUtf8ChildScript(params: {
   stream: "stdout" | "stderr";
   value: string;
@@ -64,12 +73,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
       code: 0,
     }));
     const sandbox = createSandboxContext({ runShellCommand });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
 
@@ -102,12 +106,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
       code: 0,
     }));
     const sandbox = createSandboxContext({ runShellCommand });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
 
@@ -129,12 +128,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
       stdinMode: "pipe-closed" as const,
     }));
     const sandbox = createSandboxContext({ buildExecSpec });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
 
@@ -185,12 +179,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
       code: 0,
     }));
     const sandbox = createSandboxContext({ buildExecSpec, runShellCommand });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     const notifications = collectNotifications(socket);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
@@ -251,12 +240,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
         stdinMode: "pipe-closed",
       }),
     });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
 
@@ -297,12 +281,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
         stdinMode: "pipe-closed",
       }),
     });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     const notifications = collectNotifications(socket);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
@@ -353,12 +332,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
       }),
       finalizeExec,
     });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
 
@@ -406,12 +380,7 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
       }),
       finalizeExec,
     });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
+    const socket = await openSandboxHttpSocket(sandbox);
     await rpc(socket, "initialize", { clientName: "test" });
     socket.send(JSON.stringify({ method: "initialized" }));
 


### PR DESCRIPTION
Related: #108618

AI-assisted maintainer follow-up requested during the landing pass for #108618.

## What Problem This Solves

The sandbox HTTP test suite repeated the same client registration and WebSocket opening sequence in all eight tests. That duplication made protocol-fixture updates noisy and made it easier for one test to drift from the suite's shared setup.

## Why This Change Was Made

One local `openSandboxHttpSocket` helper now owns the repeated environment registration and socket opening. Initialization and notification-listener ordering remain at each call site, so test behavior is unchanged. The patch is limited to the owning HTTP test file and removes 31 net lines.

## User Impact

No user-visible or runtime behavior change. Maintainers get one canonical setup path for this regression suite.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/sandbox-exec-server.http.test.ts` — 1 file, 8 tests passed.
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/sandbox-exec-server.http.test.ts` — Testbox `tbx_01kxnxatk2ezhyq0q4seh58s92`; format, guards, extension test typecheck, and lint passed. Run: https://github.com/openclaw/openclaw/actions/runs/29517208230
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings; confidence 0.99.
- `git diff --check` — passed.
