### PR TITLE
fix(sessions): require capEntryCount override (no silent default)

### DIFF
--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -528,17 +528,25 @@ function wouldCapActiveSession(params: {
  * Cap the store to the N most recently updated entries.
  * Entries without `updatedAt` are sorted last (removed first when over limit).
  * Mutates `store` in-place.
+ *
+ * `overrideMax` is required: the previous no-arg fallback that called
+ * `resolveMaintenanceConfigFromInput()` could only ever read built-in defaults
+ * (it bypassed `getRuntimeConfig()`), so a caller that forgot to pass the
+ * configured `session.maintenance.maxEntries` silently fell back to 500 even
+ * when the user's config said otherwise (see issue #109191). All production
+ * callers already supply the resolved value, so refusing to default here is
+ * the safe-and-honest behavior; tests pass an integer directly.
  */
 export function capEntryCount(
   store: Record<string, SessionEntry>,
-  overrideMax?: number,
+  overrideMax: number,
   opts: {
     log?: boolean;
     onCapped?: (params: { key: string; entry: SessionEntry }) => void;
     preserveKeys?: ReadonlySet<string>;
   } = {},
 ): number {
-  const maxEntries = overrideMax ?? resolveMaintenanceConfigFromInput().maxEntries;
+  const maxEntries = overrideMax;
   const preservedCount = Object.entries(store).filter(([key, entry]) =>
     shouldPreserveMaintenanceEntry({ key, entry, preserveKeys: opts.preserveKeys }),
   ).length;

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -701,6 +701,27 @@ describe("capEntryCount", () => {
     }
   });
 
+  it("honors caller-supplied overrideMax even when it differs from the 500 default (regression: #109191)", () => {
+    // Issue #109191: the previous no-arg fallback to resolveMaintenanceConfigFromInput()
+    // would silently substitute DEFAULT_SESSION_MAX_ENTRIES (500) regardless of
+    // what the caller's override said, because the fallback ORed with the
+    // override — but it also meant a future caller that forgot to pass the
+    // runtime-resolved value would have been bitten by the silent default.
+    // The fix requires overrideMax directly: verify it is used as-is for any
+    // value, including the user's configured 4096.
+    const now = Date.now();
+    const store = makeStore([
+      ["a", makeEntry(now - 4)],
+      ["b", makeEntry(now - 3)],
+      ["c", makeEntry(now - 2)],
+      ["d", makeEntry(now - 1)],
+      ["e", makeEntry(now)],
+    ]);
+
+    expect(capEntryCount(store, 4096)).toBe(0); // override honored; nothing evicted
+    expect(Object.keys(store)).toHaveLength(5);
+  });
+
   it("normalizes runtime-provided preserve keys to match lowercased store keys", () => {
     const now = Date.now();
     const childKey = "agent:main:subagent:child";


### PR DESCRIPTION
Closes #109191

The `capEntryCount` fallback `overrideMax ?? resolveMaintenanceConfigFromInput().maxEntries`
could only ever read the `DEFAULT_SESSION_MAX_ENTRIES = 500` constant: a no-arg
call to `resolveMaintenanceConfigFromInput()` bypasses `getRuntimeConfig()`, so
even an explicit `session.maintenance.maxEntries` in the user's config was
ignored on the fallback path.

Production callers all already pass the runtime-resolved value, so the safest
fix is to require the override directly — the silent-default code path was both
broken and unused. Anyone who relied on the no-arg call now gets a clear
TypeScript error and surfaces their misconfiguration at build time instead of
the misclassified log line at runtime.

Verification gap: this cron env runs Node 18.19.1 against a project whose
`engines.node` requires `>=22.19.0` and whose vitest build fails at the same
`styleText` import surfaced in earlier openclaw runs. The logic change was
exercised by an isolated regression harness in `/tmp` that proves the prior
fallback returned 500 with runtime config present and the new signature does
not silently substitute — full text lives in the run report. Project-side
vitest should be re-run by a maintainer on a Node-22 host before merge.
