### PR TITLE
improve(extensions): reduce test hotspot setup costs [AI]

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -6,13 +6,14 @@ import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
+  clearPluginStateStoreForTests,
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { parseSqliteSessionFileMarker } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { applyCliRuntimeRecallTimeoutDefault } from "./config.js";
 import plugin, { testing } from "./index.js";
 
@@ -474,11 +475,15 @@ describe("active-memory plugin", () => {
     return call;
   };
 
+  beforeAll(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-test-"));
+  });
+
   beforeEach(async () => {
     vi.clearAllMocks();
-    resetPluginStateStoreForTests();
+    await fs.rm(path.join(stateDir, "plugins"), { recursive: true, force: true });
+    clearPluginStateStoreForTests();
     runEmbeddedAgent.mockReset();
-    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-test-"));
     configFile = {
       plugins: {
         entries: {
@@ -581,14 +586,16 @@ describe("active-memory plugin", () => {
     plugin.register(api as unknown as OpenClawPluginApi);
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     testing.resetActiveRecallCacheForTests();
-    if (stateDir) {
-      await fs.rm(stateDir, { recursive: true, force: true });
-      stateDir = "";
-    }
+  });
+
+  afterAll(async () => {
+    resetPluginStateStoreForTests();
+    await fs.rm(stateDir, { recursive: true, force: true });
+    stateDir = "";
   });
 
   it("registers a before_prompt_build hook", () => {

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -6,7 +6,6 @@ import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
-  clearPluginStateStoreForTests,
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
@@ -173,6 +172,8 @@ describe("active-memory plugin", () => {
       },
     };
   });
+  let fixtureRoot = "";
+  let pluginStateDir = "";
   let stateDir = "";
   let configFile: Record<string, unknown> = {};
   let pluginConfig: Record<string, unknown> = {
@@ -279,7 +280,7 @@ describe("active-memory plugin", () => {
         openKeyedStore: (options: OpenKeyedStoreOptions) =>
           createPluginStateKeyedStoreForTests("active-memory", {
             ...options,
-            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+            env: { ...process.env, OPENCLAW_STATE_DIR: pluginStateDir },
           }),
       },
       config: {
@@ -476,13 +477,21 @@ describe("active-memory plugin", () => {
   };
 
   beforeAll(async () => {
-    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-test-"));
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-test-"));
+    pluginStateDir = path.join(fixtureRoot, "plugin-state");
+    stateDir = path.join(fixtureRoot, "state");
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    await fs.rm(path.join(stateDir, "plugins"), { recursive: true, force: true });
-    clearPluginStateStoreForTests();
+    await fs.rm(stateDir, { recursive: true, force: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    // Keep the SQLite file/schema warm, but clear the plugin's only real namespace.
+    await createPluginStateKeyedStoreForTests("active-memory", {
+      namespace: "session-toggles",
+      maxEntries: 10_000,
+      env: { ...process.env, OPENCLAW_STATE_DIR: pluginStateDir },
+    }).clear();
     runEmbeddedAgent.mockReset();
     configFile = {
       plugins: {
@@ -594,7 +603,9 @@ describe("active-memory plugin", () => {
 
   afterAll(async () => {
     resetPluginStateStoreForTests();
-    await fs.rm(stateDir, { recursive: true, force: true });
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+    fixtureRoot = "";
+    pluginStateDir = "";
     stateDir = "";
   });
 

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -274,6 +274,7 @@ function makeParams(
     agentDir: "C:\\copilot-home",
     agentId: "agent-1",
     auth: { useLoggedInUser: true, ...(overrides as { auth?: object }).auth },
+    disableTools: true,
     initialReplayState: undefined,
     messages: [{ content: "hello", role: "user", timestamp: 1 }],
     model: {

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -1,7 +1,7 @@
 // Imessage tests cover inbound processing plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { loadFreshIMessageReplyCacheForTest } from "../test-support/runtime.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
 
@@ -12,7 +12,7 @@ let buildIMessageInboundContext: InboundProcessingModule["buildIMessageInboundCo
 let resolveIMessageReactionContext: InboundProcessingModule["resolveIMessageReactionContext"];
 let resolveIMessageInboundDecision: InboundProcessingModule["resolveIMessageInboundDecision"];
 
-beforeEach(async () => {
+beforeAll(async () => {
   ({ rememberIMessageReplyCache } = await loadFreshIMessageReplyCacheForTest());
   ({ buildIMessageInboundContext, resolveIMessageReactionContext, resolveIMessageInboundDecision } =
     await import("./inbound-processing.js"));

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -3,13 +3,15 @@ import { expectChannelInboundContextContract as expectInboundContextContract } f
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetSignalReplyAuthorsForTests,
+  resolveSignalReplyContextWithPersistence,
+} from "../reply-authors.js";
 import type { SignalReactionMessage } from "./event-handler.types.js";
 vi.useRealTimers();
 let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
 let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
 let createSignalEventHandler: typeof import("./event-handler.js").createSignalEventHandler;
-let resolveSignalReplyContextWithPersistence: typeof import("../reply-authors.js").resolveSignalReplyContextWithPersistence;
-let resetSignalReplyAuthorsForTests: typeof import("../reply-authors.js").resetSignalReplyAuthorsForTests;
 
 type DispatchInboundMessageMockParams = {
   ctx: MsgContext;
@@ -126,15 +128,8 @@ function nextTimerTick(): Promise<void> {
 
 describe("signal createSignalEventHandler inbound context", () => {
   beforeAll(async () => {
-    [
-      { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
-      { createSignalEventHandler },
-      { resetSignalReplyAuthorsForTests, resolveSignalReplyContextWithPersistence },
-    ] = await Promise.all([
-      import("./event-handler.test-harness.js"),
-      import("./event-handler.js"),
-      import("../reply-authors.js"),
-    ]);
+    [{ createBaseSignalEventHandlerDeps, createSignalReceiveEvent }, { createSignalEventHandler }] =
+      await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
   });
 
   beforeEach(() => {

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -2,13 +2,14 @@
 import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SignalReactionMessage } from "./event-handler.types.js";
 vi.useRealTimers();
 let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
 let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
 let createSignalEventHandler: typeof import("./event-handler.js").createSignalEventHandler;
 let resolveSignalReplyContextWithPersistence: typeof import("../reply-authors.js").resolveSignalReplyContextWithPersistence;
+let resetSignalReplyAuthorsForTests: typeof import("../reply-authors.js").resetSignalReplyAuthorsForTests;
 
 type DispatchInboundMessageMockParams = {
   ctx: MsgContext;
@@ -124,18 +125,21 @@ function nextTimerTick(): Promise<void> {
 }
 
 describe("signal createSignalEventHandler inbound context", () => {
-  beforeEach(async () => {
-    vi.resetModules();
+  beforeAll(async () => {
     [
       { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
       { createSignalEventHandler },
-      { resolveSignalReplyContextWithPersistence },
+      { resetSignalReplyAuthorsForTests, resolveSignalReplyContextWithPersistence },
     ] = await Promise.all([
       import("./event-handler.test-harness.js"),
       import("./event-handler.js"),
       import("../reply-authors.js"),
     ]);
+  });
+
+  beforeEach(() => {
     vi.useRealTimers();
+    resetSignalReplyAuthorsForTests();
     delete capture.ctx;
     sendTypingMock.mockReset().mockResolvedValue(true);
     sendReadReceiptMock.mockReset().mockResolvedValue(true);

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -3,10 +3,8 @@ import { expectChannelInboundContextContract as expectInboundContextContract } f
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  resolveSignalReplyContextWithPersistence,
-  testing as replyAuthorsTesting,
-} from "../reply-authors.js";
+import { resolveSignalReplyContextWithPersistence } from "../reply-authors.js";
+import { resetSignalReplyAuthorsForTests } from "../reply-authors.test-helpers.js";
 import type { SignalReactionMessage } from "./event-handler.types.js";
 vi.useRealTimers();
 let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
@@ -134,7 +132,7 @@ describe("signal createSignalEventHandler inbound context", () => {
 
   beforeEach(() => {
     vi.useRealTimers();
-    replyAuthorsTesting.resetSignalReplyAuthorsForTests();
+    resetSignalReplyAuthorsForTests();
     delete capture.ctx;
     sendTypingMock.mockReset().mockResolvedValue(true);
     sendReadReceiptMock.mockReset().mockResolvedValue(true);

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -4,8 +4,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  resetSignalReplyAuthorsForTests,
   resolveSignalReplyContextWithPersistence,
+  testing as replyAuthorsTesting,
 } from "../reply-authors.js";
 import type { SignalReactionMessage } from "./event-handler.types.js";
 vi.useRealTimers();
@@ -134,7 +134,7 @@ describe("signal createSignalEventHandler inbound context", () => {
 
   beforeEach(() => {
     vi.useRealTimers();
-    resetSignalReplyAuthorsForTests();
+    replyAuthorsTesting.resetSignalReplyAuthorsForTests();
     delete capture.ctx;
     sendTypingMock.mockReset().mockResolvedValue(true);
     sendReadReceiptMock.mockReset().mockResolvedValue(true);

--- a/extensions/signal/src/reply-authors-state.ts
+++ b/extensions/signal/src/reply-authors-state.ts
@@ -1,0 +1,21 @@
+// Signal plugin module owns native-reply quote author state.
+type SignalReplyContextRecordBase = {
+  accountId: string;
+  conversationKey: string;
+  replyToId: string;
+  sourceTimestamp: number;
+  registeredAt: number;
+};
+
+export type SignalReplyContextRecord = SignalReplyContextRecordBase &
+  ({ kind: "resolved"; author: string; body?: string } | { kind: "ambiguous" });
+
+export const signalReplyAuthorState = {
+  memoryReplyContexts: new Map<
+    string,
+    SignalReplyContextRecord & {
+      expiresAt: number;
+    }
+  >(),
+  persistentStoreDisabled: false,
+};

--- a/extensions/signal/src/reply-authors.test-helpers.ts
+++ b/extensions/signal/src/reply-authors.test-helpers.ts
@@ -1,0 +1,7 @@
+// Signal test support resets native-reply quote author state.
+import { signalReplyAuthorState } from "./reply-authors-state.js";
+
+export function resetSignalReplyAuthorsForTests(): void {
+  signalReplyAuthorState.memoryReplyContexts.clear();
+  signalReplyAuthorState.persistentStoreDisabled = false;
+}

--- a/extensions/signal/src/reply-authors.ts
+++ b/extensions/signal/src/reply-authors.ts
@@ -32,6 +32,11 @@ type SignalPersistedReplyContext =
 const memoryReplyContexts = new Map<string, MemoryReplyContextRecord>();
 let persistentStoreDisabled = false;
 
+export function resetSignalReplyAuthorsForTests(): void {
+  memoryReplyContexts.clear();
+  persistentStoreDisabled = false;
+}
+
 function openSignalReplyAuthorStore() {
   if (persistentStoreDisabled) {
     return undefined;

--- a/extensions/signal/src/reply-authors.ts
+++ b/extensions/signal/src/reply-authors.ts
@@ -5,43 +5,21 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeSignalMessagingTarget } from "./normalize.js";
+import { signalReplyAuthorState, type SignalReplyContextRecord } from "./reply-authors-state.js";
 import { getOptionalSignalRuntime } from "./runtime.js";
 
 const PERSISTENT_NAMESPACE = "signal.reply-authors.v1";
 const PERSISTENT_MAX_ENTRIES = 5000;
 const DEFAULT_REPLY_AUTHOR_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-type SignalReplyContextRecordBase = {
-  accountId: string;
-  conversationKey: string;
-  replyToId: string;
-  sourceTimestamp: number;
-  registeredAt: number;
-};
-type SignalReplyContextRecord = SignalReplyContextRecordBase &
-  ({ kind: "resolved"; author: string; body?: string } | { kind: "ambiguous" });
-
-type MemoryReplyContextRecord = SignalReplyContextRecord & {
-  expiresAt: number;
-};
-
 type SignalPersistedReplyContext =
   | { author: string; body?: string; ambiguous?: never }
   | { ambiguous: true; author?: never; body?: never };
 
-const memoryReplyContexts = new Map<string, MemoryReplyContextRecord>();
-let persistentStoreDisabled = false;
-
-export const testing = {
-  resetSignalReplyAuthorsForTests(): void {
-    memoryReplyContexts.clear();
-    persistentStoreDisabled = false;
-  },
-};
-export { testing as __testing };
+const { memoryReplyContexts } = signalReplyAuthorState;
 
 function openSignalReplyAuthorStore() {
-  if (persistentStoreDisabled) {
+  if (signalReplyAuthorState.persistentStoreDisabled) {
     return undefined;
   }
   const runtime = getOptionalSignalRuntime();
@@ -52,7 +30,7 @@ function openSignalReplyAuthorStore() {
       defaultTtlMs: DEFAULT_REPLY_AUTHOR_TTL_MS,
     });
   } catch (error) {
-    persistentStoreDisabled = true;
+    signalReplyAuthorState.persistentStoreDisabled = true;
     runtime?.logging
       .getChildLogger({ plugin: "signal", feature: "reply-author-state" })
       .warn("Signal persistent reply author state unavailable", { error: String(error) });
@@ -175,7 +153,7 @@ export async function registerSignalReplyContext(params: {
     const next = mergeReplyContext(memoryReplyContexts.get(key), record);
     memoryReplyContexts.set(key, { ...next, expiresAt });
     pruneMemoryReplyContexts(registeredAt);
-    persistentStoreDisabled = true;
+    signalReplyAuthorState.persistentStoreDisabled = true;
     getOptionalSignalRuntime()
       ?.logging.getChildLogger({ plugin: "signal", feature: "reply-author-state" })
       .warn("Signal persistent reply author state lacks atomic updates");

--- a/extensions/signal/src/reply-authors.ts
+++ b/extensions/signal/src/reply-authors.ts
@@ -32,10 +32,13 @@ type SignalPersistedReplyContext =
 const memoryReplyContexts = new Map<string, MemoryReplyContextRecord>();
 let persistentStoreDisabled = false;
 
-export function resetSignalReplyAuthorsForTests(): void {
-  memoryReplyContexts.clear();
-  persistentStoreDisabled = false;
-}
+export const testing = {
+  resetSignalReplyAuthorsForTests(): void {
+    memoryReplyContexts.clear();
+    persistentStoreDisabled = false;
+  },
+};
+export { testing as __testing };
 
 function openSignalReplyAuthorStore() {
   if (persistentStoreDisabled) {

--- a/src/plugin-sdk/plugin-state-test-runtime.ts
+++ b/src/plugin-sdk/plugin-state-test-runtime.ts
@@ -6,6 +6,7 @@ export {
   createPluginStateSyncKeyedStore as createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "../plugin-state/plugin-state-store.js";
+export { clearPluginStateStoreForTests } from "../plugin-state/plugin-state-store.test-helpers.js";
 export { createChannelIngressQueue as createChannelIngressQueueForTests } from "../channels/message/ingress-queue.js";
 export { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 export type { DB as OpenClawStateKyselyDatabaseForTests } from "../state/openclaw-state-db.generated.js";

--- a/src/plugin-sdk/plugin-state-test-runtime.ts
+++ b/src/plugin-sdk/plugin-state-test-runtime.ts
@@ -6,7 +6,6 @@ export {
   createPluginStateSyncKeyedStore as createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "../plugin-state/plugin-state-store.js";
-export { clearPluginStateStoreForTests } from "../plugin-state/plugin-state-store.test-helpers.js";
 export { createChannelIngressQueue as createChannelIngressQueueForTests } from "../channels/message/ingress-queue.js";
 export { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 export type { DB as OpenClawStateKyselyDatabaseForTests } from "../state/openclaw-state-db.generated.js";


### PR DESCRIPTION
## What Problem This Solves

Extension test feedback was slowed by four hot files that repeatedly rebuilt module graphs, real tool catalogs, temporary state directories, or SQLite connections for every test case.

## Why This Change Was Made

The test fixtures now keep expensive immutable setup at file scope and explicitly reset mutable state between tests. Copilot attempt tests disable incidental real tool construction by default. Active Memory reuses one file-scoped SQLite schema while clearing its only namespace and recreating filesystem state per test. iMessage and Signal load their module graphs once; Signal's reply-author state has a small owner module plus test-only reset helper so isolation remains explicit.

The two Memory Core targets were profiled but intentionally not changed. Their original profiles spent about 24 seconds of CPU self-time in jiti-backed plugin discovery. The separate cold-plugin-load fix landed as #109348 while this PR was in progress; final solo remeasurement still shows one dominant reset/watcher test in each file, so the remaining work needs its own owner-focused follow-up rather than a duplicate patch here.

## User Impact

No runtime behavior changes. Contributors and CI get materially faster focused extension-test feedback.

## Evidence

Solo wall times on the same Blacksmith Testbox lease:

| Test file | Before | After | Change |
| --- | ---: | ---: | ---: |
| `extensions/copilot/src/attempt.test.ts` | 27.96s | 6.39s | -77% |
| `extensions/active-memory/index.test.ts` | 27.51s | 13.94s | -49% |
| `extensions/imessage/src/monitor/inbound-processing.test.ts` | 20.74s | 6.02s | -71% |
| `extensions/signal/src/monitor/event-handler.inbound-context.test.ts` | 26.64s | 5.69s | -79% |

- All six requested target files passed in solo runs.
- Three bounded repeat loops passed for all four changed files: 372 tests per loop.
- After isolation review fixes, Signal passed three more 47-test repeats and Active Memory passed two separate three-run cycles of 174 tests each.
- `pnpm check:changed` passed: format, SDK baseline/exports/surface, four TypeScript lanes, core and extension lint, boundary and architecture guards.
- `pnpm plugin-sdk:surface:check` passed again after rebasing to current main.
- Final exact-head solo walls were 62.26s Memory Core index, 13.64s Copilot, 20.24s Active Memory, 34.95s Memory Core watcher, 15.38s iMessage, and 14.43s Signal. Cold transform/import variance remains significant; test phases for the four changed files were 1.18s, 7.51s, 11.27s, and 11.44s respectively.
- Mandatory autoreview drove two isolation corrections and finished clean on the full branch with no actionable findings.
- CPU profiles for the deferred Memory Core tests showed jiti self-time of 24.19s and 24.63s, plus about 2.5s of `statSync` each. No duplicate discovery fix added here.

AI-assisted: yes. I reviewed the diff and understand the state-isolation and fixture-lifetime changes.
