### PR TITLE
fix(windows): prevent encoding probes from blocking commands

### DIFF
--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -1,7 +1,18 @@
 // Covers Windows command-output code page parsing and decoding.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawnSync: spawnSyncMock,
+  };
+});
+
 import {
   createWindowsOutputDecoder,
   decodeWindowsOutputBuffer,
@@ -9,6 +20,70 @@ import {
 } from "./windows-encoding.js";
 
 describe("windows output encoding", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    spawnSyncMock.mockReset();
+  });
+
+  it("bounds and caches failed Windows encoding probes", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    spawnSyncMock.mockReturnValue({
+      error: Object.assign(new Error("spawnSync ETIMEDOUT"), { code: "ETIMEDOUT" }),
+      output: [null, "", ""],
+      pid: 1,
+      signal: "SIGKILL",
+      status: null,
+      stderr: "",
+      stdout: "",
+    });
+    vi.resetModules();
+    const {
+      decodeWindowsOutputBuffer: decodeOutputWithFreshCache,
+      decodeWindowsTextFileBuffer: decodeTextWithFreshCache,
+    } = await import("./windows-encoding.js");
+    const undecodableByte = Buffer.from([0x80]);
+
+    expect(decodeOutputWithFreshCache({ buffer: undecodableByte, platform: "win32" })).toBe(
+      undecodableByte.toString("utf8"),
+    );
+    expect(decodeOutputWithFreshCache({ buffer: undecodableByte, platform: "win32" })).toBe(
+      undecodableByte.toString("utf8"),
+    );
+    expect(decodeTextWithFreshCache({ buffer: undecodableByte, platform: "win32" })).toBe(
+      undecodableByte.toString("utf8"),
+    );
+    expect(decodeTextWithFreshCache({ buffer: undecodableByte, platform: "win32" })).toBe(
+      undecodableByte.toString("utf8"),
+    );
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      ["/d", "/s", "/c", "chcp"],
+      {
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 5_000,
+        windowsHide: true,
+      },
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      2,
+      "powershell.exe",
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "[Text.Encoding]::Default.CodePage"],
+      {
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 5_000,
+        windowsHide: true,
+      },
+    );
+  });
+
   it("decodes GBK output on Windows when UTF-8 is invalid and code page is known", () => {
     const raw = Buffer.from([0xb2, 0xe2, 0xca, 0xd4, 0xa1, 0xab, 0xa3, 0xbb]);
 

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -21,6 +21,7 @@ const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
   1257: "windows-1257",
   1258: "windows-1258",
 };
+const WINDOWS_ENCODING_PROBE_TIMEOUT_MS = 5_000;
 
 let cachedWindowsConsoleEncoding: string | null | undefined;
 let cachedWindowsSystemEncoding: string | null | undefined;
@@ -53,7 +54,9 @@ export function resolveWindowsConsoleEncoding(): string | null {
     const result = spawnSync(getWindowsCmdExePath(), ["/d", "/s", "/c", "chcp"], {
       windowsHide: true,
       encoding: "utf8",
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "pipe"],
+      timeout: WINDOWS_ENCODING_PROBE_TIMEOUT_MS,
     });
     const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
     const codePage = parseWindowsCodePage(raw);
@@ -80,7 +83,9 @@ export function resolveWindowsSystemEncoding(): string | null {
       {
         windowsHide: true,
         encoding: "utf8",
+        killSignal: "SIGKILL",
         stdio: ["ignore", "pipe", "pipe"],
+        timeout: WINDOWS_ENCODING_PROBE_TIMEOUT_MS,
       },
     );
     const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;


### PR DESCRIPTION
AI-assisted: Codex.

## What Problem This Solves

Fixes an issue where Windows command execution or legacy text decoding could block indefinitely when the console or system code-page probe stopped responding. The console probe runs before the caller's command timeout starts, so an existing per-command timeout could not recover this path.

## Why This Change Was Made

Both one-shot encoding probes now have a five-second deadline and use `SIGKILL` for a hard stop. Existing null fallback and module-level caching remain unchanged, so a failed probe falls back to UTF-8 behavior and is not retried on every command.

## User Impact

Windows users no longer wait indefinitely on a stalled `chcp` or PowerShell code-page lookup before commands run or output is decoded. There are no config, migration, or API changes.

## Evidence

- Focused regression test: `node scripts/run-vitest.mjs src/infra/windows-encoding.test.ts --run` (`9/9` passed on Node 24.15.0).
- Controlled stalled-child proof with a 75 ms deadline returned in 80 ms with `errorCode: "ETIMEDOUT"`, `signal: "SIGKILL"`, and `status: null`.
- The regression test verifies both exact probe commands, the five-second deadline, hard-kill signal, null fallback, and one-result-per-probe caching.
- `oxfmt --check`, targeted `oxlint`, and `git diff --check` passed for the two changed files.
- Fresh independent Codex review completed with no actionable findings after the test was made compatible with the public decoder seams.
