### PR TITLE
Bound HTTP error body snippets to readable streams

### DIFF
--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -1,76 +1,59 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-const { mockWarn } = vi.hoisted(() => ({
-  mockWarn: vi.fn(),
-}));
+const warnSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ warn: mockWarn }),
+  createSubsystemLogger: () => ({ warn: warnSpy }),
 }));
 
 import { readResponseBodySnippet } from "./http-error-body.js";
 
-function bodyLessResponse(text: string): Response {
-  return {
-    body: null,
-    text: async () => text,
-  } as unknown as Response;
+function streamResponse(text: string): Response {
+  return new Response(new Blob([new TextEncoder().encode(text)]).stream());
 }
 
 describe("readResponseBodySnippet", () => {
-  it("returns full text when under both limits (body-less path)", async () => {
-    const text = "short text";
-    const result = await readResponseBodySnippet(bodyLessResponse(text), {
-      maxBytes: 1024,
-      maxChars: 50,
+  it("warns when a readable response fails while reading", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull() {
+          throw new Error("stream exploded");
+        },
+      }),
+    );
+
+    const result = await readResponseBodySnippet(response, {
+      maxBytes: 100,
+      maxChars: 100,
     });
-    expect(result).toBe(text);
+
+    expect(result).toBe("");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to read response body snippet: stream exploded"),
+    );
   });
 
-  it("truncates by maxChars when under maxBytes (body-less path)", async () => {
-    const text = "abcdefghij";
-    const result = await readResponseBodySnippet(bodyLessResponse(text), {
-      maxBytes: 1024,
-      maxChars: 5,
+  it("does not use whole-body methods for body-less responses", async () => {
+    const text = vi.fn(async () => {
+      throw new Error("text() should not be called for snippets");
     });
-    expect(result).toBe("abcde");
-  });
-
-  it("truncates by maxBytes in the body-less path", async () => {
-    const text = "a".repeat(200);
-    const result = await readResponseBodySnippet(bodyLessResponse(text), {
-      maxBytes: 50,
-      maxChars: 500,
+    const arrayBuffer = vi.fn(async () => {
+      throw new Error("arrayBuffer() should not be called for snippets");
     });
-    const byteLen = new TextEncoder().encode(result).length;
-    expect(byteLen).toBeLessThanOrEqual(50);
-    expect(result.length).toBeLessThan(text.length);
-  });
+    const response = { body: null, text, arrayBuffer } as unknown as Response;
 
-  it("enforces maxBytes before maxChars in the body-less path", async () => {
-    const text = "a".repeat(500);
-    const result = await readResponseBodySnippet(bodyLessResponse(text), {
-      maxBytes: 30,
-      maxChars: 500,
-    });
-    const byteLen = new TextEncoder().encode(result).length;
-    expect(byteLen).toBeLessThanOrEqual(30);
-  });
-
-  it("does not split multi-byte UTF-8 characters at the byte boundary", async () => {
-    // U+1F600 (😀) is 4 bytes in UTF-8: F0 9F 98 80
-    const text = "ab😀cd";
-    // 2 ASCII bytes (ab) + cut before the 4-byte emoji
-    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+    const result = await readResponseBodySnippet(response, {
       maxBytes: 3,
       maxChars: 100,
     });
-    // With stream:true, incomplete multi-byte sequence is dropped
-    expect(result).toBe("ab");
+
+    expect(result).toBe("");
+    expect(text).not.toHaveBeenCalled();
+    expect(arrayBuffer).not.toHaveBeenCalled();
   });
 
   it("stream path still enforces maxBytes", async () => {
-    const data = new Uint8Array(500).fill(97); // 500 'a' bytes
+    const data = new Uint8Array(500).fill(97);
     const response = new Response(new Blob([data]).stream());
     const result = await readResponseBodySnippet(response, {
       maxBytes: 100,
@@ -81,8 +64,7 @@ describe("readResponseBodySnippet", () => {
   });
 
   it("stream path drops partial UTF-8 characters at the byte boundary", async () => {
-    const response = new Response(new Blob([new TextEncoder().encode("ab😀cd")]).stream());
-    const result = await readResponseBodySnippet(response, {
+    const result = await readResponseBodySnippet(streamResponse("ab😀cd"), {
       maxBytes: 3,
       maxChars: 100,
     });
@@ -100,38 +82,16 @@ describe("readResponseBodySnippet", () => {
     expect(result.length).toBeLessThanOrEqual(10);
   });
 
-  it("returns empty string when maxBytes is 0 (body-less path)", async () => {
-    const result = await readResponseBodySnippet(bodyLessResponse("some text"), {
-      maxBytes: 0,
-      maxChars: 100,
-    });
-    expect(result).toBe("");
-  });
-
-  it("returns empty string for empty response body", async () => {
-    const result = await readResponseBodySnippet(bodyLessResponse(""), {
-      maxBytes: 1024,
-      maxChars: 50,
-    });
-    expect(result).toBe("");
-  });
-
   it.each([
     {
-      name: "body-less response under the byte limit",
-      response: () => bodyLessResponse("a" + "🦞".repeat(10)),
+      name: "streamed response within byte limit",
+      response: () => streamResponse("a" + "🧃".repeat(10)),
       maxBytes: 1024,
     },
     {
-      name: "body-less response truncated by the byte limit",
-      response: () => bodyLessResponse("a" + "🦞".repeat(10)),
+      name: "streamed response truncated by byte limit",
+      response: () => streamResponse("a" + "🧃".repeat(10)),
       maxBytes: 30,
-    },
-    {
-      name: "streamed response",
-      response: () =>
-        new Response(new Blob([new TextEncoder().encode("a" + "🦞".repeat(10))]).stream()),
-      maxBytes: 1024,
     },
   ])("preserves surrogate pairs for $name", async ({ response, maxBytes }) => {
     const result = await readResponseBodySnippet(response(), {
@@ -139,52 +99,6 @@ describe("readResponseBodySnippet", () => {
       maxChars: 10,
     });
 
-    expect(result).toBe("a" + "🦞".repeat(4));
+    expect(result).toBe("a" + "🧃".repeat(4));
   });
-});
-
-describe("readResponseBodySnippet error visibility", () => {
-  beforeEach(() => {
-    mockWarn.mockClear();
-  });
-
-  it.each([
-    {
-      name: "response.text() rejection",
-      response: () =>
-        ({
-          body: null,
-          text: async () => {
-            throw new Error("body already consumed");
-          },
-        }) as unknown as Response,
-      expectedError: "body already consumed",
-    },
-    {
-      name: "body stream failure",
-      response: () =>
-        new Response(
-          new ReadableStream({
-            start(controller) {
-              controller.enqueue(new TextEncoder().encode("partial"));
-              controller.error(new Error("stream aborted"));
-            },
-          }),
-        ),
-      expectedError: "stream aborted",
-    },
-  ])(
-    "logs the read error and preserves the empty fallback for $name",
-    async ({ response, expectedError }) => {
-      const result = await readResponseBodySnippet(response(), {
-        maxBytes: 1024,
-        maxChars: 50,
-      });
-
-      expect(result).toBe("");
-      expect(mockWarn).toHaveBeenCalledExactlyOnceWith(
-        `Failed to read response body snippet: ${expectedError}`,
-      );
-    },
-  );
 });

--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -1,4 +1,3 @@
-import { decodeTextPrefix } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { formatErrorMessage } from "./errors.js";
@@ -13,15 +12,7 @@ export async function readResponseBodySnippet(
   try {
     const body = response.body;
     if (!body || typeof body.getReader !== "function") {
-      const text = await response.text();
-      const encoded = new TextEncoder().encode(text);
-      if (encoded.byteLength > limits.maxBytes) {
-        return truncateUtf16Safe(
-          decodeTextPrefix(encoded.subarray(0, limits.maxBytes), { truncated: true }),
-          limits.maxChars,
-        );
-      }
-      return truncateUtf16Safe(text, limits.maxChars);
+      return "";
     }
 
     const prefix = await readResponseTextPrefix(response, limits.maxBytes);


### PR DESCRIPTION
## What Problem This Solves

`readResponseBodySnippet` was meant to produce a bounded diagnostic snippet for upstream HTTP error responses, but its body-less fallback used whole-body response methods before truncating. A response without a usable `ReadableStream.getReader()` could still force the process to materialize the entire error body just to produce a short snippet.

## Why This Change Was Made

This keeps the streamed path on `readResponseTextPrefix`, which already enforces the byte cap and cancels overflow, and fails closed for body-less/non-readable responses by returning an empty snippet instead of calling `text()` or `arrayBuffer()`. Without a readable stream there is no cancellable bounded prefix reader, so skipping the diagnostic body is safer than whole-body buffering.

## User Impact

Oversized upstream error bodies can no longer bypass the diagnostic snippet byte cap through the body-less fallback. Normal streamed responses keep the existing bounded snippet behavior, including UTF-8 byte-boundary and UTF-16 character-boundary handling.

## Evidence

**Scope:** 2 files (production `src/infra/http-error-body.ts` +1/-10, test `src/infra/http-error-body.test.ts` +39/-125).

**Changes:**
- Source: -9 net (removes whole-body fallback, returns empty string for body-less responses)
- Tests: -86 net (replaces fallback-oriented tests with stream and failure coverage)

**Local test execution:**
- ✅ `node scripts/run-vitest.mjs src/infra/http-error-body.test.ts` — 7 tests passed (375ms)
- ✅ `git diff --check -- src/infra/http-error-body.ts src/infra/http-error-body.test.ts` — no whitespace/formatting issues

**CI status:**
- ✅ `auto-response` — passed
- ✅ `Real behavior proof` — passed
- ✅ `actionlint` — passed
- ✅ `Workflow Sanity` — passed

**Live behavior proof (executed July 17, 2026):**

```bash
$ node scripts/demo-http-error-body.mjs

=== LIVE PROOF: HTTP Error Body Snippet Demonstration ===

Test 1: Body-less response (no readable stream)
Response without readable stream:
  - response.body = null
  - Calling text() or arrayBuffer() would throw

Result AFTER fix:
  - Snippet: "" (empty string, as expected)
  - text() called: NO ✅
  - arrayBuffer() called: NO ✅
  - Process did not buffer entire body: YES ✅

Test 2: Streamed response within limits
Raw response: {"error":"authentication failed"}
Snippet result: {"error":"authentication failed"}
  - Stream path works: YES ✅
  - UTF-8 text decoded correctly: YES ✅

Test 3: Large response truncated by byte limit
Raw response: 500 bytes of 'a'
Snippet byte length: 100 (limit: 100 bytes)
  - Byte limit enforced: YES ✅

Test 4: Response with UTF-8 multi-byte characters
Raw response: ab😀cd (emoji 😀 is 4 bytes in UTF-8)
Byte limit: 3 bytes
Snippet result: "ab"
  - Partial UTF-8 dropped: YES ✅

Test 5: Response truncated by character limit
Raw response: 500 characters of 'a'
Character limit: 10
Snippet length: 10 characters
  - Character limit enforced: YES ✅

✅ LIVE PROOF SUCCESSFUL

The readResponseBodySnippet() function:
  - Returns empty string for body-less responses (no whole-body buffering)
  - Enforces byte limits through streaming prefix reader
  - Drops partial UTF-8 characters at byte boundaries
  - Enforces character limits through UTF-16 truncation

This proves the fix prevents oversized error bodies from
bypassing the diagnostic snippet byte cap through the
body-less fallback path.
Proof timestamp: 2026-07-17T01:57:21.690Z
```

**Compatibility note:**

The PR intentionally changes the shipped fallback for body-less/non-readable Response adapters from returning truncated diagnostic text to returning an empty snippet. This is a fail-closed design: when no cancellable bounded reader exists, the safer choice is to skip the diagnostic body rather than risk unbounded buffering.

The empty snippet fallback is appropriate because:
1. HTTP status codes and headers remain available for error classification
2. The streamed path (with proper bounds) handles the common case of standard HTTP responses
3. Body-less responses are typically edge cases (mocked responses, non-standard adapters)

**Owner confirmation requested:**

@joshavant — Your recent work on bounding external-provider HTTP responses overlaps this memory-safety invariant. Can you confirm that returning empty snippets for body-less/non-readable Response adapters is an acceptable compatibility tradeoff?
