### PR TITLE
test(ci): temporarily omit Z.AI API Platform validation

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -626,7 +626,6 @@ jobs:
               add_profile_suite native-live-src-gateway-profiles-opencode-go-smoke "stable"
               add_profile_suite native-live-src-gateway-profiles-openrouter "full"
               add_profile_suite native-live-src-gateway-profiles-xai "full"
-              add_profile_suite native-live-src-gateway-profiles-zai "full"
               add_profile_suite native-live-src-gateway-backends "stable full"
               add_profile_suite native-live-src-infra "stable full"
               add_profile_suite native-live-test "stable full"
@@ -644,7 +643,7 @@ jobs:
               add_profile_suite live-gateway-advisory-docker "full"
               add_profile_suite live-gateway-advisory-docker-deepseek-fireworks "full"
               add_profile_suite live-gateway-advisory-docker-opencode-openrouter "full"
-              add_profile_suite live-gateway-advisory-docker-xai-zai "full"
+              add_profile_suite live-gateway-advisory-docker-xai "full"
               add_profile_suite live-cli-backend-docker "stable full"
               add_profile_suite live-acp-bind-docker "stable full"
               add_profile_suite live-codex-harness-docker "stable full"
@@ -706,6 +705,17 @@ jobs:
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           RELEASE_TEST_PROFILE: ${{ inputs.release_test_profile }}
         run: node scripts/plan-release-workflow-matrix.mjs >> "$GITHUB_OUTPUT"
+
+      - name: Record temporary Z.AI API Platform omission
+        if: inputs.include_live_suites
+        shell: bash
+        run: |
+          {
+            echo
+            echo "### Temporary provider omission"
+            echo
+            echo "Z.AI API Platform validation is temporarily disabled while its CI account is unavailable. Z.AI Coding Plan validation remains enabled."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   validate_release_live_cache:
     needs: validate_selected_ref
@@ -2827,7 +2837,9 @@ jobs:
         include:
           - suite_id: native-live-src-agents
             label: Native live agents
-            command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents
+            # Keep the dedicated Coding Plan suite below while temporarily omitting
+            # API Platform calls from the broad agents shard.
+            command: ZAI_API_KEY= Z_AI_API_KEY= node .release-harness/scripts/test-live-shard.mjs native-live-src-agents
             timeout_minutes: 60
             profile_env_only: false
             profiles: stable full
@@ -2958,13 +2970,6 @@ jobs:
           - suite_id: native-live-src-gateway-profiles-xai
             label: Native live gateway profiles xAI
             command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
-            timeout_minutes: 30
-            profile_env_only: false
-            advisory: true
-            profiles: full
-          - suite_id: native-live-src-gateway-profiles-zai
-            label: Native live gateway profiles Z.ai
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=zai node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
             timeout_minutes: 30
             profile_env_only: false
             advisory: true
@@ -3226,10 +3231,10 @@ jobs:
             profile_env_only: false
             advisory: true
             profiles: full
-          - suite_id: live-gateway-advisory-docker-xai-zai
+          - suite_id: live-gateway-advisory-docker-xai
             suite_group: live-gateway-advisory-docker
-            label: Docker live gateway advisory xAI/Z.ai
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai,zai OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
+            label: Docker live gateway advisory xAI
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
             timeout_minutes: 40
             profile_env_only: false
             advisory: true

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -130,11 +130,6 @@ const LIVE_MODEL_PROVIDERS = [
     profiles: "full",
   },
   {
-    provider_label: "Z.ai",
-    providers: "zai",
-    profiles: "full",
-  },
-  {
     provider_label: "Fireworks",
     providers: "fireworks",
     profiles: "full",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1604,7 +1604,7 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("suite_id: native-live-src-agents");
     expect(workflow).toContain("Checkout trusted live shard harness");
     expect(workflow).toContain(
-      "command: node .release-harness/scripts/test-live-shard.mjs native-live-src-agents",
+      "command: ZAI_API_KEY= Z_AI_API_KEY= node .release-harness/scripts/test-live-shard.mjs native-live-src-agents",
     );
     expect(workflow).toContain("suite_id: native-live-src-agents-zai-coding");
     expect(workflow).toContain(
@@ -1633,7 +1633,7 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain(
       'add_profile_suite live-gateway-advisory-docker-opencode-openrouter "full"',
     );
-    expect(workflow).toContain('add_profile_suite live-gateway-advisory-docker-xai-zai "full"');
+    expect(workflow).toContain('add_profile_suite live-gateway-advisory-docker-xai "full"');
     expect(workflow).toContain('add_profile_suite live-cli-backend-docker "stable full"');
     expect(workflow).toContain('add_profile_suite live-subagent-announce-docker "stable full"');
     expect(workflow).toContain(
@@ -1643,12 +1643,12 @@ describe("package artifact reuse", () => {
     expect(workflow).not.toContain("src/agents/openai-ws-stream.e2e.test.ts");
     expect(workflow).toContain("suite_id: live-gateway-advisory-docker-deepseek-fireworks");
     expect(workflow).toContain("suite_id: live-gateway-advisory-docker-opencode-openrouter");
-    expect(workflow).toContain("suite_id: live-gateway-advisory-docker-xai-zai");
+    expect(workflow).toContain("suite_id: live-gateway-advisory-docker-xai");
     expect(workflow).toContain("suite_id: live-subagent-announce-docker");
     expect(workflow).toContain("suite_group: live-gateway-advisory-docker");
     expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek,fireworks");
     expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=opencode-go,openrouter");
-    expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai,zai");
+    expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai");
     expect(workflow).toContain("inputs.live_suite_filter == matrix.suite_group");
     expect(workflow).toContain("OPENCLAW_LIVE_CLI_BACKEND_MODEL=claude-cli/claude-sonnet-4-6");
     expect(workflow).toContain("OPENCLAW_LIVE_CLI_BACKEND_AUTH=api-key");
@@ -1710,7 +1710,8 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-opencode-go");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-openrouter");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-xai");
-    expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-zai");
+    expect(workflow).not.toContain("suite_id: native-live-src-gateway-profiles-zai");
+    expect(workflow).toContain("Z.AI API Platform validation is temporarily disabled");
     expect(workflow).not.toContain(
       "OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek,opencode-go,openrouter,xai,zai",
     );

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -308,7 +308,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
     });
 
     expect(plan.liveModels.count).toBe(0);
-    expect(plan.liveModels.omitted).toHaveLength(10);
+    expect(plan.liveModels.omitted).toHaveLength(9);
     expect(plan.liveModels.omitted[0]?.reason).toBe(
       "Docker live model matrix disabled by input selection",
     );

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -127,7 +127,6 @@ const PROFILE_EXPECTATIONS = [
       "opencode-go",
       "openrouter",
       "xai",
-      "zai",
       "fireworks",
     ],
   },
@@ -243,7 +242,6 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       "opencode-go",
       "openrouter",
       "xai",
-      "zai",
       "fireworks",
     ]);
   });


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's release validation has been blocked for more than 24 hours because the CI credential for Z.AI API Platform returns HTTP 429 with `Insufficient balance or no resource package`. The separate Z.AI Coding Plan endpoint remains healthy.

## Why This Change Was Made

Temporarily omit only Z.AI API Platform coverage from the default release-validation matrix:

- clear the Z.AI key only for the broad native-agent shard;
- remove Z.AI from the default full-profile Docker model matrix;
- remove the dedicated native Z.AI gateway profile;
- keep the combined advisory Docker lane running as xAI-only.

The dedicated `native-live-src-agents-zai-coding` suite remains enabled with the existing CI secret. Release summaries explicitly record the temporary API Platform omission. Explicit targeted Docker requests can still select `zai` for diagnosis.

This waiver should be reverted after the replacement API Platform credential is installed and passes a real completion probe.

## User Impact

No product runtime or release-candidate code changes. Release validation temporarily loses Z.AI API Platform proof while retaining Z.AI Coding Plan and every unrelated provider lane.

## Evidence

- `actionlint .github/workflows/openclaw-live-and-e2e-checks-reusable.yml`
- Full-profile matrix planner returns nine providers, retains xAI, and omits Z.AI.
- `git diff --check`
- Focused Vitest could not start in the fresh linked worktree because dependencies are intentionally absent; PR CI will run the workflow contract suites.
- Blocking diagnostic: https://github.com/openclaw/openclaw/actions/runs/29464800779
