### PR TITLE
fix(cli): avoid false relay timeout for silent hook success

### DIFF
--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -16,6 +16,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const activeChildren = new Set<ChildProcessWithoutNullStreams>();
 const outputTimeoutMs = 20_000;
 const exitAfterOutputTimeoutMs = 5_000;
+const exitOnlyTimeoutMs = 45_000;
 
 afterEach(async () => {
   nativeHookRelayTesting.clearNativeHookRelaysForTests();
@@ -110,6 +111,7 @@ async function createLingeringPreloadFixture(): Promise<{
 
 async function runHooksCli(params: {
   args: string[];
+  completion: "exit" | "output-then-exit";
   label: string;
   env?: NodeJS.ProcessEnv;
   stdin?: string;
@@ -139,13 +141,16 @@ async function runHooksCli(params: {
   }>((resolve, reject) => {
     let timedOut = false;
     let outputObserved = false;
+    // Silent relay success has no stream milestone. Give it an exit deadline
+    // while keeping the tighter post-output deadline for leaked handles.
+    const initialTimeoutMs = params.completion === "exit" ? exitOnlyTimeoutMs : outputTimeoutMs;
     let timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGKILL");
-    }, outputTimeoutMs);
+    }, initialTimeoutMs);
     child.stdout.on("data", (chunk: string) => {
       stdout += chunk;
-      if (outputObserved) {
+      if (params.completion === "exit" || outputObserved) {
         return;
       }
       outputObserved = true;
@@ -167,9 +172,12 @@ async function runHooksCli(params: {
       clearTimeout(timer);
       activeChildren.delete(child);
       if (timedOut) {
-        const timeoutMessage = outputObserved
-          ? `${params.label} did not exit within ${exitAfterOutputTimeoutMs}ms after emitting output`
-          : `${params.label} did not emit output within ${outputTimeoutMs}ms`;
+        const timeoutMessage =
+          params.completion === "exit"
+            ? `${params.label} did not exit within ${exitOnlyTimeoutMs}ms`
+            : outputObserved
+              ? `${params.label} did not exit within ${exitAfterOutputTimeoutMs}ms after emitting output`
+              : `${params.label} did not emit output within ${outputTimeoutMs}ms`;
         reject(new Error(`${timeoutMessage}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
         return;
       }
@@ -193,6 +201,7 @@ async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; 
       "--timeout",
       "50",
     ],
+    completion: params.event === "post_tool_use" ? "exit" : "output-then-exit",
     label: `hooks relay ${params.event}`,
     env: {
       LINGER_MARKER: fixture.markerPath,
@@ -239,6 +248,7 @@ describe("hooks CLI process lifecycle", () => {
         "--timeout",
         "5000",
       ],
+      completion: "exit",
       label: "hooks relay explicit state database",
       env: {
         OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
@@ -260,6 +270,7 @@ describe("hooks CLI process lifecycle", () => {
     // bootstraps sequential so low-core shards test lifecycle, not startup contention.
     const listResult = await runHooksCli({
       args: ["hooks", "list", "--json"],
+      completion: "output-then-exit",
       label: "hooks list",
       env: {
         LINGER_MARKER: fixture.markerPath,


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent `agentic-cli` CI failure where the hooks CLI process test could kill a successful silent relay child after 20 seconds under a slow shard. A successful Codex `PostToolUse` no-op intentionally exits with no stdout or stderr, so output was not a valid completion milestone for that case.

## Why This Change Was Made

The process-test helper now distinguishes exit-only commands from commands expected to emit output. Silent relay success gets a bounded exit deadline below the enclosing test budget, while output-producing commands retain the existing 20-second first-output deadline and 5-second post-output deadline that detects leaked handles. Production relay, database, and child-process behavior are unchanged.

## User Impact

There is no user-visible runtime change. Maintainers get a process lifecycle test that still detects stuck children without treating intentionally empty relay output as a hang.

## Evidence

- Source failure: [run 29529808317, job 87727267887](https://github.com/openclaw/openclaw/actions/runs/29529808317/job/87727267887) killed the silent relay test at 20.229 seconds with empty stdout/stderr; its sibling process test passed at 18.8 seconds.
- Blacksmith Testbox before the patch: isolated test, exact 163-file CLI shard, four-core constrained shard, and five focused repeats all passed, supporting a load-exposed false timing assumption rather than a relay/database defect.
- Blacksmith Testbox after the patch: five focused repeats passed (2.102-2.605 seconds for the target), the changed gate passed its `coreTests` lane, and a four-core constrained 163-file `agentic-cli` shard passed 2,992 tests plus one skipped in 32.21 seconds.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29532358431
- `git diff --check`

AI-assisted: yes. I reviewed the complete change and its runtime/test contracts.
