### PR TITLE
fix(qa): resolve profile channels through selected driver

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -521,7 +521,7 @@ describe("qa cli runtime", () => {
     expect(suiteArgs.channelDriverSelection).toBeUndefined();
   });
 
-  it("keeps channel-specific scenarios out of generic live profile runs", async () => {
+  it("keeps portable channel scenarios in driver-selected profile runs", async () => {
     await runQaProfileCommand({
       repoRoot: "/tmp/openclaw-repo",
       profile: "release",
@@ -532,7 +532,10 @@ describe("qa cli runtime", () => {
 
     const suiteArgs = mockFirstObjectArg(runQaSuite);
     expect(suiteArgs.scenarioIds).toContain("channel-chat-baseline");
-    expect(suiteArgs.scenarioIds).not.toContain("telegram-help-command");
+    expect(suiteArgs.scenarioIds).toContain("telegram-help-command");
+    expect(suiteArgs.adapterFactories).toBe(
+      listLiveTransportQaAdapterFactories.mock.results[0]?.value,
+    );
   });
 
   it("runs the all profile through the live taxonomy profile path", async () => {
@@ -781,14 +784,19 @@ describe("qa cli runtime", () => {
     expect(runQaSuite).not.toHaveBeenCalled();
   });
 
-  it("keeps live taxonomy metadata unchanged without an explicit adapter channel", async () => {
+  it("loads contributed adapters without preselecting a scenario channel", async () => {
     await runQaSuiteCommand({
       channelDriver: "live",
       scenarioIds: ["channel-chat-baseline"],
     });
 
     expect(runQaSuite).toHaveBeenCalledWith(
-      expect.not.objectContaining({ adapterFactories: expect.anything() }),
+      expect.objectContaining({
+        adapterFactories: listLiveTransportQaAdapterFactories.mock.results[0]?.value,
+      }),
+    );
+    expect(runQaSuite).toHaveBeenCalledWith(
+      expect.not.objectContaining({ channelId: expect.anything() }),
     );
   });
 

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -521,6 +521,20 @@ describe("qa cli runtime", () => {
     expect(suiteArgs.channelDriverSelection).toBeUndefined();
   });
 
+  it("keeps channel-specific scenarios out of generic live profile runs", async () => {
+    await runQaProfileCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      profile: "release",
+      surface: "channel-framework",
+      providerMode: "mock-openai",
+      scenarioIds: ["channel-chat-baseline", "telegram-help-command"],
+    });
+
+    const suiteArgs = mockFirstObjectArg(runQaSuite);
+    expect(suiteArgs.scenarioIds).toContain("channel-chat-baseline");
+    expect(suiteArgs.scenarioIds).not.toContain("telegram-help-command");
+  });
+
   it("runs the all profile through the live taxonomy profile path", async () => {
     await runQaProfileCommand({
       repoRoot: "/tmp/openclaw-repo",

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -795,13 +795,14 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     ) {
       return false;
     }
+    // Generic live profiles do not select a transport; dedicated channel commands own those
+    // adapters. Treating a scenario declaration as the selected channel misroutes the profile.
     const channel =
       profileReport.channelDriver === "qa-channel"
         ? "qa-channel"
-        : (scenario.execution.channel ??
-          (profileReport.channelDriver === "crabline"
-            ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL
-            : undefined));
+        : profileReport.channelDriver === "crabline"
+          ? (scenario.execution.channel ?? OPENCLAW_CRABLINE_DEFAULT_CHANNEL)
+          : undefined;
     return scenarioMatchesQaProviderLane({
       scenario,
       providerMode: normalizedProviderMode,

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -795,14 +795,13 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     ) {
       return false;
     }
-    // Generic live profiles do not select a transport; dedicated channel commands own those
-    // adapters. Treating a scenario declaration as the selected channel misroutes the profile.
     const channel =
       profileReport.channelDriver === "qa-channel"
         ? "qa-channel"
-        : profileReport.channelDriver === "crabline"
-          ? (scenario.execution.channel ?? OPENCLAW_CRABLINE_DEFAULT_CHANNEL)
-          : undefined;
+        : (scenario.execution.channel ??
+          (profileReport.channelDriver === "crabline"
+            ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL
+            : undefined));
     return scenarioMatchesQaProviderLane({
       scenario,
       providerMode: normalizedProviderMode,
@@ -995,7 +994,8 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     throw new Error("--channel override requires --channel-driver crabline or live.");
   }
   const liveChannelId = channelDriver === "live" ? opts.channel?.trim() : undefined;
-  const liveAdapterFactories = liveChannelId ? listLiveTransportQaAdapterFactories() : undefined;
+  const liveAdapterFactories =
+    channelDriver === "live" ? listLiveTransportQaAdapterFactories() : undefined;
   const liveAdapterFactory = liveChannelId
     ? liveAdapterFactories?.find((factory) => factory.id === liveChannelId)
     : undefined;
@@ -1126,10 +1126,10 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       evidenceMode: opts.evidenceMode,
       transportId,
       channelDriver,
-      ...(liveChannelId
+      ...(liveAdapterFactories
         ? {
             adapterFactories: liveAdapterFactories,
-            channelId: liveChannelId,
+            ...(liveChannelId ? { channelId: liveChannelId } : {}),
             adapterOptions: {
               repoRoot,
               sutAccountId: opts.sutAccountId,

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -186,7 +186,7 @@ describe("qa suite runtime launcher", () => {
     expect(runQaTestFileScenarios).not.toHaveBeenCalled();
   });
 
-  it("runs runtime-specific live scenarios in dedicated workers", async () => {
+  it("runs runtime-specific channel scenarios in dedicated workers", async () => {
     const repoRoot = await makeTempRepo("qa-suite-live-runtime-");
     await runQaSuite({
       repoRoot,
@@ -211,6 +211,81 @@ describe("qa suite runtime launcher", () => {
         outputDir: path.join(outputDir, "runtime-codex-1"),
         forcedRuntime: "codex",
         scenarioIds: ["slack-codex-approval-exec-native"],
+      }),
+    );
+  });
+
+  it("partitions portable scenarios by channel for a pluggable driver", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-pluggable-channels-");
+    const adapterFactories = [
+      {
+        id: "portable-driver",
+        matches: vi.fn(),
+        create: vi.fn(),
+      },
+    ];
+
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/pluggable-channels",
+      providerMode: "mock-openai",
+      channelDriver: "live",
+      adapterFactories,
+      scenarioIds: ["channel-chat-baseline", "telegram-help-command", "matrix-restart-resume"],
+    });
+
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "pluggable-channels");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(3);
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterFactories,
+        channelId: undefined,
+        outputDir: path.join(outputDir, "flow"),
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterFactories,
+        channelId: "telegram",
+        outputDir: path.join(outputDir, "flow", "telegram"),
+        scenarioIds: ["telegram-help-command"],
+      }),
+    );
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterFactories,
+        channelId: "matrix",
+        outputDir: path.join(outputDir, "flow", "matrix"),
+        scenarioIds: ["matrix-restart-resume"],
+      }),
+    );
+  });
+
+  it("binds one portable channel scenario without an explicit channel override", async () => {
+    const adapterFactories = [
+      {
+        id: "portable-driver",
+        matches: vi.fn(),
+        create: vi.fn(),
+      },
+    ];
+
+    const result = await runQaSuite({
+      repoRoot: process.cwd(),
+      providerMode: "mock-openai",
+      channelDriver: "live",
+      adapterFactories,
+      scenarioIds: ["telegram-help-command"],
+    });
+
+    expect(result.executionKind).toBe("suite");
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterFactories,
+        channelId: "telegram",
+        scenarioIds: ["telegram-help-command"],
       }),
     );
   });

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -93,6 +93,7 @@ type QaUnifiedPartitionTask = {
 
 type QaFlowChannelGroup = {
   channel: string | undefined;
+  channelId: string | undefined;
   channelDriverSelection: QaSuiteRunParams["channelDriverSelection"];
   scenarios: QaSeedScenarioWithSource[];
 };
@@ -132,10 +133,37 @@ async function resolveQaFlowChannelGroups(
   runParams: QaSuiteRunParams | undefined,
   scenarios: readonly QaSeedScenarioWithSource[],
 ): Promise<QaFlowChannelGroup[]> {
+  if (runParams?.adapterFactories) {
+    const explicitChannel = runParams.channelId?.trim().toLowerCase();
+    if (explicitChannel) {
+      return [
+        {
+          channel: explicitChannel,
+          channelId: explicitChannel,
+          channelDriverSelection: runParams.channelDriverSelection,
+          scenarios: [...scenarios],
+        },
+      ];
+    }
+    const groups = new Map<string | undefined, QaSeedScenarioWithSource[]>();
+    for (const scenario of scenarios) {
+      const channel = normalizeQaSuiteScenarioChannel(scenario);
+      const group = groups.get(channel) ?? [];
+      group.push(scenario);
+      groups.set(channel, group);
+    }
+    return [...groups].map(([channel, groupedScenarios]) => ({
+      channel,
+      channelId: channel,
+      channelDriverSelection: runParams.channelDriverSelection,
+      scenarios: groupedScenarios,
+    }));
+  }
   if (runParams?.channelDriver !== "crabline") {
     return [
       {
-        channel: runParams?.channelDriverSelection?.channel,
+        channel: runParams?.channelId ?? runParams?.channelDriverSelection?.channel,
+        channelId: runParams?.channelId,
         channelDriverSelection: runParams?.channelDriverSelection,
         scenarios: [...scenarios],
       },
@@ -155,6 +183,7 @@ async function resolveQaFlowChannelGroups(
     return [
       {
         channel: singleChannel,
+        channelId: undefined,
         channelDriverSelection:
           runParams.channelDriverSelection ??
           resolveOpenClawCrablineChannelDriverSelection({ channel: singleChannel }),
@@ -166,6 +195,7 @@ async function resolveQaFlowChannelGroups(
   // launch one flow partition per channel and aggregate them at this owner.
   return channels.map((channel) => ({
     channel,
+    channelId: undefined,
     channelDriverSelection: resolveOpenClawCrablineChannelDriverSelection({ channel }),
     scenarios: scenarios.filter(
       (scenario) =>
@@ -196,10 +226,14 @@ async function resolveSuiteExecutionPlan(
     scenarios.push(scenario);
     testFileScenariosByKind.set(scenario.execution.kind, scenarios);
   }
+  const channelGroups = (await resolveQaFlowChannelGroups(params, flowScenarios)).filter(
+    (group) => group.scenarios.length > 0,
+  );
   const requiresFlowPartitions =
-    (await resolveQaFlowChannelGroups(params, flowScenarios)).filter(
-      (group) => group.scenarios.length > 0,
-    ).length > 1 ||
+    channelGroups.length > 1 ||
+    channelGroups.some(
+      (group) => group.channelId !== undefined && group.channelId !== params?.channelId,
+    ) ||
     (flowScenarios.length > 1 && flowScenarios.some(scenarioRequiresIsolatedQaSuiteWorker));
   if (testFileScenariosByKind.size === 0 && !requiresFlowPartitions) {
     return { kind: "flow" };
@@ -560,12 +594,18 @@ async function runUnifiedQaSuite(params: {
       const ordinaryIsolatedFlowScenarios = isolatedFlowScenarios.filter(
         (scenario) => !runtimeScenarioSet.has(scenario),
       );
-      const sharedFlowPartitions = partitionSharedFlowScenarios(sharedFlowScenarios, concurrency);
+      const usesContributedChannelDriver = Boolean(
+        channelGroup.channelId && params.runParams?.adapterFactories,
+      );
+      const sharedFlowPartitions = partitionSharedFlowScenarios(
+        sharedFlowScenarios,
+        usesContributedChannelDriver ? 1 : concurrency,
+      );
       // Channel-driver flow workers each launch a gateway plus transport harness.
       // Serializing their isolated workers keeps state-mutating smoke checks from
       // flaking under concurrent child gateways while preserving non-driver speed.
       const channelDriverFlowRequiresExclusiveWorkers = Boolean(
-        channelGroup.channelDriverSelection,
+        channelGroup.channelDriverSelection || usesContributedChannelDriver,
       );
       const isolatedFlowConcurrencyLimit = channelDriverFlowRequiresExclusiveWorkers
         ? 1
@@ -633,6 +673,7 @@ async function runUnifiedQaSuite(params: {
                   ? (partition.scenarios[0].execution.runtime ?? params.runParams?.forcedRuntime)
                   : params.runParams?.forcedRuntime,
               concurrency: partition.concurrency,
+              channelId: channelGroup.channelId,
               channelDriverSelection: channelGroup.channelDriverSelection,
               workerStartStaggerMs: isolatedPartition
                 ? (params.runParams?.workerStartStaggerMs ??


### PR DESCRIPTION
## What Problem This Solves

Fixes taxonomy-backed `release` and `all` QA profiles failing before writing `qa-evidence.json` after channel-driver eligibility moved from scenarios to the run. The profile selected portable scenarios from several logical channels, but the suite host passed them into one unbound driver lane and rejected them as channel mismatches.

## Why This Change Was Made

Profile selection now preserves every portable scenario whose provider/model constraints match. When the selected run driver is backed by contributed adapter factories, the suite host groups flow scenarios by `execution.channel`, binds each group to that logical channel through the same selected driver, and aggregates the partition evidence. Scenarios without a channel stay on the shared QA transport. Explicit channel overrides and Crabline's existing selection path remain unchanged.

This keeps channel and driver independent: scenarios declare a required logical channel when `execution.channel` is present, while the run chooses the interchangeable driver implementation. A selected driver that cannot provide that channel fails adapter resolution; there are no scenario-side `live` eligibility rules.

This PR is AI-assisted. The failure, profile-to-suite bridge, driver registry, channel grouping owner, focused regressions, and adjacent selection tests were reviewed directly.

## User Impact

No production messaging behavior changes. QA maintainers can run mixed-channel scorecard profiles without dropping channel coverage or failing lane validation before evidence generation.

## Evidence

- Before: [QA Profile Evidence run 29533288626](https://github.com/openclaw/openclaw/actions/runs/29533288626) failed on `main` SHA `6dc3e6055f65f2b1752f436d37a9ff02cd1bbecf` with 24 channel-lane mismatches and no evidence artifact.
- Regression proof: before the corrected implementation, the focused tests failed because `telegram-help-command` was dropped and contributed adapters produced no channel partitions. After the fix, 198/198 tests passed across `cli.runtime`, `suite-launch.runtime`, `suite`, `suite-planning`, and `scenario-lane`.
- Current-head CI: [run 29541037416](https://github.com/openclaw/openclaw/actions/runs/29541037416) passed all four QA smoke profile shards, production types, test types, channel contract shards, build artifacts, guards, and all compact test shards on refreshed head `a73b98285437e76761b284522e3aef388d96ac39`.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh Codex autoreview (`gpt-5.6-sol`, high reasoning) returned no findings and judged the corrected patch sound (confidence 0.86).
- Remaining red code checks are unrelated current-`main` failures in untouched ClickClack files: oxlint reports two errors in `extensions/clickclack/src/setup-core.ts`, while deadcode reports unused exports in that file and `extensions/clickclack/src/setup-claim.ts`.
- Dependency Guard, Security Sensitive Guard, and one Critical Quality selector repeatedly received GitHub `503 Service Unavailable` HTML from `gh api`; they produced no code finding.
- Blacksmith Testbox was unavailable during final local preparation (`backend.blacksmith.sh` API timeout), and direct AWS Crabbox lacked broker login.
