### PR TITLE
feat(onboarding): prefer strongest local model in guided detection

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-4a1e3eef297eba243eae0c72710560c8fcea403764cc481a306cb7d2cb489d5f  plugin-sdk-api-baseline.json
-c16ac4e279fe0a485baba3d986dbfd8f8915dabd13c04b50fea0fef54d6020d0  plugin-sdk-api-baseline.jsonl
+3fc61e844ced788c276503228bb6248a6fdaff0f9276e6e248ecdac66ad63c7f  plugin-sdk-api-baseline.json
+cfe57713951912169ef66cd8f40e9f329f57fdf268070e0994f0f8aa0ca2b8c1  plugin-sdk-api-baseline.jsonl

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -34,8 +34,10 @@ Guided inference detection runs on the Gateway host on macOS or Linux. The CLI
 and macOS app call the same Gateway-owned detector, which checks configured
 models, supported CLI logins, API-key environment variables, and already
 installed Ollama or LM Studio models. Local models are never downloaded by this
-automatic pass; the selected candidate must answer a real completion before its
-provider and model configuration is saved.
+automatic pass. Detected local runtimes are auto-tested after CLI and API-key
+candidates; when several local models are available, OpenClaw prefers the
+strongest tool-calling instruct family. The selected candidate must answer a
+real completion before its provider and model configuration is saved.
 
 `setup` accepts the same onboarding flags as `openclaw onboard`, including
 auth (`--auth-choice`, `--token`, provider key flags), Gateway

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -174,7 +174,7 @@ and pairing-path families.
     | `plugin-sdk/provider-auth-result` | Standard OAuth auth-result builder |
     | `plugin-sdk/provider-env-vars` | Provider auth env-var lookup helpers |
     | `plugin-sdk/provider-auth` | `createProviderApiKeyAuthMethod`, `ensureApiKeyFromOptionEnvOrPrompt`, `upsertAuthProfile`, `upsertApiKeyProfile`, `writeOAuthCredentials`, OpenAI Codex auth-import helpers, deprecated `resolveOpenClawAgentDir` compatibility export |
-    | `plugin-sdk/provider-model-shared` | `ProviderReplayFamily`, `buildProviderReplayFamilyHooks`, `normalizeModelCompat`, shared replay-policy builders, provider-endpoint helpers, and shared model-id normalization helpers |
+    | `plugin-sdk/provider-model-shared` | `ProviderReplayFamily`, `buildProviderReplayFamilyHooks`, `selectPreferredLocalModelId`, `normalizeModelCompat`, shared replay-policy builders, provider-endpoint helpers, and shared model-id normalization helpers |
     | `plugin-sdk/provider-catalog-live-runtime` | Live provider model catalog helpers for guarded `/models`-style discovery: `buildLiveModelProviderConfig`, `fetchLiveProviderModelRows`, `getCachedLiveProviderModelRows`, `fetchLiveProviderModelIds`, `LiveModelCatalogHttpError`, `clearLiveCatalogCacheForTests`, model-id filtering, TTL cache, and static fallback |
     | `plugin-sdk/provider-catalog-runtime` | Provider catalog augmentation runtime hook and plugin-provider registry seams for contract tests |
     | `plugin-sdk/provider-catalog-shared` | `findCatalogTemplate`, `buildSingleProviderApiKeyCatalog`, `buildManifestModelProviderConfig`, `supportsNativeStreamingUsageCompat`, `applyProviderNativeStreamingUsageCompat` |

--- a/extensions/lmstudio/src/setup.test.ts
+++ b/extensions/lmstudio/src/setup.test.ts
@@ -405,6 +405,34 @@ describe("lmstudio setup", () => {
     ).resolves.toBeNull();
   });
 
+  it("prefers the strongest tool-calling family among installed models", async () => {
+    fetchLmstudioModelsMock.mockResolvedValue({
+      reachable: true,
+      status: 200,
+      models: [
+        {
+          type: "llm",
+          key: "llama3.3-70b-instruct",
+          capabilities: { trained_for_tool_use: true },
+        },
+        {
+          type: "llm",
+          key: "qwen3.5-4b-instruct",
+          capabilities: { trained_for_tool_use: true },
+        },
+        {
+          type: "llm",
+          key: "nomic-embed-text",
+          capabilities: { trained_for_tool_use: true },
+        },
+      ],
+    });
+
+    const result = await prepareAppGuidedLmstudioSetup({ config: {}, env: {} });
+
+    expect(result?.defaultModel).toBe("lmstudio/qwen3.5-4b-instruct");
+  });
+
   it("non-interactive setup discovers catalog and writes LM Studio provider config", async () => {
     const ctx = buildNonInteractiveContext({
       customBaseUrl: "http://localhost:1234/api/v1/",
@@ -487,7 +515,7 @@ describe("lmstudio setup", () => {
     });
   });
 
-  it("non-interactive setup auto-selects a discovered LM Studio model when none is provided", async () => {
+  it("non-interactive setup selects the preferred discovered model when none is provided", async () => {
     const ctx = buildNonInteractiveContext({
       customBaseUrl: "http://localhost:1234/api/v1/",
     });
@@ -516,9 +544,11 @@ describe("lmstudio setup", () => {
     );
     const setupCtx = requireRecord(setupCall.ctx, "self-hosted setup context");
     expectRecordFields(setupCtx.opts, "self-hosted setup opts", {
-      customModelId: "phi-4",
+      customModelId: "qwen3-8b-instruct",
     });
-    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe("lmstudio/phi-4");
+    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
+      "lmstudio/qwen3-8b-instruct",
+    );
     const models = requireProviderModels(requireNonInteractiveLmstudioProvider(result));
     expect(models).toHaveLength(2);
     expectModelFields(models[0], {

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -11,9 +11,10 @@ import {
   type SecretInput,
   type SecretInputMode,
 } from "openclaw/plugin-sdk/provider-auth";
-import type {
-  ModelDefinitionConfig,
-  ModelProviderConfig,
+import {
+  selectPreferredLocalModelId,
+  type ModelDefinitionConfig,
+  type ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { withAgentModelAliases } from "openclaw/plugin-sdk/provider-onboard";
 import {
@@ -344,7 +345,9 @@ function selectDefaultLmstudioModelId(
   if (ids.length === 0) {
     return undefined;
   }
-  return ids.includes(LMSTUDIO_DEFAULT_MODEL_ID) ? LMSTUDIO_DEFAULT_MODEL_ID : ids[0];
+  return ids.includes(LMSTUDIO_DEFAULT_MODEL_ID)
+    ? LMSTUDIO_DEFAULT_MODEL_ID
+    : (selectPreferredLocalModelId(ids) ?? ids[0]);
 }
 
 function collectAppGuidedLmstudioModelIds(discovery: LmstudioDiscoveryResult): Set<string> {

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -334,6 +334,30 @@ describe("ollama plugin", () => {
     expect(ensureOllamaModelPulledMock).not.toHaveBeenCalled();
   });
 
+  it("prefers the strongest tool-calling family among installed models", async () => {
+    const provider = registerProvider();
+    buildOllamaProviderMock.mockResolvedValue({
+      baseUrl: "http://127.0.0.1:11434",
+      api: "ollama",
+      models: [
+        { id: "llama3.3:70b", name: "llama3.3:70b", compat: { supportsTools: true } },
+        { id: "qwen3.5:4b", name: "qwen3.5:4b", compat: { supportsTools: true } },
+        {
+          id: "nomic-embed-text",
+          name: "nomic-embed-text",
+          compat: { supportsTools: true },
+        },
+      ],
+    });
+
+    await expect(provider.auth[0].appGuidedSetup?.detect({ config: {}, env: {} })).resolves.toEqual(
+      {
+        modelRef: "ollama/qwen3.5:4b",
+        detail: "qwen3.5:4b at http://127.0.0.1:11434",
+      },
+    );
+  });
+
   it("uses configured Ollama access while discovering installed models", async () => {
     const provider = registerProvider();
     const configuredValue = "configured-access";

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -27,6 +27,7 @@ import type {
 import {
   buildOpenAICompatibleReplayPolicy,
   buildProviderReplayFamilyHooks,
+  selectPreferredLocalModelId,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import {
@@ -117,7 +118,11 @@ async function discoverAppGuidedOllamaModel(ctx: ProviderAppGuidedSetupContext) 
     quiet: true,
     ...discoveryAccess,
   });
-  const model = provider.models?.find((candidate) => candidate.compat?.supportsTools === true);
+  const toolModels =
+    provider.models?.filter((candidate) => candidate.compat?.supportsTools === true) ?? [];
+  const preferredModelId = selectPreferredLocalModelId(toolModels.map((candidate) => candidate.id));
+  const model =
+    toolModels.find((candidate) => candidate.id.trim() === preferredModelId) ?? toolModels[0];
   let ownerValue = existing?.apiKey;
   if (ownerValue === undefined) {
     if (accessValue) {

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -249,7 +249,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // Harvest: retired AudioConfig type -1.
       // +4: bounded plugin blob store options, entry, entry info, and store types.
       // +6: shared progress receipt tracker + compositor snapshot across channel barrels.
-      8005,
+      // +1: selectPreferredLocalModelId shares app-guided local model ranking across providers.
+      8006,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -273,7 +274,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +3: receipt tracker/snapshot callables across channel barrels.
       // +3: lightweight speech settings normalizers and config resolver.
       // +1: unified implicit-mention policy resolver.
-      4472,
+      // +1: selectPreferredLocalModelId shares app-guided local model ranking across providers.
+      4473,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -95,9 +95,9 @@ describe("modelCostsEqual", () => {
 
 describe("selectPreferredLocalModelId", () => {
   const familyOrder = [
+    "google/gemma-4-27b",
     "qwen3.5:4b",
     "qwen3:8b",
-    "google/gemma-4-27b",
     "gpt-oss:20b",
     "google/gemma-3-12b",
     "meta-llama/Llama-4-17B",

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -14,6 +14,7 @@ import {
   resolveClaudeSonnet5ModelIdentity,
   resolveClaudeThinkingProfile,
   requiresClaudeDefaultSampling,
+  selectPreferredLocalModelId,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
@@ -89,6 +90,59 @@ describe("modelCostsEqual", () => {
     expect(modelCostsEqual(EXPECTED_COST, EXPECTED_COST)).toBe(true);
     expect(modelCostsEqual(undefined, EXPECTED_COST)).toBe(false);
     expect(modelCostsEqual({ ...EXPECTED_COST, output: 15 }, EXPECTED_COST)).toBe(false);
+  });
+});
+
+describe("selectPreferredLocalModelId", () => {
+  const familyOrder = [
+    "qwen3.5:4b",
+    "qwen3:8b",
+    "google/gemma-4-27b",
+    "gpt-oss:20b",
+    "google/gemma-3-12b",
+    "meta-llama/Llama-4-17B",
+    "meta-llama/Llama-3.3-70B-Instruct",
+    "phi-4:14b",
+    "mistral-small:24b",
+    "deepseek-r1:14b",
+  ];
+
+  it.each(familyOrder.slice(0, -1).map((id, index) => [id, familyOrder[index + 1]!] as const))(
+    "prefers %s over %s",
+    (preferred, fallback) => {
+      expect(selectPreferredLocalModelId([fallback, preferred])).toBe(preferred);
+    },
+  );
+
+  it("sinks specialist variants below general chat models", () => {
+    expect(selectPreferredLocalModelId(["nomic-embed-text", "qwen3.5-vl:7b", "custom-chat"])).toBe(
+      "custom-chat",
+    );
+    expect(selectPreferredLocalModelId(["guard-model", "vision-model"])).toBe("guard-model");
+  });
+
+  it("ranks coder variants below general instruct families", () => {
+    expect(
+      selectPreferredLocalModelId(["qwen3-coder:30b", "meta-llama/Llama-3.3-70B-Instruct"]),
+    ).toBe("meta-llama/Llama-3.3-70B-Instruct");
+  });
+
+  it("distinguishes family versions from colon-delimited size tags", () => {
+    expect(selectPreferredLocalModelId(["qwen3:5b", "qwen3.5:4b"])).toBe("qwen3.5:4b");
+    expect(selectPreferredLocalModelId(["qwen:32b", "llama3:8b"])).toBe("llama3:8b");
+    expect(selectPreferredLocalModelId(["qwen-35b", "deepseek:8b"])).toBe("deepseek:8b");
+  });
+
+  it("matches case-insensitively and preserves caller order within a family", () => {
+    expect(selectPreferredLocalModelId(["  QWEN3:4B  ", "qwen3:8b"])).toBe("QWEN3:4B");
+  });
+
+  it("falls back to the first normalized general model", () => {
+    expect(selectPreferredLocalModelId(["  custom-chat  ", "another-chat"])).toBe("custom-chat");
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(selectPreferredLocalModelId(["", "   "])).toBeUndefined();
   });
 });
 

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -115,6 +115,52 @@ export function modelCostsEqual(
     current?.cacheWrite === expected.cacheWrite
   );
 }
+
+const LOCAL_MODEL_FAMILY_PREFERENCES = [
+  /qwen[-_.]?3[._]5(?!\d)/,
+  /qwen[-_.]?3(?!\d)/,
+  /gemma[-_.]?4(?!\d)/,
+  /gpt[-_.]?oss/,
+  /gemma[-_.]?3(?!\d)/,
+  /llama[-_.]?4(?!\d)/,
+  /llama[-_.]?3(?!\d)/,
+  /phi[-_.]?4(?!\d)/,
+  /mistral/,
+  /deepseek/,
+] as const;
+const LOCAL_MODEL_SPECIALIST_PATTERN = /embed|rerank|whisper|-vl\b|vision|omni|guard/;
+
+/**
+ * Setup-assistant preference for agentic tool-calling quality in current BFCL-class results.
+ * Heuristic contract; safe to retune as local model families improve.
+ */
+export function selectPreferredLocalModelId(modelIds: readonly string[]): string | undefined {
+  const familyCount = LOCAL_MODEL_FAMILY_PREFERENCES.length;
+  let preferred: string | undefined;
+  let preferredRank = Number.POSITIVE_INFINITY;
+
+  for (const rawId of modelIds) {
+    const id = rawId.trim();
+    if (!id) {
+      continue;
+    }
+    const normalized = id.toLowerCase();
+    const familyRank = LOCAL_MODEL_FAMILY_PREFERENCES.findIndex((pattern) =>
+      pattern.test(normalized),
+    );
+    const rank = LOCAL_MODEL_SPECIALIST_PATTERN.test(normalized)
+      ? familyCount * 3
+      : familyRank >= 0
+        ? familyRank + (normalized.includes("coder") ? familyCount : 0)
+        : familyCount * 2 + (normalized.includes("coder") ? 1 : 0);
+    if (rank < preferredRank) {
+      preferred = id;
+      preferredRank = rank;
+    }
+  }
+
+  return preferred;
+}
 export {
   createMoonshotThinkingWrapper,
   resolveMoonshotThinkingType,

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -148,6 +148,9 @@ export function selectPreferredLocalModelId(modelIds: readonly string[]): string
     const familyRank = LOCAL_MODEL_FAMILY_PREFERENCES.findIndex((pattern) =>
       pattern.test(normalized),
     );
+    // Rank buckets, best to worst: known family (0..N-1), known-family coder
+    // (N..2N-1), unknown chat (2N), unknown coder (2N+1), specialist (3N).
+    // Strict `<` below keeps the caller's original order within a bucket.
     const rank = LOCAL_MODEL_SPECIALIST_PATTERN.test(normalized)
       ? familyCount * 3
       : familyRank >= 0

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -117,9 +117,12 @@ export function modelCostsEqual(
 }
 
 const LOCAL_MODEL_FAMILY_PREFERENCES = [
+  // Gemma 4 leads: live bench of the system-agent contract (planner JSON +
+  // openclaw tool calls) scored gemma4:e4b well above qwen3.5:4b on approval
+  // follow-through and structured-command accuracy at ~2.5x lower latency.
+  /gemma[-_.]?4(?!\d)/,
   /qwen[-_.]?3[._]5(?!\d)/,
   /qwen[-_.]?3(?!\d)/,
-  /gemma[-_.]?4(?!\d)/,
   /gpt[-_.]?oss/,
   /gemma[-_.]?3(?!\d)/,
   /llama[-_.]?4(?!\d)/,


### PR DESCRIPTION
## What Problem This Solves

Guided onboarding auto-detects running local runtimes (Ollama, LM Studio) and offers one of their models as the zero-key inference route, but it picks the FIRST tools-capable model discovery returns — effectively random for users with many pulled models. A 70B llama or a coder/vision specialist can win over an ideal small instruct model, giving a slow or poorly-suited model for the setup assistant.

## Why This Change Was Made

Onboarding's detected-candidate quality decides whether the conversational setup (system agent) works well. Small mainstream instruct families (Qwen3.x, Gemma 4, etc.) are the strongest tool-callers per current BFCL-class results; specialists (embedding/vision/rerank) and coder variants are worse choices for a setup assistant. Both plugins had the same naive pick, so the ranking lives once in the plugin SDK (`extensions/AGENTS.md`: shared helper over per-plugin copies).

- New `selectPreferredLocalModelId` in `openclaw/plugin-sdk/provider-model-shared`: deterministic family-preference ranking (gemma4 > qwen3.5 > qwen3 > gpt-oss > gemma3 > llama4 > llama3 > phi4 > mistral > deepseek), coder-variant and specialist sinking, caller-order stability. Heuristic contract, safe to retune.
- `extensions/ollama`: app-guided discovery ranks all tools-capable models instead of taking the first.
- `extensions/lmstudio`: default-model selection keeps the explicit documented default, then ranks, then falls back to first.
- `docs/cli/setup.md`: documents the preference in the setup bootstrap ladder contract.
- SDK surface budget +1 with the standard checker-workflow comment; API baseline regenerated via `pnpm plugin-sdk:api:check`.

## User Impact

Users with several local models get the strongest setup-assistant model picked automatically during `openclaw onboard` / `openclaw setup`; behavior with zero or one model is unchanged. No config surface changes.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/provider-model-shared.test.ts` — 30 passed (pairwise family order, specialist/coder sinking, size-tag vs version disambiguation, stability, empty input).
- `node scripts/run-vitest.mjs extensions/ollama` — 16 files, 371 passed (incl. new multi-model preference test).
- `node scripts/run-vitest.mjs extensions/lmstudio` — 6 files, 117 passed (incl. new preference tests).
- `pnpm plugin-sdk:surface:check` + `pnpm plugin-sdk:api:check` — clean.
- Autoreview (codex, gpt-5.6-sol, branch vs origin/main): clean, no actionable findings.
- Live model bench backing the ranking order (macOS, Ollama, real system-agent prompts/parsers driven directly; 10 scenarios x 3 repeats per mode): planner-contract mode gemma4:e4b 26/30 vs qwen3.5:4b 13/30 (both ~100% valid JSON via the tolerant extractor); native tool-call mode gemma4:e4b 25/30 (median 2.7s/turn) vs qwen3.5:4b 21/30 (median 6.8s/turn). Qwen3.5 failed the approval-follow-through scenario 0/6 across both modes (wrong action or claims success without a command); with thinking enabled its latency exceeds 2min/turn. Hence gemma4 ranks first.

Related: #109228 (local-model onboarding track — Apple Foundation Models provider card).
