### PR TITLE
fix: prevent generated asset watch loops

### DIFF
--- a/scripts/build-discord-activity-sdk.d.mts
+++ b/scripts/build-discord-activity-sdk.d.mts
@@ -1,0 +1,20 @@
+type DiscordActivitySdkBuild = (options: {
+  absWorkingDir: string;
+  bundle: boolean;
+  entryPoints: string[];
+  format: string;
+  legalComments: string;
+  minify: boolean;
+  outfile: string;
+  platform: string;
+  target: string;
+  write: false;
+}) => Promise<{
+  outputFiles?: Array<{ text: string }>;
+}>;
+
+/** Builds the browser SDK bundle and returns whether the generated asset changed. */
+export function buildDiscordActivitySdk(params?: {
+  build?: DiscordActivitySdkBuild;
+  outputPath?: string;
+}): Promise<boolean>;

--- a/scripts/build-discord-activity-sdk.mjs
+++ b/scripts/build-discord-activity-sdk.mjs
@@ -10,7 +10,7 @@ const repoRoot = path.resolve(path.dirname(modulePath), "..");
 const discordDir = path.join(repoRoot, "extensions/discord");
 const outputPath = path.join(repoRoot, "extensions/discord/assets/embedded-app-sdk.mjs");
 
-/** Builds the browser SDK bundle without rewriting an identical tracked asset. */
+/** Builds the browser SDK bundle without rewriting an identical generated asset. */
 export async function buildDiscordActivitySdk(params = {}) {
   const buildImpl = params.build ?? build;
   const targetPath = params.outputPath ?? outputPath;

--- a/scripts/build-discord-activity-sdk.mjs
+++ b/scripts/build-discord-activity-sdk.mjs
@@ -10,15 +10,46 @@ const repoRoot = path.resolve(path.dirname(modulePath), "..");
 const discordDir = path.join(repoRoot, "extensions/discord");
 const outputPath = path.join(repoRoot, "extensions/discord/assets/embedded-app-sdk.mjs");
 
-await fs.mkdir(path.dirname(outputPath), { recursive: true });
-await build({
-  entryPoints: ["@discord/embedded-app-sdk"],
-  absWorkingDir: discordDir,
-  bundle: true,
-  platform: "browser",
-  target: "es2020",
-  format: "esm",
-  minify: true,
-  legalComments: "none",
-  outfile: outputPath,
-});
+/** Builds the browser SDK bundle without rewriting an identical tracked asset. */
+export async function buildDiscordActivitySdk(params = {}) {
+  const buildImpl = params.build ?? build;
+  const targetPath = params.outputPath ?? outputPath;
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  const result = await buildImpl({
+    entryPoints: ["@discord/embedded-app-sdk"],
+    absWorkingDir: discordDir,
+    bundle: true,
+    platform: "browser",
+    target: "es2020",
+    format: "esm",
+    minify: true,
+    legalComments: "none",
+    outfile: targetPath,
+    write: false,
+  });
+
+  const outputFile = result.outputFiles?.[0];
+  if (!outputFile) {
+    throw new Error("esbuild did not produce the Discord Embedded App SDK bundle");
+  }
+
+  const nextBundle = outputFile.text;
+  let currentBundle = null;
+  try {
+    currentBundle = await fs.readFile(targetPath, "utf8");
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  if (currentBundle === nextBundle) {
+    return false;
+  }
+  await fs.writeFile(targetPath, nextBundle);
+  return true;
+}
+
+if (process.argv[1] === modulePath) {
+  await buildDiscordActivitySdk();
+}

--- a/scripts/run-node-watch-paths.d.mts
+++ b/scripts/run-node-watch-paths.d.mts
@@ -1,0 +1,15 @@
+/** Source roots whose changes require the root dev build pipeline. */
+export const runNodeSourceRoots: string[];
+/** Root config files whose changes invalidate the dev build. */
+export const runNodeConfigFiles: string[];
+/** Combined watch list used by the run-node wrapper. */
+export const runNodeWatchedPaths: string[];
+/** Plugin metadata files that require a runtime restart even without source edits. */
+export const extensionRestartMetadataFiles: Set<string>;
+
+/** Normalizes watch paths to repository-style POSIX separators. */
+export function normalizeRunNodePath(filePath: unknown): string;
+/** Returns true when a repo path should trigger a dev rebuild. */
+export function isBuildRelevantRunNodePath(repoPath: unknown): boolean;
+/** Returns true when a repo path should restart the running dev process. */
+export function isRestartRelevantRunNodePath(repoPath: unknown): boolean;

--- a/scripts/run-node-watch-paths.mjs
+++ b/scripts/run-node-watch-paths.mjs
@@ -40,7 +40,7 @@ const ignoredRunNodeRepoPathPatterns = [
   /^extensions\/[^/]+\/src\/host\/.+\/\.bundle\.hash$/u,
   /^extensions\/[^/]+\/src\/host\/.+\/[^/]+\.bundle\.js$/u,
 ];
-// Asset build hooks write these tracked runtime bundles. They are outputs, not
+// Asset build hooks write these generated runtime bundles. They are outputs, not
 // source inputs; watching them makes the dev build react to its own writes.
 const generatedPluginAssetPaths = new Set([
   "extensions/diffs-language-pack/assets/viewer-runtime.js",

--- a/scripts/run-node-watch-paths.mjs
+++ b/scripts/run-node-watch-paths.mjs
@@ -40,6 +40,13 @@ const ignoredRunNodeRepoPathPatterns = [
   /^extensions\/[^/]+\/src\/host\/.+\/\.bundle\.hash$/u,
   /^extensions\/[^/]+\/src\/host\/.+\/[^/]+\.bundle\.js$/u,
 ];
+// Asset build hooks write these tracked runtime bundles. They are outputs, not
+// source inputs; watching them makes the dev build react to its own writes.
+const generatedPluginAssetPaths = new Set([
+  "extensions/diffs-language-pack/assets/viewer-runtime.js",
+  "extensions/diffs/assets/viewer-runtime.js",
+  "extensions/discord/assets/embedded-app-sdk.mjs",
+]);
 const extensionSourceFilePattern = /\.(?:[cm]?[jt]sx?)$/;
 
 /** Normalizes watch paths to repository-style POSIX separators. */
@@ -69,7 +76,10 @@ const isRestartRelevantExtensionPath = (relativePath) => {
 
 const isRelevantRunNodePath = (repoPath, isRelevantBundledPluginPath) => {
   const normalizedPath = normalizeRunNodePath(repoPath).replace(/^\.\/+/, "");
-  if (ignoredRunNodeRepoPathPatterns.some((pattern) => pattern.test(normalizedPath))) {
+  if (
+    generatedPluginAssetPaths.has(normalizedPath) ||
+    ignoredRunNodeRepoPathPatterns.some((pattern) => pattern.test(normalizedPath))
+  ) {
     return false;
   }
   if (runNodeConfigFiles.includes(normalizedPath)) {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2092,7 +2092,9 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/e2e/cron-mcp-cleanup-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
   ["scripts/bundled-plugin-assets.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
   ["scripts/bundle-a2ui.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
+  ["scripts/build-discord-activity-sdk.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
   ["scripts/build-diffs-viewer-runtime.mjs", ["test/scripts/build-diffs-viewer-runtime.test.ts"]],
+  ["scripts/run-node-watch-paths.mjs", ["test/scripts/bundled-plugin-assets.test.ts"]],
   ["extensions/canvas/scripts/bundle-a2ui.mjs", ["extensions/canvas/scripts/bundle-a2ui.test.ts"]],
   ["extensions/canvas/scripts/copy-a2ui.mjs", ["extensions/canvas/scripts/copy-a2ui.test.ts"]],
 ]);

--- a/test/scripts/bundled-plugin-assets.test.ts
+++ b/test/scripts/bundled-plugin-assets.test.ts
@@ -44,7 +44,7 @@ async function withPluginAssetFixture(run: (rootDir: string) => Promise<void>) {
 }
 
 describe("bundled plugin assets", () => {
-  it("does not rewrite an unchanged Discord SDK bundle", async () => {
+  it("creates a missing Discord SDK bundle without rewriting it when unchanged", async () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-discord-sdk-"));
     const outputPath = path.join(rootDir, "embedded-app-sdk.mjs");
     const build = vi.fn(async () => ({
@@ -52,7 +52,9 @@ describe("bundled plugin assets", () => {
     }));
 
     try {
-      fs.writeFileSync(outputPath, "export const sdk = true;\n");
+      await expect(buildDiscordActivitySdk({ build, outputPath })).resolves.toBe(true);
+      expect(fs.readFileSync(outputPath, "utf8")).toBe("export const sdk = true;\n");
+
       const initialTime = new Date("2026-07-16T12:00:00.000Z");
       fs.utimesSync(outputPath, initialTime, initialTime);
 

--- a/test/scripts/bundled-plugin-assets.test.ts
+++ b/test/scripts/bundled-plugin-assets.test.ts
@@ -1,8 +1,7 @@
 // Bundled Plugin Assets tests cover bundled plugin assets script behavior.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildDiscordActivitySdk } from "../../scripts/build-discord-activity-sdk.mjs";
 import {
   parseBundledPluginAssetArgs,
@@ -12,64 +11,59 @@ import {
   isBuildRelevantRunNodePath,
   isRestartRelevantRunNodePath,
 } from "../../scripts/run-node-watch-paths.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withPluginAssetFixture(run: (rootDir: string) => Promise<void>) {
-  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-assets-"));
-  try {
-    fs.mkdirSync(path.join(rootDir, "extensions", "canvas"), { recursive: true });
-    fs.writeFileSync(
-      path.join(rootDir, "extensions", "canvas", "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/canvas-plugin",
-          openclaw: {
-            assetScripts: {
-              build: "node scripts/bundle-a2ui.mjs",
-              copy: "node scripts/copy-a2ui.mjs",
-            },
+  const rootDir = tempDirs.make("openclaw-plugin-assets-");
+  fs.mkdirSync(path.join(rootDir, "extensions", "canvas"), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "extensions", "canvas", "package.json"),
+    JSON.stringify(
+      {
+        name: "@openclaw/canvas-plugin",
+        openclaw: {
+          assetScripts: {
+            build: "node scripts/bundle-a2ui.mjs",
+            copy: "node scripts/copy-a2ui.mjs",
           },
         },
-        null,
-        2,
-      ),
-    );
-    fs.writeFileSync(
-      path.join(rootDir, "extensions", "canvas", "openclaw.plugin.json"),
-      JSON.stringify({ id: "canvas" }, null, 2),
-    );
-    await run(rootDir);
-  } finally {
-    fs.rmSync(rootDir, { force: true, recursive: true });
-  }
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "extensions", "canvas", "openclaw.plugin.json"),
+    JSON.stringify({ id: "canvas" }, null, 2),
+  );
+  await run(rootDir);
 }
 
 describe("bundled plugin assets", () => {
   it("creates a missing Discord SDK bundle without rewriting it when unchanged", async () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-discord-sdk-"));
+    const rootDir = tempDirs.make("openclaw-discord-sdk-");
     const outputPath = path.join(rootDir, "embedded-app-sdk.mjs");
     const build = vi.fn(async () => ({
       outputFiles: [{ text: "export const sdk = true;\n" }],
     }));
 
-    try {
-      await expect(buildDiscordActivitySdk({ build, outputPath })).resolves.toBe(true);
-      expect(fs.readFileSync(outputPath, "utf8")).toBe("export const sdk = true;\n");
+    await expect(buildDiscordActivitySdk({ build, outputPath })).resolves.toBe(true);
+    expect(fs.readFileSync(outputPath, "utf8")).toBe("export const sdk = true;\n");
 
-      const initialTime = new Date("2026-07-16T12:00:00.000Z");
-      fs.utimesSync(outputPath, initialTime, initialTime);
+    const initialTime = new Date("2026-07-16T12:00:00.000Z");
+    fs.utimesSync(outputPath, initialTime, initialTime);
 
-      await expect(buildDiscordActivitySdk({ build, outputPath })).resolves.toBe(false);
-      expect(fs.statSync(outputPath).mtimeMs).toBe(initialTime.getTime());
-      expect(build).toHaveBeenCalledWith(
-        expect.objectContaining({
-          absWorkingDir: path.join(process.cwd(), "extensions/discord"),
-          outfile: outputPath,
-          write: false,
-        }),
-      );
-    } finally {
-      fs.rmSync(rootDir, { force: true, recursive: true });
-    }
+    await expect(buildDiscordActivitySdk({ build, outputPath })).resolves.toBe(false);
+    expect(fs.statSync(outputPath).mtimeMs).toBe(initialTime.getTime());
+    expect(build).toHaveBeenCalledWith(
+      expect.objectContaining({
+        absWorkingDir: path.join(process.cwd(), "extensions/discord"),
+        outfile: outputPath,
+        write: false,
+      }),
+    );
   });
 
   it("discovers the Discord Embedded App SDK build hook", async () => {

--- a/test/scripts/bundled-plugin-assets.test.ts
+++ b/test/scripts/bundled-plugin-assets.test.ts
@@ -2,11 +2,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { buildDiscordActivitySdk } from "../../scripts/build-discord-activity-sdk.mjs";
 import {
   parseBundledPluginAssetArgs,
   readBundledPluginAssetHooks,
 } from "../../scripts/bundled-plugin-assets.mjs";
+import {
+  isBuildRelevantRunNodePath,
+  isRestartRelevantRunNodePath,
+} from "../../scripts/run-node-watch-paths.mjs";
 
 async function withPluginAssetFixture(run: (rootDir: string) => Promise<void>) {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-assets-"));
@@ -39,14 +44,30 @@ async function withPluginAssetFixture(run: (rootDir: string) => Promise<void>) {
 }
 
 describe("bundled plugin assets", () => {
-  it("resolves the Discord SDK entry from the package that declares it", () => {
-    const script = fs.readFileSync(
-      path.join(process.cwd(), "scripts/build-discord-activity-sdk.mjs"),
-      "utf8",
-    );
+  it("does not rewrite an unchanged Discord SDK bundle", async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-discord-sdk-"));
+    const outputPath = path.join(rootDir, "embedded-app-sdk.mjs");
+    const build = vi.fn(async () => ({
+      outputFiles: [{ text: "export const sdk = true;\n" }],
+    }));
 
-    expect(script).toContain('const discordDir = path.join(repoRoot, "extensions/discord")');
-    expect(script).toContain("absWorkingDir: discordDir");
+    try {
+      fs.writeFileSync(outputPath, "export const sdk = true;\n");
+      const initialTime = new Date("2026-07-16T12:00:00.000Z");
+      fs.utimesSync(outputPath, initialTime, initialTime);
+
+      await expect(buildDiscordActivitySdk({ build, outputPath })).resolves.toBe(false);
+      expect(fs.statSync(outputPath).mtimeMs).toBe(initialTime.getTime());
+      expect(build).toHaveBeenCalledWith(
+        expect.objectContaining({
+          absWorkingDir: path.join(process.cwd(), "extensions/discord"),
+          outfile: outputPath,
+          write: false,
+        }),
+      );
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true });
+    }
   });
 
   it("discovers the Discord Embedded App SDK build hook", async () => {
@@ -64,6 +85,30 @@ describe("bundled plugin assets", () => {
         pluginId: "discord",
       },
     ]);
+  });
+
+  it("keeps build-generated static assets out of the source watcher", async () => {
+    const rootDir = process.cwd();
+    const hooks = await readBundledPluginAssetHooks({ phase: "build", rootDir });
+    const generatedAssetSources = hooks.flatMap((hook) => {
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(hook.pluginDir, "package.json"), "utf8"),
+      ) as {
+        openclaw?: { build?: { staticAssets?: Array<{ source?: string }> } };
+      };
+      const pluginPath = path.relative(rootDir, hook.pluginDir).replaceAll(path.sep, "/");
+      return (packageJson.openclaw?.build?.staticAssets ?? []).flatMap((asset) => {
+        const source = asset.source?.replace(/^\.\/+/u, "");
+        return source ? [path.posix.join(pluginPath, source)] : [];
+      });
+    });
+
+    expect(generatedAssetSources).toContain("extensions/discord/assets/embedded-app-sdk.mjs");
+    for (const source of generatedAssetSources) {
+      expect(isBuildRelevantRunNodePath(source), source).toBe(false);
+      expect(isRestartRelevantRunNodePath(source), source).toBe(false);
+    }
+    expect(isRestartRelevantRunNodePath("extensions/discord/src/activities/http.ts")).toBe(true);
   });
 
   it("discovers plugin-owned asset scripts by manifest id", async () => {


### PR DESCRIPTION
## Summary

- stop development watch mode from treating generated plugin asset bundles as source changes
- make the Discord Embedded App SDK build create missing output without rewriting identical output
- add strict regression coverage for asset generation, watcher classification, and changed-test routing

## Verification

- clean-checkout watch proof completed with one bundled asset build and no watcher restart
- Testbox `tbx_01kxpcqda71b2zz5c0bfawt6vr`: committed-state changed-surface checks passed
- Testbox `tbx_01kxpcqda71b2zz5c0bfawt6vr`: full production build passed in 2m 50.8s
- autoreview completed with no findings
