### PR TITLE
fix(docs-sync): export pruneOrphanLocaleDocs in publish typings

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -12,6 +12,10 @@ export function parseArgs(argv: unknown): {
  */
 export function resolveClawHubRepoPath(value?: string, options?: Record<string, unknown>): string;
 /**
+ * Deletes localized docs that no longer have a matching English source file.
+ */
+export function pruneOrphanLocaleDocs(targetDocsDir: unknown): void;
+/**
  * Mirrors ClawHub docs into the target docs tree.
  */
 export function syncClawHubDocsTree(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `pnpm check:test-types` / `tsgo:test:root` fails on current `main` because `test/scripts/docs-sync-publish.test.ts` imports `pruneOrphanLocaleDocs` but `scripts/docs-sync-publish.d.mts` does not declare that export.

## Why This Change Was Made

`fix(docs-sync): preserve translated mirrored pages` added the runtime export in `scripts/docs-sync-publish.mjs` without updating the companion typings file used by the root test typecheck lane. This restores the missing declaration only.

Collision check: also temporarily carried on [#106519](https://github.com/openclaw/openclaw/pull/106519) so that PR's CI is not blocked; this PR is the narrow typings-only landing unit.

## User Impact

- **Before:** root test typecheck fails with `Module '"../../scripts/docs-sync-publish.mjs"' has no exported member 'pruneOrphanLocaleDocs'`.
- **After:** typings match the runtime export; `check:test-types` can pass again.

## Evidence

Exact head: `3ebcf75b9a9d51c19cbaf194fa716f27835e4d9b`

```bash
rg -n "pruneOrphanLocaleDocs" scripts/docs-sync-publish.mjs scripts/docs-sync-publish.d.mts test/scripts/docs-sync-publish.test.ts
```

```text
scripts/docs-sync-publish.d.mts:17:export function pruneOrphanLocaleDocs(targetDocsDir: unknown): void;
scripts/docs-sync-publish.mjs:442:export function pruneOrphanLocaleDocs(targetDocsDir) {
test/scripts/docs-sync-publish.test.ts:5:import { parseArgs, pruneOrphanLocaleDocs } from "../../scripts/docs-sync-publish.mjs";
```