### PR TITLE
fix(skills): support portable Copilot agent transcripts

### DIFF
--- a/.agents/skills/agent-transcript/SKILL.md
+++ b/.agents/skills/agent-transcript/SKILL.md
@@ -24,45 +24,56 @@ Best-effort local-only provenance for OpenClaw PR/issue bodies. Use during agent
 
 ## Helper
 
-```bash
-.agents/skills/agent-transcript/scripts/agent-transcript --help
+```text
+node "{baseDir}/scripts/agent-transcript" --help
 ```
 
 Find a likely local session:
 
-```bash
-.agents/skills/agent-transcript/scripts/agent-transcript find \
-  --query "$PR_TITLE $BRANCH_OR_PR_URL" \
-  --cwd "$PWD" \
-  --since-days 14
+```text
+node "{baseDir}/scripts/agent-transcript" find --query "<PR title> <branch or PR URL>" --cwd "<repo root>" --since-days 14
 ```
 
-`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
+`find` scans the newest 400 matching local JSONL logs by default across GitHub
+Copilot, Codex, Claude, Pi, and OpenClaw agent sessions. Copilot sessions are
+discovered under `~/.copilot/session-state/*/events.jsonl`. Use `--max-files N`
+for a wider local search.
+
+For Copilot events, keep only original `user.message` content, visible
+`assistant.message` content, and aggregate tool-call counts. Drop system
+messages, transformed prompts, hooks, opaque/encrypted reasoning, and raw tool
+results.
 
 Render a PR/issue body section:
 
-```bash
-.agents/skills/agent-transcript/scripts/agent-transcript render \
-  --session "$SESSION_JSONL" \
-  --out /tmp/agent-transcript.md
+```text
+node "{baseDir}/scripts/agent-transcript" render --session "<session.jsonl>" --out "<agent-transcript.md>"
 ```
 
 Preview one candidate session locally:
 
+```text
+node "{baseDir}/scripts/agent-transcript" preview --session "<session.jsonl>" --out "<agent-transcript-preview.html>"
+```
+
+Open the generated preview with the host-native command:
+
+```powershell
+Start-Process "<agent-transcript-preview.html>"
+```
+
 ```bash
-.agents/skills/agent-transcript/scripts/agent-transcript preview \
-  --session "$SESSION_JSONL" \
-  --out /tmp/agent-transcript-preview.html
-open /tmp/agent-transcript-preview.html
+# macOS
+open "<agent-transcript-preview.html>"
+
+# Linux
+xdg-open "<agent-transcript-preview.html>"
 ```
 
 Append/update a body file before `gh pr create --body-file` or connector PR creation:
 
-```bash
-.agents/skills/agent-transcript/scripts/agent-transcript append-body \
-  --body /tmp/pr-body.md \
-  --session "$SESSION_JSONL" \
-  --out /tmp/pr-body.with-transcript.md
+```text
+node "{baseDir}/scripts/agent-transcript" append-body --body "<pr-body.md>" --session "<session.jsonl>" --out "<pr-body.with-transcript.md>"
 ```
 
 ## PR/Issue Workflow
@@ -71,7 +82,7 @@ Append/update a body file before `gh pr create --body-file` or connector PR crea
 2. Run `find` with title, branch, PR URL/number if known, and cwd.
 3. If a high-confidence session is found, ask:
    `Include a redacted agent transcript? It helps reviewers and can make the PR easier to prioritize. I can open a local preview first.`
-4. If the user wants preview, run `preview`, open the HTML with `open`, and wait for confirmation.
+4. If the user wants preview, run `preview`, open the HTML with the host-native command above, and wait for confirmation.
 5. Before insertion, trim unrelated session turns from the generated section. Keep only turns that explain this PR/issue's goal, implementation choices, files, tests, proof, blockers, and final outcome.
 6. If the user approves, run `append-body`.
 7. Use the enriched body file for creation/update.
@@ -81,8 +92,6 @@ Append/update a body file before `gh pr create --body-file` or connector PR crea
 
 For manual audits across many PR/session candidates, create a local HTML preview from a local JSON file. This is for maintainers only and is not part of the PR/issue workflow:
 
-```bash
-.agents/skills/agent-transcript/scripts/agent-transcript html \
-  --prs /tmp/recent-prs.json \
-  --out /tmp/agent-transcript-preview.html
+```text
+node "{baseDir}/scripts/agent-transcript" html --prs "<recent-prs.json>" --out "<agent-transcript-preview.html>"
 ```

--- a/.agents/skills/agent-transcript/scripts/agent-transcript
+++ b/.agents/skills/agent-transcript/scripts/agent-transcript
@@ -8,6 +8,8 @@ const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const POSIX_LOCAL_ROOTS =
+  "(?:Applications|Library|System|Users|Volumes|app|bin|boot|builds?|data|dev|etc|home|lib|lib64|media|mnt|nix|opt|private|proc|repo|root|run|sbin|snap|srv|tmp|usr|var|workspaces?)";
 
 function usage() {
   console.log(`Usage:
@@ -51,6 +53,90 @@ function homePath(...parts) {
   return path.join(os.homedir(), ...parts);
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replacePathToken(value, marker) {
+  const trailing = value.match(/[.,;!?]+$/)?.[0] || "";
+  return `${marker}${trailing}`;
+}
+
+function replacePosixPath(value, prefix, localPath) {
+  if (prefix && /[A-Za-z0-9_./\\]/.test(prefix)) return value;
+  return `${prefix}${replacePathToken(localPath, "[LOCAL_PATH]")}`;
+}
+
+function replacePosixNetworkPath(value, prefix, localPath, offset, input) {
+  if (prefix === ":") {
+    const scheme = input.slice(0, offset + 1).match(/([A-Za-z][A-Za-z0-9+.-]*):$/)?.[1]?.toLowerCase();
+    if (scheme === "http" || scheme === "https") return value;
+  }
+  return replacePosixPath(value, prefix, localPath);
+}
+
+function isPrivateIpv4(hostname) {
+  const parts = hostname.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+  return (
+    parts[0] === 10 ||
+    parts[0] === 127 ||
+    (parts[0] === 169 && parts[1] === 254) ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168)
+  );
+}
+
+function isPrivateHostname(hostname) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+  if (!normalized) return true;
+  if (isPrivateIpv4(normalized)) return true;
+  if (
+    normalized === "0.0.0.0" ||
+    normalized === "::" ||
+    normalized === "::1" ||
+    /^f[cd][0-9a-f]{2}:/i.test(normalized) ||
+    /^fe[89ab][0-9a-f]:/i.test(normalized)
+  ) {
+    return true;
+  }
+  if (!normalized.includes(".") && !normalized.includes(":")) return true;
+  return /(?:^|\.)(?:corp|home|internal|intranet|lan|local|localhost)$/.test(normalized);
+}
+
+function isPrivateUrl(value, depth = 0) {
+  const trailing = value.match(/[.,;!?]+$/)?.[0] || "";
+  const candidate = trailing ? value.slice(0, -trailing.length) : value;
+  try {
+    const url = new URL(candidate);
+    if (url.username || url.password || isPrivateHostname(url.hostname)) return true;
+    const nestedValues = [...url.searchParams.values()];
+    if (url.hash.length > 1) {
+      try {
+        nestedValues.push(decodeURIComponent(url.hash.slice(1)));
+      } catch {
+        nestedValues.push(url.hash.slice(1));
+      }
+    }
+    if (depth >= 4) {
+      return nestedValues.some((nestedValue) => /https?:\/\//i.test(nestedValue));
+    }
+    return nestedValues.some((nestedValue) =>
+      (nestedValue.match(/https?:\/\/[^\s`"'<>\|)]+/gi) || []).some((nestedUrl) =>
+        isPrivateUrl(nestedUrl, depth + 1),
+      ),
+    );
+  } catch {
+    return true;
+  }
+}
+
+function replacePrivateUrl(value) {
+  return isPrivateUrl(value) ? replacePathToken(value, "[PRIVATE_URL]") : value;
+}
+
 function openClawSessionRoots() {
   const stateDir = process.env.OPENCLAW_STATE_DIR || homePath(".openclaw");
   const agentsDir = path.join(stateDir, "agents");
@@ -78,6 +164,7 @@ function defaultRoots() {
   return [
     homePath(".codex", "sessions"),
     homePath(".claude", "projects"),
+    homePath(".copilot", "session-state"),
     homePath(".pi", "agent", "sessions"),
     ...openClawSessionRoots(),
   ];
@@ -133,19 +220,30 @@ function stringContent(value) {
 function detectAgent(file, rows) {
   if (file.includes(`${path.sep}.codex${path.sep}`)) return "codex";
   if (file.includes(`${path.sep}.claude${path.sep}`)) return "claude";
+  if (
+    file.includes(`${path.sep}.copilot${path.sep}session-state${path.sep}`) ||
+    rows.some((row) => row?.type === "session.start" && row?.data?.producer === "copilot-agent")
+  ) {
+    return "copilot";
+  }
   if (file.includes(`${path.sep}.pi${path.sep}`)) return "pi";
   if (
     file.includes(`${path.sep}.openclaw${path.sep}`) ||
-    (file.includes(`${path.sep}agents${path.sep}`) && file.includes(`${path.sep}sessions${path.sep}`))
+    (file.includes(`${path.sep}agents${path.sep}`) &&
+      file.includes(`${path.sep}sessions${path.sep}`))
   ) {
     return "openclaw";
   }
-  if (rows.some((row) => row?.type === "session_meta" || row?.type === "response_item")) return "codex";
+  if (rows.some((row) => row?.type === "session_meta" || row?.type === "response_item"))
+    return "codex";
   if (rows.some((row) => row?.sessionId && row?.userType)) return "claude";
   return "agent";
 }
 
 function eventText(row) {
+  if (row?.type === "user.message" || row?.type === "assistant.message") {
+    return stringContent(row.data?.content);
+  }
   if (row?.type === "event_msg") {
     const payload = row.payload || {};
     return stringContent(payload.message || payload.text_elements || payload.content);
@@ -161,6 +259,13 @@ function eventText(row) {
 }
 
 function eventRole(row) {
+  if (row?.type === "user.message") return "user";
+  if (row?.type === "assistant.message") return "assistant";
+  if (row?.type === "tool.execution_start" || row?.type === "external_tool.requested")
+    return "tool";
+  if (row?.type === "tool.execution_complete" || row?.type === "external_tool.completed") {
+    return "tool_output";
+  }
   if (row?.type === "event_msg") {
     const type = row.payload?.type;
     if (type === "user_message") return "user";
@@ -199,6 +304,21 @@ function hasSetupBlob(text) {
 
 function redact(input, stats) {
   let s = String(input ?? "");
+  const homeVariants = new Set([
+    os.homedir(),
+    os.homedir().replaceAll("\\", "/"),
+    os.homedir().replaceAll("/", "\\"),
+  ]);
+  for (const home of homeVariants) {
+    if (!home) continue;
+    const before = s;
+    const homePathPattern = new RegExp(
+      `${escapeRegExp(home)}(?:[\\\\/][^\\r\\n\`"'<>\\|)]+|(?=$|[\\s\`"'<>\\|),.;!?:]))`,
+      "gi",
+    );
+    s = s.replace(homePathPattern, (value) => replacePathToken(value, "[HOME_PATH]"));
+    if (s !== before) stats.redactions++;
+  }
   const rules = [
     [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "[REDACTED_PRIVATE_KEY]"],
     [/sk-[A-Za-z0-9_-]{20,}/g, "[REDACTED_OPENAI_KEY]"],
@@ -208,8 +328,17 @@ function redact(input, stats) {
     [/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi, "[REDACTED_AUTH_HEADER]"],
     [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[REDACTED_EMAIL]"],
     [/\b(?:\+?\d[\d .()-]{7,}\d)\b/g, "[REDACTED_PHONE]"],
-    [/\/Users\/[^\s`"'>)]+/g, "[LOCAL_PATH]"],
-    [/~\/[^\s`"'>)]+/g, "[HOME_PATH]"],
+    [/\bhttps?:\/\/[^\s`"'<>\|)]+/gi, replacePrivateUrl],
+    [/\b[A-Za-z]:[\\/][^\r\n`"'<>\|)]+/g, (value) => replacePathToken(value, "[LOCAL_PATH]")],
+    [/\\\\[^\r\n`"'<>\|)]+/g, (value) => replacePathToken(value, "[LOCAL_PATH]")],
+    [/\/Users\/[^\r\n`"'<>\|)]+/g, (value) => replacePathToken(value, "[LOCAL_PATH]")],
+    [/\/home\/[^\r\n`"'<>\|)]+/g, (value) => replacePathToken(value, "[LOCAL_PATH]")],
+    [/~[\\/][^\r\n`"'<>\|)]+/g, (value) => replacePathToken(value, "[HOME_PATH]")],
+    [/(^|.)(\/\/(?!\s)[^\r\n`"'<>\|)]+)/gm, replacePosixNetworkPath],
+    [
+      new RegExp(`(^|.)(/${POSIX_LOCAL_ROOTS}(?:/[^\\r\\n\`"'<>\\|)]+)?)`, "gm"),
+      replacePosixPath,
+    ],
     [/([?&](?:token|key|secret|signature|sig|access_token|auth)=)[^\s`"'>&]+/gi, "$1[REDACTED]"],
   ];
   for (const [re, repl] of rules) {
@@ -227,8 +356,19 @@ function unsafe(text) {
     /\b(?:user_session|_gh_sess|__Host-user_session_same_site|GH_SESSION_TOKEN)\b/i,
     /\b(?:GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY)\b/,
     /\/upload\/policies\/assets|uploadToken|authenticity_token/i,
+    /\b[A-Za-z]:[\\/]/,
+    /\\\\[^\\\s]+\\[^\\\s]+/,
+    /\/(?:Users|home)\//,
+    /~[\\/]/,
+    /(^|[^A-Za-z0-9_./\\:])\/\/(?![\/\s])/m,
+    new RegExp(`(^|[^A-Za-z0-9_./\\\\])/${POSIX_LOCAL_ROOTS}(?:/|$)`, "m"),
+    /\[HOME_PATH\](?=[^\s`"'<>\|),.;!?:])/,
   ];
-  return patterns.filter((pattern) => pattern.test(text)).map((pattern) => String(pattern));
+  const findings = patterns.filter((pattern) => pattern.test(text)).map((pattern) => String(pattern));
+  if ((text.match(/\bhttps?:\/\/[^\s`"'<>\|)]+/gi) || []).some((url) => isPrivateUrl(url))) {
+    findings.push("private URL");
+  }
+  return findings;
 }
 
 function normalizeEntry(role, text, stats, options = {}) {
@@ -315,7 +455,7 @@ function shellFamily(command) {
 }
 
 function toolCallFamily(row) {
-  const name = row.payload?.name || row.name || row.message?.name || row.type || "tool";
+  const name = row.data?.toolName || row.payload?.name || row.name || row.message?.name || row.type || "tool";
   if (name === "exec_command") {
     try {
       const args = JSON.parse(row.payload?.arguments || "{}");
@@ -373,7 +513,11 @@ function renderSession(file, options = {}) {
   for (const row of rows) {
     const role = eventRole(row);
     if (!role) continue;
-    if (hasEventDialogue && row.type === "response_item" && (role === "user" || role === "assistant")) {
+    if (
+      hasEventDialogue &&
+      row.type === "response_item" &&
+      (role === "user" || role === "assistant")
+    ) {
       continue;
     }
     if (role === "tool_output") {
@@ -410,7 +554,8 @@ function renderSession(file, options = {}) {
   recountEntries(stats, renderedItems);
   const maxChars = Number(options.maxChars || DEFAULT_MAX_CHARS);
   let joined = renderedItems.join("\n\n");
-  if (joined.length > maxChars) joined = `${joined.slice(0, maxChars).trimEnd()}\n\n...[transcript truncated to ${maxChars} chars]`;
+  if (joined.length > maxChars)
+    joined = `${joined.slice(0, maxChars).trimEnd()}\n\n...[transcript truncated to ${maxChars} chars]`;
   const headerBits = [options.title, options.url].filter(Boolean).join(" | ");
   const unsafeAfter = unsafe(joined);
   const safe = unsafeAfter.length === 0;
@@ -480,7 +625,10 @@ function scoreScanRecord(record, terms, cwd) {
   }
   if (cwd) {
     const cwdLower = cwd.toLowerCase();
-    if (haystack.includes(cwdLower) || record.file.toLowerCase().includes(cwdLower.replaceAll("/", "-"))) {
+    if (
+      haystack.includes(cwdLower) ||
+      record.file.toLowerCase().includes(cwdLower.replaceAll("/", "-"))
+    ) {
       score += 8;
       reasons.push("cwd");
     }
@@ -602,7 +750,8 @@ function main() {
   if (command === "render") {
     if (!args.session) throw new Error("--session is required");
     const rendered = renderSession(args.session, args);
-    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    if (!rendered.safe)
+      throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
     if (args.out) fs.writeFileSync(args.out, rendered.markdown);
     else process.stdout.write(rendered.markdown);
     return;
@@ -610,7 +759,8 @@ function main() {
   if (command === "preview") {
     if (!args.session) throw new Error("--session is required");
     const rendered = renderSession(args.session, args);
-    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    if (!rendered.safe)
+      throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
     const output = singlePreviewDocument({
       title: args.title || "Agent Transcript Preview",
       url: args.url || "",
@@ -625,7 +775,8 @@ function main() {
   if (command === "append-body") {
     if (!args.body || !args.session) throw new Error("--body and --session are required");
     const rendered = renderSession(args.session, args);
-    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    if (!rendered.safe)
+      throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
     const body = fs.readFileSync(args.body, "utf8");
     const next = replaceSection(body, rendered.markdown);
     if (args.out) fs.writeFileSync(args.out, next);

--- a/test/scripts/agent-transcript.test.ts
+++ b/test/scripts/agent-transcript.test.ts
@@ -1,0 +1,336 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const scriptPath = path.join(repoRoot, ".agents/skills/agent-transcript/scripts/agent-transcript");
+const { createTempDir } = createScriptTestHarness();
+
+type TranscriptEvent = Record<string, unknown>;
+
+function writeJsonl(file: string, events: TranscriptEvent[]): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+}
+
+function runTranscript(
+  args: string[],
+  options: {
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): string {
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...options.env,
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout);
+  }
+  return result.stdout;
+}
+
+function copilotEvents(messages: TranscriptEvent[]): TranscriptEvent[] {
+  return [
+    {
+      type: "session.start",
+      data: {
+        sessionId: "copilot-session",
+        producer: "copilot-agent",
+      },
+    },
+    ...messages,
+  ];
+}
+
+describe("agent transcript helper", () => {
+  it("discovers Copilot sessions from the default local session-state root", () => {
+    const home = createTempDir("agent-transcript-home-");
+    const sessionFile = path.join(
+      home,
+      ".copilot",
+      "session-state",
+      "copilot-session",
+      "events.jsonl",
+    );
+    writeJsonl(
+      sessionFile,
+      copilotEvents([
+        {
+          type: "user.message",
+          data: {
+            content: "Implement portable-copilot-marker in C:\\repo\\openclaw.",
+          },
+        },
+      ]),
+    );
+
+    const output = runTranscript(
+      ["find", "--query", "portable-copilot-marker", "--cwd", "C:\\repo\\openclaw"],
+      {
+        env: {
+          HOME: home,
+          USERPROFILE: home,
+        },
+      },
+    );
+    const results = JSON.parse(output) as Array<{
+      agent: string;
+      file: string;
+    }>;
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      agent: "copilot",
+      file: sessionFile,
+    });
+  });
+
+  it("renders visible Copilot dialogue and drops private event data", () => {
+    const tempDir = createTempDir("agent-transcript-copilot-");
+    const sessionFile = path.join(
+      tempDir,
+      ".copilot",
+      "session-state",
+      "copilot-session",
+      "events.jsonl",
+    );
+    writeJsonl(
+      sessionFile,
+      copilotEvents([
+        {
+          type: "system.message",
+          data: {
+            role: "system",
+            content: "PRIVATE_SYSTEM_PROMPT",
+          },
+        },
+        {
+          type: "user.message",
+          data: {
+            content: "Please update C:\\Users\\alice\\repo\\src\\index.ts.",
+            transformedContent: "PRIVATE_TRANSFORMED_PROMPT",
+          },
+        },
+        {
+          type: "assistant.message",
+          data: {
+            content: "Updated E:/repo/openclaw/src/index.ts.",
+            reasoningOpaque: "PRIVATE_REASONING",
+            encryptedContent: "PRIVATE_ENCRYPTED_CONTENT",
+          },
+        },
+        {
+          type: "tool.execution_start",
+          data: {
+            toolCallId: "tool-1",
+            toolName: "view",
+            arguments: {
+              path: "C:\\Users\\alice\\repo\\src\\index.ts",
+            },
+          },
+        },
+        {
+          type: "tool.execution_complete",
+          data: {
+            toolCallId: "tool-1",
+            success: true,
+            result: "PRIVATE_TOOL_OUTPUT",
+          },
+        },
+        {
+          type: "external_tool.requested",
+          data: {
+            requestId: "tool-2",
+            toolName: "powershell",
+            arguments: {
+              command: "Get-ChildItem",
+            },
+          },
+        },
+        {
+          type: "external_tool.completed",
+          data: {
+            requestId: "tool-2",
+          },
+        },
+      ]),
+    );
+
+    const output = runTranscript(["render", "--session", sessionFile]);
+
+    expect(output).toContain("<summary>Redacted copilot session transcript</summary>");
+    expect(output).toContain("[user]\nPlease update [LOCAL_PATH].");
+    expect(output).toContain("[assistant]\nUpdated [LOCAL_PATH].");
+    expect(output).toContain("1 read, 1 execute; raw tool outputs dropped: 2");
+    expect(output).not.toContain("PRIVATE_SYSTEM_PROMPT");
+    expect(output).not.toContain("PRIVATE_TRANSFORMED_PROMPT");
+    expect(output).not.toContain("PRIVATE_REASONING");
+    expect(output).not.toContain("PRIVATE_ENCRYPTED_CONTENT");
+    expect(output).not.toContain("PRIVATE_TOOL_OUTPUT");
+  });
+
+  it("redacts Windows home, drive-qualified, and UNC paths", () => {
+    const tempDir = createTempDir("agent-transcript-paths-");
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const fakeHome = "C:\\Users\\alice";
+    let deeplyNestedPrivateUrl = "http://localhost:3000/admin";
+    for (let depth = 0; depth < 5; depth += 1) {
+      deeplyNestedPrivateUrl = `https://example.com/callback?next=${encodeURIComponent(deeplyNestedPrivateUrl)}`;
+    }
+    writeJsonl(sessionFile, [
+      {
+        type: "user",
+        content: [
+          `${fakeHome}\\repo\\src\\index.ts`,
+          "C:/Users/alice/docs/notes.md",
+          "~\\Documents\\secret.txt",
+          "~/Documents/secret.txt",
+          "C:\\Users\\alice-backup\\private\\notes.txt",
+          "C:/Users/alice-backup/private/notes.txt",
+          "C:\\Program Files\\OpenClaw\\config.json",
+          "D:/tmp/my notes.txt",
+          "/home/bob/My Docs",
+          "/workspaces/openclaw/src/index.ts",
+          "/tmp/my notes.txt",
+          "/dev/shm/secret.txt",
+          "/proc/self/environ",
+          "/run/user/1000/keyring/file.txt",
+          "/Library/Application Support/App/config.json",
+          "path:/workspaces/openclaw/src/labelled.ts",
+          "cwd:/tmp/secret folder/file.txt",
+          "//server/share/private.txt",
+          "https://example.com/path",
+          "https://fcc.gov/",
+          "https://fda.gov/",
+          "https://[2606:4700:4700::1111]/",
+          "http://localhost:3000/app",
+          "https://corp-internal-host.local/admin",
+          "http://127.0.0.1:18789/status",
+          "http://10.0.0.4/admin",
+          "http://[::1]:3000/status",
+          "http://[fc00::1]:3000/status",
+          "https://intranet/dashboard",
+          "https://example.com/callback?next=http://localhost:3000/admin",
+          "https://example.com/callback?next=https%3A%2F%2F10.0.0.5%2Fadmin",
+          deeplyNestedPrivateUrl,
+          "file:///tmp/secret.txt",
+          "relative/path.txt",
+          "foo//bar",
+          "Check /api/v1/auth/login and https://example.com/api/v1/auth/login",
+          "Keep https://example.com/callback?next=https%3A%2F%2Fdocs.openclaw.ai%2Ftools%2Fskills",
+          "Keep this comment with API route: // /api/v1/auth/login",
+          "D:/repo/openclaw/src/index.ts",
+          "\\\\server\\share\\private\\notes.txt",
+        ].join("\n"),
+      },
+    ]);
+
+    const output = runTranscript(["render", "--session", sessionFile], {
+      env: {
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+      },
+    });
+
+    expect(output).not.toContain(fakeHome);
+    expect(output).not.toContain("~\\Documents");
+    expect(output).not.toContain("~/Documents");
+    expect(output).not.toContain("alice-backup");
+    expect(output).not.toContain("repo\\src");
+    expect(output).not.toContain("repo/src");
+    expect(output).not.toContain("docs/notes");
+    expect(output).not.toContain("C:\\Program Files");
+    expect(output).not.toContain("my notes.txt");
+    expect(output).not.toContain("My Docs");
+    expect(output).not.toContain("/workspaces/openclaw");
+    expect(output).not.toContain("/tmp/");
+    expect(output).not.toContain("/dev/");
+    expect(output).not.toContain("/proc/");
+    expect(output).not.toContain("/run/");
+    expect(output).not.toContain("/Library/");
+    expect(output).not.toContain("labelled.ts");
+    expect(output).not.toContain("secret folder");
+    expect(output).not.toContain("//server/share");
+    expect(output).not.toContain("localhost:3000");
+    expect(output).not.toContain("corp-internal-host.local");
+    expect(output).not.toContain("127.0.0.1");
+    expect(output).not.toContain("10.0.0.4");
+    expect(output).not.toContain("[::1]");
+    expect(output).not.toContain("[fc00::1]");
+    expect(output).not.toContain("intranet/dashboard");
+    expect(output).not.toContain("next=http://localhost");
+    expect(output).not.toContain("10.0.0.5");
+    expect(output).not.toContain(
+      encodeURIComponent(encodeURIComponent("http://localhost:3000/admin")),
+    );
+    expect(output).not.toContain("file:///tmp");
+    expect(output).not.toContain("D:/repo");
+    expect(output).not.toContain("\\\\server\\share");
+    expect(output).toContain("https://example.com/path");
+    expect(output).toContain("https://fcc.gov/");
+    expect(output).toContain("https://fda.gov/");
+    expect(output).toContain("https://[2606:4700:4700::1111]/");
+    expect(output).toContain("file:[LOCAL_PATH]");
+    expect(output).toContain("relative/path.txt");
+    expect(output).toContain("foo//bar");
+    expect(output).toContain("/api/v1/auth/login");
+    expect(output).toContain("https://example.com/api/v1/auth/login");
+    expect(output).toContain(
+      "https://example.com/callback?next=https%3A%2F%2Fdocs.openclaw.ai%2Ftools%2Fskills",
+    );
+    expect(output).toContain("// /api/v1/auth/login");
+    expect(output.match(/\[HOME_PATH\]/g)).toHaveLength(4);
+    expect(output.match(/\[LOCAL_PATH\]/g)).toHaveLength(17);
+    expect(output.match(/\[PRIVATE_URL\]/g)).toHaveLength(10);
+  });
+
+  it("preserves existing Codex event dialogue and tool summaries", () => {
+    const tempDir = createTempDir("agent-transcript-codex-");
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    writeJsonl(sessionFile, [
+      {
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          message: "Existing user message",
+        },
+      },
+      {
+        type: "event_msg",
+        payload: {
+          type: "agent_message",
+          message: "Existing assistant message",
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "apply_patch",
+          arguments: "{}",
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call_output",
+          output: "PRIVATE_EXISTING_TOOL_OUTPUT",
+        },
+      },
+    ]);
+
+    const output = runTranscript(["render", "--session", sessionFile]);
+
+    expect(output).toContain("<summary>Redacted codex session transcript</summary>");
+    expect(output).toContain("[user]\nExisting user message");
+    expect(output).toContain("[assistant]\nExisting assistant message");
+    expect(output).toContain("1 write; raw tool outputs dropped: 1");
+    expect(output).not.toContain("PRIVATE_EXISTING_TOOL_OUTPUT");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw contributors using GitHub Copilot could not include their local Copilot sessions in agent-created PR or issue provenance. The existing helper also used POSIX-only invocation examples and did not consistently redact Windows paths, broader POSIX paths, or private local endpoints.

## Why This Change Was Made

The agent transcript helper now discovers Copilot CLI sessions, keeps only visible user and assistant dialogue plus aggregate tool counts, and drops system prompts, transformed prompts, reasoning, hooks, and raw tool results. It also applies cross-platform path and private-endpoint redaction while preserving public URLs and API routes, and documents a portable `node`-based workflow.

The workflow remains local-only and fail-closed. It does not upload raw logs or add network access.

## User Impact

Developers can safely preview and optionally attach a redacted GitHub Copilot transcript when creating OpenClaw PRs or issues from Windows, macOS, or Linux. Existing Codex, Claude, Pi, and OpenClaw transcript handling remains supported.

AI-assisted: Yes. I reviewed the implementation, understand the behavior, and verified the resulting transcript output.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/agent-transcript.test.ts`
  - 4 tests passed
- `node --check .agents/skills/agent-transcript/scripts/agent-transcript`
- `oxfmt --check .agents/skills/agent-transcript/SKILL.md test/scripts/agent-transcript.test.ts`
- `git diff --check upstream/main...HEAD`
- Real local Copilot session rendered as `copilot`, with no generated truncation marker
- Structured autoreview against `upstream/main`
  - no accepted or actionable findings

### Local cross-platform proof

- Windows (`d4b3953a811`)
  - `node scripts/run-vitest.mjs test/scripts/agent-transcript.test.ts`: 4 tests passed
  - helper syntax, targeted Oxfmt, and `git diff --check` passed
- WSL2 Linux
  - Ubuntu 24.04, kernel `6.18.33.2-microsoft-standard-WSL2`, Node `v24.13.0`, x64
  - production helper executed directly from the mounted worktree without installing repository dependencies
  - 21 assertions passed: Copilot discovery/classification, Windows and Linux path redaction, private endpoint redaction, public URL/API-route preservation, internal-event omission, tool summaries, and no truncation
  - rendered stats: 1 user turn, 1 assistant turn, 2 tool calls, 2 raw outputs dropped, 4 redactions, 0 unsafe omissions
<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted GitHub Copilot session transcript: portable agent transcripts</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, account identifiers, session identifiers, emails, token-shaped strings, auth details, and private endpoints
omitted: raw tool output, system/developer prompts, reasoning, credentials, device-auth codes, unrelated earlier work, and local paths

[user]
Rebase this branch onto the latest upstream main and open a PR. Use CONTRIBUTING.md when planning the PR.

[assistant]
I read CONTRIBUTING.md, the PR template, CODEOWNERS, and the issue-routing configuration. This is a bounded bug/small-fix PR, so it can go directly to a PR. The body will disclose AI assistance, preserve the required template sections, include focused evidence, and keep maintainer edits enabled.

[user]
Include a redacted agent transcript and show me a local preview first.

[assistant]
The branch rebased conflict-free onto the latest upstream main with an unchanged patch identity. Focused Vitest, syntax, formatting, diff, and real Copilot transcript smoke checks passed.

Structured review identified additional privacy edge cases involving private endpoints and nested URLs. Those were fixed with focused regression coverage. The final structured autoreview reported no accepted or actionable findings.

The branch history was collapsed to one reviewable commit and updated on the fork with force-with-lease. The local and remote full SHAs match.

[tool summary]
Repository reads, focused tests, Git rebase/push operations, local transcript rendering, and structured review were performed. Raw tool output was omitted.
````

</details>
<!-- agent-transcript:end -->
