### PR TITLE
fix(types): restore docs sync test typecheck

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -23,3 +23,4 @@ export function syncClawHubDocsTree(
   path: string;
   files: number;
 };
+export function pruneOrphanLocaleDocs(targetDocsDir: string): void;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the `check-test-types` lane fails for docs sync tests after `pruneOrphanLocaleDocs` became a tested module export. The regression is present independently on current `main`, not introduced by the PR where it was first observed.

## Why This Change Was Made

Declares the existing runtime export in the script's companion `.d.mts` contract. This keeps TypeScript's `.mjs` resolution aligned with the implementation without changing runtime behavior or CI caching.

## User Impact

Maintainers and contributors can run the root test-type program without the false missing-export error. There is no product runtime behavior change.

## Evidence

- Before: current-main CI run https://github.com/openclaw/openclaw/actions/runs/29536178574, `check-test-types` job https://github.com/openclaw/openclaw/actions/runs/29536178574/job/87749395940 failed at `test/scripts/docs-sync-publish.test.ts:5` with TS2305.
- Independent retry: https://github.com/openclaw/openclaw/actions/runs/29536682752/job/87751048674 failed identically.
- Focused test: `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` — 1 file, 3 tests passed.
- Exact failing type program on Blacksmith Testbox: `pnpm tsgo:test:root` — passed; run https://github.com/openclaw/openclaw/actions/runs/29537396417.
- Changed gate on the same Testbox: scripts/tooling `check:changed` — passed, including formatting, `tsgo:scripts`, guards, and targeted lint.
- `git diff --check` — passed.
- Fresh structured autoreview — clean, no accepted/actionable findings.

AI-assisted: yes. The one-line declaration and its implementation contract were inspected directly.
