### PR TITLE
feat(feeds): fetch publisher feed projections

### DIFF
--- a/src/plugins/official-external-plugin-catalog-envelope.test.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.test.ts
@@ -57,13 +57,11 @@ function signedEnvelope(params: {
   const payload = payloadBytes.toString(params.encoding ?? "base64url");
   const input = signingInput(payloadType, payloadBytes);
   return {
-    schemaVersion: 1,
     payloadType,
     payload,
     signatures: params.keys.map((key) => ({
-      keyId: key.keyId,
-      algorithm: "ed25519",
-      signature: crypto.sign(null, input, key.privateKey).toString("base64url"),
+      keyid: key.keyId,
+      sig: crypto.sign(null, input, key.privateKey).toString("base64url"),
     })),
   };
 }
@@ -167,7 +165,7 @@ describe("official external plugin catalog signed envelopes", () => {
           ...envelope,
           signatures: Array.from({ length: 17 }, (_, index) => ({
             ...signature,
-            keyId: `key-${index}`,
+            keyid: `key-${index}`,
           })),
         },
         { trustedKeys },
@@ -198,10 +196,77 @@ describe("official external plugin catalog signed envelopes", () => {
   });
 
   it("rejects malformed envelopes before verification", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
     expect(
       verifyOfficialExternalPluginCatalogSignedEnvelope(
-        { schemaVersion: 1, payloadType: PAYLOAD_TYPE, payload: "", signatures: [] },
+        { payloadType: PAYLOAD_TYPE, payload: "", signatures: [] },
         { trustedKeys: [] },
+      ),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        { ...envelope, signatures: [{ sig: signature.sig }] },
+        { trustedKeys: [{ keyId: key.keyId, publicKey: exportPublicKey(key) }] },
+      ),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+  });
+
+  it("ignores unrecognized DSSE envelope and signature fields", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        {
+          ...envelope,
+          futureEnvelopeField: true,
+          signatures: [{ ...signature, futureSignatureField: true }],
+        },
+        { trustedKeys: [{ keyId: key.keyId, publicKey: exportPublicKey(key) }] },
+      ),
+    ).toMatchObject({ ok: true, signedBy: key.keyId });
+  });
+
+  it("accepts the beta legacy field names without allowing mixed formats", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
+    const legacySignature = {
+      keyId: signature.keyid,
+      algorithm: "ed25519",
+      signature: signature.sig,
+    };
+    const trustedKeys = [{ keyId: key.keyId, publicKey: exportPublicKey(key) }];
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        {
+          ...envelope,
+          schemaVersion: 1,
+          signatures: [legacySignature],
+        },
+        { trustedKeys },
+      ),
+    ).toMatchObject({ ok: true, signedBy: key.keyId });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        { ...envelope, schemaVersion: 1, signatures: [signature, legacySignature] },
+        { trustedKeys },
       ),
     ).toMatchObject({ ok: false, error: "invalid-envelope" });
   });

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -13,6 +13,10 @@ const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES = 16;
 
 type OfficialExternalPluginCatalogEnvelopeSignature = {
+  keyid?: string;
+  sig?: string;
+};
+type LegacyOfficialExternalPluginCatalogEnvelopeSignature = {
   keyId?: string;
   algorithm?: string;
   signature?: string;
@@ -87,7 +91,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   const trustedSignatureKeyIds: string[] = [];
   const trustedSignaturePublicKeys = new Set<string>();
   for (const envelopeSignature of envelope.signatures) {
-    const keyId = envelopeSignature.keyId;
+    const keyId = envelopeSignature.keyid;
     const trustedKey = params.trustedKeys.find((candidate) => candidate.keyId === keyId);
     if (!trustedKey || trustedSignatureKeyIds.includes(trustedKey.keyId)) {
       continue;
@@ -100,7 +104,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
       verifyEd25519SignatureBytes({
         publicKey: trustedKey.publicKey,
         payload: signingInput,
-        signatureBase64Url: envelopeSignature.signature,
+        signatureBase64Url: envelopeSignature.sig,
       })
     ) {
       trustedSignatureKeyIds.push(trustedKey.keyId);
@@ -134,7 +138,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     };
   }
   const hasKnownKey = envelope.signatures.some((signature) =>
-    params.trustedKeys.some((key) => key.keyId === signature.keyId),
+    params.trustedKeys.some((key) => key.keyId === signature.keyid),
   );
   return hasKnownKey
     ? {
@@ -157,7 +161,7 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   payload: string;
   signatures: readonly Required<OfficialExternalPluginCatalogEnvelopeSignature>[];
 } | null {
-  if (!isRecord(raw) || raw.schemaVersion !== 1) {
+  if (!isRecord(raw)) {
     return null;
   }
   const payloadType = raw.payloadType;
@@ -172,15 +176,38 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   if (signatures.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES) {
     return null;
   }
-  const parsedSignatures = signatures.filter(
+  // Hosted Feed v1 requires keyid even though generic DSSE makes it optional:
+  // trust thresholds and rotation are resolved against configured key ids.
+  const standardSignatures = signatures.filter(
     (signature): signature is Required<OfficialExternalPluginCatalogEnvelopeSignature> =>
       isRecord(signature) &&
-      typeof signature.keyId === "string" &&
-      signature.keyId.trim().length > 0 &&
-      signature.algorithm === "ed25519" &&
-      typeof signature.signature === "string" &&
-      signature.signature.trim().length > 0,
+      typeof signature.keyid === "string" &&
+      signature.keyid.trim().length > 0 &&
+      typeof signature.sig === "string" &&
+      signature.sig.trim().length > 0,
   );
+  // Beta releases briefly accepted this pre-DSSE field shape. Keep it as an
+  // all-or-nothing read path while every producer moves to the standard shape.
+  const legacySignatures =
+    raw.schemaVersion === 1
+      ? signatures
+          .filter(
+            (
+              signature,
+            ): signature is Required<LegacyOfficialExternalPluginCatalogEnvelopeSignature> =>
+              isRecord(signature) &&
+              typeof signature.keyId === "string" &&
+              signature.keyId.trim().length > 0 &&
+              signature.algorithm === "ed25519" &&
+              typeof signature.signature === "string" &&
+              signature.signature.trim().length > 0,
+          )
+          .map((signature) => ({ keyid: signature.keyId, sig: signature.signature }))
+      : [];
+  if (standardSignatures.length > 0 && legacySignatures.length > 0) {
+    return null;
+  }
+  const parsedSignatures = standardSignatures.length > 0 ? standardSignatures : legacySignatures;
   if (parsedSignatures.length === 0) {
     return null;
   }
@@ -189,10 +216,10 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   }
   const keyIds = new Set<string>();
   for (const signature of parsedSignatures) {
-    if (keyIds.has(signature.keyId)) {
+    if (keyIds.has(signature.keyid)) {
       return null;
     }
-    keyIds.add(signature.keyId);
+    keyIds.add(signature.keyid);
   }
   return {
     payloadType,

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -21,10 +21,31 @@ type LegacyOfficialExternalPluginCatalogEnvelopeSignature = {
   algorithm?: string;
   signature?: string;
 };
-type OfficialExternalPluginCatalogTrustedSigningKey = {
+export type TrustedFeedSigningKey = {
   keyId: string;
   publicKey: string;
 };
+
+export type SignedFeedEnvelopePayloadVerificationResult =
+  | {
+      ok: true;
+      payloadType: string;
+      payloadBytes: Buffer;
+      signedBy: string;
+      signedByKeyIds: readonly string[];
+      signatureCount: number;
+      threshold: number;
+    }
+  | {
+      ok: false;
+      error:
+        | "invalid-envelope"
+        | "unsupported-payload"
+        | "invalid-payload"
+        | "missing-trust-key"
+        | "invalid-signature";
+      message: string;
+    };
 
 type OfficialExternalPluginCatalogEnvelopeVerificationResult =
   | {
@@ -56,23 +77,65 @@ function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
 export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   raw: unknown,
   params: {
-    trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    trustedKeys: readonly TrustedFeedSigningKey[];
     threshold?: number;
   },
 ): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+  const verified = verifySignedFeedEnvelopePayload(raw, {
+    expectedPayloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+    trustedKeys: params.trustedKeys,
+    threshold: params.threshold,
+    context: "hosted catalog",
+  });
+  if (verified.ok) {
+    const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(verified.payloadBytes);
+    if (!decoded?.feed) {
+      return {
+        ok: false,
+        error: "invalid-payload",
+        message: "hosted catalog signed envelope payload is invalid",
+        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
+      };
+    }
+    return {
+      ok: true,
+      feed: decoded.feed,
+      signedBy: verified.signedBy,
+      ...(verified.threshold > 1
+        ? {
+            signedByKeyIds: verified.signedByKeyIds,
+            signatureCount: verified.signatureCount,
+            threshold: verified.threshold,
+          }
+        : {}),
+    };
+  }
+  return verified;
+}
+
+export function verifySignedFeedEnvelopePayload(
+  raw: unknown,
+  params: {
+    expectedPayloadType: string;
+    trustedKeys: readonly TrustedFeedSigningKey[];
+    threshold?: number;
+    context?: string;
+  },
+): SignedFeedEnvelopePayloadVerificationResult {
+  const context = params.context?.trim() || "signed feed";
   const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw);
   if (!envelope) {
     return {
       ok: false,
       error: "invalid-envelope",
-      message: "hosted catalog signed envelope is malformed",
+      message: `${context} signed envelope is malformed`,
     };
   }
-  if (envelope.payloadType !== OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+  if (envelope.payloadType !== params.expectedPayloadType) {
     return {
       ok: false,
       error: "unsupported-payload",
-      message: "hosted catalog signed envelope payload type is unsupported",
+      message: `${context} signed envelope payload type is unsupported`,
     };
   }
   const payloadBytes = decodeOfficialExternalPluginCatalogEnvelopePayloadBytes(envelope.payload);
@@ -80,7 +143,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     return {
       ok: false,
       error: "invalid-payload",
-      message: "hosted catalog signed envelope payload is invalid",
+      message: `${context} signed envelope payload is invalid`,
     };
   }
   const signingInput = createOfficialExternalPluginCatalogEnvelopeSigningInput({
@@ -115,26 +178,14 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     }
   }
   if (trustedSignaturePublicKeys.size >= threshold) {
-    const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
-    if (!decoded?.feed) {
-      return {
-        ok: false,
-        error: "invalid-payload",
-        message: "hosted catalog signed envelope payload is invalid",
-        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
-      };
-    }
     return {
       ok: true,
-      feed: decoded.feed,
+      payloadType: envelope.payloadType,
+      payloadBytes,
       signedBy: trustedSignatureKeyIds[0] ?? "",
-      ...(threshold > 1
-        ? {
-            signedByKeyIds: trustedSignatureKeyIds,
-            signatureCount: trustedSignaturePublicKeys.size,
-            threshold,
-          }
-        : {}),
+      signedByKeyIds: trustedSignatureKeyIds,
+      signatureCount: trustedSignaturePublicKeys.size,
+      threshold,
     };
   }
   const hasKnownKey = envelope.signatures.some((signature) =>
@@ -146,13 +197,13 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
         error: "invalid-signature",
         message:
           trustedSignatureKeyIds.length > 0
-            ? "hosted catalog signed envelope did not meet the configured signature threshold"
-            : "hosted catalog signed envelope signature is invalid",
+            ? `${context} signed envelope did not meet the configured signature threshold`
+            : `${context} signed envelope signature is invalid`,
       }
     : {
         ok: false,
         error: "missing-trust-key",
-        message: "hosted catalog signed envelope was not signed by a trusted key",
+        message: `${context} signed envelope was not signed by a trusted key`,
       };
 }
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -125,14 +125,12 @@ function signedHostedCatalogFeed(params: {
   ]);
   return {
     body: JSON.stringify({
-      schemaVersion: 1,
       payloadType: HOSTED_CATALOG_PAYLOAD_TYPE,
       payload: payloadBytes.toString("base64url"),
       signatures: [
         {
-          keyId: "acme-root",
-          algorithm: "ed25519",
-          signature: crypto
+          keyid: "acme-root",
+          sig: crypto
             .sign(null, signingInput, crypto.createPrivateKey(keys.privateKeyPem))
             .toString("base64url"),
         },

--- a/src/plugins/publisher-feed-projections.test.ts
+++ b/src/plugins/publisher-feed-projections.test.ts
@@ -21,14 +21,12 @@ function signedEnvelope(key: SigningKey, payloadType: string, payload: unknown) 
     payloadBytes,
   ]);
   return {
-    schemaVersion: 1,
     payloadType,
     payload: payloadBytes.toString("base64url"),
     signatures: [
       {
-        keyId: key.keyId,
-        algorithm: "ed25519",
-        signature: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
+        keyid: key.keyId,
+        sig: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
       },
     ],
   };

--- a/src/plugins/publisher-feed-projections.test.ts
+++ b/src/plugins/publisher-feed-projections.test.ts
@@ -1,0 +1,170 @@
+import crypto, { type KeyObject } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+  PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+  verifyPublisherFeedProjection,
+} from "./publisher-feed-projections.js";
+
+type SigningKey = { keyId: string; privateKey: KeyObject; publicKey: KeyObject };
+
+function signingKey(): SigningKey {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return { keyId: "clawhub-feed-2026-q3", privateKey, publicKey };
+}
+
+function signedEnvelope(key: SigningKey, payloadType: string, payload: unknown) {
+  const payloadBytes = Buffer.from(JSON.stringify(payload));
+  const typeBytes = Buffer.from(payloadType);
+  const signingInput = Buffer.concat([
+    Buffer.from(`DSSEv1 ${typeBytes.length} ${payloadType} ${payloadBytes.length} `),
+    payloadBytes,
+  ]);
+  return {
+    schemaVersion: 1,
+    payloadType,
+    payload: payloadBytes.toString("base64url"),
+    signatures: [
+      {
+        keyId: key.keyId,
+        algorithm: "ed25519",
+        signature: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
+      },
+    ],
+  };
+}
+
+function verification(key: SigningKey) {
+  return {
+    trustedKeys: [
+      {
+        keyId: key.keyId,
+        publicKey: key.publicKey.export({ type: "spki", format: "pem" }).toString(),
+      },
+    ],
+  };
+}
+
+const entry = {
+  kind: "skill",
+  id: "skills:cuda",
+  name: "cuda-helper",
+  displayName: "CUDA Helper",
+  summary: "GPU tools",
+  url: "/alice/skills/cuda-helper",
+  updatedAt: 2,
+};
+
+const projectionBase = {
+  schemaVersion: 1,
+  feedId: "clawhub.publisher.publishers:alice",
+  generatedAt: "2026-07-16T00:00:00.000Z",
+  expiresAt: "2026-07-16T00:05:00.000Z",
+};
+
+describe("publisher feed signed projections", () => {
+  it("verifies a strict signed query page without treating it as an install catalog", () => {
+    const key = signingKey();
+    const payload = {
+      ...projectionBase,
+      sequence: 7,
+      query: { text: "CUDA Helper", kinds: ["skill"] },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 1,
+      entries: [entry],
+      nextCursor: null,
+    };
+    const result = verifyPublisherFeedProjection(
+      signedEnvelope(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload),
+      { payloadType: PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, ...verification(key) },
+    );
+
+    expect(result).toMatchObject({
+      payload,
+      signedBy: key.keyId,
+      signatureCount: 1,
+      threshold: 1,
+    });
+  });
+
+  it("verifies complete change pages and reset-required responses", () => {
+    const key = signingKey();
+    const changes = {
+      ...projectionBase,
+      fromSequence: 7,
+      toSequence: 8,
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      changeCount: 1,
+      changes: [
+        {
+          sequence: 8,
+          operation: "remove",
+          entryId: "skills:old",
+          entryKind: "skill",
+        },
+      ],
+      nextCursor: null,
+    };
+    const reset = {
+      ...projectionBase,
+      fromSequence: 1,
+      currentSequence: 8,
+      resetRequired: true,
+      snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+    };
+
+    expect(
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, changes),
+        { payloadType: PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, ...verification(key) },
+      ).payload,
+    ).toEqual(changes);
+    expect(
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, reset),
+        { payloadType: PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, ...verification(key) },
+      ).payload,
+    ).toEqual(reset);
+  });
+
+  it("rejects payload type confusion before parsing", () => {
+    const key = signingKey();
+    expect(() =>
+      verifyPublisherFeedProjection(signedEnvelope(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {}), {
+        payloadType: PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+        ...verification(key),
+      }),
+    ).toThrow("payload type is unsupported");
+  });
+
+  it.each([
+    { query: { text: " CUDA" }, reason: "non-normalized query" },
+    { query: { kinds: ["skill", "skill"] }, reason: "duplicate query kinds" },
+    { unexpected: true, reason: "unknown page fields" },
+    { entries: [{ ...entry, url: "//evil.example/skill" }], reason: "unsafe entry URL" },
+  ])("rejects $reason", ({ reason: _reason, ...override }) => {
+    const key = signingKey();
+    const payload = {
+      ...projectionBase,
+      sequence: 7,
+      query: { text: "CUDA" },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 1,
+      entries: [entry],
+      nextCursor: null,
+      ...override,
+    };
+    expect(() =>
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload),
+        { payloadType: PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, ...verification(key) },
+      ),
+    ).toThrow("projection payload is invalid");
+  });
+});

--- a/src/plugins/publisher-feed-projections.ts
+++ b/src/plugins/publisher-feed-projections.ts
@@ -341,10 +341,14 @@ function parseChangePayload(
     value.changes.length > 500 ||
     !value.changes.every(isPublisherFeedChange) ||
     !isNullableString(value.nextCursor) ||
-    value.startIndex + value.changes.length > value.changeCount ||
-    value.changes.some(
-      (change) => change.sequence <= value.fromSequence || change.sequence > value.toSequence,
-    )
+    value.startIndex + value.changes.length > value.changeCount
+  ) {
+    return null;
+  }
+  const fromSequence = value.fromSequence;
+  const toSequence = value.toSequence;
+  if (
+    value.changes.some((change) => change.sequence <= fromSequence || change.sequence > toSequence)
   ) {
     return null;
   }

--- a/src/plugins/publisher-feed-projections.ts
+++ b/src/plugins/publisher-feed-projections.ts
@@ -1,0 +1,393 @@
+import { isRecord } from "../utils.js";
+import {
+  verifySignedFeedEnvelopePayload,
+  type TrustedFeedSigningKey,
+} from "./official-external-plugin-catalog-envelope.js";
+
+export const PUBLISHER_FEED_QUERY_PAYLOAD_TYPE = "openclaw.clawhub-publisher-feed-query-results.v1";
+export const PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE = "openclaw.clawhub-publisher-feed-changes.v1";
+
+export type PublisherFeedEntry = {
+  kind: "skill" | "plugin";
+  id: string;
+  name: string;
+  displayName: string;
+  summary: string | null;
+  url: string;
+  updatedAt: number;
+};
+
+export type PublisherFeedQuery = {
+  text?: string;
+  kinds?: readonly ("skill" | "plugin")[];
+};
+
+export type PublisherFeedChange =
+  | { sequence: number; operation: "upsert"; entry: PublisherFeedEntry }
+  | {
+      sequence: number;
+      operation: "remove";
+      entryId: string;
+      entryKind: "skill" | "plugin";
+    }
+  | {
+      sequence: number;
+      operation: "metadata";
+      metadata: { publisherId: string; handle: string | null; displayName: string };
+    };
+
+export type PublisherFeedQueryPage = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  query: PublisherFeedQuery;
+  requestCursor: string | null;
+  pageIndex: number;
+  startIndex: number;
+  resultCount: number;
+  entries: readonly PublisherFeedEntry[];
+  nextCursor: string | null;
+};
+
+export type PublisherFeedChangePage = {
+  schemaVersion: 1;
+  feedId: string;
+  fromSequence: number;
+  toSequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  requestCursor: string | null;
+  pageIndex: number;
+  startIndex: number;
+  changeCount: number;
+  changes: readonly PublisherFeedChange[];
+  nextCursor: string | null;
+};
+
+export type PublisherFeedResetRequired = {
+  schemaVersion: 1;
+  feedId: string;
+  fromSequence: number;
+  currentSequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  resetRequired: true;
+  snapshotUrl: string;
+};
+
+export type VerifiedPublisherFeedProjection = {
+  payload: PublisherFeedQueryPage | PublisherFeedChangePage | PublisherFeedResetRequired;
+  signedBy: string;
+  signedByKeyIds: readonly string[];
+  signatureCount: number;
+  threshold: number;
+};
+
+const QUERY_PAGE_KEYS = [
+  "schemaVersion",
+  "feedId",
+  "sequence",
+  "generatedAt",
+  "expiresAt",
+  "query",
+  "requestCursor",
+  "pageIndex",
+  "startIndex",
+  "resultCount",
+  "entries",
+  "nextCursor",
+] as const;
+const CHANGE_PAGE_KEYS = [
+  "schemaVersion",
+  "feedId",
+  "fromSequence",
+  "toSequence",
+  "generatedAt",
+  "expiresAt",
+  "requestCursor",
+  "pageIndex",
+  "startIndex",
+  "changeCount",
+  "changes",
+  "nextCursor",
+] as const;
+const RESET_KEYS = [
+  "schemaVersion",
+  "feedId",
+  "fromSequence",
+  "currentSequence",
+  "generatedAt",
+  "expiresAt",
+  "resetRequired",
+  "snapshotUrl",
+] as const;
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).toSorted().join("\0") === keys.toSorted().join("\0");
+}
+
+function isSafeNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isDateString(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function hasValidProjectionBase(value: Record<string, unknown>): boolean {
+  return (
+    value.schemaVersion === 1 &&
+    typeof value.feedId === "string" &&
+    value.feedId.length > 0 &&
+    isDateString(value.generatedAt) &&
+    isDateString(value.expiresAt) &&
+    Date.parse(value.expiresAt) > Date.parse(value.generatedAt)
+  );
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isEntryKind(value: unknown): value is "skill" | "plugin" {
+  return value === "skill" || value === "plugin";
+}
+
+function isPublisherFeedEntry(value: unknown): value is PublisherFeedEntry {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (
+    !(
+      hasExactKeys(value, ["kind", "id", "name", "displayName", "summary", "url", "updatedAt"]) &&
+      isEntryKind(value.kind) &&
+      typeof value.id === "string" &&
+      value.id.length > 0 &&
+      typeof value.name === "string" &&
+      value.name.length > 0 &&
+      typeof value.displayName === "string" &&
+      value.displayName.length > 0 &&
+      isNullableString(value.summary) &&
+      typeof value.url === "string" &&
+      value.url.length > 0 &&
+      typeof value.updatedAt === "number" &&
+      Number.isFinite(value.updatedAt) &&
+      value.updatedAt >= 0
+    )
+  ) {
+    return false;
+  }
+  if (value.url.startsWith("/")) {
+    return (
+      !value.url.startsWith("//") &&
+      !value.url.includes("\\") &&
+      !containsAsciiControlCharacter(value.url)
+    );
+  }
+  try {
+    const url = new URL(value.url);
+    return url.protocol === "https:" && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function containsAsciiControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeQueryTextWhitespace(value: string): string {
+  let result = "";
+  let pendingSpace = false;
+  for (const character of value.normalize("NFC")) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if ((codePoint >= 0x09 && codePoint <= 0x0d) || codePoint === 0x20) {
+      pendingSpace = result.length > 0;
+      continue;
+    }
+    if (pendingSpace) {
+      result += " ";
+    }
+    result += character;
+    pendingSpace = false;
+  }
+  return result;
+}
+
+function isPublisherFeedQuery(value: unknown): value is PublisherFeedQuery {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  if (keys.length === 0 || keys.some((key) => key !== "text" && key !== "kinds")) {
+    return false;
+  }
+  if (
+    value.text !== undefined &&
+    (typeof value.text !== "string" ||
+      !value.text ||
+      new TextEncoder().encode(value.text).length > 256 ||
+      normalizeQueryTextWhitespace(value.text) !== value.text)
+  ) {
+    return false;
+  }
+  if (
+    value.kinds !== undefined &&
+    (!Array.isArray(value.kinds) ||
+      value.kinds.length === 0 ||
+      !value.kinds.every(isEntryKind) ||
+      [...new Set(value.kinds)].toSorted().join("\0") !== value.kinds.join("\0"))
+  ) {
+    return false;
+  }
+  return value.text !== undefined || value.kinds !== undefined;
+}
+
+function isPublisherFeedChange(value: unknown): value is PublisherFeedChange {
+  if (!isRecord(value) || !isSafeNonNegativeInteger(value.sequence)) {
+    return false;
+  }
+  if (value.operation === "upsert") {
+    return (
+      hasExactKeys(value, ["sequence", "operation", "entry"]) && isPublisherFeedEntry(value.entry)
+    );
+  }
+  if (value.operation === "remove") {
+    return (
+      hasExactKeys(value, ["sequence", "operation", "entryId", "entryKind"]) &&
+      typeof value.entryId === "string" &&
+      value.entryId.length > 0 &&
+      isEntryKind(value.entryKind)
+    );
+  }
+  if (value.operation !== "metadata" || !isRecord(value.metadata)) {
+    return false;
+  }
+  return (
+    hasExactKeys(value, ["sequence", "operation", "metadata"]) &&
+    hasExactKeys(value.metadata, ["publisherId", "handle", "displayName"]) &&
+    typeof value.metadata.publisherId === "string" &&
+    value.metadata.publisherId.length > 0 &&
+    isNullableString(value.metadata.handle) &&
+    typeof value.metadata.displayName === "string"
+  );
+}
+
+function parseQueryPage(value: unknown): PublisherFeedQueryPage | null {
+  if (!isRecord(value) || !hasExactKeys(value, QUERY_PAGE_KEYS) || !hasValidProjectionBase(value)) {
+    return null;
+  }
+  if (
+    !isSafeNonNegativeInteger(value.sequence) ||
+    !isPublisherFeedQuery(value.query) ||
+    !isNullableString(value.requestCursor) ||
+    !isSafeNonNegativeInteger(value.pageIndex) ||
+    !isSafeNonNegativeInteger(value.startIndex) ||
+    !isSafeNonNegativeInteger(value.resultCount) ||
+    !Array.isArray(value.entries) ||
+    value.entries.length > 200 ||
+    !value.entries.every(isPublisherFeedEntry) ||
+    !isNullableString(value.nextCursor) ||
+    value.startIndex + value.entries.length > value.resultCount
+  ) {
+    return null;
+  }
+  return value as PublisherFeedQueryPage;
+}
+
+function parseChangePayload(
+  value: unknown,
+): PublisherFeedChangePage | PublisherFeedResetRequired | null {
+  if (!isRecord(value) || !hasValidProjectionBase(value)) {
+    return null;
+  }
+  if (value.resetRequired === true) {
+    if (
+      !hasExactKeys(value, RESET_KEYS) ||
+      !isSafeNonNegativeInteger(value.fromSequence) ||
+      !isSafeNonNegativeInteger(value.currentSequence) ||
+      value.currentSequence < value.fromSequence ||
+      typeof value.snapshotUrl !== "string"
+    ) {
+      return null;
+    }
+    try {
+      if (new URL(value.snapshotUrl).protocol !== "https:") {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    return value as PublisherFeedResetRequired;
+  }
+  if (
+    !hasExactKeys(value, CHANGE_PAGE_KEYS) ||
+    !isSafeNonNegativeInteger(value.fromSequence) ||
+    !isSafeNonNegativeInteger(value.toSequence) ||
+    value.toSequence < value.fromSequence ||
+    !isNullableString(value.requestCursor) ||
+    !isSafeNonNegativeInteger(value.pageIndex) ||
+    !isSafeNonNegativeInteger(value.startIndex) ||
+    !isSafeNonNegativeInteger(value.changeCount) ||
+    !Array.isArray(value.changes) ||
+    value.changes.length > 500 ||
+    !value.changes.every(isPublisherFeedChange) ||
+    !isNullableString(value.nextCursor) ||
+    value.startIndex + value.changes.length > value.changeCount ||
+    value.changes.some(
+      (change) => change.sequence <= value.fromSequence || change.sequence > value.toSequence,
+    )
+  ) {
+    return null;
+  }
+  return value as PublisherFeedChangePage;
+}
+
+export function verifyPublisherFeedProjection(
+  raw: unknown,
+  params: {
+    payloadType:
+      | typeof PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+      | typeof PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE;
+    trustedKeys: readonly TrustedFeedSigningKey[];
+    threshold?: number;
+  },
+): VerifiedPublisherFeedProjection {
+  const verified = verifySignedFeedEnvelopePayload(raw, {
+    expectedPayloadType: params.payloadType,
+    trustedKeys: params.trustedKeys,
+    threshold: params.threshold,
+    context: "publisher feed projection",
+  });
+  if (!verified.ok) {
+    throw new Error(verified.message);
+  }
+  let rawPayload: unknown;
+  try {
+    rawPayload = JSON.parse(verified.payloadBytes.toString("utf8"));
+  } catch {
+    throw new Error("publisher feed projection payload is not valid JSON");
+  }
+  const payload =
+    params.payloadType === PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+      ? parseQueryPage(rawPayload)
+      : parseChangePayload(rawPayload);
+  if (!payload) {
+    throw new Error("publisher feed projection payload is invalid");
+  }
+  return {
+    payload,
+    signedBy: verified.signedBy,
+    signedByKeyIds: verified.signedByKeyIds,
+    signatureCount: verified.signatureCount,
+    threshold: verified.threshold,
+  };
+}

--- a/src/plugins/publisher-feed-transport.test.ts
+++ b/src/plugins/publisher-feed-transport.test.ts
@@ -1,0 +1,528 @@
+import crypto, { type KeyObject } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const transportMocks = vi.hoisted(() => ({
+  guardedFetch: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: transportMocks.guardedFetch,
+}));
+
+import {
+  PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+  PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+} from "./publisher-feed-projections.js";
+import {
+  applyPublisherFeedChanges,
+  fetchPublisherFeedChanges,
+  fetchPublisherFeedQuery,
+} from "./publisher-feed-transport.js";
+
+type SigningKey = { keyId: string; privateKey: KeyObject; publicKey: KeyObject };
+type QueuedResponse = { response: Response; finalUrl?: string };
+
+const queuedResponses: QueuedResponse[] = [];
+const release = vi.fn(async () => undefined);
+
+function signingKey(): SigningKey {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return { keyId: "clawhub-feed-2026-q3", privateKey, publicKey };
+}
+
+function verification(key: SigningKey) {
+  return {
+    trustedKeys: [
+      {
+        keyId: key.keyId,
+        publicKey: key.publicKey.export({ type: "spki", format: "pem" }),
+      },
+    ],
+  };
+}
+
+function signedEnvelope(key: SigningKey, payloadType: string, payload: unknown) {
+  const payloadBytes = Buffer.from(JSON.stringify(payload));
+  const typeBytes = Buffer.from(payloadType);
+  const signingInput = Buffer.concat([
+    Buffer.from(`DSSEv1 ${typeBytes.length} ${payloadType} ${payloadBytes.length} `),
+    payloadBytes,
+  ]);
+  return JSON.stringify({
+    schemaVersion: 1,
+    payloadType,
+    payload: payloadBytes.toString("base64url"),
+    signatures: [
+      {
+        keyId: key.keyId,
+        algorithm: "ed25519",
+        signature: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
+      },
+    ],
+  });
+}
+
+function enqueueSigned(
+  key: SigningKey,
+  payloadType: string,
+  payload: unknown,
+  status = 200,
+  headers?: HeadersInit,
+) {
+  const responseHeaders = new Headers(headers);
+  if (!responseHeaders.has("content-type")) {
+    responseHeaders.set("content-type", "application/vnd.dsse+json; charset=utf-8");
+  }
+  queuedResponses.push({
+    response: new Response(signedEnvelope(key, payloadType, payload), {
+      status,
+      headers: responseHeaders,
+    }),
+  });
+}
+
+const entry = {
+  kind: "skill",
+  id: "skills:cuda",
+  name: "cuda-helper",
+  displayName: "CUDA Helper",
+  summary: "GPU tools",
+  url: "/alice/skills/cuda-helper",
+  updatedAt: 2,
+};
+
+const base = {
+  schemaVersion: 1,
+  feedId: "clawhub.publisher.publishers:alice",
+  generatedAt: "2026-07-16T00:00:00.000Z",
+  expiresAt: "2026-07-16T00:05:00.000Z",
+};
+
+beforeEach(() => {
+  queuedResponses.length = 0;
+  release.mockClear();
+  transportMocks.guardedFetch.mockReset();
+  transportMocks.guardedFetch.mockImplementation(async ({ url }: { url: string }) => {
+    const queued = queuedResponses.shift();
+    if (!queued) {
+      throw new Error("missing queued publisher feed response");
+    }
+    return {
+      response: queued.response,
+      finalUrl: queued.finalUrl ?? url,
+      release,
+    };
+  });
+});
+
+describe("publisher feed projection transport", () => {
+  it("assembles a complete signed query across revision-bound pages", async () => {
+    const key = signingKey();
+    const query = { text: "CUDA Helper", kinds: ["skill"] };
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query: { kinds: ["skill"], text: "CUDA Helper" },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 2,
+      entries: [entry],
+      nextCursor: "",
+    });
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query,
+      requestCursor: "",
+      pageIndex: 1,
+      startIndex: 1,
+      resultCount: 2,
+      entries: [{ ...entry, id: "skills:cuda-two", name: "cuda-two" }],
+      nextCursor: null,
+    });
+
+    const result = await fetchPublisherFeedQuery({
+      baseUrl: "https://clawhub.ai",
+      publisherId: "publishers:alice",
+      verification: verification(key),
+      query: { text: "  CUDA\tHelper ", kinds: ["skill", "skill"] },
+      limit: 1,
+      now: () => new Date("2026-07-16T00:01:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ sequence: 7, query });
+    expect(result.entries[0]).toMatchObject({ id: "skills:cuda" });
+    expect(result.entries).toHaveLength(2);
+    expect(transportMocks.guardedFetch.mock.calls.map(([args]) => args.url)).toEqual([
+      "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/query?q=CUDA+Helper&kind=skill&limit=1",
+      "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/query?cursor=",
+    ]);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      name: "revision drift",
+      second: { sequence: 8, requestCursor: "next", pageIndex: 1, startIndex: 1 },
+      error: "revision changed",
+    },
+    {
+      name: "cursor replay",
+      second: {
+        sequence: 7,
+        requestCursor: "next",
+        pageIndex: 1,
+        startIndex: 1,
+        nextCursor: "next",
+      },
+      error: "cursor repeated",
+    },
+    {
+      name: "premature terminal page",
+      second: {
+        sequence: 7,
+        requestCursor: "next",
+        pageIndex: 1,
+        startIndex: 1,
+        nextCursor: null,
+        resultCount: 3,
+      },
+      error: "revision changed",
+    },
+  ])("rejects query $name without returning partial entries", async ({ second, error }) => {
+    const key = signingKey();
+    const query = { text: "CUDA" };
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query,
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 2,
+      entries: [entry],
+      nextCursor: "next",
+    });
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query,
+      requestCursor: "next",
+      pageIndex: 1,
+      startIndex: 1,
+      resultCount: 2,
+      entries: [{ ...entry, id: "skills:two", name: "two" }],
+      nextCursor: null,
+      ...second,
+    });
+
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow(error);
+  });
+
+  it("assembles a complete signed changed-since range", async () => {
+    const key = signingKey();
+    enqueueSigned(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {
+      ...base,
+      fromSequence: 7,
+      toSequence: 9,
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      changeCount: 2,
+      changes: [{ sequence: 8, operation: "remove", entryId: "skills:old", entryKind: "skill" }],
+      nextCursor: "next-change",
+    });
+    enqueueSigned(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {
+      ...base,
+      fromSequence: 7,
+      toSequence: 9,
+      requestCursor: "next-change",
+      pageIndex: 1,
+      startIndex: 1,
+      changeCount: 2,
+      changes: [{ sequence: 9, operation: "upsert", entry }],
+      nextCursor: null,
+    });
+
+    const result = await fetchPublisherFeedChanges({
+      baseUrl: "https://clawhub.ai",
+      publisherId: "publishers:alice",
+      verification: verification(key),
+      fromSequence: 7,
+      limit: 1,
+      now: () => new Date("2026-07-16T00:01:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ status: "complete", fromSequence: 7, toSequence: 9 });
+    if (result.status === "complete") {
+      expect(result.changes).toHaveLength(2);
+    }
+  });
+
+  it("applies a complete change range atomically without mutating current state", () => {
+    const currentEntry = { ...entry, id: "skills:old", name: "old", updatedAt: 1 };
+    const current = {
+      feedId: base.feedId,
+      sequence: 7,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [currentEntry],
+    };
+    const applied = applyPublisherFeedChanges(current, {
+      status: "complete",
+      feedId: base.feedId,
+      fromSequence: 7,
+      toSequence: 9,
+      generatedAt: base.generatedAt,
+      expiresAt: base.expiresAt,
+      changes: [
+        { sequence: 8, operation: "remove", entryId: "skills:old", entryKind: "skill" },
+        { sequence: 9, operation: "upsert", entry },
+        {
+          sequence: 9,
+          operation: "metadata",
+          metadata: {
+            publisherId: "publishers:alice",
+            handle: "alice-ai",
+            displayName: "Alice AI",
+          },
+        },
+      ],
+    });
+
+    expect(applied).toMatchObject({
+      status: "applied",
+      state: {
+        sequence: 9,
+        handle: "alice-ai",
+        displayName: "Alice AI",
+        entries: [{ id: "skills:cuda" }],
+      },
+    });
+    expect(current).toMatchObject({ sequence: 7, handle: "alice", entries: [currentEntry] });
+  });
+
+  it("orders equal-timestamp entries by locale-independent code units", () => {
+    const current = {
+      feedId: base.feedId,
+      sequence: 7,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [],
+    };
+    const applied = applyPublisherFeedChanges(current, {
+      status: "complete",
+      feedId: base.feedId,
+      fromSequence: 7,
+      toSequence: 8,
+      generatedAt: base.generatedAt,
+      expiresAt: base.expiresAt,
+      changes: [
+        { sequence: 8, operation: "upsert", entry: { ...entry, id: "skills:a" } },
+        { sequence: 8, operation: "upsert", entry: { ...entry, id: "skills:Z" } },
+      ],
+    });
+
+    expect(applied).toMatchObject({
+      status: "applied",
+      state: { entries: [{ id: "skills:Z" }, { id: "skills:a" }] },
+    });
+  });
+
+  it("rejects incomplete change ranges before exposing a next state", () => {
+    const current = {
+      feedId: base.feedId,
+      sequence: 7,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [],
+    };
+    expect(() =>
+      applyPublisherFeedChanges(current, {
+        status: "complete",
+        feedId: base.feedId,
+        fromSequence: 7,
+        toSequence: Number.MAX_SAFE_INTEGER,
+        generatedAt: base.generatedAt,
+        expiresAt: base.expiresAt,
+        changes: [{ sequence: 9, operation: "upsert", entry }],
+      }),
+    ).toThrow("omitted a revision");
+    expect(() =>
+      applyPublisherFeedChanges(current, {
+        status: "complete",
+        feedId: base.feedId,
+        fromSequence: 7,
+        toSequence: 9,
+        generatedAt: base.generatedAt,
+        expiresAt: base.expiresAt,
+        changes: [
+          {
+            sequence: 7,
+            operation: "remove",
+            entryId: "skills:old",
+            entryKind: "skill",
+          },
+          { sequence: 8, operation: "upsert", entry },
+        ],
+      }),
+    ).toThrow("not ordered within the signed range");
+  });
+
+  it("rejects reset instructions that do not continue the current state", () => {
+    expect(() =>
+      applyPublisherFeedChanges(
+        {
+          feedId: base.feedId,
+          sequence: 7,
+          publisherId: "publishers:alice",
+          handle: "alice",
+          displayName: "Alice",
+          entries: [],
+        },
+        {
+          status: "reset-required",
+          reset: {
+            ...base,
+            feedId: "clawhub.publisher.publishers:bob",
+            fromSequence: 7,
+            currentSequence: 9,
+            resetRequired: true,
+            snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Abob/feed",
+          },
+        },
+      ),
+    ).toThrow("reset does not continue");
+  });
+
+  it("accepts only a first-page same-origin signed reset response", async () => {
+    const key = signingKey();
+    enqueueSigned(
+      key,
+      PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      {
+        ...base,
+        fromSequence: 1,
+        currentSequence: 9,
+        resetRequired: true,
+        snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+      },
+      409,
+    );
+
+    await expect(
+      fetchPublisherFeedChanges({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        fromSequence: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).resolves.toMatchObject({ status: "reset-required", reset: { currentSequence: 9 } });
+
+    enqueueSigned(
+      key,
+      PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      {
+        ...base,
+        fromSequence: 1,
+        currentSequence: 9,
+        resetRequired: true,
+        snapshotUrl: "https://evil.example/api/v1/publishers/publishers%3Aalice/feed",
+      },
+      409,
+    );
+    await expect(
+      fetchPublisherFeedChanges({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        fromSequence: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow("reset instruction is invalid");
+
+    enqueueSigned(
+      key,
+      PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      {
+        ...base,
+        fromSequence: 1,
+        currentSequence: 9,
+        resetRequired: true,
+        snapshotUrl: "https://user:secret@clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+      },
+      409,
+    );
+    await expect(
+      fetchPublisherFeedChanges({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        fromSequence: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow("reset instruction is invalid");
+  });
+
+  it("rejects redirects, wrong content types, and page-count exhaustion", async () => {
+    const key = signingKey();
+    const payload = {
+      ...base,
+      sequence: 7,
+      query: { text: "CUDA" },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 2,
+      entries: [entry],
+      nextCursor: "next",
+    };
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload);
+    queuedResponses[0]!.finalUrl = "https://clawhub.ai/redirected";
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query: { text: "CUDA" },
+      }),
+    ).rejects.toThrow("redirected away");
+
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload, 200, {
+      "content-type": "application/json",
+    });
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query: { text: "CUDA" },
+      }),
+    ).rejects.toThrow("unsupported content type");
+
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload);
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query: { text: "CUDA" },
+        maxPages: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow("exceeded 1 pages");
+  });
+});

--- a/src/plugins/publisher-feed-transport.ts
+++ b/src/plugins/publisher-feed-transport.ts
@@ -1,0 +1,560 @@
+import { readResponseWithLimit } from "../infra/http-body.js";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import type { TrustedFeedSigningKey } from "./official-external-plugin-catalog-envelope.js";
+import {
+  PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+  PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+  verifyPublisherFeedProjection,
+  type PublisherFeedChange,
+  type PublisherFeedChangePage,
+  type PublisherFeedEntry,
+  type PublisherFeedQuery,
+  type PublisherFeedQueryPage,
+  type PublisherFeedResetRequired,
+} from "./publisher-feed-projections.js";
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type PublisherFeedVerification = {
+  trustedKeys: readonly TrustedFeedSigningKey[];
+  threshold?: number;
+};
+
+type PublisherFeedTransportOptions = {
+  baseUrl: string;
+  publisherId: string;
+  verification: PublisherFeedVerification;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  chunkTimeoutMs?: number;
+  maxPages?: number;
+  now?: () => Date;
+};
+
+export type PublisherFeedQueryResult = {
+  feedId: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  query: PublisherFeedQuery;
+  entries: readonly PublisherFeedEntry[];
+};
+
+export type PublisherFeedChangesResult =
+  | {
+      status: "complete";
+      feedId: string;
+      fromSequence: number;
+      toSequence: number;
+      generatedAt: string;
+      expiresAt: string;
+      changes: readonly PublisherFeedChange[];
+    }
+  | { status: "reset-required"; reset: PublisherFeedResetRequired };
+
+export type PublisherFeedState = {
+  feedId: string;
+  sequence: number;
+  publisherId: string;
+  handle: string | null;
+  displayName: string;
+  entries: readonly PublisherFeedEntry[];
+};
+
+export type PublisherFeedApplyResult =
+  | { status: "applied"; state: PublisherFeedState }
+  | { status: "reset-required"; reset: PublisherFeedResetRequired };
+
+const PUBLISHER_FEED_PAGE_MAX_BYTES = 1024 * 1024;
+const PUBLISHER_FEED_DEFAULT_TIMEOUT_MS = 5_000;
+const PUBLISHER_FEED_DEFAULT_MAX_PAGES = 50;
+const PUBLISHER_FEED_MAX_MAX_PAGES = 100;
+const PUBLISHER_FEED_QUERY_MAX_LIMIT = 200;
+const PUBLISHER_FEED_CHANGE_MAX_LIMIT = 500;
+const PUBLISHER_FEED_CONTENT_TYPE = "application/vnd.dsse+json";
+
+function normalizeBaseUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    throw new Error("publisher feed base URL is invalid");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "/" && url.pathname !== "")
+  ) {
+    throw new Error("publisher feed base URL must be an HTTPS origin without credentials");
+  }
+  return new URL(url.origin);
+}
+
+function normalizePublisherId(raw: string): string {
+  const publisherId = raw.trim();
+  if (!publisherId || new TextEncoder().encode(publisherId).length > 200) {
+    throw new Error("publisher feed publisher id is invalid");
+  }
+  return publisherId;
+}
+
+function normalizeLimit(value: number | undefined, fallback: number, maximum: number): number {
+  const limit = value ?? fallback;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximum) {
+    throw new Error(`publisher feed page limit must be between 1 and ${maximum}`);
+  }
+  return limit;
+}
+
+function normalizeMaxPages(value: number | undefined): number {
+  const maxPages = value ?? PUBLISHER_FEED_DEFAULT_MAX_PAGES;
+  if (!Number.isSafeInteger(maxPages) || maxPages < 1 || maxPages > PUBLISHER_FEED_MAX_MAX_PAGES) {
+    throw new Error(
+      `publisher feed max pages must be between 1 and ${PUBLISHER_FEED_MAX_MAX_PAGES}`,
+    );
+  }
+  return maxPages;
+}
+
+function normalizeQueryTextWhitespace(value: string): string {
+  let result = "";
+  let pendingSpace = false;
+  for (const character of value.normalize("NFC")) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if ((codePoint >= 0x09 && codePoint <= 0x0d) || codePoint === 0x20) {
+      pendingSpace = result.length > 0;
+      continue;
+    }
+    if (pendingSpace) {
+      result += " ";
+    }
+    result += character;
+    pendingSpace = false;
+  }
+  return result;
+}
+
+function normalizeQuery(query: PublisherFeedQuery): PublisherFeedQuery {
+  const normalized: PublisherFeedQuery = {};
+  if (query.text !== undefined) {
+    const text = normalizeQueryTextWhitespace(query.text);
+    if (!text || new TextEncoder().encode(text).length > 256) {
+      throw new Error("publisher feed query text must be between 1 and 256 UTF-8 bytes");
+    }
+    normalized.text = text;
+  }
+  if (query.kinds !== undefined) {
+    const kinds = [...new Set(query.kinds)].toSorted();
+    if (kinds.length === 0 || kinds.some((kind) => kind !== "skill" && kind !== "plugin")) {
+      throw new Error("publisher feed query kinds are invalid");
+    }
+    normalized.kinds = kinds;
+  }
+  if (normalized.text === undefined && normalized.kinds === undefined) {
+    throw new Error("publisher feed query must include text or kinds");
+  }
+  return normalized;
+}
+
+function sameQuery(left: PublisherFeedQuery, right: PublisherFeedQuery): boolean {
+  if (left.text !== right.text) {
+    return false;
+  }
+  const leftKinds = left.kinds ?? [];
+  const rightKinds = right.kinds ?? [];
+  return (
+    leftKinds.length === rightKinds.length &&
+    leftKinds.every((kind, index) => kind === rightKinds[index])
+  );
+}
+
+function projectionPath(publisherId: string, operation: "query" | "changes"): string {
+  return `/api/v1/publishers/${encodeURIComponent(publisherId)}/feed/${operation}`;
+}
+
+function initialQueryUrl(
+  baseUrl: URL,
+  publisherId: string,
+  query: PublisherFeedQuery,
+  limit: number,
+) {
+  const url = new URL(projectionPath(publisherId, "query"), baseUrl);
+  if (query.text !== undefined) {
+    url.searchParams.set("q", query.text);
+  }
+  for (const kind of query.kinds ?? []) {
+    url.searchParams.append("kind", kind);
+  }
+  url.searchParams.set("limit", String(limit));
+  return url;
+}
+
+function initialChangesUrl(baseUrl: URL, publisherId: string, fromSequence: number, limit: number) {
+  const url = new URL(projectionPath(publisherId, "changes"), baseUrl);
+  url.searchParams.set("fromSequence", String(fromSequence));
+  url.searchParams.set("limit", String(limit));
+  return url;
+}
+
+function continuationUrl(
+  baseUrl: URL,
+  publisherId: string,
+  operation: "query" | "changes",
+  cursor: string,
+) {
+  const url = new URL(projectionPath(publisherId, operation), baseUrl);
+  url.searchParams.set("cursor", cursor);
+  return url;
+}
+
+function assertContentLength(response: Response): void {
+  const raw = response.headers.get("content-length");
+  if (raw === null) {
+    return;
+  }
+  if (!/^\d+$/u.test(raw)) {
+    throw new Error("publisher feed response has invalid content-length");
+  }
+  const length = Number(raw);
+  if (!Number.isSafeInteger(length) || length > PUBLISHER_FEED_PAGE_MAX_BYTES) {
+    throw new Error(`publisher feed response exceeds ${PUBLISHER_FEED_PAGE_MAX_BYTES} bytes`);
+  }
+}
+
+async function readProjectionEnvelope(params: {
+  url: URL;
+  operation: "query" | "changes";
+  verification: PublisherFeedVerification;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  chunkTimeoutMs?: number;
+}) {
+  const guarded = await fetchWithSsrFGuard({
+    url: params.url.href,
+    fetchImpl: params.fetchImpl,
+    init: { method: "GET", headers: { accept: PUBLISHER_FEED_CONTENT_TYPE } },
+    requireHttps: true,
+    maxRedirects: 2,
+    timeoutMs: params.timeoutMs ?? PUBLISHER_FEED_DEFAULT_TIMEOUT_MS,
+    policy: { hostnameAllowlist: [params.url.hostname] },
+    auditContext: "publisher-feed-projection",
+  });
+  try {
+    if (guarded.finalUrl !== params.url.href) {
+      throw new Error("publisher feed projection redirected away from the requested page");
+    }
+    const allowedStatuses = params.operation === "changes" ? [200, 409] : [200];
+    if (!allowedStatuses.includes(guarded.response.status)) {
+      throw new Error(`publisher feed projection returned HTTP ${guarded.response.status}`);
+    }
+    const contentType = guarded.response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+    if (contentType !== PUBLISHER_FEED_CONTENT_TYPE) {
+      throw new Error("publisher feed projection returned an unsupported content type");
+    }
+    assertContentLength(guarded.response);
+    const body = await readResponseWithLimit(guarded.response, PUBLISHER_FEED_PAGE_MAX_BYTES, {
+      chunkTimeoutMs: params.chunkTimeoutMs ?? PUBLISHER_FEED_DEFAULT_TIMEOUT_MS,
+      onOverflow: ({ maxBytes }) => new Error(`publisher feed response exceeds ${maxBytes} bytes`),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`publisher feed response timed out after ${chunkTimeoutMs}ms`),
+    });
+    let envelope: unknown;
+    try {
+      envelope = JSON.parse(body.toString("utf8"));
+    } catch {
+      throw new Error("publisher feed projection envelope is not valid JSON");
+    }
+    const verified = verifyPublisherFeedProjection(envelope, {
+      payloadType:
+        params.operation === "query"
+          ? PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+          : PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      ...params.verification,
+    });
+    return { status: guarded.response.status, payload: verified.payload };
+  } finally {
+    if (!guarded.response.bodyUsed) {
+      await guarded.response.body?.cancel().catch(() => undefined);
+    }
+    await guarded.release();
+  }
+}
+
+function assertNotExpired(expiresAt: string, now: () => Date): void {
+  if (Date.parse(expiresAt) <= now().getTime()) {
+    throw new Error("publisher feed projection expired during traversal");
+  }
+}
+
+function assertUniqueEntries(entries: readonly PublisherFeedEntry[]): void {
+  const identities = new Set<string>();
+  for (const entry of entries) {
+    const identity = `${entry.kind}\0${entry.id}`;
+    if (identities.has(identity)) {
+      throw new Error("publisher feed query returned duplicate entries");
+    }
+    identities.add(identity);
+  }
+}
+
+function entryIdentity(entry: Pick<PublisherFeedEntry, "kind" | "id">): string {
+  return `${entry.kind}\0${entry.id}`;
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareEntries(left: PublisherFeedEntry, right: PublisherFeedEntry): number {
+  return (
+    right.updatedAt - left.updatedAt ||
+    compareCodeUnits(left.kind, right.kind) ||
+    compareCodeUnits(left.id, right.id)
+  );
+}
+
+export function applyPublisherFeedChanges(
+  current: PublisherFeedState,
+  result: PublisherFeedChangesResult,
+): PublisherFeedApplyResult {
+  if (result.status === "reset-required") {
+    if (
+      result.reset.feedId !== current.feedId ||
+      result.reset.fromSequence !== current.sequence ||
+      current.feedId !== `clawhub.publisher.${current.publisherId}`
+    ) {
+      throw new Error("publisher feed reset does not continue the current state");
+    }
+    return result;
+  }
+  if (
+    result.feedId !== current.feedId ||
+    result.fromSequence !== current.sequence ||
+    current.feedId !== `clawhub.publisher.${current.publisherId}`
+  ) {
+    throw new Error("publisher feed changes do not continue the current state");
+  }
+  const entries = new Map(current.entries.map((entry) => [entryIdentity(entry), { ...entry }]));
+  if (entries.size !== current.entries.length) {
+    throw new Error("current publisher feed state contains duplicate entries");
+  }
+  let publisherId = current.publisherId;
+  let handle = current.handle;
+  let displayName = current.displayName;
+  let previousSequence = result.fromSequence;
+  const seenSequences = new Set<number>();
+  for (const change of result.changes) {
+    if (
+      !Number.isSafeInteger(change.sequence) ||
+      change.sequence <= result.fromSequence ||
+      change.sequence < previousSequence ||
+      change.sequence > result.toSequence
+    ) {
+      throw new Error("publisher feed changes are not ordered within the signed range");
+    }
+    previousSequence = change.sequence;
+    seenSequences.add(change.sequence);
+    if (change.operation === "upsert") {
+      entries.set(entryIdentity(change.entry), { ...change.entry });
+    } else if (change.operation === "remove") {
+      entries.delete(`${change.entryKind}\0${change.entryId}`);
+    } else {
+      if (
+        change.metadata.publisherId !== current.publisherId ||
+        result.feedId !== `clawhub.publisher.${change.metadata.publisherId}`
+      ) {
+        throw new Error("publisher feed metadata changed stable publisher identity");
+      }
+      publisherId = change.metadata.publisherId;
+      handle = change.metadata.handle;
+      displayName = change.metadata.displayName;
+    }
+  }
+  const expectedSequenceCount = result.toSequence - result.fromSequence;
+  if (seenSequences.size !== expectedSequenceCount) {
+    throw new Error("publisher feed changes omitted a revision from the signed range");
+  }
+  return {
+    status: "applied",
+    state: {
+      feedId: current.feedId,
+      sequence: result.toSequence,
+      publisherId,
+      handle,
+      displayName,
+      entries: [...entries.values()].toSorted(compareEntries),
+    },
+  };
+}
+
+export async function fetchPublisherFeedQuery(
+  params: PublisherFeedTransportOptions & { query: PublisherFeedQuery; limit?: number },
+): Promise<PublisherFeedQueryResult> {
+  const baseUrl = normalizeBaseUrl(params.baseUrl);
+  const publisherId = normalizePublisherId(params.publisherId);
+  const expectedFeedId = `clawhub.publisher.${publisherId}`;
+  const query = normalizeQuery(params.query);
+  const limit = normalizeLimit(params.limit, 50, PUBLISHER_FEED_QUERY_MAX_LIMIT);
+  const maxPages = normalizeMaxPages(params.maxPages);
+  const now = params.now ?? (() => new Date());
+  const entries: PublisherFeedEntry[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | null = null;
+  let first: PublisherFeedQueryPage | null = null;
+
+  for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+    const url =
+      cursor === null
+        ? initialQueryUrl(baseUrl, publisherId, query, limit)
+        : continuationUrl(baseUrl, publisherId, "query", cursor);
+    const response = await readProjectionEnvelope({
+      url,
+      operation: "query",
+      verification: params.verification,
+      fetchImpl: params.fetchImpl,
+      timeoutMs: params.timeoutMs,
+      chunkTimeoutMs: params.chunkTimeoutMs,
+    });
+    const page = response.payload as PublisherFeedQueryPage;
+    if (
+      page.feedId !== expectedFeedId ||
+      page.pageIndex !== pageIndex ||
+      page.startIndex !== entries.length ||
+      page.requestCursor !== cursor ||
+      !sameQuery(page.query, query)
+    ) {
+      throw new Error("publisher feed query page continuity check failed");
+    }
+    assertNotExpired(page.expiresAt, now);
+    if (!first) {
+      first = page;
+    } else if (
+      page.sequence !== first.sequence ||
+      page.generatedAt !== first.generatedAt ||
+      page.expiresAt !== first.expiresAt ||
+      page.resultCount !== first.resultCount
+    ) {
+      throw new Error("publisher feed query revision changed during traversal");
+    }
+    entries.push(...page.entries);
+    cursor = page.nextCursor;
+    if (cursor === null) {
+      if (entries.length !== page.resultCount) {
+        throw new Error("publisher feed query terminated before its signed result count");
+      }
+      assertUniqueEntries(entries);
+      return {
+        feedId: page.feedId,
+        sequence: page.sequence,
+        generatedAt: page.generatedAt,
+        expiresAt: page.expiresAt,
+        query: page.query,
+        entries,
+      };
+    }
+    if (seenCursors.has(cursor)) {
+      throw new Error("publisher feed query cursor repeated during traversal");
+    }
+    seenCursors.add(cursor);
+  }
+  throw new Error(`publisher feed query exceeded ${maxPages} pages`);
+}
+
+export async function fetchPublisherFeedChanges(
+  params: PublisherFeedTransportOptions & { fromSequence: number; limit?: number },
+): Promise<PublisherFeedChangesResult> {
+  const baseUrl = normalizeBaseUrl(params.baseUrl);
+  const publisherId = normalizePublisherId(params.publisherId);
+  const expectedFeedId = `clawhub.publisher.${publisherId}`;
+  if (!Number.isSafeInteger(params.fromSequence) || params.fromSequence < 0) {
+    throw new Error("publisher feed from sequence is invalid");
+  }
+  const limit = normalizeLimit(params.limit, 100, PUBLISHER_FEED_CHANGE_MAX_LIMIT);
+  const maxPages = normalizeMaxPages(params.maxPages);
+  const now = params.now ?? (() => new Date());
+  const changes: PublisherFeedChange[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | null = null;
+  let first: PublisherFeedChangePage | null = null;
+
+  for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+    const url =
+      cursor === null
+        ? initialChangesUrl(baseUrl, publisherId, params.fromSequence, limit)
+        : continuationUrl(baseUrl, publisherId, "changes", cursor);
+    const response = await readProjectionEnvelope({
+      url,
+      operation: "changes",
+      verification: params.verification,
+      fetchImpl: params.fetchImpl,
+      timeoutMs: params.timeoutMs,
+      chunkTimeoutMs: params.chunkTimeoutMs,
+    });
+    if (response.status === 409) {
+      const reset = response.payload as PublisherFeedResetRequired;
+      const expectedSnapshotUrl = new URL(
+        `/api/v1/publishers/${encodeURIComponent(publisherId)}/feed`,
+        baseUrl,
+      );
+      if (
+        pageIndex !== 0 ||
+        !reset.resetRequired ||
+        reset.feedId !== expectedFeedId ||
+        reset.fromSequence !== params.fromSequence ||
+        new URL(reset.snapshotUrl).href !== expectedSnapshotUrl.href
+      ) {
+        throw new Error("publisher feed reset instruction is invalid");
+      }
+      assertNotExpired(reset.expiresAt, now);
+      return { status: "reset-required", reset };
+    }
+    if ((response.payload as PublisherFeedResetRequired).resetRequired) {
+      throw new Error("publisher feed reset instruction used an invalid HTTP status");
+    }
+    const page = response.payload as PublisherFeedChangePage;
+    if (
+      page.feedId !== expectedFeedId ||
+      page.fromSequence !== params.fromSequence ||
+      page.pageIndex !== pageIndex ||
+      page.startIndex !== changes.length ||
+      page.requestCursor !== cursor
+    ) {
+      throw new Error("publisher feed change page continuity check failed");
+    }
+    assertNotExpired(page.expiresAt, now);
+    if (!first) {
+      first = page;
+    } else if (
+      page.toSequence !== first.toSequence ||
+      page.generatedAt !== first.generatedAt ||
+      page.expiresAt !== first.expiresAt ||
+      page.changeCount !== first.changeCount
+    ) {
+      throw new Error("publisher feed change range changed during traversal");
+    }
+    changes.push(...page.changes);
+    cursor = page.nextCursor;
+    if (cursor === null) {
+      if (changes.length !== page.changeCount) {
+        throw new Error("publisher feed changes terminated before their signed change count");
+      }
+      return {
+        status: "complete",
+        feedId: page.feedId,
+        fromSequence: page.fromSequence,
+        toSequence: page.toSequence,
+        generatedAt: page.generatedAt,
+        expiresAt: page.expiresAt,
+        changes,
+      };
+    }
+    if (seenCursors.has(cursor)) {
+      throw new Error("publisher feed change cursor repeated during traversal");
+    }
+    seenCursors.add(cursor);
+  }
+  throw new Error(`publisher feed changes exceeded ${maxPages} pages`);
+}


### PR DESCRIPTION
## Summary

- fetch signed publisher query and changed-since projections through bounded same-origin HTTP traversal
- enforce page, revision, query, range, cursor, expiry, result-count, and duplicate-entry continuity before returning data
- apply complete change ranges atomically, with a validated reset-to-snapshot boundary and deterministic state ordering
- guard every request with HTTPS/SSRF policy, exact redirect rejection, DSSE content type, 1 MiB response limits, timeouts, and configurable page bounds

## Stack

- depends on #109305
- producer stack: openclaw/clawhub#3116, openclaw/clawhub#3117, and openclaw/clawhub#3005
- protocol contract: openclaw/rfcs#39

## Validation

- focused verifier and transport tests: 26 tests across 2 shards
- scoped type-aware oxlint
- scoped oxfmt
- git diff --check
- final Codex review: no actionable correctness issues

A full TypeScript run is not claimed from this borrowed dependency tree: its stale install reports unrelated dependency errors under local Node 24.14.0. Fresh CI is authoritative for repository-wide type proof.