### PR TITLE
fix(docker): bound attestation registry inspection

### DIFF
--- a/scripts/verify-docker-attestations.d.mts
+++ b/scripts/verify-docker-attestations.d.mts
@@ -15,6 +15,12 @@ export function parsePlatform(value: unknown): {
  * Collects missing/mismatched attestation errors for required image platforms.
  */
 export function collectDockerAttestationErrors(params: unknown): string[];
+export function inspectRaw(
+  imageRef: unknown,
+  params?: {
+    execFileSyncImpl?: (command: string, args: string[], options: unknown) => string;
+  },
+): string;
 export function parseArgs(argv: unknown): {
   help: boolean;
   imageRefs: unknown[];

--- a/scripts/verify-docker-attestations.mjs
+++ b/scripts/verify-docker-attestations.mjs
@@ -7,6 +7,7 @@ import process from "node:process";
 const ATTESTATION_REFERENCE_TYPE = "attestation-manifest";
 const EXPECTED_ATTESTATION_ARTIFACT_TYPE = "application/vnd.docker.attestation.manifest.v1+json";
 const REQUIRED_PREDICATES = ["https://spdx.dev/Document", "https://slsa.dev/provenance/v1"];
+const DOCKER_INSPECT_TIMEOUT_MS = 120_000;
 
 /**
  * Rewrites an image reference to use the provided digest.
@@ -124,11 +125,14 @@ export function collectDockerAttestationErrors(params) {
   return errors;
 }
 
-function inspectRaw(imageRef) {
-  return execFileSync("docker", ["buildx", "imagetools", "inspect", "--raw", imageRef], {
+export function inspectRaw(imageRef, params = {}) {
+  const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
+  return execFileSyncImpl("docker", ["buildx", "imagetools", "inspect", "--raw", imageRef], {
     encoding: "utf8",
+    killSignal: "SIGKILL",
     maxBuffer: 20 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: DOCKER_INSPECT_TIMEOUT_MS,
   });
 }
 

--- a/test/scripts/verify-docker-attestations.test.ts
+++ b/test/scripts/verify-docker-attestations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectDockerAttestationErrors,
   imageRefForDigest,
+  inspectRaw,
   parseArgs,
   parsePlatform,
 } from "../../scripts/verify-docker-attestations.mjs";
@@ -54,6 +55,32 @@ function createAttestation(
 }
 
 describe("verify-docker-attestations", () => {
+  it("bounds docker manifest inspection calls", () => {
+    const calls: unknown[] = [];
+    const imageRef = "ghcr.io/openclaw/openclaw:test";
+    const output = inspectRaw(imageRef, {
+      execFileSyncImpl(command: string, args: string[], options: unknown) {
+        calls.push({ args, command, options });
+        return "{}";
+      },
+    });
+
+    expect(output).toBe("{}");
+    expect(calls).toStrictEqual([
+      {
+        args: ["buildx", "imagetools", "inspect", "--raw", imageRef],
+        command: "docker",
+        options: {
+          encoding: "utf8",
+          killSignal: "SIGKILL",
+          maxBuffer: 20 * 1024 * 1024,
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 120_000,
+        },
+      },
+    ]);
+  });
+
   it("parses required platforms and image refs", () => {
     expect(
       parseArgs(["--platform", "linux/amd64", "--platform", "linux/arm64", "ghcr.io/openclaw/app"]),


### PR DESCRIPTION
AI-assisted: Codex.

## What Problem This Solves

Docker release attestation verification synchronously inspects image indexes and attestation manifests in GHCR and Docker Hub. A registry request that accepts a connection but never finishes can therefore block the verification step indefinitely.

## Why This Change Was Made

Each `docker buildx imagetools inspect --raw` invocation now has a 120-second hard deadline and uses `SIGKILL`, so the existing verification step fails instead of waiting forever. The boundary is per registry inspection; workflow sequencing and attestation policy are unchanged.

Buildx passes the command context into the image-tools registry path but does not add a deadline ([command](https://github.com/docker/buildx/blob/2adf2bc447e258371dbaa3291b35806997107420/commands/imagetools/inspect.go#L22-L53), [resolver](https://github.com/docker/buildx/blob/2adf2bc447e258371dbaa3291b35806997107420/util/imagetools/inspect.go#L57-L70)). Its BuildKit HTTP client configures a transport but no overall client timeout ([source](https://github.com/moby/buildkit/blob/da1e02337d108a657fe3253957a8166d5f24671d/util/tracing/tracing.go#L72-L76)).

## User Impact

Release operators get a bounded failure from a stalled registry inspection instead of a release verification job that can hang indefinitely. This does not change runtime behavior, configuration, or public APIs.

## Evidence

- Exact rebased head `240879ea6cda`: `node scripts/run-vitest.mjs test/scripts/verify-docker-attestations.test.ts --run` passed 9/9; targeted `oxfmt --check` and `git diff --check` passed.
- Exact changed path, controlled stalled registry, Docker Buildx v0.35.0: `inspectRaw("localhost:48791/openclaw:stall")` returned `{"elapsedMs":120105,"name":"Error","code":"ETIMEDOUT","status":null,"signal":"SIGKILL"}`. The local HTTP registry completed `/v2/` and then held the manifest response body open, exercising Buildx's real registry request path rather than a mocked child-process call.
- Successful live registry margin through the same exported `inspectRaw` path: GHCR `ghcr.io/openclaw/openclaw:latest` completed in 1,960 ms (1,609 bytes); Docker Hub `docker.io/openclaw/openclaw:latest` completed in 2,388 ms (1,609 bytes). Both were more than 50x below the 120-second cutoff.
- The focused test verifies the exact Docker command, 120-second timeout, `SIGKILL`, stdio, buffer limit, and returned output.
- The Docker release workflow invokes this verifier in six sequential groups and does not define a job-level timeout.
- Node documents that synchronous child-process calls send the configured signal on timeout and wait for process close ([source](https://github.com/nodejs/node/blob/848430679556aed0bd073f2bc263331ad84fa119/doc/api/child_process.md#L1187-L1191)).
- The pre-rebase exact code also passed the full required CI matrix on Node 24. The rebase changed only the parent; the production and focused-test blob hashes are identical before and after rebase.
- Fresh independent Codex adversarial review found no actionable issues and judged the per-inspection owner boundary preferable to a coarse workflow timeout or new configuration.
