### PR TITLE
fix(ci): restore restart health lint

### DIFF
--- a/src/cli/daemon-cli/restart-health-listener.test.ts
+++ b/src/cli/daemon-cli/restart-health-listener.test.ts
@@ -1,0 +1,165 @@
+// Listener-specific restart health tests cover gateway lock replacement behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PortUsage } from "../../infra/ports.js";
+
+const inspectPortUsage = vi.hoisted(() => vi.fn<(port: number) => Promise<PortUsage>>());
+const probeGateway = vi.hoisted(() => vi.fn());
+const readActiveGatewayLockIdentity = vi.hoisted(() => vi.fn());
+const sleep = vi.hoisted(() => vi.fn(async () => {}));
+const readBestEffortConfig = vi.hoisted(() => vi.fn(async () => ({})));
+const resolveGatewayProbeAuthSafeWithSecretInputs = vi.hoisted(() =>
+  vi.fn(async () => ({ auth: {} })),
+);
+
+vi.mock("../../infra/ports.js", () => ({
+  classifyPortListener: vi.fn(() => "gateway"),
+  formatPortDiagnostics: vi.fn(() => []),
+  inspectPortUsage: (port: number) => inspectPortUsage(port),
+}));
+
+vi.mock("../../gateway/probe.js", () => ({
+  probeGateway: (opts: unknown) => probeGateway(opts),
+}));
+
+vi.mock("../../config/io.js", () => ({
+  createConfigIO: vi.fn(() => ({
+    readBestEffortConfig: () => readBestEffortConfig(),
+  })),
+}));
+
+vi.mock("../../gateway/probe-auth.js", () => ({
+  resolveGatewayProbeAuthSafeWithSecretInputs: (opts: unknown) =>
+    resolveGatewayProbeAuthSafeWithSecretInputs(opts),
+}));
+
+vi.mock("../../infra/gateway-lock.js", () => ({
+  readActiveGatewayLockIdentity: () => readActiveGatewayLockIdentity(),
+  isSameGatewayLockIdentity: (
+    previous: { ownerId?: string; pid: number; createdAt: string; startTime?: number },
+    current: { ownerId?: string; pid: number; createdAt: string; startTime?: number },
+  ) =>
+    previous.ownerId && current.ownerId
+      ? previous.ownerId === current.ownerId
+      : previous.pid === current.pid &&
+        previous.createdAt === current.createdAt &&
+        previous.startTime === current.startTime,
+}));
+
+vi.mock("../../utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils.js")>("../../utils.js");
+  return { ...actual, sleep: (ms: number) => sleep(ms) };
+});
+
+const previousLockIdentity = {
+  pid: 4200,
+  ownerId: "gateway-owner-old",
+  createdAt: "2026-07-16T12:00:00.000Z",
+  port: 18789,
+};
+
+function mockReplacementLock(pid = 4200) {
+  readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
+    ...previousLockIdentity,
+    pid,
+    ownerId: "gateway-owner-new",
+    createdAt: "2026-07-16T12:00:01.000Z",
+  });
+}
+
+describe("waitForGatewayHealthyListener", () => {
+  beforeEach(() => {
+    inspectPortUsage.mockReset();
+    probeGateway.mockReset();
+    readActiveGatewayLockIdentity.mockReset();
+    sleep.mockReset();
+    readBestEffortConfig.mockReset();
+    readBestEffortConfig.mockResolvedValue({});
+    resolveGatewayProbeAuthSafeWithSecretInputs.mockReset();
+    resolveGatewayProbeAuthSafeWithSecretInputs.mockResolvedValue({ auth: {} });
+  });
+
+  it("does not accept listener health until the gateway lock owner changes", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 4200, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: { version: "2026.7.16", connId: "gateway" },
+    });
+    mockReplacementLock();
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      previousLockIdentity,
+      attempts: 2,
+      delayMs: 500,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(readActiveGatewayLockIdentity).toHaveBeenCalledTimes(2);
+    expect(inspectPortUsage).toHaveBeenCalledTimes(1);
+    expect(probeGateway).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { listenerPid: 4300, healthy: true },
+    { listenerPid: 4400, healthy: false },
+  ])(
+    "accepts device identity policy close only for the verified replacement listener",
+    async ({ listenerPid, healthy }) => {
+      inspectPortUsage.mockResolvedValue({
+        port: 18789,
+        status: "busy",
+        listeners: [{ pid: listenerPid, commandLine: "openclaw-gateway" }],
+        hints: [],
+      });
+      probeGateway.mockResolvedValue({
+        ok: false,
+        close: { code: 1008, reason: "device identity required" },
+      });
+      mockReplacementLock(4300);
+
+      const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+      const snapshot = await waitForGatewayHealthyListener({
+        port: 18789,
+        previousLockIdentity,
+        attempts: 1,
+        delayMs: 500,
+      });
+
+      expect(snapshot.healthy).toBe(healthy);
+      expect(inspectPortUsage).toHaveBeenCalledTimes(1);
+      expect(probeGateway).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("bounds replacement health after an indefinite previous-owner wait", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+    mockReplacementLock();
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      previousLockIdentity,
+      attempts: 2,
+      delayMs: 500,
+      waitIndefinitelyForPreviousOwner: true,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(readActiveGatewayLockIdentity).toHaveBeenCalledTimes(2);
+    expect(inspectPortUsage).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/cli/daemon-cli/restart-health-port.ts
+++ b/src/cli/daemon-cli/restart-health-port.ts
@@ -1,0 +1,79 @@
+// Port ownership and diagnostics helpers for gateway restart health checks.
+import { formatPortDiagnostics, type PortUsage } from "../../infra/ports.js";
+import type { GatewayPortHealthSnapshot, GatewayRestartSnapshot } from "./restart-health.js";
+
+export function hasListenerAttributionGap(portUsage: PortUsage): boolean {
+  // lsof/netstat may report a busy port without a PID; keep that distinct from a free port.
+  if (portUsage.status !== "busy" || portUsage.listeners.length > 0) {
+    return false;
+  }
+  if (portUsage.errors?.length) {
+    return true;
+  }
+  return portUsage.hints.some((hint) => hint.includes("process details are unavailable"));
+}
+
+export function listenerOwnedByRuntimePid(params: {
+  listener: PortUsage["listeners"][number];
+  runtimePid: number;
+}): boolean {
+  return params.listener.pid === params.runtimePid || params.listener.ppid === params.runtimePid;
+}
+
+function renderPortUsageDiagnostics(snapshot: GatewayPortHealthSnapshot): string[] {
+  const lines: string[] = [];
+
+  if (snapshot.portUsage.status === "busy") {
+    lines.push(...formatPortDiagnostics(snapshot.portUsage));
+  } else {
+    lines.push(`Gateway port ${snapshot.portUsage.port} status: ${snapshot.portUsage.status}.`);
+  }
+
+  if (snapshot.portUsage.errors?.length) {
+    lines.push(`Port diagnostics errors: ${snapshot.portUsage.errors.join("; ")}`);
+  }
+
+  return lines;
+}
+
+export function renderRestartDiagnostics(snapshot: GatewayRestartSnapshot): string[] {
+  const lines: string[] = [];
+  if (snapshot.versionMismatch) {
+    const actual = snapshot.versionMismatch.actual ?? "unavailable";
+    lines.push(
+      `Gateway version mismatch: expected ${snapshot.versionMismatch.expected}, running gateway reported ${actual}.`,
+    );
+  }
+  if (snapshot.activatedPluginErrors?.length) {
+    lines.push("Activated plugin load errors:");
+    for (const plugin of snapshot.activatedPluginErrors) {
+      lines.push(`- ${plugin.id}: ${plugin.error}`);
+    }
+  }
+  if (snapshot.channelProbeErrors?.length) {
+    lines.push("Channel health probe errors:");
+    for (const channel of snapshot.channelProbeErrors) {
+      lines.push(`- ${channel.id}: ${channel.error}`);
+    }
+  }
+  const runtimeSummary = [
+    snapshot.runtime.status ? `status=${snapshot.runtime.status}` : null,
+    snapshot.runtime.state ? `state=${snapshot.runtime.state}` : null,
+    snapshot.runtime.pid != null ? `pid=${snapshot.runtime.pid}` : null,
+    snapshot.runtime.lastExitStatus != null ? `lastExit=${snapshot.runtime.lastExitStatus}` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  if (runtimeSummary) {
+    lines.push(`Service runtime: ${runtimeSummary}`);
+  }
+
+  lines.push(...renderPortUsageDiagnostics(snapshot));
+
+  return lines;
+}
+
+export function renderGatewayPortHealthDiagnostics(snapshot: GatewayPortHealthSnapshot): string[] {
+  return renderPortUsageDiagnostics(snapshot);
+}

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -26,7 +26,6 @@ const resolveGatewayProbeAuthSafeWithSecretInputs = vi.hoisted(() =>
 const hasActiveStartupMigrationLease = vi.hoisted(() =>
   vi.fn<(_params?: unknown) => boolean>(() => false),
 );
-const readActiveGatewayLockIdentity = vi.hoisted(() => vi.fn());
 
 vi.mock("../../infra/ports.js", () => ({
   classifyPortListener: (listener: unknown, port: number) => classifyPortListener(listener, port),
@@ -50,19 +49,6 @@ vi.mock("../../gateway/probe-auth.js", () => ({
 vi.mock("../../infra/startup-migration-checkpoint.js", () => ({
   hasActiveStartupMigrationLease: (params: unknown) => hasActiveStartupMigrationLease(params),
   STARTUP_MIGRATION_LEASE_TTL_MS: 5 * 60_000,
-}));
-
-vi.mock("../../infra/gateway-lock.js", () => ({
-  readActiveGatewayLockIdentity: () => readActiveGatewayLockIdentity(),
-  isSameGatewayLockIdentity: (
-    previous: { ownerId?: string; pid: number; createdAt: string; startTime?: number },
-    current: { ownerId?: string; pid: number; createdAt: string; startTime?: number },
-  ) =>
-    previous.ownerId && current.ownerId
-      ? previous.ownerId === current.ownerId
-      : previous.pid === current.pid &&
-        previous.createdAt === current.createdAt &&
-        previous.startTime === current.startTime,
 }));
 
 vi.mock("../../utils.js", async () => {
@@ -195,8 +181,6 @@ describe("inspectGatewayRestart", () => {
     });
     hasActiveStartupMigrationLease.mockReset();
     hasActiveStartupMigrationLease.mockReturnValue(false);
-    readActiveGatewayLockIdentity.mockReset();
-    readActiveGatewayLockIdentity.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -984,122 +968,6 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.elapsedMs).toBe(1_000);
     expect(snapshot.versionMismatch).toBeUndefined();
     expect(sleep).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not accept listener health until the gateway lock owner changes", async () => {
-    inspectPortUsage.mockResolvedValue({
-      port: 18789,
-      status: "busy",
-      listeners: [{ pid: 4200, commandLine: "openclaw-gateway" }],
-      hints: [],
-    });
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.7.16", connId: "gateway" },
-    });
-    const previousLockIdentity = {
-      pid: 4200,
-      ownerId: "gateway-owner-old",
-      createdAt: "2026-07-16T12:00:00.000Z",
-      port: 18789,
-    };
-    readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
-      ...previousLockIdentity,
-      ownerId: "gateway-owner-new",
-      createdAt: "2026-07-16T12:00:01.000Z",
-    });
-
-    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
-    const snapshot = await waitForGatewayHealthyListener({
-      port: 18789,
-      previousLockIdentity,
-      attempts: 2,
-      delayMs: 500,
-    });
-
-    expect(snapshot.healthy).toBe(true);
-    expect(readActiveGatewayLockIdentity).toHaveBeenCalledTimes(2);
-    expect(inspectPortUsage).toHaveBeenCalledTimes(1);
-    expect(probeGateway).toHaveBeenCalledTimes(1);
-    expect(sleep).toHaveBeenCalledTimes(1);
-  });
-
-  it.each([
-    { listenerPid: 4300, healthy: true },
-    { listenerPid: 4400, healthy: false },
-  ])(
-    "accepts device identity policy close only for the verified replacement listener",
-    async ({ listenerPid, healthy }) => {
-      inspectPortUsage.mockResolvedValue({
-        port: 18789,
-        status: "busy",
-        listeners: [{ pid: listenerPid, commandLine: "openclaw-gateway" }],
-        hints: [],
-      });
-      probeGateway.mockResolvedValue({
-        ok: false,
-        close: { code: 1008, reason: "device identity required" },
-      });
-      const previousLockIdentity = {
-        pid: 4200,
-        ownerId: "gateway-owner-old",
-        createdAt: "2026-07-16T12:00:00.000Z",
-        port: 18789,
-      };
-      readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
-        ...previousLockIdentity,
-        pid: 4300,
-        ownerId: "gateway-owner-new",
-        createdAt: "2026-07-16T12:00:01.000Z",
-      });
-
-      const { waitForGatewayHealthyListener } = await import("./restart-health.js");
-      const snapshot = await waitForGatewayHealthyListener({
-        port: 18789,
-        previousLockIdentity,
-        attempts: 1,
-        delayMs: 500,
-      });
-
-      expect(snapshot.healthy).toBe(healthy);
-      expect(inspectPortUsage).toHaveBeenCalledTimes(1);
-      expect(probeGateway).toHaveBeenCalledTimes(1);
-    },
-  );
-
-  it("bounds replacement health after an indefinite previous-owner wait", async () => {
-    inspectPortUsage.mockResolvedValue({
-      port: 18789,
-      status: "free",
-      listeners: [],
-      hints: [],
-    });
-    const previousLockIdentity = {
-      pid: 4200,
-      ownerId: "gateway-owner-old",
-      createdAt: "2026-07-16T12:00:00.000Z",
-      port: 18789,
-    };
-    readActiveGatewayLockIdentity.mockResolvedValueOnce(previousLockIdentity).mockResolvedValue({
-      ...previousLockIdentity,
-      ownerId: "gateway-owner-new",
-      createdAt: "2026-07-16T12:00:01.000Z",
-    });
-
-    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
-    const snapshot = await waitForGatewayHealthyListener({
-      port: 18789,
-      previousLockIdentity,
-      attempts: 2,
-      delayMs: 500,
-      waitIndefinitelyForPreviousOwner: true,
-    });
-
-    expect(snapshot.healthy).toBe(false);
-    expect(readActiveGatewayLockIdentity).toHaveBeenCalledTimes(2);
-    expect(inspectPortUsage).toHaveBeenCalledTimes(3);
-    expect(sleep).toHaveBeenCalledTimes(3);
   });
 
   it("annotates timeout waits when the health loop exhausts all attempts", async () => {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -11,18 +11,18 @@ import type { GatewayService } from "../../daemon/service.js";
 import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../../gateway/probe-auth.js";
 import { probeGateway } from "../../gateway/probe.js";
 import type { GatewayLockIdentity } from "../../infra/gateway-lock.js";
-import {
-  classifyPortListener,
-  formatPortDiagnostics,
-  inspectPortUsage,
-  type PortUsage,
-} from "../../infra/ports.js";
+import { classifyPortListener, inspectPortUsage, type PortUsage } from "../../infra/ports.js";
 import {
   hasActiveStartupMigrationLease,
   STARTUP_MIGRATION_LEASE_TTL_MS,
 } from "../../infra/startup-migration-checkpoint.js";
 import { sleep } from "../../utils.js";
+import { hasListenerAttributionGap, listenerOwnedByRuntimePid } from "./restart-health-port.js";
 import { waitForGatewayLockReplacement } from "./restart-lock-replacement.js";
+export {
+  renderGatewayPortHealthDiagnostics,
+  renderRestartDiagnostics,
+} from "./restart-health-port.js";
 export { terminateStaleGatewayPids } from "./restart-stale-pids.js";
 
 const DEFAULT_RESTART_HEALTH_TIMEOUT_MS = 60_000;
@@ -76,24 +76,6 @@ type GatewayRestartProbeAuth = {
   token?: string;
   password?: string;
 };
-
-function hasListenerAttributionGap(portUsage: PortUsage): boolean {
-  // lsof/netstat may report a busy port without a PID; keep that distinct from a free port.
-  if (portUsage.status !== "busy" || portUsage.listeners.length > 0) {
-    return false;
-  }
-  if (portUsage.errors?.length) {
-    return true;
-  }
-  return portUsage.hints.some((hint) => hint.includes("process details are unavailable"));
-}
-
-function listenerOwnedByRuntimePid(params: {
-  listener: PortUsage["listeners"][number];
-  runtimePid: number;
-}): boolean {
-  return params.listener.pid === params.runtimePid || params.listener.ppid === params.runtimePid;
-}
 
 function looksLikeAuthClose(code: number | undefined, reason: string | undefined): boolean {
   if (code !== 1008) {
@@ -715,62 +697,4 @@ export async function waitForGatewayHealthyListener(params: {
   }
 
   return snapshot;
-}
-
-function renderPortUsageDiagnostics(snapshot: GatewayPortHealthSnapshot): string[] {
-  const lines: string[] = [];
-
-  if (snapshot.portUsage.status === "busy") {
-    lines.push(...formatPortDiagnostics(snapshot.portUsage));
-  } else {
-    lines.push(`Gateway port ${snapshot.portUsage.port} status: ${snapshot.portUsage.status}.`);
-  }
-
-  if (snapshot.portUsage.errors?.length) {
-    lines.push(`Port diagnostics errors: ${snapshot.portUsage.errors.join("; ")}`);
-  }
-
-  return lines;
-}
-
-export function renderRestartDiagnostics(snapshot: GatewayRestartSnapshot): string[] {
-  const lines: string[] = [];
-  if (snapshot.versionMismatch) {
-    const actual = snapshot.versionMismatch.actual ?? "unavailable";
-    lines.push(
-      `Gateway version mismatch: expected ${snapshot.versionMismatch.expected}, running gateway reported ${actual}.`,
-    );
-  }
-  if (snapshot.activatedPluginErrors?.length) {
-    lines.push("Activated plugin load errors:");
-    for (const plugin of snapshot.activatedPluginErrors) {
-      lines.push(`- ${plugin.id}: ${plugin.error}`);
-    }
-  }
-  if (snapshot.channelProbeErrors?.length) {
-    lines.push("Channel health probe errors:");
-    for (const channel of snapshot.channelProbeErrors) {
-      lines.push(`- ${channel.id}: ${channel.error}`);
-    }
-  }
-  const runtimeSummary = [
-    snapshot.runtime.status ? `status=${snapshot.runtime.status}` : null,
-    snapshot.runtime.state ? `state=${snapshot.runtime.state}` : null,
-    snapshot.runtime.pid != null ? `pid=${snapshot.runtime.pid}` : null,
-    snapshot.runtime.lastExitStatus != null ? `lastExit=${snapshot.runtime.lastExitStatus}` : null,
-  ]
-    .filter(Boolean)
-    .join(", ");
-
-  if (runtimeSummary) {
-    lines.push(`Service runtime: ${runtimeSummary}`);
-  }
-
-  lines.push(...renderPortUsageDiagnostics(snapshot));
-
-  return lines;
-}
-
-export function renderGatewayPortHealthDiagnostics(snapshot: GatewayPortHealthSnapshot): string[] {
-  return renderPortUsageDiagnostics(snapshot);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where current `main` CI fails its global lint shard because the restart-health implementation and test files exceed the enforced max-lines limits after #109273. The unrelated failure blocks otherwise valid pull requests from reaching a green CI cohort.

## Why This Change Was Made

Port ownership and diagnostic helpers now live in a focused module, while listener restart coverage lives in a focused test file. Existing exports and runtime behavior remain unchanged; no max-lines suppression or limit increase was added.

## User Impact

No product behavior change. Maintainers and contributors can obtain green lint results again without bypassing repository quality gates.

## Evidence

- Reproduced `check-lint` failure on current `main`: `restart-health.ts` and `restart-health.test.ts` exceeded max-lines.
- Exact failed command now passes on Blacksmith Testbox: `node scripts/run-oxlint-shards.mjs --threads=8` reported zero warnings and zero errors across core, plugins, and scripts.
- Focused tests pass: 3 files, 65 tests (`restart-health`, listener restart health, and lock replacement).
- `pnpm check:changed` passes max-lines ratchet, formatting, ownership, dependency, and duplicate guards. Its only failure is the pre-existing Plugin SDK API baseline hash mismatch, reproduced identically from a clean `origin/main` archive.
- `autoreview --mode uncommitted`: no accepted/actionable findings (0.98 confidence).
- `git diff --check`: clean.

AI-assisted. I reviewed the refactor and understand the preserved restart-health behavior.
