### PR TITLE
improve(tests): speed Telegram webhook shutdown proof

### DIFF
--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -238,6 +238,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   clearTelegramRuntime();
   closeOpenClawStateDatabaseForTest();
   const stateDir = webhookStateDir;
@@ -1216,6 +1217,7 @@ describe("startTelegramWebhook", () => {
   });
 
   it("stops claimed completion retries when the webhook stops", async () => {
+    vi.useFakeTimers();
     let completeAttempts = 0;
     setTelegramRuntime({
       state: {
@@ -1253,7 +1255,7 @@ describe("startTelegramWebhook", () => {
     );
     await started.stop();
     const attemptsAfterStop = completeAttempts;
-    await sleep(400);
+    await vi.advanceTimersByTimeAsync(400);
 
     expect(completeAttempts).toBe(attemptsAfterStop);
   });


### PR DESCRIPTION
## What Problem This Solves

The Telegram webhook shutdown test spent a fixed 400 ms waiting in real time after the webhook had already stopped, slowing every run of that extension shard.

## Why This Change Was Made

Use Vitest fake timers for the completion-retry shutdown case and restore real timers in shared teardown. The test still waits for the retry to be scheduled, stops the webhook, advances beyond the retry window, and verifies that no additional completion attempt occurs.

## User Impact

No user-visible behavior change. Telegram test feedback is faster while retaining the same shutdown and retry coverage.

## Evidence

- Blacksmith Testbox `tbx_01kxp2e7n4ag1m1b5mr174svq2`: isolated five-run median improved from 486 ms to 158 ms (67% faster).
- `corepack pnpm test extensions/telegram/src/webhook.test.ts`: 35 tests passed.
- `corepack pnpm check:changed`: formatting, guards, extension test types, and extension lint passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.
- AI-assisted; implementation and proof reviewed.
