### PR TITLE
fix(update): dev channel update builds from an unverified checkout at the git install path

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -123,8 +123,8 @@ It does not install a new core package and does not restart the Gateway.
 ## `update wizard`
 
 Interactive flow to pick an update channel and confirm whether to restart the
-Gateway afterward (defaults to restart). Selecting `dev` without a git
-checkout offers to create one.
+Gateway afterward (defaults to restart). Selecting `dev` from a package
+installation offers to create a fresh checkout at an unused path.
 
 | Flag                  | Default | Description                   |
 | --------------------- | ------- | ----------------------------- |
@@ -135,10 +135,12 @@ checkout offers to create one.
 Switching channels explicitly (`--channel ...`) also keeps the install method
 aligned:
 
-- `dev` -> ensures a git checkout (default `~/openclaw`, or
-  `$OPENCLAW_HOME/openclaw` when `OPENCLAW_HOME` is set; override with
-  `OPENCLAW_GIT_DIR`), updates it, and installs the global CLI from that
-  checkout.
+- `dev` -> package installations create a fresh git checkout (default
+  `~/openclaw`, or `$OPENCLAW_HOME/openclaw` when `OPENCLAW_HOME` is set;
+  override with `OPENCLAW_GIT_DIR`), update it, and install the global CLI from
+  that checkout. Package-to-dev conversion refuses an existing file or
+  directory at that path instead of adopting its Git configuration, refs, or
+  contents. Existing git installations continue to update in place.
 - `stable` -> installs from npm using `latest`.
 - `extended-stable` -> resolves the public npm `extended-stable` selector,
   verifies the exact selected package, and installs that exact version. It

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -48,6 +48,15 @@ For `dev` git installs, the default checkout is `~/openclaw` (or
 `$OPENCLAW_HOME/openclaw` when `OPENCLAW_HOME` is set); override with
 `OPENCLAW_GIT_DIR`.
 
+When a package installation switches to `dev`, this path must not exist.
+OpenClaw creates a fresh checkout and does not adopt an existing directory,
+even when it already contains an OpenClaw checkout. Git installations that are
+already running from their own checkout continue to update in place.
+
+If a conversion is interrupted, OpenClaw recognizes the checkout it created at
+that path and replaces it when you run the update again. A directory OpenClaw
+did not create is still refused; move it or choose an unused `OPENCLAW_GIT_DIR`.
+
 <Tip>
 To keep stable and dev in parallel, use two separate checkouts and point each gateway at its own.
 </Tip>

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -451,7 +451,8 @@ const {
   updateWizardCommand,
 } = await import("./update-cli.js");
 const updateCliShared = await import("./update-cli/shared.js");
-const { ensureGitCheckout, resolveGitInstallDir } = updateCliShared;
+const { createGitCheckout, resolveGitInstallDir } = updateCliShared;
+const { claimManagedGitCheckout } = await import("./update-cli/managed-checkout.js");
 const { spawnSync } = await import("node:child_process");
 const { readRestartSentinel } = await import("../infra/restart-sentinel.js");
 
@@ -948,6 +949,9 @@ describe("update-cli", () => {
       },
     });
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "git" && argv[1] === "clone" && argv[3]) {
+        await fs.mkdir(path.join(argv[3], ".git"), { recursive: true });
+      }
       if (argv[0] === "npm" && argv[1] === "pack") {
         const destination = argv[argv.indexOf("--pack-destination") + 1];
         if (destination) {
@@ -4477,7 +4481,7 @@ describe("update-cli", () => {
     expect(logs.join("\n")).not.toContain("Gateway: restarted and verified.");
   });
 
-  it("stops a managed gateway rooted at the git checkout when switching package installs to dev", async () => {
+  it("rejects an existing git checkout before stopping its managed gateway", async () => {
     const packageRoot = createCaseDir("openclaw-update-package-root");
     const gitRoot = await createTrackedTempDir("openclaw-update-git-service-root-");
     const serviceEntrypoint = path.join(gitRoot, "dist", "index.js");
@@ -4504,35 +4508,133 @@ describe("update-cli", () => {
       pid: 4242,
       state: "running",
     });
+    await expect(
+      withEnvAsync({ OPENCLAW_GIT_DIR: gitRoot }, async () => {
+        await updateCommand({ channel: "dev", yes: true });
+      }),
+    ).rejects.toThrow(/will not reuse existing directories/u);
+
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+  });
+
+  it("removes its new checkout when package-to-dev cloning fails", async () => {
+    const packageRoot = createCaseDir("openclaw-update-package-root");
+    const gitParent = await createTrackedTempDir("openclaw-update-git-clone-parent-");
+    const gitRoot = path.join(gitParent, "checkout");
+    mockPackageInstallStatus(packageRoot);
+    pathExists.mockResolvedValue(false);
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => ({
+      stdout: "",
+      stderr: argv[0] === "git" && argv[1] === "clone" ? "network unavailable" : "",
+      code: argv[0] === "git" && argv[1] === "clone" ? 1 : 0,
+      signal: null,
+      killed: false,
+      termination: "exit" as const,
+    }));
+
+    await withEnvAsync({ OPENCLAW_GIT_DIR: gitRoot }, async () => {
+      await updateCommand({ channel: "dev", yes: true });
+    });
+
+    await expect(fs.stat(gitRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+  });
+
+  it("removes its new checkout when package-to-dev updating fails", async () => {
+    const packageRoot = createCaseDir("openclaw-update-package-root");
+    const gitParent = await createTrackedTempDir("openclaw-update-git-update-parent-");
+    const gitRoot = path.join(gitParent, "checkout");
+    mockPackageInstallStatus(packageRoot);
+    pathExists.mockResolvedValue(false);
+    mockGitUpdateAfterMutation({
+      status: "error",
+      mode: "git",
+      root: gitRoot,
+      reason: "fetch-failed",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await withEnvAsync({ OPENCLAW_GIT_DIR: gitRoot }, async () => {
+      await updateCommand({ channel: "dev", yes: true });
+    });
+
+    await expect(fs.stat(gitRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves its new checkout when doctor may have rewritten the managed service", async () => {
+    const packageRoot = createCaseDir("openclaw-update-package-root");
+    const gitParent = await createTrackedTempDir("openclaw-update-git-doctor-parent-");
+    const gitRoot = path.join(gitParent, "checkout");
+    mockPackageInstallStatus(packageRoot);
+    pathExists.mockResolvedValue(false);
+    mockGitUpdateAfterMutation({
+      status: "error",
+      mode: "git",
+      root: gitRoot,
+      reason: "ui-build-failed",
+      steps: [
+        {
+          name: "openclaw doctor",
+          command: "node openclaw.mjs doctor --non-interactive --fix",
+          cwd: gitRoot,
+          durationMs: 10,
+          exitCode: 0,
+        },
+      ],
+      durationMs: 100,
+    });
+
+    await withEnvAsync({ OPENCLAW_GIT_DIR: gitRoot }, async () => {
+      await updateCommand({ channel: "dev", yes: true });
+    });
+
+    await expect(fs.stat(gitRoot)).resolves.toBeDefined();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("preserves its new checkout when the global link step fails", async () => {
+    const packageRoot = createCaseDir("openclaw-update-package-root");
+    const gitParent = await createTrackedTempDir("openclaw-update-git-install-parent-");
+    const gitRoot = path.join(gitParent, "checkout");
+    mockPackageInstallStatus(packageRoot);
+    pathExists.mockResolvedValue(false);
     mockGitUpdateAfterMutation(
       makeOkUpdateResult({
         mode: "git",
         root: gitRoot,
       }),
     );
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "git" && argv[1] === "clone" && argv[3]) {
+        await fs.mkdir(path.join(argv[3], ".git"), { recursive: true });
+      }
+      return {
+        stdout: "",
+        stderr: argv[0] === "npm" && argv[1] === "i" ? "link failed" : "",
+        code: argv[0] === "npm" && argv[1] === "i" ? 1 : 0,
+        signal: null,
+        killed: false,
+        termination: "exit" as const,
+      };
+    });
 
     await withEnvAsync({ OPENCLAW_GIT_DIR: gitRoot }, async () => {
       await updateCommand({ channel: "dev", yes: true });
     });
 
-    expect(serviceStop).toHaveBeenCalledTimes(1);
-    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
-    const updateCall = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
-    expect(updateCall?.cwd).toBe(gitRoot);
-    expect(updateCall?.beforeGitMutation).toEqual(expect.any(Function));
+    await expect(fs.stat(gitRoot)).resolves.toBeDefined();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
   it("stops a managed gateway rooted at the package install when switching package installs to dev", async () => {
     const packageRoot = await createTrackedTempDir("openclaw-update-package-service-root-");
     const packageEntrypoint = path.join(packageRoot, "dist", "index.js");
-    const gitRoot = await createTrackedTempDir("openclaw-update-git-service-root-");
-    await fs.mkdir(path.join(gitRoot, ".git"), { recursive: true });
+    const gitParent = await createTrackedTempDir("openclaw-update-git-service-parent-");
+    const gitRoot = path.join(gitParent, "checkout");
     await fs.mkdir(path.dirname(packageEntrypoint), { recursive: true });
-    await fs.writeFile(
-      path.join(gitRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.4.21" }),
-      "utf-8",
-    );
     await fs.writeFile(
       path.join(packageRoot, "package.json"),
       JSON.stringify({ name: "openclaw", version: "2026.4.20" }),
@@ -4540,7 +4642,7 @@ describe("update-cli", () => {
     );
     await fs.writeFile(packageEntrypoint, "export {};\n", "utf-8");
     mockPackageInstallStatus(packageRoot);
-    pathExists.mockImplementation(async (candidate: string) => candidate === gitRoot);
+    pathExists.mockResolvedValue(false);
     serviceReadCommand.mockResolvedValue({
       programArguments: ["node", packageEntrypoint, "gateway", "run"],
       environment: {
@@ -4554,7 +4656,7 @@ describe("update-cli", () => {
       pid: 4242,
       state: "running",
     });
-    mockGitUpdateAfterMutation(
+    const preparations = mockGitUpdateAfterMutation(
       makeOkUpdateResult({
         mode: "git",
         root: gitRoot,
@@ -4570,6 +4672,13 @@ describe("update-cli", () => {
     const updateCall = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
     expect(updateCall?.cwd).toBe(gitRoot);
     expect(updateCall?.beforeGitMutation).toEqual(expect.any(Function));
+    expect(updateCall?.commandEnv).toMatchObject({
+      GIT_CONFIG_GLOBAL: os.devNull,
+      GIT_CONFIG_NOSYSTEM: "1",
+    });
+    expect(preparations).toEqual([
+      { allowGatewayServiceRepair: true, allowGatewayActivation: true },
+    ]);
   });
 
   it("does not stop or restart a managed gateway owned by another git checkout", async () => {
@@ -8103,9 +8212,11 @@ describe("update-cli", () => {
   });
 
   it("updateWizardCommand offers dev checkout and forwards selections", async () => {
-    const tempDir = createCaseDir("openclaw-update-wizard");
-    await withEnvAsync({ OPENCLAW_GIT_DIR: tempDir }, async () => {
+    const tempDir = await createTrackedTempDir("openclaw-update-wizard-");
+    const unusedGitDir = path.join(tempDir, "checkout");
+    await withEnvAsync({ OPENCLAW_GIT_DIR: unusedGitDir }, async () => {
       setTty(true);
+      pathExists.mockResolvedValue(false);
 
       vi.mocked(checkUpdateStatus).mockResolvedValue({
         root: "/test/path",
@@ -8117,6 +8228,62 @@ describe("update-cli", () => {
           lockfilePath: null,
           markerPath: null,
         },
+      });
+      select.mockResolvedValue("dev");
+      confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+      vi.mocked(runGatewayUpdate).mockResolvedValue({
+        status: "ok",
+        mode: "git",
+        steps: [],
+        durationMs: 100,
+      });
+
+      await updateWizardCommand({});
+
+      const call = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
+      expect(call?.channel).toBe("dev");
+    });
+  });
+
+  it("updateWizardCommand refuses a dev conversion into an existing checkout path", async () => {
+    const tempDir = createCaseDir("openclaw-update-wizard-existing");
+    await withEnvAsync({ OPENCLAW_GIT_DIR: tempDir }, async () => {
+      setTty(true);
+      pathExists.mockResolvedValue(true);
+
+      vi.mocked(checkUpdateStatus).mockResolvedValue({
+        root: "/test/path",
+        installKind: "package",
+        packageManager: "npm",
+        deps: { manager: "npm", status: "ok", lockfilePath: null, markerPath: null },
+      });
+      select.mockResolvedValue("dev");
+
+      await updateWizardCommand({});
+
+      expect(runGatewayUpdate).not.toHaveBeenCalled();
+      const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+      expect(errors.join("\n")).toContain(`OPENCLAW_GIT_DIR already exists: ${tempDir}`);
+    });
+  });
+
+  it("updateWizardCommand continues a dev conversion interrupted before its checkout landed", async () => {
+    const stateDir = await createTrackedTempDir("openclaw-update-wizard-state-");
+    const gitDir = path.join(
+      await createTrackedTempDir("openclaw-update-wizard-reserved-"),
+      "checkout",
+    );
+    await withEnvAsync({ OPENCLAW_GIT_DIR: gitDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
+      setTty(true);
+      pathExists.mockResolvedValue(true);
+      claimManagedGitCheckout(gitDir, process.env);
+      await fs.mkdir(gitDir, { recursive: true });
+
+      vi.mocked(checkUpdateStatus).mockResolvedValue({
+        root: "/test/path",
+        installKind: "package",
+        packageManager: "npm",
+        deps: { manager: "npm", status: "ok", lockfilePath: null, markerPath: null },
       });
       select.mockResolvedValue("dev");
       confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
@@ -8175,7 +8342,7 @@ describe("update-cli", () => {
     await withEnvAsync({ OPENCLAW_GIT_DIR: undefined, OPENCLAW_HOME: home }, async () => {
       const dir = resolveGitInstallDir();
       expect(dir).toBe(checkoutDir);
-      await ensureGitCheckout({ dir, timeoutMs: 1_000, env: process.env });
+      await createGitCheckout({ dir, timeoutMs: 1_000, env: process.env });
     });
 
     expect((await fs.stat(home)).isDirectory()).toBe(true);
@@ -8185,9 +8352,11 @@ describe("update-cli", () => {
     expect(cloneCall?.[0]).toEqual([
       "git",
       "clone",
+      expect.stringMatching(/^--template=.*\.openclaw-git-template-/u),
       "https://github.com/openclaw/openclaw.git",
-      checkoutDir,
+      expect.stringMatching(/openclaw\.staging-/u),
     ]);
+    expect(path.dirname(String(cloneCall?.[0][4]))).toBe(home);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/cli/update-cli/aggregate-error.ts
+++ b/src/cli/update-cli/aggregate-error.ts
@@ -1,0 +1,8 @@
+// Aggregate error construction shared by update-cli paths that must preserve a cause.
+export function createAggregateErrorWithCause(
+  errors: unknown[],
+  message: string,
+  cause: unknown,
+): AggregateError {
+  return new AggregateError(errors, message, { cause });
+}

--- a/src/cli/update-cli/managed-checkout.ts
+++ b/src/cli/update-cli/managed-checkout.ts
@@ -1,0 +1,119 @@
+// Ownership records for updater-created dev checkouts, held in the shared state database.
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createCorePluginStateSyncKeyedStore } from "../../plugin-state/plugin-state-store.js";
+
+const MANAGED_CHECKOUT_OWNER_ID = "core:update-cli" as const;
+const MANAGED_CHECKOUT_NAMESPACE = "managed-checkouts";
+const MANAGED_CHECKOUT_MAX_ENTRIES = 64;
+
+const MANAGED_CHECKOUT_MARKER = ".openclaw-update-managed";
+
+type ManagedCheckoutRecord = {
+  token: string;
+  dir: string;
+  createdAtMs: number;
+};
+
+function openManagedCheckoutStore(env?: NodeJS.ProcessEnv) {
+  return createCorePluginStateSyncKeyedStore<ManagedCheckoutRecord>({
+    ownerId: MANAGED_CHECKOUT_OWNER_ID,
+    namespace: MANAGED_CHECKOUT_NAMESPACE,
+    maxEntries: MANAGED_CHECKOUT_MAX_ENTRIES,
+    overflowPolicy: "evict-oldest",
+    ...(env ? { env } : {}),
+  });
+}
+
+function managedCheckoutKey(dir: string): string {
+  return createHash("sha256").update(path.resolve(dir)).digest("hex");
+}
+
+function managedCheckoutMarkerPath(dir: string): string {
+  return path.join(dir, ".git", MANAGED_CHECKOUT_MARKER);
+}
+
+function readManagedCheckoutToken(dir: string, env?: NodeJS.ProcessEnv): string | null {
+  const record = openManagedCheckoutStore(env).lookup(managedCheckoutKey(dir));
+  const token = record?.token?.trim();
+  return token ? token : null;
+}
+
+async function readMarkerToken(dir: string): Promise<string | null> {
+  return await fs
+    .readFile(managedCheckoutMarkerPath(dir), "utf8")
+    .then((value) => value.trim() || null)
+    .catch(() => null);
+}
+
+/** Claim `dir` as an updater-owned conversion target and return the ownership token. */
+export function claimManagedGitCheckout(dir: string, env?: NodeJS.ProcessEnv): string {
+  const token = randomUUID();
+  openManagedCheckoutStore(env).register(managedCheckoutKey(dir), {
+    token,
+    dir: path.resolve(dir),
+    createdAtMs: Date.now(),
+  });
+  return token;
+}
+
+/** Write the in-checkout half of the ownership pair before the checkout is swapped in. */
+export async function writeManagedCheckoutMarker(dir: string, token: string): Promise<void> {
+  await fs.mkdir(path.dirname(managedCheckoutMarkerPath(dir)), { recursive: true });
+  await fs.writeFile(managedCheckoutMarkerPath(dir), `${token}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+/** Resolve the ownership token when `dir` is a checkout this updater created and left behind. */
+export async function resolveManagedGitCheckoutToken(
+  dir: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | null> {
+  const recordToken = readManagedCheckoutToken(dir, env);
+  if (!recordToken) {
+    return null;
+  }
+  return recordToken === (await readMarkerToken(dir)) ? recordToken : null;
+}
+
+/** Report whether `dir` is a checkout this updater created and left behind. */
+export async function isManagedGitCheckoutRetry(
+  dir: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  return (await resolveManagedGitCheckoutToken(dir, env)) !== null;
+}
+
+/** Report whether `dir` is an empty destination this updater reserved but never filled. */
+export async function isReclaimableManagedReservation(
+  dir: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  if (!readManagedCheckoutToken(dir, env)) {
+    return false;
+  }
+  const entries = await fs.readdir(dir).catch(() => null);
+  return entries?.length === 0;
+}
+
+/** Report whether an existing `dir` is one a package-to-dev conversion may still take over. */
+export async function isReusableManagedGitCheckoutPath(
+  dir: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  return (
+    (await isManagedGitCheckoutRetry(dir, env)) || (await isReclaimableManagedReservation(dir, env))
+  );
+}
+
+/** Retire the ownership pair once the conversion has succeeded or its checkout is gone. */
+export async function completeManagedGitCheckout(
+  dir: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<void> {
+  openManagedCheckoutStore(env).delete(managedCheckoutKey(dir));
+  await fs.rm(managedCheckoutMarkerPath(dir), { force: true });
+}

--- a/src/cli/update-cli/shared.git-checkout.test.ts
+++ b/src/cli/update-cli/shared.git-checkout.test.ts
@@ -1,0 +1,350 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetPluginStateStoreForTests } from "../../plugin-state/plugin-state-store.js";
+import type { CommandOptions } from "../../process/exec.js";
+import { claimManagedGitCheckout, completeManagedGitCheckout } from "./managed-checkout.js";
+import { createGitCheckout } from "./shared.js";
+
+const CANONICAL_REPO_URL = "https://github.com/openclaw/openclaw.git";
+const runCommandWithTimeout = vi.hoisted(() => vi.fn());
+
+vi.mock("../../process/exec.js", () => ({ runCommandWithTimeout }));
+
+function seedRemoteMain(dir: string): void {
+  execFileSync("git", ["-C", dir, "update-ref", "refs/remotes/origin/main", "HEAD"]);
+}
+
+async function createHostileCheckout(setup: (dir: string) => void): Promise<string> {
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-adopt-")));
+  execFileSync("git", ["-C", dir, "init", "--quiet"]);
+  execFileSync("git", ["-C", dir, "config", "user.name", "OpenClaw Test"]);
+  execFileSync("git", ["-C", dir, "config", "user.email", "test@openclaw.invalid"]);
+  execFileSync("git", ["-C", dir, "remote", "add", "origin", CANONICAL_REPO_URL]);
+  await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({ name: "openclaw" }));
+  execFileSync("git", ["-C", dir, "add", "package.json"]);
+  execFileSync("git", ["-C", dir, "commit", "--quiet", "-m", "seed hostile checkout"]);
+  setup(dir);
+  return dir;
+}
+
+describe("createGitCheckout", () => {
+  afterEach(() => {
+    resetPluginStateStoreForTests();
+  });
+
+  beforeEach(() => {
+    runCommandWithTimeout.mockReset();
+    runCommandWithTimeout.mockImplementation(async (argv: string[]) => {
+      const destination = argv.at(-1);
+      if (argv[0] === "git" && argv[1] === "clone" && destination) {
+        await fs.mkdir(path.join(destination, ".git"), { recursive: true });
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+  });
+
+  it("clones the canonical repository only when the destination does not exist", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-clone-")));
+    const dir = path.join(root, "checkout");
+
+    const result = await createGitCheckout({
+      dir,
+      timeoutMs: 30_000,
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") },
+    });
+
+    expect(result?.name).toBe("git clone");
+    expect(runCommandWithTimeout).toHaveBeenCalledWith(
+      [
+        "git",
+        "clone",
+        expect.stringMatching(/^--template=.*\.openclaw-git-template-/u),
+        CANONICAL_REPO_URL,
+        expect.stringMatching(/checkout\.staging-/u),
+      ],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GIT_CONFIG_GLOBAL: os.devNull,
+          GIT_CONFIG_NOSYSTEM: "1",
+        }),
+        timeoutMs: 30_000,
+      }),
+    );
+    await expect(fs.stat(path.join(dir, ".git"))).resolves.toBeDefined();
+    expect(await fs.readdir(root)).not.toContainEqual(expect.stringContaining("staging-"));
+    expect(await fs.readdir(root)).not.toContainEqual(expect.stringContaining("git-template-"));
+  });
+
+  it("ignores config injection that could rewrite the canonical clone URL", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-clone-")));
+    const dir = path.join(root, "checkout");
+
+    await createGitCheckout({
+      dir,
+      timeoutMs: 30_000,
+      env: {
+        PATH: process.env.PATH,
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+        GIT_CONFIG_GLOBAL: "/tmp/hostile-global-config",
+        GIT_TEMPLATE_DIR: "/tmp/hostile-template",
+        GIT_CONFIG_PARAMETERS: "'url.https://evil.invalid/.insteadOf'='https://github.com/'",
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "url.https://evil.invalid/.insteadOf",
+        GIT_CONFIG_VALUE_0: "https://github.com/",
+      },
+    });
+
+    const env = vi.mocked(runCommandWithTimeout).mock.calls[0]?.[1]?.env;
+    expect(env).toMatchObject({
+      GIT_CONFIG_GLOBAL: os.devNull,
+      GIT_CONFIG_NOSYSTEM: "1",
+    });
+    expect(env).not.toHaveProperty("GIT_CONFIG_PARAMETERS");
+    expect(env).not.toHaveProperty("GIT_TEMPLATE_DIR");
+    expect(env).not.toHaveProperty("GIT_CONFIG_COUNT");
+    expect(env).not.toHaveProperty("GIT_CONFIG_KEY_0");
+    expect(env).not.toHaveProperty("GIT_CONFIG_VALUE_0");
+  });
+
+  it("forces an empty template so an inherited post-checkout hook cannot execute", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-hook-")));
+    const sourceDir = path.join(root, "source");
+    const unsafeCloneDir = path.join(root, "unsafe-clone");
+    const dir = path.join(root, "checkout");
+    const templateDir = path.join(root, "hostile-template");
+    const hookDir = path.join(templateDir, "hooks");
+    const marker = path.join(root, "post-checkout-ran");
+    const env = {
+      ...process.env,
+      GIT_TEMPLATE_DIR: templateDir,
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+    };
+
+    await fs.mkdir(sourceDir);
+    await fs.mkdir(hookDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "fixture.txt"), "fixture\n");
+    await fs.writeFile(
+      path.join(hookDir, "post-checkout"),
+      `#!/bin/sh\ntouch ${JSON.stringify(marker)}\n`,
+    );
+    await fs.chmod(path.join(hookDir, "post-checkout"), 0o755);
+    execFileSync("git", ["-C", sourceDir, "init", "--quiet"]);
+    execFileSync("git", ["-C", sourceDir, "config", "user.name", "OpenClaw Test"]);
+    execFileSync("git", ["-C", sourceDir, "config", "user.email", "test@openclaw.invalid"]);
+    execFileSync("git", ["-C", sourceDir, "add", "fixture.txt"]);
+    execFileSync("git", ["-C", sourceDir, "commit", "--quiet", "-m", "fixture"]);
+
+    execFileSync("git", ["clone", "--quiet", sourceDir, unsafeCloneDir], { env });
+    await expect(fs.stat(marker)).resolves.toBeDefined();
+    await fs.rm(marker);
+
+    runCommandWithTimeout.mockImplementationOnce(
+      async (argv: string[], options: CommandOptions) => {
+        const localArgv = argv.map((arg) => (arg === CANONICAL_REPO_URL ? sourceDir : arg));
+        const [command, ...args] = localArgv;
+        if (!command) {
+          throw new Error("missing Git command");
+        }
+        execFileSync(command, args, { env: options.env });
+        return {
+          stdout: "",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      },
+    );
+
+    const result = await createGitCheckout({ dir, timeoutMs: 30_000, env });
+
+    expect(result.exitCode).toBe(0);
+    await expect(fs.stat(path.join(dir, "fixture.txt"))).resolves.toBeDefined();
+    await expect(fs.stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    const cloneEnv = vi.mocked(runCommandWithTimeout).mock.calls[0]?.[1]?.env;
+    expect(cloneEnv).not.toHaveProperty("GIT_TEMPLATE_DIR");
+  });
+
+  it("replaces only a checkout recorded by an earlier conversion", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-clone-")));
+    const dir = path.join(root, "checkout");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+
+    await createGitCheckout({ dir, timeoutMs: 30_000, env });
+    await fs.writeFile(path.join(dir, "partial-build"), "retained\n");
+    await createGitCheckout({ dir, timeoutMs: 30_000, env });
+
+    await expect(fs.stat(path.join(dir, "partial-build"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(runCommandWithTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      name: "skipFetchAll",
+      setup: (dir: string) => {
+        execFileSync("git", ["-C", dir, "config", "remote.origin.skipFetchAll", "true"]);
+        seedRemoteMain(dir);
+      },
+    },
+    {
+      name: "a hostile fetch refspec",
+      setup: (dir: string) => {
+        execFileSync("git", [
+          "-C",
+          dir,
+          "config",
+          "remote.origin.fetch",
+          "+refs/heads/safe:refs/remotes/origin/safe",
+        ]);
+        seedRemoteMain(dir);
+      },
+    },
+    {
+      name: "a pre-seeded remote-tracking ref",
+      setup: seedRemoteMain,
+    },
+  ])("rejects a canonical-url checkout containing $name", async ({ setup }) => {
+    const dir = await createHostileCheckout(setup);
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env: process.env })).rejects.toThrow(
+      /creates a fresh OpenClaw checkout and will not reuse existing directories/u,
+    );
+    await expect(fs.stat(dir)).resolves.toBeDefined();
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("removes the directory it created when launching git clone throws", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-clone-")));
+    const dir = path.join(root, "checkout");
+    runCommandWithTimeout.mockRejectedValueOnce(new Error("unable to launch git"));
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env: process.env })).rejects.toThrow(
+      /unable to launch git/u,
+    );
+    await expect(fs.stat(dir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects even an existing empty directory", async () => {
+    const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-empty-")));
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env: process.env })).rejects.toThrow(
+      /OPENCLAW_GIT_DIR already exists/u,
+    );
+  });
+
+  it("retries after an interrupted conversion left its reserved destination behind", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-crash-")));
+    const dir = path.join(root, "checkout");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+    claimManagedGitCheckout(dir, env);
+    await fs.mkdir(dir, { recursive: true });
+
+    const result = await createGitCheckout({ dir, timeoutMs: 30_000, env });
+
+    expect(result.exitCode).toBe(0);
+    await expect(fs.stat(path.join(dir, ".git"))).resolves.toBeDefined();
+  });
+
+  it("refuses a destination that gained checkout state after the conversion was interrupted", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-crash-")));
+    const dir = path.join(root, "checkout");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+    claimManagedGitCheckout(dir, env);
+    await fs.mkdir(path.join(dir, ".git"), { recursive: true });
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env })).rejects.toThrow(
+      /creates a fresh OpenClaw checkout and will not reuse existing directories/u,
+    );
+  });
+
+  it("refuses the destination again once a completed conversion retires its ownership", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-done-")));
+    const dir = path.join(root, "checkout");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+
+    await createGitCheckout({ dir, timeoutMs: 30_000, env });
+    await completeManagedGitCheckout(dir, env);
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env })).rejects.toThrow(
+      /creates a fresh OpenClaw checkout and will not reuse existing directories/u,
+    );
+  });
+
+  it("keeps the previous checkout when replacing it fails", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-swap-")));
+    const dir = path.join(root, "checkout");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+
+    await createGitCheckout({ dir, timeoutMs: 30_000, env });
+    await fs.writeFile(path.join(dir, "partial-build"), "retained\n");
+    runCommandWithTimeout.mockImplementationOnce(async () => {
+      throw new Error("clone exploded");
+    });
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env })).rejects.toThrow(
+      /clone exploded/u,
+    );
+
+    await expect(fs.readFile(path.join(dir, "partial-build"), "utf8")).resolves.toBe("retained\n");
+  });
+
+  it("refuses an unrelated empty directory after a failed conversion was cleaned up", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-stale-")));
+    const dir = path.join(root, "checkout");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+    runCommandWithTimeout.mockImplementationOnce(async () => {
+      throw new Error("killed mid-clone");
+    });
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env })).rejects.toThrow(
+      /killed mid-clone/u,
+    );
+    await fs.mkdir(dir, { recursive: true });
+
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env })).rejects.toThrow(
+      /creates a fresh OpenClaw checkout and will not reuse existing directories/u,
+    );
+  });
+
+  it("keeps a failed replacement retryable", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-retry-")));
+    const dir = path.join(root, "checkout");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+
+    await createGitCheckout({ dir, timeoutMs: 30_000, env });
+    await fs.writeFile(path.join(dir, "partial-build"), "retained\n");
+    runCommandWithTimeout.mockImplementationOnce(async () => {
+      throw new Error("clone exploded");
+    });
+    await expect(createGitCheckout({ dir, timeoutMs: 30_000, env })).rejects.toThrow(
+      /clone exploded/u,
+    );
+
+    const stopped = vi.fn(async () => undefined);
+    const result = await createGitCheckout({
+      dir,
+      timeoutMs: 30_000,
+      env,
+      beforeReplaceManagedCheckout: stopped,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(stopped).toHaveBeenCalledTimes(1);
+    await expect(fs.stat(path.join(dir, "partial-build"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -1,10 +1,12 @@
 // Shared update command primitives for channel resolution, install roots, and subprocess steps.
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageName, readPackageVersion } from "../../infra/package-json.js";
@@ -26,6 +28,14 @@ import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { pathExists } from "../../utils.js";
 import { COMPLETION_SKIP_PLUGIN_COMMANDS_ENV } from "../completion-runtime.js";
+import { createAggregateErrorWithCause } from "./aggregate-error.js";
+import {
+  claimManagedGitCheckout,
+  completeManagedGitCheckout,
+  isReclaimableManagedReservation,
+  resolveManagedGitCheckoutToken,
+  writeManagedCheckoutMarker,
+} from "./managed-checkout.js";
 
 export type UpdateCommandOptions = {
   json?: boolean;
@@ -59,6 +69,22 @@ export type UpdateWizardOptions = {
 const INVALID_TIMEOUT_ERROR = "--timeout must be a positive integer (seconds)";
 const MAX_SAFE_TIMEOUT_SECONDS = Math.floor(Number.MAX_SAFE_INTEGER / 1000);
 
+/** Build a Git environment that cannot redirect the canonical repository through config. */
+export function createSanitizedGitEnv(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const gitEnv = { ...(env ?? process.env) };
+  gitEnv.GIT_CONFIG_NOSYSTEM = "1";
+  gitEnv.GIT_CONFIG_GLOBAL = os.devNull;
+  delete gitEnv.GIT_TEMPLATE_DIR;
+  delete gitEnv.GIT_CONFIG_PARAMETERS;
+  delete gitEnv.GIT_CONFIG_COUNT;
+  for (const key of Object.keys(gitEnv)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/u.test(key)) {
+      delete gitEnv[key];
+    }
+  }
+  return gitEnv;
+}
+
 /** Parse a CLI timeout in seconds, exiting through the runtime on invalid input. */
 export function parseTimeoutMsOrExit(timeout?: string): number | undefined | null {
   if (timeout === undefined) {
@@ -78,7 +104,6 @@ const OPENCLAW_REPO_URL = "https://github.com/openclaw/openclaw.git";
 const MAX_LOG_CHARS = 8000;
 
 export const DEFAULT_PACKAGE_NAME = "openclaw";
-const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME]);
 
 /** Normalize a CLI tag/version/spec into the npm target form accepted by update flows. */
 export function normalizeTag(value?: string | null): string | null {
@@ -118,31 +143,6 @@ export async function resolveTargetVersion(
     env: options.env,
   });
   return res.version ?? null;
-}
-
-/** Return true when `root` is a local git checkout directory. */
-export async function isGitCheckout(root: string): Promise<boolean> {
-  try {
-    await fs.stat(path.join(root, ".git"));
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function isCorePackage(root: string): Promise<boolean> {
-  const name = await readPackageName(root);
-  return Boolean(name && CORE_PACKAGE_NAMES.has(name));
-}
-
-/** Return true only for existing directories with no entries. */
-export async function isEmptyDir(targetPath: string): Promise<boolean> {
-  try {
-    const entries = await fs.readdir(targetPath);
-    return entries.length === 0;
-  } catch {
-    return false;
-  }
 }
 
 /** Resolve the checkout path used by source-based self-update. */
@@ -238,49 +238,117 @@ export async function runUpdateStep(params: {
   };
 }
 
-/** Ensure the configured source-update directory exists and points at an OpenClaw checkout. */
-export async function ensureGitCheckout(params: {
+/** Reserve the destination so no pre-existing directory is ever adopted. */
+async function reserveGitCheckoutDir(dir: string, env?: NodeJS.ProcessEnv): Promise<void> {
+  try {
+    await fs.mkdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw err;
+    }
+    if (!(await isReclaimableManagedReservation(dir, env))) {
+      throw new Error(
+        `OPENCLAW_GIT_DIR already exists: ${dir}. Package-to-dev conversion creates a fresh OpenClaw checkout and will not reuse existing directories. Move it or set OPENCLAW_GIT_DIR to an unused path.`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+/** Move a finished checkout onto the destination, keeping the old one until it lands. */
+async function swapInGitCheckout(params: {
+  dir: string;
+  stagingDir: string;
+  managedRetry: boolean;
+}): Promise<void> {
+  if (!params.managedRetry) {
+    await fs.rmdir(params.dir);
+    await fs.rename(params.stagingDir, params.dir);
+    return;
+  }
+  const backupDir = `${params.dir}.previous-${randomUUID()}`;
+  await fs.rename(params.dir, backupDir);
+  try {
+    await fs.rename(params.stagingDir, params.dir);
+  } catch (err) {
+    await fs.rm(params.dir, { recursive: true, force: true });
+    await fs.rename(backupDir, params.dir);
+    throw err;
+  }
+  await fs.rm(backupDir, { recursive: true, force: true }).catch(() => undefined);
+}
+
+/** Create the source-update checkout without adopting any pre-existing directory state. */
+export async function createGitCheckout(params: {
   dir: string;
   timeoutMs: number;
   progress?: UpdateStepProgress;
   env?: NodeJS.ProcessEnv;
-}): Promise<UpdateStepResult | null> {
-  const gitEnv = params.env ?? (await createGlobalInstallEnv());
-  const dirExists = await pathExists(params.dir);
-  if (!dirExists) {
-    await fs.mkdir(path.dirname(params.dir), { recursive: true });
-    return await runUpdateStep({
+  beforeReplaceManagedCheckout?: (stagingDir: string) => Promise<void>;
+}): Promise<UpdateStepResult> {
+  const ownedToken = await resolveManagedGitCheckoutToken(params.dir, params.env);
+  const managedRetry = ownedToken !== null;
+  await fs.mkdir(path.dirname(params.dir), { recursive: true });
+  if (!managedRetry) {
+    await reserveGitCheckoutDir(params.dir, params.env);
+  }
+
+  const token = ownedToken ?? claimManagedGitCheckout(params.dir, params.env);
+  const stagingDir = path.join(
+    path.dirname(params.dir),
+    `.${path.basename(params.dir)}.staging-${randomUUID()}`,
+  );
+  await fs.mkdir(stagingDir);
+  let templateDir: string | null = null;
+  const discard = async (): Promise<void> => {
+    await fs.rm(stagingDir, { recursive: true, force: true });
+    if (!managedRetry) {
+      await fs.rm(params.dir, { recursive: true, force: true });
+      await completeManagedGitCheckout(params.dir, params.env);
+    }
+  };
+
+  try {
+    templateDir = await fs.mkdtemp(
+      path.join(path.dirname(params.dir), ".openclaw-git-template-"),
+    );
+    await fs.chmod(templateDir, 0o700);
+    const gitEnv = createSanitizedGitEnv(params.env ?? (await createGlobalInstallEnv()));
+    const result = await runUpdateStep({
       name: "git clone",
-      argv: ["git", "clone", OPENCLAW_REPO_URL, params.dir],
+      argv: ["git", "clone", `--template=${templateDir}`, OPENCLAW_REPO_URL, stagingDir],
       env: gitEnv,
       timeoutMs: params.timeoutMs,
       progress: params.progress,
     });
-  }
-
-  if (!(await isGitCheckout(params.dir))) {
-    const empty = await isEmptyDir(params.dir);
-    if (!empty) {
-      throw new Error(
-        `OPENCLAW_GIT_DIR points at a non-git directory: ${params.dir}. Set OPENCLAW_GIT_DIR to an empty folder or an openclaw checkout.`,
+    if (result.exitCode !== 0) {
+      await discard();
+      return result;
+    }
+    if (managedRetry) {
+      await params.beforeReplaceManagedCheckout?.(stagingDir);
+    }
+    await writeManagedCheckoutMarker(stagingDir, token);
+    await swapInGitCheckout({ dir: params.dir, stagingDir, managedRetry });
+    return result;
+  } catch (err) {
+    const cleanupError = await discard().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    if (cleanupError) {
+      throw createAggregateErrorWithCause(
+        [err, cleanupError],
+        `Git clone failed (${formatErrorMessage(err)}) and its new checkout could not be removed (${formatErrorMessage(cleanupError)})`,
+        err,
       );
     }
-
-    return await runUpdateStep({
-      name: "git clone",
-      argv: ["git", "clone", OPENCLAW_REPO_URL, params.dir],
-      cwd: params.dir,
-      env: gitEnv,
-      timeoutMs: params.timeoutMs,
-      progress: params.progress,
-    });
+    throw err;
+  } finally {
+    if (templateDir) {
+      await fs.rm(templateDir, { recursive: true, force: true });
+    }
   }
-
-  if (!(await isCorePackage(params.dir))) {
-    throw new Error(`OPENCLAW_GIT_DIR does not look like a core checkout: ${params.dir}.`);
-  }
-
-  return null;
 }
 
 /** Detect the package manager that owns a global/package OpenClaw install. */

--- a/src/cli/update-cli/update-command-git.ts
+++ b/src/cli/update-cli/update-command-git.ts
@@ -1,11 +1,18 @@
+import fs from "node:fs/promises";
 import type { UpdateChannel } from "../../infra/update-channels.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import {
   createGlobalInstallEnv,
   globalInstallArgs,
   resolveGlobalInstallTarget,
   resolvePnpmGlobalDirFromGlobalRoot,
 } from "../../infra/update-global.js";
-import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
+import {
+  runGatewayUpdate,
+  type UpdateRunResult,
+  type UpdateStepResult,
+} from "../../infra/update-runner.js";
+import { prepareGitMutation } from "../../infra/update-runner-git-target.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
@@ -16,15 +23,21 @@ import {
 } from "../../state/openclaw-database-preflight.js";
 import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
 import { createUpdateProgress, printResult } from "./progress.js";
+import { completeManagedGitCheckout, isManagedGitCheckoutRetry } from "./managed-checkout.js";
 import {
   createGlobalCommandRunner,
-  ensureGitCheckout,
+  createGitCheckout,
+  createSanitizedGitEnv,
   resolveGitInstallDir,
   resolveGlobalManager,
   runUpdateStep,
   type UpdateCommandOptions,
 } from "./shared.js";
-import { UpdateCommandAbort, type PreManagedServiceStop } from "./update-command-service.js";
+import {
+  createAggregateErrorWithCause,
+  UpdateCommandAbort,
+  type PreManagedServiceStop,
+} from "./update-command-service.js";
 
 const DEFAULT_UPDATE_STEP_TIMEOUT_MS = 30 * 60_000;
 
@@ -78,40 +91,64 @@ export function createBeforeGitMutation(params: {
   getPreManagedServiceStop: () => PreManagedServiceStop | undefined;
   markSchemaRefusalAfterStop: () => void;
 }): BeforeGitMutation {
+  // A managed retry validates before swapping, then the runner validates its selected target.
+  // Stop the service once, but never let the cached preparation bypass the second schema check.
+  let preparation: {
+    allowGatewayServiceRepair?: boolean;
+    allowGatewayActivation?: boolean;
+  } | null = null;
   return async (target) => {
     if (target?.metadataUnreadable) {
+      if (preparation) {
+        params.markSchemaRefusalAfterStop();
+      }
       defaultRuntime.error(
         `Update refused: could not inspect the target's schema support (${target.metadataUnreadable}). Retry, or see ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
       );
-      defaultRuntime.exit(1);
+      if (!preparation) {
+        defaultRuntime.exit(1);
+      }
       throw new UpdateCommandAbort();
     }
-    const preStopSchemas = checkTargetDatabaseSchemas(target?.schemaVersions);
+    const preManagedServiceStop = params.getPreManagedServiceStop();
+    const preStopSchemas = checkTargetDatabaseSchemas(
+      target?.schemaVersions,
+      preparation ? (preManagedServiceStop?.serviceEnv ?? process.env) : process.env,
+    );
     if (hasSchemaRefusal(preStopSchemas)) {
+      if (preparation) {
+        params.markSchemaRefusalAfterStop();
+      }
       defaultRuntime.error(formatSchemaRefusalLines(preStopSchemas).join("\n"));
-      defaultRuntime.exit(1);
+      if (!preparation) {
+        defaultRuntime.exit(1);
+      }
       throw new UpdateCommandAbort();
+    }
+    if (preparation) {
+      return preparation;
     }
     await params.stopManagedService(params.roots);
-    const preManagedServiceStop = params.getPreManagedServiceStop();
+    const stoppedService = params.getPreManagedServiceStop();
     const postStopSchemas = checkTargetDatabaseSchemas(
       target?.schemaVersions,
-      preManagedServiceStop?.serviceEnv ?? process.env,
+      stoppedService?.serviceEnv ?? process.env,
     );
     if (hasSchemaRefusal(postStopSchemas)) {
       params.markSchemaRefusalAfterStop();
       defaultRuntime.error(formatSchemaRefusalLines(postStopSchemas).join("\n"));
       throw new UpdateCommandAbort();
     }
-    return {
+    preparation = {
       // Only a positively owned service may be rewritten. Activation
       // additionally requires this update to have stopped it.
-      allowGatewayServiceRepair: preManagedServiceStop?.serviceMatchesMutationRoot === true,
+      allowGatewayServiceRepair: stoppedService?.serviceMatchesMutationRoot === true,
       allowGatewayActivation:
         params.shouldRestart &&
-        preManagedServiceStop?.stopped === true &&
-        preManagedServiceStop.serviceMatchesMutationRoot === true,
+        stoppedService?.stopped === true &&
+        stoppedService.serviceMatchesMutationRoot === true,
     };
+    return preparation;
   };
 }
 
@@ -135,17 +172,57 @@ export async function runGitUpdate(params: {
   const updateRoot = params.switchToGit ? resolveGitInstallDir() : params.root;
   const effectiveTimeout = params.timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
   const installEnv = await createGlobalInstallEnv();
+  const freshCheckoutEnv = params.switchToGit ? createSanitizedGitEnv(installEnv) : undefined;
+  const managedCheckoutRetry = params.switchToGit
+    ? await isManagedGitCheckoutRetry(updateRoot, installEnv)
+    : false;
+  const cleanupCreatedCheckout = async (primaryError?: unknown): Promise<void> => {
+    if (!params.switchToGit) {
+      return;
+    }
+    try {
+      await fs.rm(updateRoot, { recursive: true, force: true });
+      await completeManagedGitCheckout(updateRoot, installEnv);
+    } catch (cleanupError) {
+      if (primaryError !== undefined) {
+        throw createAggregateErrorWithCause(
+          [primaryError, cleanupError],
+          `Package-to-dev conversion failed (${formatErrorMessage(primaryError)}) and its new checkout could not be removed (${formatErrorMessage(cleanupError)})`,
+          primaryError,
+        );
+      }
+      throw cleanupError;
+    }
+  };
 
   const cloneStep = params.switchToGit
-    ? await ensureGitCheckout({
+    ? await createGitCheckout({
         dir: updateRoot,
         env: installEnv,
         timeoutMs: effectiveTimeout,
         progress: params.progress,
+        beforeReplaceManagedCheckout: async (stagingDir) => {
+          const runCommand = createGlobalCommandRunner();
+          await prepareGitMutation({
+            runCommand: async (argv, options) =>
+              await runCommand(argv, {
+                cwd: options.cwd,
+                timeoutMs: options.timeoutMs ?? effectiveTimeout,
+                env: freshCheckoutEnv,
+              }),
+            root: stagingDir,
+            revision: "HEAD",
+            timeoutMs: effectiveTimeout,
+            beforeGitMutation: params.beforeGitMutation,
+          });
+        },
       })
     : null;
 
   if (cloneStep && cloneStep.exitCode !== 0) {
+    if (!managedCheckoutRetry) {
+      await cleanupCreatedCheckout();
+    }
     const result: UpdateRunResult = {
       status: "error",
       mode: "git",
@@ -172,6 +249,7 @@ export async function runGitUpdate(params: {
     allowGatewayServiceRepair: params.allowGatewayServiceRepair,
     allowGatewayActivation: params.allowGatewayActivation,
     beforeGitMutation: params.beforeGitMutation,
+    commandEnv: freshCheckoutEnv,
   });
   const steps = [...(cloneStep ? [cloneStep] : []), ...updateResult.steps];
 
@@ -192,9 +270,19 @@ export async function runGitUpdate(params: {
       installTarget.manager === "pnpm"
         ? resolvePnpmGlobalDirFromGlobalRoot(installTarget.globalRoot)
         : null;
-    const installStep = await runUpdateStep({
+    const installArgv = globalInstallArgs(
+      installTarget,
+      updateRoot,
+      undefined,
+      installLocation,
+      updateRoot,
+    );
+    // From this point onward the package manager may already have persisted a
+    // symlink to updateRoot even when it later reports failure. Preserve the
+    // checkout so a failed install never leaves the global CLI dangling.
+    const installStep: UpdateStepResult = await runUpdateStep({
       name: "global install",
-      argv: globalInstallArgs(installTarget, updateRoot, undefined, installLocation, updateRoot),
+      argv: installArgv,
       cwd: updateRoot,
       env: installEnv,
       timeoutMs: effectiveTimeout,
@@ -203,12 +291,24 @@ export async function runGitUpdate(params: {
     steps.push(installStep);
 
     const failedStep = installStep.exitCode !== 0 ? installStep : null;
+    if (!failedStep) {
+      await completeManagedGitCheckout(updateRoot, installEnv);
+    }
     return {
       ...updateResult,
-      status: updateResult.status === "ok" && !failedStep ? "ok" : "error",
+      status: failedStep ? "error" : "ok",
       steps,
       durationMs: Date.now() - params.startedAt,
     };
+  }
+
+  if (params.switchToGit) {
+    const doctorMayHaveRewrittenService = updateResult.steps.some(
+      (step) => step.name === "openclaw doctor",
+    );
+    if (!managedCheckoutRetry && !doctorMayHaveRewrittenService) {
+      await cleanupCreatedCheckout();
+    }
   }
 
   return {

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -57,6 +57,7 @@ import {
   registerSignalExitGate,
   waitForSignalExitBarriers,
 } from "../signal-exit-barrier.js";
+import { createAggregateErrorWithCause } from "./aggregate-error.js";
 import { runRestartScript } from "./restart-helper.js";
 import { resolveNodeRunner, type UpdateCommandOptions } from "./shared.js";
 import { createUpdateConfigSnapshot } from "./update-command-config.js";
@@ -295,13 +296,7 @@ export class UpdateCommandAbort extends Error {
   }
 }
 
-export function createAggregateErrorWithCause(
-  errors: unknown[],
-  message: string,
-  cause: unknown,
-): AggregateError {
-  return new AggregateError(errors, message, { cause });
-}
+export { createAggregateErrorWithCause };
 
 export type ManagedServiceRootRedirect = {
   root: string;

--- a/src/cli/update-cli/wizard.ts
+++ b/src/cli/update-cli/wizard.ts
@@ -13,9 +13,8 @@ import {
 import { checkUpdateStatus } from "../../infra/update-check.js";
 import { defaultRuntime } from "../../runtime.js";
 import { pathExists } from "../../utils.js";
+import { isReusableManagedGitCheckoutPath } from "./managed-checkout.js";
 import {
-  isEmptyDir,
-  isGitCheckout,
   parseTimeoutMsOrExit,
   resolveGitInstallDir,
   resolveUpdateRoot,
@@ -108,31 +107,27 @@ export async function updateWizardCommand(opts: UpdateWizardOptions = {}): Promi
 
   if (requestedChannel === "dev" && updateStatus.installKind !== "git") {
     const gitDir = resolveGitInstallDir();
-    const hasGit = await isGitCheckout(gitDir);
-    if (!hasGit) {
-      const dirExists = await pathExists(gitDir);
-      if (dirExists) {
-        const empty = await isEmptyDir(gitDir);
-        if (!empty) {
-          defaultRuntime.error(
-            `OPENCLAW_GIT_DIR points at a non-git directory: ${gitDir}. Set OPENCLAW_GIT_DIR to an empty folder or an openclaw checkout.`,
-          );
-          defaultRuntime.exit(1);
-          return;
-        }
-      }
+    if (
+      (await pathExists(gitDir)) &&
+      !(await isReusableManagedGitCheckoutPath(gitDir, process.env))
+    ) {
+      defaultRuntime.error(
+        `OPENCLAW_GIT_DIR already exists: ${gitDir}. Package-to-dev conversion creates a fresh OpenClaw checkout and will not reuse existing directories. Move it or set OPENCLAW_GIT_DIR to an unused path.`,
+      );
+      defaultRuntime.exit(1);
+      return;
+    }
 
-      const ok = await confirm({
-        message: stylePromptMessage(
-          `Create a git checkout at ${gitDir}? (override via OPENCLAW_GIT_DIR)`,
-        ),
-        initialValue: true,
-      });
-      if (isCancel(ok) || !ok) {
-        defaultRuntime.log(theme.muted("Update cancelled."));
-        defaultRuntime.exit(0);
-        return;
-      }
+    const ok = await confirm({
+      message: stylePromptMessage(
+        `Create a fresh git checkout at ${gitDir}? (override via OPENCLAW_GIT_DIR)`,
+      ),
+      initialValue: true,
+    });
+    if (isCancel(ok) || !ok) {
+      defaultRuntime.log(theme.muted("Update cancelled."));
+      defaultRuntime.exit(0);
+      return;
     }
   }
 

--- a/src/infra/update-runner-command.ts
+++ b/src/infra/update-runner-command.ts
@@ -81,8 +81,9 @@ export function normalizeFallbackFailureReason(
 
 export async function buildUpdateCommandRunner(
   runCommand?: CommandRunner,
+  commandEnv?: NodeJS.ProcessEnv,
 ): Promise<{ defaultCommandEnv: NodeJS.ProcessEnv | undefined; runCommand: CommandRunner }> {
-  const defaultCommandEnv = await createGlobalInstallEnv();
+  const defaultCommandEnv = commandEnv ?? (await createGlobalInstallEnv());
   if (runCommand) {
     return { defaultCommandEnv, runCommand };
   }

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -131,6 +131,7 @@ export type UpdateRunnerOptions = {
   timeoutMs?: number;
   runCommand?: CommandRunner;
   progress?: UpdateStepProgress;
+  commandEnv?: NodeJS.ProcessEnv;
 };
 
 export type UpdateInstallSurface =

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -28,7 +28,10 @@ export { resolveUpdateDoctorExecutionPolicy, resolveUpdateInstallSurface };
 
 export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<UpdateRunResult> {
   const startedAt = Date.now();
-  const { defaultCommandEnv, runCommand } = await buildUpdateCommandRunner(opts.runCommand);
+  const { defaultCommandEnv, runCommand } = await buildUpdateCommandRunner(
+    opts.runCommand,
+    opts.commandEnv,
+  );
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const candidates = buildStartDirs(opts);
   const pkgRoot = await findPackageRoot(candidates);


### PR DESCRIPTION
## What Problem This Solves

Package-to-dev conversion previously adopted whatever Git checkout already existed at `OPENCLAW_GIT_DIR`. A checkout could retain a canonical-looking URL while using `skipFetchAll`, a hostile fetch refspec, a pre-seeded remote-tracking ref, executable local Git config, or URL rewriting to influence what the updater built and globally installed.

## Why This Change Was Made

Remote validation cannot make an adopted checkout safe. Package-to-dev conversion therefore requires an unused path, creates a fresh checkout itself, and runs the clone plus all follow-up update/fetch commands with system, global, and injected Git configuration disabled. Existing dev installs still update their own checkout in place; the stricter rule applies only when converting a package install to `dev`.

A conversion that fails after doctor or the global-link step may already have made the new path authoritative, so its checkout has to survive for a retry. Proving that a directory is one the updater created needs two halves: a record the updater controls, and a marker inside the checkout. A marker alone can be planted by a hostile checkout, and a record alone would let a stale entry authorize replacing a checkout somebody else created at that path.

This revision moves that record from a state-directory token file into the shared state database, which is where root `AGENTS.md` requires OpenClaw-owned runtime and recovery state to live. It also fixes the ordering the token file made visible. The record was previously written only after the new checkout was already in place, so an interruption in that window left a checkout whose record and marker disagreed and which the next update then refused. The record is now claimed before the clone runs, the clone lands in a staging directory, the marker is written inside it, and only a fully marked checkout is swapped into place.

## User Impact

- `openclaw update --channel dev` from a package install requires an unused `OPENCLAW_GIT_DIR`.
- Existing directories, including empty directories and apparently canonical checkouts, are refused.
- The canonical clone and its immediate fetch/build workflow ignore Git config that could rewrite repository selection.
- A conversion interrupted partway can be run again. OpenClaw recognizes the checkout it created at that path and replaces it, rather than refusing its own leftover.
- Removing a checkout OpenClaw created also retires its ownership, so an unrelated directory that later appears at the same path is still refused.
- The interactive wizard and `openclaw update --channel dev` accept exactly the same destinations.
- Existing Git/dev installations are unchanged.

## Regression Coverage

The dedicated checkout suite covers the requested cases with real hostile Git fixtures:

- canonical URL plus `remote.origin.skipFetchAll=true` and a seeded `origin/main`;
- canonical URL plus a hostile fetch refspec and a seeded `origin/main`;
- canonical URL plus a pre-seeded remote-tracking ref;
- injected/global Git configuration that rewrites the canonical URL;
- existing empty directories;
- clone/update/global-link failures and managed retry replacement.

Interrupted state transitions are covered explicitly:

- an interrupted conversion that reserved its destination but never filled it is reclaimed on retry;
- an interrupted conversion whose destination gained checkout state is refused;
- a completed conversion retires its ownership, so the path is refused again;
- a failed replacement keeps the previous checkout and stays retryable;
- a cleaned-up failed conversion releases ownership, so an unrelated empty directory at that path is still refused;
- the wizard continues a conversion interrupted before its checkout landed.

The command-level suite also verifies refusal occurs before service mutation, follow-up fetches receive the sanitized Git environment, failed initial conversions clean up safely, service-repair-aware failures retain a usable target, and successful conversion retires retry ownership.

## Evidence

Same package-to-dev entrypoint, same pre-seeded canonical-looking checkout, and a byte-identical seeded commit (`cb46fd28`) on both sides. Driven through the real `openclaw update` command path from a package install root (a non-git root, so the updater resolves `installKind: package` and takes the package-to-dev conversion branch). Private paths are replaced with placeholders.

Hostile fixture in both runs: canonical `remote.origin.url`, `remote.origin.skipFetchAll=true`, a pre-seeded `refs/remotes/origin/main`, and a `PAYLOAD.txt` the canonical repository does not contain.

```text
BEFORE (pristine base 7cde0ac8c0) - the existing checkout is adopted
$ git -C $OPENCLAW_GIT_DIR config remote.origin.url
https://github.com/openclaw/openclaw.git
$ git -C $OPENCLAW_GIT_DIR config remote.origin.skipFetchAll
true
$ git -C $OPENCLAW_GIT_DIR rev-parse refs/remotes/origin/main
cb46fd28114f2f92783c352b390506b416720e7f
$ openclaw update --channel dev --yes
Updating OpenClaw...

Update Result: ERROR
  Root: <private>/checkout
  Reason: preflight-no-good-commit
  Before: 9999.0.0

Steps:
  OK   clean check (12ms)
  OK   git fetch (15ms)
  FAIL git show-ref main (10ms)
      fatal: 'refs/heads/main' - not a valid ref
  OK   git remote (9ms)
  FAIL upstream check (10ms)
      fatal: no such branch: 'main'
  OK   git rev-parse refs/remotes/origin/main (10ms)
  OK   git rev-list (11ms)
  OK   preflight worktree (20ms)
  OK   preflight checkout (cb46fd28) (12ms)
  OK   preflight deps install (cb46fd28) (402ms)
  FAIL preflight build (cb46fd28) (403ms)
  OK   preflight cleanup (11ms)

Total time: 1.82s
```

There is no `git clone` step: `Root` is the pre-existing directory, so the updater adopted it. `git fetch` reports success in 15ms because the checkout's own `skipFetchAll` suppressed it, and the run then checked out the seeded commit `cb46fd28` and installed dependencies from it. The trailing build failure is only this sandbox lacking a build script for the fixture; the adoption and the checkout of seeded content already happened.

```text
AFTER (this patch, head d6d958118d, identical inputs) - refused before any mutation
$ openclaw update --channel dev --yes
Updating OpenClaw...

Error: OPENCLAW_GIT_DIR already exists: <private>/checkout. Package-to-dev conversion
creates a fresh OpenClaw checkout and will not reuse existing directories. Move it or
set OPENCLAW_GIT_DIR to an unused path.
    at reserveGitCheckoutDir (<private>/openclaw/src/cli/update-cli/shared.ts:249:13)
    at async createGitCheckout (<private>/openclaw/src/cli/update-cli/shared.ts:295:5)
  [cause]: Error: EEXIST: file already exists, mkdir '<private>/checkout'
      at async reserveGitCheckoutDir (<private>/openclaw/src/cli/update-cli/shared.ts:243:5)
      at async createGitCheckout (<private>/openclaw/src/cli/update-cli/shared.ts:295:5)
      at async runGitUpdate (<private>/openclaw/src/cli/update-cli/update-command.ts:456:7)
      at async updateCommandInternal (<private>/openclaw/src/cli/update-cli/update-command.ts:1211:11)
      at async updateCommand (<private>/openclaw/src/cli/update-cli/update-command.ts:583:10)
    errno: -17, code: 'EEXIST', syscall: 'mkdir', path: '<private>/checkout'

$ git -C $OPENCLAW_GIT_DIR log --oneline -1
cb46fd2 seed hostile checkout
$ ls $OPENCLAW_GIT_DIR
PAYLOAD.txt package.json
```

The refusal comes from the reservation `mkdir` inside `createGitCheckout`, before any step runs against the directory, and the pre-existing checkout is left exactly as it was.

Same head, unused `OPENCLAW_GIT_DIR`, showing the reordered crash-safe conversion:

```text
AFTER (this patch, head d6d958118d) - fresh path clones for real
$ openclaw update --channel dev --yes
Updating OpenClaw...

Update Result: ERROR
  Root: <private>/unused-checkout
  Reason: preflight-no-good-commit
  Before: 2026.7.2

Steps:
  OK   git clone (174s)
  OK   clean check (1.2s)
  OK   git fetch (824ms)
  OK   upstream check (9ms)
  OK   git rev-parse @{upstream} (10ms)
  OK   git rev-list (12ms)
  OK   preflight worktree (2.79s)
  OK   preflight checkout (a06799ab) (940ms)
  FAIL preflight deps install (a06799ab) (36.36s)
  [9 further preflight checkout / deps install pairs elided; each install failed identically]
  OK   preflight cleanup (3.19s)

Total time: 324.47s
```

Observed while that clone was still running: the destination is reserved but still empty, the clone is staged out of place, and ownership is already recorded in the shared state database.

```text
$ ls -a <private>/fresh-parent
.
..
.unused-checkout.staging-dd7685e9-133e-45fe-893a-95d689fc5329
unused-checkout
$ du -sh <private>/fresh-parent/unused-checkout <private>/fresh-parent/.unused-checkout.staging-*
4.0K	<private>/fresh-parent/unused-checkout
124K	<private>/fresh-parent/.unused-checkout.staging-dd7685e9-133e-45fe-893a-95d689fc5329
$ node -e "... select plugin_id,namespace,value_json from plugin_state_entries where plugin_id='core:update-cli' ..."
[{"plugin_id":"core:update-cli","namespace":"managed-checkouts","value_json":"{\"token\":\"3af8bfdc-0b8e-48ed-bfbb-fd851284582e\",\"dir\":\"<private>/unused-checkout\",\"createdAtMs\":1784258040670}"}]
```

After the staging clone was swapped into place:

```text
$ ls -a <private>/fresh-parent
.
..
unused-checkout
$ ls -l <private>/unused-checkout/.git/.openclaw-update-managed
-rw------- 1 root root 37 Jul 17 03:16 <private>/unused-checkout/.git/.openclaw-update-managed
$ cat <private>/unused-checkout/.git/.openclaw-update-managed
3af8bfdc-0b8e-48ed-bfbb-fd851284582e
$ git -C <private>/unused-checkout config remote.origin.url
https://github.com/openclaw/openclaw.git
$ git -C <private>/unused-checkout config remote.origin.skipFetchAll; echo "(exit=$?)"
(exit=1)
```

The clone runs into `.unused-checkout.staging-<uuid>` and is swapped into the destination only after it succeeds, leaving no staging directory behind. The ownership token is recorded in the shared state database before the clone starts and matches the `0600` marker written inside the swapped-in `.git`. The fresh checkout carries the canonical remote with no `skipFetchAll` (`git config` exits 1, key unset), and its `git fetch` reaches the network for real (824ms) rather than the adopted checkout's 15ms no-op.

That conversion still ends in `ERROR` because dependency installation cannot run in this sandbox. The failure exercised the recovery path: the updater removed the checkout it had created and retired its ownership record, leaving nothing adopted.

```text
$ ls -a <private>/fresh-parent
.
..
$ node -e "... select plugin_id,namespace,value_json from plugin_state_entries where plugin_id='core:update-cli' ..."
(no rows)
```

### Interrupted conversion, then managed replacement (current head)

Driven through the same package-to-dev conversion path on this head, with a real clone of the canonical remote, an isolated state directory, and an unused `OPENCLAW_GIT_DIR`. Nothing in `update-cli` is mocked. Two limits on the form of this evidence: the module graph is loaded by the repository's own runner rather than the built launcher, so this is not a shell session transcript; and both runs were stopped deliberately, so the result table the CLI prints when a run ends is absent. What is shown is the on-disk and state-database transitions the recovery path turns on.

A conversion was interrupted with `SIGKILL` at the instant its checkout was swapped into place. Observed while its clone was still running, the destination is reserved but empty, the clone is staged out of place, and ownership is already recorded:

```text
$ ls -a <private>/fresh-parent
.
..
.unused-checkout.staging-418e65e0-3133-441f-a0a4-d3e96abade95
unused-checkout
$ node -e "... select value_json from plugin_state_entries where plugin_id='core:update-cli' ..."
{"token":"e647b160-3cd3-4482-bb5c-8a8bf3e92cde","dir":"<private>/unused-checkout","createdAtMs":1784261913425}
```

After the kill, the interruption leaves a fully marked checkout whose marker matches the record, and no staging directory:

```text
$ ls -a <private>/fresh-parent
.
..
unused-checkout
$ cat <private>/unused-checkout/.git/.openclaw-update-managed
e647b160-3cd3-4482-bb5c-8a8bf3e92cde
$ git -C <private>/unused-checkout log --oneline -1
233922b5d8b fix(anthropic): accept Claude CLI apiKeyHelper auth (#97492)
```

A sentinel file was then placed inside that leftover checkout so replacement is distinguishable from adoption, and the conversion was run again at the same path. Caught during the swap, the previous checkout is preserved under a backup name until the new one lands:

```text
$ ls -a <private>/fresh-parent
.
..
unused-checkout
unused-checkout.previous-8cee865a-f8fd-44ee-a655-e14455566026
```

After the replacement:

```text
$ ls <private>/unused-checkout/INTERRUPTED-SENTINEL.txt
ls: cannot access '<private>/unused-checkout/INTERRUPTED-SENTINEL.txt': No such file or directory
$ cat <private>/unused-checkout/.git/.openclaw-update-managed
e647b160-3cd3-4482-bb5c-8a8bf3e92cde
$ node -e "... select value_json from plugin_state_entries where plugin_id='core:update-cli' ..."
{"token":"e647b160-3cd3-4482-bb5c-8a8bf3e92cde","dir":"<private>/unused-checkout","createdAtMs":1784261913425}
$ git -C <private>/unused-checkout log --oneline -1
a0fac37f141 feat: add OpenAI Video Talk (#109579)
$ git -C <private>/unused-checkout config remote.origin.url
https://github.com/openclaw/openclaw.git
$ ls -a <private>/fresh-parent
.
..
unused-checkout
```

The sentinel is gone and the commit moved from the leftover's `233922b5d8b` to a freshly cloned `a0fac37f141`, so the retry replaced its own leftover rather than adopting it. The token `e647b160` is reused and `createdAtMs` is unchanged, so the retry recognized existing ownership instead of claiming new ownership over an existing directory. No staging directory and no `.previous-` backup survive the swap.

Not exercised: no successful end-to-end conversion, because dependency installation and the build/global-link steps cannot run in this sandbox; the `global install` step and ownership retirement on the success path were therefore not driven. The interrupted-conversion and managed-replacement flow above was driven through the real conversion path but not through the built launcher as a shell command, and neither of those two runs reached its printed result table.

### Hostile inherited Git template hook (final head)

Driven on final head `16e5d9cae780cebda1e9371e06ec7c30aee7042e` through the real `updateCommand({ channel: "dev", yes: true })` package-to-dev path. The proof used a non-Git package install root, unused `OPENCLAW_GIT_DIR`, isolated state/home, canonical network clone, and inherited `GIT_TEMPLATE_DIR` with an executable `post-checkout`.

An unsafe control clone first executed the hook and created its marker. After removing that marker, the same hostile template was inherited during conversion; execution stopped after the managed checkout landed, then the checkout was inspected. Private paths and machine details are omitted.

```text
proof_head=16e5d9cae780cebda1e9371e06ec7c30aee7042e
package_install_root_git=absent
unsafe_control_hook=executed
conversion_hook_marker=absent
conversion_hook_copied=absent
managed_checkout_marker=present
checkout_remote=https://github.com/openclaw/openclaw.git
```

The hostile hook neither executed nor copied into the updater-managed checkout; the managed marker and canonical remote establish that the inspected checkout was the updater result. This ran in sanitized AWS Crabbox with public networking, no Tailscale, no instance profile, and the trusted bootstrap verifying the exact head, isolated HOME, pinned Node/pnpm, and dependencies. The proof exited 0 in 3m52s.

## Validation

- Sanitized AWS Crabbox final-head package-to-dev hook proof: exit 0; redacted transcript above.

- `node scripts/run-vitest.mjs src/cli/update-cli/shared.git-checkout.test.ts`: 14 passed.
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts`: 188 passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: exit 0.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`: exit 0.
- `oxlint src/cli/update-cli/ src/infra/errors.ts` and `oxfmt --check`: clean.
- `node --import tsx scripts/check-import-cycles.ts`: 0 runtime value cycles.
- `node scripts/check-database-first-legacy-stores.mjs`: passed.
- `git diff --check` is clean.

Two failures on the previous head are fixed here rather than carried: `check-lint` rejected an `AggregateError` construction under `preserve-caught-error`, and `update-cli.test.ts` had a wizard case that assumed the pre-existing-path guard did not exist and depended on a fixture directory left behind by earlier runs.
The `createAggregateErrorWithCause` helper lives in a leaf `update-cli` module rather than `src/infra/errors.ts` so the shared plugin-SDK public surface budget stays where it was; `src/infra/errors.ts` is untouched by this PR.

Hosted PR CI is green on this head.

Notes for reviewers:

- Non-test lines grow by roughly 110 against the previous head. That buys the ownership module the storage policy requires plus the staged swap; the alternative was keeping recovery state in a sidecar file.
- Reserving the destination happens immediately before the record is claimed, not after. Claiming first would let the record just written vouch for any empty directory at that path, which would defeat the refusal this PR exists for. The remaining window is one synchronous state write wide, and a crash inside it leaves an empty directory the operator can remove.
- The permanent existing-path policy is still an owner decision and is not settled by this revision.

AI-assisted implementation and review; all final changes were inspected and revised against the repository's contributor and update-safety policies.

