### PR TITLE
fix: reject malformed bracket config paths

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3156,6 +3156,15 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 
+    it("rejects non-delimited text after a bracket path segment", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "agents.list[0]id", '"renamed"']),
+      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0]id");
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
     it("preserves valid bracket path forms", async () => {
       const resolved: OpenClawConfig = {
         agents: { list: [{ id: "main" }, { id: "other" }] },

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -386,7 +386,7 @@ function parsePath(raw: string): PathSegment[] {
   let segmentEmitted = false;
   let i = 0;
   while (i < trimmed.length) {
-    const ch = trimmed[i];
+    const ch = trimmed[i] ?? "";
     if (ch === "\\") {
       const next = trimmed[i + 1];
       if (next) {
@@ -432,6 +432,9 @@ function parsePath(raw: string): PathSegment[] {
       segmentEmitted = true;
       i = close + 1;
       continue;
+    }
+    if (segmentEmitted && current === "" && ch.trim()) {
+      throw new Error(`Invalid path (missing separator after bracket): ${raw}`);
     }
     current += ch;
     i += 1;


### PR DESCRIPTION
Related: #109299

## What Problem This Solves

Fixes an issue where malformed config paths such as `agents.list[0]id` were accepted and parsed the same way as `agents.list[0].id`.

## Why This Change Was Made

The config path parser now rejects bare non-separator text immediately after a bracket segment. Valid forms such as `foo[0].bar`, `foo[0][1]`, and `[0]` remain accepted.

This bug report and fix proposal are meant to give the OpenClaw team a concrete reproduction and a reviewable patch so maintainers can choose the right direction. It is not intended to bypass maintainer judgment.

## User Impact

Users get a clear error for typoed config paths instead of accidentally reading, setting, unsetting, or patching a different path.

## Evidence

Focused parser probe:

```text
agents.list[0]id ERROR Invalid path (missing separator after bracket): agents.list[0]id
agents.list[0].id ["agents","list","0","id"]
agents.list[0][1] ["agents","list","0","1"]
```

Focused tests:

```text
node scripts/run-vitest.mjs src/cli/config-cli.test.ts -t "non-delimited text after a bracket path segment|preserves valid bracket path forms"

1 file passed; 2 tests passed, 128 skipped
```
