### PR TITLE
fix(ci): bound OpenGrep installer fetches

### DIFF
--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -41,10 +41,10 @@ jobs:
           # Download first so a timed-out transfer cannot execute a partial installer.
           installer="$(mktemp "${RUNNER_TEMP}/opengrep-install.XXXXXX")"
           trap 'rm -f "$installer"' EXIT
-          curl -fsSL --connect-timeout 10 --max-time 120 \
+          curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 \
             -o "$installer" \
             "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh"
-          bash "$installer" -v "$OPENGREP_VERSION"
+          timeout --signal=TERM --kill-after=10s 300s bash "$installer" -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - name: Verify opengrep

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -67,10 +67,10 @@ jobs:
           # Download first so a timed-out transfer cannot execute a partial installer.
           installer="$(mktemp "${RUNNER_TEMP}/opengrep-install.XXXXXX")"
           trap 'rm -f "$installer"' EXIT
-          curl -fsSL --connect-timeout 10 --max-time 120 \
+          curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 \
             -o "$installer" \
             "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh"
-          bash "$installer" -v "$OPENGREP_VERSION"
+          timeout --signal=TERM --kill-after=10s 300s bash "$installer" -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - name: Verify opengrep

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1670,7 +1670,7 @@ describe("ci workflow guards", () => {
     }
   });
 
-  it("downloads the opengrep installer completely before execution", () => {
+  it("downloads and bounds the OpenGrep installer before execution", () => {
     for (const workflowPath of [OPENGREP_PR_DIFF_WORKFLOW, OPENGREP_FULL_WORKFLOW]) {
       const workflow = parse(readFileSync(workflowPath, "utf8"));
       const run = expectDefined(
@@ -1682,12 +1682,19 @@ describe("ci workflow guards", () => {
       expect(run, workflowPath).toContain(
         'installer="$(mktemp "${RUNNER_TEMP}/opengrep-install.XXXXXX")"',
       );
-      expect(run, workflowPath).toContain("curl -fsSL --connect-timeout 10 --max-time 120 \\");
+      expect(run, workflowPath).toContain(
+        "curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 \\",
+      );
       expect(run, workflowPath).toContain('-o "$installer"');
-      expect(run, workflowPath).toContain('bash "$installer" -v "$OPENGREP_VERSION"');
+      expect(run, workflowPath).toContain(
+        'timeout --signal=TERM --kill-after=10s 300s bash "$installer" -v "$OPENGREP_VERSION"',
+      );
       expect(run, workflowPath).toContain("trap 'rm -f \"$installer\"' EXIT");
       expect(run.indexOf('-o "$installer"'), workflowPath).toBeLessThan(
-        run.indexOf('bash "$installer"'),
+        run.indexOf('timeout --signal=TERM --kill-after=10s 300s bash "$installer"'),
+      );
+      expect(run.indexOf("curl -fsSL"), workflowPath).toBeLessThan(
+        run.indexOf('timeout --signal=TERM --kill-after=10s 300s bash "$installer"'),
       );
       expect(run, workflowPath).not.toMatch(/\|\s*bash/u);
     }


### PR DESCRIPTION
AI-assisted: yes (Codex)

## What Problem This Solves

Fixes an issue where OpenGrep precise scan workflows could wait indefinitely on a stalled installer-script download or on downloads performed by the installer itself when network transfer stops making progress.

## Why This Change Was Made

The OpenGrep install steps now download the pinned installer to a temporary file with bounded curl connection, transfer, and retry limits, execute it only after the download completes, and wrap the installer subprocess in an outer timeout. A workflow guard covers both the PR-diff and full precise scan workflows.

## User Impact

CI operators get bounded retry and failure behavior for the complete OpenGrep install path instead of a workflow step that can stall without a useful deadline.

## Evidence

Validated on current head b7600c6ca9895318bd519e1db2254921fd0bdf2b.

- GitHub `Real behavior proof` passed on current head b7600c6ca9895318bd519e1db2254921fd0bdf2b after the branch rebase.

- Stalled installer-script download proof with shortened local deadlines: a loopback server accepted 2 attempts and stalled each transfer; curl exited 28 after 7 seconds with partial installer bytes written to the temporary target, and no installer execution marker was observed.
- Stalled installer subprocess proof with shortened local deadline: a downloaded installer started and then slept; the outer timeout returned 124 after 2 seconds, and temporary installer cleanup was confirmed.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -- -t "downloads and bounds the OpenGrep installer before execution"` passed: 1 test passed, 80 skipped.
- `git diff --check upstream/main...HEAD` passed.