### PR TITLE
fix(docs-sync): remove duplicate pruning declaration

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -24,4 +24,3 @@ export function syncClawHubDocsTree(
   path: string;
   files: number;
 };
-export function pruneOrphanLocaleDocs(targetDocsDir: string): void;


### PR DESCRIPTION
Closes #109379

## What Problem This Solves

Fixes an issue where all pull requests containing current `main` fail the lint gate after two concurrent fixes added the same docs sync declaration in different locations.

## Why This Change Was Made

Keep the first `pruneOrphanLocaleDocs` declaration beside the module's other top-level exports and remove the later duplicate. Runtime behavior is unchanged.

## User Impact

No product behavior change. Maintainer CI can complete its lint gate again.

## Evidence

- Before: exact-head lint fails with `typescript(adjacent-overload-signatures)`: https://github.com/openclaw/openclaw/actions/runs/29538790402/job/87756373731
- `./node_modules/.bin/oxlint scripts/docs-sync-publish.d.mts` — passed.
- `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` — 3/3 passed.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings (0.98).

AI-assisted maintainer fix. I reviewed the one-line declaration change and its exact failure evidence.
