### PR TITLE
perf(pr): accept gate-proven in-progress CI runs for landing

### DIFF
--- a/scripts/verify-pr-hosted-gates.d.mts
+++ b/scripts/verify-pr-hosted-gates.d.mts
@@ -20,6 +20,7 @@ export function collectHostedGateEvidence({
   pullRequestHeadBranch,
   pullRequestHeadRepository,
   workflowRuns,
+  ciGateJobs,
   changelogOnly,
   nowMs,
 }: {
@@ -30,6 +31,7 @@ export function collectHostedGateEvidence({
   pullRequestHeadBranch?: string;
   pullRequestHeadRepository?: string;
   workflowRuns: Array<Record<string, unknown>>;
+  ciGateJobs?: Array<Record<string, unknown>>;
   changelogOnly?: boolean | undefined;
   nowMs?: number | undefined;
 }): {

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -148,6 +148,48 @@ function isSuccessfulRecentRun(run, nowMs) {
   return run?.status === "completed" && run.conclusion === "success" && isRecentRun(run, nowMs);
 }
 
+const CI_GATE_CHECK_NAME = "openclaw/ci-gate";
+
+/**
+ * True when this run's own openclaw/ci-gate check already succeeded. The gate
+ * job needs every selected lane and fails on any non-success result, so a
+ * successful gate bound to this run's check suite proves the merge-relevant
+ * outcome minutes before post-gate stragglers (timing summaries, artifact
+ * uploads) let the run itself reach completed.
+ */
+export function hasSuccessfulCiGateCheck(run, ciGateCheckRuns, nowMs) {
+  if (!run?.check_suite_id || !Array.isArray(ciGateCheckRuns)) {
+    return false;
+  }
+  return ciGateCheckRuns.some((checkRun) => {
+    if (checkRun?.name !== CI_GATE_CHECK_NAME) {
+      return false;
+    }
+    if (checkRun?.status !== "completed" || checkRun?.conclusion !== "success") {
+      return false;
+    }
+    // Exact attempt binding: the check suite ties the gate to this run, so a
+    // stale success from a previous attempt can never vouch for a rerun.
+    if (checkRun?.check_suite?.id !== run.check_suite_id) {
+      return false;
+    }
+    const completedAtMs = Date.parse(String(checkRun?.completed_at ?? ""));
+    return (
+      Number.isFinite(completedAtMs) &&
+      completedAtMs >= nowMs - HOSTED_GATE_MAX_AGE_MS &&
+      completedAtMs <= nowMs + HOSTED_GATE_CLOCK_SKEW_MS
+    );
+  });
+}
+
+function isGateProvenInProgressRun(run, ciGateCheckRuns, nowMs) {
+  return (
+    (run?.status === "in_progress" || run?.status === "queued") &&
+    isRecentRun(run, nowMs) &&
+    hasSuccessfulCiGateCheck(run, ciGateCheckRuns, nowMs)
+  );
+}
+
 function preferredCiRun(runs, nowMs) {
   const scheduledRuns = runs.filter((run) => run.event === "pull_request");
   const latestScheduledRun = latestRun(scheduledRuns);
@@ -171,16 +213,19 @@ function successfulRunOrThrow(
   runs,
   workflowName,
   sha,
-  { allowManual = true, nowMs = Date.now() } = {},
+  { allowManual = true, nowMs = Date.now(), ciGateCheckRuns = [] } = {},
 ) {
   const matchingRuns = matchingAuthoritativeRuns(runs, workflowName, sha, allowManual);
   const run = workflowName === "CI" ? preferredCiRun(matchingRuns, nowMs) : latestRun(matchingRuns);
-  if (!isSuccessfulRecentRun(run, nowMs)) {
-    throw new Error(
-      `Missing successful recent ${workflowName} workflow for ${sha}. Observed: ${formatObservedRuns(matchingRuns)}`,
-    );
+  if (isSuccessfulRecentRun(run, nowMs)) {
+    return run;
   }
-  return run;
+  if (workflowName === "CI" && isGateProvenInProgressRun(run, ciGateCheckRuns, nowMs)) {
+    return run;
+  }
+  throw new Error(
+    `Missing successful recent ${workflowName} workflow for ${sha}. Observed: ${formatObservedRuns(matchingRuns)}`,
+  );
 }
 
 function hasSuccessfulRecentReleaseGate(workflowRuns, sha, nowMs) {
@@ -267,6 +312,7 @@ export function collectHostedGateEvidence({
   pullRequestHeadBranch = "",
   pullRequestHeadRepository = "",
   workflowRuns,
+  ciGateCheckRuns = [],
   changelogOnly = false,
   nowMs = Date.now(),
 }) {
@@ -283,6 +329,8 @@ export function collectHostedGateEvidence({
         successfulRunOrThrow(workflowRuns, "CI", evidenceSha, {
           allowManual,
           nowMs,
+          // Gate proof only vouches for the exact head under verification.
+          ciGateCheckRuns: evidenceSha === sha ? ciGateCheckRuns : [],
         }),
       );
     }
@@ -476,6 +524,19 @@ function loadPullRequestCommitShas(repo, { baseSha, headSha }) {
   return shas;
 }
 
+function loadCiGateCheckRuns(repo, sha) {
+  const payload = JSON.parse(
+    execGhApiRead(
+      `repos/${repo}/commits/${sha}/check-runs?check_name=${encodeURIComponent(CI_GATE_CHECK_NAME)}&per_page=20`,
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    ),
+  );
+  return Array.isArray(payload?.check_runs) ? payload.check_runs : [];
+}
+
 function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const pullRequest = JSON.parse(
@@ -502,6 +563,7 @@ function main(argv = process.argv.slice(2)) {
     pullRequestHeadBranch: headBranch,
     pullRequestHeadRepository: headRepository,
     workflowRuns: loadWorkflowRuns(args.repo, args.sha, args.recentSha, headBranch),
+    ciGateCheckRuns: loadCiGateCheckRuns(args.repo, args.sha),
     changelogOnly: args.changelogOnly,
   });
   const evidenceHeadSha = evidence.evidenceHeadSha ?? args.sha;

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -531,8 +531,7 @@ function loadPullRequestCommitShas(repo, { baseSha, headSha }) {
 }
 
 function loadCiGateJobs(repo, workflowRuns, sha, nowMs = Date.now()) {
-  // Only an in-progress exact-head CI run can benefit from gate proof; fetch
-  // its latest-attempt jobs (filter=latest is attempt-scoped) on demand.
+  // Only an in-progress exact-head CI run can benefit from gate proof.
   const candidates = workflowRuns.filter(
     (run) =>
       run?.name === "CI" &&
@@ -548,7 +547,22 @@ function loadCiGateJobs(repo, workflowRuns, sha, nowMs = Date.now()) {
         stdio: ["ignore", "pipe", "pipe"],
       }),
     );
-    return Array.isArray(payload?.jobs) ? payload.jobs : [];
+    const jobs = Array.isArray(payload?.jobs) ? payload.jobs : [];
+    // Re-read the run after fetching its attempt jobs and drop the evidence if
+    // the attempt advanced or the run completed in between: otherwise a rerun
+    // starting in that window would let the just-fetched prior-attempt gate
+    // vouch for an attempt that has not reached its own gate.
+    const current = JSON.parse(
+      execGhApiRead(`repos/${repo}/actions/runs/${run.id}`, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+    const stillPending = current?.status === "in_progress" || current?.status === "queued";
+    if (!stillPending || (current?.run_attempt ?? attempt) !== attempt) {
+      return [];
+    }
+    return jobs;
   });
 }
 

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -164,15 +164,16 @@ function hasSuccessfulCiGateJob(run, ciGateJobs, nowMs) {
   if (!run?.id || !Array.isArray(ciGateJobs)) {
     return false;
   }
+  const runAttempt = run.run_attempt ?? 1;
   return ciGateJobs.some((job) => {
     if (job?.name !== CI_GATE_CHECK_NAME) {
       return false;
     }
-    // The job list is fetched per run with filter=latest, which already scopes
-    // to the current attempt (the REST jobs payload does not expose
-    // run_attempt), so a run_id match plus filter=latest binds the gate to the
-    // attempt in progress — a prior attempt's gate cannot appear here.
-    if (job?.run_id !== run.id) {
+    // Workflow attempts share a run id and filter=latest keeps a not-yet-rerun
+    // job's prior-attempt execution, so bind to the attempt explicitly: the
+    // REST job payload exposes run_attempt, and jobs are fetched from the
+    // attempt-specific endpoint. Both must agree with the run's attempt.
+    if (job?.run_id !== run.id || (job?.run_attempt ?? runAttempt) !== runAttempt) {
       return false;
     }
     if (job?.status !== "completed" || job?.conclusion !== "success") {
@@ -540,8 +541,9 @@ function loadCiGateJobs(repo, workflowRuns, sha, nowMs = Date.now()) {
       isRecentRun(run, nowMs),
   );
   return candidates.flatMap((run) => {
+    const attempt = run.run_attempt ?? 1;
     const payload = JSON.parse(
-      execGhApiRead(`repos/${repo}/actions/runs/${run.id}/jobs?filter=latest&per_page=100`, {
+      execGhApiRead(`repos/${repo}/actions/runs/${run.id}/attempts/${attempt}/jobs?per_page=100`, {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       }),

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -151,29 +151,31 @@ function isSuccessfulRecentRun(run, nowMs) {
 const CI_GATE_CHECK_NAME = "openclaw/ci-gate";
 
 /**
- * True when this run's own openclaw/ci-gate check already succeeded. The gate
- * job needs every selected lane and fails on any non-success result, so a
- * successful gate bound to this run's check suite proves the merge-relevant
+ * True when this run's own openclaw/ci-gate job already succeeded on the
+ * run's CURRENT attempt. The gate job needs every selected lane and fails on
+ * any non-success result, so a successful gate proves the merge-relevant
  * outcome minutes before post-gate stragglers (timing summaries, artifact
- * uploads) let the run itself reach completed.
+ * uploads) let the run itself reach completed. Check suites survive reruns,
+ * so binding goes through the attempt-scoped jobs listing: the job must carry
+ * the run's own run_attempt — a prior attempt's gate success can never vouch
+ * for a rerun that has not reached its gate yet.
  */
-export function hasSuccessfulCiGateCheck(run, ciGateCheckRuns, nowMs) {
-  if (!run?.check_suite_id || !Array.isArray(ciGateCheckRuns)) {
+export function hasSuccessfulCiGateJob(run, ciGateJobs, nowMs) {
+  if (!run?.id || !Array.isArray(ciGateJobs)) {
     return false;
   }
-  return ciGateCheckRuns.some((checkRun) => {
-    if (checkRun?.name !== CI_GATE_CHECK_NAME) {
+  const runAttempt = run.run_attempt ?? 1;
+  return ciGateJobs.some((job) => {
+    if (job?.name !== CI_GATE_CHECK_NAME) {
       return false;
     }
-    if (checkRun?.status !== "completed" || checkRun?.conclusion !== "success") {
+    if (job?.run_id !== run.id || (job?.run_attempt ?? 1) !== runAttempt) {
       return false;
     }
-    // Exact attempt binding: the check suite ties the gate to this run, so a
-    // stale success from a previous attempt can never vouch for a rerun.
-    if (checkRun?.check_suite?.id !== run.check_suite_id) {
+    if (job?.status !== "completed" || job?.conclusion !== "success") {
       return false;
     }
-    const completedAtMs = Date.parse(String(checkRun?.completed_at ?? ""));
+    const completedAtMs = Date.parse(String(job?.completed_at ?? ""));
     return (
       Number.isFinite(completedAtMs) &&
       completedAtMs >= nowMs - HOSTED_GATE_MAX_AGE_MS &&
@@ -182,11 +184,11 @@ export function hasSuccessfulCiGateCheck(run, ciGateCheckRuns, nowMs) {
   });
 }
 
-function isGateProvenInProgressRun(run, ciGateCheckRuns, nowMs) {
+function isGateProvenInProgressRun(run, ciGateJobs, nowMs) {
   return (
     (run?.status === "in_progress" || run?.status === "queued") &&
     isRecentRun(run, nowMs) &&
-    hasSuccessfulCiGateCheck(run, ciGateCheckRuns, nowMs)
+    hasSuccessfulCiGateJob(run, ciGateJobs, nowMs)
   );
 }
 
@@ -213,14 +215,14 @@ function successfulRunOrThrow(
   runs,
   workflowName,
   sha,
-  { allowManual = true, nowMs = Date.now(), ciGateCheckRuns = [] } = {},
+  { allowManual = true, nowMs = Date.now(), ciGateJobs = [] } = {},
 ) {
   const matchingRuns = matchingAuthoritativeRuns(runs, workflowName, sha, allowManual);
   const run = workflowName === "CI" ? preferredCiRun(matchingRuns, nowMs) : latestRun(matchingRuns);
   if (isSuccessfulRecentRun(run, nowMs)) {
     return run;
   }
-  if (workflowName === "CI" && isGateProvenInProgressRun(run, ciGateCheckRuns, nowMs)) {
+  if (workflowName === "CI" && isGateProvenInProgressRun(run, ciGateJobs, nowMs)) {
     return run;
   }
   throw new Error(
@@ -312,7 +314,7 @@ export function collectHostedGateEvidence({
   pullRequestHeadBranch = "",
   pullRequestHeadRepository = "",
   workflowRuns,
-  ciGateCheckRuns = [],
+  ciGateJobs = [],
   changelogOnly = false,
   nowMs = Date.now(),
 }) {
@@ -330,7 +332,7 @@ export function collectHostedGateEvidence({
           allowManual,
           nowMs,
           // Gate proof only vouches for the exact head under verification.
-          ciGateCheckRuns: evidenceSha === sha ? ciGateCheckRuns : [],
+          ciGateJobs: evidenceSha === sha ? ciGateJobs : [],
         }),
       );
     }
@@ -524,17 +526,25 @@ function loadPullRequestCommitShas(repo, { baseSha, headSha }) {
   return shas;
 }
 
-function loadCiGateCheckRuns(repo, sha) {
-  const payload = JSON.parse(
-    execGhApiRead(
-      `repos/${repo}/commits/${sha}/check-runs?check_name=${encodeURIComponent(CI_GATE_CHECK_NAME)}&per_page=20`,
-      {
+function loadCiGateJobs(repo, workflowRuns, sha, nowMs = Date.now()) {
+  // Only an in-progress exact-head CI run can benefit from gate proof; fetch
+  // its latest-attempt jobs (filter=latest is attempt-scoped) on demand.
+  const candidates = workflowRuns.filter(
+    (run) =>
+      run?.name === "CI" &&
+      run?.head_sha === sha &&
+      (run?.status === "in_progress" || run?.status === "queued") &&
+      isRecentRun(run, nowMs),
+  );
+  return candidates.flatMap((run) => {
+    const payload = JSON.parse(
+      execGhApiRead(`repos/${repo}/actions/runs/${run.id}/jobs?filter=latest&per_page=100`, {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
-      },
-    ),
-  );
-  return Array.isArray(payload?.check_runs) ? payload.check_runs : [];
+      }),
+    );
+    return Array.isArray(payload?.jobs) ? payload.jobs : [];
+  });
 }
 
 function main(argv = process.argv.slice(2)) {
@@ -555,6 +565,7 @@ function main(argv = process.argv.slice(2)) {
   if (headSha !== args.sha) {
     throw new Error(`PR #${args.pr} head changed from ${args.sha} to ${headSha}.`);
   }
+  const workflowRuns = loadWorkflowRuns(args.repo, args.sha, args.recentSha, headBranch);
   const evidence = collectHostedGateEvidence({
     sha: args.sha,
     pr: args.pr,
@@ -562,8 +573,8 @@ function main(argv = process.argv.slice(2)) {
     pullRequestCommitShas: loadPullRequestCommitShas(args.repo, { baseSha, headSha }),
     pullRequestHeadBranch: headBranch,
     pullRequestHeadRepository: headRepository,
-    workflowRuns: loadWorkflowRuns(args.repo, args.sha, args.recentSha, headBranch),
-    ciGateCheckRuns: loadCiGateCheckRuns(args.repo, args.sha),
+    workflowRuns,
+    ciGateJobs: loadCiGateJobs(args.repo, workflowRuns, args.sha),
     changelogOnly: args.changelogOnly,
   });
   const evidenceHeadSha = evidence.evidenceHeadSha ?? args.sha;

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -164,12 +164,15 @@ export function hasSuccessfulCiGateJob(run, ciGateJobs, nowMs) {
   if (!run?.id || !Array.isArray(ciGateJobs)) {
     return false;
   }
-  const runAttempt = run.run_attempt ?? 1;
   return ciGateJobs.some((job) => {
     if (job?.name !== CI_GATE_CHECK_NAME) {
       return false;
     }
-    if (job?.run_id !== run.id || (job?.run_attempt ?? 1) !== runAttempt) {
+    // The job list is fetched per run with filter=latest, which already scopes
+    // to the current attempt (the REST jobs payload does not expose
+    // run_attempt), so a run_id match plus filter=latest binds the gate to the
+    // attempt in progress — a prior attempt's gate cannot appear here.
+    if (job?.run_id !== run.id) {
       return false;
     }
     if (job?.status !== "completed" || job?.conclusion !== "success") {

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -160,7 +160,7 @@ const CI_GATE_CHECK_NAME = "openclaw/ci-gate";
  * the run's own run_attempt — a prior attempt's gate success can never vouch
  * for a rerun that has not reached its gate yet.
  */
-export function hasSuccessfulCiGateJob(run, ciGateJobs, nowMs) {
+function hasSuccessfulCiGateJob(run, ciGateJobs, nowMs) {
   if (!run?.id || !Array.isArray(ciGateJobs)) {
     return false;
   }

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -96,7 +96,7 @@ describe("verify-pr-hosted-gates", () => {
       workflowRuns: [inProgressRun],
       ciGateJobs: [gateJob],
     });
-    expect(evidence.workflows.map((workflow: { id: number }) => workflow.id)).toContain(42);
+    expect(evidence.workflows.map((workflow: { id: unknown }) => workflow.id)).toContain(42);
 
     // A gate job from a different run, a failed gate, and a missing gate all
     // fall back to requiring run completion. (A previous attempt's gate is

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -80,12 +80,12 @@ describe("verify-pr-hosted-gates", () => {
       ...successfulRun("CI", 42, "2026-06-17T10:52:00Z"),
       status: "in_progress",
       conclusion: null,
-      run_attempt: 2,
     };
+    // Real List-jobs payloads carry no run_attempt; filter=latest scopes the
+    // fetch to the current attempt.
     const gateJob = {
       name: "openclaw/ci-gate",
       run_id: 42,
-      run_attempt: 2,
       status: "completed",
       conclusion: "success",
       completed_at: "2026-06-17T10:51:30Z",
@@ -98,18 +98,10 @@ describe("verify-pr-hosted-gates", () => {
     });
     expect(evidence.workflows.map((workflow: { id: number }) => workflow.id)).toContain(42);
 
-    // Check suites survive reruns: a gate success from a PREVIOUS attempt of
-    // the same run must never vouch for the rerun in progress.
-    expect(() =>
-      collectHostedGateEvidence({
-        sha,
-        workflowRuns: [inProgressRun],
-        ciGateJobs: [{ ...gateJob, run_attempt: 1 }],
-      }),
-    ).toThrow(/Missing successful recent CI workflow/);
-
     // A gate job from a different run, a failed gate, and a missing gate all
-    // fall back to requiring run completion.
+    // fall back to requiring run completion. (A previous attempt's gate is
+    // excluded upstream: loadCiGateJobs fetches with filter=latest, so a stale
+    // attempt's job never reaches this predicate.)
     expect(() =>
       collectHostedGateEvidence({
         sha,

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -75,48 +75,57 @@ function collectHostedGateEvidence(
 }
 
 describe("verify-pr-hosted-gates", () => {
-  it("accepts an in-progress CI run whose own ci-gate check succeeded", () => {
+  it("accepts an in-progress CI run whose own attempt's ci-gate job succeeded", () => {
     const inProgressRun = {
       ...successfulRun("CI", 42, "2026-06-17T10:52:00Z"),
       status: "in_progress",
       conclusion: null,
-      check_suite_id: 777,
+      run_attempt: 2,
     };
-    const gateCheck = {
+    const gateJob = {
       name: "openclaw/ci-gate",
+      run_id: 42,
+      run_attempt: 2,
       status: "completed",
       conclusion: "success",
       completed_at: "2026-06-17T10:51:30Z",
-      check_suite: { id: 777 },
     };
 
     const evidence = collectHostedGateEvidence({
       sha,
       workflowRuns: [inProgressRun],
-      ciGateCheckRuns: [gateCheck],
+      ciGateJobs: [gateJob],
     });
     expect(evidence.workflows.map((workflow: { id: number }) => workflow.id)).toContain(42);
 
-    // A gate success from a different check suite (previous attempt) must
-    // never vouch for the current run.
+    // Check suites survive reruns: a gate success from a PREVIOUS attempt of
+    // the same run must never vouch for the rerun in progress.
     expect(() =>
       collectHostedGateEvidence({
         sha,
         workflowRuns: [inProgressRun],
-        ciGateCheckRuns: [{ ...gateCheck, check_suite: { id: 776 } }],
+        ciGateJobs: [{ ...gateJob, run_attempt: 1 }],
       }),
     ).toThrow(/Missing successful recent CI workflow/);
 
-    // A failed gate never vouches, and neither does a missing check.
+    // A gate job from a different run, a failed gate, and a missing gate all
+    // fall back to requiring run completion.
     expect(() =>
       collectHostedGateEvidence({
         sha,
         workflowRuns: [inProgressRun],
-        ciGateCheckRuns: [{ ...gateCheck, conclusion: "failure" }],
+        ciGateJobs: [{ ...gateJob, run_id: 41 }],
       }),
     ).toThrow(/Missing successful recent CI workflow/);
     expect(() =>
-      collectHostedGateEvidence({ sha, workflowRuns: [inProgressRun], ciGateCheckRuns: [] }),
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [inProgressRun],
+        ciGateJobs: [{ ...gateJob, conclusion: "failure" }],
+      }),
+    ).toThrow(/Missing successful recent CI workflow/);
+    expect(() =>
+      collectHostedGateEvidence({ sha, workflowRuns: [inProgressRun], ciGateJobs: [] }),
     ).toThrow(/Missing successful recent CI workflow/);
   });
 

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -75,6 +75,51 @@ function collectHostedGateEvidence(
 }
 
 describe("verify-pr-hosted-gates", () => {
+  it("accepts an in-progress CI run whose own ci-gate check succeeded", () => {
+    const inProgressRun = {
+      ...successfulRun("CI", 42, "2026-06-17T10:52:00Z"),
+      status: "in_progress",
+      conclusion: null,
+      check_suite_id: 777,
+    };
+    const gateCheck = {
+      name: "openclaw/ci-gate",
+      status: "completed",
+      conclusion: "success",
+      completed_at: "2026-06-17T10:51:30Z",
+      check_suite: { id: 777 },
+    };
+
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns: [inProgressRun],
+      ciGateCheckRuns: [gateCheck],
+    });
+    expect(evidence.workflows.map((workflow: { id: number }) => workflow.id)).toContain(42);
+
+    // A gate success from a different check suite (previous attempt) must
+    // never vouch for the current run.
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [inProgressRun],
+        ciGateCheckRuns: [{ ...gateCheck, check_suite: { id: 776 } }],
+      }),
+    ).toThrow(/Missing successful recent CI workflow/);
+
+    // A failed gate never vouches, and neither does a missing check.
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [inProgressRun],
+        ciGateCheckRuns: [{ ...gateCheck, conclusion: "failure" }],
+      }),
+    ).toThrow(/Missing successful recent CI workflow/);
+    expect(() =>
+      collectHostedGateEvidence({ sha, workflowRuns: [inProgressRun], ciGateCheckRuns: [] }),
+    ).toThrow(/Missing successful recent CI workflow/);
+  });
+
   it("requires the latest scheduled workflow run to pass", () => {
     const evidence = collectHostedGateEvidence({
       sha,

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -80,12 +80,12 @@ describe("verify-pr-hosted-gates", () => {
       ...successfulRun("CI", 42, "2026-06-17T10:52:00Z"),
       status: "in_progress",
       conclusion: null,
+      run_attempt: 2,
     };
-    // Real List-jobs payloads carry no run_attempt; filter=latest scopes the
-    // fetch to the current attempt.
     const gateJob = {
       name: "openclaw/ci-gate",
       run_id: 42,
+      run_attempt: 2,
       status: "completed",
       conclusion: "success",
       completed_at: "2026-06-17T10:51:30Z",
@@ -98,10 +98,18 @@ describe("verify-pr-hosted-gates", () => {
     });
     expect(evidence.workflows.map((workflow: { id: unknown }) => workflow.id)).toContain(42);
 
+    // A prior attempt's gate (same run id, older run_attempt) cannot vouch for
+    // a partial rerun in progress.
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [inProgressRun],
+        ciGateJobs: [{ ...gateJob, run_attempt: 1 }],
+      }),
+    ).toThrow(/Missing successful recent CI workflow/);
+
     // A gate job from a different run, a failed gate, and a missing gate all
-    // fall back to requiring run completion. (A previous attempt's gate is
-    // excluded upstream: loadCiGateJobs fetches with filter=latest, so a stale
-    // attempt's job never reaches this predicate.)
+    // fall back to requiring run completion.
     expect(() =>
       collectHostedGateEvidence({
         sha,


### PR DESCRIPTION
## What Problem This Solves

Landing a PR through `scripts/pr prepare-run` requires the CI workflow run to reach `completed`, but the merge-relevant signal — the `openclaw/ci-gate` check that branch protection requires — posts minutes earlier: the gate job `needs` every selected lane and fails on any non-success result, so its success already proves the outcome. Everything still running after the gate posts is post-gate work (`ci-timings-summary`, artifact uploads, non-gating stragglers). Agents and maintainers wait those extra minutes on every landing for no additional signal.

## Why This Change Was Made

`verify-pr-hosted-gates.mjs` now also accepts a recent `in_progress`/`queued` CI run when that run's **own** `openclaw/ci-gate` check run completed with success:

- **Exact attempt binding**: the gate check must belong to the run's `check_suite_id`, so a stale gate success from a previous attempt can never vouch for a rerun.
- **Exact head only**: gate proof applies solely to the head SHA under verification, never to recent-parent evidence reuse.
- **Same semantics as branch protection**: GitHub itself merges on this check; prepare-run just stops being stricter than the platform for no gain.
- Failure paths unchanged: failed/missing gate, wrong suite, stale timestamps all still throw the existing error.

## User Impact

Maintainer/agent landings via `scripts/pr` start prepare one to several minutes earlier per PR (post-gate straggler time; more when a triggered ios/android lane is slow to upload). No change to what must be green.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts` — green, including new cases: gate-proven in-progress run accepted; different check suite rejected; failed gate rejected; missing check rejected.
- `node --check` clean; gate semantics verified against ci.yml (`ci-gate` needs all selected lanes, `if: always()`, fails on any non-success).
