### PR TITLE
refactor(daemon): restore restart health line budgets

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -1,6 +1,7 @@
 // Daemon restart health tests cover health checks after daemon restart operations.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayService } from "../../daemon/service.js";
+import type { GatewayLockIdentity } from "../../infra/gateway-lock.js";
 import type { PortUsage } from "../../infra/ports.js";
 
 type PortListenerKind = ReturnType<typeof import("../../infra/ports.js").classifyPortListener>;
@@ -89,6 +90,24 @@ function firstCallArg(mock: { mock: { calls: unknown[][] } }): unknown {
     throw new Error("Expected first mock call");
   }
   return call[0];
+}
+
+const previousGatewayLockIdentity: GatewayLockIdentity = {
+  pid: 4200,
+  ownerId: "gateway-owner-old",
+  createdAt: "2026-07-16T12:00:00.000Z",
+  port: 18789,
+};
+
+function mockGatewayLockReplacement(overrides: Partial<GatewayLockIdentity> = {}) {
+  const previousLockIdentity = { ...previousGatewayLockIdentity };
+  readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
+    ...previousLockIdentity,
+    ownerId: "gateway-owner-new",
+    createdAt: "2026-07-16T12:00:01.000Z",
+    ...overrides,
+  });
+  return previousLockIdentity;
 }
 
 async function inspectGatewayRestartWithSnapshot(params: {
@@ -998,17 +1017,7 @@ describe("inspectGatewayRestart", () => {
       close: null,
       server: { version: "2026.7.16", connId: "gateway" },
     });
-    const previousLockIdentity = {
-      pid: 4200,
-      ownerId: "gateway-owner-old",
-      createdAt: "2026-07-16T12:00:00.000Z",
-      port: 18789,
-    };
-    readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
-      ...previousLockIdentity,
-      ownerId: "gateway-owner-new",
-      createdAt: "2026-07-16T12:00:01.000Z",
-    });
+    const previousLockIdentity = mockGatewayLockReplacement();
 
     const { waitForGatewayHealthyListener } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyListener({
@@ -1041,18 +1050,7 @@ describe("inspectGatewayRestart", () => {
         ok: false,
         close: { code: 1008, reason: "device identity required" },
       });
-      const previousLockIdentity = {
-        pid: 4200,
-        ownerId: "gateway-owner-old",
-        createdAt: "2026-07-16T12:00:00.000Z",
-        port: 18789,
-      };
-      readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
-        ...previousLockIdentity,
-        pid: 4300,
-        ownerId: "gateway-owner-new",
-        createdAt: "2026-07-16T12:00:01.000Z",
-      });
+      const previousLockIdentity = mockGatewayLockReplacement({ pid: 4300 });
 
       const { waitForGatewayHealthyListener } = await import("./restart-health.js");
       const snapshot = await waitForGatewayHealthyListener({
@@ -1075,17 +1073,7 @@ describe("inspectGatewayRestart", () => {
       listeners: [],
       hints: [],
     });
-    const previousLockIdentity = {
-      pid: 4200,
-      ownerId: "gateway-owner-old",
-      createdAt: "2026-07-16T12:00:00.000Z",
-      port: 18789,
-    };
-    readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
-      ...previousLockIdentity,
-      ownerId: "gateway-owner-new",
-      createdAt: "2026-07-16T12:00:01.000Z",
-    });
+    const previousLockIdentity = mockGatewayLockReplacement();
 
     const { waitForGatewayHealthyListener } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyListener({

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -23,6 +23,11 @@ import {
 } from "../../infra/startup-migration-checkpoint.js";
 import { sleep } from "../../utils.js";
 import { waitForGatewayLockReplacement } from "./restart-lock-replacement.js";
+import {
+  allListenersOwnedByRuntimePid,
+  hasListenerAttributionGap,
+  listenerOwnedByRuntimePid,
+} from "./restart-port-ownership.js";
 export { terminateStaleGatewayPids } from "./restart-stale-pids.js";
 
 const DEFAULT_RESTART_HEALTH_TIMEOUT_MS = 60_000;
@@ -76,24 +81,6 @@ type GatewayRestartProbeAuth = {
   token?: string;
   password?: string;
 };
-
-function hasListenerAttributionGap(portUsage: PortUsage): boolean {
-  // lsof/netstat may report a busy port without a PID; keep that distinct from a free port.
-  if (portUsage.status !== "busy" || portUsage.listeners.length > 0) {
-    return false;
-  }
-  if (portUsage.errors?.length) {
-    return true;
-  }
-  return portUsage.hints.some((hint) => hint.includes("process details are unavailable"));
-}
-
-function listenerOwnedByRuntimePid(params: {
-  listener: PortUsage["listeners"][number];
-  runtimePid: number;
-}): boolean {
-  return params.listener.pid === params.runtimePid || params.listener.ppid === params.runtimePid;
-}
 
 function looksLikeAuthClose(code: number | undefined, reason: string | undefined): boolean {
   if (code !== 1008) {
@@ -322,13 +309,7 @@ async function inspectGatewayPortHealth(params: {
     const expectedListenerPid = params.expectedListenerPid;
     const listenerOwnershipVerified =
       expectedListenerPid !== undefined &&
-      portUsage.listeners.length > 0 &&
-      portUsage.listeners.every((listener) =>
-        listenerOwnedByRuntimePid({
-          listener,
-          runtimePid: expectedListenerPid,
-        }),
-      );
+      allListenersOwnedByRuntimePid(portUsage.listeners, expectedListenerPid);
     try {
       healthy = (
         await confirmGatewayReachable({

--- a/src/cli/daemon-cli/restart-port-ownership.ts
+++ b/src/cli/daemon-cli/restart-port-ownership.ts
@@ -1,0 +1,29 @@
+import type { PortUsage } from "../../infra/ports.js";
+
+export function hasListenerAttributionGap(portUsage: PortUsage): boolean {
+  // lsof/netstat may report a busy port without a PID; keep that distinct from a free port.
+  if (portUsage.status !== "busy" || portUsage.listeners.length > 0) {
+    return false;
+  }
+  if (portUsage.errors?.length) {
+    return true;
+  }
+  return portUsage.hints.some((hint) => hint.includes("process details are unavailable"));
+}
+
+export function listenerOwnedByRuntimePid(params: {
+  listener: PortUsage["listeners"][number];
+  runtimePid: number;
+}): boolean {
+  return params.listener.pid === params.runtimePid || params.listener.ppid === params.runtimePid;
+}
+
+export function allListenersOwnedByRuntimePid(
+  listeners: PortUsage["listeners"],
+  runtimePid: number,
+): boolean {
+  return (
+    listeners.length > 0 &&
+    listeners.every((listener) => listenerOwnedByRuntimePid({ listener, runtimePid }))
+  );
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Restores the repository lint gate after the restart-health implementation and test crossed their configured max-lines budgets, leaving current `main` and unrelated PRs unable to complete CI.

## Why This Change Was Made

Moves the reusable port-listener ownership predicates into their own daemon helper and deduplicates the repeated gateway-lock fixture setup. Runtime branches and assertions remain unchanged; the affected files return below their existing budgets without suppressions or relaxed limits.

## User Impact

No user-visible behavior change. Maintainer CI and PR prepare flows can complete again.

## Evidence

- Current `main` failure: https://github.com/openclaw/openclaw/actions/runs/29525622395/job/87714264286
- Focused `restart-health.test.ts`: 62/62 passed.
- Targeted oxfmt and oxlint: clean; both former max-lines errors removed.
- Changed gate: conflict, max-lines ratchet, attribution, wildcard, duplicate, dependency, and formatting lanes passed. The later plugin-SDK baseline failure is existing `main` drift unrelated to this refactor.
- Fresh autoreview: clean, 0.98.
