### PR TITLE
fix(types): remove duplicate pruneOrphanLocaleDocs declaration

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -24,4 +24,3 @@ export function syncClawHubDocsTree(
   path: string;
   files: number;
 };
-export function pruneOrphanLocaleDocs(targetDocsDir: string): void;


### PR DESCRIPTION
## What Problem This Solves

`main` currently fails `check-lint` on every PR: `scripts/docs-sync-publish.d.mts` declares `pruneOrphanLocaleDocs` twice (identical signatures at lines 10 and 27), which trips oxlint `typescript(adjacent-overload-signatures)`. This blocks CI for all open PRs.

## Why This Change Was Made

Two PRs independently added the same declaration to fix the same type error: #109358 (`fix(docs-sync): declare locale pruning export`) added it, and #109372 (`fix(types): declare docs sync pruning helper`) added it again — leaving a duplicate. Removing the redundant second declaration resolves the lint failure; the single remaining declaration still satisfies `check-test-types` (which requires the export for `test/scripts/docs-sync-publish.test.ts`).

## User Impact

Unblocks CI. No runtime behavior change (declaration-only file).

## Evidence

- Before: two identical `export function pruneOrphanLocaleDocs(targetDocsDir: string): void;` at lines 10 and 27. After: one (line 10).
- The remaining declaration matches the runtime export in `scripts/docs-sync-publish.mjs:442`, keeping the test's import type-valid.
