### PR TITLE
fix: stabilize UI and gateway auth timing tests

### DIFF
--- a/src/gateway/probe.auth.integration.test.ts
+++ b/src/gateway/probe.auth.integration.test.ts
@@ -116,25 +116,19 @@ describe("probeGateway auth integration", () => {
     expect(fs.existsSync(statePath("identity", "device-auth.json"))).toBe(false);
   });
 
-  describe("with cached device auth", () => {
-    let cachedProbeResult: Awaited<ReturnType<typeof probeGateway>>;
-
-    beforeAll(async () => {
-      const token = requireGatewayToken();
-      await seedCachedOperatorToken(["operator.read"]);
-      cachedProbeResult = await probeGateway({
-        url: `ws://127.0.0.1:${gatewayHarness.port}`,
-        auth: { token },
-        timeoutMs: 5_000,
-      });
+  it("keeps detail RPCs available for local authenticated probes with cached device auth", async () => {
+    const token = requireGatewayToken();
+    await seedCachedOperatorToken(["operator.read"]);
+    const result = await probeGateway({
+      url: `ws://127.0.0.1:${gatewayHarness.port}`,
+      auth: { token },
+      timeoutMs: 10_000,
     });
 
-    it("keeps detail RPCs available for local authenticated probes with cached device auth", async () => {
-      expect(cachedProbeResult.ok).toBe(true);
-      expect(cachedProbeResult.error).toBeNull();
-      expectRecord(cachedProbeResult.health, "probe health");
-      expectRecord(cachedProbeResult.status, "probe status");
-      expectRecord(cachedProbeResult.configSnapshot, "probe config snapshot");
-    });
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+    expectRecord(result.health, "probe health");
+    expectRecord(result.status, "probe status");
+    expectRecord(result.configSnapshot, "probe config snapshot");
   });
 });

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -236,9 +236,12 @@ it("gates profile usage refreshes by payload age and page visibility", async () 
     pendingFiles: 1,
     staleFiles: 0,
   });
-  page.lastProfileLoadedAtMs = Date.now();
+  const nowMs = Date.now();
+  const nowSpy = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+  page.lastProfileLoadedAtMs = nowMs;
   page.scheduleCacheSettleRefresh();
   expect(settleDelayMs).toBe(USAGE_PAYLOAD_TTL_MS);
+  nowSpy.mockRestore();
 
   page.lastProfileLoadedAtMs = Date.now() - USAGE_PAYLOAD_TTL_MS;
   visibility.mockReturnValue("hidden");


### PR DESCRIPTION
## What Problem This Solves

Resolves two unrelated CI flakes: the profile usage refresh test could cross a real-clock millisecond boundary and assert 299,999 ms instead of 300,000 ms, while the cached-device-auth gateway probe used setup outside the normal per-case lifecycle and a tighter timeout than the gateway test helpers use under saturated CI.

Related CI failures:

- https://github.com/openclaw/openclaw/actions/runs/29521267673/job/87698765622
- https://github.com/openclaw/openclaw/actions/runs/29521267673/job/87698765754

## Why This Change Was Made

The UI test now pins one clock reading around the exact interval assertion. The gateway test now seeds and probes cached auth inside its test case and uses the established 10-second saturated-CI RPC budget. Production behavior is unchanged.

AI-assisted: Codex inspected the failing jobs, traced the relevant test/runtime paths, and prepared this patch.

## User Impact

No user-visible behavior changes. CI should no longer fail from these two test timing/lifecycle races.

## Evidence

- Before: UI failed with `expected 299999 to be 300000`; gateway cached-auth probe returned `ok: false` in CI.
- Blacksmith Testbox `tbx_01kxp1nz0wtdx557mx8actpnpf`: `pnpm test ui/src/pages/profile/profile-page.test.ts src/gateway/probe.auth.integration.test.ts` passed both files and all 5 tests.
- The same focused command passed 10 consecutive times on the same Testbox (50/50 tests).
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29522524380
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings (0.98 confidence).
