### PR TITLE
fix(memory-wiki): stop Obsidian CLI calls hanging indefinitely

### DIFF
--- a/extensions/memory-wiki/src/obsidian.test.ts
+++ b/extensions/memory-wiki/src/obsidian.test.ts
@@ -4,7 +4,7 @@ import { resolveMemoryWikiConfig } from "./config.js";
 import { runObsidianDaily, runObsidianSearch } from "./obsidian.js";
 
 describe("runObsidianSearch", () => {
-  it("builds the official obsidian cli argv with the configured vault name", async () => {
+  it("builds the official obsidian cli argv and bounds the request", async () => {
     const config = resolveMemoryWikiConfig(
       {
         obsidian: {
@@ -15,9 +15,13 @@ describe("runObsidianSearch", () => {
       },
       { homedir: "/Users/tester" },
     );
-    const calls: Array<{ command: string; argv: string[] }> = [];
-    const execImpl = async (command: string, argv?: readonly string[] | null) => {
-      calls.push({ command, argv: argv ? [...argv] : [] });
+    const calls: Array<{ command: string; argv: string[]; options: unknown }> = [];
+    const execImpl = async (
+      command: string,
+      argv?: readonly string[] | null,
+      options?: unknown,
+    ) => {
+      calls.push({ command, argv: argv ? [...argv] : [], options });
       return { stdout: "search output\n", stderr: "" };
     };
     const exec = execImpl as unknown as NonNullable<
@@ -37,6 +41,7 @@ describe("runObsidianSearch", () => {
       {
         command: "/usr/local/bin/obsidian",
         argv: ["vault=OpenClaw Wiki", "search", "query=agent memory"],
+        options: { logOutput: false, timeoutMs: 10_000 },
       },
     ]);
     expect(result.stdout).toBe("search output\n");

--- a/extensions/memory-wiki/src/obsidian.ts
+++ b/extensions/memory-wiki/src/obsidian.ts
@@ -17,11 +17,14 @@ type ObsidianCliResult = {
   stderr: string;
 };
 
+// User-triggered CLI helpers must not pin the gateway when Obsidian stops responding.
+const OBSIDIAN_CLI_TIMEOUT_MS = 10_000;
+
 type ObsidianCliDeps = {
   exec?: (
     command: string,
     args: string[],
-    options: { encoding: "utf8" },
+    options: { logOutput: false; timeoutMs: number },
   ) => Promise<{ stdout: string; stderr: string }>;
   resolveCommand?: (command: string) => Promise<string | null>;
 };
@@ -86,9 +89,11 @@ async function runObsidianCli(params: {
     throw new Error("Obsidian CLI is not available on PATH.");
   }
   const argv = [...buildVaultPrefix(params.config), params.subcommand, ...(params.args ?? [])];
-  const { stdout, stderr } = params.deps?.exec
-    ? await params.deps.exec(probe.command, argv, { encoding: "utf8" })
-    : await runExec(probe.command, argv, { logOutput: false });
+  const exec = params.deps?.exec ?? runExec;
+  const { stdout, stderr } = await exec(probe.command, argv, {
+    logOutput: false,
+    timeoutMs: OBSIDIAN_CLI_TIMEOUT_MS,
+  });
   return {
     command: probe.command,
     argv,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the Memory Wiki Obsidian helpers could wait indefinitely when the official Obsidian CLI stopped responding. This affected both direct commands such as `openclaw wiki obsidian search` and the matching gateway RPC methods.

## Why This Change Was Made

The shared Obsidian CLI boundary now passes an explicit 10-second timeout together with its existing output-logging option. Passing an options object had previously bypassed `runExec`'s numeric default timeout, leaving search, open, command, and daily calls unbounded.

## User Impact

Stalled Obsidian CLI calls now fail with a timeout instead of pinning the CLI or gateway request indefinitely. Successful calls and their argv remain unchanged.

## Evidence

- Live before: the production `runObsidianDaily` path invoked a test-only stalled `obsidian` executable and was still running when a 12-second outer guard terminated it (`exit_status=124`).
- Live after: the same production path rejected after 10,137 ms with `Command timed out after 10000 milliseconds` and exited cleanly.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/memory-wiki/src/obsidian.test.ts extensions/memory-wiki/src/cli.test.ts extensions/memory-wiki/src/gateway.test.ts extensions/memory-wiki/src/status.test.ts` — 4 files, 71 tests passed on the rebased commit.
- `./node_modules/.bin/oxfmt --check extensions/memory-wiki/src/obsidian.ts extensions/memory-wiki/src/obsidian.test.ts`
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-wiki/src/obsidian.ts extensions/memory-wiki/src/obsidian.test.ts`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` — no actionable findings.

Full repository build and test suites were not run locally; CI remains authoritative for those lanes.
