### PR TITLE
improve: speed up config-write-heavy unit suites

### DIFF
--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -81,7 +81,16 @@ vi.mock("./backup-rotation.js", async (importOriginal) => {
 type ConfigIoOptions = Parameters<typeof createObservedConfigIO>[0];
 
 function createConfigIO(options: ConfigIoOptions = {}) {
-  return createObservedConfigIO({ observe: false, ...options });
+  const env = options.env ?? ({} as NodeJS.ProcessEnv);
+  if (!("NODE_ENV" in env)) {
+    // Route real SQLite state through Vitest's worker DB without adding a key to config env snapshots.
+    Object.defineProperty(env, "NODE_ENV", { configurable: true, value: "test" });
+  }
+  return createObservedConfigIO({
+    observe: false,
+    ...options,
+    env,
+  });
 }
 
 describe("config io write", () => {
@@ -115,7 +124,6 @@ describe("config io write", () => {
   });
 
   afterEach(() => {
-    closeOpenClawStateDatabaseForTest();
     resetConfigRuntimeState();
     clearLoadPluginMetadataSnapshotMemo();
     mockMaintainConfigBackups.mockReset();
@@ -218,7 +226,10 @@ describe("config io write", () => {
       const warn = vi.fn();
       const io = createConfigIO({
         configPath,
-        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+        env: {
+          OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
+          OPENCLAW_TEST_FAST: "1",
+        } as NodeJS.ProcessEnv,
         homedir: () => home,
         logger: { warn, error: vi.fn() },
         observe: true,

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentDir } from "../agents/agent-scope-config.js";
 import {
   readAuthProfileStoreForTest,
@@ -32,6 +31,7 @@ import {
 import { ensurePluginRegistryLoaded } from "../plugins/runtime/runtime-registry-loader.js";
 import type { ProviderPlugin } from "../plugins/types.js";
 import { disposeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { cleanupSystemAgentSession, createSystemAgentSession } from "./agent-turn.js";
 import { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
@@ -40,12 +40,14 @@ import { resolveSetupInferenceProbeStreamParams } from "./setup-inference-probe.
 import {
   SetupInferenceActivationIndeterminateError,
   activateSetupInference as activateSetupInferenceImpl,
+  type BoundVerifySetupInferenceResult,
   detectSetupInference,
   listSetupInferenceAuthOptions,
   listSetupInferenceManualProviders,
   resolvePersistentApplyInference,
-  verifySetupInference,
-  verifySetupInferenceConfig,
+  type VerifySetupInferenceResult,
+  verifySetupInference as verifySetupInferenceImpl,
+  verifySetupInferenceConfig as verifySetupInferenceConfigImpl,
 } from "./setup-inference.js";
 import {
   createSystemAgentVerifiedInferenceBinding,
@@ -114,14 +116,45 @@ const testCodexRuntimeArtifact = {
   id: "codex-app-server",
   fingerprint: "codex-runtime-v1",
 } as const;
+const suiteTempRootTracker = createSuiteTempRootTracker({
+  prefix: "setup-inference-test-",
+});
+
+beforeAll(async () => {
+  await suiteTempRootTracker.setup();
+});
+
+afterAll(async () => {
+  await suiteTempRootTracker.cleanup();
+});
+
+async function makeTempDir(): Promise<string> {
+  return await suiteTempRootTracker.make("case");
+}
+
+const deferSuiteTempDirCleanup = async () => {};
+
+function withSuiteTempDirs<
+  T extends NonNullable<Parameters<typeof activateSetupInferenceImpl>[0]["deps"]>,
+>(input: T | undefined): T {
+  // Keep operation dirs real and unique; only their routine cleanup moves to suite teardown.
+  const deps = Object.create(
+    Object.getPrototypeOf(input ?? {}),
+    Object.getOwnPropertyDescriptors(input ?? {}),
+  ) as T;
+  if (!deps.createTempDir) {
+    deps.createTempDir = makeTempDir;
+  }
+  if (deps.createTempDir === makeTempDir && !deps.removeTempDir) {
+    deps.removeTempDir = deferSuiteTempDirCleanup;
+  }
+  return deps;
+}
 
 async function activateSetupInference(
   params: Parameters<typeof activateSetupInferenceImpl>[0],
 ): ReturnType<typeof activateSetupInferenceImpl> {
-  const deps = Object.create(
-    Object.getPrototypeOf(params.deps ?? {}),
-    Object.getOwnPropertyDescriptors(params.deps ?? {}),
-  ) as NonNullable<typeof params.deps>;
+  const deps = withSuiteTempDirs(params.deps);
   const ownerPluginArtifacts = { ownerPluginIds: [], ownerPluginArtifacts: [] } as const;
   const usesRealOwnerBinding =
     params.deps?.createSystemAgentVerifiedInferenceBinding ===
@@ -148,8 +181,30 @@ async function activateSetupInference(
   });
 }
 
-async function makeTempDir(): Promise<string> {
-  return await fs.mkdtemp(path.join(os.tmpdir(), "setup-inference-test-"));
+type TestVerifySetupInferenceParams = Omit<
+  Parameters<typeof verifySetupInferenceImpl>[0],
+  "bindSession"
+>;
+
+function verifySetupInference(
+  params: TestVerifySetupInferenceParams & { bindSession: true },
+): Promise<BoundVerifySetupInferenceResult>;
+function verifySetupInference(
+  params: TestVerifySetupInferenceParams & { bindSession?: false },
+): Promise<VerifySetupInferenceResult>;
+function verifySetupInference(
+  params: TestVerifySetupInferenceParams & { bindSession?: boolean },
+): Promise<VerifySetupInferenceResult | BoundVerifySetupInferenceResult> {
+  return verifySetupInferenceImpl({
+    ...params,
+    deps: withSuiteTempDirs(params.deps),
+  } as never);
+}
+
+async function verifySetupInferenceConfig(
+  params: Parameters<typeof verifySetupInferenceConfigImpl>[0],
+): ReturnType<typeof verifySetupInferenceConfigImpl> {
+  return verifySetupInferenceConfigImpl({ ...params, deps: withSuiteTempDirs(params.deps) });
 }
 
 type SuccessfulRunParams = {


### PR DESCRIPTION
## What Problem This Solves

The config-write-heavy `setup-inference` and config IO unit suites repeatedly created and removed full temporary roots and reopened fresh SQLite state databases. That fixed per-test filesystem and database cost dominated their core test lanes even though most cases vary only the config content.

## Why This Change Was Made

Reuse suite-owned temporary roots while keeping every operation in a unique real directory, and route ordinary config-health writes through Vitest's real worker-scoped SQLite database. Tests with custom cleanup behavior or explicit state paths still exercise the exact production filesystem and SQLite composition. No production code changed.

AI-assisted; the patch was reviewed with the repository autoreview workflow.

## User Impact

Developers and CI get materially faster core unit lanes. Runtime behavior and shipped code are unchanged.

## Evidence

Same kept Linux Blacksmith Testbox lease, solo `/usr/bin/time -v` runs:

- `src/system-agent/setup-inference.test.ts`: 108/108 pass. Wall 32.44s before; 16.25s and 22.03s on two final runs (32-50% lower). Max RSS 1,345,444 KB before; 960,796-1,022,072 KB after (24-29% lower).
- `src/config/io.write-config.test.ts`: 79/79 pass. Wall 12.23s before; 7.11s after (42% lower). Max RSS 798,444 KB before; 654,596 KB after (18% lower).
- `pnpm check:changed -- src/system-agent/setup-inference.test.ts src/config/io.write-config.test.ts`: format, policy checks, core-test typecheck, and changed-file lint pass.
- Autoreview: clean, no accepted/actionable findings.
- `git diff --numstat`: test files only; production LOC delta 0.
