### PR TITLE
fix(docs-sync): restore type contract for locale pruning

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -7,6 +7,7 @@ export function parseArgs(argv: unknown): {
   clawhubSourceRepo: string;
   clawhubSourceSha: string;
 };
+export function pruneOrphanLocaleDocs(targetDocsDir: string): void;
 /**
  * Resolves the local ClawHub repository path used for docs mirroring.
  */


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the main branch `check:test-types` gate fails because the docs sync module's exported locale-pruning helper is absent from its declaration file.

## Why This Change Was Made

Declares the existing `pruneOrphanLocaleDocs` runtime export in the matching `.d.mts` surface. Runtime behavior is unchanged.

## User Impact

No user-visible behavior change. The docs sync module's TypeScript contract and the main CI gate are restored.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` — 3 tests passed.
- Blacksmith Testbox `pnpm check:test-types` — passed: https://github.com/openclaw/openclaw/actions/runs/29537303549
- Fresh autoreview — no actionable findings.
