### PR TITLE
fix(codeql): allowlist openApnsTlsTunnel raw-socket owner scope

### DIFF
--- a/.github/codeql/openclaw-boundary/queries/raw-socket-callsite-classification.ql
+++ b/.github/codeql/openclaw-boundary/queries/raw-socket-callsite-classification.ql
@@ -70,6 +70,8 @@ predicate allowedRawSocketClientCall(Expr call) {
   or
   allowedOwnerScope(call, "src/infra/net/http-connect-tunnel.ts", "startTargetTls")
   or
+  allowedOwnerScope(call, "src/infra/push-apns-http2.ts", "openApnsTlsTunnel")
+  or
   allowedOwnerScope(call, "src/infra/push-apns-http2.ts", "openProxiedApnsHttp2Session")
   or
   allowedOwnerScope(call, "src/infra/push-apns-http2.ts", "connectApnsHttp2Session")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Critical Quality `network-runtime-boundary` fails closed on current `main` whenever a PR touches `extensions/codex/src/app-server/transport-websocket.ts` (or otherwise triggers the full raw-socket CodeQL shard), because `openApnsTlsTunnel` performs a managed `tls.connect` that is not classified in the owner allowlist.

## Why This Change Was Made

The proxy CONNECT refactor extracted APNs target TLS into `openApnsTlsTunnel`, but the raw-socket CodeQL allowlist still only named the outer `openProxiedApnsHttp2Session` / `connectApnsHttp2Session` scopes. CodeQL attributes the call to the immediate enclosing function (`openApnsTlsTunnel`), so the existing outer-function entries do not cover it.

This PR only restores the missing owner classification for that already-shipped managed APNs tunnel callsite. No runtime behavior change.

Collision check: searched open/closed PRs for `openApnsTlsTunnel` allowlist; only overlapping work was bundled inside [#106519](https://github.com/openclaw/openclaw/pull/106519), which ClawSweeper asked to split. This is that separated security-boundary unit.

## User Impact

- **Before:** Unrelated Codex/network PRs that trigger the full network-runtime CodeQL shard can fail on an unclassified APNs `tls.connect` that already exists on `main`.
- **After:** The managed APNs TLS tunnel owner is classified, so the shard can evaluate new raw-socket calls without failing on this pre-existing callsite.

## Evidence

Exact head: `d8fa51909878ac64fdddfbaa564d0bd451e624b5`

```bash
git show HEAD:.github/codeql/openclaw-boundary/queries/raw-socket-callsite-classification.ql | rg -n "openApnsTlsTunnel|openProxiedApnsHttp2Session|connectApnsHttp2Session"
```

```text
73:  allowedOwnerScope(call, "src/infra/push-apns-http2.ts", "openApnsTlsTunnel")
75:  allowedOwnerScope(call, "src/infra/push-apns-http2.ts", "openProxiedApnsHttp2Session")
77:  allowedOwnerScope(call, "src/infra/push-apns-http2.ts", "connectApnsHttp2Session")
```

Source proof that the callsite exists on current `main`:

```bash
git show origin/main:src/infra/push-apns-http2.ts | rg -n "async function openApnsTlsTunnel|tls\.connect"
```

```text
101:async function openApnsTlsTunnel(params: {
124:    targetTlsSocket = tls.connect({
```

What was not tested: did not re-run the full CodeQL Critical Quality job locally (requires GitHub CodeQL action). CI on this head is the validation path for the classification query.

## Risk / Compatibility

Low for runtime (query-only). Security-boundary change: expands the raw-socket allowlist by one already-managed APNs owner scope introduced by the CONNECT-tunnel refactor. Mitigation: keep the exception scoped to `openApnsTlsTunnel` only; no new egress path.


Made with [Cursor](https://cursor.com)