### PR TITLE
fix(plugin-sdk): restore API baseline validation

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-336b76c2642b15524c672158d7209dda8f22efe4b5ce88f5e3ee6674dc293882  plugin-sdk-api-baseline.json
-26fd03f65ea0893b3592f3b070d9c5f2b1ff7d2a89271cdf0b6579de20c569c9  plugin-sdk-api-baseline.jsonl
+e92bead6ecd7b79e789e67ef631a125aa9f69887e82112c99471932ebd578587  plugin-sdk-api-baseline.json
+ab0f1f57323d75ade752d6961834a94ddf9eb4fe78c334d43b7ddce26ea0d6c1  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Plugin SDK API baseline gate fails on current `main`, blocking unrelated changes that run the SDK surface checks.

## Why This Change Was Made

Refreshes the generated API digests for the combined intentional surfaces from #109336 and #109344. The former adds progress compositor exports consumed by Slack through the supported `channel-outbound` boundary; the latter splits TTS settings and adds the `speech-settings` SDK subpath. Their independently generated hashes did not describe the merged tree.

## User Impact

No runtime behavior change. Contributors can run the Plugin SDK API gate against current `main` without a false drift failure.

## Evidence

- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` failed on current `main` before this change and passes after it.
- `git diff --check`
- Fresh branch autoreview: clean, confidence 0.95.
