### PR TITLE
perf: avoid plugin cold loads in request hot paths

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -12,6 +12,10 @@ describe("Codex agent harness supports()", () => {
     expect(harness.authBootstrap).toBe("harness");
   });
 
+  it("publishes provider ids for lightweight auto selection", () => {
+    expect(harness.autoSelection?.providerIds).toEqual(["codex", "openai"]);
+  });
+
   const harness = createCodexAppServerAgentHarness({
     bindingStore: testCodexAppServerBindingStore,
   });
@@ -216,6 +220,7 @@ describe("Codex agent harness supports()", () => {
     });
     const result = narrowHarness.supports({ provider: "openai", requestedRuntime: "codex" });
     expect(result.supported).toBe(false);
+    expect(narrowHarness.autoSelection?.providerIds).toEqual(["codex"]);
   });
 
   it("exposes the fail-closed exact runtime artifact validator", async () => {

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -62,6 +62,7 @@ export function createCodexAppServerAgentHarness(options: {
   const harness: CodexAppServerAgentHarness = {
     id: harnessRuntimeId,
     label: options?.label ?? "Codex agent harness",
+    autoSelection: { providerIds: [...providerIds] },
     delegatedExecutionPluginIds: ["voice-call"],
     contextEngineHostCapabilities: CODEX_APP_SERVER_CONTEXT_ENGINE_HOST_CAPABILITIES,
     deliveryDefaults: {

--- a/extensions/copilot/harness.test.ts
+++ b/extensions/copilot/harness.test.ts
@@ -161,6 +161,8 @@ describe("createCopilotAgentHarness", () => {
   it("supports returns false in auto runtime even for github provider", () => {
     const harness = createCopilotAgentHarness();
 
+    expect(harness.autoSelection?.providerIds).toEqual([]);
+
     expect(
       harness.supports({
         provider: "github-copilot",

--- a/extensions/copilot/harness.ts
+++ b/extensions/copilot/harness.ts
@@ -657,6 +657,7 @@ export function createCopilotAgentHarness(
   return {
     id: options?.id ?? "copilot",
     label: options?.label ?? "GitHub Copilot agent runtime",
+    autoSelection: { providerIds: [] },
 
     supports(ctx) {
       const requestedRuntime = String(ctx.requestedRuntime ?? "")

--- a/src/agents/harness/auto-selection.ts
+++ b/src/agents/harness/auto-selection.ts
@@ -1,0 +1,22 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { AgentHarness, AgentHarnessSupport } from "./types.js";
+
+/** Returns a prepared negative auto-selection fact, or undefined when full support needs probing. */
+export function resolveAgentHarnessAutoSelectionHint(params: {
+  harness: AgentHarness;
+  provider: string;
+}): AgentHarnessSupport | undefined {
+  const providerIds = params.harness.autoSelection?.providerIds;
+  if (providerIds === undefined) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(params.provider);
+  if (providerIds.some((id) => normalizeProviderId(id) === provider)) {
+    return undefined;
+  }
+  return {
+    supported: false,
+    reason:
+      providerIds.length === 0 ? "harness is explicit-only" : "provider is not auto-selectable",
+  };
+}

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1007,6 +1007,23 @@ describe("selectAgentHarness", () => {
     expect(supports).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects statically unrelated auto harnesses before provider discovery", () => {
+    const supports = vi.fn(() => ({ supported: true as const, priority: 100 }));
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      autoSelection: { providerIds: ["openai", "codex"] },
+      supports,
+      runAttempt: vi.fn(async () => createAttemptResult("codex")),
+    });
+
+    expect(selectAgentHarness({ provider: "deepseek", modelId: "deepseek-v4-pro" }).id).toBe(
+      "openclaw",
+    );
+    expect(supports).not.toHaveBeenCalled();
+    expect(providerOwnerMocks.resolveProviderRefOwnership).not.toHaveBeenCalled();
+  });
+
   it("auto-selects the highest-priority plugin harness without duplicate support probes", () => {
     const lowPrioritySupports = vi.fn(() => ({
       supported: true as const,

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -50,7 +50,6 @@ import type { AgentHarness, AgentHarnessSupport, AgentHarnessSupportContext } fr
 
 const log = createSubsystemLogger("agents/harness");
 export { resolveAgentHarnessPolicy } from "./policy.js";
-export type { AgentHarnessPolicy };
 
 type AgentHarnessAvailabilityParams = {
   provider?: string;

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -31,6 +31,7 @@ import {
 import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
 import { expandToolGroups, mergeAlsoAllowPolicy, normalizeToolName } from "../tool-policy.js";
 import type { SystemAgentToolOptions } from "../tools/system-agent-tool.js";
+import { resolveAgentHarnessAutoSelectionHint } from "./auto-selection.js";
 import { createOpenClawAgentHarness } from "./builtin-openclaw.js";
 import { MissingAgentHarnessError } from "./errors.js";
 import { runAgentHarnessLifecycleAttempt } from "./lifecycle.js";
@@ -389,29 +390,35 @@ function selectAgentHarnessDecision(
     throw new MissingAgentHarnessError(runtime);
   }
 
-  const candidates =
-    pluginHarnesses.length > 0
-      ? (() => {
-          const supportContext = buildAgentHarnessSupportContext({
+  const hintedCandidates = pluginHarnesses.map((harness) => ({
+    harness,
+    support: resolveAgentHarnessAutoSelectionHint({ harness, provider: params.provider }),
+  }));
+  const candidates = hintedCandidates.some((entry) => entry.support === undefined)
+    ? (() => {
+        const supportContext = buildAgentHarnessSupportContext({
+          provider: params.provider,
+          modelId: params.modelId,
+          modelProvider: params.modelProvider,
+          requestedRuntime: runtime,
+          config: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          preparedModelProvider: params.preparedModelProvider,
+          providerOwnership: resolveProviderRefOwnership({
             provider: params.provider,
-            modelId: params.modelId,
-            modelProvider: params.modelProvider,
-            requestedRuntime: runtime,
             config: params.config,
-            agentId: params.agentId,
-            sessionKey: params.sessionKey,
-            preparedModelProvider: params.preparedModelProvider,
-            providerOwnership: resolveProviderRefOwnership({
-              provider: params.provider,
-              config: params.config,
-            }),
-          });
-          return pluginHarnesses.map((harness) => ({
-            harness,
-            support: harness.supports(supportContext),
-          }));
-        })()
-      : [];
+          }),
+        });
+        return hintedCandidates.map(({ harness, support }) => ({
+          harness,
+          support: support ?? harness.supports(supportContext),
+        }));
+      })()
+    : hintedCandidates.map(({ harness, support }) => ({
+        harness,
+        support: support as AgentHarnessSupport,
+      }));
   const supported = candidates
     .filter(
       (

--- a/src/agents/harness/support.ts
+++ b/src/agents/harness/support.ts
@@ -15,6 +15,7 @@ import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { hasModelExtraParams } from "../model-extra-params.js";
 import { canonicalizeProviderModelId } from "../provider-model-route.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
+import { resolveAgentHarnessAutoSelectionHint } from "./auto-selection.js";
 import { listRegisteredAgentHarnesses } from "./registry.js";
 import type {
   AgentHarness,
@@ -215,12 +216,26 @@ export function resolveAutoAgentHarnessId(params: {
   agentId?: string;
   sessionKey?: string;
 }): string | undefined {
+  const registeredHarnesses = listRegisteredAgentHarnesses();
+  if (registeredHarnesses.length === 0) {
+    return undefined;
+  }
+  const candidates = registeredHarnesses.map(({ harness }) => ({
+    harness,
+    support: resolveAgentHarnessAutoSelectionHint({ harness, provider: params.provider }),
+  }));
+  if (candidates.every((entry) => entry.support !== undefined)) {
+    return undefined;
+  }
   const supportContext = buildAgentHarnessSupportContext({
     ...params,
     requestedRuntime: "auto",
   });
-  return listRegisteredAgentHarnesses()
-    .map(({ harness }) => ({ harness, support: harness.supports(supportContext) }))
+  return candidates
+    .map(({ harness, support }) => ({
+      harness,
+      support: support ?? harness.supports(supportContext),
+    }))
     .filter(isSupportedHarness)
     .toSorted(compareHarnessSupport)[0]?.harness.id;
 }

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -145,6 +145,11 @@ type AgentHarnessRunCapability = {
   label: string;
   pluginId?: string;
   /**
+   * Exhaustive provider ids eligible for automatic selection. Omitting this hint preserves
+   * dynamic probing; an empty list marks an explicit-only harness.
+   */
+  autoSelection?: { providerIds: readonly string[] };
+  /**
    * Plugin ids this harness owner permits to execute its locked sessions.
    * Delegates receive work admission and execution only; session mutation stays owner-only.
    */

--- a/src/agents/thinking-runtime.test.ts
+++ b/src/agents/thinking-runtime.test.ts
@@ -65,6 +65,28 @@ describe("resolveEffectiveAgentRuntime", () => {
     ).toBe("openclaw");
   });
 
+  it("uses static auto-selection facts before resolving provider routes", () => {
+    const supports = vi.fn<AgentHarness["supports"]>(() => ({ supported: true, priority: 100 }));
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      autoSelection: { providerIds: ["openai", "codex"] },
+      supports,
+      runAttempt: async () => {
+        throw new Error("not exercised");
+      },
+    });
+
+    expect(
+      resolveEffectiveAgentRuntime({
+        cfg: {},
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+      }),
+    ).toBe("openclaw");
+    expect(supports).not.toHaveBeenCalled();
+  });
+
   it("keeps an authored custom route on OpenClaw before registered harness selection", () => {
     const supports = vi.fn<AgentHarness["supports"]>(({ provider }) =>
       provider === "openai" ? { supported: true, priority: 100 } : { supported: false },

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../agents/subagent-registry.test-helpers.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ModelDefinitionConfig } from "../../config/types.models.js";
+import type { ProviderThinkingProfile } from "../../plugins/provider-thinking.types.js";
 import {
   completeTaskRunByRunId,
   createQueuedTaskRun,
@@ -40,6 +41,14 @@ const providerUsageMock = vi.hoisted(() => ({
     updatedAt: Date.now(),
     providers: [],
   })),
+}));
+const activeProviderThinkingMock = vi.hoisted(() => ({
+  resolveThinkingProfile: vi.fn<
+    (params: {
+      provider: string;
+      context: { modelId: string };
+    }) => ProviderThinkingProfile | null | undefined
+  >(() => undefined),
 }));
 type StatusPluginHealthSnapshot =
   import("../../status/status-plugin-health.js").StatusPluginHealthSnapshot;
@@ -72,6 +81,11 @@ vi.mock("../../infra/provider-usage.js", async (importOriginal) => {
     loadProviderUsageSummary: providerUsageMock.loadProviderUsageSummary,
   };
 });
+
+vi.mock("../../plugins/provider-thinking-active.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/provider-thinking-active.js")>()),
+  resolveActiveProviderThinkingProfile: activeProviderThinkingMock.resolveThinkingProfile,
+}));
 
 vi.mock("../../status/status-plugin-health.runtime.js", () => pluginHealthRuntimeMock);
 
@@ -201,6 +215,8 @@ afterEach(() => {
     updatedAt: Date.now(),
     providers: [],
   });
+  activeProviderThinkingMock.resolveThinkingProfile.mockReset();
+  activeProviderThinkingMock.resolveThinkingProfile.mockReturnValue(undefined);
   pluginHealthRuntimeMock.collectInstalledPluginHealthSnapshot.mockReset();
   pluginHealthRuntimeMock.collectInstalledPluginHealthSnapshot.mockResolvedValue({
     plugins: [],
@@ -2273,6 +2289,46 @@ describe("buildStatusReply subagent summary", () => {
     const normalized = normalizeTestText(text);
     expect(normalized).toContain("Think: max");
     expect(normalized).not.toContain("Think: ultra");
+  });
+
+  it("clamps off to the active provider's always-thinking level", async () => {
+    activeProviderThinkingMock.resolveThinkingProfile.mockReturnValue({
+      levels: [{ id: "max", label: "max" }],
+      defaultLevel: "max",
+    });
+
+    const text = await buildStatusText({
+      cfg: baseCfg,
+      sessionEntry: {
+        sessionId: "sess-status-kimi-k3",
+        updatedAt: 0,
+        thinkingLevel: "off",
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "mobilechat",
+      provider: "moonshot",
+      model: "kimi-k3",
+      contextTokens: 262_144,
+      resolvedThinkLevel: "off",
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+    });
+
+    expect(normalizeTestText(text)).toContain("Think: max");
+    expect(activeProviderThinkingMock.resolveThinkingProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "moonshot",
+        context: expect.objectContaining({ modelId: "kimi-k3" }),
+      }),
+    );
   });
 
   it("treats the persisted harness id as observational in /status", async () => {

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -137,6 +137,7 @@ function registerStatusCodexHarness(): void {
   const harness: AgentHarness = {
     id: "codex",
     label: "Codex",
+    autoSelection: { providerIds: [...codexProviders] },
     supports: (ctx) =>
       codexProviders.has(ctx.provider.trim().toLowerCase())
         ? { supported: true, priority: 100 }
@@ -1528,6 +1529,7 @@ describe("buildStatusReply subagent summary", () => {
   });
 
   it("shows DeepSeek balance summaries in /status output", async () => {
+    registerStatusCodexHarness();
     providerUsageMock.loadProviderUsageSummary.mockResolvedValue({
       updatedAt: Date.now(),
       providers: [

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -142,6 +142,21 @@ describe("listThinkingLevels", () => {
     });
   });
 
+  it("can clamp from active provider facts without public artifact fallback", () => {
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "deepseek",
+        model: "deepseek-v4-pro",
+        level: "medium",
+        providerPolicySource: "active",
+      }),
+    ).toBe("medium");
+    expect(providerRuntimeMocks.resolveProviderThinkingProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "deepseek" }),
+      { allowPublicArtifactFallback: false },
+    );
+  });
+
   it("does not include adaptive without provider support", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("adaptive");
     expect(listThinkingLevels("openai", "gpt-5.4")).not.toContain("adaptive");

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -179,6 +179,7 @@ export function resolveThinkingProfile(params: {
   model?: string | null;
   catalog?: ThinkingCatalogEntry[];
   agentRuntime?: string | null;
+  providerPolicySource?: "active" | "active-or-bundled";
 }): ResolvedThinkingProfile {
   const context = resolveThinkingPolicyContext(params);
   if (!context.normalizedProvider) {
@@ -193,10 +194,16 @@ export function resolveThinkingProfile(params: {
     ...(context.params ? { params: context.params } : {}),
     compat: context.compat,
   };
-  const providerProfile = resolveProviderThinkingProfile({
+  const providerProfileParams = {
     provider: context.normalizedProvider,
     context: providerContext,
-  });
+  };
+  const providerProfile =
+    params.providerPolicySource === "active"
+      ? resolveProviderThinkingProfile(providerProfileParams, {
+          allowPublicArtifactFallback: false,
+        })
+      : resolveProviderThinkingProfile(providerProfileParams);
   // Any anthropic-messages catalog row routes through the canonical Claude
   // resolver: Claude families get the proper profile (incl. xhigh/adaptive/max);
   // non-Claude models on the anthropic-messages transport collapse to the Claude
@@ -377,12 +384,14 @@ export function resolveSupportedThinkingLevel(params: {
   level: ThinkLevel;
   catalog?: ThinkingCatalogEntry[];
   agentRuntime?: string | null;
+  providerPolicySource?: "active" | "active-or-bundled";
 }): ThinkLevel {
   const profile = resolveThinkingProfile({
     provider: params.provider,
     model: params.model,
     catalog: params.catalog,
     agentRuntime: params.agentRuntime,
+    providerPolicySource: params.providerPolicySource,
   });
   return resolveSupportedThinkingLevelFromProfile(profile, params.level);
 }

--- a/src/channels/plugins/acp-bindings.test.ts
+++ b/src/channels/plugins/acp-bindings.test.ts
@@ -7,7 +7,7 @@ import * as bindingRegistry from "./configured-binding-registry.js";
 const resolveAgentConfigMock = vi.hoisted(() => vi.fn());
 const resolveDefaultAgentIdMock = vi.hoisted(() => vi.fn());
 const resolveAgentWorkspaceDirMock = vi.hoisted(() => vi.fn());
-const getChannelPluginMock = vi.hoisted(() => vi.fn());
+const getLoadedChannelPluginMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: resolveAgentConfigMock,
@@ -16,7 +16,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("./index.js", () => ({
-  getChannelPlugin: getChannelPluginMock,
+  getLoadedChannelPlugin: getLoadedChannelPluginMock,
 }));
 
 function createConfig(options?: { bindingAgentId?: string; accountId?: string }) {
@@ -88,13 +88,13 @@ describe("configured binding registry", () => {
     resolveAgentConfigMock.mockReset().mockReturnValue(undefined);
     resolveDefaultAgentIdMock.mockReset().mockReturnValue("main");
     resolveAgentWorkspaceDirMock.mockReset().mockReturnValue("/tmp/workspace");
-    getChannelPluginMock.mockReset();
+    getLoadedChannelPluginMock.mockReset();
     ensureConfiguredBindingBuiltinsRegistered();
   });
 
   it("resolves configured ACP bindings from an already loaded channel plugin", () => {
     const plugin = createDiscordAcpPlugin();
-    getChannelPluginMock.mockReturnValue(plugin);
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
 
     const resolved = bindingRegistry.resolveConfiguredBindingRecord({
       cfg: createConfig() as never,
@@ -110,7 +110,7 @@ describe("configured binding registry", () => {
 
   it("resolves configured ACP bindings from canonical conversation refs", () => {
     const plugin = createDiscordAcpPlugin();
-    getChannelPluginMock.mockReturnValue(plugin);
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
 
     const resolved = bindingRegistry.resolveConfiguredBinding({
       cfg: createConfig() as never,
@@ -139,7 +139,7 @@ describe("configured binding registry", () => {
   it("primes compiled ACP bindings from the already loaded channel registry", () => {
     const plugin = createDiscordAcpPlugin();
     const cfg = createConfig({ bindingAgentId: "codex" });
-    getChannelPluginMock.mockReturnValue(plugin);
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
 
     const primed = bindingRegistry.primeConfiguredBindingRegistry({
       cfg: cfg as never,
@@ -166,7 +166,7 @@ describe("configured binding registry", () => {
 
   it("resolves wildcard binding session keys from the compiled registry", () => {
     const plugin = createDiscordAcpPlugin();
-    getChannelPluginMock.mockReturnValue(plugin);
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
 
     const resolved = bindingRegistry.resolveConfiguredBindingRecordBySessionKey({
       cfg: createConfig({ accountId: "*" }) as never,
@@ -196,10 +196,39 @@ describe("configured binding registry", () => {
     expect(resolved).toBeNull();
   });
 
+  it("skips ordinary route bindings before reading the loaded channel registry", () => {
+    const cfg = {
+      ...createConfig(),
+      bindings: [
+        {
+          agentId: "codex",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: {
+              kind: "channel",
+              id: "1479098716916023408",
+            },
+          },
+        },
+      ],
+    };
+
+    expect(
+      bindingRegistry.resolveConfiguredBindingRecord({
+        cfg: cfg as never,
+        channel: "discord",
+        accountId: "default",
+        conversationId: "1479098716916023408",
+      }),
+    ).toBeNull();
+    expect(getLoadedChannelPluginMock).not.toHaveBeenCalled();
+  });
+
   it("uses the current loaded channel plugin on each resolve", () => {
     const firstPlugin = createDiscordAcpPlugin();
     const secondPlugin = createDiscordAcpPlugin();
-    getChannelPluginMock.mockReturnValueOnce(firstPlugin).mockReturnValueOnce(secondPlugin);
+    getLoadedChannelPluginMock.mockReturnValueOnce(firstPlugin).mockReturnValueOnce(secondPlugin);
     const cfg = createConfig();
 
     bindingRegistry.resolveConfiguredBindingRecord({

--- a/src/channels/plugins/configured-binding-compiler.ts
+++ b/src/channels/plugins/configured-binding-compiler.ts
@@ -12,8 +12,11 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { pickFirstExistingAgentId } from "../../routing/resolve-route.js";
 import { resolveChannelConfiguredBindingProvider } from "./binding-provider.js";
 import type { CompiledConfiguredBinding, ConfiguredBindingChannel } from "./binding-types.js";
-import { resolveConfiguredBindingConsumer } from "./configured-binding-consumers.js";
-import { getChannelPlugin } from "./index.js";
+import {
+  resolveConfiguredBindingConsumer,
+  type ConfiguredBindingConsumer,
+} from "./configured-binding-consumers.js";
+import { getLoadedChannelPlugin } from "./index.js";
 import type {
   ChannelConfiguredBindingConversationRef,
   ChannelConfiguredBindingProvider,
@@ -28,7 +31,7 @@ function resolveLoadedChannelPlugin(channel: string) {
   if (!normalized) {
     return undefined;
   }
-  return getChannelPlugin(normalized as ConfiguredBindingChannel);
+  return getLoadedChannelPlugin(normalized as ConfiguredBindingChannel);
 }
 
 function resolveConfiguredBindingAdapter(channel: string): {
@@ -79,13 +82,10 @@ function compileConfiguredBindingRule(params: {
   target: ChannelConfiguredBindingConversationRef;
   bindingConversationId: string;
   provider: ChannelConfiguredBindingProvider;
+  consumer: ConfiguredBindingConsumer;
 }): CompiledConfiguredBinding | null {
   const agentId = pickFirstExistingAgentId(params.cfg, params.binding.agentId ?? "main");
-  const consumer = resolveConfiguredBindingConsumer(params.binding);
-  if (!consumer) {
-    return null;
-  }
-  const targetFactory = consumer.buildTargetFactory({
+  const targetFactory = params.consumer.buildTargetFactory({
     cfg: params.cfg,
     binding: params.binding,
     channel: params.channel,
@@ -126,6 +126,12 @@ function compileConfiguredBindingRegistry(params: {
   const rulesByChannel = new Map<ConfiguredBindingChannel, CompiledConfiguredBinding[]>();
 
   for (const binding of listConfiguredBindings(params.cfg)) {
+    // Ordinary routing bindings share the config array but have no stateful target consumer.
+    // Reject them before consulting the loaded channel registry on request-time route lookups.
+    const consumer = resolveConfiguredBindingConsumer(binding);
+    if (!consumer) {
+      continue;
+    }
     const bindingConversationId = resolveBindingConversationId(binding);
     if (!bindingConversationId) {
       continue;
@@ -152,6 +158,7 @@ function compileConfiguredBindingRegistry(params: {
       target,
       bindingConversationId,
       provider: resolvedChannel.provider,
+      consumer,
     });
     if (!rule) {
       continue;

--- a/src/plugins/provider-thinking-active.ts
+++ b/src/plugins/provider-thinking-active.ts
@@ -1,0 +1,85 @@
+// Reads provider thinking policy from the active runtime registry only.
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type {
+  ProviderDefaultThinkingPolicyContext,
+  ProviderThinkingProfile,
+  ProviderThinkingPolicyContext,
+} from "./provider-thinking.types.js";
+import { PLUGIN_REGISTRY_STATE } from "./runtime-state-key.js";
+
+type ActiveThinkingProvider = {
+  id: string;
+  aliases?: string[];
+  hookAliases?: string[];
+  isBinaryThinking?: (ctx: ProviderThinkingPolicyContext) => boolean | undefined;
+  supportsXHighThinking?: (ctx: ProviderThinkingPolicyContext) => boolean | undefined;
+  resolveThinkingProfile?: (
+    ctx: ProviderDefaultThinkingPolicyContext,
+  ) => ProviderThinkingProfile | null | undefined;
+  resolveDefaultThinkingLevel?: (
+    ctx: ProviderDefaultThinkingPolicyContext,
+  ) => "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | null | undefined;
+};
+
+type ActiveThinkingRegistryState = {
+  activeRegistry?: {
+    providers?: Array<{
+      provider: ActiveThinkingProvider;
+    }>;
+  } | null;
+};
+
+type ThinkingHookParams<TContext> = {
+  provider: string;
+  context: TContext;
+};
+
+function matchesProviderId(provider: ActiveThinkingProvider, providerId: string): boolean {
+  const normalized = normalizeProviderId(providerId);
+  if (!normalized) {
+    return false;
+  }
+  if (normalizeProviderId(provider.id) === normalized) {
+    return true;
+  }
+  return [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
+    (alias) => normalizeProviderId(alias) === normalized,
+  );
+}
+
+function resolveActiveThinkingProvider(providerId: string): ActiveThinkingProvider | undefined {
+  const state = (
+    globalThis as typeof globalThis & {
+      [PLUGIN_REGISTRY_STATE]?: ActiveThinkingRegistryState;
+    }
+  )[PLUGIN_REGISTRY_STATE];
+  return state?.activeRegistry?.providers?.find((entry) =>
+    matchesProviderId(entry.provider, providerId),
+  )?.provider;
+}
+
+export function resolveActiveProviderBinaryThinking(
+  params: ThinkingHookParams<ProviderThinkingPolicyContext>,
+) {
+  return resolveActiveThinkingProvider(params.provider)?.isBinaryThinking?.(params.context);
+}
+
+export function resolveActiveProviderXHighThinking(
+  params: ThinkingHookParams<ProviderThinkingPolicyContext>,
+) {
+  return resolveActiveThinkingProvider(params.provider)?.supportsXHighThinking?.(params.context);
+}
+
+export function resolveActiveProviderThinkingProfile(
+  params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
+) {
+  return resolveActiveThinkingProvider(params.provider)?.resolveThinkingProfile?.(params.context);
+}
+
+export function resolveActiveProviderDefaultThinkingLevel(
+  params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
+) {
+  return resolveActiveThinkingProvider(params.provider)?.resolveDefaultThinkingLevel?.(
+    params.context,
+  );
+}

--- a/src/plugins/provider-thinking.ts
+++ b/src/plugins/provider-thinking.ts
@@ -89,12 +89,16 @@ export function resolveProviderXHighThinking(
 /** Resolves a provider thinking profile from active plugins or bundled policy surface. */
 export function resolveProviderThinkingProfile(
   params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
+  options?: { allowPublicArtifactFallback?: boolean },
 ) {
   const activeProfile = resolveActiveThinkingProvider(params.provider)?.resolveThinkingProfile?.(
     params.context,
   );
   if (activeProfile !== undefined) {
     return activeProfile;
+  }
+  if (options?.allowPublicArtifactFallback === false) {
+    return undefined;
   }
   return resolveProviderPublicPolicySurface(params.provider)?.resolveThinkingProfile?.(
     params.context,

--- a/src/plugins/provider-thinking.ts
+++ b/src/plugins/provider-thinking.ts
@@ -1,61 +1,16 @@
-// Resolves provider thinking-level policy from plugin metadata.
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+// Resolves provider thinking-level policy from active plugins or plugin metadata.
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveProviderPolicySurface } from "./provider-public-artifacts.js";
+import {
+  resolveActiveProviderBinaryThinking,
+  resolveActiveProviderDefaultThinkingLevel,
+  resolveActiveProviderThinkingProfile,
+  resolveActiveProviderXHighThinking,
+} from "./provider-thinking-active.js";
 import type {
   ProviderDefaultThinkingPolicyContext,
-  ProviderThinkingProfile,
   ProviderThinkingPolicyContext,
 } from "./provider-thinking.types.js";
-import { PLUGIN_REGISTRY_STATE } from "./runtime-state-key.js";
-
-type ThinkingProviderPlugin = {
-  id: string;
-  aliases?: string[];
-  hookAliases?: string[];
-  isBinaryThinking?: (ctx: ProviderThinkingPolicyContext) => boolean | undefined;
-  supportsXHighThinking?: (ctx: ProviderThinkingPolicyContext) => boolean | undefined;
-  resolveThinkingProfile?: (
-    ctx: ProviderDefaultThinkingPolicyContext,
-  ) => ProviderThinkingProfile | null | undefined;
-  resolveDefaultThinkingLevel?: (
-    ctx: ProviderDefaultThinkingPolicyContext,
-  ) => "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | null | undefined;
-};
-
-type ThinkingRegistryState = {
-  activeRegistry?: {
-    providers?: Array<{
-      provider: ThinkingProviderPlugin;
-    }>;
-  } | null;
-};
-
-function matchesProviderId(provider: ThinkingProviderPlugin, providerId: string): boolean {
-  const normalized = normalizeProviderId(providerId);
-  if (!normalized) {
-    return false;
-  }
-  if (normalizeProviderId(provider.id) === normalized) {
-    return true;
-  }
-  return [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
-    (alias) => normalizeProviderId(alias) === normalized,
-  );
-}
-
-function resolveActiveThinkingProvider(providerId: string): ThinkingProviderPlugin | undefined {
-  const state = (
-    globalThis as typeof globalThis & { [PLUGIN_REGISTRY_STATE]?: ThinkingRegistryState }
-  )[PLUGIN_REGISTRY_STATE];
-  const activeProvider = state?.activeRegistry?.providers?.find((entry) => {
-    return matchesProviderId(entry.provider, providerId);
-  })?.provider;
-  if (activeProvider) {
-    return activeProvider;
-  }
-  return undefined;
-}
 
 function resolveProviderPublicPolicySurface(providerId: string) {
   const metadataSnapshot = getCurrentPluginMetadataSnapshot({
@@ -76,14 +31,14 @@ type ThinkingHookParams<TContext> = {
 export function resolveProviderBinaryThinking(
   params: ThinkingHookParams<ProviderThinkingPolicyContext>,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.isBinaryThinking?.(params.context);
+  return resolveActiveProviderBinaryThinking(params);
 }
 
 /** Resolves whether a provider supports xhigh thinking. */
 export function resolveProviderXHighThinking(
   params: ThinkingHookParams<ProviderThinkingPolicyContext>,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.supportsXHighThinking?.(params.context);
+  return resolveActiveProviderXHighThinking(params);
 }
 
 /** Resolves a provider thinking profile from active plugins or bundled policy surface. */
@@ -91,9 +46,7 @@ export function resolveProviderThinkingProfile(
   params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
   options?: { allowPublicArtifactFallback?: boolean },
 ) {
-  const activeProfile = resolveActiveThinkingProvider(params.provider)?.resolveThinkingProfile?.(
-    params.context,
-  );
+  const activeProfile = resolveActiveProviderThinkingProfile(params);
   if (activeProfile !== undefined) {
     return activeProfile;
   }
@@ -109,7 +62,5 @@ export function resolveProviderThinkingProfile(
 export function resolveProviderDefaultThinkingLevel(
   params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.resolveDefaultThinkingLevel?.(
-    params.context,
-  );
+  return resolveActiveProviderDefaultThinkingLevel(params);
 }

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -11,6 +11,9 @@ import {
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { resolveContextTokensForModel, waitForContextWindowCacheLoad } from "../agents/context.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
+import { resolveAgentHarnessAutoSelectionHint } from "../agents/harness/auto-selection.js";
+import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
+import { listRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
 import {
   areRuntimeModelRefsEquivalent,
@@ -26,7 +29,7 @@ import {
 } from "../agents/tools/sessions-helpers.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
-import { resolveSupportedThinkingLevel, type ThinkLevel } from "../auto-reply/thinking.js";
+import type { ThinkLevel } from "../auto-reply/thinking.js";
 import { toAgentModelListLike } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
@@ -105,9 +108,10 @@ const loadStatusMessageRuntime = createLazyPromise(
     import("./status-message.runtime.js").then((module) => module.loadStatusMessageRuntimeModule()),
   { cacheRejections: true },
 );
-const loadAgentHarnessSelectionRuntime = createLazyRuntimeModule(
-  () => import("../agents/harness/selection.js"),
+const loadAgentThinkingRuntime = createLazyRuntimeModule(
+  () => import("../agents/thinking-runtime.js"),
 );
+const loadThinkingLevelRuntime = createLazyRuntimeModule(() => import("../auto-reply/thinking.js"));
 const loadStatusSubagentsRuntime = createLazyRuntimeModule(
   () => import("./status-subagents.runtime.js"),
 );
@@ -214,22 +218,42 @@ async function resolveStatusHarnessId(params: {
   sessionEntry?: SessionEntry;
 }): Promise<string | undefined> {
   try {
-    const { selectAgentHarness } = await loadAgentHarnessSelectionRuntime();
-    const agentHarnessRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
+    const sessionRuntime = resolveSessionRuntimeOverrideForProvider({
       provider: params.provider,
       entry: params.sessionEntry,
       cfg: params.cfg,
     });
-    const selected = selectAgentHarness({
+    const configuredRuntime = resolveAgentHarnessPolicy({
       provider: params.provider,
       modelId: params.model,
       config: params.cfg,
       agentId: params.agentId,
       sessionKey: params.sessionKey,
-      agentHarnessRuntimeOverride,
+    }).runtime;
+    const runtime = sessionRuntime ?? configuredRuntime;
+    if (runtime !== "auto") {
+      return normalizeOptionalLowercaseString(runtime) || undefined;
+    }
+    const registeredHarnesses = listRegisteredAgentHarnesses();
+    if (
+      registeredHarnesses.every(
+        ({ harness }) =>
+          resolveAgentHarnessAutoSelectionHint({ harness, provider: params.provider }) !==
+          undefined,
+      )
+    ) {
+      return "openclaw";
+    }
+    const { resolveEffectiveAgentRuntime } = await loadAgentThinkingRuntime();
+    const id = resolveEffectiveAgentRuntime({
+      cfg: params.cfg,
+      provider: params.provider,
+      modelId: params.model,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      sessionEntry: params.sessionEntry,
     });
-    const id = normalizeOptionalLowercaseString(selected.id);
-    return id || undefined;
+    return normalizeOptionalLowercaseString(id) || undefined;
   } catch {
     // Harness selection is nice-to-have for display. Status should still render
     // if dynamic harness modules are unavailable.
@@ -597,12 +621,23 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     (await resolveDefaultThinkingLevel()) ??
     (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
     "off";
-  const effectiveThinkLevel = resolveSupportedThinkingLevel({
-    provider: selectedLookupProvider,
-    model: selectedLookupModel,
-    level: requestedThinkLevel,
-    agentRuntime: effectiveHarness,
-  });
+  const effectiveThinkLevel =
+    requestedThinkLevel === "off"
+      ? "off"
+      : (await loadThinkingLevelRuntime()).resolveSupportedThinkingLevel({
+          provider: selectedLookupProvider,
+          model: selectedLookupModel,
+          level: requestedThinkLevel,
+          agentRuntime: effectiveHarness,
+          // Status uses loaded provider facts unless Codex needs OpenAI's static thinking contract.
+          providerPolicySource:
+            normalizeOptionalLowercaseString(effectiveHarness) === "codex" &&
+            ["codex", "openai"].includes(
+              normalizeOptionalLowercaseString(selectedLookupProvider) ?? "",
+            )
+              ? "active-or-bundled"
+              : "active",
+        });
   return buildStatusMessage({
     config: cfg,
     agent: {

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -39,6 +39,7 @@ import {
   loadProviderUsageSummary,
   resolveUsageProviderId,
 } from "../infra/provider-usage.js";
+import { resolveActiveProviderThinkingProfile } from "../plugins/provider-thinking-active.js";
 import { normalizeAccountId } from "../routing/account-id.js";
 import { resolveNormalizedAccountEntry } from "../routing/account-lookup.js";
 import { createLazyPromise, createLazyRuntimeModule } from "../shared/lazy-runtime.js";
@@ -621,8 +622,25 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     (await resolveDefaultThinkingLevel()) ??
     (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
     "off";
-  const effectiveThinkLevel =
+  // Active profiles can forbid `off` (for example, always-thinking models). Absence means
+  // there is no prepared policy fact, so status must not fall back to manifest discovery.
+  const activeThinkingProfile =
     requestedThinkLevel === "off"
+      ? resolveActiveProviderThinkingProfile({
+          provider: selectedLookupProvider,
+          context: {
+            provider: selectedLookupProvider,
+            modelId: selectedLookupModel,
+            agentRuntime: effectiveHarness,
+          },
+        })
+      : undefined;
+  const activeProfileSupportsOff = activeThinkingProfile?.levels.some(
+    (level) => level.id === "off",
+  );
+  const effectiveThinkLevel =
+    requestedThinkLevel === "off" &&
+    (activeThinkingProfile == null || activeProfileSupportsOff === true)
       ? "off"
       : (await loadThinkingLevelRuntime()).resolveSupportedThinkingLevel({
           provider: selectedLookupProvider,


### PR DESCRIPTION
Related: #41608

## What Problem This Solves

Fixes an issue where status rendering and configured binding resolution could cold-load plugin manifests and evaluate bundled plugin source through jiti on request-time paths. CPU profiles showed one Slack routing test spending most of its runtime in jiti and filesystem discovery, while `/status` repeated the same work for providers absent from the active registry.

## Why This Change Was Made

Configured binding compilation now rejects ordinary route bindings before consulting the loaded channel registry, and stateful bindings use only active channel plugins. Agent harness auto-selection and status thinking resolution now consume registered harness hints and active provider facts. A lightweight active-registry thinking projection preserves always-thinking provider clamps without restoring manifest discovery. Dynamic probing remains for external harnesses that do not publish hints, and Codex retains its static OpenAI thinking policy.

No changelog edit: release-note context belongs in the PR body for this maintainer change.

## User Impact

Gateway routing and `/status` avoid broad plugin discovery on hot paths. Existing explicit harness selection, unknown external harness probing, ACP bindings, always-thinking models, and Codex thinking-level behavior remain intact.

## Evidence

- Slack focused file: 65.46s test time before; 487ms after on Testbox. Local M4 wall time after: 12.00s (reported baseline: 43.7s).
- DeepSeek `/status`: 576ms solo locally after the final review fix (reported baseline: 4.8s).
- Focused files: 123 Slack tests and 41 status tests passed.
- Sibling coverage passed across thinking, harness selection/runtime, provider policy, Codex/Copilot harnesses, and ACP bindings.
- `pnpm build` passed.
- Exact changed-surface gate passed: formatting, tsgo, oxlint, SDK surfaces, plugin boundaries, import cycles, and storage/runtime guards.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29535537961
- Final autoreview: clean, no accepted/actionable findings.

AI-assisted. I reviewed the implementation and validation evidence.
