### PR TITLE
perf: complete multi-tool code-mode blocks in one exec turn instead of a wait per await

### DIFF
--- a/docs/reference/code-mode.md
+++ b/docs/reference/code-mode.md
@@ -307,12 +307,15 @@ type CodeModeFailedResult = {
 };
 ```
 
-`exec` returns `waiting` when the QuickJS VM suspends with resumable state that
-still needs a model-visible continuation; the result includes a `runId` for
-`wait`. Namespace bridge calls, including MCP namespace calls, are auto-drained
-inside the same `exec`/`wait` call while they are ready, so a compact code
-block can call an MCP tool without forcing one model tool call per namespace
-await.
+`exec` returns `waiting` when the guest suspends with resumable state that still
+needs a model-visible continuation — an explicit `yield_control(...)`, or a
+bridge tool call that has not resolved within the exec deadline. The result
+includes a `runId` for `wait`. Bridge tool calls — `tools.search`/`describe`/
+`call` and namespace calls, including MCP namespace calls — are auto-drained
+inside the same `exec`/`wait` call while they resolve within the deadline, so a
+compact code block that awaits several tools runs to completion in one model
+turn instead of forcing one model tool call per await. Restart-safe runs never
+auto-drain; their pending work still goes through the replay-safe checks.
 
 `exec` returns `completed` only when the guest VM has no pending work and the
 final value is JSON-compatible after OpenClaw's output adapter runs.

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -429,6 +429,46 @@ describe("Code Mode", () => {
     expect(compacted.tools[0]?.description).toContain("Tickets.currentAgent() returns undefined.");
   });
 
+  it("omits MCP and namespace guidance from the exec schema when the run catalog has neither", () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    const compacted = applyCodeModeCatalog({
+      tools: [...tools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const description = compacted.tools[0]?.description ?? "";
+    // Base tool guidance always stays; MCP/API and namespace guidance drop out so
+    // the model never probes an empty virtual API surface.
+    expect(description).toContain("`tools.search(query)`");
+    expect(description).not.toContain("API.list");
+    expect(description).not.toContain("MCP tools are available only through");
+    expect(description).not.toContain("Registered plugin namespaces are available");
+    expect(description).not.toContain("Registered namespace globals");
+  });
+
+  it("keeps MCP guidance in the exec schema when the run catalog has MCP tools", () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    const compacted = applyCodeModeCatalog({
+      tools: [
+        ...tools,
+        mcpTool({ name: "github__create_issue", serverName: "github", toolName: "create_issue" }),
+      ],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const description = compacted.tools[0]?.description ?? "";
+    expect(description).toContain("API.list(prefix?)");
+    expect(description).toContain("MCP tools are available only through");
+  });
+
   it("validates namespace registrations before exposing globals", () => {
     expect(() =>
       registerTestNamespace({
@@ -825,6 +865,152 @@ describe("Code Mode", () => {
     expect(ticket.execute).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves sequential bridge tool calls inline within one exec instead of a wait per call", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    // maxPendingToolCalls stays a per-batch concurrency cap; five sequential
+    // awaits must drain inline even with a cap of 2.
+    const config = {
+      tools: { codeMode: { enabled: true, maxPendingToolCalls: 2 } },
+    } as never;
+    const ctx = {
+      config,
+      runtimeConfig: config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    };
+    const codeModeTools = createCodeModeTools(ctx);
+    const ticket = pluginTool("fake_create_ticket", "Create a fake ticket");
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, ticket],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    // Five separate awaits would each suspend to the model under a wait-per-call
+    // design; inline resumption collapses them into a single completed exec so
+    // the model spends one turn instead of six.
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "codeModeTools[0] test invariant").execute(
+        "code-call-inline",
+        {
+          code: `
+            const ids = [];
+            for (let index = 0; index < 5; index += 1) {
+              const called = await tools.call("fake_create_ticket", { value: index });
+              ids.push(called.result.details.input.value);
+            }
+            return ids;
+          `,
+        },
+      ),
+    );
+
+    expect(details.status).toBe("completed");
+    expect(details.value).toEqual([0, 1, 2, 3, 4]);
+    expect(ticket.execute).toHaveBeenCalledTimes(5);
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it("fails fast without parking a suspended run when the exec call is aborted", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    // Long timeout so a missing abort short-circuit would block the whole test.
+    const config = {
+      tools: { codeMode: { enabled: true, timeoutMs: 30_000 } },
+    } as never;
+    const ctx = {
+      config,
+      runtimeConfig: config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    };
+    const codeModeTools = createCodeModeTools(ctx);
+    applyCodeModeCatalog({
+      tools: [
+        ...codeModeTools,
+        // A tool that never settles and ignores its abort signal; only the
+        // host-level abort race can free the cancelled exec.
+        pluginToolWithExecute("fake_stuck", "Stuck helper", async () => {
+          await new Promise<never>(() => {});
+          return null as never;
+        }),
+      ],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "codeModeTools[0] test invariant").execute(
+        "code-call-abort",
+        { code: "await tools.fake_stuck({}); return 'done';" },
+        controller.signal,
+      ),
+    );
+
+    // Abort drops the run instead of parking it; a cancelled call must not pin
+    // one of the process-global suspended-run slots until TTL expiry.
+    expect(details.status).toBe("failed");
+    expect(details.error).toBe("code mode execution aborted");
+    expect(details.code).toBe("aborted");
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it("terminates a running guest promptly when the exec call is aborted", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    // Long timeout so only the abort race can end the hostile loop quickly.
+    const config = {
+      tools: { codeMode: { enabled: true, timeoutMs: 30_000 } },
+    } as never;
+    const ctx = {
+      config,
+      runtimeConfig: config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    };
+    const codeModeTools = createCodeModeTools(ctx);
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), 200);
+    const startedAt = Date.now();
+    try {
+      const details = resultDetails(
+        await expectDefined(codeModeTools[0], "codeModeTools[0] test invariant").execute(
+          "code-call-abort-live",
+          { code: "while (true) {}" },
+          controller.signal,
+        ),
+      );
+      expect(details.status).toBe("failed");
+      expect(details.error).toBe("code mode execution aborted");
+      expect(details.code).toBe("aborted");
+    } finally {
+      clearTimeout(abortTimer);
+    }
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
   it("uses tools recovery guidance for guessed tool ids", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     const writeTool = pluginTool("write", "Write a file to the workspace");
@@ -926,6 +1112,7 @@ describe("Code Mode", () => {
         const rootApi = await MCP.$api();
         const api = await MCP.github.$api("createIssue", { schema: true });
         const apiFiles = await API.list("mcp");
+        const apiFilesTrailingSlash = await API.list("mcp/");
         const rootFile = await API.read("mcp/index.d.ts");
         const serverFile = await API.read("mcp/github.d.ts");
         const created = await MCP.github.createIssue({
@@ -953,6 +1140,7 @@ describe("Code Mode", () => {
         return {
           apiHeader: api.header,
           apiFilePaths: apiFiles.files.map((file) => file.path),
+          apiFilePathsTrailingSlash: apiFilesTrailingSlash.files.map((file) => file.path),
           listedServerFileBytes: apiFiles.files.find((file) => file.path === "mcp/github.d.ts").bytes,
           serverFileBytes: serverFile.bytes,
           serverFileContent: serverFile.content,
@@ -1004,6 +1192,7 @@ describe("Code Mode", () => {
       apiSchemaTitle: "object",
       apiHeader: expect.stringContaining("function createIssue("),
       apiFilePaths: ["mcp/index.d.ts", "mcp/github.d.ts"],
+      apiFilePathsTrailingSlash: ["mcp/index.d.ts", "mcp/github.d.ts"],
       listedServerFileBytes: expect.any(Number),
       serverFileBytes: expect.any(Number),
       serverFileContent: expect.stringContaining("Repository 名称"),

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -1259,8 +1259,25 @@ function createCodeModeExecDescription(
   catalog?: readonly ToolSearchCatalogEntry[],
 ): string {
   const namespacePrompt = describeCodeModeNamespacesForPrompt(ctx, catalog);
+  // A known run catalog with no MCP tools has no virtual API files, so drop the
+  // API.list/API.read/MCP guidance instead of luring the model into wasting exec
+  // turns probing an empty surface. An unknown catalog (initial tool creation,
+  // before compaction binds the run catalog) keeps the full guidance.
+  const catalogKnown = catalog !== undefined;
+  const hasMcp = catalog?.some((entry) => entry.source === "mcp") ?? false;
+  const mcpGuidance =
+    !catalogKnown || hasMcp
+      ? " Read TypeScript-style declaration files with `API.list(prefix?)` and `API.read(path)`. MCP tools are available only through the `MCP` namespace."
+      : "";
+  const namespaceGuidance =
+    !catalogKnown || namespacePrompt
+      ? " Registered plugin namespaces are available as direct globals and through `namespaces` when their required tools are visible in the run catalog."
+      : "";
   return (
-    'Run JavaScript or TypeScript in OpenClaw code mode. Use `return` to pass the final value back to the agent; awaited calls without a returned value complete as `null`. Node.js modules and `require`/`import` are NOT available; for any shell, file, network, or external action, use enabled catalog tools allowed by policy from inside your code: `tools.search(query)` to find catalog entries, `tools.describe(entry.id)` for the input schema, then `tools.call(entry.id, args)`. Read TypeScript-style declaration files with `API.list(prefix?)` and `API.read(path)`. MCP tools are available only through the `MCP` namespace. Registered plugin namespaces are available as direct globals and through `namespaces` when their required tools are visible in the run catalog. The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.' +
+    "Run JavaScript or TypeScript in OpenClaw code mode. Use `return` to pass the final value back to the agent; awaited calls without a returned value complete as `null`. Node.js modules and `require`/`import` are NOT available; for any shell, file, network, or external action, use enabled catalog tools allowed by policy from inside your code: `tools.search(query)` to find catalog entries, `tools.describe(entry.id)` for the input schema, then `tools.call(entry.id, args)`." +
+    mcpGuidance +
+    namespaceGuidance +
+    ' The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.' +
     (namespacePrompt ? `\n\n${namespacePrompt}` : "")
   );
 }
@@ -1283,8 +1300,20 @@ async function runExec(params: {
     throw new ToolInputError("code mode is disabled.");
   }
   const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config));
+  if (params.signal?.aborted) {
+    return {
+      status: "failed" as const,
+      error: "code mode execution aborted",
+      code: "aborted" as const,
+      output: [],
+      replaySafe: params.restartSafe,
+      telemetry: telemetry(runtime),
+    };
+  }
   const catalog = runtime.all({ includeMcp: false });
   const namespaceCatalog = runtime.namespaceEntries();
+  // Namespace scope factories are trusted plugin registrations; abort is
+  // re-checked at the worker boundary rather than racing this setup.
   const namespaceRuntime = await createCodeModeNamespaceRuntime(params.ctx, namespaceCatalog);
   const apiFiles = createCodeModeApiVirtualFiles(namespaceCatalog);
   let source: string;
@@ -1300,6 +1329,7 @@ async function runExec(params: {
       telemetry: telemetry(runtime),
     };
   }
+  const deadlineMs = Date.now() + config.timeoutMs;
   try {
     const result = normalizeCodeModeWorkerResult(
       await runCodeModeWorker(
@@ -1312,12 +1342,15 @@ async function runExec(params: {
           namespaces: namespaceRuntime.descriptors,
         },
         config.timeoutMs + 1000,
+        undefined,
+        params.signal,
       ),
     );
     return await settleCodeModeResult({
       result,
       output: result.output,
       replaySafe: params.restartSafe,
+      deadlineMs,
       parentToolCallId: params.toolCallId,
       ctx: params.ctx,
       config,
@@ -1338,22 +1371,52 @@ async function runExec(params: {
   }
 }
 
-async function waitForPending(pending: PendingBridgeState[], timeoutMs: number): Promise<boolean> {
+function usableResumeBudgetMs(deadlineMs: number, config: CodeModeConfig): number | undefined {
+  // VM restore costs tens of ms and counts against the guest interrupt budget;
+  // resuming with less than this floor converts an otherwise successful run
+  // into an immediate interrupt timeout, so callers park the snapshot instead.
+  const minimum = Math.min(250, Math.max(1, Math.floor(config.timeoutMs / 2)));
+  const remaining = deadlineMs - Date.now();
+  return remaining >= minimum ? remaining : undefined;
+}
+
+async function waitForPending(
+  pending: PendingBridgeState[],
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  // Abort wins even over already-settled requests: callers treat `false` as
+  // "do not resume the guest", which is what a cancelled exec/wait needs.
+  if (signal?.aborted) {
+    return false;
+  }
   const pendingPromises = pending.filter((entry) => !entry.settled).map((entry) => entry.promise);
   if (pendingPromises.length === 0) {
     return true;
   }
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
   try {
     return await Promise.race([
       Promise.all(pendingPromises).then(() => true),
       new Promise<boolean>((resolve) => {
         timer = setTimeout(() => resolve(false), timeoutMs);
       }),
+      ...(signal
+        ? [
+            new Promise<boolean>((resolve) => {
+              onAbort = () => resolve(false);
+              signal.addEventListener("abort", onAbort, { once: true });
+            }),
+          ]
+        : []),
     ]);
   } finally {
     if (timer) {
       clearTimeout(timer);
+    }
+    if (signal && onAbort) {
+      signal.removeEventListener("abort", onAbort);
     }
   }
 }
@@ -1367,34 +1430,59 @@ async function settleCodeModeResult(params: {
   config: CodeModeConfig;
   runtime: ToolSearchRuntime;
   namespaceRuntime: CodeModeNamespaceRuntime;
+  deadlineMs: number;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
   let result = params.result;
   const output = params.output;
-  let namespaceRounds = 0;
-  const settleDeadline = Date.now() + params.config.timeoutMs;
-  // Namespace calls are trusted synchronous-looking plugin helpers. Resolve
-  // them inline when possible so the model avoids unnecessary wait turns.
+  // One exec/wait call shares a single wall-clock deadline across its initial
+  // worker run and this inline settle phase, so auto-draining bridge calls
+  // cannot stack a second full `timeoutMs` budget on top of the run that
+  // produced them. The deadline is also the only bound on sequential drain
+  // rounds; maxPendingToolCalls stays a per-batch concurrency cap enforced in
+  // the worker.
+  const settleDeadline = params.deadlineMs;
+  const abortedResult = () => ({
+    status: "failed" as const,
+    error: "code mode execution aborted",
+    code: "aborted" as const,
+    output,
+    replaySafe: params.replaySafe,
+    telemetry: telemetry(params.runtime),
+  });
+  // Bridge tool calls (search/describe/call/namespace) run through the same
+  // policy-checked executor whether the model awaits them one at a time or in a
+  // batch, so resolve them inline within the exec deadline and resume the VM
+  // instead of forcing a `wait` round-trip per await. Only explicit
+  // yield_control hands control back to the model; a call that outlives the
+  // deadline still falls back to a suspended snapshot below.
   while (
     result.status === "waiting" &&
     result.pendingRequests.length > 0 &&
-    result.pendingRequests.every((request) => request.method === "namespace") &&
-    namespaceRounds < params.config.maxPendingToolCalls
+    result.pendingRequests.every((request) => request.method !== "yield")
   ) {
     if (params.replaySafe) {
-      return {
-        status: "failed" as const,
-        error: "restart-safe code mode cannot call plugin namespaces.",
-        code: "invalid_input" as const,
-        output,
-        replaySafe: true,
-        telemetry: telemetry(params.runtime),
-      };
+      // Replay-safe runs never inline-drain: namespace calls stay a hard error
+      // and other pending work falls through to the replay-safe snapshot check.
+      if (result.pendingRequests.every((request) => request.method === "namespace")) {
+        return {
+          status: "failed" as const,
+          error: "restart-safe code mode cannot call plugin namespaces.",
+          code: "invalid_input" as const,
+          output,
+          replaySafe: true,
+          telemetry: telemetry(params.runtime),
+        };
+      }
+      break;
     }
     const remainingMs = settleDeadline - Date.now();
     if (remainingMs <= 0) {
       break;
+    }
+    if (params.signal?.aborted) {
+      return abortedResult();
     }
     enforceSnapshotPayloadLimits({
       snapshotBytes: result.snapshotBytes,
@@ -1411,8 +1499,19 @@ async function settleCodeModeResult(params: {
         signal: params.signal,
         onUpdate: params.onUpdate,
       });
-      const ready = await waitForPending(pending, remainingMs);
-      if (!ready) {
+      const ready = await waitForPending(pending, remainingMs, params.signal);
+      const resumeBudgetMs = ready
+        ? usableResumeBudgetMs(settleDeadline, params.config)
+        : undefined;
+      if (!ready || resumeBudgetMs === undefined) {
+        // Abort drops the run instead of parking it: a suspended snapshot for a
+        // cancelled call could never be waited on and would pin one of the
+        // process-global active-run slots until TTL expiry.
+        if (params.signal?.aborted) {
+          return abortedResult();
+        }
+        // Parked rather than resumed: without a usable budget the restore alone
+        // would burn the remaining deadline and fail a recoverable run.
         return storeSnapshotState({
           pending,
           replaySafe: false,
@@ -1429,15 +1528,23 @@ async function settleCodeModeResult(params: {
       for (const entry of pending) {
         settledRequests.push(entry.settled ?? (await entry.promise));
       }
+      // The resumed guest inherits only the remaining shared budget as its
+      // QuickJS interrupt deadline; the extra 1000ms is host watchdog grace,
+      // not extra guest run time.
       result = normalizeCodeModeWorkerResult(
         await runCodeModeWorker(
           {
             kind: "resume",
             snapshotBytes: result.snapshotBytes,
-            config: params.config,
+            config: {
+              ...params.config,
+              timeoutMs: resumeBudgetMs,
+            },
             settledRequests,
           },
-          Math.max(1, settleDeadline - Date.now()) + 1000,
+          resumeBudgetMs + 1000,
+          undefined,
+          params.signal,
         ),
       );
     } finally {
@@ -1445,9 +1552,11 @@ async function settleCodeModeResult(params: {
     }
     output.push(...result.output);
     enforceOutputLimit(output, params.config);
-    namespaceRounds += 1;
   }
   if (result.status === "waiting") {
+    if (params.signal?.aborted) {
+      return abortedResult();
+    }
     const pendingReplaySafe = pendingBridgeRequestsReplaySafe(
       result.pendingRequests,
       params.runtime,
@@ -1517,9 +1626,33 @@ async function runWait(params: {
     throw new ToolInputError("code mode run is already being resumed.");
   }
   resumingRunIds.add(state.runId);
+  // One wait call shares a single wall-clock deadline across draining the prior
+  // pending calls, the resume worker, and the inline settle phase.
+  const deadlineMs = Date.now() + state.config.timeoutMs;
   try {
-    const ready = await waitForPending(state.pending, state.config.timeoutMs);
-    if (!ready) {
+    const ready = await waitForPending(
+      state.pending,
+      Math.max(1, deadlineMs - Date.now()),
+      params.signal,
+    );
+    const resumeBudgetMs = ready ? usableResumeBudgetMs(deadlineMs, state.config) : undefined;
+    if (!ready || resumeBudgetMs === undefined) {
+      // An aborted wait drops the suspended run: nothing will resume it, and
+      // parking it would pin a process-global active-run slot until TTL expiry.
+      if (params.signal?.aborted) {
+        activeRuns.delete(state.runId);
+        return {
+          status: "failed" as const,
+          error: "code mode execution aborted",
+          code: "aborted" as const,
+          output: state.output,
+          replaySafe: state.replaySafe,
+          telemetry: telemetry(state.runtime),
+        };
+      }
+      // Not ready, or ready without a usable resume budget: keep the snapshot
+      // so the next wait can resume with a fresh deadline instead of losing
+      // the run to a restore-only interrupt timeout.
       const pending = state.pending.filter((entry) => !entry.settled);
       return {
         status: "waiting" as const,
@@ -1537,15 +1670,22 @@ async function runWait(params: {
     for (const entry of state.pending) {
       settledRequests.push(entry.settled ?? (await entry.promise));
     }
+    // The resumed guest inherits only the remaining shared budget as its QuickJS
+    // interrupt deadline; the extra 1000ms is host watchdog grace only.
     const result = normalizeCodeModeWorkerResult(
       await runCodeModeWorker(
         {
           kind: "resume",
           snapshotBytes: state.snapshotBytes,
-          config: state.config,
+          config: {
+            ...state.config,
+            timeoutMs: resumeBudgetMs,
+          },
           settledRequests,
         },
-        state.config.timeoutMs + 1000,
+        resumeBudgetMs + 1000,
+        undefined,
+        params.signal,
       ),
     );
     const output = [...state.output, ...result.output];
@@ -1554,6 +1694,7 @@ async function runWait(params: {
       result,
       output,
       replaySafe: state.replaySafe,
+      deadlineMs,
       parentToolCallId: params.toolCallId,
       ctx: state.ctx,
       config: state.config,
@@ -1690,7 +1831,11 @@ export function applyCodeModeCatalog(params: {
     isVisibleControlTool: isCodeModeControlTool,
     shouldCatalogTool: (tool) => !isCodeModeControlTool(tool),
   });
-  const visibleCatalog = params.catalogRef?.current?.entries ?? [];
+  // Only the catalog ref reflects the freshly compacted run catalog. Without it
+  // the real catalog is registered under session keys and resolved later, so
+  // keep the catalog "unknown" (undefined) rather than an empty array that would
+  // wrongly strip MCP/namespace guidance from the exec description.
+  const visibleCatalog = params.catalogRef?.current?.entries;
   for (const tool of compacted.tools) {
     if (tool.name === CODE_MODE_EXEC_TOOL_NAME) {
       tool.description = createCodeModeExecDescription(

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -300,7 +300,10 @@ const CONTROLLER_SOURCE = String.raw`
   }
   const api = Object.freeze({
     list: async (prefix = "") => {
-      const normalizedPrefix = prefix == null || String(prefix).trim() === "" ? "" : normalizeApiPath(prefix);
+      // list takes a directory prefix, so tolerate a trailing slash (API.list("mcp/"))
+      // that read's exact-path normalizer would otherwise reject as an empty segment.
+      const rawPrefix = prefix == null ? "" : String(prefix).trim().replace(/\/+$/, "");
+      const normalizedPrefix = rawPrefix === "" ? "" : normalizeApiPath(rawPrefix);
       const files = [...apiFileMap.values()]
         .filter((file) => !normalizedPrefix || file.path === normalizedPrefix || file.path.startsWith(normalizedPrefix.replace(/\/?$/, "/")))
         .map((file) => Object.freeze({


### PR DESCRIPTION
Closes #109288

## What Problem This Solves

Fixes an issue where code mode agents would spend one `wait` tool round-trip per awaited bridge tool call: a guest block awaiting N `tools.search`/`describe`/`call` operations took N+1 model turns, making code mode ~3x slower and 2-4.5x more token-expensive than direct tool exposure on identical live tasks (measured across OpenAI, Anthropic, and Google). It also fixes three issues found while stress-testing the same surface: cancelled exec/wait calls kept hostile guest code running until the interrupt deadline and parked orphaned snapshots in the process-global 64-slot table until TTL; the exec description lured models into probing an empty `API`/`MCP` surface on runs with no MCP tools; and `API.list("mcp/")` rejected the trailing-slash prefix models actually type.

## Why This Change Was Made

Bridge tool calls run through the same policy-checked host executor whether the model awaits them one at a time or in a batch, so the host now resolves them inline within the exec deadline and resumes the QuickJS snapshot without a model turn - the contract namespace calls already had. That made the per-call budget the real boundary, so one shared wall-clock deadline now bounds the initial worker, inline drain rounds, and the resumed guest interrupt budget; a near-deadline settle parks the snapshot (recoverable via `wait`) instead of burning the remaining budget on VM restore; and abort terminates the worker, skips resume, and drops suspended runs. `maxPendingToolCalls` stays a per-batch concurrency cap and no longer doubles as a sequential-round cap.

## User Impact

Agents running with `tools.codeMode` complete multi-tool code blocks in one exec turn instead of a wait per await: live A/B across OpenAI/Anthropic/Google shows ~45% fewer turns, ~45% fewer input tokens, and ~50% lower latency at equal task success. Cancelling a run now stops guest code promptly and cannot exhaust the shared suspended-run capacity. No config changes; `waiting`/`wait` semantics remain for `yield_control()` and calls that outlive the deadline.

## Evidence

Live bench (real `Agent` runtime, 72-tool catalog with adversarial decoys, 4 validated tasks, code mode enabled, defaults):

| provider | code-mode turns before -> after | input tokens before -> after | latency before -> after | success |
|---|---|---|---|---|
| openai gpt-5.4-mini | 39 -> 22 | 28.5k -> 14.6k | 94s -> 48s | 4/4 -> equal (see A/B) |
| anthropic claude-sonnet-5 | 30 -> 18 | (prompt-cached) | 120s -> 56s | 4/4 -> 4/4 |
| google gemini-3-flash-preview | 48 -> 30 | 107.7k -> 59.6k | 115s -> 93s | 4/4 -> 4/4 |

Success-rate A/B on the weakest model (gpt-5.4-mini, 20 runs per arm): before 14/20 pass, avg 7.9 turns; after 15/20 pass, avg 4.3 turns - equal success within noise, turns nearly halved. Final live sanity with the landed code: Anthropic 4/4, Google 4/4, OpenAI 3/4 (the one miss is the model answering without checking sensors, a failure mode present in the before arm too).

Deterministic proof: `pnpm test src/agents/code-mode.test.ts src/agents/tool-search.test.ts src/agents/tool-search.stream-errors.test.ts test/scripts/mcp-code-mode-gateway-client.test.ts` - 136 tests green on Blacksmith Testbox (lease `tbx_01kxp6xtqf78ykjhtr0xryssjt`) on the rebased head, including all replay-safe and abort-classification tests that landed on main meanwhile, plus new tests: five sequential `tools.call` awaits complete in a single exec with `maxPendingToolCalls: 2`; a pre-aborted exec fails fast with no parked run; a live abort terminates a hostile `while(true)` guest promptly; `API.list("mcp/")` equals `API.list("mcp")`; exec description drops/keeps MCP guidance by actual catalog content. `pnpm tsgo` and `pnpm build` green on the same Testbox; `node scripts/report-test-temp-creations.mjs` green locally (the delegated warning-only lane cannot diff `origin/main...HEAD` on the Testbox's shallow sync - infra, not this change).

Reviewed with autoreview (codex gpt-5.6-sol, xhigh) through seven cycles until clean; review-driven fixes included the shared deadline, abort-drop semantics, the resume-budget floor, and not misreading a missing catalog ref as an empty catalog. The change was then re-ported onto current main - which had meanwhile gained `replaySafe` threading and an `aborted` failure code - preserving replay-safe no-drain semantics and reusing the existing abort classification; a fresh autoreview pass on the ported diff was clean, and the live sanity re-ran green (Anthropic 4/4, Google 4/4, OpenAI within its measured flake band).
