### PR TITLE
fix(gateway): read pinned session-extension registry for catalog node commands

### DIFF
--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { gatewaySubagentState } from "../../plugins/runtime/gateway-bindings.js";
+import { createPluginRuntime } from "../../plugins/runtime/index.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
 
 const hoisted = vi.hoisted(() => ({
   activeRegistry: { sessionCatalogs: [] as unknown[] },
+  pinnedSessionExtensionRegistry: undefined as { sessionCatalogs: unknown[] } | undefined,
   recordSessionStateEvent: vi.fn(),
   upsertSessionUpstreamLink: vi.fn(),
 }));
@@ -14,8 +17,9 @@ const conversationBindingMocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("../../plugins/runtime-state.js", () => ({
-  getPluginRegistryState: () => ({ activeRegistry: hoisted.activeRegistry }),
+vi.mock("../../plugins/runtime.js", () => ({
+  getActivePluginSessionExtensionRegistry: () =>
+    hoisted.pinnedSessionExtensionRegistry ?? hoisted.activeRegistry,
 }));
 
 vi.mock("../../sessions/session-state-events.js", () => ({
@@ -64,6 +68,7 @@ async function call(
 describe("session catalog Gateway methods", () => {
   beforeEach(() => {
     hoisted.activeRegistry.sessionCatalogs = [];
+    hoisted.pinnedSessionExtensionRegistry = undefined;
     hoisted.recordSessionStateEvent.mockClear();
     hoisted.upsertSessionUpstreamLink.mockClear();
     conversationBindingMocks.bindPluginSessionConversation.mockClear();
@@ -91,6 +96,39 @@ describe("session catalog Gateway methods", () => {
         expect.objectContaining({ id: "zeta", hosts: [] }),
       ],
     });
+  });
+
+  it("uses the pinned Gateway catalog runtime after active registry churn", async () => {
+    const previousNodesRuntime = gatewaySubagentState.nodes;
+    const listNodes = vi.fn(async () => ({ nodes: [] }));
+    gatewaySubagentState.nodes = {
+      list: listNodes,
+      invoke: vi.fn(async () => undefined),
+    };
+    try {
+      const gatewayRuntime = createPluginRuntime({ allowGatewaySubagentBinding: true });
+      const standaloneRuntime = createPluginRuntime();
+      const catalogUsing = (runtime: ReturnType<typeof createPluginRuntime>) =>
+        provider("codex", {
+          list: async () => {
+            await runtime.nodes.list();
+            return [];
+          },
+        });
+      hoisted.pinnedSessionExtensionRegistry = {
+        sessionCatalogs: [{ provider: catalogUsing(gatewayRuntime) }],
+      };
+      hoisted.activeRegistry.sessionCatalogs = [{ provider: catalogUsing(standaloneRuntime) }];
+
+      const respond = await call("sessions.catalog.list", { catalogId: "codex" });
+
+      expect(listNodes).toHaveBeenCalledOnce();
+      expect(respond).toHaveBeenCalledWith(true, {
+        catalogs: [expect.objectContaining({ id: "codex", hosts: [] })],
+      });
+    } finally {
+      gatewaySubagentState.nodes = previousNodesRuntime;
+    }
   });
 
   it("normalizes search once before dispatching every provider", async () => {

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -13,7 +13,7 @@ import {
   validateSessionsCatalogListParams,
   validateSessionsCatalogReadParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { getPluginRegistryState } from "../../plugins/runtime-state.js";
+import { getActivePluginSessionExtensionRegistry } from "../../plugins/runtime.js";
 import type {
   SessionCatalogCreateTarget,
   SessionCatalogProvider,
@@ -57,8 +57,8 @@ export function resolveSessionCatalogProvider(
 }
 
 function registrations() {
-  return (getPluginRegistryState()?.activeRegistry?.sessionCatalogs ?? []).toSorted((left, right) =>
-    left.provider.id.localeCompare(right.provider.id),
+  return (getActivePluginSessionExtensionRegistry()?.sessionCatalogs ?? []).toSorted(
+    (left, right) => left.provider.id.localeCompare(right.provider.id),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Control UI Codex/Anthropic session catalogs surface `[NODE_LIST_FAILED] Paired nodes could not be listed: Plugin node runtime is only available inside the Gateway`, even though the gateway binds a real nodes runtime at startup and CLI `openclaw nodes list` works. Reproduced live on a running gateway: the sidebar "Local Codex" catalog shows the error chip while `nodes list` returns cleanly.

## Why This Change Was Made

`registrations()` in the session-catalog gateway method read the **mutable** `getPluginRegistryState()?.activeRegistry`. A later standalone plugin load can replace `activeRegistry` with catalog providers constructed from **default** plugin runtimes (no gateway subagent/nodes binding). Those runtimes fall through to the unavailable-nodes stub (`src/plugins/runtime/index.ts:218`), so `provider.list()` throws when it calls `runtime.nodes.list()`.

The gateway already pins a stable session-extension registry at startup (`pinActivePluginSessionExtensionRegistry`, `src/gateway/server-plugin-bootstrap.ts`). Reading that pinned registry instead keeps catalog providers on the gateway-bound runtime across plugin-registry churn. Generic across all session-catalog plugins — no per-plugin special-casing. CLI `nodes list` was unaffected because it uses the gateway nodes RPC directly, bypassing the stale catalog provider runtime.

## User Impact

Remote Claude/Codex session rows and terminal-resume availability render correctly in Control UI instead of showing a node-list error. No config or protocol change; no migration.

## Evidence

- Root-cause chain verified in source (see commit body).
- Regression test `session-catalog.test.ts` "uses the pinned Gateway catalog runtime after active registry churn": sets a pinned registry with a gateway-bound runtime and an active registry with a standalone (unbound) runtime, asserts the pinned runtime is used (`listNodes` called once). **Red before the fix** (`listNodes` called 0 times → throw), green after.
- `node scripts/run-vitest.mjs src/gateway/server-methods/session-catalog.test.ts` → Test Files 1 passed, Tests 15 passed.
- Autoreview (Codex gpt-5.6-sol, high): clean, no accepted/actionable findings.
