### PR TITLE
feat: add featured plugin icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6579,7 +6579,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Nextcloud Talk: report malformed room-info and bot-admin JSON with channel-owned errors instead of leaking raw parser failures.
 - Microsoft Teams: report malformed Graph and delegated OAuth JSON with channel-owned errors instead of leaking raw parser failures.
 - Google Chat: report malformed Chat API and certificate JSON with channel-owned errors instead of leaking raw parser failures.
-- Firecrawl: report malformed search and scrape API JSON with provider-owned errors instead of leaking raw parser failures.
+- FireCrawl: report malformed search and scrape API JSON with provider-owned errors instead of leaking raw parser failures.
 - Tavily: report malformed search and extract API JSON with provider-owned errors instead of leaking raw parser failures.
 - Perplexity: report malformed Search API and chat completion JSON with provider-owned errors instead of leaking raw parser failures.
 - Exa: report malformed search API JSON with a provider-owned error instead of leaking raw parser failures.
@@ -8305,7 +8305,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - External plugin installation now covers diagnostics, onboarding, doctor repair, channel setup, install/update records, and artifact metadata while keeping bare package installs on npm for the first cutover. Thanks @vincentkoc.
 - Gateway startup, session listing, task maintenance, prompt prep, plugin loading, and filesystem hot paths get targeted cache and fanout reductions for large or plugin-heavy installs.
 - Control UI and WebChat reliability improves across Sessions, Cron, long-running Gateway WebSockets, grouped-message width, slash-command feedback, iOS PWA bounds, selection contrast, and Talk diagnostics.
-- Channel and provider fixes cover Telegram topic commands and networking, Discord delivery and startup edge cases, OpenAI-compatible TTS/Realtime, OpenRouter/DeepSeek replay, Anthropic-compatible streaming, Brave/SearXNG/Firecrawl web search, and voice-call routing.
+- Channel and provider fixes cover Telegram topic commands and networking, Discord delivery and startup edge cases, OpenAI-compatible TTS/Realtime, OpenRouter/DeepSeek replay, Anthropic-compatible streaming, Brave/SearXNG/FireCrawl web search, and voice-call routing.
 
 ### Changes
 
@@ -8464,16 +8464,16 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Codex/app-server: restart the shared Codex app-server client once when it closes during startup thread resume, preserving the existing thread binding instead of retrying `thread/start` on a closed client. Thanks @vincentkoc.
 - Gateway/watch: keep colored subsystem log prefixes in the managed tmux pane even when the parent shell exports `NO_COLOR`, while preserving explicit `FORCE_COLOR=0` opt-out. Thanks @vincentkoc.
 - Agents/compaction: submit a non-empty runtime-event marker for pre-compaction memory flush turns, so strict Anthropic providers no longer reject the silent flush as an empty user message. Fixes #75305. Thanks @sableassistant3777-source.
-- Plugin SDK: re-export `isPrivateIpAddress` from `plugin-sdk/ssrf-runtime`, restoring source-checkout builds for SearXNG and Firecrawl private-network guards. Thanks @vincentkoc.
+- Plugin SDK: re-export `isPrivateIpAddress` from `plugin-sdk/ssrf-runtime`, restoring source-checkout builds for SearXNG and FireCrawl private-network guards. Thanks @vincentkoc.
 - Discord/message actions: advertise `upload-file` and route it through Discord's send runtime with agent-scoped media reads, so agents can discover and send file attachments. Fixes #60652 and supersedes #60808, #61087, and #61100. Thanks @claw-io, @efe-arv, @joelnishanth, and @sjhddh.
 - Sessions: suppress exact inter-session control replies such as `NO_REPLY` and keep agent-to-agent announce bookkeeping out of visible transcripts. Fixes #53145. Thanks @TarahAssistant.
 - CLI/directory: report unsupported directory operations for installed channel plugins instead of prompting to reinstall the plugin when it lacks a directory adapter. Fixes #75770. Thanks @lawong888.
 - Web search/SearXNG: show the JSON API `search.formats` prerequisite during SearXNG setup before prompting for the base URL. Supersedes #65592. Thanks @evanpaul14.
 - Web search/SearXNG: pass through `img_src` image URLs from SearXNG image-category results. Supersedes #61416. Thanks @sghael.
 - Web search/Kimi: fail explicitly when Moonshot returns an ungrounded chat answer instead of native web-search evidence, so Kimi no longer reports generic fallback text as a successful search. Fixes #52573. Thanks @wangwllu.
-- Web search: keep public provider requests on the strict SSRF guard and reserve private-network access for explicit self-hosted SearXNG/Firecrawl endpoints. Fixes #74357 and supersedes #74360. Thanks @fede-kamel.
-- Firecrawl: reject private, loopback, metadata, and non-HTTP(S) `firecrawl_scrape` target URLs before forwarding them to Firecrawl. Supersedes #48133. Thanks @kn1ghtc.
-- Web search/Firecrawl: allow self-hosted private/internal Firecrawl `baseUrl` endpoints, including HTTP for private targets, while keeping hosted Firecrawl on the strict official endpoint. Fixes #63877 and supersedes #59666, #63941, and #74013. Thanks @jhthompson12, @jzakirov, @Mlightsnow, and @shad0wca7.
+- Web search: keep public provider requests on the strict SSRF guard and reserve private-network access for explicit self-hosted SearXNG/FireCrawl endpoints. Fixes #74357 and supersedes #74360. Thanks @fede-kamel.
+- FireCrawl: reject private, loopback, metadata, and non-HTTP(S) `firecrawl_scrape` target URLs before forwarding them to FireCrawl. Supersedes #48133. Thanks @kn1ghtc.
+- Web search/FireCrawl: allow self-hosted private/internal FireCrawl `baseUrl` endpoints, including HTTP for private targets, while keeping hosted FireCrawl on the strict official endpoint. Fixes #63877 and supersedes #59666, #63941, and #74013. Thanks @jhthompson12, @jzakirov, @Mlightsnow, and @shad0wca7.
 - CLI/models: report gateway model fallback attempts in `infer model run --json` and avoid double-prefixing provider-qualified defaults such as `openrouter/auto` in `models status`. Partially fixes #69527. Thanks @alexifra.
 - Providers/OpenRouter: strip trailing assistant prefill turns from verified OpenRouter Anthropic model requests when reasoning is enabled, so Claude 4.6 routes no longer fail with Anthropic's prefill rejection through the OpenAI-compatible adapter. Fixes #75395. Thanks @sbmilburn.
 - Voice Call: add per-number inbound routing for dialed-number greetings, response agents/models/prompts, and TTS voice overrides. Fixes #56604. Thanks @healthstatus.
@@ -10805,7 +10805,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Agents/model selection: clear transient auto-failover session overrides before each turn so recovered primary models are retried immediately without emitting user-override reset warnings. (#69365) Thanks @hitesh-github99.
 - Auto-reply: apply silent `NO_REPLY` policy per conversation type, so direct chats get a helpful rewritten reply while groups and internal deliveries can remain quiet. (#68644) Thanks @Takhoffman.
 - Telegram/status reactions: honor `messages.removeAckAfterReply` when lifecycle status reactions are enabled, clearing or restoring the reaction after success/error using the configured hold timings. (#68067) Thanks @poiskgit.
-- Web search/plugins: resolve plugin-scoped SecretRef API keys for bundled Exa, Firecrawl, Gemini, Kimi, Perplexity, Tavily, and Grok web-search providers when they are selected through the shared web-search config. (#68424) Thanks @afurm.
+- Web search/plugins: resolve plugin-scoped SecretRef API keys for bundled Exa, FireCrawl, Gemini, Kimi, Perplexity, Tavily, and Grok web-search providers when they are selected through the shared web-search config. (#68424) Thanks @afurm.
 - Telegram/polling: raise the default polling watchdog threshold from 90s to 120s and add configurable `channels.telegram.pollingStallThresholdMs` (also per-account) so long-running Telegram work gets more room before polling is treated as stalled. (#57737) Thanks @Vitalcheffe.
 - Telegram/polling: bound the persisted-offset confirmation `getUpdates` probe with a client-side timeout so a zombie socket cannot hang polling recovery before the runner watchdog starts. (#50368) Thanks @boticlaw.
 - Agents/Pi runner: retry silent `stopReason=error` turns with no output when no side effects ran, so non-frontier providers that briefly return empty error turns get another chance instead of ending the session early. (#68310) Thanks @Chased1k.
@@ -11942,7 +11942,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 ### Breaking
 
 - Plugins/xAI: move `x_search` settings from the legacy core `tools.web.x_search.*` path to the plugin-owned `plugins.entries.xai.config.xSearch.*` path, standardize `x_search` auth on `plugins.entries.xai.config.webSearch.apiKey` / `XAI_API_KEY`, and migrate legacy config with `openclaw doctor --fix`. (#59674) Thanks @vincentkoc.
-- Plugins/web fetch: move Firecrawl `web_fetch` config from the legacy core `tools.web.fetch.firecrawl.*` path to the plugin-owned `plugins.entries.firecrawl.config.webFetch.*` path, route `web_fetch` fallback through the new fetch-provider boundary instead of a Firecrawl-only core branch, and migrate legacy config with `openclaw doctor --fix`. (#59465) Thanks @vincentkoc.
+- Plugins/web fetch: move FireCrawl `web_fetch` config from the legacy core `tools.web.fetch.firecrawl.*` path to the plugin-owned `plugins.entries.firecrawl.config.webFetch.*` path, route `web_fetch` fallback through the new fetch-provider boundary instead of a FireCrawl-only core branch, and migrate legacy config with `openclaw doctor --fix`. (#59465) Thanks @vincentkoc.
 
 ### Changes
 
@@ -12653,7 +12653,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Plugins/Chutes: add a bundled Chutes provider with plugin-owned OAuth/API-key auth, dynamic model discovery, and default-on extension wiring. (#41416) Thanks @Veightor.
 - Web tools/Exa: add Exa as a bundled web-search plugin with Exa-native date filters, search-mode selection, and optional content extraction under `plugins.entries.exa.config.webSearch.*`. Thanks @V-Gutierrez and @vincentkoc.
 - Web tools/Tavily: add Tavily as a bundled web-search provider with dedicated `tavily_search` and `tavily_extract` tools, using canonical plugin-owned config under `plugins.entries.tavily.config.webSearch.*`. (#49200) thanks @lakshyaag-tavily.
-- Web tools/Firecrawl: add Firecrawl as an `onboard`/configure search provider via a bundled plugin, expose explicit `firecrawl_search` and `firecrawl_scrape` tools, and align core `web_fetch` fallback behavior with Firecrawl base-URL/env fallback plus guarded endpoint fetches.
+- Web tools/FireCrawl: add FireCrawl as an `onboard`/configure search provider via a bundled plugin, expose explicit `firecrawl_search` and `firecrawl_scrape` tools, and align core `web_fetch` fallback behavior with FireCrawl base-URL/env fallback plus guarded endpoint fetches.
 - Models/OpenAI: add native forward-compat support for `gpt-5.4-mini` and `gpt-5.4-nano` in the OpenAI provider catalog, runtime resolution, and reasoning capability gates. Thanks @vincentkoc.
 - Control UI/chat: add an expand-to-canvas button on assistant chat bubbles and in-app session navigation from Sessions and Cron views. Thanks @BunsDev.
 - Control UI/appearance: unify theme border radii across Claw, Knot, and Dash, and add a Roundness slider to the Appearance settings so users can adjust corner radius from sharp to fully rounded. Thanks @BunsDev.
@@ -12811,7 +12811,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - ACP/approvals: use canonical tool identity for prompting decisions and fail closed when conflicting tool identity hints are present. (#46817) Thanks @zpbrent and @vincentkoc.
 - ACP: require admin scope for mutating internal actions. (#46789) Thanks @tdjackey and @vincentkoc.
 - Subagents/follow-ups: require the same controller ownership checks for `/subagents send` as other control actions, so leaf sessions cannot message nested child runs they do not control. (#46801) Thanks @vincentkoc.
-- Web search/onboarding: clarify provider labels, key prompts, and missing-key notes so setup/configure more clearly names the required provider credential for Gemini, Kimi, Grok, Brave Search, Firecrawl, Perplexity, and Tavily. Thanks @vincentkoc.
+- Web search/onboarding: clarify provider labels, key prompts, and missing-key notes so setup/configure more clearly names the required provider credential for Gemini, Kimi, Grok, Brave Search, FireCrawl, Perplexity, and Tavily. Thanks @vincentkoc.
 - macOS/canvas actions: keep unattended local agent actions on trusted in-app canvas surfaces only, and stop exposing the deep-link fallback key to arbitrary page scripts. (#46790) Thanks @vincentkoc.
 - Agents/compaction: extend the enclosing run deadline once while compaction is actively in flight, and abort the underlying SDK compaction on timeout/cancel so large-session compactions stop freezing mid-run. (#46889) Thanks @asyncjason.
 - Gateway/Telegram shutdown: abort stalled Telegram polling fetches on shutdown, clean up per-cycle abort listeners, and keep the in-process watchdog ahead of supervisor stop timeouts so SIGTERM no longer leaves zombie gateways behind. (#51242) Thanks @juliabush.
@@ -16567,9 +16567,9 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Plugins: ship bundled plugins disabled by default and allow overrides by installed versions. (#1066) - thanks @ItzR3NO.
 - Plugins: add bundled Antigravity + Gemini CLI OAuth + Copilot Proxy provider plugins. (#1066) - thanks @ItzR3NO.
 - Tools: improve `web_fetch` extraction using Readability (with fallback).
-- Tools: add Firecrawl fallback for `web_fetch` when configured.
+- Tools: add FireCrawl fallback for `web_fetch` when configured.
 - Tools: send Chrome-like headers by default for `web_fetch` to improve extraction on bot-sensitive sites.
-- Tools: Firecrawl fallback now uses bot-circumvention + cache by default; remove basic HTML fallback when extraction fails.
+- Tools: FireCrawl fallback now uses bot-circumvention + cache by default; remove basic HTML fallback when extraction fails.
 - Tools: default `exec` exit notifications and auto-migrate legacy `tools.bash` to `tools.exec`.
 - Tools: add `exec` PTY support for interactive sessions. https://docs.openclaw.ai/tools/exec.
 - Tools: add tmux-style `process send-keys` and bracketed paste helpers for PTY sessions.

--- a/docs/concepts/features.md
+++ b/docs/concepts/features.md
@@ -73,7 +73,7 @@ title: "Features"
 **Tools and automation:**
 
 - Browser automation, exec, sandboxing
-- Web search (Brave, DuckDuckGo, Exa, Firecrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web Search, Perplexity, SearXNG, Tavily)
+- Web search (Brave, DuckDuckGo, Exa, FireCrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web Search, Perplexity, SearXNG, Tavily)
 - Cron jobs and heartbeat scheduling
 - Skills, plugins, and workflow pipelines (Lobster)
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -6399,7 +6399,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 
 - Route: /plugins/reference/firecrawl
 - Headings:
-  - H1: Firecrawl plugin
+  - H1: FireCrawl plugin
   - H2: Distribution
   - H2: Surface
   - H2: Related docs
@@ -8575,7 +8575,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Image and video generation
   - H3: Memory embeddings and semantic search
   - H3: Web search tool
-  - H3: Web fetch tool (Firecrawl)
+  - H3: Web fetch tool (FireCrawl)
   - H3: Provider usage snapshots (status/health)
   - H3: Compaction safeguard summarization
   - H3: Model scan / probe
@@ -9751,14 +9751,14 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Install plugin
   - H2: Keyless access and API keys
-  - H2: Configure Firecrawl search
-  - H2: Configure Firecrawl webfetch fallback
-  - H3: Self-hosted Firecrawl
-  - H2: Firecrawl plugin tools
+  - H2: Configure FireCrawl search
+  - H2: Configure FireCrawl webfetch fallback
+  - H3: Self-hosted FireCrawl
+  - H2: FireCrawl plugin tools
   - H3: firecrawlsearch
   - H3: firecrawlscrape
   - H2: Stealth / bot circumvention
-  - H2: How webfetch uses Firecrawl
+  - H2: How webfetch uses FireCrawl
   - H2: Related
 
 ## tools/gemini-search.md
@@ -10339,7 +10339,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: How it works
   - H2: Progress updates
   - H2: Config
-  - H2: Firecrawl fallback
+  - H2: FireCrawl fallback
   - H2: Trusted env proxy
   - H2: Limits and safety
   - H2: Tool profiles

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -364,9 +364,9 @@ inaccessible apps stay excluded. Account apps use the global
 precedence when the same app is present in both paths. If `app/list` cannot be
 read, account-wide exposure fails closed.
 
-- `plugins.entries.firecrawl.config.webFetch`: Firecrawl web-fetch provider settings.
-  - `apiKey`: Optional Firecrawl API key for higher limits (accepts SecretRef). Falls back to `plugins.entries.firecrawl.config.webSearch.apiKey`, legacy `tools.web.fetch.firecrawl.apiKey`, or `FIRECRAWL_API_KEY` env var.
-  - `baseUrl`: Firecrawl API base URL (default: `https://api.firecrawl.dev`; self-hosted overrides must target private/internal endpoints).
+- `plugins.entries.firecrawl.config.webFetch`: FireCrawl web-fetch provider settings.
+  - `apiKey`: Optional FireCrawl API key for higher limits (accepts SecretRef). Falls back to `plugins.entries.firecrawl.config.webSearch.apiKey`, legacy `tools.web.fetch.firecrawl.apiKey`, or `FIRECRAWL_API_KEY` env var.
+  - `baseUrl`: FireCrawl API base URL (default: `https://api.firecrawl.dev`; self-hosted overrides must target private/internal endpoints).
   - `onlyMainContent`: extract only the main content from pages (default: `true`).
   - `maxAgeMs`: maximum cache age in milliseconds (default: `172800000` / 2 days).
   - `timeoutSeconds`: scrape request timeout in seconds (default: `60`).

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -620,7 +620,7 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
     | Brave | No | `BRAVE_API_KEY` |
     | DuckDuckGo | Yes (unofficial HTML-based) | - |
     | Exa | No | `EXA_API_KEY` |
-    | Firecrawl | No | `FIRECRAWL_API_KEY` |
+    | FireCrawl | No | `FIRECRAWL_API_KEY` |
     | Gemini | No | `GEMINI_API_KEY` |
     | Grok | No (xAI OAuth or key) | `XAI_API_KEY` |
     | Kimi | No | `KIMI_API_KEY` or `MOONSHOT_API_KEY` |
@@ -663,11 +663,11 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
     }
     ```
 
-    Provider-specific web-search config lives under `plugins.entries.<plugin>.config.webSearch.*`. Legacy `tools.web.search.*` provider paths still load for compatibility but should not be used in new configs. Firecrawl web-fetch fallback config lives under `plugins.entries.firecrawl.config.webFetch.*`.
+    Provider-specific web-search config lives under `plugins.entries.<plugin>.config.webSearch.*`. Legacy `tools.web.search.*` provider paths still load for compatibility but should not be used in new configs. FireCrawl web-fetch fallback config lives under `plugins.entries.firecrawl.config.webFetch.*`.
 
     - Allowlists: add `web_search`/`web_fetch`/`x_search`, or `group:web` for all three.
     - `web_fetch` is enabled by default.
-    - If `tools.web.fetch.provider` is omitted, OpenClaw auto-detects the first ready fetch fallback provider from available credentials; the official Firecrawl plugin provides that fallback.
+    - If `tools.web.fetch.provider` is omitted, OpenClaw auto-detects the first ready fetch fallback provider from available credentials; the official FireCrawl plugin provides that fallback.
     - Daemons read env vars from `~/.openclaw/.env` (or the service environment).
 
     Docs: [Web tools](/tools/web).

--- a/docs/maturity/taxonomy.md
+++ b/docs/maturity/taxonomy.md
@@ -4394,7 +4394,7 @@ A surface is a product area such as Gateway runtime, Discord, or the macOS app. 
         <div><span className="maturity-score maturity-score-beta"><span className="maturity-score-label"><span className="maturity-level-pill maturity-level-beta">Beta</span><span>79%</span></span><span className="maturity-meter" aria-hidden="true"><span style={{ width: "79%" }} /></span></span></div>
         <div className="maturity-category-docs">
 
-    [Web](/tools/web), [Brave Search](/tools/brave-search), [Tavily](/tools/tavily), [Exa Search](/tools/exa-search), [Firecrawl](/tools/firecrawl), [Perplexity Search](/tools/perplexity-search), [Duckduckgo Search](/tools/duckduckgo-search), [Searxng Search](/tools/searxng-search), [Gemini Search](/tools/gemini-search), [Grok Search](/tools/grok-search), [Kimi Search](/tools/kimi-search), [Minimax Search](/tools/minimax-search), [Ollama Search](/tools/ollama-search), [Sdk Subpaths](/plugins/sdk-subpaths), [Sdk Overview](/plugins/sdk-overview), [Manifest](/plugins/manifest)
+    [Web](/tools/web), [Brave Search](/tools/brave-search), [Tavily](/tools/tavily), [Exa Search](/tools/exa-search), [FireCrawl](/tools/firecrawl), [Perplexity Search](/tools/perplexity-search), [Duckduckgo Search](/tools/duckduckgo-search), [Searxng Search](/tools/searxng-search), [Gemini Search](/tools/gemini-search), [Grok Search](/tools/grok-search), [Kimi Search](/tools/kimi-search), [Minimax Search](/tools/minimax-search), [Ollama Search](/tools/ollama-search), [Sdk Subpaths](/plugins/sdk-subpaths), [Sdk Overview](/plugins/sdk-overview), [Manifest](/plugins/manifest)
 
     </div>
       </div>
@@ -4408,7 +4408,7 @@ A surface is a product area such as Gateway runtime, Discord, or the macOS app. 
         <div><span className="maturity-score maturity-score-beta"><span className="maturity-score-label"><span className="maturity-level-pill maturity-level-beta">Beta</span><span>79%</span></span><span className="maturity-meter" aria-hidden="true"><span style={{ width: "79%" }} /></span></span></div>
         <div className="maturity-category-docs">
 
-    [Web](/tools/web), [Web Fetch](/tools/web-fetch), [Faq](/help/faq), [Api Usage Costs](/reference/api-usage-costs), [Brave Search](/tools/brave-search), [Perplexity Search](/tools/perplexity-search), [Tavily](/tools/tavily), [Firecrawl](/tools/firecrawl)
+    [Web](/tools/web), [Web Fetch](/tools/web-fetch), [Faq](/help/faq), [Api Usage Costs](/reference/api-usage-costs), [Brave Search](/tools/brave-search), [Perplexity Search](/tools/perplexity-search), [Tavily](/tools/tavily), [FireCrawl](/tools/firecrawl)
 
     </div>
       </div>
@@ -4422,7 +4422,7 @@ A surface is a product area such as Gateway runtime, Discord, or the macOS app. 
         <div><span className="maturity-score maturity-score-beta"><span className="maturity-score-label"><span className="maturity-level-pill maturity-level-beta">Beta</span><span>79%</span></span><span className="maturity-meter" aria-hidden="true"><span style={{ width: "79%" }} /></span></span></div>
         <div className="maturity-category-docs">
 
-    [Web](/tools/web), [Web Fetch](/tools/web-fetch), [Firecrawl](/tools/firecrawl), [Searxng Search](/tools/searxng-search)
+    [Web](/tools/web), [Web Fetch](/tools/web-fetch), [FireCrawl](/tools/firecrawl), [Searxng Search](/tools/searxng-search)
 
     </div>
       </div>

--- a/docs/plugins/reference/firecrawl.md
+++ b/docs/plugins/reference/firecrawl.md
@@ -2,10 +2,10 @@
 summary: "Adds agent-callable tools. Adds web fetch provider support. Adds web search provider support."
 read_when:
   - You are installing, configuring, or auditing the firecrawl plugin
-title: "Firecrawl plugin"
+title: "FireCrawl plugin"
 ---
 
-# Firecrawl plugin
+# FireCrawl plugin
 
 Adds agent-callable tools. Adds web fetch provider support. Adds web search provider support.
 

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -84,7 +84,7 @@ See [Memory](/concepts/memory).
 | Brave Search           | `BRAVE_API_KEY`                                                                                                                                                        |
 | DuckDuckGo             | key-free; unofficial, HTML-based, no billing                                                                                                                           |
 | Exa                    | `EXA_API_KEY`                                                                                                                                                          |
-| Firecrawl              | `FIRECRAWL_API_KEY`                                                                                                                                                    |
+| FireCrawl              | `FIRECRAWL_API_KEY`                                                                                                                                                    |
 | Gemini (Google Search) | `GEMINI_API_KEY`                                                                                                                                                       |
 | Grok (xAI)             | xAI OAuth profile or `XAI_API_KEY`                                                                                                                                     |
 | Kimi (Moonshot)        | `KIMI_API_KEY` or `MOONSHOT_API_KEY`                                                                                                                                   |
@@ -101,9 +101,9 @@ Legacy `tools.web.search.*` config paths still load through a compatibility shim
 
 See [Web tools](/tools/web).
 
-### Web fetch tool (Firecrawl)
+### Web fetch tool (FireCrawl)
 
-`web_fetch` can call Firecrawl with keyless starter access; add `FIRECRAWL_API_KEY` (or `plugins.entries.firecrawl.config.webFetch.apiKey`) for higher limits. If Firecrawl isn't configured, the tool falls back to direct fetch plus the bundled `web-readability` plugin (no paid API). Disable `plugins.entries.web-readability.enabled` to skip local Readability extraction.
+`web_fetch` can call FireCrawl with keyless starter access; add `FIRECRAWL_API_KEY` (or `plugins.entries.firecrawl.config.webFetch.apiKey`) for higher limits. If FireCrawl isn't configured, the tool falls back to direct fetch plus the bundled `web-readability` plugin (no paid API). Disable `plugins.entries.web-readability.enabled` to skip local Readability extraction.
 
 See [Web tools](/tools/web).
 

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -120,7 +120,7 @@ behavior and outputs, see [CLI setup reference](/start/wizard-cli-reference).
 
   </Step>
   <Step title="Web search">
-    - Pick a supported provider such as Brave, Codex (Hosted Search), DuckDuckGo, Exa, Firecrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web Search, Parallel, Perplexity, SearXNG, or Tavily (or skip).
+    - Pick a supported provider such as Brave, Codex (Hosted Search), DuckDuckGo, Exa, FireCrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web Search, Parallel, Perplexity, SearXNG, or Tavily (or skip).
     - API-backed providers can use env vars or existing config for quick setup; key-free providers use their provider-specific prerequisites instead.
     - Skip with `--skip-search`.
     - Configure later: `openclaw configure --section web`.

--- a/docs/releases/2026.7.1.md
+++ b/docs/releases/2026.7.1.md
@@ -2173,7 +2173,7 @@ Agents can read scanned PDFs with vision-capable models, work in isolated coding
 - Clarified why several network and provider paths preserve useful results when secondary cleanup or parsing steps fail. [#97701](https://github.com/openclaw/openclaw/pull/97701) Thanks @zengwen-dt.
 - Brought additional Docker checks into the shared QA inventory, improving release coverage and reducing duplicated validation work. [#97708](https://github.com/openclaw/openclaw/pull/97708) Thanks @romneyda.
 - Added structured QA coverage for ClawHub marketplace listings and packaged plugin installation checks. [#97712](https://github.com/openclaw/openclaw/pull/97712) Thanks @romneyda.
-- Strengthened Firecrawl regression coverage for URL safety, search results, scraping, and response limits. [#97714](https://github.com/openclaw/openclaw/pull/97714) Thanks @solodmd.
+- Strengthened FireCrawl regression coverage for URL safety, search results, scraping, and response limits. [#97714](https://github.com/openclaw/openclaw/pull/97714) Thanks @solodmd.
 - Strengthened coverage for clear and accurate configuration validation messages. [#97736](https://github.com/openclaw/openclaw/pull/97736) Thanks @solodmd.
 - Added regression coverage for numeric command-line and configuration options, including defaults and boundary values. [#97802](https://github.com/openclaw/openclaw/pull/97802) Thanks @dwc1997.
 - Made intentional exits in tests and wrappers easier to distinguish from real runtime failures. [#97803](https://github.com/openclaw/openclaw/pull/97803) Thanks @maweibin.
@@ -2434,7 +2434,7 @@ Agents can read scanned PDFs with vision-capable models, work in isolated coding
 - Clarified the Copilot plugin's internal boundaries without changing its runtime behavior. [#101379](https://github.com/openclaw/openclaw/pull/101379) Thanks @vincentkoc.
 - Reduced accidental API exposure in the GitHub Copilot provider, making its supported boundaries clearer. [#101393](https://github.com/openclaw/openclaw/pull/101393) Thanks @vincentkoc.
 - Kept private plugin details internal, improving dead-code reports and future cleanup. [#101406](https://github.com/openclaw/openclaw/pull/101406) Thanks @vincentkoc.
-- Clarified supported boundaries for the Brave, Firecrawl, and DeepInfra provider plugins. [#101425](https://github.com/openclaw/openclaw/pull/101425) Thanks @vincentkoc.
+- Clarified supported boundaries for the Brave, FireCrawl, and DeepInfra provider plugins. [#101425](https://github.com/openclaw/openclaw/pull/101425) Thanks @vincentkoc.
 - Kept OpenCode Go streaming and catalog internals private so extension developers see clearer integration boundaries. [#101440](https://github.com/openclaw/openclaw/pull/101440) Thanks @vincentkoc.
 - Cleaned up private OpenRouter and SMS plugin definitions to improve internal API accuracy. [#101452](https://github.com/openclaw/openclaw/pull/101452) Thanks @vincentkoc.
 - Enabled release operators to validate an exact extended-stable candidate before its final tag exists. [#101466](https://github.com/openclaw/openclaw/pull/101466) Thanks @kevinslin.

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -78,7 +78,7 @@ not install or modify anything on the remote host.
       `openclaw pairing approve <channel> <code>` or use allowlists.
   </Step>
   <Step title="Web search">
-    - Pick a provider (Brave, DuckDuckGo, Exa, Firecrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web Search, Perplexity, SearXNG, Tavily) or skip.
+    - Pick a provider (Brave, DuckDuckGo, Exa, FireCrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web Search, Perplexity, SearXNG, Tavily) or skip.
     - Skip this step with `--skip-search`; reconfigure later with `openclaw configure --section web`.
 
   </Step>

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -62,7 +62,7 @@ openclaw agents add <name>
 
 <Tip>
 The classic wizard includes a web search step where you can pick a provider: Brave,
-DuckDuckGo, Exa, Firecrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web
+DuckDuckGo, Exa, FireCrawl, Gemini, Grok, Kimi, MiniMax Search, Ollama Web
 Search, Perplexity, SearXNG, or Tavily. Some need an API key; others are
 key-free. Configure this later with `openclaw configure --section web`. Docs:
 [Web tools](/tools/web).

--- a/docs/tools/firecrawl.md
+++ b/docs/tools/firecrawl.md
@@ -1,15 +1,15 @@
 ---
-summary: "Firecrawl search, scrape, and web_fetch fallback"
+summary: "FireCrawl search, scrape, and web_fetch fallback"
 read_when:
-  - You want Firecrawl-backed web extraction
-  - You want keyless Firecrawl Search (Free) or keyless web_fetch
-  - You need a Firecrawl API key for search or higher limits
-  - You want Firecrawl as a web_search provider
+  - You want FireCrawl-backed web extraction
+  - You want keyless FireCrawl Search (Free) or keyless web_fetch
+  - You need a FireCrawl API key for search or higher limits
+  - You want FireCrawl as a web_search provider
   - You want anti-bot extraction for web_fetch
-title: "Firecrawl"
+title: "FireCrawl"
 ---
 
-OpenClaw can use **Firecrawl** in three ways:
+OpenClaw can use **FireCrawl** in three ways:
 
 - as the `web_search` provider
 - as explicit plugin tools: `firecrawl_search` and `firecrawl_scrape`
@@ -28,19 +28,19 @@ openclaw gateway restart
 
 ## Keyless access and API keys
 
-Firecrawl registers two `web_search` providers:
+FireCrawl registers two `web_search` providers:
 
-- **Firecrawl Search** (`firecrawl`) — uses the hosted `/v2/search` API with your
+- **FireCrawl Search** (`firecrawl`) — uses the hosted `/v2/search` API with your
   key; auto-detected when a key is present.
-- **Firecrawl Search (Free)** (`firecrawl-free`) — uses the hosted keyless starter
+- **FireCrawl Search (Free)** (`firecrawl-free`) — uses the hosted keyless starter
   tier, no API key required. It is **opt-in only** and never auto-selected, since
-  selecting it sends your search queries to Firecrawl's free tier.
+  selecting it sends your search queries to FireCrawl's free tier.
 
-The explicitly selected Firecrawl `web_fetch` fallback is also keyless. The
+The explicitly selected FireCrawl `web_fetch` fallback is also keyless. The
 explicit `firecrawl_search` and `firecrawl_scrape` tools require an API key. Add
 `FIRECRAWL_API_KEY` in the gateway environment or configure it for higher limits.
 
-## Configure Firecrawl search
+## Configure FireCrawl search
 
 ```json5
 {
@@ -69,15 +69,15 @@ explicit `firecrawl_search` and `firecrawl_scrape` tools require an API key. Add
 
 Notes:
 
-- Choosing Firecrawl in onboarding or `openclaw configure --section web` enables the installed Firecrawl plugin automatically.
-- Pick **Firecrawl Search (Free)** in onboarding (or set `provider: "firecrawl-free"`) to run keyless with no API key. The keyed **Firecrawl Search** provider sends `plugins.entries.firecrawl.config.webSearch.apiKey` or `FIRECRAWL_API_KEY`.
-- `web_search` with Firecrawl supports `query` and `count`.
-- For Firecrawl-specific controls like `sources`, `categories`, or result scraping, use `firecrawl_search`.
-- `baseUrl` defaults to hosted Firecrawl at `https://api.firecrawl.dev`. Self-hosted overrides are allowed only for private/internal endpoints; HTTP is accepted only for those private targets.
-- `FIRECRAWL_BASE_URL` is the shared env fallback for Firecrawl search and scrape base URLs.
-- Firecrawl search requests default to a 30-second timeout; `firecrawl_search`'s `timeoutSeconds` parameter overrides it per call.
+- Choosing FireCrawl in onboarding or `openclaw configure --section web` enables the installed FireCrawl plugin automatically.
+- Pick **FireCrawl Search (Free)** in onboarding (or set `provider: "firecrawl-free"`) to run keyless with no API key. The keyed **FireCrawl Search** provider sends `plugins.entries.firecrawl.config.webSearch.apiKey` or `FIRECRAWL_API_KEY`.
+- `web_search` with FireCrawl supports `query` and `count`.
+- For FireCrawl-specific controls like `sources`, `categories`, or result scraping, use `firecrawl_search`.
+- `baseUrl` defaults to hosted FireCrawl at `https://api.firecrawl.dev`. Self-hosted overrides are allowed only for private/internal endpoints; HTTP is accepted only for those private targets.
+- `FIRECRAWL_BASE_URL` is the shared env fallback for FireCrawl search and scrape base URLs.
+- FireCrawl search requests default to a 30-second timeout; `firecrawl_search`'s `timeoutSeconds` parameter overrides it per call.
 
-## Configure Firecrawl web_fetch fallback
+## Configure FireCrawl web_fetch fallback
 
 ```json5
 {
@@ -108,26 +108,26 @@ Notes:
 
 Notes:
 
-- The explicitly selected Firecrawl `web_fetch` fallback works without an API key. When configured, OpenClaw sends `plugins.entries.firecrawl.config.webFetch.apiKey` or `FIRECRAWL_API_KEY` for higher limits.
-- Choosing Firecrawl during onboarding or `openclaw configure --section web` enables the plugin and selects Firecrawl for `web_fetch` unless another fetch provider is already configured.
+- The explicitly selected FireCrawl `web_fetch` fallback works without an API key. When configured, OpenClaw sends `plugins.entries.firecrawl.config.webFetch.apiKey` or `FIRECRAWL_API_KEY` for higher limits.
+- Choosing FireCrawl during onboarding or `openclaw configure --section web` enables the plugin and selects FireCrawl for `web_fetch` unless another fetch provider is already configured.
 - `firecrawl_scrape` requires an API key.
 - `maxAgeMs` controls how old cached results can be (ms). Default is 172,800,000 ms (2 days).
 - `onlyMainContent` defaults to `true`; `timeoutSeconds` defaults to 60.
 - Legacy `tools.web.fetch.firecrawl.*` and `tools.web.search.firecrawl.*` config is auto-migrated by `openclaw doctor --fix`.
-- Firecrawl scrape/base URL overrides follow the same hosted/private rule as search: public hosted traffic uses `https://api.firecrawl.dev`; self-hosted overrides must resolve to private/internal endpoints.
-- `firecrawl_scrape` rejects obvious private, loopback, metadata, and non-HTTP(S) target URLs before forwarding them to Firecrawl, matching the `web_fetch` target-safety contract for explicit Firecrawl scrape calls.
+- FireCrawl scrape/base URL overrides follow the same hosted/private rule as search: public hosted traffic uses `https://api.firecrawl.dev`; self-hosted overrides must resolve to private/internal endpoints.
+- `firecrawl_scrape` rejects obvious private, loopback, metadata, and non-HTTP(S) target URLs before forwarding them to FireCrawl, matching the `web_fetch` target-safety contract for explicit FireCrawl scrape calls.
 
 `firecrawl_scrape` reuses the same `plugins.entries.firecrawl.config.webFetch.*` settings and env vars, including its required API key.
 
-### Self-hosted Firecrawl
+### Self-hosted FireCrawl
 
-Set `plugins.entries.firecrawl.config.webSearch.baseUrl`, `plugins.entries.firecrawl.config.webFetch.baseUrl`, or `FIRECRAWL_BASE_URL` when you run Firecrawl yourself. OpenClaw accepts `http://` only for loopback, private-network, `.local`, `.internal`, or `.localhost` targets. Public custom hosts are rejected so Firecrawl API keys are not sent to arbitrary endpoints by accident.
+Set `plugins.entries.firecrawl.config.webSearch.baseUrl`, `plugins.entries.firecrawl.config.webFetch.baseUrl`, or `FIRECRAWL_BASE_URL` when you run FireCrawl yourself. OpenClaw accepts `http://` only for loopback, private-network, `.local`, `.internal`, or `.localhost` targets. Public custom hosts are rejected so FireCrawl API keys are not sent to arbitrary endpoints by accident.
 
-## Firecrawl plugin tools
+## FireCrawl plugin tools
 
 ### `firecrawl_search`
 
-Use this when you want Firecrawl-specific search controls instead of generic `web_search`. Requires an API key.
+Use this when you want FireCrawl-specific search controls instead of generic `web_search`. Requires an API key.
 
 Parameters:
 
@@ -158,22 +158,22 @@ Parameters:
 
 ## Stealth / bot circumvention
 
-`firecrawl_scrape` and the `web_fetch` Firecrawl fallback default to `proxy: "auto"` plus `storeInCache: true` unless the caller overrides those parameters. `firecrawl_search` and the `web_search` Firecrawl provider have no `proxy`/`storeInCache` controls; stealth proxy mode only applies to scrape/fetch requests.
+`firecrawl_scrape` and the `web_fetch` FireCrawl fallback default to `proxy: "auto"` plus `storeInCache: true` unless the caller overrides those parameters. `firecrawl_search` and the `web_search` FireCrawl provider have no `proxy`/`storeInCache` controls; stealth proxy mode only applies to scrape/fetch requests.
 
-Firecrawl's `proxy` mode controls bot circumvention (`basic`, `stealth`, or `auto`). `auto` retries with stealth proxies if a basic attempt fails, which may use more credits than basic-only scraping.
+FireCrawl's `proxy` mode controls bot circumvention (`basic`, `stealth`, or `auto`). `auto` retries with stealth proxies if a basic attempt fails, which may use more credits than basic-only scraping.
 
-## How `web_fetch` uses Firecrawl
+## How `web_fetch` uses FireCrawl
 
 `web_fetch` extraction order:
 
 1. Readability (local)
-2. Configured fetch provider, such as Firecrawl (when selected, or auto-detected from configured credentials)
+2. Configured fetch provider, such as FireCrawl (when selected, or auto-detected from configured credentials)
 3. Basic HTML cleanup (last fallback)
 
-The selection knob is `tools.web.fetch.provider`. If you omit it, OpenClaw auto-detects the first ready web-fetch provider from available credentials. The official Firecrawl plugin provides that fallback.
+The selection knob is `tools.web.fetch.provider`. If you omit it, OpenClaw auto-detects the first ready web-fetch provider from available credentials. The official FireCrawl plugin provides that fallback.
 
 ## Related
 
 - [Web Search overview](/tools/web) -- all providers and auto-detection
-- [Web Fetch](/tools/web-fetch) -- web_fetch tool with Firecrawl fallback
+- [Web Fetch](/tools/web-fetch) -- web_fetch tool with FireCrawl fallback
 - [Tavily](/tools/tavily) -- search + extract tools

--- a/docs/tools/tavily.md
+++ b/docs/tools/tavily.md
@@ -157,7 +157,7 @@ The generic `web_search` tool with Tavily as provider supports `query` and `coun
   <Card title="Web Search overview" href="/tools/web" icon="magnifying-glass">
     All providers and auto-detection rules.
   </Card>
-  <Card title="Firecrawl" href="/tools/firecrawl" icon="fire">
+  <Card title="FireCrawl" href="/tools/firecrawl" icon="fire">
     Search plus scraping with content extraction.
   </Card>
   <Card title="Exa Search" href="/tools/exa-search" icon="binoculars">

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -2,7 +2,7 @@
 summary: "web_fetch tool -- HTTP fetch with readable content extraction"
 read_when:
   - You want to fetch a URL and extract readable content
-  - You need to configure web_fetch or its Firecrawl fallback
+  - You need to configure web_fetch or its FireCrawl fallback
   - You want to understand web_fetch limits and caching
 title: "Web fetch"
 sidebarTitle: "Web Fetch"
@@ -46,7 +46,7 @@ Truncate output to this many characters. Clamped to `tools.web.fetch.maxCharsCap
   </Step>
   <Step title="Fallback (optional)">
     If Readability fails and a fetch provider is available, retries through
-    that provider (for example Firecrawl's bot-circumvention mode).
+    that provider (for example FireCrawl's bot-circumvention mode).
   </Step>
   <Step title="Cache">
     Results are cached for 15 minutes (configurable) to reduce repeated
@@ -95,10 +95,10 @@ progress line is channel UI state only and never contains fetched page content.
 }
 ```
 
-## Firecrawl fallback
+## FireCrawl fallback
 
 If Readability extraction fails, `web_fetch` can fall back to
-[Firecrawl](/tools/firecrawl) for bot-circumvention and better extraction:
+[FireCrawl](/tools/firecrawl) for bot-circumvention and better extraction:
 
 ```json5
 {
@@ -133,12 +133,12 @@ Legacy `tools.web.fetch.firecrawl.*` config auto-migrates to
 `plugins.entries.firecrawl.config.webFetch` via `openclaw doctor --fix`.
 
 <Note>
-  If you configure a Firecrawl API-key SecretRef and it is unresolved with no
+  If you configure a FireCrawl API-key SecretRef and it is unresolved with no
   `FIRECRAWL_API_KEY` env fallback, gateway startup fails fast.
 </Note>
 
 <Note>
-  Firecrawl `baseUrl` overrides are locked down: hosted traffic uses
+  FireCrawl `baseUrl` overrides are locked down: hosted traffic uses
   `https://api.firecrawl.dev`; self-hosted overrides must target private or
   internal endpoints, and `http://` is accepted only for those private targets.
 </Note>
@@ -149,11 +149,11 @@ Current runtime behavior:
 - If `provider` is omitted, OpenClaw auto-detects the first ready web-fetch
   provider from configured credentials. Non-sandboxed `web_fetch` can use
   installed plugins that declare `contracts.webFetchProviders` and register a
-  matching provider at runtime. The official Firecrawl plugin provides this
+  matching provider at runtime. The official FireCrawl plugin provides this
   fallback today.
 - Sandboxed `web_fetch` calls allow bundled providers plus installed providers
   whose official npm or ClawHub provenance is verified. Today that permits the
-  official Firecrawl plugin; third-party external fetch plugins stay excluded.
+  official FireCrawl plugin; third-party external fetch plugins stay excluded.
 - If Readability is disabled, `web_fetch` skips straight to the selected
   provider fallback. If no provider is available, it fails closed.
 
@@ -206,4 +206,4 @@ If you use tool profiles or allowlists, add `web_fetch` or `group:web`:
 
 - [Web Search](/tools/web) -- search the web with multiple providers
 - [Web Browser](/tools/browser) -- full browser automation for JS-heavy sites
-- [Firecrawl](/tools/firecrawl) -- Firecrawl search and scrape tools
+- [FireCrawl](/tools/firecrawl) -- FireCrawl search and scrape tools

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -67,7 +67,7 @@ xAI Responses.
   <Card title="Exa" icon="brain" href="/tools/exa-search">
     Neural + keyword search with content extraction (highlights, text, summaries).
   </Card>
-  <Card title="Firecrawl" icon="flame" href="/tools/firecrawl">
+  <Card title="FireCrawl" icon="flame" href="/tools/firecrawl">
     Structured results. Best paired with `firecrawl_search` and `firecrawl_scrape` for deep extraction.
   </Card>
   <Card title="Gemini" icon="sparkles" href="/tools/gemini-search">
@@ -110,7 +110,7 @@ xAI Responses.
 | [Codex Hosted Search](/plugins/codex-harness)    | AI-synthesized + source URLs                                   | Domains, context size, user location             | None; uses Codex/OpenAI sign-in                                                         |
 | [DuckDuckGo](/tools/duckduckgo-search)           | Structured snippets                                            | --                                               | None (key-free)                                                                         |
 | [Exa](/tools/exa-search)                         | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
-| [Firecrawl](/tools/firecrawl)                    | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
+| [FireCrawl](/tools/firecrawl)                    | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
 | [Gemini](/tools/gemini-search)                   | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
 | [Grok](/tools/grok-search)                       | AI-synthesized + citations                                     | --                                               | xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey`              |
 | [Kimi](/tools/kimi-search)                       | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
@@ -138,7 +138,7 @@ API-backed providers first:
 4. **Grok** -- xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
 5. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey` (order 40)
 6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
-7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
+7. **FireCrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
 10. **Parallel** -- paid Parallel Search API via `PARALLEL_API_KEY` or `plugins.entries.parallel.config.webSearch.apiKey`; optional `plugins.entries.parallel.config.webSearch.baseUrl` overrides the endpoint (order 75)
@@ -164,7 +164,7 @@ instead.
 <Note>
   All provider key fields support SecretRef objects. Plugin-scoped SecretRefs
   under `plugins.entries.<plugin>.config.webSearch.apiKey` are resolved for the
-  installed API-backed web search providers, including Brave, Exa, Firecrawl,
+  installed API-backed web search providers, including Brave, Exa, FireCrawl,
   Gemini, Grok, Kimi, MiniMax, Parallel, Perplexity, and Tavily,
   whether the provider is picked explicitly via `tools.web.search.provider` or
   selected through auto-detect. In auto-detect mode, OpenClaw resolves only the
@@ -319,7 +319,7 @@ plugin or run `openclaw doctor --fix` to clean up the stale config.
 - non-sandboxed `web_fetch` can use installed plugin providers that declare
   `contracts.webFetchProviders`; sandboxed fetches allow bundled providers and
   verified official plugin installs, but exclude third-party external plugins
-- the official Firecrawl plugin is the only bundled `webFetchProviders`
+- the official FireCrawl plugin is the only bundled `webFetchProviders`
   contributor today, configured under
   `plugins.entries.firecrawl.config.webFetch.*`
 
@@ -406,7 +406,7 @@ provider, OpenClaw does not show the `x_search` prompt.
   `max_tokens_per_page` support.
   SearXNG accepts `http://` only for trusted private-network or loopback hosts;
   public SearXNG endpoints must use `https://`.
-  Firecrawl and Tavily only support `query` and `count` through `web_search`
+  FireCrawl and Tavily only support `query` and `count` through `web_search`
   -- use their dedicated tools for advanced options.
 </Warning>
 

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -5,6 +5,7 @@
   },
   "name": "Diffs",
   "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
+  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/plugin-art/diffs.webp",
   "catalog": { "featured": true, "order": 40 },
   "contracts": {
     "tools": ["diffs"]

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -5,7 +5,7 @@
   },
   "name": "Diffs",
   "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
-  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/plugin-art/diffs.webp",
+  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/401f278f111fa5ea1b79521112ba350852328dc0/ui/public/plugin-art/diffs.webp",
   "catalog": { "featured": true, "order": 40 },
   "contracts": {
     "tools": ["diffs"]

--- a/extensions/firecrawl/README.md
+++ b/extensions/firecrawl/README.md
@@ -1,6 +1,6 @@
-# OpenClaw Firecrawl Plugin
+# FireCrawl
 
-Official OpenClaw plugin for Firecrawl.
+Search the web and scrape clean, structured page content with FireCrawl.
 
 Install from OpenClaw:
 

--- a/extensions/firecrawl/README.md
+++ b/extensions/firecrawl/README.md
@@ -1,6 +1,6 @@
 # FireCrawl
 
-Search the web and scrape clean, structured page content with FireCrawl.
+Search the live web for fresh results, scrape pages into LLM-ready Markdown, and interact with dynamic sites to extract hard-to-reach data.
 
 Install from OpenClaw:
 

--- a/extensions/firecrawl/index.ts
+++ b/extensions/firecrawl/index.ts
@@ -8,8 +8,8 @@ import { createFirecrawlSearchTool } from "./src/firecrawl-search-tool.js";
 
 export default definePluginEntry({
   id: "firecrawl",
-  name: "Firecrawl Plugin",
-  description: "Bundled Firecrawl search and scrape plugin",
+  name: "FireCrawl",
+  description: "Search the web and scrape clean, structured page content with FireCrawl.",
   register(api) {
     api.registerWebFetchProvider(createFirecrawlWebFetchProvider());
     api.registerWebSearchProvider(createFirecrawlWebSearchProvider());

--- a/extensions/firecrawl/index.ts
+++ b/extensions/firecrawl/index.ts
@@ -9,7 +9,8 @@ import { createFirecrawlSearchTool } from "./src/firecrawl-search-tool.js";
 export default definePluginEntry({
   id: "firecrawl",
   name: "FireCrawl",
-  description: "Search the web and scrape clean, structured page content with FireCrawl.",
+  description:
+    "Search the live web for fresh results, scrape pages into LLM-ready Markdown, and interact with dynamic sites to extract hard-to-reach data.",
   register(api) {
     api.registerWebFetchProvider(createFirecrawlWebFetchProvider());
     api.registerWebSearchProvider(createFirecrawlWebSearchProvider());

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "firecrawl",
   "name": "FireCrawl",
   "description": "Search the web and scrape clean, structured page content with FireCrawl.",
-  "icon": "https://avatars.githubusercontent.com/u/135057108?v=4",
+  "icon": "https://www.firecrawl.dev/brand/firecrawl-logo.png",
   "activation": {
     "onStartup": false
   },

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -1,5 +1,8 @@
 {
   "id": "firecrawl",
+  "name": "FireCrawl",
+  "description": "Search the web and scrape clean, structured page content with FireCrawl.",
+  "icon": "https://avatars.githubusercontent.com/u/135057108?v=4",
   "activation": {
     "onStartup": false
   },

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -16,24 +16,24 @@
   },
   "uiHints": {
     "webSearch.apiKey": {
-      "label": "Firecrawl Search API Key",
-      "help": "Firecrawl API key for web search (fallback: FIRECRAWL_API_KEY env var).",
+      "label": "FireCrawl Search API Key",
+      "help": "FireCrawl API key for web search (fallback: FIRECRAWL_API_KEY env var).",
       "sensitive": true,
       "placeholder": "fc-..."
     },
     "webSearch.baseUrl": {
-      "label": "Firecrawl Search Base URL",
-      "help": "Firecrawl Search base URL override."
+      "label": "FireCrawl Search Base URL",
+      "help": "FireCrawl Search base URL override."
     },
     "webFetch.apiKey": {
-      "label": "Firecrawl Fetch API Key",
+      "label": "FireCrawl Fetch API Key",
       "help": "Optional for hosted keyless scraping; add a key for higher limits (fallback: FIRECRAWL_API_KEY env var).",
       "sensitive": true,
       "placeholder": "fc-..."
     },
     "webFetch.baseUrl": {
-      "label": "Firecrawl Fetch Base URL",
-      "help": "Firecrawl Fetch base URL override."
+      "label": "FireCrawl Fetch Base URL",
+      "help": "FireCrawl Fetch base URL override."
     }
   },
   "contracts": {

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "firecrawl",
   "name": "FireCrawl",
-  "description": "Search the web and scrape clean, structured page content with FireCrawl.",
+  "description": "Search the live web for fresh results, scrape pages into LLM-ready Markdown, and interact with dynamic sites to extract hard-to-reach data.",
   "icon": "https://www.firecrawl.dev/brand/firecrawl-logo.png",
   "activation": {
     "onStartup": false

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/firecrawl-plugin",
   "version": "2026.7.2",
-  "description": "OpenClaw Firecrawl plugin.",
+  "description": "Search the web and scrape clean, structured page content with FireCrawl.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/firecrawl-plugin",
   "version": "2026.7.2",
-  "description": "Search the web and scrape clean, structured page content with FireCrawl.",
+  "description": "Search the live web for fresh results, scrape pages into LLM-ready Markdown, and interact with dynamic sites to extract hard-to-reach data.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/firecrawl/src/firecrawl-client.test.ts
+++ b/extensions/firecrawl/src/firecrawl-client.test.ts
@@ -113,7 +113,7 @@ describe("assertFirecrawlScrapeTargetAllowed", () => {
 // resolveSearchItems
 // ---------------------------------------------------------------------------
 describe("resolveSearchItems", () => {
-  it("extracts items from a top-level data array (Firecrawl Search API)", () => {
+  it("extracts items from a top-level data array (FireCrawl Search API)", () => {
     const result = firecrawlClient.resolveSearchItems({
       data: [
         { url: "https://example.com", title: "Example" },
@@ -166,7 +166,7 @@ describe("resolveSearchItems", () => {
     expect(requireSearchResult(result, 0).url).toBe("https://example.com/nested");
   });
 
-  it("extracts items from data.web array (Firecrawl web search format)", () => {
+  it("extracts items from data.web array (FireCrawl web search format)", () => {
     const result = firecrawlClient.resolveSearchItems({
       data: {
         web: [{ url: "https://example.com/web", title: "Web Result" }],

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -47,9 +47,9 @@ const DEFAULT_SCRAPE_MAX_CHARS = 50_000;
 const FIRECRAWL_SCRAPE_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
 const ALLOWED_FIRECRAWL_HOSTS = new Set(["api.firecrawl.dev"]);
 const FIRECRAWL_SELF_HOSTED_PRIVATE_ERROR =
-  "Firecrawl custom baseUrl must target a private or internal self-hosted endpoint.";
+  "FireCrawl custom baseUrl must target a private or internal self-hosted endpoint.";
 const FIRECRAWL_HTTP_PRIVATE_ERROR =
-  "Firecrawl HTTP baseUrl must target a private or internal self-hosted endpoint. Use https:// for public hosts.";
+  "FireCrawl HTTP baseUrl must target a private or internal self-hosted endpoint. Use https:// for public hosts.";
 
 type FirecrawlEndpointMode = "selfHosted" | "strict";
 type FirecrawlResolvedEndpoint = {
@@ -108,16 +108,16 @@ export function assertFirecrawlScrapeTargetAllowed(url: string): void {
   try {
     parsed = new URL(url);
   } catch {
-    throw new SsrFBlockedError("Invalid URL supplied to Firecrawl scrape");
+    throw new SsrFBlockedError("Invalid URL supplied to FireCrawl scrape");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new SsrFBlockedError(
-      `Blocked non-HTTP(S) protocol in Firecrawl scrape URL: ${parsed.protocol}`,
+      `Blocked non-HTTP(S) protocol in FireCrawl scrape URL: ${parsed.protocol}`,
     );
   }
   if (isBlockedHostnameOrIp(parsed.hostname)) {
     throw new SsrFBlockedError(
-      `Blocked hostname or private/internal IP in Firecrawl scrape URL: ${parsed.hostname}`,
+      `Blocked hostname or private/internal IP in FireCrawl scrape URL: ${parsed.hostname}`,
     );
   }
 }
@@ -152,11 +152,11 @@ async function validateFirecrawlBaseUrl(
   try {
     url = new URL(baseUrl.trim() || DEFAULT_FIRECRAWL_BASE_URL);
   } catch {
-    throw new Error("Firecrawl baseUrl must be a valid http:// or https:// URL.");
+    throw new Error("FireCrawl baseUrl must be a valid http:// or https:// URL.");
   }
 
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error("Firecrawl baseUrl must use http:// or https://.");
+    throw new Error("FireCrawl baseUrl must use http:// or https://.");
   }
   if (isOfficialFirecrawlEndpoint(url)) {
     return "strict";
@@ -372,7 +372,7 @@ export async function runFirecrawlSearch(
   const apiKey = keyless ? undefined : resolveFirecrawlApiKey(params.cfg);
   if (!apiKey && !keyless) {
     throw new Error(
-      "web_search (firecrawl) needs a Firecrawl API key. Set FIRECRAWL_API_KEY in the Gateway environment, or configure plugins.entries.firecrawl.config.webSearch.apiKey.",
+      "web_search (firecrawl) needs a FireCrawl API key. Set FIRECRAWL_API_KEY in the Gateway environment, or configure plugins.entries.firecrawl.config.webSearch.apiKey.",
     );
   }
   const count =
@@ -390,7 +390,7 @@ export async function runFirecrawlSearch(
     ? params.excludeDomains.filter(Boolean)
     : [];
   if (includeDomains.length > 0 && excludeDomains.length > 0) {
-    throw new Error("Firecrawl search accepts includeDomains or excludeDomains, not both.");
+    throw new Error("FireCrawl search accepts includeDomains or excludeDomains, not both.");
   }
   const tbs = normalizeOptionalString(params.tbs);
   const location = normalizeOptionalString(params.location);
@@ -458,10 +458,10 @@ export async function runFirecrawlSearch(
       timeoutSeconds,
       apiKey,
       body,
-      errorLabel: "Firecrawl Search",
+      errorLabel: "FireCrawl Search",
     },
     async (response) => {
-      const payloadValue = await readFirecrawlJsonResponse(response, "Firecrawl Search API error");
+      const payloadValue = await readFirecrawlJsonResponse(response, "FireCrawl Search API error");
       if (payloadValue.success === false) {
         const error =
           typeof payloadValue.error === "string"
@@ -469,7 +469,7 @@ export async function runFirecrawlSearch(
             : typeof payloadValue.message === "string"
               ? payloadValue.message
               : "unknown error";
-        throw new Error(`Firecrawl Search API error: ${error}`);
+        throw new Error(`FireCrawl Search API error: ${error}`);
       }
       return payloadValue;
     },
@@ -514,7 +514,7 @@ export function parseFirecrawlScrapePayload(params: {
     (typeof data.content === "string" && data.content) ||
     "";
   if (!markdown) {
-    throw new Error("Firecrawl scrape returned no content.");
+    throw new Error("FireCrawl scrape returned no content.");
   }
   const rawText = params.extractMode === "text" ? markdownToText(markdown) : markdown;
   const truncated = truncateText(rawText, params.maxChars);
@@ -567,7 +567,7 @@ export async function runFirecrawlScrape(
   // Only the selected web_fetch provider opts into that access mode.
   if (!apiKey && params.access !== "keyless") {
     throw new Error(
-      "firecrawl_scrape needs a Firecrawl API key. Set FIRECRAWL_API_KEY in the Gateway environment, or configure plugins.entries.firecrawl.config.webFetch.apiKey.",
+      "firecrawl_scrape needs a FireCrawl API key. Set FIRECRAWL_API_KEY in the Gateway environment, or configure plugins.entries.firecrawl.config.webFetch.apiKey.",
     );
   }
   const baseUrl = resolveFirecrawlBaseUrl(params.cfg);
@@ -605,7 +605,7 @@ export async function runFirecrawlScrape(
       mode: endpoint.mode,
       timeoutSeconds,
       apiKey,
-      errorLabel: "Firecrawl",
+      errorLabel: "FireCrawl",
       body: {
         url: params.url,
         formats: ["markdown"],
@@ -617,7 +617,7 @@ export async function runFirecrawlScrape(
       },
     },
     async (response) => {
-      const payloadLocal = await readFirecrawlJsonResponse(response, "Firecrawl fetch failed", {
+      const payloadLocal = await readFirecrawlJsonResponse(response, "FireCrawl fetch failed", {
         // Scrape can legitimately return page bodies before maxChars truncates parsed output.
         maxBytes: FIRECRAWL_SCRAPE_RESPONSE_MAX_BYTES,
       });
@@ -629,7 +629,7 @@ export async function runFirecrawlScrape(
               ? payloadLocal.message
               : response.statusText;
         throw new Error(
-          `Firecrawl fetch failed (${response.status}): ${wrapWebContent(detail, "web_fetch")}`.trim(),
+          `FireCrawl fetch failed (${response.status}): ${wrapWebContent(detail, "web_fetch")}`.trim(),
         );
       }
       return payloadLocal;

--- a/extensions/firecrawl/src/firecrawl-fetch-provider-shared.ts
+++ b/extensions/firecrawl/src/firecrawl-fetch-provider-shared.ts
@@ -13,10 +13,10 @@ function ensureRecord(target: Record<string, unknown>, key: string): Record<stri
 
 export const FIRECRAWL_WEB_FETCH_PROVIDER_SHARED = {
   id: "firecrawl",
-  label: "Firecrawl",
+  label: "FireCrawl",
   hint: "Fetch pages with keyless starter access; add a key for higher limits.",
   requiresCredential: false,
-  credentialLabel: "Firecrawl API key (optional)",
+  credentialLabel: "FireCrawl API key (optional)",
   envVars: ["FIRECRAWL_API_KEY"],
   placeholder: "fc-...",
   signupUrl: "https://www.firecrawl.dev/",

--- a/extensions/firecrawl/src/firecrawl-fetch-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-fetch-provider.ts
@@ -20,7 +20,7 @@ export function createFirecrawlWebFetchProvider(): WebFetchProviderPlugin {
     ...FIRECRAWL_WEB_FETCH_PROVIDER_SHARED,
     applySelectionConfig: (config) => enablePluginInConfig(config, "firecrawl").config,
     createTool: ({ config }) => ({
-      description: "Fetch a page using Firecrawl.",
+      description: "Fetch a page using FireCrawl.",
       parameters: {},
       execute: async (args) => {
         const url = typeof args.url === "string" ? args.url : "";

--- a/extensions/firecrawl/src/firecrawl-free-search-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-free-search-provider.ts
@@ -18,7 +18,7 @@ export function createFirecrawlFreeWebSearchProvider(): WebSearchProviderPlugin 
     ...buildFirecrawlFreeWebSearchProviderBase(),
     createTool: (ctx) => ({
       description:
-        "Search the web using Firecrawl's free hosted starter tier (no API key required). Returns structured results with snippets. Use firecrawl_search for Firecrawl-specific knobs like sources or categories.",
+        "Search the web using FireCrawl's free hosted starter tier (no API key required). Returns structured results with snippets. Use firecrawl_search for FireCrawl-specific knobs like sources or categories.",
       parameters: GenericFirecrawlSearchSchema,
       execute: async (args) => {
         const { runFirecrawlSearch } = await loadFirecrawlClientModule();

--- a/extensions/firecrawl/src/firecrawl-scrape-tool.ts
+++ b/extensions/firecrawl/src/firecrawl-scrape-tool.ts
@@ -12,7 +12,7 @@ import { runFirecrawlScrape } from "./firecrawl-client.js";
 
 const FirecrawlScrapeToolSchema = Type.Object(
   {
-    url: Type.String({ description: "HTTP or HTTPS URL to scrape via Firecrawl." }),
+    url: Type.String({ description: "HTTP or HTTPS URL to scrape via FireCrawl." }),
     extractMode: optionalStringEnum(["markdown", "text"] as const, {
       description: 'Extraction mode ("markdown" or "text"). Default: markdown.',
     }),
@@ -24,26 +24,26 @@ const FirecrawlScrapeToolSchema = Type.Object(
     ),
     onlyMainContent: Type.Optional(
       Type.Boolean({
-        description: "Keep only main content when Firecrawl supports it.",
+        description: "Keep only main content when FireCrawl supports it.",
       }),
     ),
     maxAgeMs: Type.Optional(
       Type.Integer({
-        description: "Maximum Firecrawl cache age in milliseconds.",
+        description: "Maximum FireCrawl cache age in milliseconds.",
         minimum: 0,
       }),
     ),
     proxy: optionalStringEnum(["auto", "basic", "stealth"] as const, {
-      description: 'Firecrawl proxy mode ("auto", "basic", or "stealth").',
+      description: 'FireCrawl proxy mode ("auto", "basic", or "stealth").',
     }),
     storeInCache: Type.Optional(
       Type.Boolean({
-        description: "Whether Firecrawl should store the scrape in its cache.",
+        description: "Whether FireCrawl should store the scrape in its cache.",
       }),
     ),
     timeoutSeconds: Type.Optional(
       Type.Integer({
-        description: "Timeout in seconds for the Firecrawl scrape request.",
+        description: "Timeout in seconds for the FireCrawl scrape request.",
         minimum: 1,
       }),
     ),
@@ -54,9 +54,9 @@ const FirecrawlScrapeToolSchema = Type.Object(
 export function createFirecrawlScrapeTool(api: OpenClawPluginApi) {
   return {
     name: "firecrawl_scrape",
-    label: "Firecrawl Scrape",
+    label: "FireCrawl Scrape",
     description:
-      "Scrape a page using Firecrawl v2/scrape. Useful for JS-heavy or bot-protected pages where plain web_fetch is weak.",
+      "Scrape a page using FireCrawl v2/scrape. Useful for JS-heavy or bot-protected pages where plain web_fetch is weak.",
     parameters: FirecrawlScrapeToolSchema,
     execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
       const url = readStringParam(rawParams, "url", { required: true });

--- a/extensions/firecrawl/src/firecrawl-search-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-search-provider.ts
@@ -25,7 +25,7 @@ export function createFirecrawlWebSearchProvider(): WebSearchProviderPlugin {
     ...buildFirecrawlWebSearchProviderBase(),
     createTool: (ctx) => ({
       description:
-        "Search the web using Firecrawl. Returns structured results with snippets from Firecrawl Search. Use firecrawl_search for Firecrawl-specific knobs like sources or categories.",
+        "Search the web using FireCrawl. Returns structured results with snippets from FireCrawl Search. Use firecrawl_search for FireCrawl-specific knobs like sources or categories.",
       parameters: GenericFirecrawlSearchSchema,
       execute: async (args) => {
         const { runFirecrawlSearch } = await loadFirecrawlClientModule();

--- a/extensions/firecrawl/src/firecrawl-search-tool.ts
+++ b/extensions/firecrawl/src/firecrawl-search-tool.ts
@@ -26,7 +26,7 @@ const FirecrawlSearchToolSchema = Type.Object(
     ),
     categories: Type.Optional(
       Type.Array(Type.String(), {
-        description: 'Optional Firecrawl categories, for example ["github"] or ["research"].',
+        description: 'Optional FireCrawl categories, for example ["github"] or ["research"].',
       }),
     ),
     includeDomains: Type.Optional(
@@ -60,12 +60,12 @@ const FirecrawlSearchToolSchema = Type.Object(
     ),
     scrapeResults: Type.Optional(
       Type.Boolean({
-        description: "Include scraped result content when Firecrawl returns it.",
+        description: "Include scraped result content when FireCrawl returns it.",
       }),
     ),
     timeoutSeconds: Type.Optional(
       Type.Integer({
-        description: "Timeout in seconds for the Firecrawl Search request.",
+        description: "Timeout in seconds for the FireCrawl Search request.",
         minimum: 1,
       }),
     ),
@@ -76,9 +76,9 @@ const FirecrawlSearchToolSchema = Type.Object(
 export function createFirecrawlSearchTool(api: OpenClawPluginApi) {
   return {
     name: "firecrawl_search",
-    label: "Firecrawl Search",
+    label: "FireCrawl Search",
     description:
-      "Search the web using Firecrawl v2/search. Can optionally include scraped content from result pages.",
+      "Search the web using FireCrawl v2/search. Can optionally include scraped content from result pages.",
     parameters: FirecrawlSearchToolSchema,
     execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
       const query = readStringParam(rawParams, "query", { required: true });

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -107,7 +107,7 @@ describe("firecrawl tools", () => {
     });
     const pluginEntry = applied.plugins?.entries?.firecrawl;
     if (!pluginEntry) {
-      throw new Error("expected Firecrawl plugin entry");
+      throw new Error("expected FireCrawl plugin entry");
     }
     expect(pluginEntry.enabled).toBe(true);
     expect(applied.tools?.web?.fetch?.provider).toBe("firecrawl");
@@ -150,7 +150,7 @@ describe("firecrawl tools", () => {
     expect(result.truncated).toBe(false);
   });
 
-  it("extracts search items from flexible Firecrawl payload shapes", () => {
+  it("extracts search items from flexible FireCrawl payload shapes", () => {
     const items = firecrawlClientTesting.resolveSearchItems({
       success: true,
       data: [
@@ -175,7 +175,7 @@ describe("firecrawl tools", () => {
     ]);
   });
 
-  it("extracts search items from Firecrawl v2 data.web payloads", () => {
+  it("extracts search items from FireCrawl v2 data.web payloads", () => {
     const items = firecrawlClientTesting.resolveSearchItems({
       success: true,
       data: {
@@ -203,7 +203,7 @@ describe("firecrawl tools", () => {
     ]);
   });
 
-  it("wraps and safely truncates upstream error details from Firecrawl API failures", async () => {
+  it("wraps and safely truncates upstream error details from FireCrawl API failures", async () => {
     global.fetch = vi.fn(
       async () =>
         new Response(JSON.stringify({ error: `${"x".repeat(999)}🚀tail` }), {
@@ -220,7 +220,7 @@ describe("firecrawl tools", () => {
           timeoutSeconds: 5,
           apiKey: "firecrawl-key",
           body: { query: "openclaw" },
-          errorLabel: "Firecrawl search",
+          errorLabel: "FireCrawl search",
         },
         async () => "ok",
       ),
@@ -233,7 +233,7 @@ describe("firecrawl tools", () => {
     );
   });
 
-  it("normalizes Firecrawl authorization headers before requests", async () => {
+  it("normalizes FireCrawl authorization headers before requests", async () => {
     let capturedInit: RequestInit | undefined;
     const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       capturedInit = init;
@@ -250,7 +250,7 @@ describe("firecrawl tools", () => {
         timeoutSeconds: 5,
         apiKey: "firecrawl-test-\r\nkey",
         body: { query: "openclaw" },
-        errorLabel: "Firecrawl search",
+        errorLabel: "FireCrawl search",
       },
       async () => "ok",
     );
@@ -259,7 +259,7 @@ describe("firecrawl tools", () => {
     expect(authHeader).toBe("Bearer firecrawl-test-key");
   });
 
-  it("omits Firecrawl authorization for keyless scrape requests", async () => {
+  it("omits FireCrawl authorization for keyless scrape requests", async () => {
     let capturedInit: RequestInit | undefined;
     global.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       capturedInit = init;
@@ -322,10 +322,10 @@ describe("firecrawl tools", () => {
         url: "https://example.com/direct-scrape",
         extractMode: "markdown",
       }),
-    ).rejects.toThrow("firecrawl_scrape needs a Firecrawl API key");
+    ).rejects.toThrow("firecrawl_scrape needs a FireCrawl API key");
   });
 
-  it("omits Firecrawl authorization for keyless search requests", async () => {
+  it("omits FireCrawl authorization for keyless search requests", async () => {
     let capturedInit: RequestInit | undefined;
     global.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       capturedInit = init;
@@ -362,7 +362,7 @@ describe("firecrawl tools", () => {
     expect(new Headers(capturedInit?.headers).has("Authorization")).toBe(false);
   });
 
-  it("never sends a configured Firecrawl key on keyless search", async () => {
+  it("never sends a configured FireCrawl key on keyless search", async () => {
     let capturedInit: RequestInit | undefined;
     global.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       capturedInit = init;
@@ -440,7 +440,7 @@ describe("firecrawl tools", () => {
         } as OpenClawConfig,
         query: "direct firecrawl search",
       }),
-    ).rejects.toThrow("web_search (firecrawl) needs a Firecrawl API key");
+    ).rejects.toThrow("web_search (firecrawl) needs a FireCrawl API key");
   });
 
   it("rejects combining includeDomains and excludeDomains", async () => {
@@ -467,7 +467,7 @@ describe("firecrawl tools", () => {
     ).rejects.toThrow("includeDomains or excludeDomains, not both");
   });
 
-  it("forwards domain, time, and location search filters to Firecrawl", async () => {
+  it("forwards domain, time, and location search filters to FireCrawl", async () => {
     let capturedBody: Record<string, unknown> | undefined;
     global.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const rawBody = typeof init?.body === "string" ? init.body : "{}";
@@ -512,7 +512,7 @@ describe("firecrawl tools", () => {
     expect(capturedBody?.includeDomains).toBeUndefined();
   });
 
-  it("blocks private and non-http scrape targets before Firecrawl requests", () => {
+  it("blocks private and non-http scrape targets before FireCrawl requests", () => {
     expect(
       firecrawlClientTesting.assertFirecrawlScrapeTargetAllowed("https://example.com/page"),
     ).toBeUndefined();
@@ -534,7 +534,7 @@ describe("firecrawl tools", () => {
       firecrawlClientTesting.assertFirecrawlScrapeTargetAllowed("not-a-valid-url?token=secret");
       expect.fail("Expected invalid URL to be blocked");
     } catch (error) {
-      expect((error as Error).message).toBe("Invalid URL supplied to Firecrawl scrape");
+      expect((error as Error).message).toBe("Invalid URL supplied to FireCrawl scrape");
       expect((error as Error).message).not.toContain("token=secret");
     }
   });
@@ -596,7 +596,7 @@ describe("firecrawl tools", () => {
   it("is keyless and opt-in for the free search provider", () => {
     const provider = createFirecrawlFreeWebSearchProvider();
     expect(provider.id).toBe("firecrawl-free");
-    expect(provider.label).toBe("Firecrawl Search (Free)");
+    expect(provider.label).toBe("FireCrawl Search (Free)");
     expect(provider.requiresCredential).toBe(false);
     expect(provider.autoDetectOrder).toBeUndefined();
   });
@@ -650,7 +650,7 @@ describe("firecrawl tools", () => {
     ).rejects.toThrow("count must be an integer from 1 to 10");
   });
 
-  it("keeps the compare-helper fetch facade owned by the Firecrawl extension", async () => {
+  it("keeps the compare-helper fetch facade owned by the FireCrawl extension", async () => {
     await fetchFirecrawlContent({
       url: "https://docs.openclaw.ai",
       extractMode: "markdown",
@@ -706,7 +706,7 @@ describe("firecrawl tools", () => {
     expect(provider.requiresCredential).toBe(false);
     const pluginEntry = applied.plugins?.entries?.firecrawl;
     if (!pluginEntry) {
-      throw new Error("expected Firecrawl fetch plugin entry");
+      throw new Error("expected FireCrawl fetch plugin entry");
     }
     expect(pluginEntry.enabled).toBe(true);
   });
@@ -768,7 +768,7 @@ describe("firecrawl tools", () => {
     ).rejects.toThrow("maxChars must be a positive integer");
   });
 
-  it("normalizes optional search parameters before invoking Firecrawl", async () => {
+  it("normalizes optional search parameters before invoking FireCrawl", async () => {
     runFirecrawlSearch.mockImplementationOnce(async (params: Record<string, unknown>) => ({
       ok: true,
       params,
@@ -863,7 +863,7 @@ describe("firecrawl tools", () => {
     });
   });
 
-  it("rejects malformed numeric Firecrawl search options before dispatch", async () => {
+  it("rejects malformed numeric FireCrawl search options before dispatch", async () => {
     const searchTool = createFirecrawlSearchTool({
       config: { env: "test" },
     } as never);
@@ -884,7 +884,7 @@ describe("firecrawl tools", () => {
     expect(runFirecrawlSearch).not.toHaveBeenCalled();
   });
 
-  it("rejects malformed numeric Firecrawl scrape options before dispatch", async () => {
+  it("rejects malformed numeric FireCrawl scrape options before dispatch", async () => {
     const scrapeTool = createFirecrawlScrapeTool({
       config: { env: "test" },
     } as never);
@@ -978,7 +978,7 @@ describe("firecrawl tools", () => {
     expect(resolveFirecrawlBaseUrl({} as OpenClawConfig)).not.toBe(DEFAULT_FIRECRAWL_BASE_URL);
   });
 
-  it("resolves env SecretRefs for Firecrawl API key without requiring a runtime snapshot", () => {
+  it("resolves env SecretRefs for FireCrawl API key without requiring a runtime snapshot", () => {
     vi.stubEnv("FIRECRAWL_API_KEY", "firecrawl-env-ref-key");
     const cfg = {
       plugins: {
@@ -1024,7 +1024,7 @@ describe("firecrawl tools", () => {
     expect(resolveFirecrawlApiKey(cfg)).toBeUndefined();
   });
 
-  it("does not read arbitrary env SecretRef ids for Firecrawl API key resolution", () => {
+  it("does not read arbitrary env SecretRef ids for FireCrawl API key resolution", () => {
     vi.stubEnv("UNRELATED_SECRET", "should-not-be-read");
     const cfg = {
       plugins: {
@@ -1109,7 +1109,7 @@ describe("firecrawl tools", () => {
     expect(resolveFirecrawlApiKey(cfg)).toBeUndefined();
   });
 
-  it("allows hosted Firecrawl and private self-hosted endpoints only", async () => {
+  it("allows hosted FireCrawl and private self-hosted endpoints only", async () => {
     await expect(
       firecrawlClientTesting.resolveEndpoint("https://api.firecrawl.dev", "/v2/scrape"),
     ).resolves.toEqual({
@@ -1133,16 +1133,16 @@ describe("firecrawl tools", () => {
     });
     await expect(
       firecrawlClientTesting.resolveEndpoint("http://api.firecrawl.dev", "/v2/scrape"),
-    ).rejects.toThrow("Firecrawl HTTP baseUrl must target a private or internal");
+    ).rejects.toThrow("FireCrawl HTTP baseUrl must target a private or internal");
     await expect(
       firecrawlClientTesting.resolveEndpoint("https://attacker.example", "/v2/search"),
-    ).rejects.toThrow("Firecrawl custom baseUrl must target a private or internal");
+    ).rejects.toThrow("FireCrawl custom baseUrl must target a private or internal");
     await expect(
       firecrawlClientTesting.resolveEndpoint("ftp://127.0.0.1:8787", "/v2/scrape"),
-    ).rejects.toThrow("Firecrawl baseUrl must use http:// or https://.");
+    ).rejects.toThrow("FireCrawl baseUrl must use http:// or https://.");
   });
 
-  it("routes private self-hosted Firecrawl endpoints through the self-hosted fetch guard", async () => {
+  it("routes private self-hosted FireCrawl endpoints through the self-hosted fetch guard", async () => {
     ssrfMock?.mockRestore();
     ssrfMock = mockPinnedHostnameResolution(["127.0.0.1"]);
     const fetchSpy = vi.fn(
@@ -1160,7 +1160,7 @@ describe("firecrawl tools", () => {
         timeoutSeconds: 5,
         apiKey: "firecrawl-key",
         body: { query: "openclaw" },
-        errorLabel: "Firecrawl Search",
+        errorLabel: "FireCrawl Search",
       },
       async (response) => (await response.json()) as Record<string, unknown>,
     );
@@ -1169,7 +1169,7 @@ describe("firecrawl tools", () => {
     expect(result.success).toBe(true);
   });
 
-  it("reports malformed Firecrawl search JSON with a stable provider error", async () => {
+  it("reports malformed FireCrawl search JSON with a stable provider error", async () => {
     global.fetch = vi.fn(
       async () =>
         new Response("{ nope", {
@@ -1196,10 +1196,10 @@ describe("firecrawl tools", () => {
         } as OpenClawConfig,
         query: "openclaw malformed search",
       }),
-    ).rejects.toThrow("Firecrawl Search API error: malformed JSON response");
+    ).rejects.toThrow("FireCrawl Search API error: malformed JSON response");
   });
 
-  it("bounds successful Firecrawl JSON bodies before parsing", async () => {
+  it("bounds successful FireCrawl JSON bodies before parsing", async () => {
     const streamed = createStreamingResponse({
       chunkCount: 32,
       chunkSize: 1024 * 1024,
@@ -1211,16 +1211,16 @@ describe("firecrawl tools", () => {
     await expect(
       firecrawlClientTesting.readFirecrawlJsonResponse(
         streamed.response,
-        "Firecrawl Search API error",
+        "FireCrawl Search API error",
       ),
-    ).rejects.toThrow("Firecrawl Search API error: JSON response exceeds 16777216 bytes");
+    ).rejects.toThrow("FireCrawl Search API error: JSON response exceeds 16777216 bytes");
 
     expect(streamed.getReadCount()).toBeLessThan(32);
     expect(streamed.wasCanceled()).toBe(true);
     expect(jsonSpy).not.toHaveBeenCalled();
   });
 
-  it("reports malformed Firecrawl scrape JSON with a stable provider error", async () => {
+  it("reports malformed FireCrawl scrape JSON with a stable provider error", async () => {
     global.fetch = vi.fn(
       async () =>
         new Response("{ nope", {
@@ -1248,7 +1248,7 @@ describe("firecrawl tools", () => {
         url: "https://example.com/firecrawl-malformed-scrape",
         extractMode: "markdown",
       }),
-    ).rejects.toThrow("Firecrawl fetch failed: malformed JSON response");
+    ).rejects.toThrow("FireCrawl fetch failed: malformed JSON response");
   });
 
   it("respects positive numeric overrides for scrape and cache behavior", () => {
@@ -1347,7 +1347,7 @@ describe("firecrawl tools", () => {
         extractMode: "markdown",
         maxChars: 100,
       }),
-    ).toThrow("Firecrawl scrape returned no content.");
+    ).toThrow("FireCrawl scrape returned no content.");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/firecrawl/web-search-shared.ts
+++ b/extensions/firecrawl/web-search-shared.ts
@@ -31,10 +31,10 @@ export function buildFirecrawlWebSearchProviderBase(): Omit<WebSearchProviderPlu
 
   return {
     id: "firecrawl",
-    label: "Firecrawl Search",
+    label: "FireCrawl Search",
     hint: "Structured results with optional result scraping",
     onboardingScopes: ["text-inference"],
-    credentialLabel: "Firecrawl API key",
+    credentialLabel: "FireCrawl API key",
     envVars: ["FIRECRAWL_API_KEY"],
     placeholder: "fc-...",
     signupUrl: "https://www.firecrawl.dev/",
@@ -71,8 +71,8 @@ export function buildFirecrawlFreeWebSearchProviderBase(): Omit<
 > {
   return {
     id: "firecrawl-free",
-    label: "Firecrawl Search (Free)",
-    hint: "Free web search via Firecrawl's hosted starter tier — no API key required",
+    label: "FireCrawl Search (Free)",
+    hint: "Free web search via FireCrawl's hosted starter tier — no API key required",
     onboardingScopes: ["text-inference"],
     requiresCredential: false,
     envVars: [],

--- a/extensions/lobster/openclaw.plugin.json
+++ b/extensions/lobster/openclaw.plugin.json
@@ -5,6 +5,7 @@
   },
   "name": "Lobster",
   "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
+  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/plugin-art/lobster.webp",
   "catalog": { "featured": true, "order": 50 },
   "contracts": {
     "tools": ["lobster"]

--- a/extensions/lobster/openclaw.plugin.json
+++ b/extensions/lobster/openclaw.plugin.json
@@ -5,7 +5,7 @@
   },
   "name": "Lobster",
   "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
-  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/plugin-art/lobster.webp",
+  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/401f278f111fa5ea1b79521112ba350852328dc0/ui/public/plugin-art/lobster.webp",
   "catalog": { "featured": true, "order": 50 },
   "contracts": {
     "tools": ["lobster"]

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "memory-lancedb",
   "name": "Memory LanceDB",
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
+  "icon": "https://avatars.githubusercontent.com/u/108903835?v=4",
   "catalog": { "featured": true, "order": 70 },
   "commandAliases": [{ "name": "ltm" }],
   "activation": {

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memory-lancedb",
   "name": "Memory LanceDB",
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
-  "icon": "https://avatars.githubusercontent.com/u/108903835?v=4",
+  "icon": "https://raw.githubusercontent.com/lancedb/lancedb/f05140f21c12b2f9c6598145004e83bcf1dfeb82/plugins/lancedb/skills/lancedb/assets/icon.png",
   "catalog": { "featured": true, "order": 70 },
   "commandAliases": [{ "name": "ltm" }],
   "activation": {

--- a/extensions/tokenjuice/openclaw.plugin.json
+++ b/extensions/tokenjuice/openclaw.plugin.json
@@ -5,6 +5,7 @@
   },
   "name": "tokenjuice",
   "description": "Compacts exec and bash tool results with tokenjuice reducers.",
+  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/plugin-art/tokenjuice.webp",
   "catalog": { "featured": true, "order": 60 },
   "contracts": {
     "agentToolResultMiddleware": ["openclaw", "codex"]

--- a/extensions/tokenjuice/openclaw.plugin.json
+++ b/extensions/tokenjuice/openclaw.plugin.json
@@ -5,7 +5,7 @@
   },
   "name": "tokenjuice",
   "description": "Compacts exec and bash tool results with tokenjuice reducers.",
-  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/main/ui/public/plugin-art/tokenjuice.webp",
+  "icon": "https://raw.githubusercontent.com/openclaw/openclaw/401f278f111fa5ea1b79521112ba350852328dc0/ui/public/plugin-art/tokenjuice.webp",
   "catalog": { "featured": true, "order": 60 },
   "contracts": {
     "agentToolResultMiddleware": ["openclaw", "codex"]

--- a/scripts/check-web-fetch-provider-boundaries.mjs
+++ b/scripts/check-web-fetch-provider-boundaries.mjs
@@ -58,7 +58,7 @@ export async function collectWebFetchProviderBoundaryViolations() {
         }
         const lines = content.split(/\r?\n/);
         for (const [index, line] of lines.entries()) {
-          if (!line.includes("firecrawl") && !line.includes("Firecrawl")) {
+          if (!line.toLowerCase().includes("firecrawl")) {
             continue;
           }
           if (!suspiciousPatterns.some((pattern) => pattern.test(line))) {
@@ -67,7 +67,7 @@ export async function collectWebFetchProviderBoundaryViolations() {
           violations.push({
             file: relativeFile,
             line: index + 1,
-            reason: "core web-fetch runtime/tooling contains Firecrawl-specific fetch logic",
+            reason: "core web-fetch runtime/tooling contains FireCrawl-specific fetch logic",
           });
         }
       }

--- a/scripts/firecrawl-compare.ts
+++ b/scripts/firecrawl-compare.ts
@@ -87,7 +87,7 @@ async function fetchHtml(
 
 async function run() {
   if (!apiKey) {
-    console.log("FIRECRAWL_API_KEY not set. Firecrawl comparisons will be skipped.");
+    console.log("FIRECRAWL_API_KEY not set. FireCrawl comparisons will be skipped.");
   }
 
   for (const url of targets) {

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -213,13 +213,13 @@
     },
     {
       "name": "@openclaw/firecrawl-plugin",
-      "description": "OpenClaw Firecrawl plugin.",
+      "description": "Search the web and scrape clean, structured page content with FireCrawl.",
       "source": "official",
       "kind": "plugin",
       "openclaw": {
         "plugin": {
           "id": "firecrawl",
-          "label": "Firecrawl"
+          "label": "FireCrawl"
         },
         "contracts": {
           "webFetchProviders": [
@@ -237,12 +237,12 @@
         "webSearchProviders": [
           {
             "id": "firecrawl",
-            "label": "Firecrawl Search",
+            "label": "FireCrawl Search",
             "hint": "Structured results with optional result scraping",
             "onboardingScopes": [
               "text-inference"
             ],
-            "credentialLabel": "Firecrawl API key",
+            "credentialLabel": "FireCrawl API key",
             "envVars": [
               "FIRECRAWL_API_KEY"
             ],
@@ -254,8 +254,8 @@
           },
           {
             "id": "firecrawl-free",
-            "label": "Firecrawl Search (Free)",
-            "hint": "Free web search via Firecrawl's hosted starter tier — no API key required",
+            "label": "FireCrawl Search (Free)",
+            "hint": "Free web search via FireCrawl's hosted starter tier — no API key required",
             "onboardingScopes": [
               "text-inference"
             ],

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -213,7 +213,7 @@
     },
     {
       "name": "@openclaw/firecrawl-plugin",
-      "description": "Search the web and scrape clean, structured page content with FireCrawl.",
+      "description": "Search the live web for fresh results, scrape pages into LLM-ready Markdown, and interact with dynamic sites to extract hard-to-reach data.",
       "source": "official",
       "kind": "plugin",
       "openclaw": {

--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -187,7 +187,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
     expect(details?.text).toContain('"patch": true');
   });
 
-  it("bypasses Firecrawl when runtime metadata marks Firecrawl inactive", async () => {
+  it("bypasses FireCrawl when runtime metadata marks FireCrawl inactive", async () => {
     // Runtime metadata is authoritative for the current credential snapshot; a
     // stale configured provider should not force provider fallback.
     const fetchSpy = vi

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -558,7 +558,7 @@ describe("command secret target ids", () => {
     expect(scoped.forcedActivePaths).toEqual(new Set(["models.providers.ollama.apiKey"]));
   });
 
-  it("uses Firecrawl web fetch credentials as search fallback targets", () => {
+  it("uses FireCrawl web fetch credentials as search fallback targets", () => {
     const scoped = getCapabilityWebSearchCommandSecretTargets({
       tools: { web: { search: { provider: "firecrawl", enabled: true } } },
       plugins: {
@@ -845,7 +845,7 @@ describe("command secret target ids", () => {
     expect(fetchConfigured.forcedActivePaths).toBeUndefined();
   });
 
-  it("keeps selected legacy Firecrawl web fetch refs in command targets", () => {
+  it("keeps selected legacy FireCrawl web fetch refs in command targets", () => {
     const scoped = getCapabilityWebFetchCommandSecretTargets({
       tools: {
         web: {

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -328,9 +328,9 @@ describe("runConfigureWizard", () => {
     mocks.resolveSearchProviderOptions.mockReturnValue([
       {
         id: "firecrawl",
-        label: "Firecrawl Search",
+        label: "FireCrawl Search",
         hint: "Structured results with optional result scraping",
-        credentialLabel: "Firecrawl API key",
+        credentialLabel: "FireCrawl API key",
         envVars: ["FIRECRAWL_API_KEY"],
         placeholder: "fc-...",
         signupUrl: "https://www.firecrawl.dev/",

--- a/src/commands/doctor/shared/legacy-web-fetch-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-web-fetch-migrate.test.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { migrateLegacyWebFetchConfig } from "./legacy-web-fetch-migrate.js";
 
 describe("legacy web fetch config", () => {
-  it("migrates legacy Firecrawl fetch config into plugin-owned config", () => {
+  it("migrates legacy FireCrawl fetch config into plugin-owned config", () => {
     const res = migrateLegacyWebFetchConfig({
       tools: {
         web: {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -4920,18 +4920,18 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.warnings).toStrictEqual([]);
   });
 
-  it("installs Firecrawl for env-only web fetch when search is disabled", async () => {
+  it("installs FireCrawl for env-only web fetch when search is disabled", async () => {
     mocks.resolveOfficialExternalWebProviderContractPluginIdsForEnv.mockReturnValue(["firecrawl"]);
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       {
         id: "firecrawl",
-        label: "Firecrawl",
+        label: "FireCrawl",
         install: {
           npmSpec: "@openclaw/firecrawl-plugin",
           defaultChoice: "npm",
         },
         openclaw: {
-          plugin: { id: "firecrawl", label: "Firecrawl" },
+          plugin: { id: "firecrawl", label: "FireCrawl" },
         },
       },
     ]);

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -378,7 +378,7 @@ describe("configured plugin install release step", () => {
     expect(result.channelIds).toStrictEqual([]);
   });
 
-  it("collects Firecrawl for env-only web fetch when search is disabled", async () => {
+  it("collects FireCrawl for env-only web fetch when search is disabled", async () => {
     const result = await collectReleaseConfiguredPluginIdsThroughDoctor({
       cfg: {
         tools: {

--- a/src/commands/onboard-search.providers.test.ts
+++ b/src/commands/onboard-search.providers.test.ts
@@ -55,7 +55,7 @@ function createBundledFirecrawlEntry(): PluginWebSearchProviderEntry {
   return {
     id: "firecrawl",
     pluginId: "firecrawl",
-    label: "Firecrawl Search",
+    label: "FireCrawl Search",
     hint: "Structured results",
     onboardingScopes: ["text-inference"],
     envVars: ["FIRECRAWL_API_KEY"],

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -20,7 +20,7 @@ const SEARCH_PROVIDER_PLUGINS: Record<
   { pluginId: string; envVars: string[]; label: string; credentialLabel?: string }
 > = {
   brave: { pluginId: "brave", envVars: ["BRAVE_API_KEY"], label: "Brave Search" },
-  firecrawl: { pluginId: "firecrawl", envVars: ["FIRECRAWL_API_KEY"], label: "Firecrawl" },
+  firecrawl: { pluginId: "firecrawl", envVars: ["FIRECRAWL_API_KEY"], label: "FireCrawl" },
   gemini: { pluginId: "google", envVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"], label: "Gemini" },
   grok: { pluginId: "xai", envVars: ["XAI_API_KEY"], label: "Grok" },
   kimi: {
@@ -415,7 +415,7 @@ describe("setupSearch", () => {
     }
   });
 
-  it("keeps keyless Firecrawl fetch configured when search setup has no key", async () => {
+  it("keeps keyless FireCrawl fetch configured when search setup has no key", async () => {
     const original = process.env.FIRECRAWL_API_KEY;
     delete process.env.FIRECRAWL_API_KEY;
     try {

--- a/src/plugins/contracts/registry.retry.test.ts
+++ b/src/plugins/contracts/registry.retry.test.ts
@@ -302,8 +302,8 @@ describe("plugin contract registry scoped retries", () => {
               pluginId: "firecrawl",
               provider: {
                 id: "firecrawl",
-                label: "Firecrawl",
-                hint: "Fetch with Firecrawl",
+                label: "FireCrawl",
+                hint: "Fetch with FireCrawl",
                 envVars: ["FIRECRAWL_API_KEY"],
                 placeholder: "fc-...",
                 signupUrl: "https://firecrawl.dev",

--- a/src/plugins/web-fetch-providers.runtime.test.ts
+++ b/src/plugins/web-fetch-providers.runtime.test.ts
@@ -82,12 +82,12 @@ function createManifestRegistryFixture(origin: "bundled" | "global" = "bundled")
 function createRuntimeWebFetchProvider() {
   return {
     pluginId: "firecrawl",
-    pluginName: "Firecrawl",
+    pluginName: "FireCrawl",
     source: "test" as const,
     provider: {
       id: "firecrawl",
-      label: "Firecrawl",
-      hint: "Firecrawl runtime provider",
+      label: "FireCrawl",
+      hint: "FireCrawl runtime provider",
       envVars: ["FIRECRAWL_API_KEY"],
       placeholder: "firecrawl-...",
       signupUrl: "https://example.com/firecrawl",

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -572,7 +572,7 @@ describe("runtime web tools resolution", () => {
     });
   });
 
-  it("selects the configured keyless Firecrawl fetch provider without an API key", async () => {
+  it("selects the configured keyless FireCrawl fetch provider without an API key", async () => {
     const { metadata } = await runRuntimeWebTools({
       config: asConfig({
         tools: {
@@ -590,7 +590,7 @@ describe("runtime web tools resolution", () => {
     expect(metadata.fetch.selectedProviderKeySource).toBe("missing");
   });
 
-  it("does not auto-select keyless Firecrawl fetch without a credential", async () => {
+  it("does not auto-select keyless FireCrawl fetch without a credential", async () => {
     const { metadata } = await runRuntimeWebTools({
       config: asConfig({
         tools: {
@@ -1423,7 +1423,7 @@ describe("runtime web tools resolution", () => {
     expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
-  it("resolves SecretRefs for verified installed Firecrawl fetch config", async () => {
+  it("resolves SecretRefs for verified installed FireCrawl fetch config", async () => {
     loadInstalledPluginIndexInstallRecordsSyncMock.mockReturnValue({
       firecrawl: {
         source: "npm",
@@ -1587,7 +1587,7 @@ describe("runtime web tools resolution", () => {
     ).toBe("firecrawl-runtime-key");
   });
 
-  it("resolves legacy Firecrawl web fetch SecretRefs through the plugin-owned path", async () => {
+  it("resolves legacy FireCrawl web fetch SecretRefs through the plugin-owned path", async () => {
     const { metadata, resolvedConfig } = await runRuntimeWebTools({
       config: asConfig({
         tools: {

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -1274,7 +1274,7 @@ describe("finalizeSetupWizard", () => {
     listConfiguredWebSearchProviders.mockReturnValue([
       createWebSearchProviderEntry({
         id: "firecrawl",
-        label: "Firecrawl Search",
+        label: "FireCrawl Search",
         hint: "Structured results",
         envVars: ["FIRECRAWL_API_KEY"],
         placeholder: "fc-...",

--- a/test/web-provider-boundary.test.ts
+++ b/test/web-provider-boundary.test.ts
@@ -28,7 +28,7 @@ async function getJsonOutput(
 }
 
 describe("web provider boundaries", () => {
-  it("keeps Firecrawl-specific fetch logic out of core runtime/tooling", async () => {
+  it("keeps FireCrawl-specific fetch logic out of core runtime/tooling", async () => {
     const violations = await webFetchViolationsPromise;
     const jsonOutput = await webFetchJsonOutputPromise;
 


### PR DESCRIPTION
## Summary

- add icon metadata for the first-party Featured plugins: Memory LanceDB, Lobster, tokenjuice, Diffs, and FireCrawl
- use the official LanceDB and FireCrawl brand assets, and pin repository-hosted artwork to immutable commit SHAs
- standardize all human-facing FireCrawl copy across plugin metadata, provider/wizard labels, tooling messages, tests, and docs while preserving lowercase technical identifiers and existing `Firecrawl` code-symbol names
- align this description across the manifest, package, entry point, README, and official catalog: “Search the live web for fresh results, scrape pages into LLM-ready Markdown, and interact with dynamic sites to extract hard-to-reach data.”

## Validation

- `pnpm exec vitest run extensions/firecrawl/src/firecrawl-client.test.ts extensions/firecrawl/src/firecrawl-tools.test.ts` (97 passed)
- affected copy/provider/wizard/doctor projects: 303 tests passed
- `pnpm exec oxfmt --check ...` on all changed files
- targeted type-aware `oxlint` passed
- JSON parse checks for all five changed plugin manifests
- icon URL checks returned HTTP 200
- no unexpected `Firecrawl` human-facing string literals remain; lowercase technical identifiers and code-symbol names are unchanged
- `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kxpahcq8e2swbny5ywz8f8e8`
- autoreview clean with the explicit FireCrawl copy requirement

References OCF-55