### PR TITLE
fix(agents): scope tool-terminal completion proof to post-assistant results

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1019,6 +1019,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: { path: "note.txt" } }],
     } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
     const settledToolResults = [
+      toolUseAssistant,
       { role: "toolResult", toolCallId: "tool_1", toolName: "write", isError: false },
     ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"];
     mockedClassifyFailoverReason.mockReturnValue(null);
@@ -1071,6 +1072,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         toolMetas: [{ toolName: "write", meta: "path=note.txt" }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         messagesSnapshot: [
+          toolUseAssistant,
           { role: "toolResult", toolCallId: "tool_1", toolName: "write", isError: false },
         ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
         lastAssistant: toolUseAssistant,
@@ -1125,6 +1127,44 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectNoWarnMessageWith("tool-use terminal turn lacked a final answer");
   });
 
+  it("ignores stale prior-turn tool results with colliding ids", async () => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: { path: "note.txt" } }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [],
+        itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+        // A completed result from a PRIOR turn reusing the same id sits before
+        // the terminal assistant; it must not prove the new batch dispatched.
+        messagesSnapshot: [
+          { role: "toolResult", toolCallId: "tool_1", toolName: "write", isError: false },
+          toolUseAssistant,
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-use-terminal-stale-prior-result",
+    });
+
+    for (let call = 0; call < mockedRunEmbeddedAttempt.mock.calls.length; call += 1) {
+      expect(runAttemptCall(call).prompt).not.toContain(TOOL_USE_TERMINAL_CONTINUATION_INSTRUCTION);
+    }
+    expectNoWarnMessageWith("tool-use terminal turn lacked a final answer");
+  });
+
   it("does not claim completion when only part of a multi-tool request dispatched", async () => {
     const toolUseAssistant = {
       role: "assistant",
@@ -1143,6 +1183,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         toolMetas: [{ toolName: "write", meta: "path=a.txt" }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         messagesSnapshot: [
+          toolUseAssistant,
           { role: "toolResult", toolCallId: "tool_1", toolName: "write", isError: false },
         ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
         lastAssistant: toolUseAssistant,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -750,8 +750,14 @@ export function resolveToolUseTerminalContinuationInstruction(params: {
         return block?.type === "toolCall" ? [typeof block.id === "string" ? block.id : null] : [];
       })
     : [];
+  // Scan only results AFTER the terminal assistant: the snapshot spans the whole
+  // session, and a prior turn's toolResult with a model-reused id would otherwise
+  // prove "completion" for a batch that never dispatched. Assistant not found in
+  // the snapshot fails closed to the existing incomplete-turn error.
+  const snapshot = params.attempt.messagesSnapshot ?? [];
+  const assistantIndex = assistant ? snapshot.indexOf(assistant) : -1;
   const completedToolCallIds = new Set(
-    (params.attempt.messagesSnapshot ?? []).flatMap((message) => {
+    (assistantIndex >= 0 ? snapshot.slice(assistantIndex + 1) : []).flatMap((message) => {
       const result = message as { role?: unknown; toolCallId?: unknown; isError?: unknown };
       return result.role === "toolResult" &&
         result.isError !== true &&


### PR DESCRIPTION
## What Problem This Solves

Hardens the tool-terminal continuation guard landed in PR #108966. A fresh-eyes adversarial review found that `completedToolCallIds` scanned the **entire session snapshot**, so a non-error `toolResult` from a *prior* turn with a colliding tool-call id could prove "completion" for a terminal batch that never dispatched — converting the fail-closed incomplete-turn error into a continuation where the model may claim skipped side effects succeeded. Low probability (runner normalizes blank/duplicate ids per message; most providers synthesize unique ids) but real: per-request-only dedupe (e.g. Gemini's `providedId` path) lets a model that reuses the same literal id across turns realize it.

## Why This Change Was Made

Scope the scan to snapshot entries **after** the terminal assistant. Both `currentAttemptAssistant` and `lastAssistant` are produced by `.find()` over the same snapshot array, so reference-identity `indexOf` is reliable; if the assistant is not in the snapshot the guard fails closed to the existing error path. Positive-path fixtures now model the real shape (assistant present in the snapshot before its results), and a new regression pins the stale prior-turn-result case.

## User Impact

None visible when things work; removes a rare path where a codex tool-terminal turn could be continued despite its tool batch never running.

## Evidence

- `run.incomplete-turn.test.ts`: 137 tests green, including the new "ignores stale prior-turn tool results with colliding ids" regression and the reshaped settled/exhausted/partial fixtures.
- Reference-identity claim verified against `attempt-stream-settle.ts` (lastAssistant/currentAttemptAssistant are snapshot `.find()` results) and `attempt.context-engine-helpers.ts`.
- Autoreview (gpt-5.6-sol, xhigh): clean.
