### PR TITLE
fix(video-generation): DashScope downloads hang when CDN body stalls after headers

### DIFF
--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -1,5 +1,7 @@
 // DashScope-compatible download regressions: body idle after headers.
-import { describe, expect, it, vi } from "vitest";
+import { once } from "node:events";
+import http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { downloadDashscopeGeneratedVideos } from "./dashscope-compatible.js";
 
 function neverChunkingVideoResponse(): Response {
@@ -73,5 +75,79 @@ describe("downloadDashscopeGeneratedVideos", () => {
     }
     expect(buffer.toString("utf8")).toBe("mp4-bytes");
     expect(video?.mimeType).toBe("video/mp4");
+  });
+
+  it("fails closed when a function-valued remaining budget is exhausted", async () => {
+    const fetchFn = vi.fn(async () => neverChunkingVideoResponse());
+    const startedAt = Date.now();
+
+    await expect(
+      downloadDashscopeGeneratedVideos({
+        providerLabel: "Alibaba Wan",
+        urls: ["https://example.com/out.mp4"],
+        // Function-valued timeout returns 0: header fetch consumed the entire
+        // deadline. Must fail closed, not reset to the full default timeout.
+        timeoutMs: () => 0,
+        fetchFn: fetchFn as unknown as typeof fetch,
+        maxBytes: 10 * 1024 * 1024,
+      }),
+    ).rejects.toThrow("remaining budget exhausted");
+
+    const elapsedMs = Date.now() - startedAt;
+    // Should reject quickly (0ms budget), not wait for the 60s default.
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("downloadDashscopeGeneratedVideos loopback HTTP", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (!server) {
+      return;
+    }
+    server.closeAllConnections?.();
+    server.close();
+    await once(server, "close").catch(() => undefined);
+    server = undefined;
+  });
+
+  it("bounds a stalled loopback HTTP body with a real server", async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "video/mp4" });
+      // Write one chunk so fetch resolves (Node fetch hangs until first body byte).
+      // Then never write more — simulates stalled CDN.
+      res.write("first-chunk");
+    });
+    server.on("clientError", (_err, socket) => socket.destroy());
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+    const port = address.port;
+
+    const timeoutMs = 200;
+    const startedAt = Date.now();
+
+    // Accept either error because the fetch-level AbortSignal timeout and
+    // the post-header chunk-idle timeout race; both are bounded within the
+    // configured budget.
+    await expect(
+      downloadDashscopeGeneratedVideos({
+        providerLabel: "Alibaba Wan",
+        urls: [`http://127.0.0.1:${port}/out.mp4`],
+        timeoutMs,
+        fetchFn: fetch,
+        allowPrivateNetwork: true,
+        maxBytes: 10 * 1024 * 1024,
+      }),
+    ).rejects.toThrow();
+
+    const elapsedMs = Date.now() - startedAt;
+    // Bounded proof: the download rejects within 5s, not an indefinite hang.
+    expect(elapsedMs).toBeLessThan(5_000);
   });
 });

--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -64,7 +64,12 @@ describe("downloadDashscopeGeneratedVideos", () => {
     });
 
     expect(videos).toHaveLength(1);
-    expect(videos[0]?.buffer.toString("utf8")).toBe("mp4-bytes");
-    expect(videos[0]?.mimeType).toBe("video/mp4");
+    const video = videos[0];
+    expect(video).toBeDefined();
+    if (!video) {
+      throw new Error("expected downloaded video asset");
+    }
+    expect(video.buffer.toString("utf8")).toBe("mp4-bytes");
+    expect(video.mimeType).toBe("video/mp4");
   });
 });

--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -1,7 +1,5 @@
 // DashScope-compatible download regressions: body idle after headers.
-import { once } from "node:events";
-import http from "node:http";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { downloadDashscopeGeneratedVideos } from "./dashscope-compatible.js";
 
 function neverChunkingVideoResponse(): Response {
@@ -100,56 +98,46 @@ describe("downloadDashscopeGeneratedVideos", () => {
     // Exhausted deadline is checked before fetch — no network I/O is initiated.
     expect(fetchFn).not.toHaveBeenCalled();
   });
-});
 
-describe("downloadDashscopeGeneratedVideos loopback HTTP", () => {
-  let server: http.Server | undefined;
+  it("releases the guarded fetch when the remaining-budget resolver throws", async () => {
+    vi.useFakeTimers();
+    try {
+      let requestSignal: AbortSignal | undefined;
+      const cancelBody = vi.fn();
+      const timeoutMs = vi
+        .fn<() => number>()
+        .mockReturnValueOnce(100)
+        .mockImplementationOnce(() => {
+          throw new Error("remaining-budget resolver failed");
+        });
+      const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        requestSignal = init?.signal ?? undefined;
+        return new Response(new ReadableStream({ cancel: cancelBody }), {
+          status: 200,
+          headers: { "content-type": "video/mp4" },
+        });
+      });
 
-  afterEach(async () => {
-    if (!server) {
-      return;
+      await expect(
+        downloadDashscopeGeneratedVideos({
+          providerLabel: "Alibaba Wan",
+          urls: ["https://example.com/out.mp4"],
+          timeoutMs,
+          fetchFn: fetchFn as typeof fetch,
+          maxBytes: 10 * 1024 * 1024,
+        }),
+      ).rejects.toThrow("remaining-budget resolver failed");
+
+      expect(timeoutMs).toHaveBeenCalledTimes(2);
+      expect(cancelBody).toHaveBeenCalledOnce();
+      expect(cancelBody.mock.calls[0]?.[0]).toMatchObject({
+        message: "remaining-budget resolver failed",
+      });
+      expect(requestSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(requestSignal?.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
     }
-    server.closeAllConnections?.();
-    server.close();
-    await once(server, "close").catch(() => undefined);
-    server = undefined;
-  });
-
-  it("bounds a stalled loopback HTTP body with a real server", async () => {
-    server = http.createServer((_req, res) => {
-      res.writeHead(200, { "content-type": "video/mp4" });
-      // Write one chunk so fetch resolves (Node fetch hangs until first body byte).
-      // Then never write more — simulates stalled CDN.
-      res.write("first-chunk");
-    });
-    server.on("clientError", (_err, socket) => socket.destroy());
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("expected loopback server address");
-    }
-    const port = address.port;
-
-    const timeoutMs = 200;
-    const startedAt = Date.now();
-
-    // Accept either error because the fetch-level AbortSignal timeout and
-    // the post-header chunk-idle timeout race; both are bounded within the
-    // configured budget.
-    await expect(
-      downloadDashscopeGeneratedVideos({
-        providerLabel: "Alibaba Wan",
-        urls: [`http://127.0.0.1:${port}/out.mp4`],
-        timeoutMs,
-        fetchFn: fetch,
-        allowPrivateNetwork: true,
-        maxBytes: 10 * 1024 * 1024,
-      }),
-    ).rejects.toThrow();
-
-    const elapsedMs = Date.now() - startedAt;
-    // Bounded proof: the download rejects within 5s, not an indefinite hang.
-    expect(elapsedMs).toBeLessThan(5_000);
   });
 });

--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -65,12 +65,13 @@ describe("downloadDashscopeGeneratedVideos", () => {
 
     expect(videos).toHaveLength(1);
     const video = videos[0];
+    const buffer = video?.buffer;
     expect(video).toBeDefined();
-    expect(video?.buffer).toBeInstanceOf(Buffer);
-    if (!video?.buffer) {
+    expect(buffer).toBeInstanceOf(Buffer);
+    if (!buffer) {
       throw new Error("expected downloaded video asset buffer");
     }
-    expect(video.buffer.toString("utf8")).toBe("mp4-bytes");
-    expect(video.mimeType).toBe("video/mp4");
+    expect(buffer.toString("utf8")).toBe("mp4-bytes");
+    expect(video?.mimeType).toBe("video/mp4");
   });
 });

--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -66,8 +66,9 @@ describe("downloadDashscopeGeneratedVideos", () => {
     expect(videos).toHaveLength(1);
     const video = videos[0];
     expect(video).toBeDefined();
-    if (!video) {
-      throw new Error("expected downloaded video asset");
+    expect(video?.buffer).toBeInstanceOf(Buffer);
+    if (!video?.buffer) {
+      throw new Error("expected downloaded video asset buffer");
     }
     expect(video.buffer.toString("utf8")).toBe("mp4-bytes");
     expect(video.mimeType).toBe("video/mp4");

--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -77,7 +77,7 @@ describe("downloadDashscopeGeneratedVideos", () => {
     expect(video?.mimeType).toBe("video/mp4");
   });
 
-  it("fails closed when a function-valued remaining budget is exhausted", async () => {
+  it("fails closed before fetch when a function-valued remaining budget is exhausted", async () => {
     const fetchFn = vi.fn(async () => neverChunkingVideoResponse());
     const startedAt = Date.now();
 
@@ -86,7 +86,8 @@ describe("downloadDashscopeGeneratedVideos", () => {
         providerLabel: "Alibaba Wan",
         urls: ["https://example.com/out.mp4"],
         // Function-valued timeout returns 0: header fetch consumed the entire
-        // deadline. Must fail closed, not reset to the full default timeout.
+        // deadline. Must fail closed before any network I/O, not reset to the
+        // full default timeout.
         timeoutMs: () => 0,
         fetchFn: fetchFn as unknown as typeof fetch,
         maxBytes: 10 * 1024 * 1024,
@@ -96,7 +97,8 @@ describe("downloadDashscopeGeneratedVideos", () => {
     const elapsedMs = Date.now() - startedAt;
     // Should reject quickly (0ms budget), not wait for the 60s default.
     expect(elapsedMs).toBeLessThan(2_000);
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    // Exhausted deadline is checked before fetch — no network I/O is initiated.
+    expect(fetchFn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -1,0 +1,70 @@
+// DashScope-compatible download regressions: body idle after headers.
+import { describe, expect, it, vi } from "vitest";
+import { downloadDashscopeGeneratedVideos } from "./dashscope-compatible.js";
+
+function neverChunkingVideoResponse(): Response {
+  return new Response(
+    new ReadableStream({
+      start() {
+        // Headers only — never enqueue so chunk idle must win.
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "video/mp4" },
+    },
+  );
+}
+
+describe("downloadDashscopeGeneratedVideos", () => {
+  it("aborts a stalled generated video body via chunk idle timeout", async () => {
+    const fetchFn = vi.fn(async () => neverChunkingVideoResponse());
+    const timeoutMs = 80;
+    const startedAt = Date.now();
+
+    await expect(
+      downloadDashscopeGeneratedVideos({
+        providerLabel: "Alibaba Wan",
+        urls: ["https://example.com/out.mp4"],
+        timeoutMs,
+        fetchFn: fetchFn as unknown as typeof fetch,
+        maxBytes: 10 * 1024 * 1024,
+      }),
+    ).rejects.toThrow("Alibaba Wan generated video download stalled: no data received for 80ms");
+
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 20);
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists a complete generated video body before the idle deadline", async () => {
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("mp4-bytes"));
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "video/mp4" },
+          },
+        ),
+    );
+
+    const videos = await downloadDashscopeGeneratedVideos({
+      providerLabel: "Alibaba Wan",
+      urls: ["https://example.com/ok.mp4"],
+      timeoutMs: 5_000,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      maxBytes: 10 * 1024 * 1024,
+    });
+
+    expect(videos).toHaveLength(1);
+    expect(videos[0]?.buffer.toString("utf8")).toBe("mp4-bytes");
+    expect(videos[0]?.mimeType).toBe("video/mp4");
+  });
+});

--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -377,10 +377,21 @@ export async function downloadDashscopeGeneratedVideos(params: {
       provider: params.providerLabel,
       stage: "download",
       operation: async () => {
+        const downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
+          params.timeoutMs,
+          params.defaultTimeoutMs,
+        );
+        // Reject a non-positive remaining budget before starting fetch so an
+        // already-exhausted operation does not initiate network I/O.
+        if (downloadTimeoutMs <= 0) {
+          throw new Error(
+            `${params.providerLabel} generated video download stalled: remaining budget exhausted`,
+          );
+        }
         const guarded = await fetchWithTimeoutGuarded(
           url,
           { method: "GET" },
-          resolveDashscopeVideoDownloadTimeoutMs(params.timeoutMs, params.defaultTimeoutMs),
+          downloadTimeoutMs,
           params.fetchFn,
           {
             ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
@@ -407,13 +418,6 @@ export async function downloadDashscopeGeneratedVideos(params: {
     let buffer: Buffer;
     let mimeType: string;
     try {
-      if (downloadTimeoutMs <= 0) {
-        // Exhausted remaining budget: fail closed instead of reading with no chunk timeout
-        // (readResponseWithLimit skips chunkTimeoutMs when it is 0/falsy).
-        throw new Error(
-          `${params.providerLabel} generated video download stalled: remaining budget exhausted`,
-        );
-      }
       buffer = await readResponseWithLimit(result.response, params.maxBytes, {
         chunkTimeoutMs: downloadTimeoutMs,
         onOverflow: ({ maxBytes }) =>

--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -344,23 +344,25 @@ export async function runDashscopeVideoGenerationTask(params: {
 }
 
 function resolveDashscopeVideoDownloadTimeoutMs(
+  providerLabel: string,
   timeoutMs: ProviderOperationTimeoutMs | undefined,
   defaultTimeoutMs: number | undefined,
 ): number {
   const resolved = typeof timeoutMs === "function" ? timeoutMs() : timeoutMs;
-  if (typeof resolved === "number" && Number.isFinite(resolved)) {
-    // Preserve exhausted budgets (0 or negative) so a function-valued remaining
-    // deadline that the header fetch consumed fails closed instead of getting
-    // reset to the full default timeout.
-    return Math.max(0, Math.floor(resolved));
+  const downloadTimeoutMs =
+    typeof resolved === "number" && Number.isFinite(resolved)
+      ? Math.max(0, Math.floor(resolved))
+      : (defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS);
+  if (downloadTimeoutMs <= 0) {
+    throw new Error(
+      `${providerLabel} generated video download stalled: remaining budget exhausted`,
+    );
   }
-  return defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS;
+  return downloadTimeoutMs;
 }
 
 // Downloads task result URLs into generated video assets. The byte limit comes
 // from OpenClaw media config so provider URLs cannot overfill memory.
-// chunkTimeoutMs is required after headers: fetchWithTimeoutGuarded clears its
-// abort once the response arrives, so a dripping CDN body would hang forever.
 export async function downloadDashscopeGeneratedVideos(params: {
   providerLabel: string;
   urls: string[];
@@ -378,16 +380,10 @@ export async function downloadDashscopeGeneratedVideos(params: {
       stage: "download",
       operation: async () => {
         const downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
+          params.providerLabel,
           params.timeoutMs,
           params.defaultTimeoutMs,
         );
-        // Reject a non-positive remaining budget before starting fetch so an
-        // already-exhausted operation does not initiate network I/O.
-        if (downloadTimeoutMs <= 0) {
-          throw new Error(
-            `${params.providerLabel} generated video download stalled: remaining budget exhausted`,
-          );
-        }
         const guarded = await fetchWithTimeoutGuarded(
           url,
           { method: "GET" },
@@ -410,14 +406,23 @@ export async function downloadDashscopeGeneratedVideos(params: {
         }
       },
     });
-    // Resolve after headers so a function timeout still sees remaining budget.
-    const downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
-      params.timeoutMs,
-      params.defaultTimeoutMs,
-    );
     let buffer: Buffer;
     let mimeType: string;
     try {
+      // Re-resolve after headers so the body uses the remaining operation budget.
+      let downloadTimeoutMs: number;
+      try {
+        downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
+          params.providerLabel,
+          params.timeoutMs,
+          params.defaultTimeoutMs,
+        );
+      } catch (error) {
+        // The body reader normally owns cancellation. If deadline resolution
+        // fails first, cancel here before release clears the guarded abort.
+        await result.response.body?.cancel(error).catch(() => undefined);
+        throw error;
+      }
       buffer = await readResponseWithLimit(result.response, params.maxBytes, {
         chunkTimeoutMs: downloadTimeoutMs,
         onOverflow: ({ maxBytes }) =>

--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -348,8 +348,11 @@ function resolveDashscopeVideoDownloadTimeoutMs(
   defaultTimeoutMs: number | undefined,
 ): number {
   const resolved = typeof timeoutMs === "function" ? timeoutMs() : timeoutMs;
-  if (typeof resolved === "number" && Number.isFinite(resolved) && resolved > 0) {
-    return Math.floor(resolved);
+  if (typeof resolved === "number" && Number.isFinite(resolved)) {
+    // Preserve exhausted budgets (0 or negative) so a function-valued remaining
+    // deadline that the header fetch consumed fails closed instead of getting
+    // reset to the full default timeout.
+    return Math.max(0, Math.floor(resolved));
   }
   return defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS;
 }
@@ -404,6 +407,13 @@ export async function downloadDashscopeGeneratedVideos(params: {
     let buffer: Buffer;
     let mimeType: string;
     try {
+      if (downloadTimeoutMs <= 0) {
+        // Exhausted remaining budget: fail closed instead of reading with no chunk timeout
+        // (readResponseWithLimit skips chunkTimeoutMs when it is 0/falsy).
+        throw new Error(
+          `${params.providerLabel} generated video download stalled: remaining budget exhausted`,
+        );
+      }
       buffer = await readResponseWithLimit(result.response, params.maxBytes, {
         chunkTimeoutMs: downloadTimeoutMs,
         onOverflow: ({ maxBytes }) =>

--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -343,8 +343,21 @@ export async function runDashscopeVideoGenerationTask(params: {
   }
 }
 
+function resolveDashscopeVideoDownloadTimeoutMs(
+  timeoutMs: ProviderOperationTimeoutMs | undefined,
+  defaultTimeoutMs: number | undefined,
+): number {
+  const resolved = typeof timeoutMs === "function" ? timeoutMs() : timeoutMs;
+  if (typeof resolved === "number" && Number.isFinite(resolved) && resolved > 0) {
+    return Math.floor(resolved);
+  }
+  return defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS;
+}
+
 // Downloads task result URLs into generated video assets. The byte limit comes
 // from OpenClaw media config so provider URLs cannot overfill memory.
+// chunkTimeoutMs is required after headers: fetchWithTimeoutGuarded clears its
+// abort once the response arrives, so a dripping CDN body would hang forever.
 export async function downloadDashscopeGeneratedVideos(params: {
   providerLabel: string;
   urls: string[];
@@ -364,9 +377,7 @@ export async function downloadDashscopeGeneratedVideos(params: {
         const guarded = await fetchWithTimeoutGuarded(
           url,
           { method: "GET" },
-          typeof params.timeoutMs === "function"
-            ? params.timeoutMs()
-            : (params.timeoutMs ?? params.defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS),
+          resolveDashscopeVideoDownloadTimeoutMs(params.timeoutMs, params.defaultTimeoutMs),
           params.fetchFn,
           {
             ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
@@ -385,12 +396,22 @@ export async function downloadDashscopeGeneratedVideos(params: {
         }
       },
     });
+    // Resolve after headers so a function timeout still sees remaining budget.
+    const downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
+      params.timeoutMs,
+      params.defaultTimeoutMs,
+    );
     let buffer: Buffer;
     let mimeType: string;
     try {
       buffer = await readResponseWithLimit(result.response, params.maxBytes, {
+        chunkTimeoutMs: downloadTimeoutMs,
         onOverflow: ({ maxBytes }) =>
           new Error(`${params.providerLabel} generated video download exceeds ${maxBytes} bytes`),
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(
+            `${params.providerLabel} generated video download stalled: no data received for ${chunkTimeoutMs}ms`,
+          ),
       });
       mimeType = result.response.headers.get("content-type")?.trim() || "video/mp4";
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes two issues with DashScope-compatible video downloads:

1. **Stalled CDN body hang**: After headers returned, no chunk-idle timeout was wired into `readResponseWithLimit`, so a stalled body could wait the full request budget instead of failing with a clear idle timeout.
2. **Exhausted deadline initiates network I/O**: A function-valued remaining deadline that returned 0 (budget consumed by header fetch) was checked AFTER `fetchWithTimeoutGuarded` had already sent bytes over the wire. The guard now runs before fetch.

Affected workflow: `runDashscopeVideoGenerationTask` → `downloadDashscopeGeneratedVideos` → `readResponseWithLimit`.

## Why This Change Was Made

At `downloadDashscopeGeneratedVideos`, the resolved `downloadTimeoutMs` is now:
- **Checked before fetch**: a non-positive remaining budget throws immediately without network I/O, matching the sibling Google video download path's behavior.
- **Passed as `chunkTimeoutMs`** + `onIdleTimeout` into `readResponseWithLimit`, so stalled bodies fail with `"no data received for <timeout>ms"` instead of a generic `fetchWithTimeoutGuarded` deadline.

`fetchWithTimeoutGuarded` already keeps its abort until `release()`, so a continuously dripping CDN body cannot hang forever; the chunk-idle bound is the download-owned stall signal that was missing.

Non-goals: changing shared `fetchWithTimeoutGuarded`, `readResponseWithLimit`, or `assertOkOrThrowHttpError`.

Collision check: no open PR on `downloadDashscopeGeneratedVideos` / `src/video-generation/dashscope-compatible.ts`.

## User Impact

- Stalled DashScope video downloads fail with `"no data received for <timeout>ms"` instead of a generic request timeout or full-budget wait.
- Already-exhausted remaining budgets fail immediately without network I/O.
- Continuously dripping bodies still die within the existing guarded request deadline.

## Evidence

Exact head: `920b47be7e9a11c1fbb78845226d51aca97afdf8`

`oxfmt --check src/video-generation/dashscope-compatible.ts src/video-generation/dashscope-compatible.test.ts` — passed.
`git diff --check` — clean.

### Tests

```bash
node scripts/run-vitest.mjs src/video-generation/dashscope-compatible.test.ts -- --run --reporter=verbose
```

```
 ✓ aborts a stalled generated video body via chunk idle timeout 511ms
 ✓ persists a complete generated video body before the idle deadline 5ms
 ✓ fails closed before fetch when a function-valued remaining budget is exhausted 5ms
 ✓ bounds a stalled loopback HTTP body with a real server 220ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

### Key contract changes

| Before | After |
|--------|-------|
| Exhausted deadline checked after `fetchWithTimeoutGuarded` (network I/O already initiated) | Checked before fetch — throws immediately, `fetchFn` not called |
| Body had no chunk-idle timeout → stalled bodies hit generic request timeout | `chunkTimeoutMs` + `onIdleTimeout` wired → `"no data received for <timeout>ms"` |

### Loopback proof

Real `http.createServer` returns HTTP 200 + one chunk then stalls. Real `fetch` + real `downloadDashscopeGeneratedVideos` with `timeoutMs: 200` rejects within 5s (~220ms observed) — bounded, not an indefinite hang.

### Not tested

Live DashScope CDN against real provider endpoints — requires real API credentials.