### PR TITLE
fix(file-transfer): denyPaths does not deny listing the denied directory itself

### DIFF
--- a/extensions/file-transfer/src/shared/policy.test.ts
+++ b/extensions/file-transfer/src/shared/policy.test.ts
@@ -201,7 +201,28 @@ describe("evaluateFilePolicy — denyPaths always wins", () => {
     );
   });
 
-  it("denies the denied directory itself, not just paths under it", () => {
+  it.each([
+    {
+      label: "the bare denied directory",
+      requestedPath: path.join(os.homedir(), ".ssh"),
+      expected: { ok: false, code: "POLICY_DENIED", askable: false },
+    },
+    {
+      label: "the denied directory with a trailing separator",
+      requestedPath: `${path.join(os.homedir(), ".ssh")}/`,
+      expected: { ok: false, code: "POLICY_DENIED", askable: false },
+    },
+    {
+      label: "the bare denied directory on Windows",
+      requestedPath: "C:\\Users\\me\\.ssh",
+      expected: { ok: false, code: "POLICY_DENIED", askable: false },
+    },
+    {
+      label: "a sibling sharing only the denied directory prefix",
+      requestedPath: path.join(os.homedir(), ".sshrc"),
+      expected: { ok: true },
+    },
+  ])("handles $label", ({ requestedPath, expected }) => {
     withConfig({
       n1: {
         allowReadPaths: ["/**"],
@@ -209,46 +230,8 @@ describe("evaluateFilePolicy — denyPaths always wins", () => {
       },
     });
     expectResultFields(
-      evaluateFilePolicy({
-        nodeId: "n1",
-        kind: "read",
-        path: path.join(os.homedir(), ".ssh"),
-      }),
-      { ok: false, code: "POLICY_DENIED", askable: false },
-    );
-  });
-
-  it("denies a trailing-separator form of the denied directory", () => {
-    withConfig({
-      n1: {
-        allowReadPaths: ["/**"],
-        denyPaths: ["**/.ssh/**"],
-      },
-    });
-    expectResultFields(
-      evaluateFilePolicy({
-        nodeId: "n1",
-        kind: "read",
-        path: `${path.join(os.homedir(), ".ssh")}/`,
-      }),
-      { ok: false, code: "POLICY_DENIED", askable: false },
-    );
-  });
-
-  it("keeps allowing sibling paths that only share the denied directory prefix", () => {
-    withConfig({
-      n1: {
-        allowReadPaths: ["/**"],
-        denyPaths: ["**/.ssh/**"],
-      },
-    });
-    expectResultFields(
-      evaluateFilePolicy({
-        nodeId: "n1",
-        kind: "read",
-        path: path.join(os.homedir(), ".sshrc"),
-      }),
-      { ok: true },
+      evaluateFilePolicy({ nodeId: "n1", kind: "read", path: requestedPath }),
+      expected,
     );
   });
 

--- a/extensions/file-transfer/src/shared/policy.test.ts
+++ b/extensions/file-transfer/src/shared/policy.test.ts
@@ -201,6 +201,57 @@ describe("evaluateFilePolicy — denyPaths always wins", () => {
     );
   });
 
+  it("denies the denied directory itself, not just paths under it", () => {
+    withConfig({
+      n1: {
+        allowReadPaths: ["/**"],
+        denyPaths: ["**/.ssh/**"],
+      },
+    });
+    expectResultFields(
+      evaluateFilePolicy({
+        nodeId: "n1",
+        kind: "read",
+        path: path.join(os.homedir(), ".ssh"),
+      }),
+      { ok: false, code: "POLICY_DENIED", askable: false },
+    );
+  });
+
+  it("denies a trailing-separator form of the denied directory", () => {
+    withConfig({
+      n1: {
+        allowReadPaths: ["/**"],
+        denyPaths: ["**/.ssh/**"],
+      },
+    });
+    expectResultFields(
+      evaluateFilePolicy({
+        nodeId: "n1",
+        kind: "read",
+        path: `${path.join(os.homedir(), ".ssh")}/`,
+      }),
+      { ok: false, code: "POLICY_DENIED", askable: false },
+    );
+  });
+
+  it("keeps allowing sibling paths that only share the denied directory prefix", () => {
+    withConfig({
+      n1: {
+        allowReadPaths: ["/**"],
+        denyPaths: ["**/.ssh/**"],
+      },
+    });
+    expectResultFields(
+      evaluateFilePolicy({
+        nodeId: "n1",
+        kind: "read",
+        path: path.join(os.homedir(), ".sshrc"),
+      }),
+      { ok: true },
+    );
+  });
+
   it("denies even with ask=always (denyPaths is hard)", () => {
     withConfig({
       n1: {

--- a/extensions/file-transfer/src/shared/policy.ts
+++ b/extensions/file-transfer/src/shared/policy.ts
@@ -156,6 +156,13 @@ function matchesAny(target: string, patterns: string[]): boolean {
   return false;
 }
 
+function matchesAnyDeny(target: string, patterns: string[]): boolean {
+  if (matchesAny(target, patterns)) {
+    return true;
+  }
+  return matchesAny(`${target.replace(/[\\/]+$/u, "")}/`, patterns);
+}
+
 function resolveNodePolicy(
   config: FilePolicyConfig,
   nodeId: string,
@@ -262,7 +269,7 @@ export function evaluateFilePolicy(input: {
 
   // 1. Deny patterns always win.
   const denyPatterns = normalizeGlobs(nodeConfig.denyPaths);
-  if (matchesAny(input.path, denyPatterns)) {
+  if (matchesAnyDeny(input.path, denyPatterns)) {
     return {
       ok: false,
       code: "POLICY_DENIED",


### PR DESCRIPTION
## What Problem This Solves

A `denyPaths` entry like `**/.ssh/**` does not deny `dir.list` on the denied directory itself. With `denyPaths: ["**/.ssh/**"]` configured, `dir.list` on `/home/me/.ssh` returns the full listing, including entries such as `id_rsa`, `id_rsa.pub`, `authorized_keys`, and `known_hosts`. Only paths strictly under the directory are denied, so the operator's hard deny is bypassed on the exact directory it names.

`denyPaths` is documented as an absolute hard deny that wins over every allow rule and over `ask: always`, so returning the protected directory's filenames is a policy break. Filenames alone disclose which keys and hosts exist, and they hand an agent the exact paths to target next.

## Root cause

`extensions/file-transfer/src/shared/policy.ts:265` matches the requested path against the deny globs as a plain string:

```ts
// before
  // 1. Deny patterns always win.
  const denyPatterns = normalizeGlobs(nodeConfig.denyPaths);
  if (matchesAny(input.path, denyPatterns)) {
```

`matchesAny` delegates to `minimatch`, and a trailing `/**` requires something after the separator. The bare directory has nothing after it, so it does not match:

```
minimatch("/home/me/.ssh",        "**/.ssh/**", {dot: true})  ->  false
minimatch("/home/me/.ssh/",       "**/.ssh/**", {dot: true})  ->  true
minimatch("/home/me/.ssh/id_rsa", "**/.ssh/**", {dot: true})  ->  true
```

Every file-transfer command routes its path through `evaluateFilePolicy`, so the gate misses the bare directory for all of them. `dir.list` is the surface where that is observable: it is the one command whose payload is the directory's own contents.

`dir.fetch` was incidentally safe rather than correct. `validateDirFetchEntries` (`node-invoke-policy.ts:552`) rechecks `canonicalPath` plus every returned entry, and the entries (`/home/me/.ssh/id_rsa`) do match the pattern, so the archive is refused on the entries after `canonicalPath` itself passed the gate. `dir.list` has no equivalent recheck, so nothing catches the miss.

## Fix

Treat the deny check as covering the directory a pattern protects, at the single gate every command already routes through:

```ts
// after
function matchesAnyDeny(target: string, patterns: string[]): boolean {
  if (matchesAny(target, patterns)) {
    return true;
  }
  return matchesAny(`${target.replace(/[\\/]+$/u, "")}/`, patterns);
}
```

The directory form is what the pattern already means: `**/.ssh/**` protects the contents of any `.ssh`, and listing that directory is a read of exactly those contents. Normalizing the separator before appending keeps the form canonical for an already-slashed path, and `matchesAny` still normalizes Windows separators internally, so `C:\Users\me\.ssh` is covered too.

## Why This Change Was Made

Fixing this at `evaluateFilePolicy` rather than at `dir.list` keeps one canonical deny path. Adding a `dir.list` preflight recheck would have copied the `dir.fetch` workaround to a second caller and left the shared matcher still wrong for any future command.

The change is deny-side only. `matchesAny` is shared with the allow list, and widening it there would have loosened access (`allowReadPaths: ["/tmp/**"]` would begin to allow `/tmp` itself). Only the `denyPaths` call site takes the directory form, so this can fail closed but never open.

Sibling surfaces: `file.fetch` and `file.write` are unaffected in practice, since the bare path they would need is a directory, which their handlers reject anyway. `dir.fetch` keeps denying, now at the gate instead of via its per-entry recheck.

## User Impact

Operators who configured `denyPaths` get the deny they asked for on the named directory. `dir.list` on a denied directory now returns `POLICY_DENIED` instead of its contents. No allow rule changes; paths that were readable before remain readable.

## Evidence

- New coverage in `policy.test.ts` fails on pristine `main` (`denies the denied directory itself, not just paths under it`) and passes with the patch. Sibling coverage asserts `.sshrc` is still allowed, so the deny does not widen to prefix-sharing neighbors.
- `node scripts/run-vitest.mjs extensions/file-transfer/src/shared/policy.test.ts extensions/file-transfer/src/shared/node-invoke-policy.test.ts extensions/file-transfer/src/shared/lazy-node-invoke-policy.test.ts` -> 64 passed.
- `oxlint` and `oxfmt --check` on both changed files -> clean.
- `run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` -> both clean, no diagnostics.

## Real behavior proof
Behavior addressed: with `denyPaths: ["**/.ssh/**"]` configured, `dir.list` on the `.ssh` directory itself returned the directory's full listing instead of being denied.
Real environment tested: the real file-transfer node invoke policy built from its production factory `createFileTransferNodeInvokePolicy()`, driven on pristine main f193c505 and on the patched tree with identical inputs. `policy.ts` and `node-invoke-policy.ts` are byte-identical between f193c505 and current main 1eda44ee, so the before output is current main's behavior. Real throughout: the policy gate, `evaluateFilePolicy`, the operator policy config read through the plugin config seam, the node host `handleDirList` handler, and a real on-disk directory holding real key files. The only stubbed seam is the gateway-to-node network transport, which hands the invoke straight to the real node host handler in-process.
Exact steps or command run after this patch: created a real directory `/private/var/folders/.../T/ft-proof-home/.ssh` containing `id_rsa`, `id_rsa.pub`, `authorized_keys`, `known_hosts`; configured the node policy `allowReadPaths: ["/**"]`, `denyPaths: ["**/.ssh/**"]`, `ask: "off"`; then dispatched `dir.list` for that directory through the policy, and a path under it as an unchanged control.
Evidence after fix:
```
# BEFORE (pristine main f193c505)
$ openclaw node invoke laptop-1 dir.list --path '/private/var/folders/xd/z6c82k954n1_kdj59zrg03kh0000gn/T/ft-proof-home/.ssh'
  [target: the denied directory itself] denyPaths = ["**/.ssh/**"]
  RESULT: ok=true  entries=4
    - authorized_keys
    - id_rsa
    - id_rsa.pub
    - known_hosts

$ openclaw node invoke laptop-1 dir.list --path '/private/var/folders/xd/z6c82k954n1_kdj59zrg03kh0000gn/T/ft-proof-home/.ssh/id_rsa'
  [control: a path under the denied directory] denyPaths = ["**/.ssh/**"]
  RESULT: ok=false  code=POLICY_DENIED
  dir.list POLICY_DENIED: path matches a denyPaths pattern

# AFTER (this patch, identical inputs)
$ openclaw node invoke laptop-1 dir.list --path '/private/var/folders/xd/z6c82k954n1_kdj59zrg03kh0000gn/T/ft-proof-home/.ssh'
  [target: the denied directory itself] denyPaths = ["**/.ssh/**"]
  RESULT: ok=false  code=POLICY_DENIED
  dir.list POLICY_DENIED: path matches a denyPaths pattern

$ openclaw node invoke laptop-1 dir.list --path '/private/var/folders/xd/z6c82k954n1_kdj59zrg03kh0000gn/T/ft-proof-home/.ssh/id_rsa'
  [control: a path under the denied directory] denyPaths = ["**/.ssh/**"]
  RESULT: ok=false  code=POLICY_DENIED
  dir.list POLICY_DENIED: path matches a denyPaths pattern
```
Observed result after fix: on identical inputs the denied directory flips from `ok=true` with all four key filenames disclosed to `POLICY_DENIED`, while the control path under it reads `POLICY_DENIED` in both runs, so the deny gate is the only thing that moved.
What was not tested: no live paired remote node over a real gateway socket, so the gateway-to-node transport hop was in-process rather than over the wire; the node host handler, policy gate, and filesystem were real. Windows separator handling was reasoned from the existing normalization in `matchesAny` and not run on a Windows node. Full build not run; the change touches no packaging or dynamic-import boundary.
