### PR TITLE
fix: honor null inbound conversation resolution

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -112,6 +112,16 @@ describe("message hook mappers", () => {
             },
           },
         },
+        {
+          pluginId: "reject-chat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "reject-chat", label: "Reject chat" }),
+            messaging: {
+              resolveInboundConversation: () => null,
+            },
+          },
+        },
       ]),
     );
   });
@@ -210,6 +220,23 @@ describe("message hook mappers", () => {
       replyToSender: "Ada",
       replyToIsQuote: true,
     });
+  });
+
+  it("does not fall back when a channel resolver rejects an inbound claim conversation", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        Provider: "reject-chat",
+        Surface: "reject-chat",
+        OriginatingChannel: "reject-chat",
+        To: "channel:room-123",
+        OriginatingTo: "channel:room-123",
+        GroupChannel: "room",
+        GroupSubject: "guild",
+      }),
+    );
+
+    expect(toPluginInboundClaimContext(canonical).conversationId).toBeUndefined();
+    expect(toPluginInboundClaimEvent(canonical).conversationId).toBeUndefined();
   });
 
   it("falls back to raw body when command body is blank", () => {

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -314,16 +314,20 @@ function resolveInboundConversation(canonical: CanonicalInboundMessageHookContex
   parentConversationId?: string;
 } {
   const channelId = normalizeChannelId(canonical.channelId);
-  const pluginResolved = channelId
-    ? getChannelPlugin(channelId)?.messaging?.resolveInboundConversation?.({
-        from: canonical.from,
-        to: canonical.to ?? canonical.originatingTo,
-        conversationId: canonical.conversationId,
-        threadId: canonical.threadId,
-        threadParentId: canonical.threadParentId,
-        isGroup: canonical.isGroup,
-      })
-    : null;
+  const resolver = channelId
+    ? getChannelPlugin(channelId)?.messaging?.resolveInboundConversation
+    : undefined;
+  const pluginResolved = resolver?.({
+    from: canonical.from,
+    to: canonical.to ?? canonical.originatingTo,
+    conversationId: canonical.conversationId,
+    threadId: canonical.threadId,
+    threadParentId: canonical.threadParentId,
+    isGroup: canonical.isGroup,
+  });
+  if (pluginResolved === null) {
+    return {};
+  }
   if (pluginResolved) {
     return {
       conversationId: normalizeOptionalString(pluginResolved.conversationId),


### PR DESCRIPTION
Related: #109300

## What Problem This Solves

Fixes an issue where `inbound_claim` hook payloads could fall back to generic conversation parsing after a channel plugin explicitly rejected inbound conversation resolution by returning `null`.

## Why This Change Was Made

The hook mapper now preserves the channel resolver contract: `null` means no conversation mapping and should not fall through. Object results and missing resolver results keep their previous behavior.

This bug report and fix proposal are meant to give the OpenClaw team a concrete reproduction and a reviewable patch so maintainers can choose the right direction. It is not intended to bypass maintainer judgment.

## User Impact

Plugin-provided inbound claim payloads no longer receive a generic conversation id when the channel integration deliberately rejects a conversation mapping.

## Evidence

Focused test:

```text
node scripts/run-vitest.mjs src/hooks/message-hook-mappers.test.ts -t "does not fall back when a channel resolver rejects an inbound claim conversation"

1 file passed; 1 test passed, 15 skipped
```
