### PR TITLE
test: stabilize flaky tests at root cause (batch 1)

### DIFF
--- a/test/scripts/test-group-report.test.ts
+++ b/test/scripts/test-group-report.test.ts
@@ -1107,10 +1107,14 @@ describe("scripts/test-group-report child process guard", () => {
     let childPid: number | undefined;
     let runner: ReturnType<typeof spawn> | undefined;
     try {
+      // Publish the pid via rename so it appears atomically: waitForFile polls
+      // existence only, and a direct writeFileSync leaves an empty-file window
+      // that made the pid parse as NaN (isProcessAlive false) on loaded CI.
       const childScript = [
         "const fs = require('node:fs');",
         "process.on('SIGTERM', () => {});",
-        `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+        `fs.writeFileSync(${JSON.stringify(`${childPidPath}.tmp`)}, String(process.pid));`,
+        `fs.renameSync(${JSON.stringify(`${childPidPath}.tmp`)}, ${JSON.stringify(childPidPath)});`,
         "setInterval(() => {}, 1000);",
       ].join("\n");
       const parentScript = [
@@ -1133,8 +1137,10 @@ describe("scripts/test-group-report child process guard", () => {
         cwd: process.cwd(),
         stdio: ["ignore", "ignore", "pipe"],
       });
-      await waitForFile(readyPath, 2_000);
-      await waitForFile(childPidPath, 2_000);
+      // Generous poll deadlines: spawning the nested runner/parent/child node
+      // chain can take multiple seconds on loaded CI runners.
+      await waitForFile(readyPath, 10_000);
+      await waitForFile(childPidPath, 10_000);
       childPid = Number.parseInt(fs.readFileSync(childPidPath, "utf8"), 10);
       expect(isProcessAlive(childPid)).toBe(true);
 
@@ -1144,7 +1150,7 @@ describe("scripts/test-group-report child process guard", () => {
         code: null,
         signal: "SIGTERM",
       });
-      await waitForDead(childPid, 2_000);
+      await waitForDead(childPid, 10_000);
     } finally {
       if (runner?.pid && isProcessAlive(runner.pid)) {
         runner.kill("SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

Policy shift: no more flake reruns — flaky tests get fixed as discovered. This batch stabilizes flakes observed in today's CI runs, each fixed at root cause in an isolated worktree with a bounded stress-loop proof.

**Fix 1: test-group-report SIGTERM descendant-cleanup race** (failed run 29515993768, `expected false to be true`). The fixture's grandchild published its pid with a plain `writeFileSync` — `open(O_CREAT|O_TRUNC)` creates the file empty before the write lands — while the test's `waitForFile` polls existence only. Uniquely in this test the ready file is written by the parent right after `spawn()`, so the pid poll races the grandchild's write directly: a loaded runner reads the empty window, `parseInt("")` → NaN → `isProcessAlive(NaN)` false. The product's reap-before-forward ordering was never at fault (the assertion fires before SIGTERM is sent).

## Why This Change Was Made

- The pid is now published via write-to-`.tmp` + `renameSync` — atomic, so existence implies complete content. Deterministic; no sleep widening.
- The nested triple-node spawn chain's poll-until deadlines widen 2s → 10s (pass-path speed unchanged; deadlines only bound the polling loops).
- Assertion strength unchanged: descendants alive before SIGTERM, reaped before/at forwarding.

Further worker fixes (gateway timing/mock family, chat-responsive browser locators) will join this branch as their proofs complete.

## User Impact

None at runtime — test-only. CI stops paying rerun cycles for this flake.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/test-group-report.test.ts` — 43/43 passed; bounded stress loop 10/10 iterations green in the fix worktree.
- Root-cause analysis in the commit message; sibling tests are ordering-protected (pid file closed before their ready file), which is why only this one flaked.
