### PR TITLE
fix: keep /think and /verbose session prefs past freshness gate

### DIFF
--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -113,4 +113,58 @@ describe("command resolveSession provider-owned daily reset", () => {
     expect(result.isNewSession).toBe(false);
     expect(result.sessionId).toBe("locked-session-id");
   });
+
+  it("exposes stored thinking and verbose preferences when the session is still fresh", () => {
+    const sessionKey = "agent:main:cli";
+    const now = Date.now();
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "active-session-id",
+        updatedAt: now,
+        sessionStartedAt: now,
+        lastInteractionAt: now,
+        thinkingLevel: "high",
+        verboseLevel: "on",
+      },
+    };
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe("active-session-id");
+    expect(result.persistedThinking).toBe("high");
+    expect(result.persistedVerbose).toBe("on");
+  });
+
+  it("keeps stored thinking and verbose preferences when lifecycle marks the session not fresh", () => {
+    const sessionKey = "agent:main:cli";
+    const startedAt = Date.now() - DAY_MS;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "stale-session-id",
+        updatedAt: startedAt,
+        sessionStartedAt: startedAt,
+        lastInteractionAt: startedAt,
+        thinkingLevel: "high",
+        verboseLevel: "full",
+      },
+    };
+    // Forces !fresh without model lock: same path as terminal transcript ahead of registry.
+    hoisted.terminalTranscriptNewer = true;
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("stale-session-id");
+    expect(result.persistedThinking).toBe("high");
+    expect(result.persistedVerbose).toBe("full");
+  });
 });

--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -140,7 +140,7 @@ describe("command resolveSession provider-owned daily reset", () => {
     expect(result.persistedVerbose).toBe("on");
   });
 
-  it("keeps stored thinking and verbose preferences when lifecycle marks the session not fresh", () => {
+  it("keeps stored thinking and verbose preferences for terminal transcript-registry recovery", () => {
     const sessionKey = "agent:main:cli";
     const startedAt = Date.now() - DAY_MS;
     hoisted.store = {
@@ -166,5 +166,65 @@ describe("command resolveSession provider-owned daily reset", () => {
     expect(result.sessionId).not.toBe("stale-session-id");
     expect(result.persistedThinking).toBe("high");
     expect(result.persistedVerbose).toBe("full");
+  });
+
+  it("does not inherit thinking/verbose prefs across a configured daily reset boundary", () => {
+    const sessionKey = "agent:main:cli";
+    const startedAt = Date.now() - DAY_MS;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "daily-expired-session-id",
+        updatedAt: startedAt,
+        sessionStartedAt: startedAt,
+        lastInteractionAt: startedAt,
+        thinkingLevel: "high",
+        verboseLevel: "full",
+      },
+    };
+    // Default daily policy + age past the boundary → isNewSession without
+    // terminal-transcript recovery; prefs must not cross that reset.
+    hoisted.terminalTranscriptNewer = false;
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("daily-expired-session-id");
+    expect(result.persistedThinking).toBeUndefined();
+    expect(result.persistedVerbose).toBeUndefined();
+  });
+
+  it("does not inherit thinking/verbose prefs across a configured idle reset boundary", () => {
+    const sessionKey = "agent:main:cli";
+    const startedAt = Date.now() - 60 * 60 * 1000;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "idle-expired-session-id",
+        updatedAt: startedAt,
+        sessionStartedAt: startedAt,
+        lastInteractionAt: startedAt,
+        thinkingLevel: "high",
+        verboseLevel: "on",
+      },
+    };
+    hoisted.terminalTranscriptNewer = false;
+
+    const result = resolveSession({
+      cfg: {
+        session: {
+          reset: { mode: "idle", idleMinutes: 30 },
+        },
+      } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("idle-expired-session-id");
+    expect(result.persistedThinking).toBeUndefined();
+    expect(result.persistedVerbose).toBeUndefined();
   });
 });

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -456,14 +456,16 @@ export function resolveSession(opts: {
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,
   });
 
-  const persistedThinking =
-    fresh && sessionEntry?.thinkingLevel
-      ? normalizeThinkLevel(sessionEntry.thinkingLevel)
-      : undefined;
-  const persistedVerbose =
-    fresh && sessionEntry?.verboseLevel
-      ? normalizeVerboseLevel(sessionEntry.verboseLevel)
-      : undefined;
+  // Session lifecycle uses `fresh` for rollover / sessionId reuse only.
+  // Stored /think and /verbose preferences must still apply on every turn
+  // while the entry remains in the store (including after implicit rotation
+  // or when a terminal transcript is newer than the registry snapshot).
+  const persistedThinking = sessionEntry?.thinkingLevel
+    ? normalizeThinkLevel(sessionEntry.thinkingLevel)
+    : undefined;
+  const persistedVerbose = sessionEntry?.verboseLevel
+    ? normalizeVerboseLevel(sessionEntry.verboseLevel)
+    : undefined;
 
   return {
     sessionId,

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -456,16 +456,22 @@ export function resolveSession(opts: {
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,
   });
 
-  // Session lifecycle uses `fresh` for rollover / sessionId reuse only.
-  // Stored /think and /verbose preferences must still apply on every turn
-  // while the entry remains in the store (including after implicit rotation
-  // or when a terminal transcript is newer than the registry snapshot).
-  const persistedThinking = sessionEntry?.thinkingLevel
-    ? normalizeThinkLevel(sessionEntry.thinkingLevel)
-    : undefined;
-  const persistedVerbose = sessionEntry?.verboseLevel
-    ? normalizeVerboseLevel(sessionEntry.verboseLevel)
-    : undefined;
+  // Preference carryover is intentionally narrower than session-id reuse:
+  // keep /think and /verbose for genuine continuation and for terminal
+  // transcript-registry recovery (new sessionId, same stored prefs), but do
+  // not inherit them across a configured daily/idle new-session boundary.
+  // Without this split, not-fresh configured resets would silently reuse the
+  // prior session's choices (CS: preserve configured session-reset boundary).
+  const carryPersistedPreferences =
+    Boolean(sessionEntry) && (!isNewSession || terminalMainTranscriptNewerThanRegistry);
+  const persistedThinking =
+    carryPersistedPreferences && sessionEntry?.thinkingLevel
+      ? normalizeThinkLevel(sessionEntry.thinkingLevel)
+      : undefined;
+  const persistedVerbose =
+    carryPersistedPreferences && sessionEntry?.verboseLevel
+      ? normalizeVerboseLevel(sessionEntry.verboseLevel)
+      : undefined;
 
   return {
     sessionId,


### PR DESCRIPTION
Closes #109275

## What Problem This Solves

Fixes an issue where users who set `/think` or `/verbose` on a session could see those stored preferences dropped during agent-command session resolution whenever lifecycle freshness failed for transcript-registry recovery (for example when a terminal main transcript is newer than the registry snapshot). The preferences remained in the session store, but `persistedThinking` / `persistedVerbose` were gated on `fresh` and became `undefined`, so later turns fell through to agent/provider defaults instead of the session override.

## Why This Change Was Made

Session freshness should only control session-id reuse and rollover. For **genuine continuation** and **terminal transcript-registry recovery**, stored thinking and verbose levels must still be exposed to the agent-command resolution chain. Configured **daily/idle** new-session boundaries intentionally mint a new session and must **not** inherit the prior session's `/think` / `/verbose` choices.

The fix keeps the existing `fresh` lifecycle path for session-id reuse, carries preferences only when the session continues or the not-fresh reason is terminal-transcript recovery, and drops them on configured daily/idle reset. Explicit per-turn overrides remain higher priority via `thinkOnce ?? thinkOverride ?? persistedThinking`.

Compatibility: no config/API shape change; restores intended preference propagation for recovery without redefining configured reset semantics. Performance: no extra I/O or hot-path discovery. Usability: `/think` / `/verbose` stick across recovery, and configured resets clear them as before. Security: no trust-boundary change; preferences already trusted from the local session store.

## User Impact

After `/think high` (or `/verbose …`) is stored on a session, later agent-command turns continue to honor that level through terminal transcript-registry recovery. Configured daily or idle session resets still start clean for those preferences, so operators do not silently inherit old choices on a scheduled new session.

## Evidence

Verification host: local macOS (focused Vitest)

```text
# Focused primary
node scripts/run-vitest.mjs \
  src/agents/command/session.provider-owned-reset.test.ts
# Test Files  1 passed (1)
# Tests       7 passed (7)

# Path-scoped format (oxfmt) on both touched files: clean
# git diff --check: clean
```

Regression cases in `session.provider-owned-reset.test.ts`:
1. Fresh active session still exposes stored `thinkingLevel` / `verboseLevel`
2. Terminal-transcript-newer recovery (`!fresh` + new session id) still surfaces `persistedThinking` / `persistedVerbose`
3. Configured daily reset boundary mints a new session **without** inheriting prior prefs
4. Configured idle reset boundary mints a new session **without** inheriting prior prefs

Head: `4db80f0dbee24092c4d6af7ff11af29c0427086d`

## Real behavior proof

- Behavior addressed: Session-stored `/think` and `/verbose` remain available through terminal transcript-registry recovery, while configured daily/idle resets do not inherit those preferences into the replacement session.
- Environment: local macOS OpenClaw checkout at branch `fix/109275-persisted-thinking-fresh-gate` (head `4db80f0dbee`), Node 24, focused Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: on `origin/main`, `resolveSession` computes `persistedThinking` / `persistedVerbose` only when `fresh && sessionEntry?.thinkingLevel|verboseLevel`. With stored `thinkingLevel: "high"` and `terminalTranscriptNewer=true` (forces `!fresh`), main returns `persistedThinking === undefined` while rotating the session id.
- After this patch (carry rule):
  - Terminal recovery: `isNewSession === true`, new `sessionId`, and still `persistedThinking === "high"` / `persistedVerbose === "full"`.
  - Configured daily (age past default daily boundary, no terminal recovery): `isNewSession === true` and `persistedThinking` / `persistedVerbose` are `undefined`.
  - Configured idle (`session.reset.mode=idle`, idleMinutes=30, last interaction 1h ago): same drop of prefs on the new session.
- Exact command run:
  ```bash
  node scripts/run-vitest.mjs src/agents/command/session.provider-owned-reset.test.ts
  ```
  Result: 7 passed (fresh carry, terminal-recovery carry, daily drop, idle drop, plus existing provider-owned / model-locked lifecycle cases).
- Control check: provider-owned daily-boundary and model-locked session cases still pass unchanged; only preference carry is scoped by recovery vs configured reset.
- What was not tested: live multi-turn CLI chat against a real model provider end-to-end; channel auto-reply paths (sibling lifecycle already has its own explicit behavior-override carry policy).

## AI disclosure

This PR was authored with AI assistance (Grok).