### PR TITLE
fix(docs-sync): restore test typecheck after locale pruning

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -7,6 +7,7 @@ export function parseArgs(argv: unknown): {
   clawhubSourceRepo: string;
   clawhubSourceSha: string;
 };
+export function pruneOrphanLocaleDocs(targetDocsDir: string): void;
 /**
  * Resolves the local ClawHub repository path used for docs mirroring.
  */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the root test typecheck failed after the locale-pruning helper became a named export without a matching declaration.

## Why This Change Was Made

Adds the missing declaration to the existing typed script surface. Runtime behavior is unchanged. AI-assisted: yes.

## User Impact

No product behavior change. Maintainer and contributor CI can complete the test typecheck again.

## Evidence

- Before: exact-head CI reproduced `TS2305` in `test/scripts/docs-sync-publish.test.ts` because `pruneOrphanLocaleDocs` was absent from `scripts/docs-sync-publish.d.mts`: https://github.com/openclaw/openclaw/actions/runs/29536287540/job/87748476817
- `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` — 1 file, 3 passed.
- `git diff --check` — pass.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, confidence 0.99.
