### PR TITLE
fix(doctor): doctor no longer hangs when TUI process sampling stalls

### DIFF
--- a/src/commands/doctor-whatsapp-responsiveness.test.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.test.ts
@@ -50,6 +50,11 @@ describe("doctor WhatsApp responsiveness", () => {
         { pid: 104, command: "openclaw tui --local" },
         { pid: 105, command: "/usr/bin/openclaw chat" },
       ]);
+      expect(spawnSyncMock).toHaveBeenCalledWith("ps", ["-axo", "pid=,command="], {
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        timeout: 1_000,
+      });
     }
   });
 

--- a/src/commands/doctor-whatsapp-responsiveness.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.ts
@@ -21,6 +21,7 @@ type ProcessController = {
 
 const LOCAL_TUI_SUBCOMMANDS = new Set(["chat", "terminal", "tui"]);
 const WHATSAPP_RESPONSIVENESS_CHECK_ID = "core/doctor/whatsapp-responsiveness";
+const LOCAL_TUI_PROCESS_PROBE_TIMEOUT_MS = 1_000;
 
 function tokenizeCommandLine(command: string): string[] {
   return command.trim().split(/\s+/u).filter(Boolean);
@@ -62,7 +63,8 @@ function listLocalTuiProcesses(): LocalTuiProcess[] {
   }
   const ps = spawnSync("ps", ["-axo", "pid=,command="], {
     encoding: "utf8",
-    timeout: 1000,
+    killSignal: "SIGKILL",
+    timeout: LOCAL_TUI_PROCESS_PROBE_TIMEOUT_MS,
   });
   if (ps.error || ps.status !== 0 || typeof ps.stdout !== "string") {
     return [];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw doctor` could remain blocked after its existing one-second deadline while checking for local TUI processes if the `ps` executable ignored the default termination signal.

## Why This Change Was Made

The best-effort TUI process probe now force-stops `ps` at the existing deadline. Process matching, warning behavior, repair behavior, and the Windows no-probe path are unchanged.

## User Impact

Doctor runs with WhatsApp enabled no longer hang indefinitely while sampling local TUI processes. Healthy `ps` output continues to produce the same responsiveness warning and repair guidance.

## Evidence

- Regression test before the fix: the new timeout-signal assertion failed while 5 tests passed.
- Focused test on exact head `5562e6b267`: `src/commands/doctor-whatsapp-responsiveness.test.ts` passed 6/6.
- Real production-path proof on current main `419c61a590`: the Doctor WhatsApp contribution with a test `ps` executable that ignored `SIGTERM` was still blocked when an 8-second external watchdog stopped it. The exact patched head force-stopped the same probe and returned in 1.005 seconds.
- Full source-CLI proof was not claimed because this local checkout exits earlier on an unrelated `unicorn-magic` package-export error.
- `oxfmt`, targeted `oxlint`, and `git diff --check` passed for the changed files.
- Local `codex review --base origin/main` found no confirmed regression.
