### PR TITLE
fix(ui): show dead reattached terminals as exited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI terminal restore:** keep persisted sessions whose gateway PTYs disappeared visible as exited tabs without replaying stale terminal output or opening replacement shells.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal restore:** keep persisted sessions whose gateway PTYs disappeared visible as exited tabs without replaying stale terminal output or opening replacement shells.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -406,6 +406,135 @@ describe("OpenClawTerminalPanel", () => {
     );
   });
 
+  it("restores a vanished persisted session as exited without replaying stale output", async () => {
+    sessionStorage.setItem("openclaw.terminal.sessions.v1", JSON.stringify(["gone-1"]));
+    const controller = createTerminalController();
+    createGhosttyTerminalMock.mockResolvedValue(controller);
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        if (method === "terminal.list") {
+          return { sessions: [] } as T;
+        }
+        if (method === "terminal.open") {
+          return terminalOpenResult("replacement-1") as T;
+        }
+        return {} as T;
+      },
+      addEventListener: () => () => {},
+    };
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+
+    panel.toggle();
+
+    await vi.waitFor(() => {
+      expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).toBe("exited");
+    });
+    expect(requests.filter((entry) => entry.method === "terminal.list")).toHaveLength(1);
+    expect(requests.some((entry) => entry.method === "terminal.attach")).toBe(false);
+    expect(requests.some((entry) => entry.method === "terminal.open")).toBe(false);
+    expect(controller.terminal.reset).not.toHaveBeenCalled();
+    expect(controller.write).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toBe("[]");
+  });
+
+  it("keeps a persisted session exited when it disappears during attach", async () => {
+    sessionStorage.setItem("openclaw.terminal.sessions.v1", JSON.stringify(["gone-1"]));
+    const controller = createTerminalController();
+    createGhosttyTerminalMock.mockResolvedValue(controller);
+    const requests: Array<{ method: string; params: unknown }> = [];
+    let listCalls = 0;
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        if (method === "terminal.list") {
+          listCalls += 1;
+          return {
+            sessions:
+              listCalls === 1
+                ? [{ ...terminalOpenResult("gone-1"), attached: false, createdAtMs: 1 }]
+                : [],
+          } as T;
+        }
+        if (method === "terminal.attach") {
+          throw new Error('unknown terminal session "gone-1"');
+        }
+        if (method === "terminal.open") {
+          return terminalOpenResult("replacement-1") as T;
+        }
+        return {} as T;
+      },
+      addEventListener: () => () => {},
+    };
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+
+    panel.toggle();
+
+    await vi.waitFor(() => {
+      expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).toBe("exited");
+    });
+    expect(requests.filter((entry) => entry.method === "terminal.attach")).toHaveLength(1);
+    expect(requests.filter((entry) => entry.method === "terminal.list")).toHaveLength(2);
+    expect(requests.some((entry) => entry.method === "terminal.open")).toBe(false);
+    expect(controller.terminal.reset).not.toHaveBeenCalled();
+    expect(controller.write).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toBe("[]");
+  });
+
+  it("does not mark a live persisted session exited after a transient attach failure", async () => {
+    sessionStorage.setItem("openclaw.terminal.sessions.v1", JSON.stringify(["live-1"]));
+    const controllers = [createTerminalController(), createTerminalController()] as const;
+    createGhosttyTerminalMock
+      .mockResolvedValueOnce(controllers[0])
+      .mockResolvedValueOnce(controllers[1]);
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        if (method === "terminal.list") {
+          return {
+            sessions: [{ ...terminalOpenResult("live-1"), attached: false, createdAtMs: 1 }],
+          } as T;
+        }
+        if (method === "terminal.attach") {
+          throw new Error("gateway temporarily unavailable");
+        }
+        if (method === "terminal.open") {
+          return terminalOpenResult("replacement-1") as T;
+        }
+        return {} as T;
+      },
+      addEventListener: () => () => {},
+    };
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+
+    panel.toggle();
+
+    await vi.waitFor(() => {
+      expect(requests.filter((entry) => entry.method === "terminal.open")).toHaveLength(1);
+    });
+    expect(requests.filter((entry) => entry.method === "terminal.list")).toHaveLength(2);
+    expect(requests.filter((entry) => entry.method === "terminal.attach")).toHaveLength(1);
+    expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).not.toBe("exited");
+    expect(controllers[0].write).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toBe(
+      JSON.stringify(["replacement-1"]),
+    );
+  });
+
   it("discovers and attaches detached sessions from a fresh browser profile", async () => {
     const controllers = [
       createTerminalController(),
@@ -778,7 +907,7 @@ describe("OpenClawTerminalPanel", () => {
     expect(controllers[1].write).not.toHaveBeenCalled();
   });
 
-  it("rebinds to a replacement client while availability stays true", async () => {
+  it("marks the old session exited when a replacement client no longer lists it", async () => {
     const controllers = [createTerminalController(), createTerminalController()] as const;
     createGhosttyTerminalMock
       .mockResolvedValueOnce(controllers[0])
@@ -819,12 +948,14 @@ describe("OpenClawTerminalPanel", () => {
     await panel.updateComplete;
 
     await vi.waitFor(() => {
-      expect(newRequests).toContain("terminal.open");
+      expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).toBe("exited");
     });
     expect(oldRequests.filter((method) => method === "terminal.open")).toHaveLength(1);
+    expect(newRequests).toEqual(["terminal.list"]);
     expect(oldUnsubscribe).toHaveBeenCalledOnce();
     expect(controllers[0].dispose).toHaveBeenCalledOnce();
     expect(createGhosttyTerminalMock).toHaveBeenCalledTimes(2);
+    expect(controllers[1].write).not.toHaveBeenCalled();
   });
 
   it("discards an async boot that finishes after disconnect and reconnect", async () => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -422,12 +422,18 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
           return;
         }
         const known = new Map(listed.map((session) => [session.sessionId, session]));
-        for (const sessionId of persisted.filter((id) => known.has(id))) {
-          await this.attachSession(
-            sessionId,
-            operation,
-            known.get(sessionId)?.owner?.startsWith("agent:") === true,
-          );
+        for (const sessionId of persisted) {
+          const session = known.get(sessionId);
+          if (!session) {
+            await this.restoreExitedSession(sessionId, operation);
+          } else {
+            await this.attachSession(
+              sessionId,
+              operation,
+              session.owner?.startsWith("agent:") === true,
+              true,
+            );
+          }
           if (!this.isTerminalOperationCurrent(operation)) {
             return;
           }
@@ -747,16 +753,19 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     }
   }
 
-  /** Reattaches one persisted session; returns false when it is gone. */
+  /** Reattaches one session and reports whether adoption succeeded. */
   private async attachSession(
     sessionId: string,
     operation: TerminalOperation,
     agentOwned = false,
+    confirmGoneOnFailure = false,
   ): Promise<boolean> {
     let createdTab: TerminalTabState | undefined;
+    let createdConnection: TerminalConnection | undefined;
     try {
       const boot = await this.bootTab(operation);
       createdTab = boot.tab;
+      createdConnection = boot.connection;
       const result = await boot.connection.attach(sessionId, this.tabSink(boot.tab));
       if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
         // A user close is deliberate; lifecycle cancellation leaves the existing
@@ -773,14 +782,58 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       this.adoptSession(boot.tab, result, agentOwned);
       return true;
     } catch {
-      // Session expired between list and attach (reaper race) or an older
-      // gateway: quietly drop the placeholder tab; restore falls back to a
-      // fresh session when nothing could be reattached.
+      const sessionGone =
+        confirmGoneOnFailure && createdConnection
+          ? await this.confirmRestoredSessionGone(createdConnection, sessionId, operation)
+          : false;
       if (createdTab && !createdTab.gatewaySessionId && this.tabs.includes(createdTab)) {
-        this.dropFailedTab(createdTab);
+        if (sessionGone) {
+          this.markRestoredSessionExited(createdTab, sessionId);
+        } else {
+          this.dropFailedTab(createdTab);
+        }
       }
       return false;
     }
+  }
+
+  private async confirmRestoredSessionGone(
+    connection: TerminalConnection,
+    sessionId: string,
+    operation: TerminalOperation,
+  ): Promise<boolean> {
+    try {
+      const sessions = await connection.list();
+      return (
+        this.isTerminalOperationCurrent(operation) &&
+        !sessions.some((session) => session.sessionId === sessionId)
+      );
+    } catch {
+      // A failed confirmation cannot turn a transport or authorization error
+      // into an authoritative terminal exit.
+      return false;
+    }
+  }
+
+  /** Keeps a dead persisted session visible without replaying bytes from a missing PTY. */
+  private async restoreExitedSession(
+    sessionId: string,
+    operation: TerminalOperation,
+  ): Promise<void> {
+    const boot = await this.bootTab(operation);
+    if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
+      if (this.tabs.includes(boot.tab)) {
+        boot.tab.cancelled = "lifecycle";
+        this.dropFailedTab(boot.tab);
+      }
+      return;
+    }
+    this.markRestoredSessionExited(boot.tab, sessionId);
+  }
+
+  private markRestoredSessionExited(tab: TerminalTabState, sessionId: string): void {
+    tab.gatewaySessionId = sessionId;
+    this.handleExit(tab.id, { reason: "disconnected", exitCode: null });
   }
 
   private handleExit(

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -12,6 +12,8 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const deadSessionScreenshotPath = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_SCREENSHOT?.trim();
+const deadSessionVideoDir = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_VIDEO_DIR?.trim();
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -126,6 +128,71 @@ describeControlUiE2e("embedded terminal document", () => {
       await closeControl.click();
       const terminalClose = await gateway.waitForRequest("terminal.close");
       expect(terminalClose.params).toEqual({ sessionId: "terminal-e2e" });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("restores a persisted session with no gateway PTY as exited", async () => {
+    const context = await browser.newContext({
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 800 },
+      ...(deadSessionVideoDir
+        ? { recordVideo: { dir: deadSessionVideoDir, size: { width: 1280, height: 800 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      (
+        window as Window & {
+          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: {
+            gatewayUrl: string;
+            token: string;
+          };
+        }
+      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+        gatewayUrl: "ws://gateway.example.test",
+        token: "test",
+      };
+      window.sessionStorage.setItem(
+        "openclaw.terminal.sessions.v1",
+        JSON.stringify(["terminal-dead-after-restart"]),
+      );
+    });
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["connect"],
+      featureMethods: ["terminal.open"],
+      methodResponses: {
+        "terminal.list": { sessions: [] },
+        "terminal.open": {
+          agentId: "main",
+          confined: false,
+          cwd: "/workspace",
+          sessionId: "replacement-terminal",
+          shell: "/bin/bash",
+        },
+      },
+      terminalEnabled: true,
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}?view=terminal`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("connect");
+      await gateway.resolveDeferred("connect");
+      await gateway.waitForRequest("terminal.list");
+      await page.waitForTimeout(250);
+
+      if (deadSessionScreenshotPath) {
+        await page.screenshot({ path: deadSessionScreenshotPath, fullPage: true });
+      }
+      const status = page.locator("openclaw-terminal-panel .tabstrip-tab__status");
+      await expect.poll(async () => await status.textContent(), { timeout: 5_000 }).toBe("exited");
+      expect(await gateway.getRequests("terminal.attach")).toHaveLength(0);
+      expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
+      expect(
+        await page.evaluate(() => window.sessionStorage.getItem("openclaw.terminal.sessions.v1")),
+      ).toBe("[]");
     } finally {
       await context.close();
     }


### PR DESCRIPTION
Closes #109280

Related: #108629, #109005

## What Problem This Solves

Fixes an issue where users reloading the Control UI after a Gateway restart would see a persisted terminal restored as a live shell, sometimes with garbled terminal output, even though its PTY no longer existed.

## Why This Change Was Made

Persisted terminal IDs are checked against the Gateway's authoritative session list before replay. Missing sessions stay visible as empty exited tabs, without attach, replacement-shell open, or replay. If a session disappears during attach, a confirming list distinguishes a real exit from a transient transport failure.

## User Impact

Dead terminal tabs now show `exited` after reload. Live sessions still reattach and replay normally; transient attach failures are not mislabeled as exits.

## Evidence

- Focused terminal panel suite: 22/22 passed, including list-miss, attach-race, transient attach failure, live replay, fresh open, and client rebind.
- Real Chromium mocked-Gateway E2E: 2/2 passed. The dead persisted ID rendered `shell 1 exited`; request capture showed no `terminal.attach` or `terminal.open`, session storage was pruned, and the terminal viewport stayed empty.
- Full changed gate passed: formatting, conflict markers, changelog attribution, i18n catalog, core-test and UI tsgo, and changed-file lint.
- Blacksmith Testbox exact-head proof: https://github.com/openclaw/openclaw/actions/runs/29524802899

Before: the missing persisted ID silently opened a replacement `bash` tab.

After: the same reload retained an empty `shell 1 exited` tab.

Before/after screenshots and recordings will be attached below.
