### PR TITLE
fix(ui): stop local assistant attachments from checking forever

### DIFF
--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2157,6 +2157,56 @@ describe("grouped chat rendering", () => {
     ).toBe(expectedMetaUrl.replace("&meta=1", "&mediaTicket=ticket-local"));
   });
 
+  it("stops checking when local assistant attachment metadata fetch stalls", async () => {
+    vi.useFakeTimers();
+    const source = `/tmp/openclaw/${crypto.randomUUID()}-stalled.txt`;
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener(
+            "abort",
+            () => reject(signal.reason ?? new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const container = document.createElement("div");
+    const rerender = () =>
+      renderAssistantMessage(
+        container,
+        {
+          id: "assistant-local-media-stalled-metadata",
+          role: "assistant",
+          content: `Local document\nMEDIA:${source}`,
+          timestamp: Date.now(),
+        },
+        {
+          showToolCalls: false,
+          basePath: "/openclaw",
+          localMediaPreviewRoots: ["/tmp/openclaw"],
+          onRequestUpdate: rerender,
+        },
+      );
+
+    rerender();
+    expect(container.querySelector(".chat-assistant-attachment-badge")?.textContent?.trim()).toBe(
+      "Checking...",
+    );
+
+    const expectedMetaUrl = `/openclaw/__openclaw__/assistant-media?source=${encodeURIComponent(source)}&meta=1`;
+    const [, fetchInit] = requireFetchCallForUrl(fetchMock, expectedMetaUrl);
+    await vi.advanceTimersByTimeAsync(30_001);
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    expect(fetchInit?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchInit?.signal?.aborted).toBe(true);
+    expect(container.querySelector(".chat-assistant-attachment-badge")?.textContent?.trim()).toBe(
+      "Unavailable",
+    );
+  });
+
   it("refreshes local assistant media tickets before expiry without another render", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-30T00:00:00Z"));

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2166,7 +2166,12 @@ describe("grouped chat rendering", () => {
           const signal = init?.signal;
           signal?.addEventListener(
             "abort",
-            () => reject(signal.reason ?? new DOMException("aborted", "AbortError")),
+            () =>
+              reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new DOMException("aborted", "AbortError"),
+              ),
             { once: true },
           );
         }),

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -88,6 +88,7 @@ const assistantAttachmentAvailabilityCache = new Map<string, AssistantAttachment
 const assistantAttachmentRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const pairingQrExpiryRefreshTimers = new Map<string, PairingQrExpiryRefreshTimer>();
 const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
+const ASSISTANT_ATTACHMENT_METADATA_FETCH_TIMEOUT_MS = 30_000;
 const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
 let assistantAttachmentAvailabilityRenderVersion = 0;
 
@@ -1662,10 +1663,19 @@ function resolveAssistantAttachmentAvailability(
     if (normalizedAuthToken) {
       headers.set("Authorization", `Bearer ${normalizedAuthToken}`);
     }
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () =>
+        controller.abort(
+          new DOMException("assistant attachment metadata fetch timed out", "TimeoutError"),
+        ),
+      ASSISTANT_ATTACHMENT_METADATA_FETCH_TIMEOUT_MS,
+    );
     void fetch(buildAssistantAttachmentMetaUrl(source, basePath), {
       method: "GET",
       headers,
       credentials: "same-origin",
+      signal: controller.signal,
     })
       .then(async (res) => {
         const payload = (await res.json().catch(() => null)) as {
@@ -1710,6 +1720,7 @@ function resolveAssistantAttachmentAvailability(
         });
       })
       .finally(() => {
+        clearTimeout(timeout);
         onRequestUpdate?.();
       });
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a local assistant attachment in the Control UI could see it remain on `Checking...` indefinitely when the authenticated metadata response stalled.

## Why This Change Was Made

The attachment availability owner applies a 30-second abort deadline to its metadata request and clears the timer on every terminal path. Existing failure handling then marks the attachment unavailable and requests a rerender; successful media-ticket handling and Gateway routes are unchanged.

## User Impact

Stalled local attachment checks now settle to `Unavailable` instead of leaving the chat UI permanently on `Checking...`. Attachments with normal metadata responses continue to render normally.

## Evidence

- `pnpm --dir ui test src/pages/chat/components/chat-message.test.ts` — 93 passing tests, including the stalled metadata-fetch regression.
- The rebased head was started in an isolated gateway and connected successfully to the Control UI on a dedicated local port.
- `pnpm check:max-lines-ratchet --base edef9822eefc0cef68b2c7b2e965a2daf32341d9` passed on the exact synthetic merge preview.
- Existing hosted real-behavior proof covers the same unchanged timeout path: a stalled request aborts at 30 seconds, changes the badge to `Unavailable`, and a normal attachment remains available.
