### PR TITLE
fix: restore lint after duplicate docs sync declarations

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -24,4 +24,3 @@ export function syncClawHubDocsTree(
   path: string;
   files: number;
 };
-export function pruneOrphanLocaleDocs(targetDocsDir: string): void;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the full lint gate fails on current `main` because two concurrently landed docs-sync fixes added the same declaration twice.

## Why This Change Was Made

Remove only the duplicate declaration. The remaining declaration still matches the exported helper; runtime behavior and CI workflow behavior are unchanged.

## User Impact

No user-visible behavior change. Pull requests can pass the existing lint gate again.

## Evidence

- Blacksmith Testbox `tbx_01kxpg7e78z95p03p90e0277g9`.
- `pnpm check:changed` passed, including scripts typecheck, formatting, and lint.
- Fresh autoreview: clean, no accepted/actionable findings.
