### PR TITLE
feat(linux): OS integration for the desktop companion (single-instance, deep links, autostart, notifications, window state)

### DIFF
--- a/apps/linux/src-tauri/Cargo.lock
+++ b/apps/linux/src-tauri/Cargo.lock
@@ -217,6 +217,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +511,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +612,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -729,11 +766,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -744,7 +801,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -792,6 +849,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -871,7 +937,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1443,6 +1509,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2039,6 +2111,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,6 +2258,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -2448,9 +2548,14 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
+ "tauri-plugin-deep-link",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "webkit2gtk",
 ]
 
@@ -2465,6 +2570,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -2695,6 +2810,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +2923,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,6 +2964,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2924,6 +3088,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -3647,7 +3821,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3698,7 +3872,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -3769,6 +3943,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3801,13 +4029,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -3831,6 +4076,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3934,6 +4194,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,6 +4294,15 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4290,7 +4570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -4831,6 +5111,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5141,6 +5432,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5171,7 +5471,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",
@@ -5318,6 +5618,26 @@ dependencies = [
  "serde",
  "winnow 1.0.3",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/apps/linux/src-tauri/Cargo.toml
+++ b/apps/linux/src-tauri/Cargo.toml
@@ -19,9 +19,14 @@ mdns-sd = { version = "0.20", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 tauri = { version = "2.11.5", features = ["image-png", "tray-icon"] }
+tauri-plugin-autostart = "2.5.1"
+tauri-plugin-deep-link = "2.4.9"
+tauri-plugin-notification = "2.3.3"
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-process = "2.3.1"
+tauri-plugin-single-instance = { version = "2.4.3", features = ["deep-link"] }
 tauri-plugin-updater = "2.10.1"
+tauri-plugin-window-state = "2.4.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cairo-rs = { version = "0.18.5", features = ["png"] }

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod discovery;
 mod gateway;
 mod installer;
+mod notify;
 mod tray;
 mod updater;
 
@@ -16,6 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use tauri::{AppHandle, Manager, State, Url, WebviewWindow};
+use tauri_plugin_deep_link::DeepLinkExt;
 
 const CONNECTED_WATCH_INTERVAL: Duration = Duration::from_secs(15);
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(3);
@@ -30,6 +32,52 @@ struct BuildInfo {
 fn is_release_version(version: &str) -> bool {
     // The committed 0.1.0 version identifies branch builds; release builds are stamped by CI.
     version != "0.1.0"
+}
+
+// The openclaw:// URL contract is deliberately tiny and handled entirely in
+// Rust: `openclaw://dashboard` opens/connects the dashboard; anything else
+// just focuses the app. New routes are added to this enum — the renderer
+// (which is often navigated away to the remote dashboard) never sees URLs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeepLinkRoute {
+    Dashboard,
+    FocusOnly,
+}
+
+fn deep_link_route(url: &Url) -> DeepLinkRoute {
+    if url.scheme() == "openclaw" && url.host_str() == Some("dashboard") {
+        DeepLinkRoute::Dashboard
+    } else {
+        DeepLinkRoute::FocusOnly
+    }
+}
+
+fn handle_deep_links(app: &AppHandle, urls: Vec<Url>) {
+    for url in urls {
+        match deep_link_route(&url) {
+            DeepLinkRoute::Dashboard => {
+                let desktop = app.state::<DesktopState>();
+                tray::open_dashboard(app, desktop.inner());
+            }
+            DeepLinkRoute::FocusOnly => tray::show_window(app),
+        }
+    }
+}
+
+#[cfg(test)]
+mod deep_link_tests {
+    use super::{deep_link_route, DeepLinkRoute, Url};
+
+    #[test]
+    fn dashboard_route_matches_only_the_openclaw_dashboard_host() {
+        let dashboard = Url::parse("openclaw://dashboard/ignored?source=test").unwrap();
+        let other = Url::parse("openclaw://settings/dashboard").unwrap();
+        let other_scheme = Url::parse("https://dashboard/").unwrap();
+
+        assert_eq!(deep_link_route(&dashboard), DeepLinkRoute::Dashboard);
+        assert_eq!(deep_link_route(&other), DeepLinkRoute::FocusOnly);
+        assert_eq!(deep_link_route(&other_scheme), DeepLinkRoute::FocusOnly);
+    }
 }
 
 #[derive(Default)]
@@ -571,11 +619,25 @@ async fn gateway_action(
 }
 
 fn main() {
-    let builder = tauri::Builder::default();
-    let builder = builder
+    // Single-instance must run first so it can pass deep-link argv to the primary process.
+    let builder = tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            tray::show_window(app);
+        }))
+        .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init());
+        .plugin(tauri_plugin_process::init())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_denylist(&["canvas"])
+                .build(),
+        );
     #[cfg(target_os = "linux")]
     let builder = canvas::register_protocol(builder);
 
@@ -585,6 +647,18 @@ fn main() {
             .expect("tauri.conf.json must define the main window");
         let state = DesktopState::new(window.url()?);
         app.manage(state.clone());
+        let deep_link_app = app.handle().clone();
+        app.deep_link().on_open_url(move |event| {
+            handle_deep_links(&deep_link_app, event.urls());
+        });
+        if let Some(urls) = app.deep_link().get_current()? {
+            handle_deep_links(app.handle(), urls);
+        }
+        #[cfg(any(target_os = "linux", all(debug_assertions, target_os = "windows")))]
+        if let Err(error) = app.deep_link().register_all() {
+            eprintln!("Deep-link registration unavailable: {error}");
+        }
+
         app.manage(discovery::GatewayDiscovery::default());
         app.manage(updater::UpdaterState::default());
         #[cfg(target_os = "linux")]

--- a/apps/linux/src-tauri/src/notify.rs
+++ b/apps/linux/src-tauri/src/notify.rs
@@ -1,0 +1,26 @@
+use tauri::AppHandle;
+use tauri_plugin_notification::{NotificationExt, PermissionState};
+
+pub fn notify(app: &AppHandle, title: &str, body: &str) {
+    let notification = app.notification();
+    let permission = match notification.permission_state() {
+        Ok(PermissionState::Granted) => PermissionState::Granted,
+        Ok(_) => match notification.request_permission() {
+            Ok(permission) => permission,
+            Err(error) => {
+                eprintln!("Could not request notification permission: {error}");
+                return;
+            }
+        },
+        Err(error) => {
+            eprintln!("Could not check notification permission: {error}");
+            return;
+        }
+    };
+    if !matches!(permission, PermissionState::Granted) {
+        return;
+    }
+    if let Err(error) = notification.builder().title(title).body(body).show() {
+        eprintln!("Could not show notification: {error}");
+    }
+}

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -1,11 +1,13 @@
 use crate::gateway::{GatewayAction, GatewaySnapshot};
 use crate::DesktopState;
-use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use tauri::{App, AppHandle, Manager};
+use tauri_plugin_autostart::ManagerExt;
 
 const OPEN_ID: &str = "open-dashboard";
 const CHECK_UPDATES_ID: &str = "check-for-updates";
+const START_AT_LOGIN_ID: &str = "start-at-login";
 const START_ID: &str = "start-gateway";
 const STOP_ID: &str = "stop-gateway";
 const RESTART_ID: &str = "restart-gateway";
@@ -16,6 +18,7 @@ pub struct TrayHandles {
     status: MenuItem<tauri::Wry>,
     open: MenuItem<tauri::Wry>,
     _check_updates: MenuItem<tauri::Wry>,
+    _start_at_login: CheckMenuItem<tauri::Wry>,
     start: MenuItem<tauri::Wry>,
     stop: MenuItem<tauri::Wry>,
     restart: MenuItem<tauri::Wry>,
@@ -53,6 +56,21 @@ pub fn build(app: &App, state: DesktopState) -> tauri::Result<TrayHandles> {
         true,
         None::<&str>,
     )?;
+    let autostart_enabled = match app.autolaunch().is_enabled() {
+        Ok(enabled) => enabled,
+        Err(error) => {
+            eprintln!("Could not read autostart state: {error}");
+            false
+        }
+    };
+    let start_at_login = CheckMenuItem::with_id(
+        app,
+        START_AT_LOGIN_ID,
+        "Start at Login",
+        true,
+        autostart_enabled,
+        None::<&str>,
+    )?;
     let start = MenuItem::with_id(app, START_ID, "Start Gateway", false, None::<&str>)?;
     let stop = MenuItem::with_id(app, STOP_ID, "Stop Gateway", false, None::<&str>)?;
     let restart = MenuItem::with_id(app, RESTART_ID, "Restart Gateway", false, None::<&str>)?;
@@ -67,6 +85,7 @@ pub fn build(app: &App, state: DesktopState) -> tauri::Result<TrayHandles> {
             &separator_one,
             &open,
             &check_updates,
+            &start_at_login,
             &separator_two,
             &start,
             &stop,
@@ -78,12 +97,13 @@ pub fn build(app: &App, state: DesktopState) -> tauri::Result<TrayHandles> {
 
     let tray_icon = tauri::image::Image::from_bytes(include_bytes!("../icons/32x32.png"))?;
     let menu_state = state.clone();
+    let menu_start_at_login = start_at_login.clone();
     let tray_builder = TrayIconBuilder::with_id("openclaw-main")
         .icon(tray_icon)
         .menu(&menu)
         .show_menu_on_left_click(false)
         .on_menu_event(move |app, event| {
-            handle_menu(app, &menu_state, event.id().as_ref());
+            handle_menu(app, &menu_state, &menu_start_at_login, event.id().as_ref());
         })
         // Linux tray backends expose the Open action through the menu; Tauri also
         // emits this direct click event on platforms that support it.
@@ -108,6 +128,7 @@ pub fn build(app: &App, state: DesktopState) -> tauri::Result<TrayHandles> {
         status,
         open,
         _check_updates: check_updates,
+        _start_at_login: start_at_login,
         start,
         stop,
         restart,
@@ -122,24 +143,58 @@ pub fn show_window(app: &AppHandle) {
     }
 }
 
-fn handle_menu(app: &AppHandle, state: &DesktopState, id: &str) {
+pub fn open_dashboard(app: &AppHandle, state: &DesktopState) {
+    show_window(app);
+    spawn_connect(app.clone(), state.clone());
+}
+
+fn handle_menu(
+    app: &AppHandle,
+    state: &DesktopState,
+    start_at_login: &CheckMenuItem<tauri::Wry>,
+    id: &str,
+) {
     match id {
         QUIT_ID => {
             state.quit();
             app.exit(0);
         }
-        OPEN_ID => {
-            show_window(app);
-            spawn_connect(app.clone(), state.clone());
-        }
+        OPEN_ID => open_dashboard(app, state),
         CHECK_UPDATES_ID => {
             show_window(app);
             crate::updater::spawn_check(app.clone());
         }
+        START_AT_LOGIN_ID => toggle_autostart(app, start_at_login),
         START_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Start),
         STOP_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Stop),
         RESTART_ID => spawn_action(app.clone(), state.clone(), GatewayAction::Restart),
         _ => {}
+    }
+}
+
+fn toggle_autostart(app: &AppHandle, item: &CheckMenuItem<tauri::Wry>) {
+    let manager = app.autolaunch();
+    let enabled = match manager.is_enabled() {
+        Ok(enabled) => enabled,
+        Err(error) => {
+            eprintln!("Could not read autostart state: {error}");
+            return;
+        }
+    };
+    let next = !enabled;
+    let result = if next {
+        manager.enable()
+    } else {
+        manager.disable()
+    };
+    match result {
+        Ok(()) => {
+            let _ = item.set_checked(next);
+        }
+        Err(error) => {
+            eprintln!("Could not update autostart state: {error}");
+            let _ = item.set_checked(enabled);
+        }
     }
 }
 

--- a/apps/linux/src-tauri/src/updater.rs
+++ b/apps/linux/src-tauri/src/updater.rs
@@ -210,6 +210,7 @@ async fn run_check(app: AppHandle, manual: bool) {
 
     let install_kind = install_kind();
     if install_kind == InstallKind::NotifyOnly {
+        let version = info.version.clone();
         emit(
             &app,
             AVAILABLE_MANUAL_EVENT,
@@ -219,6 +220,9 @@ async fn run_check(app: AppHandle, manual: bool) {
                 release_url: RELEASE_URL,
             },
         );
+        if main_window(&app).is_some_and(|window| matches!(window.is_focused(), Ok(false))) {
+            crate::notify::notify(&app, "OpenClaw", &manual_notification_body(&version));
+        }
         return;
     }
 
@@ -239,6 +243,7 @@ async fn run_check(app: AppHandle, manual: bool) {
     };
     match result {
         Ok(deferred_bytes) => {
+            let version = info.version.clone();
             if let Some(bytes) = deferred_bytes {
                 app.state::<UpdaterState>()
                     .deferred_update
@@ -247,6 +252,9 @@ async fn run_check(app: AppHandle, manual: bool) {
                     .replace(DeferredUpdate { update, bytes });
             }
             let _ = window.emit(READY_EVENT, info);
+            if matches!(window.is_focused(), Ok(false)) {
+                crate::notify::notify(&app, "OpenClaw", &ready_notification_body(&version));
+            }
         }
         Err(error) => emit_error(&app, error),
     }
@@ -322,6 +330,14 @@ fn emit_error(app: &AppHandle, error: impl std::fmt::Display) {
     );
 }
 
+fn ready_notification_body(version: &str) -> String {
+    format!("Update ready — restart OpenClaw to install v{version}")
+}
+
+fn manual_notification_body(version: &str) -> String {
+    format!("Update available: v{version} — download from the release page")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -357,5 +373,17 @@ mod tests {
         assert_eq!(PROGRESS_EVENT, "updater://progress");
         assert_eq!(READY_EVENT, "updater://ready");
         assert_eq!(ERROR_EVENT, "updater://error");
+    }
+
+    #[test]
+    fn notification_copy_includes_update_version() {
+        assert_eq!(
+            ready_notification_body("2026.7.16"),
+            "Update ready — restart OpenClaw to install v2026.7.16"
+        );
+        assert_eq!(
+            manual_notification_body("2026.7.16"),
+            "Update available: v2026.7.16 — download from the release page"
+        );
     }
 }

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -7,6 +7,11 @@
     "frontendDist": "../ui"
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["openclaw"]
+      }
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRDODJFMzU1QTQ0MUMwNkYKUldSdndFR2tWZU9DVE9RYnlIcHFoNG1xUlQzUlloa0plQmZjY0dPbHpjWlEzWFozdmt0cHBlY2gK",
       "endpoints": [


### PR DESCRIPTION
## What Problem This Solves

The Linux desktop companion has none of the OS integration the macOS app enjoys: no launch-at-login, no native notifications, no URL scheme, second launches spawn a second instance, and the window forgets its size/position.

## Why This Change Was Made

Close the native-rim gap with the smallest possible surface: official Tauri v2 plugins only, driven from Rust (the renderer — often navigated away to the remote dashboard — never handles URLs).

## User Impact

- **Single instance**: launching the app again focuses the running window instead of duplicating it.
- **`openclaw://` deep links**: `openclaw://dashboard` opens + connects the dashboard; other URLs focus the app. Contract is deliberately tiny and lives in one Rust enum for future routes (pairing etc.).
- **Start at Login** tray toggle (default off; LaunchAgent/registry/.desktop autostart per platform).
- **Native notifications** when an update is ready/available and the window is not focused (no toast spam while you're looking at the app).
- **Window state** persists across launches (canvas window excluded — it is ephemeral by design).

## Evidence

- `cargo check` + full `cargo test` (22 passing) + `cargo fmt --check` clean on macOS host; `node --check` + `jq` clean; plugin pins verified against the official Tauri v2 docs (single-instance 2.4.3, deep-link 2.4.9, autostart 2.5.1, notification 2.3.3, window-state 2.4.1).
- Autoreview (codex gpt-5.6-sol/high): clean after two rounds — deep-link handling moved fully into Rust with a real `openclaw://dashboard` route (shared with the tray Open Dashboard action), and the speculative renderer-forwarding queue was deleted rather than patched.
- Renderer permission surface kept minimal: no new webview capabilities (all new plugins are Rust-driven).
- Linux runtime behavior (.desktop scheme registration, autostart entry, notifications) verified in the follow-up live test on a Linux desktop box; not exercisable on the macOS build host.