### PR TITLE
fix: bound gateway config port

### DIFF
--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -74,6 +74,16 @@ describe("config validation allowed-values metadata", () => {
     }
   });
 
+  it("rejects gateway ports above the TCP port range", () => {
+    const result = validateConfigObjectRaw({ gateway: { port: 65_536 } });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = requireIssue(result.issues, "gateway.port");
+      expect(issue.message).toContain("(maximum: 65535)");
+    }
+  });
+
   it("surfaces specific sub-issue for invalid_union bindings errors instead of generic 'Invalid input'", () => {
     const result = validateConfigObjectRaw({
       bindings: [

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1125,7 +1125,7 @@ export const OpenClawSchema = z
     talk: TalkSchema.optional(),
     gateway: z
       .strictObject({
-        port: z.number().int().positive().optional(),
+        port: z.number().int().min(1).max(65_535).optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
         bind: z
           .union([


### PR DESCRIPTION
Related: #109293

## What Problem This Solves

Fixes an issue where `gateway.port` accepted values above the valid TCP port range during config validation.

## Why This Change Was Made

The main Gateway listener port now uses the same `1..65535` bound already used for remote gateway ports and runtime TCP parsing. This makes invalid config fail early instead of being accepted and later ignored by port resolution.

This bug report and fix proposal are meant to give the OpenClaw team a concrete reproduction and a reviewable patch so maintainers can choose the right direction. It is not intended to bypass maintainer judgment.

## User Impact

Users get a clear config validation error for invalid Gateway ports rather than a config value that silently falls back at runtime.

## Evidence

Focused validation probe after the fix:

```text
node --import tsx -e "import { validateConfigObjectRaw } from './src/config/validation.ts'; console.log(JSON.stringify(validateConfigObjectRaw({gateway:{port:65536}}), null, 2));"

{
  "ok": false,
  "issues": [
    {
      "path": "gateway.port",
      "message": "Too big: expected number to be <=65535 (maximum: 65535)"
    }
  ]
}
```

Focused tests:

```text
node scripts/run-vitest.mjs src/config/validation.allowed-values.test.ts src/config/paths.test.ts

[test] passed 1 Vitest shard in 11.65s
```
