### PR TITLE
fix(macos): merge the WebChat window title band into the toolbar row

### DIFF
--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -18,6 +18,18 @@ private enum WebChatSwiftUILayout {
     static let anchorPadding: CGFloat = 8
 }
 
+/// SwiftUI's native toolbar bridge may restore visible title chrome while it
+/// installs toolbar items. Keep the full-window chat's titlebar merged.
+private final class WebChatWindow: NSWindow {
+    override var titleVisibility: NSWindow.TitleVisibility {
+        didSet {
+            if self.titleVisibility != .hidden {
+                self.titleVisibility = .hidden
+            }
+        }
+    }
+}
+
 struct MacGatewayChatTransport: OpenClawChatTransport {
     /// Shared across transport value copies so the live view model and its
     /// snapshot observer cannot diverge on the owner of the bare global alias.
@@ -580,7 +592,6 @@ final class WebChatSwiftUIWindowController {
             let hosting = NSHostingController(rootView: OpenClawChatWindowShell(
                 viewModel: vm,
                 userAccent: accent))
-            hosting.sceneBridgingOptions = [.toolbars, .title]
             self.contentController = hosting
         case .panel:
             // Anchored quick-chat panel: compact single-column chat.
@@ -705,16 +716,25 @@ final class WebChatSwiftUIWindowController {
     {
         switch presentation {
         case .window:
-            let window = NSWindow(
+            let window = WebChatWindow(
                 contentRect: NSRect(origin: .zero, size: WebChatSwiftUILayout.windowSize),
                 styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false)
             window.title = "OpenClaw Chat"
             window.contentViewController = contentViewController
+            // Attaching an NSHostingController resets scene bridging to `.all`;
+            // opt back into toolbar items only so SwiftUI cannot restore the title.
+            (contentViewController as? NSHostingController<OpenClawChatWindowShell>)?
+                .sceneBridgingOptions = [.toolbars]
             window.isReleasedWhenClosed = false
-            window.titleVisibility = .visible
+            // Keep the SwiftUI toolbar controls, but merge their unified row
+            // with the traffic lights instead of stacking it below a title band.
+            window.titleVisibility = .hidden
+            window.titlebarAppearsTransparent = true
             window.toolbarStyle = .unified
+            window.titlebarSeparatorStyle = .none
+            window.isMovableByWindowBackground = true
             window.center()
             window.setFrameAutosaveName(WebChatSwiftUILayout.windowFrameAutosaveName)
             WindowPlacement.ensureOnScreen(window: window, defaultSize: WebChatSwiftUILayout.windowSize)
@@ -801,4 +821,14 @@ final class WebChatSwiftUIWindowController {
     private static func color(fromHex raw: String?) -> Color? {
         ColorHexSupport.color(fromHex: raw)
     }
+
+    #if DEBUG
+    var _testWindow: NSWindow? {
+        self.window
+    }
+
+    var _testSceneBridgingOptions: NSHostingSceneBridgingOptions? {
+        (self.contentController as? NSHostingController<OpenClawChatWindowShell>)?.sceneBridgingOptions
+    }
+    #endif
 }

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -41,12 +41,25 @@ struct WebChatSwiftUISmokeTests {
         func setActiveSessionKey(_: String) async throws {}
     }
 
-    @Test func `window controller show and close`() {
+    @Test func `window controller merges titlebar and keeps toolbar controls`() throws {
         let controller = WebChatSwiftUIWindowController(
             sessionKey: "main",
             presentation: .window,
             transport: TestTransport())
+        let window = try #require(controller._testWindow)
+
+        #expect(window.styleMask.contains(.fullSizeContentView))
+        #expect(window.titleVisibility == .hidden)
+        #expect(window.titlebarAppearsTransparent)
+        #expect(window.toolbarStyle == .unified)
+        #expect(window.titlebarSeparatorStyle == .none)
+        #expect(window.isMovableByWindowBackground)
+        #expect(controller._testSceneBridgingOptions?.contains(.toolbars) == true)
+        #expect(controller._testSceneBridgingOptions?.contains(.title) == false)
+
         controller.show()
+        #expect(window.titleVisibility == .hidden)
+        #expect(window.toolbar != nil)
         controller.close()
     }
 


### PR DESCRIPTION
## What Problem This Solves

The standalone WebChat window stacks a full native title band (traffic lights + "OpenClaw" title) above the SwiftUI toolbar row (sidebar toggle, search, session title, pickers), wasting a band of vertical space. User-reported with screenshot.

## Why This Change Was Made

Apply the merged-chrome pattern the Dashboard window already ships (#105902): hidden title, transparent titlebar, no separator, movable-by-background — one header row with the traffic lights inline.

## User Impact

The chat window's toolbar controls and traffic lights share a single row; the empty title band is gone. Close/miniaturize/resize/fullscreen and frame restoration unchanged. The quick-chat panel (borderless) is untouched.

Two subtle traps are handled and regression-tested:
- SwiftUI's toolbar bridge can restore visible title chrome → a window subclass pins `titleVisibility = .hidden`.
- Attaching an `NSHostingController` resets `sceneBridgingOptions` to `.all` → re-set to `[.toolbars]` after attachment so the title never bridges back (toolbar controls investigated and kept: sidebar toggle, search, title/subtitle, context usage, Thinking/Model pickers, session actions, New Session).

## Evidence

- `swift build` + `swift test --filter WebChatSwiftUISmokeTests` (3/3: hidden-title pinning, bridging options, style mask) + `scripts/format-swift.sh` + `scripts/lint-swift.sh` (zero violations).
- Visual capture blocker, stated plainly: the dev-harness (bare SPM binary / locally packaged bundle) renders this SwiftUI window's *content* blank on both baseline main and this branch (pre-existing harness limitation, verified by stash-baseline comparison), so honest before/after window screenshots could not be produced off-desktop. The chrome change itself is deterministic AppKit config identical to the Dashboard window. Reporter can confirm visually on first relaunch after landing.