### PR TITLE
fix(cli): emit resolved config paths in machine output, not abbreviated home

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2368,6 +2368,32 @@ describe("config cli", () => {
       expect(resolveOptions).toBeTypeOf("object");
     });
 
+    it("emits the resolved config path in config patch JSON", async () => {
+      const home = path.join(os.tmpdir(), "openclaw-home-token-config-patch");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const resolved: OpenClawConfig = { gateway: { port: 18789 } };
+      const snapshot = buildSnapshot({ resolved, config: resolved });
+      snapshot.path = configPath;
+      mockReadConfigFileSnapshot.mockResolvedValueOnce(snapshot);
+      vi.stubEnv("OPENCLAW_HOME", home);
+
+      const patch = writeTempJson5File("openclaw-config-patch-resolved-path", {
+        gateway: { port: 18790 },
+      });
+      try {
+        await runConfigCommand(["config", "patch", "--file", patch, "--dry-run", "--json"]);
+      } finally {
+        fs.rmSync(patch, { force: true });
+        vi.unstubAllEnvs();
+      }
+
+      const payload = lastMockArg(defaultRuntime.writeJson) as { configPath: string };
+      expect(payload.configPath).toBe(configPath);
+      expect(path.isAbsolute(payload.configPath)).toBe(true);
+      expect(payload.configPath).not.toContain("$OPENCLAW_HOME");
+      expect(payload.configPath).not.toContain("~");
+    });
+
     it("dry-runs pluginIntegration provider patches against manifest integration metadata", async () => {
       const pluginId = "secret-provider-proof";
       const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-plugin-provider-"));
@@ -3853,15 +3879,26 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 
-    it("handles config file path with home directory", async () => {
+    it("prints a resolved config file path under OPENCLAW_HOME", async () => {
+      const home = path.join(os.tmpdir(), "openclaw-home-token-config-file");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
       const resolved: OpenClawConfig = { gateway: { port: 18789 } };
       const snapshot = buildSnapshot({ resolved, config: resolved });
-      snapshot.path = "/home/user/.openclaw/openclaw.json";
+      snapshot.path = configPath;
       mockReadConfigFileSnapshot.mockResolvedValueOnce(snapshot);
+      vi.stubEnv("OPENCLAW_HOME", home);
 
-      await runConfigCommand(["config", "file"]);
+      try {
+        await runConfigCommand(["config", "file"]);
+      } finally {
+        vi.unstubAllEnvs();
+      }
 
-      expect(mockLog).toHaveBeenCalledWith("/home/user/.openclaw/openclaw.json");
+      const output = String(lastMockArg(mockLog));
+      expect(output).toBe(configPath);
+      expect(path.isAbsolute(output)).toBe(true);
+      expect(output).not.toContain("$OPENCLAW_HOME");
+      expect(output).not.toContain("~");
     });
   });
 });

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2250,7 +2250,7 @@ async function runConfigOperations(params: {
     const dryRunResult: ConfigSetDryRunResult = {
       ok: dedupedErrors.length === 0,
       operations: operations.length,
-      configPath: shortenHomePath(snapshot.path),
+      configPath: snapshot.path,
       inputModes: uniqueValues(operations.map((operation) => operation.inputMode)),
       checks: {
         schema:
@@ -2522,7 +2522,7 @@ export async function runConfigUnset(opts: {
         throw new ConfigSetDryRunValidationError({
           ok: false,
           operations: 1,
-          configPath: shortenHomePath(snapshot.path),
+          configPath: snapshot.path,
           inputModes: ["unset"],
           checks: {
             schema: false,
@@ -2576,7 +2576,7 @@ async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const snapshot = await readConfigFileSnapshot();
-    runtime.log(shortenHomePath(snapshot.path));
+    runtime.log(snapshot.path);
   } catch (err) {
     runtime.error(danger(String(err)));
     runtime.exit(1);


### PR DESCRIPTION
## What Problem This Solves

Machine-facing CLI output leaked abbreviated home paths, breaking programmatic use. `openclaw config file` printed `~/.openclaw/openclaw.json` (or the literal `$OPENCLAW_HOME/…` token when that env is set) instead of a resolved absolute path — so `cat $(openclaw config file)` breaks. `config patch --dry-run --json` and `config unset --json` emitted the abbreviated form inside the JSON `configPath` field.

## Why This Change Was Made

These sites ran the path through `shortenHomePath()`, a human-readability affordance meant for terminal/table rendering, not machine output. `agents list --json` already emits resolved absolute paths — proving machine output should resolve. Fix emits the raw resolved `snapshot.path` at the three machine-output sites (`config file`, `config patch --dry-run` result, `config unset` dry-run result); human table rendering is untouched.

## User Impact

`openclaw config file` and `--json` config outputs now carry resolved absolute paths that scripts can consume. No behavior change for interactive/table output.

## Evidence

- Regression tests in `config-cli.test.ts` assert resolved (non-abbreviated) paths in `config file` and JSON output. 26+8+47 tests pass.
- `node scripts/check-changed.mjs` green on Testbox; autoreview clean (0.98).
