### PR TITLE
fix(e2e): bound OpenWebUI probe cleanup

### DIFF
--- a/scripts/e2e/lib/openwebui/http-probe.mjs
+++ b/scripts/e2e/lib/openwebui/http-probe.mjs
@@ -16,6 +16,22 @@ function resolveTimerTimeoutMs(valueMs, fallbackMs) {
   return Math.min(Math.max(Math.floor(value), 1), MAX_TIMER_TIMEOUT_MS);
 }
 
+async function awaitCancellationBeforeDeadline(cancel, signal) {
+  if (!cancel) {
+    return;
+  }
+  const cancellation = Promise.resolve().then(cancel).catch(() => undefined);
+  if (signal.aborted) {
+    return;
+  }
+  await Promise.race([
+    cancellation,
+    new Promise((resolve) => {
+      signal.addEventListener("abort", resolve, { once: true });
+    }),
+  ]);
+}
+
 export async function probeHttpStatus({
   url,
   expectedRaw = "200",
@@ -42,8 +58,11 @@ export async function probeHttpStatus({
       ? Boolean(res && res.status < 500)
       : res?.status === expectedStatus;
   } finally {
-    clearTimeout(timer);
-    await res?.body?.cancel?.().catch(() => undefined);
+    try {
+      await awaitCancellationBeforeDeadline(res?.body?.cancel?.bind(res.body), controller.signal);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }
 

--- a/scripts/e2e/lib/openwebui/http-probe.mjs
+++ b/scripts/e2e/lib/openwebui/http-probe.mjs
@@ -20,7 +20,9 @@ async function awaitCancellationBeforeDeadline(cancel, signal) {
   if (!cancel) {
     return;
   }
-  const cancellation = Promise.resolve().then(cancel).catch(() => undefined);
+  const cancellation = Promise.resolve()
+    .then(cancel)
+    .catch(() => undefined);
   if (signal.aborted) {
     return;
   }

--- a/test/scripts/e2e-helper-env-limits.test.ts
+++ b/test/scripts/e2e-helper-env-limits.test.ts
@@ -267,17 +267,19 @@ describe("e2e helper numeric env limits", () => {
         { status: 200 },
       )) as typeof fetch;
 
+    const timeoutMs = 100;
     const startedAt = Date.now();
     await expect(
       probeHttpStatus({
         fetchImpl,
-        timeoutMs: 25,
+        timeoutMs,
         url: "http://127.0.0.1/probe",
       }),
     ).resolves.toBe(true);
 
     expect(cancelCalled).toBe(true);
-    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    // Allow only scheduler jitter beyond the configured probe deadline.
+    expect(Date.now() - startedAt).toBeLessThan(timeoutMs + 100);
   });
 
   it("clamps oversized Open WebUI HTTP probe timers before scheduling", async () => {

--- a/test/scripts/e2e-helper-env-limits.test.ts
+++ b/test/scripts/e2e-helper-env-limits.test.ts
@@ -253,6 +253,33 @@ describe("e2e helper numeric env limits", () => {
     expect(canceled).toBe(true);
   });
 
+  it("keeps Open WebUI HTTP probe cleanup within the probe deadline", async () => {
+    const { probeHttpStatus } = await import("../../scripts/e2e/lib/openwebui/http-probe.mjs");
+    let cancelCalled = false;
+    const fetchImpl = (async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            cancelCalled = true;
+            return new Promise(() => {});
+          },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+
+    const startedAt = Date.now();
+    await expect(
+      probeHttpStatus({
+        fetchImpl,
+        timeoutMs: 25,
+        url: "http://127.0.0.1/probe",
+      }),
+    ).resolves.toBe(true);
+
+    expect(cancelCalled).toBe(true);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
   it("clamps oversized Open WebUI HTTP probe timers before scheduling", async () => {
     const { probeHttpStatus } = await import("../../scripts/e2e/lib/openwebui/http-probe.mjs");
     const fetchImpl = (async (_url: string, init: RequestInit) => {


### PR DESCRIPTION
AI-assisted: yes (Codex)

## What Problem This Solves

Fixes an issue where the Open WebUI HTTP probe could return a successful response but then remain stuck while awaiting response body cancellation cleanup.

## Why This Change Was Made

The probe still attempts to cancel the response body, but cleanup is now bounded by the probe's existing deadline signal so a never-settling body cancel cannot extend the probe indefinitely.

## User Impact

Open WebUI readiness checks keep their configured deadline even when response body cleanup does not settle.

## Evidence

Current head: `5deadb0617d8fecb05d34c87228ca572123e0ddd`

- Current-head [checks-node-compact-small-5](https://github.com/openclaw/openclaw/actions/runs/29649571567/job/88093521523) passed: 89 test files, 1,499 tests passed, and 13 skipped.
- Current-head [check-test-types](https://github.com/openclaw/openclaw/actions/runs/29649571567/job/88093521386) and [check-lint](https://github.com/openclaw/openclaw/actions/runs/29649571567/job/88093521367) passed.
- `git diff --check upstream/main...HEAD` passed for the current head.
