### PR TITLE
fix(scripts): remove duplicate docs sync declaration

### DIFF
--- a/scripts/docs-sync-publish.d.mts
+++ b/scripts/docs-sync-publish.d.mts
@@ -24,4 +24,3 @@ export function syncClawHubDocsTree(
   path: string;
   files: number;
 };
-export function pruneOrphanLocaleDocs(targetDocsDir: string): void;


### PR DESCRIPTION
Removes the duplicate pruneOrphanLocaleDocs declaration introduced while restoring the docs sync type contract in #109373. This repairs the current main lint gate.