### PR TITLE
fix(agents): do not label finish_reason error as LLM timeout

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -364,6 +364,14 @@ describe("formatAssistantErrorText", () => {
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
 
+  it("does not rewrite Provider finish_reason: error into a timeout (#109218)", () => {
+    const msg = makeAssistantError("Provider finish_reason: error");
+    const text = formatAssistantErrorText(msg);
+    expect(text).not.toBe("LLM request timed out.");
+    expect(text.toLowerCase()).toContain("finish_reason");
+    expect(text.toLowerCase()).toContain("error");
+  });
+
   it("returns a connection-refused message for ECONNREFUSED failures", () => {
     const msg = makeAssistantError("connect ECONNREFUSED 127.0.0.1:443 during upstream call");
     expect(formatAssistantErrorText(msg)).toBe(

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -894,13 +894,11 @@ describe("isFailoverErrorMessage", () => {
   });
 
   it("matches abort stop-reason timeout variants", () => {
+    // Bare `error` stop reasons are provider-completed failures (#109218), not hangs.
     expectTimeoutFailoverSamples([
       "Unhandled stop reason: abort",
-      "Unhandled stop reason: error",
       "stop reason: abort",
-      "stop reason: error",
       "reason: abort",
-      "reason: error",
     ]);
   });
 
@@ -950,6 +948,22 @@ describe("isFailoverErrorMessage", () => {
       "Provider finish_reason: abort",
       "Provider finish_reason: malformed_response",
     ]);
+  });
+
+  it("classifies Provider finish_reason: error as server_error, not timeout (#109218)", () => {
+    // OpenRouter/Google can complete quickly with finish_reason:error; that is a
+    // provider-completed failure, not a hung request. Fallback must remain eligible.
+    const samples = [
+      "Provider finish_reason: error",
+      "finish_reason: error",
+      "stop reason: error",
+      "Unhandled stop reason: error",
+    ];
+    for (const sample of samples) {
+      expect(isTimeoutErrorMessage(sample)).toBe(false);
+      expect(classifyFailoverReason(sample)).toBe("server_error");
+      expect(isFailoverErrorMessage(sample)).toBe(true);
+    }
   });
 
   it("does not classify MALFORMED_FUNCTION_CALL as timeout", () => {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -30,6 +30,7 @@ import {
   isBillingErrorMessage,
   isOverloadedErrorMessage,
   isPeriodicUsageLimitErrorMessage,
+  isProviderCompletedErrorFinishReasonMessage,
   isRateLimitErrorMessage,
   isServerErrorMessage,
   isTimeoutErrorMessage,
@@ -1041,6 +1042,13 @@ function classifyFailoverClassificationFromMessage(
   if (isOverloadedErrorMessage(raw)) {
     return toReasonClassification("overloaded");
   }
+  // Provider-completed `finish_reason: error` / stop-reason `error` is not a
+  // hang. Classify as server_error (failover still runs) so operators do not
+  // chase timeout knobs and user copy is not rewritten to "LLM request timed out."
+  // (#109218; keep #59524 fallback by remaining a failover reason).
+  if (isProviderCompletedErrorFinishReasonMessage(raw)) {
+    return toReasonClassification("server_error");
+  }
   if (
     isStructuredServerErrorMessage(raw) &&
     !isBillingErrorMessage(raw) &&
@@ -1527,6 +1535,12 @@ export function formatAssistantErrorText(
   const transportCopy = formatTransportErrorCopy(raw);
   if (transportCopy) {
     return transportCopy;
+  }
+
+  // Provider finished the stream with finish_reason/stop-reason `error` — not a hang.
+  // Keep the raw reason in the message so operators still see the provider signal (#109218).
+  if (isProviderCompletedErrorFinishReasonMessage(raw)) {
+    return formatRawAssistantErrorForUi(raw);
   }
 
   if (isTimeoutErrorMessage(raw)) {

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -5,6 +5,7 @@ import {
   isAuthErrorMessage,
   isBillingErrorMessage,
   isOverloadedErrorMessage,
+  isProviderCompletedErrorFinishReasonMessage,
   isRateLimitErrorMessage,
   isServerErrorMessage,
   isTimeoutErrorMessage,
@@ -177,6 +178,26 @@ describe("server error status classification", () => {
 
   it("does not classify prefixed plain internal server error status prose", () => {
     expect(isServerErrorMessage("Proxy notice: Status: Internal Server Error")).toBe(false);
+  });
+});
+
+describe("provider-completed finish_reason error (#109218)", () => {
+  it("matches bare finish/stop error reasons as provider-completed failures", () => {
+    expect(isProviderCompletedErrorFinishReasonMessage("Provider finish_reason: error")).toBe(true);
+    expect(isTimeoutErrorMessage("Provider finish_reason: error")).toBe(false);
+    expect(classifyFailoverReason("Provider finish_reason: error")).toBe("server_error");
+  });
+
+  it("keeps abort/network/malformed finish reasons in the timeout lane", () => {
+    for (const sample of [
+      "Provider finish_reason: abort",
+      "Provider finish_reason: network_error",
+      "Provider finish_reason: malformed_response",
+    ]) {
+      expect(isProviderCompletedErrorFinishReasonMessage(sample)).toBe(false);
+      expect(isTimeoutErrorMessage(sample)).toBe(true);
+      expect(classifyFailoverReason(sample)).toBe("timeout");
+    }
   });
 });
 

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -161,11 +161,14 @@ const ERROR_PATTERNS = {
     /\benotfound\b/i,
     /\beai_again\b/i,
     /without sending (?:any )?chunks?/i,
-    /\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
-    /\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
-    /\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
+    // Bare `error` is a provider-completed failure, not a hang — classified as
+    // server_error separately so diagnostics stay accurate while fallback still
+    // runs (#109218). Keep abort / network / malformed as timeout-like transients.
+    /\bstop reason:\s*(?:abort|malformed_response|network_error)\b/i,
+    /\breason:\s*(?:abort|malformed_response|network_error)\b/i,
+    /\bunhandled stop reason:\s*(?:abort|malformed_response|network_error)\b/i,
     // `\breason:` does not match provider payloads like `finish_reason: network_error` (#61281).
-    /\bfinish_reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
+    /\bfinish_reason:\s*(?:abort|malformed_response|network_error)\b/i,
     // AbortError messages from fetch/stream aborts (Ollama NDJSON stream
     // timeouts, signal aborts, etc.) — without these the flattened message
     // falls through to reason=unknown (#58315).
@@ -291,6 +294,24 @@ export function isRateLimitErrorMessage(raw: string): boolean {
 
 export function isTimeoutErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.timeout);
+}
+
+/**
+ * Provider stream completed with an explicit error finish/stop reason.
+ * These are not request timeouts: the transport finished quickly with a
+ * provider-side error. Keep them failover-eligible as server_error (#109218).
+ */
+const PROVIDER_COMPLETED_ERROR_FINISH_REASON_PATTERNS = [
+  /\bfinish_reason:\s*error\b/i,
+  /\bstop reason:\s*error\b/i,
+  /\bunhandled stop reason:\s*error\b/i,
+  // Symmetric with the timeout stop-reason family; scoped to the word `error`
+  // only so `reason: network_error` stays in the timeout lane.
+  /\breason:\s*error\b/i,
+] as const satisfies readonly ErrorPattern[];
+
+export function isProviderCompletedErrorFinishReasonMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, PROVIDER_COMPLETED_ERROR_FINISH_REASON_PATTERNS);
 }
 
 export function isPeriodicUsageLimitErrorMessage(raw: string): boolean {

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -30,6 +30,7 @@ import { stableStringify } from "../stable-stringify.js";
 import {
   isBillingErrorMessage,
   isOverloadedErrorMessage,
+  isProviderCompletedErrorFinishReasonMessage,
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
 } from "./failover-matches.js";
@@ -511,6 +512,10 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
       const transportCopy = formatTransportErrorCopy(trimmed);
       if (transportCopy) {
         return transportCopy;
+      }
+      // finish_reason/stop-reason `error` is a completed provider failure, not a timeout (#109218).
+      if (isProviderCompletedErrorFinishReasonMessage(trimmed)) {
+        return formatRawAssistantErrorForUi(trimmed);
       }
       if (isTimeoutErrorMessage(trimmed)) {
         return "LLM request timed out.";


### PR DESCRIPTION
Closes #109218

## What Problem This Solves

Fixes an issue where operators seeing a fast OpenRouter/Google candidate failure with `finish_reason: "error"` would be told the **LLM request timed out** (`failoverReason: timeout`, HTTP-like **408**), even when the provider finished in a few seconds. That mislabeling sends people to connection/timeout knobs that cannot fix a provider-completed error, while model fallback still continues.

## Why This Change Was Made

Provider-completed bare `error` finish/stop reasons are no longer matched as timeouts. They are classified as `server_error` so fallback remains eligible, diagnostics and status mapping stay accurate (500-class rather than 408), and user-facing copy keeps the provider finish_reason signal instead of rewriting to “LLM request timed out.” Genuine abort / network_error / malformed_response finish reasons stay in the timeout lane.

Quality: compatibility — no config/API change; failover still runs for these failures. Performance — pattern match only on existing error paths. Usability — operators get a provider-error signal instead of a false timeout. Security — no auth/secret surface change.

## User Impact

When a model stream ends with `Provider finish_reason: error` (or equivalent stop-reason `error`), OpenClaw reports a provider/server error and keeps fallback working, instead of claiming a hang/timeout.

## Evidence

Focused classifier and user-copy tests on local macOS:

```text
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts \
  src/agents/embedded-agent-helpers/failover-matches.test.ts \
  src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts

Test Files  3 passed (3)
Tests       272 passed (272)
```

Closeout notes: `pnpm check:changed` format + path guards OK; Plugin SDK API baseline hash mismatch also fails on clean `origin/main` without this diff (pre-existing, unrelated). Path-scoped oxlint on touched production files: 0 warnings / 0 errors.

## Real behavior proof

- Behavior addressed: `Provider finish_reason: error` must not be classified or rewritten as an LLM timeout while remaining failover-eligible.
- Environment: local macOS, OpenClaw checkout at this PR head, focused Vitest unit-fast shard.
- Current-main contrast: on main, the timeout pattern group includes bare `error` in finish/stop-reason matchers, so `isTimeoutErrorMessage("Provider finish_reason: error")` is true, `classifyFailoverReason(...)` is `"timeout"`, and assistant error formatting becomes `"LLM request timed out."`.
- Exact steps or command run after this patch:
  ```bash
  node scripts/run-vitest.mjs \
    src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts \
    src/agents/embedded-agent-helpers/failover-matches.test.ts \
    src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
  node scripts/run-vitest.mjs \
    src/agents/embedded-agent-helpers/failover-matches.test.ts \
    -t "finish_reason error"
  ```
- Evidence after fix: new and updated cases assert `isTimeoutErrorMessage("Provider finish_reason: error") === false`, `classifyFailoverReason(...) === "server_error"`, `isFailoverErrorMessage(...) === true`, and `formatAssistantErrorText` does not rewrite to `"LLM request timed out."` while still preserving finish_reason/error wording. Control cases still treat `network_error` / `abort` / `malformed_response` as timeout.
- Control check: sibling timeout finish reasons (`abort`, `network_error`, `malformed_response`) still pass timeout assertions in the same test files.
- Observed result after fix: 272/272 focused tests green; finish_reason error path is server_error + failover-eligible + non-timeout user copy.
- What was not tested: live OpenRouter/Google account turn (not required; ClawSweeper accepted source-level reproduction). Other provider-specific error copy beyond finish/stop-reason `error`.

## AI disclosure

This PR was authored with AI assistance (Grok).
