### PR TITLE
improve(tests): shorten Azure voice timeout proof

### DIFF
--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -34,40 +34,51 @@ describe("listAzureSpeechVoices timeout", () => {
     vi.unstubAllGlobals();
   });
 
-  it("aborts a hanging voice list request within the configured timeout", async () => {
-    let requestCount = 0;
-    const server = createServer((_req, _res) => {
-      requestCount += 1;
-    });
+  it(
+    "aborts a hanging voice list request within the configured timeout",
+    { timeout: 2_000 },
+    async () => {
+      let requestCount = 0;
+      const server = createServer((_req, _res) => {
+        requestCount += 1;
+      });
 
-    const port = await listenLocal(server);
+      const port = await listenLocal(server);
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-        return await originalFetch(`http://127.0.0.1:${port}/cognitiveservices/voices/list`, init);
-      }) as unknown as typeof globalThis.fetch,
-    );
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          return await originalFetch(`http://127.0.0.1:${port}/cognitiveservices/voices/list`, init);
+        }) as unknown as typeof globalThis.fetch,
+      );
 
-    const startedAt = Date.now();
+      const startedAt = Date.now();
+      let watchdog: ReturnType<typeof setTimeout> | undefined;
 
-    try {
-      await expect(
-        Promise.race([
-          listAzureSpeechVoices({
-            apiKey: "not-a-real",
-            baseUrl: "https://custom.example.com",
-            timeoutMs: 250,
-          }),
-          new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error("voices list did not time out")), 2_000);
-          }),
-        ]),
-      ).rejects.toThrow(/aborted|timeout|timed out/i);
-      expect(Date.now() - startedAt).toBeLessThan(2_000);
-      expect(requestCount).toBe(1);
-    } finally {
-      await closeServer(server);
-    }
-  });
+      try {
+        await expect(
+          Promise.race([
+            listAzureSpeechVoices({
+              apiKey: "not-a-real",
+              baseUrl: "https://custom.example.com",
+              timeoutMs: 100,
+            }),
+            new Promise<never>((_, reject) => {
+              watchdog = setTimeout(
+                () => reject(new Error("voices list did not time out")),
+                1_000,
+              );
+            }),
+          ]),
+        ).rejects.toThrow(/aborted|timeout|timed out/i);
+        expect(Date.now() - startedAt).toBeLessThan(1_000);
+        expect(requestCount).toBe(1);
+      } finally {
+        if (watchdog) {
+          clearTimeout(watchdog);
+        }
+        await closeServer(server);
+      }
+    },
+  );
 });

--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -48,7 +48,10 @@ describe("listAzureSpeechVoices timeout", () => {
       vi.stubGlobal(
         "fetch",
         vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-          return await originalFetch(`http://127.0.0.1:${port}/cognitiveservices/voices/list`, init);
+          return await originalFetch(
+            `http://127.0.0.1:${port}/cognitiveservices/voices/list`,
+            init,
+          );
         }) as unknown as typeof globalThis.fetch,
       );
 
@@ -64,10 +67,7 @@ describe("listAzureSpeechVoices timeout", () => {
               timeoutMs: 100,
             }),
             new Promise<never>((_, reject) => {
-              watchdog = setTimeout(
-                () => reject(new Error("voices list did not time out")),
-                1_000,
-              );
+              watchdog = setTimeout(() => reject(new Error("voices list did not time out")), 1_000);
             }),
           ]),
         ).rejects.toThrow(/aborted|timeout|timed out/i);


### PR DESCRIPTION
## What Problem This Solves

The real Azure Speech voice-list timeout proof spends 250 ms waiting for a loopback request to abort, even though it only needs to prove the configured deadline is honored. Its separate watchdog also remained scheduled after the successful path.

## Why This Change Was Made

Use a 100 ms real-network timeout, retain a 1 second in-body watchdog for regression cleanup, clear that watchdog after success, and give the test a bounded 2 second runner timeout. Production code and CI configuration are unchanged.

## User Impact

No user-visible behavior changes. The Azure Speech test lane gets the same real fetch-abort coverage with less test wall time and deterministic cleanup.

## Evidence

- Baseline Testbox, 5 runs: test-body median 294 ms (315, 294, 282, 282, 304 ms).
- Optimized Testbox, 5 runs: test-body median 142 ms (138, 149, 142, 142, 136 ms), 52% faster.
- Exact final head repeat: 3/3 passed; median 149 ms (184, 149, 132 ms).
- `pnpm check:changed` passed on Testbox `tbx_01kxp12dwkcqb9t5cg503q5cge` after the final rebase (format, extension test typecheck, and lint included).
- `autoreview --mode branch --base origin/main`: clean, no actionable findings.

AI-assisted: yes. I reviewed the implementation and validation evidence.
