### PR TITLE
fix(agents): add global thinkingDefault fallback in resolveAgentConfig (#109276)

### DIFF
--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -132,7 +132,7 @@ export function resolveAgentConfig(
         : undefined,
     ...(entry.models ? { models: entry.models } : {}),
     utilityModel: readStringValue(entry.utilityModel),
-    thinkingDefault: entry.thinkingDefault,
+    thinkingDefault: entry.thinkingDefault ?? agentDefaults?.thinkingDefault,
     verboseDefault: entry.verboseDefault ?? agentDefaults?.verboseDefault,
     reasoningDefault: entry.reasoningDefault,
     fastModeDefault: entry.fastModeDefault,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -95,6 +95,39 @@ describe("resolveAgentConfig", () => {
     expect(resolveAgentConfig(cfg, "main")?.verboseDefault).toBe("on");
   });
 
+  it("prefers per-agent thinkingDefault over global default", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          thinkingDefault: "low",
+        },
+        list: [
+          {
+            id: "main",
+            thinkingDefault: "high",
+          },
+        ],
+      },
+    };
+    expect(resolveAgentConfig(cfg, "main")?.thinkingDefault).toBe("high");
+  });
+
+  it("falls back to global thinkingDefault when per-agent is not set", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          thinkingDefault: "high",
+        },
+        list: [
+          {
+            id: "main",
+          },
+        ],
+      },
+    };
+    expect(resolveAgentConfig(cfg, "main")?.thinkingDefault).toBe("high");
+  });
+
   it("merges contextLimits from defaults with per-agent overrides", () => {
     const cfg: OpenClawConfig = {
       agents: {


### PR DESCRIPTION

Closes #109276

## What Problem This Solves

Fixes an issue where users who set `agents.defaults.thinkingDefault` in their `openclaw.json` config would see no effect — thinking blocks never appeared in session history for any agent that had a `list` entry without an explicit per-agent `thinkingDefault` override. The global default was silently ignored, requiring users to set `thinkingDefault` on every agent entry individually.

This was discovered while investigating why Ollama Cloud models (such as `glm-5.2:cloud`, `deepseek-v4-pro:cloud`) never produced thinking blocks. The Ollama API, stream parser, and persistence pipeline all work correctly when thinking is enabled — the root cause was that the configured thinking level never reached the stream wrapper.

## Why This Change Was Made

In `resolveAgentConfig()` (`src/agents/agent-scope-config.ts:135`), `thinkingDefault` was read directly from the per-agent entry with no nullish coalescing fallback to `agentDefaults?.thinkingDefault`. The very next line for `verboseDefault` (line 136) and a few lines below for `contextTokens` (line 139) both correctly include `?? agentDefaults?.xxx` fallback. This was an unintentional omission introduced when the `verboseDefault` fallback was added in commit `3599ab2e56` — `thinkingDefault` was left behind.

The fix applies the same `?? agentDefaults?.thinkingDefault` pattern, making `resolveAgentConfig` consistent with its own established merge logic and with the documented resolution order (per-agent default > global default).

Scope is limited to the resolver-level inheritance defect. No other fields are changed.

## User Impact

Users who set `agents.defaults.thinkingDefault` globally can now rely on it taking effect for all agents in their `agents.list[]`, without needing to duplicate the value on every entry. The config example below now works as documented:

```json
{
  "agents": {
    "defaults": {
      "thinkingDefault": "high"
    },
    "list": [
      { "id": "pax", "model": { "primary": "ollama-cloud/glm-5.2:cloud" } }
    ]
  }
}
```

## Evidence

- **`src/agents/agent-scope-config.ts:135`** — `thinkingDefault: entry.thinkingDefault ?? agentDefaults?.thinkingDefault`
- **Existing analogous patterns**: `verboseDefault` (L136) `entry.verboseDefault ?? agentDefaults?.verboseDefault`; `contextTokens` (L139) `entry.contextTokens ?? agentDefaults?.contextTokens`
- **Documentation alignment**: `docs/tools/thinking.md:44-49` defines resolution order as per-agent default > global default
- **Tests**: 2 new focused test cases in `src/agents/agent-scope.test.ts`:
  - Per-agent `thinkingDefault` overrides global default (per-agent `"high"` wins over global `"low"`)
  - Falls back to global `thinkingDefault` when per-agent is not set (global `"high"` applies)
- **Test run**: 46/46 passed (`node scripts/run-vitest.mjs src/agents/agent-scope.test.ts`)
- **Lint**: 0 warnings, 0 errors (`oxlint --deny-warnings`)
- **Whitespace**: clean (`git diff --check`)
- **Downstream code review**: Consumers like `get-reply.ts:317-319` and `status-text.ts:561-563` had already implemented manual `agentConfig?.thinkingDefault ?? agentDefaults?.thinkingDefault` workarounds, confirming this was a known missing fallback at the resolver level

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
