### PR TITLE
fix(doctor): bound GitHub issue creation

### DIFF
--- a/src/commands/doctor-session-sqlite-github-issue.test.ts
+++ b/src/commands/doctor-session-sqlite-github-issue.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSessionSqliteGithubIssue } from "./doctor-session-sqlite-github-issue.js";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
+describe("createSessionSqliteGithubIssue", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it("bounds GitHub CLI issue creation and preserves the fallback URL on timeout", () => {
+    const timeoutError = Object.assign(new Error("spawnSync gh ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    spawnSyncMock.mockReturnValue({
+      error: timeoutError,
+      status: null,
+      stderr: Buffer.alloc(0),
+      stdout: Buffer.alloc(0),
+    });
+
+    const result = createSessionSqliteGithubIssue({
+      body: "sanitized body",
+      title: "Session SQLite migration recovery report",
+      url: "https://github.com/openclaw/openclaw/issues/new?title=recovery",
+    });
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "gh",
+      [
+        "issue",
+        "create",
+        "--repo",
+        "openclaw/openclaw",
+        "--title",
+        "Session SQLite migration recovery report",
+        "--body-file",
+        "-",
+      ],
+      {
+        encoding: "buffer",
+        input: "sanitized body",
+        killSignal: "SIGKILL",
+        maxBuffer: 1024 * 1024,
+        timeout: 30_000,
+      },
+    );
+    expect(result).toEqual({
+      fallbackUrl: "https://github.com/openclaw/openclaw/issues/new?title=recovery",
+      message: "spawnSync gh ETIMEDOUT",
+      ok: false,
+    });
+  });
+});

--- a/src/commands/doctor-session-sqlite-github-issue.ts
+++ b/src/commands/doctor-session-sqlite-github-issue.ts
@@ -11,6 +11,8 @@ type SpawnGh = (
   options: { input: string },
 ) => Pick<SpawnSyncReturns<Buffer>, "error" | "status" | "stderr" | "stdout">;
 
+const GITHUB_ISSUE_CREATE_TIMEOUT_MS = 30_000;
+
 /** Creates an openclaw/openclaw issue through the GitHub CLI using sanitized stdin. */
 export function createSessionSqliteGithubIssue(
   issue: SessionSqliteMigrationFailureIssue,
@@ -45,6 +47,8 @@ function defaultSpawnGh(
   return spawnSync("gh", [...args], {
     encoding: "buffer",
     input: options.input,
+    killSignal: "SIGKILL",
     maxBuffer: 1024 * 1024,
+    timeout: GITHUB_ISSUE_CREATE_TIMEOUT_MS,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --session-sqlite recover` can synchronously invoke `gh issue create` after the user approves posting a sanitized recovery report. That subprocess had no deadline, so a stalled GitHub CLI request could block doctor indefinitely instead of returning the already-generated prefilled issue URL.

## Why This Change Was Made

Bound the owner-local `gh issue create` call to 30 seconds and use `SIGKILL` as the timeout signal. The existing failure path already reports the CLI error and preserves the prefilled URL, so the change only makes that path reachable when the subprocess stalls.

The focused regression test locks down the exact subprocess options and verifies that `ETIMEDOUT` remains a fail-soft result. No approval, report sanitization, or issue payload behavior changes.

## User Impact

Doctor no longer waits forever when approved GitHub issue creation stalls. After 30 seconds it reports the failure and gives the user the prefilled issue URL for manual submission.

## Evidence

- Node 24.15.0: `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite-github-issue.test.ts` (1/1 passed)
- `oxfmt --check` on both changed files
- `oxlint` on both changed files
- `git diff origin/main...HEAD --check`
- Controlled Node 24 child-process proof: a child that ignored `SIGTERM` returned `{ code: "ETIMEDOUT", signal: "SIGKILL", status: null, elapsedMs: 106 }` with a 100ms deadline
- Live authenticated `gh api rate_limit` completed in 1.05s; no real issue was created during validation
- Independent adversarial review: clean; the timeout is outside the SQLite maintenance lock and preserves the existing fallback contract
