### PR TITLE
fix(ci): address reviewer findings across the perf-lever batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1879,7 +1879,7 @@ jobs:
           # Same tree-OID gate as the boundary lane: restore only artifacts
           # produced from identical generative sources, so stale snapshots can
           # neither false-skip rebuilds nor leave ghost declarations.
-          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types)"
+          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels)"
           if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
             echo "boundary source trees changed since snapshot; lint prepares cold"
             exit 0
@@ -2104,7 +2104,7 @@ jobs:
           # can false-skip a rebuild, and deleted/renamed sources can never
           # leave ghost declarations because a differing tree skips the
           # restore entirely and builds cold.
-          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types)"
+          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels)"
           if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
             echo "boundary source trees changed since snapshot; building cold"
             echo "restored=false" >> "$GITHUB_OUTPUT"
@@ -2289,7 +2289,7 @@ jobs:
           fi
           find extensions -maxdepth 3 \( -name '.boundary-tsc.tsbuildinfo' -o -name '.boundary-tsc.stamp' \) \
             -exec rsync -aR {} "$sticky_root/" \;
-          git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types > "$sticky_root/.source-trees"
+          git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels > "$sticky_root/.source-trees"
           touch "$sticky_root/.snapshot-ready"
 
   # Validate docs (format, lint, broken links) only when docs files changed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1879,7 +1879,7 @@ jobs:
           # Same tree-OID gate as the boundary lane: restore only artifacts
           # produced from identical generative sources, so stale snapshots can
           # neither false-skip rebuilds nor leave ghost declarations.
-          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels)"
+          current_trees="$({ git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels; node --version; corepack pnpm --version 2>/dev/null || pnpm --version; })"
           if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
             echo "boundary source trees changed since snapshot; lint prepares cold"
             exit 0
@@ -2098,13 +2098,14 @@ jobs:
             echo "restored=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Restore only when the generative source trees are identical to the
-          # snapshotting run (tree OIDs cover content exactly). This makes the
-          # restored artifacts valid by construction: no clock-skew mtime race
-          # can false-skip a rebuild, and deleted/renamed sources can never
-          # leave ghost declarations because a differing tree skips the
-          # restore entirely and builds cold.
-          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels)"
+          # Restore only when the generative source trees AND the runner
+          # toolchain match the snapshotting run. Tree OIDs cover source
+          # content exactly; the node/pnpm versions cover toolchain-only
+          # changes (the sticky key already hashes config/scripts/lockfile, so
+          # those force a fresh key). Restored artifacts are valid by
+          # construction: no clock-skew mtime race can false-skip a rebuild,
+          # and deleted/renamed sources or a toolchain bump build cold.
+          current_trees="$({ git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels; node --version; corepack pnpm --version 2>/dev/null || pnpm --version; })"
           if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
             echo "boundary source trees changed since snapshot; building cold"
             echo "restored=false" >> "$GITHUB_OUTPUT"
@@ -2289,7 +2290,7 @@ jobs:
           fi
           find extensions -maxdepth 3 \( -name '.boundary-tsc.tsbuildinfo' -o -name '.boundary-tsc.stamp' \) \
             -exec rsync -aR {} "$sticky_root/" \;
-          git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels > "$sticky_root/.source-trees"
+          { git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types HEAD:src/plugins/types.ts HEAD:src/video-generation HEAD:src/channels; node --version; corepack pnpm --version 2>/dev/null || pnpm --version; } > "$sticky_root/.source-trees"
           touch "$sticky_root/.snapshot-ready"
 
   # Validate docs (format, lint, broken links) only when docs files changed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1736,18 +1736,28 @@ jobs:
         run: test "$(go env GOVERSION)" = "go1.25.12"
 
       - name: Configure Node test resources
-        # Scale the in-process Vitest worker budget with the runner class. Bins
-        # run one Vitest process at a time (planConcurrency 1), so workers are
-        # the only in-job parallelism; import-bound suites scale near-linearly.
+        # Scale the in-process Vitest worker budget with the cores the job
+        # actually received: runner labels over-promise under fleet load
+        # (observed: a 16 vCPU label delivering a 4-CPU cgroup) and dispatch
+        # runs fall back to hosted runners regardless of matrix.runner.
+        # Serial-plan bins (planConcurrency 1) get the full budget; anything
+        # that can overlap Vitest processes keeps the proven 2-worker cap.
         # Timing-sensitive groups stay pinned to 2 via plan-level env.
         env:
-          SHARD_RUNNER: ${{ matrix.runner || 'blacksmith-4vcpu-ubuntu-2404' }}
+          SHARD_PLAN_CONCURRENCY: ${{ matrix.plan_concurrency || '' }}
         run: |
-          if [[ "$SHARD_RUNNER" == *"-8vcpu-"* ]]; then
-            echo "OPENCLAW_VITEST_MAX_WORKERS=6" >> "$GITHUB_ENV"
+          cores="$(nproc)"
+          if [ "$SHARD_PLAN_CONCURRENCY" != "1" ]; then
+            workers=2
+          elif [ "$cores" -ge 12 ]; then
+            workers=6
+          elif [ "$cores" -ge 6 ]; then
+            workers=4
           else
-            echo "OPENCLAW_VITEST_MAX_WORKERS=3" >> "$GITHUB_ENV"
+            workers=3
           fi
+          echo "detected cores=$cores plan_concurrency=${SHARD_PLAN_CONCURRENCY:-default} -> workers=$workers"
+          echo "OPENCLAW_VITEST_MAX_WORKERS=$workers" >> "$GITHUB_ENV"
 
       - name: Run Node test shard
         # actionlint 1.7.11 lacks GitHub's current job.workflow_* fields. Serialize the
@@ -1866,8 +1876,14 @@ jobs:
             echo "boundary artifact snapshot not seeded yet; lint prepares cold"
             exit 0
           fi
-          # rsync -a preserves snapshot mtimes; fresh checkout sources stay
-          # newer, so the prepare script always takes its incremental path.
+          # Same tree-OID gate as the boundary lane: restore only artifacts
+          # produced from identical generative sources, so stale snapshots can
+          # neither false-skip rebuilds nor leave ghost declarations.
+          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types)"
+          if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
+            echo "boundary source trees changed since snapshot; lint prepares cold"
+            exit 0
+          fi
           for payload in dist packages extensions; do
             if [ -d "$sticky_root/$payload" ]; then
               rsync -a "$sticky_root/$payload/" "$payload/"
@@ -1879,6 +1895,7 @@ jobs:
           HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
           FORMAT_CHECK: ${{ needs.preflight.outputs.run_format_check }}
           RUN_CONTROL_UI_I18N: ${{ needs.preflight.outputs.run_control_ui_i18n }}
+          RUN_UI_TESTS: ${{ needs.preflight.outputs.run_ui_tests }}
           OPENCLAW_LOCAL_CHECK: "0"
           TASK: ${{ matrix.task }}
           PR_BASE_SHA: ${{ github.event_name == 'pull_request' && needs.preflight.outputs.diff_base_revision || '' }}
@@ -1917,9 +1934,10 @@ jobs:
               pnpm tsgo:prod
               ;;
             lint)
-              # Control-UI i18n catalogs only change with ui/ sources or the
-              # i18n tooling (manifest-gated); oxlint always runs.
-              if [ "$RUN_CONTROL_UI_I18N" = "true" ]; then
+              # The i18n verify covers keys extracted from every ui/ source,
+              # not just ui/src/i18n; any ui-touching diff (run_ui_tests) or
+              # i18n-tooling diff must run it. oxlint always runs.
+              if [ "$RUN_CONTROL_UI_I18N" = "true" ] || [ "$RUN_UI_TESTS" = "true" ]; then
                 pnpm lint --threads=8
               else
                 echo "[skip] changed scope cannot affect control-UI i18n catalogs"
@@ -1943,26 +1961,34 @@ jobs:
                   echo "Current CI targets must provide the deadcode:exports package script." >&2
                   exit 1
                 fi
-                dc_pids=()
-                dc_logs=()
-                for dc in "${dc_scripts[@]}"; do
-                  dc_log="$(mktemp -t deadcode-log.XXXXXX)"
-                  dc_logs+=("$dc_log")
-                  pnpm "$dc" >"$dc_log" 2>&1 &
-                  dc_pids+=($!)
-                done
-                dc_failures=0
-                for i in "${!dc_scripts[@]}"; do
-                  if wait "${dc_pids[$i]}"; then
-                    echo "[ok] ${dc_scripts[$i]}"
-                  else
-                    echo "::error title=${dc_scripts[$i]} failed::${dc_scripts[$i]} failed"
-                    dc_failures=1
+                if [ "$(nproc)" -lt 8 ]; then
+                  # Hosted/dispatch runners are too small for up to seven
+                  # concurrent Knip processes; keep the serial path there.
+                  for dc in "${dc_scripts[@]}"; do
+                    pnpm "$dc"
+                  done
+                else
+                  dc_pids=()
+                  dc_logs=()
+                  for dc in "${dc_scripts[@]}"; do
+                    dc_log="$(mktemp -t deadcode-log.XXXXXX)"
+                    dc_logs+=("$dc_log")
+                    pnpm "$dc" >"$dc_log" 2>&1 &
+                    dc_pids+=($!)
+                  done
+                  dc_failures=0
+                  for i in "${!dc_scripts[@]}"; do
+                    if wait "${dc_pids[$i]}"; then
+                      echo "[ok] ${dc_scripts[$i]}"
+                    else
+                      echo "::error title=${dc_scripts[$i]} failed::${dc_scripts[$i]} failed"
+                      dc_failures=1
+                    fi
+                    cat "${dc_logs[$i]}"
+                  done
+                  if [ "$dc_failures" -ne 0 ]; then
+                    exit 1
                   fi
-                  cat "${dc_logs[$i]}"
-                done
-                if [ "$dc_failures" -ne 0 ]; then
-                  exit 1
                 fi
               elif [[ "$HISTORICAL_TARGET" == "true" ]] && has_package_script "deadcode:ci"; then
                 pnpm deadcode:ci
@@ -2072,10 +2098,18 @@ jobs:
             echo "restored=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # rsync -a preserves the snapshotting run's artifact mtimes; the
-          # fresh checkout's newer source mtimes force the prepare script down
-          # its incremental-rebuild path, so a stale snapshot can never
-          # false-skip the boundary compile.
+          # Restore only when the generative source trees are identical to the
+          # snapshotting run (tree OIDs cover content exactly). This makes the
+          # restored artifacts valid by construction: no clock-skew mtime race
+          # can false-skip a rebuild, and deleted/renamed sources can never
+          # leave ghost declarations because a differing tree skips the
+          # restore entirely and builds cold.
+          current_trees="$(git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types)"
+          if [ ! -f "$sticky_root/.source-trees" ] || [ "$current_trees" != "$(cat "$sticky_root/.source-trees")" ]; then
+            echo "boundary source trees changed since snapshot; building cold"
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           for payload in dist packages extensions; do
             if [ -d "$sticky_root/$payload" ]; then
               rsync -a "$sticky_root/$payload/" "$payload/"
@@ -2255,6 +2289,7 @@ jobs:
           fi
           find extensions -maxdepth 3 \( -name '.boundary-tsc.tsbuildinfo' -o -name '.boundary-tsc.stamp' \) \
             -exec rsync -aR {} "$sticky_root/" \;
+          git rev-parse HEAD:src/plugin-sdk HEAD:packages HEAD:extensions HEAD:src/auto-reply HEAD:src/types > "$sticky_root/.source-trees"
           touch "$sticky_root/.snapshot-ready"
 
   # Validate docs (format, lint, broken links) only when docs files changed.

--- a/scripts/lib/ci-changed-node-test-plan.mjs
+++ b/scripts/lib/ci-changed-node-test-plan.mjs
@@ -97,7 +97,7 @@ export function hasQaSmokeAffectingChange(changedPaths, options = {}) {
 // id the graph walk cannot see), and the gate's own orchestration — changes
 // to the gate must not be able to skip the gated lane.
 const PROMPT_SNAPSHOT_SURFACE_RE =
-  /^(?:test\/(?:helpers\/agents|fixtures\/agents\/prompt-snapshots)|extensions\/codex)\/|^scripts\/(?:generate-prompt-snapshots\.ts|prompt-snapshot-files\.[cm]?[jt]s)$|^scripts\/lib\/ci-changed-node-test-plan\.mjs$|^\.github\/(?:workflows\/ci\.yml$|actions\/)|^(?:package\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json|pnpm-workspace\.yaml)$/u;
+  /^(?:test\/(?:helpers\/agents|fixtures\/agents\/prompt-snapshots)|extensions\/codex|packages)\/|^scripts\/(?:generate-prompt-snapshots\.ts|prompt-snapshot-files\.[cm]?[jt]s)$|^scripts\/lib\/ci-changed-node-test-plan\.mjs$|^\.github\/(?:workflows\/ci\.yml$|actions\/)|^(?:package\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json|pnpm-workspace\.yaml)$/u;
 // The generator renders real prompt-layer stacks, so its runtime blast radius
 // is the snapshot helper's import graph (auto-reply prompts, channel typing,
 // plugin-sdk agent harness, codex catalog fixtures).

--- a/scripts/package-openclaw-for-docker.mjs
+++ b/scripts/package-openclaw-for-docker.mjs
@@ -367,7 +367,10 @@ const PACKAGE_ARTIFACT_BUILD_STEPS = [
   {
     label: "Building OpenClaw package artifacts",
     command: "node",
-    args: ["scripts/build-all.mjs", "ciArtifacts"],
+    // The full profile keeps canonical declaration emission; ciArtifacts is a
+    // PR-CI-only profile whose step env forces dts off and would clobber the
+    // OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=0 this packaging path requires.
+    args: ["scripts/build-all.mjs", "full"],
   },
 ];
 

--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -279,7 +279,8 @@ export async function main(extraArgs = process.argv.slice(2), runtimeEnv = proce
         splitCore: shardArgs.splitCore,
       });
       const hostResources = resolveHostResources();
-      console.log(
+      // stderr: stdout may carry machine-readable oxlint output for callers.
+      console.error(
         `[oxlint] shard concurrency ${Math.max(1, Math.min(shardConcurrency, selectedShards.length))} ` +
           `(cpus=${hostResources.logicalCpuCount}, memGB=${Math.round(hostResources.totalMemoryBytes / 1024 ** 3)})`,
       );

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -93,6 +93,9 @@ describe("CI changed Node test plan", () => {
       ]),
     ).toBe(true);
     expect(hasPromptSnapshotAffectingChange(["scripts/generate-prompt-snapshots.ts"])).toBe(true);
+    // Workspace packages feed the generator through package-specifier imports
+    // the relative graph walk cannot see.
+    expect(hasPromptSnapshotAffectingChange(["packages/llm-core/src/index.ts"])).toBe(true);
     // The gate's own orchestration must not be able to skip the gated lane.
     expect(hasPromptSnapshotAffectingChange([".github/workflows/ci.yml"])).toBe(true);
     expect(hasPromptSnapshotAffectingChange(["scripts/lib/ci-changed-node-test-plan.mjs"])).toBe(


### PR DESCRIPTION
## What Problem This Solves

Codex review left P1/P2 findings on the six CI perf PRs landed today (#108788, #108949, #109083, #109144, #109151, #109169). Verified findings, most severe first:

1. **Docker packaging lost canonical declarations** (#108949 P2, verified as release-artifact P1): `package-openclaw-for-docker.mjs` invokes `build-all.mjs ciArtifacts` with `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=0`, but `resolveStepEnv` merges the profile's step env *over* the caller's env — the new ciArtifacts dts-skip silently clobbered the packaging path's requirement.
2. **Sticky-disk mtime race + ghost declarations** (#109169, both P1): clock skew across runner VMs could make restored artifact mtimes newer than checkout sources (mtime freshness would false-skip the boundary compile), and the coarse key could restore declarations for deleted/renamed sources that tsc never cleans from outDir.
3. **Worker budget trusted the runner label** (#108788 P2 ×2): dispatch runs fall back to hosted runners while `SHARD_RUNNER` still reads the matrix label, and non-compact plans (which can overlap Vitest processes) got the raised budget without pins.
4. **Lint i18n gate too narrow** (#109144 P2): `run_control_ui_i18n` only fires for `ui/src/i18n/` + tooling, but catalog keys are extracted from *all* ui sources — a `ui/src/components/*` change skipped the verify.
5. **Concurrent Knip on small hosts** (#109151 P2): dispatch/fork runs on 4-core hosted runners would launch up to seven Knip processes.
6. **Diagnostic on stdout** (#109144 P2): the `[oxlint]` line could corrupt machine-readable output.
7. **Prompt-snapshot gate missed workspace packages** (#109083 P2): the generator imports `@openclaw/*` packages via package specifiers the relative graph walk cannot see.

## Why This Change Was Made

- Docker packaging uses the `full` profile — byte-identical step list, canonical dts semantics (verified `BUILD_ALL_PROFILES.full === ciArtifacts` step-wise).
- Both sticky restores gate on `git rev-parse` **tree OIDs** of the generative sources (`src/plugin-sdk`, `packages`, `extensions`, `src/auto-reply`, `src/types`), recorded at seed time. Identical trees → restored artifacts are valid by construction (no mtime reasoning needed at all); differing trees → cold build. This resolves both P1s with one mechanism and keeps the warm path for the common non-SDK push.
- The worker budget derives from `nproc` (honest under label over-promise — observed a 16 vCPU label delivering a 4-CPU cgroup) and stays at 2 whenever `plan_concurrency != 1`.
- The lint case runs the i18n verify when `run_control_ui_i18n || run_ui_tests` (the latter fires for any `ui/` change).
- The deadcode task falls back to serial below 8 cores; the diagnostic prints to stderr; `^packages/` joins the prompt-snapshot always-run surface (test added).

## User Impact

None at runtime for CI paths; the docker-profile fix restores declaration emission for self-contained package artifacts.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/run-oxlint.test.ts test/scripts/build-all.test.ts` — green.
- Tree-OID commands verified against this checkout; YAML parse validated.
- Classifier sanity: `packages/llm-core/src/index.ts` → true, `ui/src/app.ts` → still false for snapshots.
