### PR TITLE
fix(ci): detect frozen Codex binding stores

### DIFF
--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -47,7 +47,15 @@ if [[ -z "$SESSION_STORE_CONTRACT" ]]; then
     SESSION_STORE_CONTRACT="legacy-json"
   fi
 fi
-BINDING_STORE_CONTRACT="${OPENCLAW_CODEX_NPM_PLUGIN_BINDING_STORE_CONTRACT:-plugin-kv}"
+BINDING_STORE_CONTRACT="${OPENCLAW_CODEX_NPM_PLUGIN_BINDING_STORE_CONTRACT:-}"
+if [[ -z "$BINDING_STORE_CONTRACT" ]]; then
+  if [[ -f "$CANDIDATE_ROOT/extensions/codex/src/app-server/session-binding-meta.ts" ]]; then
+    BINDING_STORE_CONTRACT="plugin-kv"
+  else
+    # Frozen targets before the binding-store migration persist a session sidecar.
+    BINDING_STORE_CONTRACT="legacy-sidecar"
+  fi
+fi
 run_log=""
 
 cleanup() {


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation against the frozen `2026.6.33` candidate completed all Codex live turns, then failed because the trusted current-main harness looked for the thread binding in SQLite plugin state. The frozen candidate predates that binding-store migration and correctly persists the binding as a session sidecar.

Failure: https://github.com/openclaw/openclaw/actions/runs/29531628591/job/87737211441

## Why This Change Was Made

The harness already detects whether the candidate uses SQLite or legacy JSON for sessions. Apply the same capability detection to Codex bindings using `session-binding-meta.ts`, the owner file introduced with the plugin-KV binding implementation. Explicit `OPENCLAW_CODEX_NPM_PLUGIN_BINDING_STORE_CONTRACT` overrides remain unchanged.

This repairs a regression introduced when #108828 separated the binding-store contract from the session-store contract but defaulted every target to `plugin-kv`, superseding the frozen-sidecar compatibility added by #108158.

## User Impact

No OpenClaw runtime or release candidate behavior changes. Trusted release validation reads Codex binding evidence from the store actually owned by the selected target: plugin KV for current targets and the legacy session sidecar for frozen targets.

## Evidence

- Failing release lane completed the Codex CLI preflight and all three OpenClaw/Codex turns before reporting `missing Codex app-server binding row`.
- Exact candidate `343a93ded32960a08325e86ca9920838587bedf7` lacks `extensions/codex/src/app-server/session-binding-meta.ts` and its `session-binding.ts` writes `${sessionFile}.codex-app-server.json`.
- Current `main` contains `session-binding-meta.ts` and its binding owner uses `PluginStateSyncKeyedStore`.
- Inspected `openai/codex` tag `rust-v0.139.0`: `ThreadStartResponse.thread.id` is the native thread identity consumed and persisted by the candidate.
- `bash -n scripts/e2e/codex-npm-plugin-live-docker.sh`
- `git diff --check`

Focused live release-lane proof will run against the exact frozen candidate from this trusted PR head.
