### PR TITLE
fix: allow markdown preview dialogs to scroll

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3487,7 +3487,8 @@ td.data-table-key-col {
 .md-preview-dialog__panel {
   position: relative;
   width: 100%;
-  min-height: min(76vh, 820px);
+  height: min(92vh, calc(100vh - 32px));
+  min-height: 0;
   max-height: calc(100vh - 32px);
   margin: 0;
   display: flex;
@@ -3627,6 +3628,7 @@ td.data-table-key-col {
 
 .md-preview-dialog__body {
   flex: 1;
+  min-height: 0;
   overflow: auto;
   overscroll-behavior: contain;
   padding: clamp(18px, 3vw, 28px);
@@ -3697,6 +3699,7 @@ td.data-table-key-col {
   --cm-code-bg: color-mix(in srgb, var(--bg-elevated) 72%, black 28%);
   --cm-inline-code-bg: color-mix(in srgb, var(--secondary) 58%, transparent);
   position: relative;
+  min-height: 0;
   width: min(100%, 82ch);
   margin: 0 auto;
   padding: clamp(26px, 4vw, 56px);
@@ -3846,6 +3849,7 @@ td.data-table-key-col {
 
 .md-preview-dialog__panel.fullscreen {
   width: 100%;
+  height: calc(100vh - 20px);
   max-height: calc(100vh - 20px);
   margin: 0;
 }
@@ -3889,7 +3893,8 @@ td.data-table-key-col {
 @media (max-width: 720px) {
   .md-preview-dialog__panel {
     width: 100%;
-    min-height: calc(100vh - 12px);
+    height: calc(100vh - 12px);
+    min-height: 0;
     max-height: calc(100vh - 12px);
     margin: 0;
     border-radius: var(--radius-xl);


### PR DESCRIPTION
## Summary

Fix large Markdown preview dialogs being clipped instead of scrollable.

## What Problem This Solves

When a Markdown preview contains enough content to exceed the dialog height, users can only see the top part of the document. The preview body already has `overflow: auto`, but it sits inside a flex column whose ancestors do not allow the scroll area to shrink. The result is a clipped preview instead of a scrollable one.

## Fix

- Give the preview panel a viewport-bounded height.
- Set `min-height: 0` on the flex panel/body/reader path so the body can shrink and expose its scroll area.
- Preserve fullscreen and mobile viewport bounds.

## Evidence

- Reproduced locally in the installed Control UI: long Markdown previews only showed the upper portion and did not scroll down.
- Applied a local equivalent hotfix to the installed OpenClaw Control UI and verified the gateway serves it:

```text
GET /assets/openclaw-local-hotfix.css -> 200
GET / -> includes openclaw-local-hotfix.css
```

- Built the Control UI successfully:

```bash
pnpm --dir ui exec vite build --mode production
```

- Ran whitespace validation:

```bash
git diff --check
```

- Ran project-local autoreview:

```bash
python .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
```

Result:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.93)
```

Note: a targeted Vitest command for `ui/src/pages/agents/view.test.ts` hung locally without output, so I killed the stale runner and used the production build, local hotfix verification, CI, and autoreview as proof.
