### PR TITLE
docs(templates): ask feature requesters whether they plan to implement

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -62,6 +62,17 @@ body:
       label: Evidence/examples
       description: Prior art, links, screenshots, logs, or metrics.
       placeholder: Comparable behavior in X, sample config, and screenshot of current limitation.
+  - type: dropdown
+    id: implementation_intent
+    attributes:
+      label: Do you plan to open a PR for this?
+      description: Helps maintainers route the idea — self-implemented features move faster.
+      options:
+        - Yes, I plan to implement this myself
+        - Maybe, with maintainer guidance
+        - No, proposing the idea only
+    validations:
+      required: true
   - type: textarea
     id: additional_information
     attributes:


### PR DESCRIPTION
## Why

Intake signal for feature triage (part of the ClawSweeper backlog-strategy work): knowing whether a requester intends to implement separates "sponsored-by-effort" proposals from idea-only submissions. brokemac79 floated exactly this field in May ("would it be worth adding a short 'When Opening Issues' section asking reporters to say whether they plan to open a PR?").

## What

One required dropdown on the feature-request template: "Do you plan to open a PR for this?" — Yes / Maybe with guidance / No, idea only. ClawSweeper review can use the answer to route: self-implemented features toward issue-first implementation lanes, idea-only submissions toward product-decision triage.

YAML validated; no other template changes.
