### PR TITLE
fix(e2e): bound CLI installer smoke fetch

### DIFF
--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -589,4 +589,7 @@ run_install_smoke_container --rm -t \
   -e OPENCLAW_NO_ONBOARD=1 \
   -e OPENCLAW_NO_PROMPT=1 \
   -e DEBIAN_FRONTEND=noninteractive \
-  "$NONROOT_IMAGE" -lc "curl -fsSL \"$CLI_INSTALL_URL\" | bash -s -- --set-npm-prefix --no-onboard"
+  "$NONROOT_IMAGE" -lc 'installer="$(mktemp)"
+trap '"'"'rm -f "$installer"'"'"' EXIT
+curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer" "$OPENCLAW_INSTALL_CLI_URL"
+bash "$installer" --set-npm-prefix --no-onboard'

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -591,5 +591,5 @@ run_install_smoke_container --rm -t \
   -e DEBIAN_FRONTEND=noninteractive \
   "$NONROOT_IMAGE" -lc 'installer="$(mktemp)"
 trap '"'"'rm -f "$installer"'"'"' EXIT
-curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer" "$OPENCLAW_INSTALL_CLI_URL"
+curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer" "$OPENCLAW_INSTALL_CLI_URL" &&
 bash "$installer" --set-npm-prefix --no-onboard'

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -662,6 +662,9 @@ describe("test-install-sh-docker", () => {
     expect(cliSmokeBlock).toContain(
       'curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer" "$OPENCLAW_INSTALL_CLI_URL"',
     );
+    expect(cliSmokeBlock).toMatch(
+      /curl -fsSL --connect-timeout 10 --max-time 120 -o "\$installer" "\$OPENCLAW_INSTALL_CLI_URL"\s*&&\s*bash "\$installer"/u,
+    );
     expect(cliSmokeBlock).toContain('bash "$installer" --set-npm-prefix --no-onboard');
     expect(cliSmokeBlock).not.toMatch(/curl[^\n]+\|\s*bash/u);
   });

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -653,6 +653,19 @@ describe("test-install-sh-docker", () => {
     expect(nonrootDockerfile).not.toMatch(/curl[^\n]+\|\s*bash/u);
   });
 
+  it("bounds the CLI installer non-root smoke download before execution", () => {
+    const wrapper = readFileSync(SCRIPT_PATH, "utf8");
+    const cliSmokeBlock = wrapper.slice(wrapper.indexOf("==> Run CLI installer non-root test"));
+
+    expect(cliSmokeBlock).toContain('installer="$(mktemp)"');
+    expect(cliSmokeBlock).toMatch(/trap .*rm -f "\$installer".* EXIT/u);
+    expect(cliSmokeBlock).toContain(
+      'curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer" "$OPENCLAW_INSTALL_CLI_URL"',
+    );
+    expect(cliSmokeBlock).toContain('bash "$installer" --set-npm-prefix --no-onboard');
+    expect(cliSmokeBlock).not.toMatch(/curl[^\n]+\|\s*bash/u);
+  });
+
   it("keeps shared install helpers parsing and verifying installed CLI versions", () => {
     const root = tempDirs.make("openclaw-install-helper-");
     const binDir = join(root, "bin");


### PR DESCRIPTION
AI-assisted: yes (Codex)

## What Problem This Solves

Fixes an issue where the CLI installer non-root Docker smoke could pipe an unbounded installer download directly into bash, allowing a stalled download to hang the smoke step.

## Why This Change Was Made

The smoke now downloads the CLI installer to a temporary file with curl connection and total-transfer deadlines, removes the temporary file on exit, and then runs the same installer arguments.

## User Impact

CLI installer smoke runs now fail within a bounded download window instead of waiting indefinitely before installer execution.

## Evidence

Validated on current head `38102f27036c40114b35c198fe120a7a07b7cb82`.

- Real Docker success path: ran the CLI installer download/execution sequence as the non-root `node` user in `node:22-bookworm` with `OPENCLAW_NO_ONBOARD=1` and `OPENCLAW_NO_PROMPT=1`; observed `OpenClaw installed (OpenClaw 2026.7.1 (2d2ddc4))`, `installed_path=/home/node/.openclaw/bin/openclaw`, and `OpenClaw 2026.7.1 (2d2ddc4)`.
- Real Docker forced-failure path: ran the same `curl ... -o "" ... && bash "" --set-npm-prefix --no-onboard` sequence against a container-local response that drops the connection after writing an installer marker; observed `curl_chain_status=52`, `marker=absent`, and `proof-failure-complete`, proving the installer is not executed after a failed download.
- `node --input-type=module -` source assertion passed: curl success gates bash installer execution and no `curl | bash` remains.
- `git diff --check origin/qingminglong/cli-installer-wrapper-curl-deadline...HEAD` passed.