### PR TITLE
refactor(proxy-capture): drop stale body reader gate

### DIFF
--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -549,37 +549,28 @@ describe("debug proxy runtime", () => {
     expect(events.some((event) => event.kind === "error")).toBe(false);
   });
 
-  it.each([undefined, "invalid", "1"])(
-    "fails closed on a streamless Response-like body with content-length %s",
-    async (contentLength) => {
-      initializeDebugProxyCapture("test", settings, deps);
-      const headers = new Headers(
-        contentLength === undefined ? undefined : { "content-length": contentLength },
-      );
-      captureHttpExchange(
-        {
-          url: "https://api.example.test/streamless",
-          method: "GET",
-          response: {
-            status: 200,
-            headers,
-            clone: () => ({ body: null, headers }),
-          } as unknown as Response,
-        },
-        settings,
-        deps,
-      );
-      await waitForResponseSettled();
-      finalizeDebugProxyCapture(settings, deps);
+  it("captures a clone-only Response-like readable body", async () => {
+    initializeDebugProxyCapture("test", settings, deps);
+    const headers = new Headers({ "content-type": "text/plain" });
+    const clone = vi.fn(() => new Response("captured", { headers }));
+    captureHttpExchange(
+      {
+        url: "https://api.example.test/clone-only",
+        method: "GET",
+        response: { status: 200, headers, clone } as unknown as Response,
+      },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
 
-      const response = events.find((event) => event.kind === "response");
-      expect(JSON.parse(String(response?.metaJson))).toMatchObject({
-        bodyCapture: "unavailable",
-      });
-      expect(response).not.toHaveProperty("dataText");
-      expect(events.some((event) => event.kind === "error")).toBe(false);
-    },
-  );
+    const response = events.find((event) => event.kind === "response");
+    expect(clone).toHaveBeenCalledOnce();
+    expect(response?.dataText).toBe("captured");
+    expect(response?.metaJson).toBeUndefined();
+    expect(events.some((event) => event.kind === "error")).toBe(false);
+  });
 
   it("records metadata-only for non-cloneable Response-like objects", async () => {
     initializeDebugProxyCapture("test", settings, deps);

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -556,7 +556,6 @@ describe("debug proxy runtime", () => {
       const headers = new Headers(
         contentLength === undefined ? undefined : { "content-length": contentLength },
       );
-      const arrayBuffer = vi.fn(async () => new Uint8Array(32 * ONE_MIB).buffer);
       captureHttpExchange(
         {
           url: "https://api.example.test/streamless",
@@ -564,8 +563,7 @@ describe("debug proxy runtime", () => {
           response: {
             status: 200,
             headers,
-            arrayBuffer,
-            clone: () => ({ body: null, headers, arrayBuffer }),
+            clone: () => ({ body: null, headers }),
           } as unknown as Response,
         },
         settings,
@@ -579,7 +577,6 @@ describe("debug proxy runtime", () => {
         bodyCapture: "unavailable",
       });
       expect(response).not.toHaveProperty("dataText");
-      expect(arrayBuffer).not.toHaveBeenCalled();
       expect(events.some((event) => event.kind === "error")).toBe(false);
     },
   );

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -566,11 +566,7 @@ export function captureHttpExchange(
       metaJson: redactedCaptureJson({ ...params.meta, bodyCapture }, runtime.safeJsonString),
     });
   };
-  const cloneable =
-    params.response &&
-    typeof params.response.clone === "function" &&
-    typeof params.response.arrayBuffer === "function";
-  if (!cloneable) {
+  if (typeof params.response.clone !== "function") {
     // Some Response-like objects cannot be cloned. Still record status/headers
     // rather than forcing capture to consume or mutate the original response.
     recordResponseMetadataOnly("unavailable");


### PR DESCRIPTION
## What Problem This Solves

Removes a stale response capability check left behind after proxy response capture switched from unbounded `arrayBuffer()` reads to bounded stream reads.

## Why This Change Was Made

Capture now requires only the capability it invokes: `clone()`. A clone without a readable stream still follows the existing metadata-only fail-closed path. This keeps the memory bound while avoiding an unrelated `arrayBuffer()` requirement.

## User Impact

No user-visible behavior change for standard Fetch `Response` objects. Cloneable response-like adapters no longer need to expose an unused unbounded body reader before bounded capture can inspect them.

## Evidence

- `node scripts/run-vitest.mjs src/proxy-capture/runtime.test.ts --reporter=verbose` — 20 tests passed, including a clone-only adapter backed by a real Fetch `Response` stream.
- `git diff --check` — passed.
- Autoreview of the regression rewrite — clean, confidence 0.95.
- Hosted changed gate: touched formatting and guards passed; the run then stopped on unrelated current-main Plugin SDK baseline drift: https://github.com/openclaw/openclaw/actions/runs/29555763245
- Fresh exact-head CI — passed: https://github.com/openclaw/openclaw/actions/runs/29555946274
- Fresh exact-head CodeQL — passed: https://github.com/openclaw/openclaw/actions/runs/29555946316
- Previously incident-affected workflows all passed on the exact head: [Dependency Guard](https://github.com/openclaw/openclaw/actions/runs/29555945229), [Security Sensitive Guard](https://github.com/openclaw/openclaw/actions/runs/29555945219), and [CodeQL Critical Quality network boundary](https://github.com/openclaw/openclaw/actions/runs/29555946279).
