### PR TITLE
improve: prove Codex auth migration product flow

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1635,6 +1635,44 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("selects ordered Codex OAuth before an OpenAI API-key backup", async () => {
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    const accessToken = "test-access-token";
+    const authProfileStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:media-api": {
+          type: "api_key",
+          provider: "openai",
+          key: "test-api-key",
+        },
+        "openai:qa-oauth": {
+          type: "oauth",
+          provider: "openai",
+          access: accessToken,
+          refresh: "test-refresh",
+          expires: Date.UTC(2036, 0, 1),
+          accountId: "qa-codex-account",
+        },
+      },
+      order: { openai: ["openai:qa-oauth", "openai:media-api"] },
+    };
+
+    expect(resolveCodexAppServerAuthProfileId({ store: authProfileStore })).toBe("openai:qa-oauth");
+    await applyCodexAppServerAuthProfile({
+      client: { request } as never,
+      agentDir: "/tmp/openclaw-codex-auth-product-proof",
+      authProfileStore,
+    });
+
+    expect(request).toHaveBeenCalledWith("account/login/start", {
+      type: "chatgptAuthTokens",
+      accessToken,
+      chatgptAccountId: "qa-codex-account",
+      chatgptPlanType: null,
+    });
+  });
+
   it("does not select Codex profiles without inline OAuth credential material", () => {
     expect(
       resolveCodexAppServerAuthProfileId({

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -315,8 +315,6 @@ describe("qa scenario catalog", () => {
 
     expect(notApplicable).toStrictEqual(
       [
-        "auth-profile-codex-mixed-profiles",
-        "auth-profile-doctor-migration-safety",
         "codex-plugin-cold-install",
         "codex-plugin-pinned-new",
         "codex-plugin-pinned-old",
@@ -560,12 +558,7 @@ describe("qa scenario catalog", () => {
     expect(coldInstall.coverage?.secondary).toBeUndefined();
     expect(coldInstall.execution.kind).toBe("script");
 
-    const fixtureScenarioIds = [
-      "codex-plugin-pinned-old",
-      "codex-plugin-pinned-new",
-      "auth-profile-codex-mixed-profiles",
-      "auth-profile-doctor-migration-safety",
-    ];
+    const fixtureScenarioIds = ["codex-plugin-pinned-old", "codex-plugin-pinned-new"];
 
     for (const scenarioId of fixtureScenarioIds) {
       const scenario = readQaScenarioById(scenarioId);
@@ -578,9 +571,32 @@ describe("qa scenario catalog", () => {
       hostVersion: "2026.5.21",
       pluginRelation: "older",
     });
-    expect(readQaScenarioExecutionConfig("auth-profile-doctor-migration-safety")).toMatchObject({
-      matrixCells: ["oauth-only", "mixed-no-pin"],
+  });
+
+  it("routes the Codex doctor migration row through the product-backed Vitest", () => {
+    const scenario = readQaScenarioById("auth-profile-doctor-migration-safety");
+
+    expect(scenario.runtimeParityTier).toBeUndefined();
+    expect(scenario.runtimeParityUsage).toBeUndefined();
+    expect(scenario.execution).toMatchObject({
+      kind: "vitest",
+      path: "test/e2e/qa-lab/runtime/codex-auth-doctor-migration-product-proof.e2e.test.ts",
     });
+    expect(scenario.coverage?.primary).toContain("runtime.doctor-repair");
+    expect(scenario.coverage?.secondary).toContain("runtime.codex-plugin.auth");
+  });
+
+  it("routes the Codex mixed-profile row through the product-backed Vitest", () => {
+    const scenario = readQaScenarioById("auth-profile-codex-mixed-profiles");
+
+    expect(scenario.runtimeParityTier).toBeUndefined();
+    expect(scenario.runtimeParityUsage).toBeUndefined();
+    expect(scenario.execution).toMatchObject({
+      kind: "vitest",
+      path: "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
+    });
+    expect(scenario.coverage?.primary).toContain("runtime.codex-plugin.auth");
+    expect(scenario.coverage?.secondary).toContain("runtime.doctor-repair");
   });
 
   it("keeps the character eval scenario natural and task-shaped", () => {

--- a/qa/scenarios/runtime/auth-profile-codex-mixed-profiles.yaml
+++ b/qa/scenarios/runtime/auth-profile-codex-mixed-profiles.yaml
@@ -3,68 +3,27 @@ title: Codex auth profile mixed profiles
 scenario:
   id: auth-profile-codex-mixed-profiles
   surface: runtime
-  runtimeParityTier: standard
-  runtimeParityUsage:
-    expectation: not-applicable
-    reason: Local auth-selection fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.codex-plugin.auth
     secondary:
       - auth-profiles.provider-selection
-  objective: Verify mixed openai OAuth and openai API-key profile stores select the Codex OAuth profile for Codex app-server turns.
+      - runtime.doctor-repair
+  objective: Verify doctor repairs mixed legacy Codex OAuth and OpenAI API-key profiles into canonical SQLite state and the Codex auth bridge sends the selected OAuth profile to App Server.
   successCriteria:
     - The selected auth profile id is openai:qa-oauth.
     - The openai:media-api API-key profile is present but not selected.
-    - The fixture rejects the residual provider mismatch covered by issue #78499.
+    - Doctor removes the legacy JSON store after verifying its canonical per-agent SQLite import.
+    - The Gateway-backed Codex turn emits account/login/start with chatgptAuthTokens; evidence redacts token material.
   docsRefs:
     - docs/cli/doctor.md
+    - docs/plugins/codex-harness.md
   codeRefs:
-    - extensions/qa-lab/src/auth-profile.fixture.ts
-    - extensions/qa-lab/src/codex-plugin-lifecycle.test.ts
+    - src/commands/doctor-auth-flat-profiles.ts
+    - src/agents/auth-profiles/sqlite.ts
+    - extensions/codex/src/app-server/auth-bridge.ts
+    - test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
   execution:
-    kind: flow
-    summary: Exercise the auth-profile fixture for mixed OpenAI API-key and Codex OAuth stores.
-    config:
-      selectedProfileId: openai:qa-oauth
-      rejectedProfileId: openai:media-api
-
-flow:
-  steps:
-    - name: validates mixed-profile Codex auth selection
-      actions:
-        - set: auth
-          value:
-            expr: await qaImport("./auth-profile.fixture.js")
-        - set: tmpRoot
-          value:
-            expr: await fs.mkdtemp(path.join(env.gateway?.workspaceDir ?? "/tmp", "qa-codex-auth-"))
-        - try:
-            actions:
-              - call: auth.seedAuthProfiles
-                args:
-                  - mixed
-                  - ref: tmpRoot
-              - set: selection
-                value:
-                  expr: auth.resolveCodexAuthProfile(await auth.snapshotAuthProfiles(tmpRoot))
-              - assert:
-                  expr: "selection.status === 'ready'"
-                  message:
-                    expr: "`expected ready Codex auth selection, got ${JSON.stringify(selection)}`"
-              - assert:
-                  expr: "selection.profileId === config.selectedProfileId"
-                  message: mixed profiles must select openai OAuth
-              - assert:
-                  expr: "selection.profileId !== config.rejectedProfileId"
-                  message: codex profile must not equal openai api-key profile
-            finally:
-              - call: fs.rm
-                args:
-                  - ref: tmpRoot
-                  - recursive: true
-                    force: true
-        - assert:
-            expr: "config.selectedProfileId !== config.rejectedProfileId"
-            message: "codex profile must not equal openai api-key profile"
-      detailsExpr: "`selected=${selection.profileId} rejected=${config.rejectedProfileId}`"
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+    summary: Run the isolated doctor-to-SQLite-to-Gateway-to-Codex-App-Server auth product path.

--- a/qa/scenarios/runtime/auth-profile-doctor-migration-safety.yaml
+++ b/qa/scenarios/runtime/auth-profile-doctor-migration-safety.yaml
@@ -3,78 +3,23 @@ title: Codex doctor migration safety matrix
 scenario:
   id: auth-profile-doctor-migration-safety
   surface: runtime
-  runtimeParityTier: standard
-  runtimeParityUsage:
-    expectation: not-applicable
-    reason: Local doctor-migration fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.doctor-repair
     secondary:
       - runtime.codex-plugin.auth
-  objective: Reproduce the doctor-migration auth cells as an automated fixture matrix for Codex OAuth selection.
+  objective: Prove that the real doctor command migrates legacy Codex OAuth stores into canonical per-agent SQLite state.
   successCriteria:
-    - OAuth-only hosts select the openai OAuth profile and use the Codex harness.
-    - Mixed-profile hosts still select openai OAuth when an openai API-key profile exists.
+    - OAuth-only legacy stores become canonical openai OAuth profiles in per-agent SQLite.
+    - Mixed legacy stores keep the migrated OAuth profile ahead of an existing openai API-key profile.
+    - The obsolete JSON auth store is removed after each successful migration.
   docsRefs:
     - docs/cli/doctor.md
   codeRefs:
-    - extensions/qa-lab/src/auth-profile.fixture.ts
-    - extensions/qa-lab/src/codex-plugin.fixture.ts
-    - extensions/qa-lab/src/codex-plugin-lifecycle.test.ts
+    - src/commands/doctor-auth-flat-profiles.ts
+    - src/agents/auth-profiles/persisted.ts
+    - test/e2e/qa-lab/runtime/codex-auth-doctor-migration-product-proof.e2e.test.ts
   execution:
-    kind: flow
-    summary: Exercise the doctor migration matrix against Codex auth routing.
-    config:
-      matrixCells:
-        - oauth-only
-        - mixed-no-pin
-
-flow:
-  steps:
-    - name: validates doctor migration safety matrix
-      actions:
-        - set: auth
-          value:
-            expr: await qaImport("./auth-profile.fixture.js")
-        - set: plugin
-          value:
-            expr: await qaImport("./codex-plugin.fixture.js")
-        - forEach:
-            items:
-              ref: config.matrixCells
-            item: cell
-            actions:
-              - set: tmpRoot
-                value:
-                  expr: await fs.mkdtemp(path.join(env.gateway?.workspaceDir ?? "/tmp", `qa-codex-doctor-${cell}-`))
-              - set: profileShape
-                value:
-                  expr: "cell === 'oauth-only' ? 'oauth-only' : 'mixed'"
-              - try:
-                  actions:
-                    - call: plugin.seedCodexPluginAt
-                      args:
-                        - current
-                        - ref: tmpRoot
-                    - call: auth.seedAuthProfiles
-                      args:
-                        - ref: profileShape
-                        - ref: tmpRoot
-                    - set: result
-                      value:
-                        expr: "plugin.evaluateCodexPluginLifecycle({ plugin: await plugin.snapshotCodexPluginState(tmpRoot), auth: await auth.snapshotAuthProfiles(tmpRoot), hostVersion: plugin.CODEX_PLUGIN_CURRENT_VERSION, doctorFix: true })"
-                    - assert:
-                        expr: "result.status === 'ready' && result.selectedAuthProfileId === auth.QA_CODEX_OAUTH_PROFILE_ID && result.tokenRoute === 'codex-oauth'"
-                        message:
-                          expr: "`doctor matrix cell ${cell} failed Codex auth routing: ${JSON.stringify(result)}`"
-                  finally:
-                    - call: fs.rm
-                      args:
-                        - ref: tmpRoot
-                        - recursive: true
-                          force: true
-        - assert:
-            expr: "config.matrixCells.length === 2"
-            message: "expected two doctor migration cells"
-      detailsExpr: "`cells=${config.matrixCells.join(',')}`"
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/codex-auth-doctor-migration-product-proof.e2e.test.ts
+    summary: Run the real doctor migration over OAuth-only and mixed legacy stores, then inspect canonical SQLite state.

--- a/scripts/e2e/lib/codex-app-server-fixture.mjs
+++ b/scripts/e2e/lib/codex-app-server-fixture.mjs
@@ -1,0 +1,106 @@
+// Shared stdio transport and response builders for fake Codex App Server E2E processes.
+import fs from "node:fs";
+import readline from "node:readline";
+
+function writeMessage(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+export function createFakeInitializeResponse({ name, userAgent, version }) {
+  return {
+    protocolVersion: "2",
+    serverInfo: { name, version },
+    userAgent,
+  };
+}
+
+export function createFakeThreadStartResponse({ params, sessionId, threadId, version }) {
+  const now = Date.now();
+  const cwd = params?.cwd ?? process.cwd();
+  return {
+    thread: {
+      id: threadId,
+      sessionId,
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: now,
+      updatedAt: now,
+      status: { type: "idle" },
+      path: null,
+      cwd,
+      cliVersion: version,
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: params?.model ?? "gpt-5.6-luna",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd,
+    runtimeWorkspaceRoots: [],
+    instructionSources: [],
+    approvalPolicy: params?.approvalPolicy ?? "never",
+    approvalsReviewer: params?.approvalsReviewer ?? "user",
+    sandbox: { type: "dangerFullAccess" },
+    activePermissionProfile: null,
+    reasoningEffort: null,
+    multiAgentMode: "explicitRequestOnly",
+  };
+}
+
+export function runFakeCodexAppServer({ handlers, logMode = "requests", requestLog }) {
+  function appendLog(message) {
+    try {
+      fs.appendFileSync(requestLog, `${JSON.stringify(message)}\n`);
+      return true;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`fake Codex app-server request log write failed: ${detail}\n`);
+      return false;
+    }
+  }
+
+  function emit(message) {
+    if (logMode === "messages") {
+      appendLog(message);
+    }
+    writeMessage(message);
+  }
+
+  const input = readline.createInterface({ input: process.stdin });
+  input.on("line", (line) => {
+    if (!line.trim()) {
+      return;
+    }
+    const request = JSON.parse(line);
+    if (!appendLog(request)) {
+      if (request?.id !== undefined) {
+        writeMessage({
+          error: { message: "fake Codex app-server request log write failed" },
+          id: request.id,
+        });
+      }
+      return;
+    }
+
+    const { id, method, params } = request;
+    if (id === undefined) {
+      return;
+    }
+    const sendResult = (result) => emit({ id, result });
+    const notify = (notificationMethod, notificationParams) =>
+      emit({ method: notificationMethod, params: notificationParams });
+    const handler =
+      typeof method === "string" && Object.hasOwn(handlers, method) ? handlers[method] : undefined;
+    if (handler) {
+      handler({ id, notify, params, sendResult });
+      return;
+    }
+    sendResult({});
+  });
+}

--- a/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
+++ b/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
@@ -1,104 +1,50 @@
 // Fake Codex app server used by media-path E2E scenarios.
-import fs from "node:fs";
-import readline from "node:readline";
+import {
+  createFakeInitializeResponse,
+  createFakeThreadStartResponse,
+  runFakeCodexAppServer,
+} from "../codex-app-server-fixture.mjs";
 
 const requestLog =
   process.env.OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG ??
   "/tmp/openclaw-codex-media-path-app-server.jsonl";
 let turnCount = 0;
 
-function appendRequest(request) {
-  try {
-    fs.appendFileSync(requestLog, `${JSON.stringify(request)}\n`);
-    return true;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`fake Codex app-server request log write failed: ${message}\n`);
-    if (request?.id != null) {
-      sendError(request.id, `fake Codex app-server request log write failed: ${message}`);
-    }
-    return false;
-  }
-}
-
-function send(id, result) {
-  process.stdout.write(`${JSON.stringify({ id, result })}\n`);
-}
-
-function sendError(id, message) {
-  process.stdout.write(`${JSON.stringify({ error: { message }, id })}\n`);
-}
-
-const rl = readline.createInterface({ input: process.stdin });
-rl.on("line", (line) => {
-  if (!line.trim()) {
-    return;
-  }
-  const request = JSON.parse(line);
-  if (!appendRequest(request)) {
-    return;
-  }
-  const { id, method, params } = request;
-  if (method === "initialize") {
-    send(id, {
-      protocolVersion: "2",
-      serverInfo: { name: "openclaw-codex-media-path-e2e", version: "0.125.0" },
-      userAgent: "openclaw-codex-media-path-e2e/0.125.0 (Docker; test)",
-    });
-    return;
-  }
-  if (method === "thread/start") {
-    const now = Date.now();
-    send(id, {
-      thread: {
-        id: "thread-codex-media-path-e2e",
-        sessionId: "session-codex-media-path-e2e",
-        forkedFromId: null,
-        preview: "",
-        ephemeral: false,
-        modelProvider: "openai",
-        createdAt: now,
-        updatedAt: now,
-        cwd: params?.cwd ?? process.cwd(),
-        status: { type: "idle" },
-        path: null,
-        cliVersion: "0.125.0",
-        source: "unknown",
-        agentNickname: null,
-        agentRole: null,
-        gitInfo: null,
-        name: null,
-        turns: [],
-      },
-      model: params?.model ?? "gpt-5.6-luna",
-      modelProvider: "openai",
-      serviceTier: null,
-      cwd: params?.cwd ?? process.cwd(),
-      instructionSources: [],
-      approvalPolicy: params?.approvalPolicy ?? "never",
-      approvalsReviewer: params?.approvalsReviewer ?? "user",
-      sandbox: { type: "dangerFullAccess" },
-      permissionProfile: null,
-      reasoningEffort: null,
-    });
-    return;
-  }
-  if (method === "turn/start") {
-    turnCount += 1;
-    send(id, {
-      turn: {
-        id: `turn-codex-media-path-e2e-${turnCount}`,
-        status: "completed",
-        items: [
-          {
-            type: "agentMessage",
-            id: `msg-codex-media-path-e2e-${turnCount}`,
-            text: "CODEX_MEDIA_PATH_E2E_OK",
-          },
-        ],
-      },
-    });
-    return;
-  }
-  send(id, {});
+runFakeCodexAppServer({
+  requestLog,
+  handlers: {
+    initialize: ({ sendResult }) =>
+      sendResult(
+        createFakeInitializeResponse({
+          name: "openclaw-codex-media-path-e2e",
+          version: "0.125.0",
+          userAgent: "openclaw-codex-media-path-e2e/0.125.0 (Docker; test)",
+        }),
+      ),
+    "thread/start": ({ params, sendResult }) =>
+      sendResult(
+        createFakeThreadStartResponse({
+          params,
+          threadId: "thread-codex-media-path-e2e",
+          sessionId: "session-codex-media-path-e2e",
+          version: "0.125.0",
+        }),
+      ),
+    "turn/start": ({ sendResult }) => {
+      turnCount += 1;
+      sendResult({
+        turn: {
+          id: `turn-codex-media-path-e2e-${turnCount}`,
+          status: "completed",
+          items: [
+            {
+              type: "agentMessage",
+              id: `msg-codex-media-path-e2e-${turnCount}`,
+              text: "CODEX_MEDIA_PATH_E2E_OK",
+            },
+          ],
+        },
+      });
+    },
+  },
 });

--- a/scripts/e2e/lib/codex-media-path/jsonl-request-tail.d.mts
+++ b/scripts/e2e/lib/codex-media-path/jsonl-request-tail.d.mts
@@ -1,6 +1,6 @@
-export function createJsonlRequestTailer(
+export function createJsonlRequestTailer<T = unknown>(
   filePath: string,
   options?: { historyLimit?: number; maxReadBytes?: number; tailLineLimit?: number },
 ): {
-  read(): unknown[];
+  read(): T[];
 };

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1836,11 +1836,26 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/e2e/lib/fixtures/mock-openai-config.mjs", ["test/scripts/mock-openai-config.test.ts"]],
   ["scripts/e2e/lib/fixtures/plugins.mjs", ["test/scripts/fixture-plugin-commands.test.ts"]],
   [
+    "scripts/e2e/lib/codex-app-server-fixture.mjs",
+    [
+      "test/scripts/codex-media-path-client.test.ts",
+      "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
+    ],
+  ],
+  [
+    "scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs",
+    [
+      "test/scripts/codex-media-path-client.test.ts",
+      "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
+    ],
+  ],
+  [
     "scripts/e2e/lib/incremental-line-reader.mjs",
     [
       "test/scripts/incremental-line-reader.test.ts",
       "test/scripts/config-reload-log-scanner.test.ts",
       "test/scripts/codex-media-path-client.test.ts",
+      "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
     ],
   ],
   [
@@ -1985,6 +2000,10 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
       "extensions/openai/image-generation-provider.test.ts",
       "src/image-generation/openai-compatible-image-provider.test.ts",
     ],
+  ],
+  [
+    "test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs",
+    ["test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts"],
   ],
   [
     "scripts/e2e/lib/openai-chat-tools/client.mjs",

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -1374,5 +1374,61 @@ describe("maybeRepairOpenAICodexAuthProfileStores", () => {
       JSON.parse(fs.readFileSync(`${authPath}.openai-provider-unification.789.bak`, "utf8")),
     ).toEqual(legacy);
   });
+
+  it("canonicalizes a mixed Codex store before importing it into SQLite", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:media-api": {
+          type: "api_key",
+          provider: "openai",
+          key: "test-api-key",
+        },
+        "openai-codex:qa-oauth": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "test-access",
+          refresh: "test-refresh",
+          expires: Date.UTC(2036, 0, 1),
+          accountId: "qa-codex-account",
+        },
+      },
+      order: {
+        openai: ["openai:media-api"],
+        "openai-codex": ["openai-codex:qa-oauth"],
+      },
+    });
+
+    const providerRepair = await maybeRepairOpenAICodexAuthProfileStores({
+      cfg: {},
+      env: state.env,
+      now: () => 790,
+    });
+    expect(providerRepair.warnings).toStrictEqual([]);
+
+    const sqliteMigration = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: state.env,
+      prompter: makePrompter(true),
+      now: () => 791,
+    });
+    expect(sqliteMigration.warnings).toStrictEqual([]);
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toMatchObject({
+      profiles: {
+        "openai:media-api": {
+          type: "api_key",
+          provider: "openai",
+        },
+        "openai:qa-oauth": {
+          type: "oauth",
+          provider: "openai",
+          accountId: "qa-codex-account",
+        },
+      },
+      order: { openai: ["openai:qa-oauth", "openai:media-api"] },
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
@@ -1,0 +1,104 @@
+// Minimal Codex app-server fixture for the QA auth product proof.
+import {
+  createFakeInitializeResponse,
+  createFakeThreadStartResponse,
+  runFakeCodexAppServer,
+} from "../../../../scripts/e2e/lib/codex-app-server-fixture.mjs";
+
+const requestLog = process.env.OPENCLAW_QA_CODEX_AUTH_APP_SERVER_LOG;
+if (!requestLog) {
+  throw new Error("missing OPENCLAW_QA_CODEX_AUTH_APP_SERVER_LOG");
+}
+
+runFakeCodexAppServer({
+  requestLog,
+  logMode: "messages",
+  handlers: {
+    initialize: ({ sendResult }) =>
+      sendResult(
+        createFakeInitializeResponse({
+          name: "openclaw-qa-codex-auth",
+          version: "0.143.0",
+          userAgent: "openclaw/0.143.0 (test)",
+        }),
+      ),
+    "account/login/start": ({ params, sendResult }) => sendResult({ type: params?.type }),
+    "account/rateLimits/read": ({ sendResult }) =>
+      sendResult({
+        rateLimits: {
+          limitId: "codex",
+          limitName: "Codex",
+          primary: null,
+          secondary: null,
+          credits: null,
+          individualLimit: null,
+          spendControlReached: null,
+          planType: "pro",
+          rateLimitReachedType: null,
+        },
+        rateLimitsByLimitId: null,
+        rateLimitResetCredits: null,
+      }),
+    "account/read": ({ sendResult }) =>
+      sendResult({
+        account: {
+          type: "chatgpt",
+          email: "qa-codex-account@example.com",
+          planType: "pro",
+        },
+        requiresOpenaiAuth: true,
+      }),
+    "thread/start": ({ params, sendResult }) =>
+      sendResult(
+        createFakeThreadStartResponse({
+          params,
+          threadId: "thread-qa-codex-auth",
+          sessionId: "session-qa-codex-auth",
+          version: "0.143.0",
+        }),
+      ),
+    "turn/start": ({ notify, params, sendResult }) => {
+      const threadId = params?.threadId ?? "thread-qa-codex-auth";
+      const turnId = "turn-qa-codex-auth";
+      const message = {
+        type: "agentMessage",
+        id: "message-qa-codex-auth",
+        text: "QA_CODEX_AUTH_PRODUCT_PROOF_OK",
+      };
+      sendResult({
+        turn: {
+          id: turnId,
+          items: [],
+          itemsView: "notLoaded",
+          status: "inProgress",
+          error: null,
+          startedAt: null,
+          completedAt: null,
+          durationMs: null,
+        },
+      });
+      setImmediate(() => {
+        const completedAtMs = Date.now();
+        notify("item/completed", {
+          item: message,
+          threadId,
+          turnId,
+          completedAtMs,
+        });
+        notify("turn/completed", {
+          threadId,
+          turn: {
+            id: turnId,
+            items: [message],
+            itemsView: "full",
+            status: "completed",
+            error: null,
+            startedAt: Math.floor(completedAtMs / 1000),
+            completedAt: Math.floor(completedAtMs / 1000),
+            durationMs: 0,
+          },
+        });
+      });
+    },
+  },
+});

--- a/test/e2e/qa-lab/runtime/codex-auth-doctor-migration-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-doctor-migration-product-proof.e2e.test.ts
@@ -1,0 +1,63 @@
+// QA Lab product proof for the legacy Codex auth doctor migration matrix.
+import { afterEach, describe, it } from "vitest";
+import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../helpers/openclaw-test-instance.js";
+import {
+  type CodexAuthMigrationShape,
+  runCodexAuthDoctorMigrationProof,
+} from "./codex-auth-product-proof.test-support.js";
+
+type MigrationCell = {
+  name: string;
+  shape: CodexAuthMigrationShape;
+};
+
+const cells: MigrationCell[] = [
+  {
+    name: "oauth-only",
+    shape: "oauth-only",
+  },
+  {
+    name: "mixed-no-pin",
+    shape: "mixed",
+  },
+];
+
+let instance: OpenClawTestInstance | undefined;
+
+afterEach(async () => {
+  closeOpenClawAgentDatabasesForTest();
+  await instance?.cleanup();
+  instance = undefined;
+});
+
+describe("Codex doctor migration product proof", () => {
+  it.each(cells)(
+    "repairs the $name legacy store into canonical per-agent SQLite",
+    { timeout: 180_000 },
+    async ({ name, shape }) => {
+      instance = await createOpenClawTestInstance({
+        name: `qa-codex-doctor-${name}`,
+      });
+
+      const accountId = `qa-codex-${name}-account`;
+      const canonicalStore = await runCodexAuthDoctorMigrationProof(instance, {
+        accountId,
+        oauthAccess: "test-access",
+        shape,
+      });
+
+      console.log(
+        `[qa-codex-doctor-migration-product-proof] ${JSON.stringify({
+          cell: name,
+          canonicalProfileIds: Object.keys(canonicalStore?.profiles ?? {}).toSorted(),
+          openaiOrder: canonicalStore?.order?.openai,
+          legacyJsonRemoved: true,
+        })}`,
+      );
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -1,0 +1,262 @@
+// QA Lab Codex auth product proof exercises doctor, SQLite, Gateway, and app-server together.
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createJsonlRequestTailer } from "../../../../scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs";
+import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
+import { connectGatewayStatusClient, postJson } from "../../../helpers/gateway-e2e-harness.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../helpers/openclaw-test-instance.js";
+import { runCodexAuthDoctorMigrationProof } from "./codex-auth-product-proof.test-support.js";
+
+const oauthAccess = "test-oauth-access";
+const ACCOUNT_ID = "qa-codex-account";
+const MODEL = "openai/gpt-5.6-luna";
+const PRODUCT_OUTPUT = "QA_CODEX_AUTH_PRODUCT_PROOF_OK";
+const REQUEST_TIMEOUT_MS = 60_000;
+
+let instance: OpenClawTestInstance | undefined;
+
+type AppServerLogEntry = {
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+};
+
+type AppServerRequestLog = { read(): AppServerLogEntry[] };
+
+type GatewayHistory = Record<string, unknown> & { messages?: unknown[] };
+
+afterEach(async () => {
+  closeOpenClawAgentDatabasesForTest();
+  await instance?.cleanup();
+  instance = undefined;
+});
+
+function waitForRequest(requestLog: AppServerRequestLog, method: string) {
+  return vi.waitFor(
+    () => {
+      const request = requestLog.read().find((entry) => entry.method === method);
+      if (!request) {
+        throw new Error(`waiting for Codex app-server method ${method}`);
+      }
+      return request;
+    },
+    { interval: 25, timeout: REQUEST_TIMEOUT_MS },
+  );
+}
+
+async function waitForAssistantHistory(testInstance: OpenClawTestInstance, expected: string) {
+  const client = await connectGatewayStatusClient(testInstance);
+  try {
+    return await vi.waitFor(
+      async () => {
+        const result = await client.request<{
+          sessions?: Array<{ key?: unknown }>;
+        }>("sessions.list", { limit: 20 });
+        const sessionKeys = (result.sessions ?? []).flatMap((session) =>
+          typeof session.key === "string" ? [session.key] : [],
+        );
+        const histories = await Promise.allSettled(
+          sessionKeys.map(async (sessionKey) => ({
+            history: await client.request<GatewayHistory>(
+              "chat.history",
+              { agentId: "main", sessionKey, limit: 50 },
+              { timeoutMs: 5_000 },
+            ),
+            sessionKey,
+          })),
+        );
+        for (const entry of histories) {
+          if (entry.status === "fulfilled") {
+            const { history, sessionKey } = entry.value;
+            const messages = Array.isArray(history.messages) ? history.messages : [];
+            if (
+              messages.some(
+                (message) =>
+                  message !== null &&
+                  typeof message === "object" &&
+                  (message as { role?: unknown }).role === "assistant" &&
+                  JSON.stringify(message).includes(expected),
+              )
+            ) {
+              return { history, sessionKey };
+            }
+          }
+        }
+        const failed = histories.filter((entry) => entry.status === "rejected").length;
+        throw new Error(
+          `waiting for assistant history text ${expected}; ${failed}/${sessionKeys.length} history reads failed`,
+        );
+      },
+      { interval: 100, timeout: REQUEST_TIMEOUT_MS },
+    );
+  } finally {
+    client.stop();
+  }
+}
+
+describe("Codex auth product proof", () => {
+  it(
+    "repairs mixed legacy auth into SQLite and sends the selected OAuth profile to app-server",
+    { timeout: 180_000 },
+    async () => {
+      const appServerFixture = fileURLToPath(
+        new URL("./codex-auth-app-server.fixture.mjs", import.meta.url),
+      );
+      instance = await createOpenClawTestInstance({
+        name: "qa-codex-auth-product-proof",
+        env: {
+          OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+        },
+        config: {
+          plugins: {
+            enabled: true,
+            allow: ["codex"],
+            entries: {
+              codex: {
+                enabled: true,
+                config: {
+                  appServer: {
+                    mode: "yolo",
+                    command: process.execPath,
+                    args: [appServerFixture],
+                    requestTimeoutMs: REQUEST_TIMEOUT_MS,
+                    turnCompletionIdleTimeoutMs: REQUEST_TIMEOUT_MS,
+                  },
+                },
+              },
+            },
+          },
+          agents: {
+            defaults: {
+              model: { primary: MODEL, fallbacks: [] },
+              models: { [MODEL]: { agentRuntime: { id: "codex" } } },
+              workspace: "~/workspace",
+              skipBootstrap: true,
+              timeoutSeconds: 60,
+              sandbox: { mode: "off" },
+            },
+          },
+        },
+      });
+
+      const requestLog = instance.state.path("codex-auth-app-server.jsonl");
+      instance.env.OPENCLAW_QA_CODEX_AUTH_APP_SERVER_LOG = requestLog;
+      const appServerLog = createJsonlRequestTailer<AppServerLogEntry>(requestLog);
+      const canonicalStore = await runCodexAuthDoctorMigrationProof(instance, {
+        accountId: ACCOUNT_ID,
+        oauthAccess,
+        shape: "mixed",
+      });
+
+      await instance.startGateway();
+      const hook = await postJson(
+        `http://127.0.0.1:${instance.port}/hooks/agent`,
+        {
+          message: `Reply with ${PRODUCT_OUTPUT}.`,
+          name: "Codex auth product proof",
+          deliver: false,
+        },
+        { Authorization: `Bearer ${instance.hookToken}` },
+      );
+      expect(hook.status, JSON.stringify(hook.json)).toBe(200);
+
+      const loginRequest = await waitForRequest(appServerLog, "account/login/start");
+      const loginParams = loginRequest.params as Record<string, unknown>;
+      expect(loginParams.type).toBe("chatgptAuthTokens");
+      expect(loginParams.accessToken === oauthAccess).toBe(true);
+      expect(loginParams.chatgptAccountId).toBe(ACCOUNT_ID);
+      expect(loginParams.chatgptPlanType).toBeNull();
+
+      await waitForRequest(appServerLog, "turn/start");
+      const turnEntries = appServerLog.read();
+      const threadStartIndex = turnEntries.findIndex(
+        (request) => request.method === "thread/start",
+      );
+      const turnStartIndex = turnEntries.findIndex((request) => request.method === "turn/start");
+      expect(threadStartIndex).toBeGreaterThanOrEqual(0);
+      expect(turnStartIndex).toBeGreaterThan(threadStartIndex);
+      const completedTurn = await waitForAssistantHistory(instance, PRODUCT_OUTPUT);
+
+      const beforeUsage = appServerLog.read().length;
+      const status = await instance.cli(["status", "--usage", "--json", "--timeout", "60000"], {
+        timeoutMs: 120_000,
+      });
+      expect(status.code, status.stderr).toBe(0);
+      expect(status.stdout).toContain("qa-codex-account@example.com");
+
+      const usageEntries = appServerLog.read().slice(beforeUsage);
+      const usageLoginIndex = usageEntries.findIndex(
+        (request) => request.method === "account/login/start",
+      );
+      const accountReadIndex = usageEntries.findIndex(
+        (request) => request.method === "account/read",
+      );
+      expect(usageLoginIndex).toBeGreaterThanOrEqual(0);
+      expect(accountReadIndex).toBeGreaterThan(usageLoginIndex);
+
+      const usageLoginRequest = usageEntries[usageLoginIndex];
+      const usageLoginParams = usageLoginRequest?.params as Record<string, unknown>;
+      expect(usageLoginParams).toEqual({
+        type: "chatgptAuthTokens",
+        accessToken: oauthAccess,
+        chatgptAccountId: ACCOUNT_ID,
+        chatgptPlanType: null,
+      });
+
+      const accountReadRequest = usageEntries[accountReadIndex];
+      expect(accountReadRequest?.params).toEqual({});
+      const accountReadResponse = usageEntries.find(
+        (entry) => entry.id === accountReadRequest?.id && entry.result !== undefined,
+      );
+      expect(accountReadResponse?.result).toEqual({
+        account: {
+          type: "chatgpt",
+          email: "qa-codex-account@example.com",
+          planType: "pro",
+        },
+        requiresOpenaiAuth: true,
+      });
+
+      console.log(
+        `[qa-codex-auth-product-proof] ${JSON.stringify({
+          selectedProfileId: canonicalStore?.order?.openai?.[0],
+          canonicalStore: {
+            profileIds: Object.keys(canonicalStore?.profiles ?? {}).toSorted(),
+            order: canonicalStore?.order?.openai,
+            legacyJsonRemoved: true,
+          },
+          gatewayTurn: {
+            threadStartOrder: threadStartIndex,
+            turnStartOrder: turnStartIndex,
+            assistantOutput: PRODUCT_OUTPUT,
+            historySessionKey: completedTurn.sessionKey,
+            historySessionId: completedTurn.history.sessionId,
+          },
+          appServer: [
+            {
+              order: usageLoginIndex,
+              method: usageLoginRequest?.method,
+              params: {
+                type: usageLoginParams.type,
+                accessToken: "redacted",
+                chatgptAccountId: usageLoginParams.chatgptAccountId,
+                chatgptPlanType: usageLoginParams.chatgptPlanType,
+              },
+            },
+            {
+              order: accountReadIndex,
+              method: accountReadRequest?.method,
+              params: accountReadRequest?.params,
+              result: accountReadResponse?.result,
+            },
+          ],
+        })}`,
+      );
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.test-support.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.test-support.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs/promises";
+import { expect } from "vitest";
+import { loadPersistedAuthProfileStore } from "../../../../src/agents/auth-profiles/persisted.js";
+import type { OpenClawTestInstance } from "../../../helpers/openclaw-test-instance.js";
+
+const OAUTH_PROFILE_ID = "openai:qa-oauth";
+const LEGACY_OAUTH_PROFILE_ID = "openai-codex:qa-oauth";
+const API_KEY_PROFILE_ID = "openai:media-api";
+
+export type CodexAuthMigrationShape = "mixed" | "oauth-only";
+
+export async function runCodexAuthDoctorMigrationProof(
+  instance: OpenClawTestInstance,
+  params: {
+    accountId: string;
+    oauthAccess: string;
+    shape: CodexAuthMigrationShape;
+  },
+) {
+  const includeApiKey = params.shape === "mixed";
+  const expectedOrder = includeApiKey ? [OAUTH_PROFILE_ID, API_KEY_PROFILE_ID] : [OAUTH_PROFILE_ID];
+  const profiles: Record<string, Record<string, unknown>> = {
+    [LEGACY_OAUTH_PROFILE_ID]: {
+      type: "oauth",
+      provider: "openai-codex",
+      access: params.oauthAccess,
+      refresh: "test-refresh",
+      expires: Date.UTC(2036, 0, 1),
+      accountId: params.accountId,
+    },
+  };
+  const order: Record<string, string[]> = {
+    "openai-codex": [LEGACY_OAUTH_PROFILE_ID],
+  };
+  if (includeApiKey) {
+    profiles[API_KEY_PROFILE_ID] = {
+      type: "api_key",
+      provider: "openai",
+      key: "test-api-key",
+    };
+    order.openai = [API_KEY_PROFILE_ID];
+  }
+
+  const legacyAuthPath = await instance.state.writeText(
+    "agents/main/agent/auth-profiles.json",
+    `${JSON.stringify({ version: 1, profiles, order }, null, 2)}\n`,
+  );
+  const doctor = await instance.cli(["doctor", "--fix", "--yes", "--non-interactive"], {
+    timeoutMs: 120_000,
+  });
+  expect(doctor.code, doctor.stderr).toBe(0);
+
+  const canonicalStore = loadPersistedAuthProfileStore(instance.state.agentDir());
+  const expectedProfiles: Record<string, Record<string, unknown>> = {
+    [OAUTH_PROFILE_ID]: {
+      type: "oauth",
+      provider: "openai",
+      access: params.oauthAccess,
+      refresh: "test-refresh",
+      expires: Date.UTC(2036, 0, 1),
+      accountId: params.accountId,
+    },
+  };
+  if (includeApiKey) {
+    expectedProfiles[API_KEY_PROFILE_ID] = { type: "api_key", provider: "openai" };
+  }
+  expect(canonicalStore).toMatchObject({
+    profiles: expectedProfiles,
+    order: { openai: expectedOrder },
+  });
+  expect(canonicalStore?.profiles[LEGACY_OAUTH_PROFILE_ID]).toBeUndefined();
+  await expect(fs.access(legacyAuthPath)).rejects.toMatchObject({ code: "ENOENT" });
+  return canonicalStore;
+}

--- a/test/helpers/gateway-e2e-harness.ts
+++ b/test/helpers/gateway-e2e-harness.ts
@@ -142,7 +142,7 @@ export async function connectNode(
   return { client, nodeId };
 }
 
-async function connectStatusClient(
+export async function connectGatewayStatusClient(
   inst: GatewayInstance,
   timeoutMs = GATEWAY_CONNECT_STATUS_TIMEOUT_MS,
 ): Promise<GatewayClient> {
@@ -202,7 +202,7 @@ export async function waitForNodeStatus(
     let client: GatewayClient | undefined;
     while (Date.now() < deadline) {
       try {
-        client = await connectStatusClient(
+        client = await connectGatewayStatusClient(
           inst,
           Math.min(2_000, GATEWAY_CONNECT_STATUS_TIMEOUT_MS, Math.max(1, deadline - Date.now())),
         );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -375,6 +375,13 @@ describe("scripts/test-projects changed-target routing", () => {
         ["test/scripts/browser-cdp-snapshot.test.ts"],
       ],
       [
+        "scripts/e2e/lib/codex-app-server-fixture.mjs",
+        [
+          "test/scripts/codex-media-path-client.test.ts",
+          "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
+        ],
+      ],
+      [
         "scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs",
         ["test/scripts/codex-media-path-client.test.ts"],
       ],
@@ -384,7 +391,10 @@ describe("scripts/test-projects changed-target routing", () => {
       ],
       [
         "scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs",
-        ["test/scripts/codex-media-path-client.test.ts"],
+        [
+          "test/scripts/codex-media-path-client.test.ts",
+          "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
+        ],
       ],
       [
         "scripts/e2e/lib/codex-media-path/limits.mjs",
@@ -606,6 +616,7 @@ describe("scripts/test-projects changed-target routing", () => {
           "test/scripts/incremental-line-reader.test.ts",
           "test/scripts/config-reload-log-scanner.test.ts",
           "test/scripts/codex-media-path-client.test.ts",
+          "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
         ],
       ],
       [


### PR DESCRIPTION
## What Problem This Solves

The QA catalog claimed Codex auth-profile migration coverage through fixture-only lifecycle oracles. Those rows did not prove that `openclaw doctor --fix` repaired the real persisted store, that the selected OAuth profile reached Codex App Server, or that a production Gateway turn and account read completed.

## Why This Change Was Made

This retargets both owned auth scenarios to native product-backed Vitest flows. The tests run the real doctor command, inspect canonical per-agent SQLite state, execute a Codex-backed Gateway turn, verify durable `chat.history`, and exercise the production status/usage handoff through an upstream-shaped App Server fixture. The auth proof reuses the existing incremental JSONL tailer and Gateway client helper; both Codex fixtures now share one App Server transport/thread-response builder instead of maintaining parallel protocol copies.

AI-assisted: yes. The implementation was reviewed with the repository autoreview workflow and all actionable findings were resolved.

## User Impact

There is no runtime behavior change. Maintainers now get honest regression proof for legacy Codex OAuth migration, mixed-profile selection, completed Gateway execution, and the Codex account handoff instead of fixture-parity assertions.

## Evidence

- Exact head `b8d800f50142eaee157b0a448afca45ec08bcbb9`: fresh Blacksmith Testbox `tbx_01kxpfpkxy7k7jc43ap8aey0xp` passed repository-wide `oxfmt --check` across 22,760 files, all core/extension/root test-type projects, and the overlapping QA catalog 43/43. The byte-identical task commit was then rebased conflict-free onto the canonical blocker-fix base with stable patch ID `5a39495f204f11c4a5c85f1c8a8ec8e69eee9782` and an equal `git range-diff`.
- The unchanged task patch previously passed 370 focused tests across the shared media fixture, changed-target resolver, Gateway helper, doctor, Codex auth bridge, QA catalog, and both product E2Es; its path-scoped `check:changed` passed all-project typecheck, full core/extensions/scripts lint, formatting, dependency/boundary/migration guards, and runtime import-cycle checks.
- Redacted product evidence selected `openai:qa-oauth`, preserved canonical order and OAuth refresh/expiry fields, removed legacy JSON, completed `QA_CODEX_AUTH_PRODUCT_PROOF_OK` through Gateway history, then emitted `account/login/start` before `account/read` with `{}` and the upstream ChatGPT account response shape.
- `waitForAssistantHistory` concurrently checks every returned session key on every poll with bounded request timeouts and retains `deliver: false` production Gateway history proof.
- Knip discovers the spawned auth fixture through its static `new URL(..., import.meta.url)` reference and both fixtures import the shared App Server helper; production and full-tree unused-file scans report zero entries.
- Fresh Codex autoreview of the final oxfmt correction (`019f6cdb-ac02-7db2-9837-802cc47f4bd5`): clean, no accepted/actionable findings, confidence 1.
- The branch is based directly on `a70d583f2461a0313735d3e0331b9eafd1931a7b`, including canonical cleanup squash `1f5299da7e1636c625e3f77790fedb2deee5f78f`; the docs-sync declaration is singular and the product-backed scenario routing and fixture resolver mapping are preserved.
- Direct upstream contract inspection: `openai/codex@2e1607ee2fa8099a233df7437adee5f16a741905`, especially `codex-rs/app-server-protocol/src/protocol/v2/account.rs:500`, `thread.rs:170`, `turn.rs:166`, `turn.rs:395`, and `item.rs:1304`.
