### PR TITLE
chore(plugin-sdk): refresh merged API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f47ce0245855b3e89eba5cf87c7f155dd3b74582d5e47f933abb0eda32b3c31f  plugin-sdk-api-baseline.json
-085aaa0b5c98b604bb0463fb49a63e9d1f2ebb64e979647b33bb90c0534497b7  plugin-sdk-api-baseline.jsonl
+739fe620027bad069221aef1e6ec68bef0448c31a1573f70802a461b212c3d7d  plugin-sdk-api-baseline.json
+08eb0ae2bd2c3b32e04661cde03260aa97462ba64a4944307a0bdf98f4f98a75  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
Related: #109226, #108776, #106840

AI-assisted: Yes (Codex). I understand the one-file generated-hash repair and verified its source contract and provenance.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where current-main changed-file validation fails the Plugin SDK API baseline check because the committed JSON and JSONL hashes do not match the authoritative generated contract.

## Why This Change Was Made

Refreshes only the tracked Plugin SDK API hash statefile after proving the generator is deterministic and the public export contract is correct. The stale state resulted from valid public declaration changes landing on main while #109226 generated its hash from an older base; no SDK exports or generator behavior change here.

## User Impact

Maintainers and contributors can run the Plugin SDK API baseline and changed-file gates successfully again. There is no user-visible runtime or Plugin SDK API behavior change.

## Evidence

- Before, `corepack pnpm plugin-sdk:api:check` failed on exact main `63b0cac9f08357176adccb1b99571f6bcea2e971` with committed hashes `f47ce024...` / `085aaa0b...`; generation produced `739fe620...` / `08eb0ae2...` twice identically.
- #109226 base `1eda44e...` and head `681c90c...` each regenerate exactly to their committed hashes. Its squash merge combined the head hash with two newer-main declaration changes: approval history attribution from #108776 and CLI backend dispatch eligibility from #106840.
- Trusted Testbox `tbx_01kxp4yxs0rb09wpga5y0wb75b`: `corepack pnpm plugin-sdk:api:check`, `corepack pnpm plugin-sdk:surface:check`, and classified `corepack pnpm check:changed` passed. Run: https://github.com/openclaw/openclaw/actions/runs/29526446678
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, no accepted/actionable findings.
