### PR TITLE
fix(agents): keep final replies scoped to the current run

### DIFF
--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -516,7 +516,6 @@ export async function runPreparedEmbeddedLoop(
       } = prepareEmbeddedRunTerminal({
         runParams: params,
         attempt,
-        attemptAssistant,
         currentAttemptAssistant,
         provider,
         model: model.id,

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -789,6 +789,38 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta.finalAssistantVisibleText).toBeUndefined();
   });
 
+  it("does not resolve a successful run from a stale transcript assistant", async () => {
+    const staleAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: "Prior transcript reply." }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "Current run reply." }]);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Current run reply."],
+        lastAssistant: staleAssistant,
+        currentAttemptAssistant: undefined,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-success-stale-transcript-assistant",
+    });
+
+    expect(result.payloads).toEqual([{ text: "Current run reply." }]);
+    expect(result.meta.finalAssistantVisibleText).toBe("Current run reply.");
+    expect(result.meta.finalAssistantRawText).toBe("Current run reply.");
+    expect(mockedBuildEmbeddedRunPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({ currentAssistant: null, lastAssistant: undefined }),
+    );
+  });
+
   it("recovers a completed prompt-timeout assistant without collected assistant text", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     const finalText = "Completed answer after the timeout race.";

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -61,6 +61,7 @@ describe("embedded attempt phase lifecycle state", () => {
         },
         isCompactionInFlight: () => false,
         getCompactionCount: () => 0,
+        getCurrentAttemptAssistant: () => undefined,
         getUsageTotals: () => undefined,
       } as never,
       state: {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -27,7 +27,6 @@ import {
 } from "./attempt.async-tasks.js";
 import {
   buildContextEnginePromptCacheInfo,
-  findCurrentAttemptAssistantMessage,
   resolvePromptCacheTouchTimestamp,
 } from "./attempt.context-engine-helpers.js";
 import type { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
@@ -173,10 +172,7 @@ export async function settleEmbeddedAttemptStream(input: {
 
   try {
     if (input.onBlockReplyFlush) {
-      const currentAssistant = findCurrentAttemptAssistantMessage({
-        messagesSnapshot: snapshot,
-        prePromptMessageCount: input.prePromptMessageCount,
-      });
+      const currentAssistant = subscription.getCurrentAttemptAssistant();
       const attemptAccepted =
         !promptError &&
         !input.readLifecycleState().aborted &&
@@ -281,10 +277,9 @@ export async function settleEmbeddedAttemptStream(input: {
       .slice()
       .toReversed()
       .find((message): message is AssistantMessage => message.role === "assistant");
-    currentAttemptAssistant = findCurrentAttemptAssistantMessage({
-      messagesSnapshot,
-      prePromptMessageCount: input.prePromptMessageCount,
-    });
+    // The subscription observes only this attempt's model events. Transcript
+    // positions can change during compaction or context-engine projection.
+    currentAttemptAssistant = subscription.getCurrentAttemptAssistant();
     attemptUsage = subscription.getUsageTotals();
     cacheBreak = input.cache.observabilityEnabled
       ? completePromptCacheObservation({

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
@@ -129,7 +129,7 @@ export function buildContextEnginePromptCacheInfo(params: {
  * Finds the assistant message produced by the current attempt, ignoring
  * historical messages that were present before prompt submission.
  */
-export function findCurrentAttemptAssistantMessage(params: {
+function findCurrentAttemptAssistantMessage(params: {
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;
 }): AssistantMessage | undefined {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -29,7 +29,6 @@ import {
   buildLoopPromptCacheInfo,
   assembleAttemptContextEngine,
   buildContextEnginePromptCacheInfo,
-  findCurrentAttemptAssistantMessage,
   finalizeAttemptContextEngineTurn,
   resolvePromptCacheTouchTimestamp,
   runAttemptContextEngineBootstrap,
@@ -3190,16 +3189,12 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         total: 1340,
       },
     } as unknown as AgentMessage;
-    const currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+    const promptCache = buildLoopPromptCacheInfo({
       messagesSnapshot: [seedMessage, priorAssistant],
       prePromptMessageCount: 2,
-    });
-    const promptCache = buildContextEnginePromptCacheInfo({
       retention: "short",
-      lastCallUsage: (currentAttemptAssistant as { usage?: undefined } | undefined)?.usage,
     });
 
-    expect(currentAttemptAssistant).toBeUndefined();
     expect(promptCache).toEqual({ retention: "short" });
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -3203,6 +3203,35 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(promptCache).toEqual({ retention: "short" });
   });
 
+  it("keeps the run assistant when a context projection reorders the transcript", async () => {
+    const currentAssistant = makeAgentAssistantMessage({ content: "Current run reply" });
+    const priorAssistant = makeAgentAssistantMessage({ content: "Prior transcript reply" });
+    const baseSubscribe = hoisted.subscribeEmbeddedAgentSessionMock.getMockImplementation();
+    if (!baseSubscribe) {
+      throw new Error("missing embedded subscription mock");
+    }
+    hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation((params) => ({
+      ...baseSubscribe(params),
+      assistantTexts: ["Current run reply"],
+      getCurrentAttemptAssistant: () => structuredClone(currentAssistant),
+    }));
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      sessionMessages: [seedMessage, priorAssistant],
+      sessionPrompt: async (session) => {
+        // Reproduce a projection that moves the current output before an older
+        // assistant, invalidating both the prompt index and transcript tail.
+        session.messages = [currentAssistant, priorAssistant];
+      },
+    });
+
+    expect(result.lastAssistant?.content).toEqual(priorAssistant.content);
+    expect(result.currentAttemptAssistant?.content).toEqual(currentAssistant.content);
+  });
+
   it("derives live loop prompt-cache info from the current attempt assistant", () => {
     const toolUseAssistant = {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -3204,8 +3204,12 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   });
 
   it("keeps the run assistant when a context projection reorders the transcript", async () => {
-    const currentAssistant = makeAgentAssistantMessage({ content: "Current run reply" });
-    const priorAssistant = makeAgentAssistantMessage({ content: "Prior transcript reply" });
+    const currentAssistant = makeAgentAssistantMessage({
+      content: [{ type: "text", text: "Current run reply" }],
+    });
+    const priorAssistant = makeAgentAssistantMessage({
+      content: [{ type: "text", text: "Prior transcript reply" }],
+    });
     const baseSubscribe = hoisted.subscribeEmbeddedAgentSessionMock.getMockImplementation();
     if (!baseSubscribe) {
       throw new Error("missing embedded subscription mock");

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -122,6 +122,7 @@ function createSubscriptionMock(): SubscriptionMock {
   // override only the lifecycle method they need.
   return {
     assistantTexts: [] as string[],
+    getCurrentAttemptAssistant: () => undefined,
     getLastAssistantTextMessageIndex: () => undefined,
     toolMetas: [] as Array<{ toolName: string; meta?: string; asyncStarted?: boolean }>,
     runToolLifecycle: async <T>(toolParams: { execute: () => Promise<T> }) =>

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -21,7 +21,6 @@ import type { EmbeddedRunAttemptResult } from "./types.js";
 export function prepareEmbeddedRunTerminal(input: {
   runParams: RunEmbeddedAgentParams;
   attempt: EmbeddedRunAttemptResult;
-  attemptAssistant?: AssistantMessage;
   currentAttemptAssistant?: AssistantMessage;
   provider: string;
   model: string;
@@ -54,12 +53,12 @@ export function prepareEmbeddedRunTerminal(input: {
   attemptToolSummary: ReturnType<typeof buildTraceToolSummary>;
   failureSignal: ReturnType<typeof resolveEmbeddedRunFailureSignal>;
 } {
-  const { runParams, attempt, attemptAssistant } = input;
+  const { runParams, attempt } = input;
   const timedOutDuringPrompt =
     input.terminalTimedOut && !input.timedOutDuringCompaction && !input.timedOutDuringToolExecution;
-  // A prior same-model assistant can remain in the session snapshot. Timeout
-  // recovery must project only output owned by the prompt that just timed out.
-  const terminalAssistant = timedOutDuringPrompt ? input.currentAttemptAssistant : attemptAssistant;
+  // Final delivery is run-scoped. Session transcript fallbacks remain useful
+  // for failure classification, but can reference an earlier rewritten turn.
+  const terminalAssistant = input.currentAttemptAssistant;
   const usageMeta = buildUsageAgentMetaFields({
     usageAccumulator: input.usageAccumulator,
     lastAssistantUsage: terminalAssistant?.usage as UsageLike | undefined,
@@ -90,14 +89,22 @@ export function prepareEmbeddedRunTerminal(input: {
         : undefined,
     compactionTokensAfter: input.contextRecoveryState.lastCompactionTokensAfter,
   };
-  const finalAssistantVisibleText = resolveFinalAssistantVisibleText(terminalAssistant);
-  const finalAssistantRawText = resolveFinalAssistantRawText(terminalAssistant);
+  const attemptFinalText = attempt.assistantTexts
+    .toReversed()
+    .map((text) => text.trim())
+    .find((text) => text.length > 0);
+  const finalAssistantVisibleText =
+    resolveFinalAssistantVisibleText(terminalAssistant) ?? attemptFinalText;
+  const finalAssistantRawText = resolveFinalAssistantRawText(terminalAssistant) ?? attemptFinalText;
   const payloads = buildEmbeddedRunPayloads({
     assistantTexts: attempt.assistantTexts,
     assistantMessageIndex: attempt.lastAssistantTextMessageIndex,
     assistantTranscriptOwned: attempt.assistantTranscriptOwned,
     toolMetas: attempt.toolMetas,
-    lastAssistant: timedOutDuringPrompt ? input.currentAttemptAssistant : attempt.lastAssistant,
+    // A current assistant makes the session candidate harmless because the
+    // payload resolver always prefers the run-owned value. Without one, omit
+    // the transcript candidate and fall back only to attempt-local texts.
+    lastAssistant: input.currentAttemptAssistant ? attempt.lastAssistant : undefined,
     currentAssistant: input.currentAttemptAssistant ?? null,
     lastToolError: attempt.lastToolError,
     config: runParams.config,

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -74,6 +74,7 @@ function createMessageUpdateContext(
     },
     log: { debug: params.debug ?? vi.fn() },
     noteLastAssistant: vi.fn(),
+    noteCompletedAssistant: vi.fn(),
     stripBlockTags: params.stripBlockTags ?? vi.fn((text: string) => text),
     consumePartialReplyDirectives:
       params.consumePartialReplyDirectives ??
@@ -160,6 +161,7 @@ function createMessageEndContext(
       ...params.state,
     },
     noteLastAssistant: vi.fn(),
+    noteCompletedAssistant: vi.fn(),
     recordAssistantUsage: vi.fn(),
     commitAssistantUsage: vi.fn(),
     log: { debug: vi.fn(), info: vi.fn(), warn: params.warn ?? vi.fn() },

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -1437,7 +1437,7 @@ describe("handleMessageEnd", () => {
       message,
     } as never);
 
-    expect(firstMockArg(ctx.noteLastAssistant as never, "last assistant")).toMatchObject({
+    expect(firstMockArg(ctx.noteCompletedAssistant as never, "completed assistant")).toMatchObject({
       usage: {
         input: 7,
         output: 5,
@@ -1480,7 +1480,7 @@ describe("handleMessageEnd", () => {
       message,
     } as never);
 
-    expect(firstMockArg(ctx.noteLastAssistant as never, "last assistant")).toBe(message);
+    expect(firstMockArg(ctx.noteCompletedAssistant as never, "completed assistant")).toBe(message);
     expect(ctx.recordAssistantUsage).toHaveBeenCalledWith(message.usage);
   });
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -1158,7 +1158,7 @@ export function handleMessageEnd(
   const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(assistantMessage);
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
   const suppressMessageToolOnlySourceReplyOutput = hasMessageToolOnlySourceDelivery(ctx);
-  ctx.noteLastAssistant(assistantMessage);
+  ctx.noteCompletedAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   ctx.commitAssistantUsage();
   if (suppressVisibleAssistantOutput) {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -61,6 +61,7 @@ function createMockContext(overrides?: {
     // Fill in remaining required fields with no-ops.
     blockChunker: null,
     noteLastAssistant: vi.fn(),
+    noteCompletedAssistant: vi.fn(),
     stripBlockTags: vi.fn((t: string) => t),
     emitBlockChunk: vi.fn(),
     flushBlockReplyBuffer: vi.fn(),

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -8,6 +8,7 @@ import type { FenceScanState } from "../../packages/markdown-core/src/fences.js"
 import type { HeartbeatToolResponse } from "../auto-reply/heartbeat-tool-response.js";
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
+import type { AssistantMessage } from "../llm/types.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { AssistantPhase } from "../shared/chat-message-content.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
@@ -182,7 +183,7 @@ export type EmbeddedAgentSubscribeState = {
   >;
   deterministicApprovalPromptPending: boolean;
   deterministicApprovalPromptSent: boolean;
-  lastAssistant?: AgentMessage;
+  lastAssistant?: AssistantMessage;
 };
 
 /** Handler context bundling params, mutable state, emitters, and helper hooks. */
@@ -196,6 +197,7 @@ export type EmbeddedAgentSubscribeContext = {
   builtinToolNames?: ReadonlySet<string>;
   trustedLocalMediaToolNames?: ReadonlySet<string>;
   noteLastAssistant: (msg: AgentMessage) => void;
+  noteCompletedAssistant: (msg: AgentMessage) => void;
 
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-emit-duplicate-block-replies-text.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-emit-duplicate-block-replies-text.test.ts
@@ -41,6 +41,21 @@ describe("subscribeEmbeddedAgentSession", () => {
 
     expect(subscription.assistantTexts).toEqual(["Hello world"]);
   });
+  it("keeps the completed assistant independent from transcript rewrites", () => {
+    const { session, emit } = createStubSessionHarness();
+    const subscription = subscribeEmbeddedAgentSession({ session, runId: "run" });
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Current run reply" }],
+    } as AssistantMessage;
+
+    emit({ type: "message_end", message: assistantMessage });
+    assistantMessage.content = [{ type: "text", text: "Rewritten transcript reply" }];
+
+    expect(subscription.getCurrentAttemptAssistant()?.content).toEqual([
+      { type: "text", text: "Current run reply" },
+    ]);
+  });
   it("does not duplicate assistantTexts when message_end repeats with trailing whitespace changes", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -1,5 +1,6 @@
 // Compaction retry subscription tests cover retry wait accounting, compaction
 // event emission, abort-on-unsubscribe, and verbose tool summary behavior.
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { createSubscribedSessionHarness } from "./embedded-agent-subscribe.e2e-harness.js";
@@ -73,6 +74,24 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
     expect(subscription.getCompactionCount()).toBe(2);
     expect(subscription.getLastCompactionTokensAfter()).toBe(6_789);
+  });
+
+  it("clears the completed assistant when compaction schedules a retry", () => {
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-compaction-assistant",
+    });
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Reply before compaction" }],
+    } as AssistantMessage;
+
+    emit({ type: "message_end", message: assistant });
+    expect(subscription.getCurrentAttemptAssistant()).toEqual(assistant);
+    expect(subscription.assistantTexts).toEqual(["Reply before compaction"]);
+
+    emit({ type: "compaction_end", willRetry: true });
+    expect(subscription.getCurrentAttemptAssistant()).toBeUndefined();
+    expect(subscription.assistantTexts).toEqual([]);
   });
 
   it("does not count compaction when result is absent", () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1280,6 +1280,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.deterministicApprovalPromptSent = false;
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
+    // A compaction retry starts a fresh model attempt. Do not let the prior
+    // attempt's assistant become the terminal result if the retry is silent.
+    state.lastAssistant = undefined;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
     state.livenessState = "working";
     resetAssistantMessageState(0);
@@ -1288,6 +1291,13 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const noteLastAssistant = (msg: AgentMessage) => {
     if (msg?.role === "assistant") {
       state.lastAssistant = msg;
+    }
+  };
+  const noteCompletedAssistant = (msg: AgentMessage) => {
+    if (msg?.role === "assistant") {
+      // Session projections may later replace or mutate transcript objects.
+      // Keep the finalized event value owned by this attempt.
+      state.lastAssistant = structuredClone(msg);
     }
   };
 
@@ -1301,6 +1311,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     builtinToolNames: params.builtinToolNames,
     trustedLocalMediaToolNames: params.trustedLocalMediaToolNames,
     noteLastAssistant,
+    noteCompletedAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,
     emitToolSummary,
@@ -1374,6 +1385,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
 
   return {
     assistantTexts,
+    getCurrentAttemptAssistant: () => {
+      const assistant = state.lastAssistant;
+      return assistant?.role === "assistant" ? structuredClone(assistant) : undefined;
+    },
     getLastAssistantTextMessageIndex: () =>
       state.lastAssistantTextMessageIndex >= 0 ? state.lastAssistantTextMessageIndex : undefined,
     toolMetas,


### PR DESCRIPTION
Closes #109352

## What Problem This Solves

Fixes an issue where users could receive growing repeats of earlier assistant replies after a context engine rewrote or reordered the working transcript during a run.

## Why This Change Was Made

The embedded runner now carries the assistant message finalized by the current model attempt through terminal delivery instead of rediscovering it by mutable transcript position. Compaction retries clear both the structured result and collected attempt text; focused lifecycle proof covers the stale-reply failure mode.

## User Impact

Final replies remain scoped to the current run even when transcript projection changes message positions, so prior assistant text is not resent as the new answer.

## Evidence

Production-path before/premise/after proof, run from this branch with `node --import tsx --input-type=module -e '<harness>'`. The harness directly imported `findCurrentAttemptAssistantMessage`, `subscribeEmbeddedAgentSession`, and `buildEmbeddedRunPayloads`; it emitted a real `message_end` event and then mutated the transcript object to simulate a context projection rewrite:

```text
before.indexCurrent=undefined
before.delivered=Prior transcript reply.
after.runCurrent=Current run reply.
after.delivered=Current run reply.
```

Focused regression coverage:

```text
$ node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.does-not-emit-duplicate-block-replies-text.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.waits-multiple-compaction-retries-before-resolving.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
Test Files  4 passed (4)
Tests  231 passed (231)
```

```text
$ oxfmt --check <changed files>
All matched files use the correct format.
$ git diff --check
(no output)
$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
autoreview clean: no accepted/actionable findings reported
```

No external context-engine/provider round trip was run. The defect and fix are at the model-event subscription-to-terminal-payload boundary before channel or provider delivery; the production exports at that boundary were exercised directly, while fork CI covers the wider build, type, and test lanes.

AI-assisted: implementation and review; production-path proof run manually.
