### PR TITLE
fix(proxy-capture): time out stalled CONNECT upstreams

### DIFF
--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -5,7 +5,7 @@ import {
   createServer as createHttpServer,
   type IncomingMessage,
 } from "node:http";
-import net, { type AddressInfo } from "node:net";
+import net, { Socket, type AddressInfo, type NetConnectOpts } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -412,7 +412,23 @@ async function rawSlowGetThroughProxy(params: {
   });
 }
 
+async function openConnectClient(proxyUrl: string, connectTarget: string): Promise<Socket> {
+  const proxy = new URL(proxyUrl);
+  const socket = new Socket();
+  socket.on("error", () => {});
+  await new Promise<void>((resolve, reject) => {
+    socket.once("error", reject);
+    socket.connect(Number(proxy.port), proxy.hostname, () => {
+      socket.off("error", reject);
+      resolve();
+    });
+  });
+  socket.write(`CONNECT ${connectTarget} HTTP/1.1\r\nHost: ${connectTarget}\r\n\r\n`);
+  return socket;
+}
+
 afterEach(async () => {
+  vi.restoreAllMocks();
   await cleanupTestRoot();
 });
 
@@ -641,6 +657,86 @@ describe("startDebugProxyServer", () => {
     } finally {
       await proxy.stop();
       await origin.stop();
+    }
+  });
+
+  it("returns 504 when a CONNECT upstream opening attempt times out", async () => {
+    const settings = await makeSettings();
+    const stalledUpstream = new Socket();
+    let resolveConnectCalled!: (options: NetConnectOpts) => void;
+    const connectCalled = new Promise<NetConnectOpts>((resolve) => {
+      resolveConnectCalled = resolve;
+    });
+    vi.spyOn(net, "connect").mockImplementation(((options: NetConnectOpts) => {
+      resolveConnectCalled(options);
+      return stalledUpstream;
+    }) as typeof net.connect);
+    const proxy = await startDebugProxyServer({ settings });
+    let client: Socket | undefined;
+
+    try {
+      client = await openConnectClient(proxy.proxyUrl, "unreachable.example:443");
+      let response = "";
+      client.setEncoding("utf8");
+      client.on("data", (chunk) => {
+        response += chunk;
+      });
+      const clientClosed = new Promise<void>((resolve) => {
+        client.once("close", resolve);
+      });
+
+      await expect(connectCalled).resolves.toMatchObject({
+        host: "unreachable.example",
+        port: 443,
+        timeout: 30_000,
+      });
+      stalledUpstream.emit("timeout");
+      await clientClosed;
+
+      expect(response).toContain("504 Gateway Timeout");
+      expect(response).toContain("Gateway Timeout\n");
+      expect(stalledUpstream.destroyed).toBe(true);
+      expect(getDebugProxyCaptureStore().getSessionEvents(settings.sessionId, 10)).toContainEqual(
+        expect.objectContaining({
+          direction: "local",
+          errorText: "CONNECT upstream timed out after 30000ms",
+          kind: "error",
+          protocol: "connect",
+        }),
+      );
+    } finally {
+      client?.destroy();
+      stalledUpstream.destroy();
+      await proxy.stop();
+    }
+  });
+
+  it("removes the CONNECT opening timeout after the upstream socket connects", async () => {
+    const settings = await makeSettings();
+    const upstream = new Socket();
+    const disableTimeout = vi.spyOn(upstream, "setTimeout");
+    let resolveConnectCalled!: () => void;
+    const connectCalled = new Promise<void>((resolve) => {
+      resolveConnectCalled = resolve;
+    });
+    vi.spyOn(net, "connect").mockImplementation((() => {
+      resolveConnectCalled();
+      return upstream;
+    }) as typeof net.connect);
+    const proxy = await startDebugProxyServer({ settings });
+    let client: Socket | undefined;
+
+    try {
+      client = await openConnectClient(proxy.proxyUrl, "example.com:443");
+      await connectCalled;
+      upstream.emit("connect");
+
+      expect(disableTimeout).toHaveBeenCalledWith(0);
+      expect(upstream.listenerCount("timeout")).toBe(0);
+    } finally {
+      client?.destroy();
+      upstream.destroy();
+      await proxy.stop();
     }
   });
 });

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -5,7 +5,7 @@ import {
   createServer as createHttpServer,
   type IncomingMessage,
 } from "node:http";
-import net, { Socket, type AddressInfo, type NetConnectOpts } from "node:net";
+import net, { Socket, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -663,33 +663,35 @@ describe("startDebugProxyServer", () => {
   it("returns 504 when a CONNECT upstream opening attempt times out", async () => {
     const settings = await makeSettings();
     const stalledUpstream = new Socket();
-    let resolveConnectCalled!: (options: NetConnectOpts) => void;
-    const connectCalled = new Promise<NetConnectOpts>((resolve) => {
+    const setOpeningTimeout = vi.spyOn(stalledUpstream, "setTimeout");
+    let resolveConnectCalled!: (target: { hostname: string; port: number }) => void;
+    const connectCalled = new Promise<{ hostname: string; port: number }>((resolve) => {
       resolveConnectCalled = resolve;
     });
-    vi.spyOn(net, "connect").mockImplementation(((options: NetConnectOpts) => {
-      resolveConnectCalled(options);
+    vi.spyOn(net, "connect").mockImplementation(((port: number, hostname: string) => {
+      resolveConnectCalled({ hostname, port });
       return stalledUpstream;
     }) as typeof net.connect);
     const proxy = await startDebugProxyServer({ settings });
     let client: Socket | undefined;
 
     try {
-      client = await openConnectClient(proxy.proxyUrl, "unreachable.example:443");
+      const connectedClient = await openConnectClient(proxy.proxyUrl, "unreachable.example:443");
+      client = connectedClient;
       let response = "";
-      client.setEncoding("utf8");
-      client.on("data", (chunk) => {
-        response += chunk;
+      connectedClient.setEncoding("utf8");
+      connectedClient.on("data", (chunk) => {
+        response += chunk.toString();
       });
       const clientClosed = new Promise<void>((resolve) => {
-        client.once("close", resolve);
+        connectedClient.once("close", resolve);
       });
 
       await expect(connectCalled).resolves.toMatchObject({
-        host: "unreachable.example",
+        hostname: "unreachable.example",
         port: 443,
-        timeout: 30_000,
       });
+      expect(setOpeningTimeout).toHaveBeenCalledWith(30_000, expect.any(Function));
       stalledUpstream.emit("timeout");
       await clientClosed;
 
@@ -719,8 +721,13 @@ describe("startDebugProxyServer", () => {
     const connectCalled = new Promise<void>((resolve) => {
       resolveConnectCalled = resolve;
     });
-    vi.spyOn(net, "connect").mockImplementation((() => {
+    vi.spyOn(net, "connect").mockImplementation(((
+      _port: number,
+      _hostname: string,
+      onConnect: () => void,
+    ) => {
       resolveConnectCalled();
+      upstream.once("connect", onConnect);
       return upstream;
     }) as typeof net.connect);
     const proxy = await startDebugProxyServer({ settings });

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -701,7 +701,7 @@ describe("startDebugProxyServer", () => {
       expect(getDebugProxyCaptureStore().getSessionEvents(settings.sessionId, 10)).toContainEqual(
         expect.objectContaining({
           direction: "local",
-          errorText: "CONNECT upstream timed out after 30000ms",
+          errorText: "CONNECT upstream opening timed out after 30000ms of inactivity",
           kind: "error",
           protocol: "connect",
         }),

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -17,6 +17,8 @@ const DEBUG_PROXY_DIRECT_CONNECT_OVERRIDE =
   "OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY";
 const CAPTURE_BODY_PREVIEW_BYTES = 8192;
 const BAD_GATEWAY_BODY = "Bad Gateway\n";
+const DEBUG_PROXY_CONNECT_TIMEOUT_MS = 30_000;
+const GATEWAY_TIMEOUT_BODY = "Gateway Timeout\n";
 
 type BodyPreviewCapture = {
   chunks: Buffer[];
@@ -407,7 +409,34 @@ export async function startDebugProxyServer(params: {
       );
       return;
     }
-    const upstreamSocket = net.connect(port, hostname, () => {
+    const upstreamSocket = net.connect({
+      host: hostname,
+      port,
+      timeout: DEBUG_PROXY_CONNECT_TIMEOUT_MS,
+    });
+    const onUpstreamConnectTimeout = () => {
+      const message = `CONNECT upstream timed out after ${DEBUG_PROXY_CONNECT_TIMEOUT_MS}ms`;
+      recordProxyEvent({
+        protocol: "connect",
+        direction: "local",
+        kind: "error",
+        flowId,
+        host: hostname,
+        path: req.url ?? "",
+        errorText: message,
+      });
+      upstreamSocket.destroy();
+      clientSocket.end(
+        `HTTP/1.1 504 Gateway Timeout\r\nConnection: close\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: ${Buffer.byteLength(GATEWAY_TIMEOUT_BODY)}\r\n\r\n${GATEWAY_TIMEOUT_BODY}`,
+        () => clientSocket.destroy(),
+      );
+    };
+    upstreamSocket.once("timeout", onUpstreamConnectTimeout);
+    upstreamSocket.once("connect", () => {
+      // The deadline only protects opening the upstream socket. CONNECT tunnels
+      // are intentionally long-lived and must not inherit an idle timeout.
+      upstreamSocket.setTimeout(0);
+      upstreamSocket.off("timeout", onUpstreamConnectTimeout);
       clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
       if (head.length > 0) {
         upstreamSocket.write(head);

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -410,8 +410,8 @@ export async function startDebugProxyServer(params: {
       return;
     }
     const upstreamSocket = net.connect(port, hostname, () => {
-      // The deadline only protects opening the upstream socket. CONNECT tunnels
-      // are intentionally long-lived and must not inherit an idle timeout.
+      // This inactivity timeout only protects opening the upstream socket. CONNECT
+      // tunnels are intentionally long-lived and must not inherit it.
       upstreamSocket.setTimeout(0);
       upstreamSocket.off("timeout", onUpstreamConnectTimeout);
       clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
@@ -422,7 +422,7 @@ export async function startDebugProxyServer(params: {
       upstreamSocket.pipe(clientSocket);
     });
     function onUpstreamConnectTimeout() {
-      const message = `CONNECT upstream timed out after ${DEBUG_PROXY_CONNECT_TIMEOUT_MS}ms`;
+      const message = `CONNECT upstream opening timed out after ${DEBUG_PROXY_CONNECT_TIMEOUT_MS}ms of inactivity`;
       recordProxyEvent({
         protocol: "connect",
         direction: "local",

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -409,12 +409,19 @@ export async function startDebugProxyServer(params: {
       );
       return;
     }
-    const upstreamSocket = net.connect({
-      host: hostname,
-      port,
-      timeout: DEBUG_PROXY_CONNECT_TIMEOUT_MS,
+    const upstreamSocket = net.connect(port, hostname, () => {
+      // The deadline only protects opening the upstream socket. CONNECT tunnels
+      // are intentionally long-lived and must not inherit an idle timeout.
+      upstreamSocket.setTimeout(0);
+      upstreamSocket.off("timeout", onUpstreamConnectTimeout);
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) {
+        upstreamSocket.write(head);
+      }
+      clientSocket.pipe(upstreamSocket);
+      upstreamSocket.pipe(clientSocket);
     });
-    const onUpstreamConnectTimeout = () => {
+    function onUpstreamConnectTimeout() {
       const message = `CONNECT upstream timed out after ${DEBUG_PROXY_CONNECT_TIMEOUT_MS}ms`;
       recordProxyEvent({
         protocol: "connect",
@@ -430,20 +437,8 @@ export async function startDebugProxyServer(params: {
         `HTTP/1.1 504 Gateway Timeout\r\nConnection: close\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: ${Buffer.byteLength(GATEWAY_TIMEOUT_BODY)}\r\n\r\n${GATEWAY_TIMEOUT_BODY}`,
         () => clientSocket.destroy(),
       );
-    };
-    upstreamSocket.once("timeout", onUpstreamConnectTimeout);
-    upstreamSocket.once("connect", () => {
-      // The deadline only protects opening the upstream socket. CONNECT tunnels
-      // are intentionally long-lived and must not inherit an idle timeout.
-      upstreamSocket.setTimeout(0);
-      upstreamSocket.off("timeout", onUpstreamConnectTimeout);
-      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-      if (head.length > 0) {
-        upstreamSocket.write(head);
-      }
-      clientSocket.pipe(upstreamSocket);
-      upstreamSocket.pipe(clientSocket);
-    });
+    }
+    upstreamSocket.setTimeout(DEBUG_PROXY_CONNECT_TIMEOUT_MS, onUpstreamConnectTimeout);
     clientSocket.on("error", (error) => {
       recordProxyEvent({
         protocol: "connect",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a debug-proxy client opening an HTTP `CONNECT` tunnel to a blackholed or stalled TCP target could wait forever without a client response or a completed capture outcome.

## Why This Change Was Made

The raw CONNECT handler in `src/proxy-capture/proxy-server.ts` owns the accepted client socket, upstream `net.Socket`, capture record, and HTTP response. It now gives only the upstream-opening phase a fixed 30-second inactivity timeout. A timeout records a local capture error, explicitly destroys the upstream socket, and returns a complete `504 Gateway Timeout`; a successful connect disables the timer and removes its listener before tunnel piping.

This is the canonical owner-boundary fix. Node's `Socket.setTimeout()` is notification-only, so explicit destruction is required. It is an inactivity timeout, not a strict wall-clock deadline: Node can refresh it during DNS/connect transitions. The internal 30-second policy is accepted for diagnostic CONNECT openings; it does not add another config or environment surface, and established tunnels remain unbounded.

## User Impact

Debug-proxy CONNECT clients now receive a visible, recorded 504 instead of hanging indefinitely when an upstream opening stalls. Successfully established tunnels retain their existing long-lived behavior.

## Owner Review and Scope

- Root cause: `net.connect()` had no opening timeout; the handler could wait forever when neither `connect` nor `error` arrived.
- Architectural owner: the raw CONNECT lifecycle in `src/proxy-capture/proxy-server.ts`, reached by the debug proxy start/run commands in `src/cli/proxy-cli.runtime.ts`.
- Best-fix judgment: keep timeout, capture, socket teardown, and client response at that owner. Downstream guards, retries, or an additional configuration surface would duplicate policy or leave the pending socket alive.
- Cleanup: preserved the existing positional `net.connect(port, host, callback)` boundary; corrected deadline wording to the dependency's inactivity semantics; removed an opportunistic clean-client-close experiment after exact-head CI proved that a lean socket-listener-only repair was incomplete.
- Current-main compatibility: the single rebase preserved CONNECT capture-header redaction and intervening proxy changes.

### Sibling coverage and named follow-ups

- Managed-proxy rejection happens before the upstream socket opens and is covered independently.
- The success regression test proves the opening timer/listener is removed before the established tunnel is piped.
- Pre-connect clean client FIN cancellation needs a buffered pre-connect handoff because Node delivers CONNECT sockets paused/half-open; this is pre-existing lifecycle debt and a named follow-up, not a safe listener-only addition here.
- Fast pre-connect upstream errors still close without a framed 502, and ordinary HTTP/HTTPS `ClientRequest` openings have a different lifecycle. Both are pre-existing, separately owned follow-ups.

## Evidence

- Original contributor head: `ba9f802b206eac3d192f6a63a8ad395067f88e92`.
- Rebased once onto: `aa7cf44c75a123a2724f20b05cd10d66cf7e65f3`.
- GitHub base at final validation: `2dd0e9b950462acc1f24fa9b207e9b7b0b4bd36b`.
- Exact final head: `a1b5ade6b89575a7f00a8cbe78469c6dddba4938`.
- Exact-head secretless CI: [run 31165520616](https://github.com/openclaw/openclaw/actions/runs/31165520616) is green, including `openclaw/ci-gate`.
- Pinned-head autoreview: clean; no accepted/actionable findings, patch correct (0.98 confidence).
- Trusted-main `oxfmt` binary/config: both changed source files conform; no contributor script, test, or package hook was executed locally.
- Direct Node v24.15 source/API inspection verified notification-only timeout behavior, timer disable/removal, destruction cleanup, and suppression of late connects on destroyed sockets.
- Final-head tests cover complete 504 framing, capture error recording, upstream destruction, and removal of timeout state after a successful connection.

Earlier production-path proof exercised the same CONNECT timeout mechanics against a deliberately blackholed TCP opening and a separate established echo tunnel:

```text
blackholed CONNECT: HTTP/1.1 504 Gateway Timeout, complete response at about 30s
established tunnel: HTTP/1.1 200 Connection Established, still usable after 31.5s
capture: local CONNECT timeout error recorded
```

The final head rebases those mechanics, preserves current-main redaction, and clarifies the capture text as an opening inactivity timeout; the exact-head CI above validates the final source and regression tests. No new live-network execution is claimed for the final wording-only cleanup.

## Change Size

- Production: `+24/-0` in `src/proxy-capture/proxy-server.ts`. Positive growth is justified by the missing availability/visible-outcome capability at the socket lifecycle owner.
- Tests: `+104/-1` in `src/proxy-capture/proxy-server.test.ts` (net `+103`) for the failure and successful phase transitions.
- No docs, config, dependency, schema, or public API surface changes.
