### PR TITLE
fix(docs-sync): restore lint checks

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -24,4 +24,3 @@ export function syncClawHubDocsTree(
   path: string;
   files: number;
 };
-export function pruneOrphanLocaleDocs(targetDocsDir: string): void;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the docs-sync declaration shim defines the locale-pruning export twice, causing the main `check-lint` job to fail `typescript(adjacent-overload-signatures)`.

## Why This Change Was Made

Keeps the original declaration and removes only the later identical duplicate. The runtime implementation and tests are unchanged.

## User Impact

No runtime behavior changes. Maintainers regain a clean lint and root test-type surface for docs-sync tooling.

## Evidence

- `git diff --check`
- Blacksmith Testbox `tbx_01kxpg98fyer5c3wewnk1njpsc`: `pnpm check:test-types`
- Same Testbox: `pnpm check:changed -- scripts/docs-sync-publish.d.mts`
- Testbox Actions run: https://github.com/openclaw/openclaw/actions/runs/29539245504
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings

AI-assisted; I reviewed the one-line change and its validation evidence.
