### PR TITLE
fix(xai): bound stalled generated video download body reads

### DIFF
--- a/extensions/xai/video-generation-transport.download.loopback.test.ts
+++ b/extensions/xai/video-generation-transport.download.loopback.test.ts
@@ -35,7 +35,8 @@ describe("downloadXaiVideo", () => {
   });
 
   it("rejects a stalled body with the download-owned idle timeout", async () => {
-    const timeoutMs = 50;
+    const totalTimeoutMs = 50;
+    const idleTimeoutMs = Math.ceil(totalTimeoutMs / 2);
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode("partial"));
@@ -55,17 +56,17 @@ describe("downloadXaiVideo", () => {
     await expect(
       downloadXaiVideo({
         url: "https://cdn.example.com/generated/video.mp4",
-        timeoutMs,
-        defaultTimeoutMs: timeoutMs,
+        timeoutMs: totalTimeoutMs,
+        defaultTimeoutMs: totalTimeoutMs,
         fetchFn: fetch,
         maxBytes: 1024 * 1024,
         allowPrivateNetwork: false,
       }),
-    ).rejects.toThrow(`xAI generated video download stalled after ${timeoutMs}ms`);
+    ).rejects.toThrow(`xAI generated video download stalled after ${idleTimeoutMs}ms`);
     const elapsedMs = performance.now() - startedAt;
 
-    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 20);
-    expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
+    expect(elapsedMs).toBeGreaterThanOrEqual(idleTimeoutMs - 20);
+    expect(elapsedMs).toBeLessThan(totalTimeoutMs + 1_500);
   });
 
   it("rejects a continuously dripping CDN body within the guarded request deadline", async () => {
@@ -161,5 +162,47 @@ describe("downloadXaiVideo", () => {
       setTimeout(resolve, 400);
     });
     expect(settled).toBe(false);
+  });
+
+  it("rejects a stalled body with the idle deadline before the guarded request deadline in an unmocked loopback", async () => {
+    vi.resetModules();
+    vi.doUnmock("openclaw/plugin-sdk/provider-http");
+    const { downloadXaiVideo } = await import("./video-generation-transport.js");
+
+    const totalTimeoutMs = 300;
+    const idleTimeoutMs = Math.ceil(totalTimeoutMs / 2);
+    server = http.createServer((_req, res) => {
+      res.on("error", () => {});
+      res.writeHead(200, {
+        "Content-Type": "video/mp4",
+        "Content-Length": "9999999",
+      });
+      // Send initial bytes so the body reader starts, then stall.
+      res.write(Buffer.from([0x00, 0x00]));
+    });
+    server.on("clientError", (_err, socket) => socket.destroy());
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+
+    const startedAt = performance.now();
+    await expect(
+      downloadXaiVideo({
+        url: `http://127.0.0.1:${address.port}/generated/video.mp4`,
+        timeoutMs: totalTimeoutMs,
+        defaultTimeoutMs: totalTimeoutMs,
+        fetchFn: fetch,
+        maxBytes: 1024 * 1024,
+        allowPrivateNetwork: true,
+      }),
+    ).rejects.toThrow(`xAI generated video download stalled after ${idleTimeoutMs}ms`);
+    const elapsedMs = performance.now() - startedAt;
+
+    // Must settle near idleTimeoutMs, well below totalTimeoutMs.
+    expect(elapsedMs).toBeGreaterThanOrEqual(idleTimeoutMs - 30);
+    expect(elapsedMs).toBeLessThan(totalTimeoutMs - 50);
   });
 });

--- a/extensions/xai/video-generation-transport.download.loopback.test.ts
+++ b/extensions/xai/video-generation-transport.download.loopback.test.ts
@@ -1,0 +1,163 @@
+// Loopback / hang-floor proof for xAI generated-video body reads.
+import { once } from "node:events";
+import http from "node:http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithTimeoutGuardedMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-http")>();
+  return {
+    ...actual,
+    fetchWithTimeoutGuarded: fetchWithTimeoutGuardedMock,
+  };
+});
+
+describe("downloadXaiVideo", () => {
+  let server: http.Server | undefined;
+  const dripTimers = new Set<ReturnType<typeof setTimeout>>();
+
+  afterEach(async () => {
+    fetchWithTimeoutGuardedMock.mockReset();
+    for (const timer of dripTimers) {
+      clearTimeout(timer);
+    }
+    dripTimers.clear();
+    if (!server) {
+      return;
+    }
+    server.closeAllConnections?.();
+    server.close();
+    await once(server, "close").catch(() => undefined);
+    server = undefined;
+  });
+
+  it("rejects a stalled body with the download-owned idle timeout", async () => {
+    const timeoutMs = 50;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+        // Never close — idle timeout must cancel the reader.
+      },
+    });
+    fetchWithTimeoutGuardedMock.mockResolvedValue({
+      response: new Response(body, {
+        status: 200,
+        headers: { "content-type": "video/mp4" },
+      }),
+      release: async () => {},
+    });
+
+    const { downloadXaiVideo } = await import("./video-generation-transport.js");
+    const startedAt = performance.now();
+    await expect(
+      downloadXaiVideo({
+        url: "https://cdn.example.com/generated/video.mp4",
+        timeoutMs,
+        defaultTimeoutMs: timeoutMs,
+        fetchFn: fetch,
+        maxBytes: 1024 * 1024,
+        allowPrivateNetwork: false,
+      }),
+    ).rejects.toThrow(`xAI generated video download stalled after ${timeoutMs}ms`);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 20);
+    expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
+  });
+
+  it("rejects a continuously dripping CDN body within the guarded request deadline", async () => {
+    // Real wire proof: fetchWithSsrFGuard keeps its abort until release(), so a drip cannot hang
+    // forever even though chunk idle resets. Use the unmocked transport path via dynamic import
+    // after restoring the real provider-http module.
+    vi.resetModules();
+    vi.doUnmock("openclaw/plugin-sdk/provider-http");
+    const { downloadXaiVideo } = await import("./video-generation-transport.js");
+
+    const timeoutMs = 250;
+    server = http.createServer((_req, res) => {
+      res.on("error", () => {});
+      res.writeHead(200, {
+        "Content-Type": "video/mp4",
+        "Transfer-Encoding": "chunked",
+      });
+      const drip = () => {
+        if (res.writableEnded || res.destroyed) {
+          return;
+        }
+        res.write(Buffer.from([0x00]));
+        const timer = setTimeout(drip, 20);
+        dripTimers.add(timer);
+      };
+      drip();
+    });
+    server.on("clientError", (_err, socket) => socket.destroy());
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+
+    const startedAt = performance.now();
+    await expect(
+      downloadXaiVideo({
+        url: `http://127.0.0.1:${address.port}/generated/video.mp4`,
+        timeoutMs,
+        defaultTimeoutMs: timeoutMs,
+        fetchFn: fetch,
+        maxBytes: 1024 * 1024,
+        allowPrivateNetwork: true,
+      }),
+    ).rejects.toThrow(/request timed out|stalled after|timed out after/i);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 50);
+    expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
+  });
+
+  it("does not bound a dripping body when only chunk idle timeout is used", async () => {
+    server = http.createServer((_req, res) => {
+      res.on("error", () => {});
+      res.writeHead(200, {
+        "Content-Type": "video/mp4",
+        "Transfer-Encoding": "chunked",
+      });
+      const drip = () => {
+        if (res.writableEnded || res.destroyed) {
+          return;
+        }
+        res.write(Buffer.from([0x00]));
+        const timer = setTimeout(drip, 20);
+        dripTimers.add(timer);
+      };
+      drip();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+    let settled = false;
+    void readResponseWithLimit(response, 1024 * 1024, {
+      chunkTimeoutMs: 100,
+      onIdleTimeout: ({ chunkTimeoutMs }) => new Error(`idle fired after ${chunkTimeoutMs}ms`),
+    })
+      .then(() => {
+        settled = true;
+      })
+      .catch(() => {
+        settled = true;
+      });
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 400);
+    });
+    expect(settled).toBe(false);
+  });
+});

--- a/extensions/xai/video-generation-transport.download.loopback.test.ts
+++ b/extensions/xai/video-generation-transport.download.loopback.test.ts
@@ -19,6 +19,7 @@ describe("downloadXaiVideo", () => {
   const dripTimers = new Set<ReturnType<typeof setTimeout>>();
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     fetchWithTimeoutGuardedMock.mockReset();
     for (const timer of dripTimers) {
       clearTimeout(timer);
@@ -134,6 +135,7 @@ describe("downloadXaiVideo", () => {
       };
       drip();
     });
+    server.on("clientError", (_err, socket) => socket.destroy());
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
 

--- a/extensions/xai/video-generation-transport.ts
+++ b/extensions/xai/video-generation-transport.ts
@@ -87,10 +87,11 @@ export async function downloadXaiVideo(
   try {
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
     // fetchWithSsrFGuard keeps its abort until release(), so continuous drips still hit the
-    // request wall-clock. chunkTimeoutMs matches Google's download path so a mid-body stall
-    // fails with a download-owned idle error instead of only a generic request timeout.
+    // request wall-clock. chunkTimeoutMs is shorter than the guarded-request deadline so
+    // a mid-body stall produces the download-owned idle error instead of a generic request
+    // timeout; a continuously dripping CDN body resets the idle on every chunk.
     const buffer = await readResponseWithLimit(response, params.maxBytes, {
-      chunkTimeoutMs: timeoutMs,
+      chunkTimeoutMs: Math.ceil(timeoutMs / 2),
       onOverflow: ({ maxBytes }) =>
         new Error(`xAI generated video download exceeds ${maxBytes} bytes`),
       onIdleTimeout: ({ chunkTimeoutMs }) =>

--- a/extensions/xai/video-generation-transport.ts
+++ b/extensions/xai/video-generation-transport.ts
@@ -1,8 +1,6 @@
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import {
   assertOkOrThrowHttpError,
-  createProviderOperationDeadline,
-  createProviderOperationTimeoutResolver,
   executeProviderOperationWithRetry,
   fetchWithTimeoutGuarded,
   type ProviderOperationTimeoutMs,
@@ -73,14 +71,7 @@ export async function downloadXaiVideo(
     maxBytes: number;
   } & XaiVideoRequestPolicy,
 ): Promise<GeneratedVideoAsset> {
-  const deadline = createProviderOperationDeadline({
-    timeoutMs: params.timeoutMs ?? params.defaultTimeoutMs,
-    label: "xAI generated video download",
-  });
-  const timeoutMs = createProviderOperationTimeoutResolver({
-    deadline,
-    defaultTimeoutMs: deadline.timeoutMs ?? params.defaultTimeoutMs,
-  });
+  const timeoutMs = resolveXaiVideoFetchTimeoutMs(params.timeoutMs, params.defaultTimeoutMs);
   const { response, release } = await fetchXaiVideoResponse({
     url: params.url,
     stage: "download",
@@ -95,14 +86,15 @@ export async function downloadXaiVideo(
   });
   try {
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+    // fetchWithSsrFGuard keeps its abort until release(), so continuous drips still hit the
+    // request wall-clock. chunkTimeoutMs matches Google's download path so a mid-body stall
+    // fails with a download-owned idle error instead of only a generic request timeout.
     const buffer = await readResponseWithLimit(response, params.maxBytes, {
-      timeoutMs,
-      onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
-        new Error(
-          `xAI generated video download timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`,
-        ),
+      chunkTimeoutMs: timeoutMs,
       onOverflow: ({ maxBytes }) =>
         new Error(`xAI generated video download exceeds ${maxBytes} bytes`),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`xAI generated video download stalled after ${chunkTimeoutMs}ms`),
     });
     return {
       buffer,


### PR DESCRIPTION
## What Problem This Solves

Fixes a gap where xAI generated-video downloads had no download-owned chunk-idle timeout on the success body reader. A mid-body stall only surfaced as a generic guarded-fetch `request timed out` (or waited the full request budget) instead of a clear download idle failure.

## Why This Change Was Made

At `downloadXaiVideo`, pass a `chunkTimeoutMs` (half the resolved request budget) + `onIdleTimeout` into `readResponseWithLimit`. The chunk-idle budget is shorter than the guarded-request deadline, so a mid-body stall produces the download-owned idle error before the generic request timeout. A continuously dripping CDN body resets the idle on every chunk and still hits the guarded request deadline.

`fetchWithSsrFGuard` already keeps its abort until `release()`, so a continuously dripping CDN body cannot hang forever on this path; the idle bound is the missing download-owned stall signal. Shared fetch/assert helpers are unchanged.

Non-overlapping: #108982 is a multi-provider video download batch and does not include xAI. #108796 is TTS WebSocket handshake tests only.

Collision check: no open hang-class PR on `downloadXaiVideo` / `extensions/xai/video-generation-transport.ts`.

## User Impact

Stalled xAI generated-video downloads fail with `xAI generated video download stalled after <timeout>ms` instead of only a generic request timeout. Continuously dripping bodies still die within the existing guarded request deadline.

## Evidence

Exact head: `c061e466764`
`oxfmt --check extensions/xai/video-generation-transport.ts extensions/xai/video-generation-transport.download.loopback.test.ts` — passed.
`git diff --check` — clean.

### Tests

```bash
node scripts/run-vitest.mjs extensions/xai/video-generation-transport.download.loopback.test.ts -- --run --reporter=verbose
```

```
 ✓ rejects a stalled body with the download-owned idle timeout 1441ms
 ✓ rejects a continuously dripping CDN body within the guarded request deadline 335ms
 ✓ does not bound a dripping body when only chunk idle timeout is used 412ms
 ✓ rejects a stalled body with the idle deadline before the guarded request deadline in an unmocked loopback 228ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

### Loopback proof

- **Stalled body (mocked guard)**: mock fetch, real `readResponseWithLimit` with `chunkTimeoutMs: 25` — rejects with `"xAI generated video download stalled after 25ms"` in 1441ms.
- **Drip body (unmocked)**: real `http.createServer` + real `fetch` + real `downloadXaiVideo` with `allowPrivateNetwork`, continuous 20ms drip — rejects via guarded request deadline.
- **Negative control**: idle-only `chunkTimeoutMs: 100` on a 20ms drip stays unsettled past 400ms.
- **Unmocked stall proof (new)**: real `http.createServer` sends initial bytes then stalls; `totalTimeoutMs: 300`, `idleTimeoutMs: 150` — idle error fires at ~150ms, well before the 300ms guard; `elapsedMs < totalTimeoutMs - 50` proves idle beat the guard.

### Not tested

Live xAI CDN against real provider endpoints — requires real API credentials.