### PR TITLE
fix(agents): guard optional provider models when resolving transcript route

### DIFF
--- a/extensions/microsoft-foundry/image-generation-provider.ts
+++ b/extensions/microsoft-foundry/image-generation-provider.ts
@@ -59,7 +59,7 @@ function resolveConfiguredModelName(
   providerConfig: ModelProviderConfig | undefined,
   model: string,
 ): { modelName: string; hasMetadata: boolean } {
-  const configuredName = providerConfig?.models.find((candidate) => candidate.id === model)?.name;
+  const configuredName = providerConfig?.models?.find((candidate) => candidate.id === model)?.name;
   const hasDistinctModelMetadata =
     normalizeOptionalLowercaseString(configuredName) !== normalizeOptionalLowercaseString(model);
   return configuredName

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -179,6 +179,36 @@ describe("redactTranscriptMessage", () => {
     expect(JSON.stringify(msgContent(result))).not.toContain("sk-abcdef1234567890xyz");
   });
 
+  it("handles configured providers without explicit models", () => {
+    const msg = {
+      role: "assistant",
+      api: "openai-responses",
+      model: "gpt-5.5",
+      provider: "openai",
+      content: [{ type: "text", text: "visible", textSignature: "response-item-1" }],
+    } as unknown as AgentMessage;
+    const inputCfg = {
+      logging: { redactSensitive: "tools" },
+      models: { providers: { openai: { apiKey: "test-key" } } },
+    } as unknown as OpenClawConfig;
+
+    const result = redactTranscriptMessage(msg, inputCfg) as unknown as {
+      api: string;
+      model: string;
+      provider: string;
+      content: Array<{ textSignature: string }>;
+    };
+
+    expect(result).toMatchObject({
+      api: "openai-responses",
+      model: "gpt-5.5",
+      provider: "openai",
+    });
+    expect(expectDefined(result.content[0], "result.content[0] test invariant").textSignature).toBe(
+      "response-item-1",
+    );
+  });
+
   it.each([
     {
       api: "openclaw-openai-responses-transport",

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -310,7 +310,7 @@ function resolveTranscriptAssistantRoute(
     ? findNormalizedProviderValue(cfg?.models?.providers, provider)
     : undefined;
   const modelConfig = model
-    ? providerConfig?.models.find((candidate) => candidate.id === model)
+    ? providerConfig?.models?.find((candidate) => candidate.id === model)
     : undefined;
   const baseUrl = modelConfig?.baseUrl ?? providerConfig?.baseUrl;
   const endpointClass = baseUrl ? resolveProviderEndpoint(baseUrl).endpointClass : undefined;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -914,7 +914,7 @@ async function prepareCronRunContext(params: {
   const configuredProvider = cfgWithAgentDefaults.models?.providers?.[provider];
   const modelApi =
     findModelInCatalog(thinkingCatalog, provider, model)?.api ??
-    configuredProvider?.models.find((candidate) => candidate.id === model)?.api ??
+    configuredProvider?.models?.find((candidate) => candidate.id === model)?.api ??
     configuredProvider?.api;
   const preflightDiagnostics = await createCronToolsAllowPreflightDiagnostics({
     cfg: cfgWithAgentDefaults,


### PR DESCRIPTION
## What Problem This Solves

Every agent turn fails to persist its transcript to the per-agent SQLite store. Reproduced live on a running gateway (v2026.7.2): each turn logs `SQLite session write failed` (with the real error swallowed to `{}`) and `Turn transcript persistence failed for <session>: Cannot read properties of undefined (reading 'find')`. The transcript SQLite append throws, so session history is not durably saved.

## Why This Change Was Made

`resolveTranscriptAssistantRoute` (src/agents/transcript-redact.ts) called `providerConfig?.models.find(...)`. Optional chaining guarded `providerConfig` but not `.models`. The config passed here is the raw user config, where `ModelProviderConfig.models` is declared required (types.models.ts) but the input shape (`ModelProviderConfigInput`) makes it optional — and a provider configured as `models.providers.openai = { apiKey }` (very common) has no `models` array. `.find` on `undefined` throws.

Live stack trace: `resolveTranscriptAssistantRoute` → `redactTranscriptStructuredValue` → `redactTranscriptMessage` → `redactTranscriptMessageForStorage` → `appendSqliteTranscriptMessageInTransaction` (inside `runOpenClawAgentWriteTransaction`).

The fix guards the optional array (`providerConfig?.models?.find`). The same raw-config hazard existed in two siblings, fixed in the same change: cron isolated-agent model API resolution (`src/cron/isolated-agent/run.ts`) and the microsoft-foundry image provider (`extensions/microsoft-foundry/image-generation-provider.ts`).

## User Impact

Agent turn transcripts persist correctly for any provider configured without an explicit `models` array — no more silent per-turn transcript data loss. No config/protocol change; no migration.

## Evidence

- Regression test `transcript-redact.test.ts` "handles configured providers without explicit models": drives `redactTranscriptMessage` with `models.providers.openai = { apiKey }`. **Red before the fix** (`TypeError: Cannot read properties of undefined (reading 'find')` at transcript-redact.ts:313), green after.
- `node scripts/run-vitest.mjs src/agents/transcript-redact.test.ts` → 49 passed.
- `node scripts/check-changed.mjs` → exit 0 (typecheck, format, lint, boundaries, database/import guards green).
- `git diff --check` clean.
