### PR TITLE
feat(feeds): persist followed publishers

### DIFF
--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -234,6 +234,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       loadModule: () => import("../clawbot-cli.js"),
       exportName: "registerClawbotCli",
     },
+    {
+      commandNames: ["publisher"],
+      loadModule: () => import("../publisher-cli.js"),
+      exportName: "registerPublisherCli",
+    },
   ]),
   {
     commandNames: ["pairing"],

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -175,6 +175,12 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     parentDefaultHelp: true,
   },
   {
+    name: "publisher",
+    description: "Follow and refresh signed publisher feeds",
+    hasSubcommands: true,
+    parentDefaultHelp: true,
+  },
+  {
     name: "channels",
     description: "Manage connected chat channels and accounts",
     hasSubcommands: true,

--- a/src/cli/publisher-cli.test.ts
+++ b/src/cli/publisher-cli.test.ts
@@ -1,0 +1,29 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerPublisherCli } from "./publisher-cli.js";
+
+describe("publisher CLI", () => {
+  it("registers the follow lifecycle as one top-level command group", () => {
+    const program = new Command().name("openclaw");
+    registerPublisherCli(program);
+
+    const publisher = program.commands.find((command) => command.name() === "publisher");
+    expect(publisher?.commands.map((command) => command.name())).toEqual([
+      "list",
+      "follow",
+      "unfollow",
+      "refresh",
+    ]);
+    expect(publisher?.commands.find((command) => command.name() === "follow")?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ long: "--feed-profile" }),
+        expect.objectContaining({ long: "--json" }),
+      ]),
+    );
+    expect(
+      publisher?.commands
+        .find((command) => command.name() === "follow")
+        ?.options.find((option) => option.long === "--feed-profile")?.mandatory,
+    ).toBe(true);
+  });
+});

--- a/src/cli/publisher-cli.ts
+++ b/src/cli/publisher-cli.ts
@@ -1,0 +1,150 @@
+import type { Command } from "commander";
+import { theme } from "../../packages/terminal-core/src/theme.js";
+import { getRuntimeConfig } from "../config/config.js";
+import {
+  followPublisherFeed,
+  listFollowedPublisherFeeds,
+  refreshFollowedPublisherFeeds,
+  unfollowPublisherFeed,
+} from "../plugins/publisher-feed-follow-service.js";
+import { createSqlitePublisherFeedFollowStore } from "../plugins/publisher-feed-follow-store.js";
+import { createSqlitePublisherFeedStateStore } from "../plugins/publisher-feed-state-store.js";
+import { defaultRuntime } from "../runtime.js";
+import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
+
+type PublisherCommandOptions = {
+  feedProfile?: string;
+  json?: boolean;
+};
+
+function createDependencies() {
+  const config = getRuntimeConfig();
+  return {
+    follows: createSqlitePublisherFeedFollowStore(),
+    states: createSqlitePublisherFeedStateStore(),
+    marketplaces: config.marketplaces,
+  };
+}
+
+function feedProfile(opts: PublisherCommandOptions): string {
+  const profile = opts.feedProfile?.trim();
+  if (!profile) {
+    throw new Error("--feed-profile is required");
+  }
+  return profile;
+}
+
+function emit(value: unknown, opts: PublisherCommandOptions, line: string): void {
+  if (opts.json) {
+    defaultRuntime.writeJson(value);
+    return;
+  }
+  defaultRuntime.log(line);
+}
+
+export function registerPublisherCli(program: Command): void {
+  const publisher = program
+    .command("publisher")
+    .description("Follow and refresh signed publisher feeds");
+
+  publisher
+    .command("list")
+    .description("List followed publisher feeds")
+    .option("--json", "Print JSON")
+    .action(async (opts: PublisherCommandOptions) => {
+      const follows = await listFollowedPublisherFeeds(createDependencies());
+      if (opts.json) {
+        defaultRuntime.writeJson({ follows });
+        return;
+      }
+      if (follows.length === 0) {
+        defaultRuntime.log(theme.muted("No publisher feeds followed."));
+        return;
+      }
+      defaultRuntime.log(
+        follows
+          .map((follow) => {
+            const sequence =
+              follow.acceptedSequence === null
+                ? "not refreshed"
+                : `sequence ${follow.acceptedSequence}`;
+            return `${theme.command(follow.publisherId)} ${theme.muted(`${follow.feedProfile} ${sequence}`)}`;
+          })
+          .join("\n"),
+      );
+    });
+
+  publisher
+    .command("follow")
+    .description("Follow a signed publisher feed")
+    .argument("<publisher-id>", "Stable publisher id")
+    .requiredOption("--feed-profile <name>", "Configured signed marketplace feed profile")
+    .option("--json", "Print JSON")
+    .action(async (publisherId: string, opts: PublisherCommandOptions) => {
+      const result = await followPublisherFeed({
+        publisherId,
+        feedProfile: feedProfile(opts),
+        deps: createDependencies(),
+      });
+      emit(
+        result,
+        opts,
+        `${theme.success("Followed")} ${result.follow.publisherId} at sequence ${result.refresh.record.state.sequence}.`,
+      );
+    });
+
+  publisher
+    .command("unfollow")
+    .description("Stop following a publisher feed")
+    .argument("<publisher-id>", "Stable publisher id")
+    .requiredOption("--feed-profile <name>", "Configured signed marketplace feed profile")
+    .option("--json", "Print JSON")
+    .action(async (publisherId: string, opts: PublisherCommandOptions) => {
+      const removed = await unfollowPublisherFeed({
+        publisherId,
+        feedProfile: feedProfile(opts),
+        deps: createDependencies(),
+      });
+      emit(
+        { publisherId: publisherId.trim(), removed },
+        opts,
+        removed
+          ? `${theme.success("Unfollowed")} ${publisherId.trim()}.`
+          : `${theme.muted("Not followed:")} ${publisherId.trim()}.`,
+      );
+    });
+
+  publisher
+    .command("refresh")
+    .description("Refresh followed publisher feeds")
+    .argument("[publisher-id]", "Refresh only this stable publisher id")
+    .option("--feed-profile <name>", "Limit refresh to one configured feed profile")
+    .option("--json", "Print JSON")
+    .action(async (publisherId: string | undefined, opts: PublisherCommandOptions) => {
+      const results = await refreshFollowedPublisherFeeds({
+        deps: createDependencies(),
+        ...(publisherId ? { publisherId } : {}),
+        ...(opts.feedProfile ? { feedProfile: opts.feedProfile } : {}),
+      });
+      if (opts.json) {
+        defaultRuntime.writeJson({ results });
+      } else if (results.length === 0) {
+        defaultRuntime.log(theme.muted("No matching publisher feeds followed."));
+      } else {
+        defaultRuntime.log(
+          results
+            .map((entry) =>
+              entry.ok
+                ? `${theme.success(entry.result.status)} ${entry.follow.publisherId} sequence ${entry.result.record.state.sequence}`
+                : `${theme.error("failed")} ${entry.follow.publisherId}: ${entry.error}`,
+            )
+            .join("\n"),
+        );
+      }
+      if (results.some((entry) => !entry.ok)) {
+        defaultRuntime.exit(1);
+      }
+    });
+
+  applyParentDefaultHelpAction(publisher);
+}

--- a/src/plugins/official-external-plugin-catalog-envelope.test.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.test.ts
@@ -57,13 +57,11 @@ function signedEnvelope(params: {
   const payload = payloadBytes.toString(params.encoding ?? "base64url");
   const input = signingInput(payloadType, payloadBytes);
   return {
-    schemaVersion: 1,
     payloadType,
     payload,
     signatures: params.keys.map((key) => ({
-      keyId: key.keyId,
-      algorithm: "ed25519",
-      signature: crypto.sign(null, input, key.privateKey).toString("base64url"),
+      keyid: key.keyId,
+      sig: crypto.sign(null, input, key.privateKey).toString("base64url"),
     })),
   };
 }
@@ -167,7 +165,7 @@ describe("official external plugin catalog signed envelopes", () => {
           ...envelope,
           signatures: Array.from({ length: 17 }, (_, index) => ({
             ...signature,
-            keyId: `key-${index}`,
+            keyid: `key-${index}`,
           })),
         },
         { trustedKeys },
@@ -198,10 +196,77 @@ describe("official external plugin catalog signed envelopes", () => {
   });
 
   it("rejects malformed envelopes before verification", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
     expect(
       verifyOfficialExternalPluginCatalogSignedEnvelope(
-        { schemaVersion: 1, payloadType: PAYLOAD_TYPE, payload: "", signatures: [] },
+        { payloadType: PAYLOAD_TYPE, payload: "", signatures: [] },
         { trustedKeys: [] },
+      ),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        { ...envelope, signatures: [{ sig: signature.sig }] },
+        { trustedKeys: [{ keyId: key.keyId, publicKey: exportPublicKey(key) }] },
+      ),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+  });
+
+  it("ignores unrecognized DSSE envelope and signature fields", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        {
+          ...envelope,
+          futureEnvelopeField: true,
+          signatures: [{ ...signature, futureSignatureField: true }],
+        },
+        { trustedKeys: [{ keyId: key.keyId, publicKey: exportPublicKey(key) }] },
+      ),
+    ).toMatchObject({ ok: true, signedBy: key.keyId });
+  });
+
+  it("accepts the beta legacy field names without allowing mixed formats", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
+    const legacySignature = {
+      keyId: signature.keyid,
+      algorithm: "ed25519",
+      signature: signature.sig,
+    };
+    const trustedKeys = [{ keyId: key.keyId, publicKey: exportPublicKey(key) }];
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        {
+          ...envelope,
+          schemaVersion: 1,
+          signatures: [legacySignature],
+        },
+        { trustedKeys },
+      ),
+    ).toMatchObject({ ok: true, signedBy: key.keyId });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        { ...envelope, schemaVersion: 1, signatures: [signature, legacySignature] },
+        { trustedKeys },
       ),
     ).toMatchObject({ ok: false, error: "invalid-envelope" });
   });

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -13,6 +13,10 @@ const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES = 16;
 
 type OfficialExternalPluginCatalogEnvelopeSignature = {
+  keyid?: string;
+  sig?: string;
+};
+type LegacyOfficialExternalPluginCatalogEnvelopeSignature = {
   keyId?: string;
   algorithm?: string;
   signature?: string;
@@ -87,7 +91,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   const trustedSignatureKeyIds: string[] = [];
   const trustedSignaturePublicKeys = new Set<string>();
   for (const envelopeSignature of envelope.signatures) {
-    const keyId = envelopeSignature.keyId;
+    const keyId = envelopeSignature.keyid;
     const trustedKey = params.trustedKeys.find((candidate) => candidate.keyId === keyId);
     if (!trustedKey || trustedSignatureKeyIds.includes(trustedKey.keyId)) {
       continue;
@@ -100,7 +104,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
       verifyEd25519SignatureBytes({
         publicKey: trustedKey.publicKey,
         payload: signingInput,
-        signatureBase64Url: envelopeSignature.signature,
+        signatureBase64Url: envelopeSignature.sig,
       })
     ) {
       trustedSignatureKeyIds.push(trustedKey.keyId);
@@ -134,7 +138,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     };
   }
   const hasKnownKey = envelope.signatures.some((signature) =>
-    params.trustedKeys.some((key) => key.keyId === signature.keyId),
+    params.trustedKeys.some((key) => key.keyId === signature.keyid),
   );
   return hasKnownKey
     ? {
@@ -157,7 +161,7 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   payload: string;
   signatures: readonly Required<OfficialExternalPluginCatalogEnvelopeSignature>[];
 } | null {
-  if (!isRecord(raw) || raw.schemaVersion !== 1) {
+  if (!isRecord(raw)) {
     return null;
   }
   const payloadType = raw.payloadType;
@@ -172,15 +176,38 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   if (signatures.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES) {
     return null;
   }
-  const parsedSignatures = signatures.filter(
+  // Hosted Feed v1 requires keyid even though generic DSSE makes it optional:
+  // trust thresholds and rotation are resolved against configured key ids.
+  const standardSignatures = signatures.filter(
     (signature): signature is Required<OfficialExternalPluginCatalogEnvelopeSignature> =>
       isRecord(signature) &&
-      typeof signature.keyId === "string" &&
-      signature.keyId.trim().length > 0 &&
-      signature.algorithm === "ed25519" &&
-      typeof signature.signature === "string" &&
-      signature.signature.trim().length > 0,
+      typeof signature.keyid === "string" &&
+      signature.keyid.trim().length > 0 &&
+      typeof signature.sig === "string" &&
+      signature.sig.trim().length > 0,
   );
+  // Beta releases briefly accepted this pre-DSSE field shape. Keep it as an
+  // all-or-nothing read path while every producer moves to the standard shape.
+  const legacySignatures =
+    raw.schemaVersion === 1
+      ? signatures
+          .filter(
+            (
+              signature,
+            ): signature is Required<LegacyOfficialExternalPluginCatalogEnvelopeSignature> =>
+              isRecord(signature) &&
+              typeof signature.keyId === "string" &&
+              signature.keyId.trim().length > 0 &&
+              signature.algorithm === "ed25519" &&
+              typeof signature.signature === "string" &&
+              signature.signature.trim().length > 0,
+          )
+          .map((signature) => ({ keyid: signature.keyId, sig: signature.signature }))
+      : [];
+  if (standardSignatures.length > 0 && legacySignatures.length > 0) {
+    return null;
+  }
+  const parsedSignatures = standardSignatures.length > 0 ? standardSignatures : legacySignatures;
   if (parsedSignatures.length === 0) {
     return null;
   }
@@ -189,10 +216,10 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   }
   const keyIds = new Set<string>();
   for (const signature of parsedSignatures) {
-    if (keyIds.has(signature.keyId)) {
+    if (keyIds.has(signature.keyid)) {
       return null;
     }
-    keyIds.add(signature.keyId);
+    keyIds.add(signature.keyid);
   }
   return {
     payloadType,

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -21,10 +21,31 @@ type LegacyOfficialExternalPluginCatalogEnvelopeSignature = {
   algorithm?: string;
   signature?: string;
 };
-type OfficialExternalPluginCatalogTrustedSigningKey = {
+export type TrustedFeedSigningKey = {
   keyId: string;
   publicKey: string;
 };
+
+export type SignedFeedEnvelopePayloadVerificationResult =
+  | {
+      ok: true;
+      payloadType: string;
+      payloadBytes: Buffer;
+      signedBy: string;
+      signedByKeyIds: readonly string[];
+      signatureCount: number;
+      threshold: number;
+    }
+  | {
+      ok: false;
+      error:
+        | "invalid-envelope"
+        | "unsupported-payload"
+        | "invalid-payload"
+        | "missing-trust-key"
+        | "invalid-signature";
+      message: string;
+    };
 
 type OfficialExternalPluginCatalogEnvelopeVerificationResult =
   | {
@@ -56,23 +77,65 @@ function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
 export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   raw: unknown,
   params: {
-    trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    trustedKeys: readonly TrustedFeedSigningKey[];
     threshold?: number;
   },
 ): OfficialExternalPluginCatalogEnvelopeVerificationResult {
+  const verified = verifySignedFeedEnvelopePayload(raw, {
+    expectedPayloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+    trustedKeys: params.trustedKeys,
+    threshold: params.threshold,
+    context: "hosted catalog",
+  });
+  if (verified.ok) {
+    const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(verified.payloadBytes);
+    if (!decoded?.feed) {
+      return {
+        ok: false,
+        error: "invalid-payload",
+        message: "hosted catalog signed envelope payload is invalid",
+        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
+      };
+    }
+    return {
+      ok: true,
+      feed: decoded.feed,
+      signedBy: verified.signedBy,
+      ...(verified.threshold > 1
+        ? {
+            signedByKeyIds: verified.signedByKeyIds,
+            signatureCount: verified.signatureCount,
+            threshold: verified.threshold,
+          }
+        : {}),
+    };
+  }
+  return verified;
+}
+
+export function verifySignedFeedEnvelopePayload(
+  raw: unknown,
+  params: {
+    expectedPayloadType: string;
+    trustedKeys: readonly TrustedFeedSigningKey[];
+    threshold?: number;
+    context?: string;
+  },
+): SignedFeedEnvelopePayloadVerificationResult {
+  const context = params.context?.trim() || "signed feed";
   const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw);
   if (!envelope) {
     return {
       ok: false,
       error: "invalid-envelope",
-      message: "hosted catalog signed envelope is malformed",
+      message: `${context} signed envelope is malformed`,
     };
   }
-  if (envelope.payloadType !== OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE) {
+  if (envelope.payloadType !== params.expectedPayloadType) {
     return {
       ok: false,
       error: "unsupported-payload",
-      message: "hosted catalog signed envelope payload type is unsupported",
+      message: `${context} signed envelope payload type is unsupported`,
     };
   }
   const payloadBytes = decodeOfficialExternalPluginCatalogEnvelopePayloadBytes(envelope.payload);
@@ -80,7 +143,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     return {
       ok: false,
       error: "invalid-payload",
-      message: "hosted catalog signed envelope payload is invalid",
+      message: `${context} signed envelope payload is invalid`,
     };
   }
   const signingInput = createOfficialExternalPluginCatalogEnvelopeSigningInput({
@@ -115,26 +178,14 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     }
   }
   if (trustedSignaturePublicKeys.size >= threshold) {
-    const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
-    if (!decoded?.feed) {
-      return {
-        ok: false,
-        error: "invalid-payload",
-        message: "hosted catalog signed envelope payload is invalid",
-        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
-      };
-    }
     return {
       ok: true,
-      feed: decoded.feed,
+      payloadType: envelope.payloadType,
+      payloadBytes,
       signedBy: trustedSignatureKeyIds[0] ?? "",
-      ...(threshold > 1
-        ? {
-            signedByKeyIds: trustedSignatureKeyIds,
-            signatureCount: trustedSignaturePublicKeys.size,
-            threshold,
-          }
-        : {}),
+      signedByKeyIds: trustedSignatureKeyIds,
+      signatureCount: trustedSignaturePublicKeys.size,
+      threshold,
     };
   }
   const hasKnownKey = envelope.signatures.some((signature) =>
@@ -146,13 +197,13 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
         error: "invalid-signature",
         message:
           trustedSignatureKeyIds.length > 0
-            ? "hosted catalog signed envelope did not meet the configured signature threshold"
-            : "hosted catalog signed envelope signature is invalid",
+            ? `${context} signed envelope did not meet the configured signature threshold`
+            : `${context} signed envelope signature is invalid`,
       }
     : {
         ok: false,
         error: "missing-trust-key",
-        message: "hosted catalog signed envelope was not signed by a trusted key",
+        message: `${context} signed envelope was not signed by a trusted key`,
       };
 }
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -125,14 +125,12 @@ function signedHostedCatalogFeed(params: {
   ]);
   return {
     body: JSON.stringify({
-      schemaVersion: 1,
       payloadType: HOSTED_CATALOG_PAYLOAD_TYPE,
       payload: payloadBytes.toString("base64url"),
       signatures: [
         {
-          keyId: "acme-root",
-          algorithm: "ed25519",
-          signature: crypto
+          keyid: "acme-root",
+          sig: crypto
             .sign(null, signingInput, crypto.createPrivateKey(keys.privateKeyPem))
             .toString("base64url"),
         },

--- a/src/plugins/publisher-feed-follow-service.test.ts
+++ b/src/plugins/publisher-feed-follow-service.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  followPublisherFeed,
+  listFollowedPublisherFeeds,
+  refreshFollowedPublisherFeeds,
+  resolveFollowedPublisherFeedTarget,
+  unfollowPublisherFeed,
+} from "./publisher-feed-follow-service.js";
+import type {
+  FollowedPublisherFeed,
+  PublisherFeedFollowStore,
+} from "./publisher-feed-follow-store.js";
+import type {
+  PublisherFeedStateStore,
+  StoredPublisherFeedState,
+} from "./publisher-feed-state-store.js";
+
+const marketplaces = {
+  feeds: {
+    "clawhub-signed": {
+      url: "https://clawhub.ai/v1/feeds/plugins",
+      verification: {
+        mode: "signed" as const,
+        keys: [{ keyId: "clawhub-2026-q3", publicKey: "public-key" }],
+      },
+    },
+    unsigned: { url: "https://clawhub.ai/v1/feeds/plugins" },
+  },
+};
+
+function acceptedState(sequence = 7): StoredPublisherFeedState {
+  return {
+    sourceOrigin: "https://clawhub.ai",
+    state: {
+      feedId: "clawhub.publisher.publishers:alice",
+      publisherId: "publishers:alice",
+      sequence,
+      generatedAt: "2026-07-16T00:00:00.000Z",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [],
+    },
+    verification: {
+      signedBy: "clawhub-2026-q3",
+      signedByKeyIds: ["clawhub-2026-q3"],
+      signatureCount: 1,
+      threshold: 1,
+    },
+    verifiedAt: "2026-07-16T00:01:00.000Z",
+  };
+}
+
+function followRecord(): FollowedPublisherFeed {
+  return {
+    sourceOrigin: "https://clawhub.ai",
+    publisherId: "publishers:alice",
+    feedProfile: "clawhub-signed",
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+}
+
+function dependencies(
+  params: {
+    follows?: FollowedPublisherFeed[];
+    state?: StoredPublisherFeedState | null;
+  } = {},
+) {
+  let follows = [...(params.follows ?? [])];
+  const followStore: PublisherFeedFollowStore = {
+    list: vi.fn(async () => follows),
+    follow: vi.fn(async (input) => {
+      const follow = {
+        sourceOrigin: input.sourceOrigin,
+        publisherId: input.publisherId,
+        feedProfile: input.feedProfile,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      };
+      follows = [follow];
+      return follow;
+    }),
+    unfollow: vi.fn(async (origin, publisherId) => {
+      const before = follows.length;
+      follows = follows.filter(
+        (follow) => follow.sourceOrigin !== origin || follow.publisherId !== publisherId,
+      );
+      return follows.length !== before;
+    }),
+  };
+  const stateStore: PublisherFeedStateStore = {
+    read: vi.fn(async () => params.state ?? null),
+    write: vi.fn(async () => undefined),
+  };
+  return { follows: followStore, states: stateStore, marketplaces };
+}
+
+describe("publisher feed follow service", () => {
+  it("requires a configured signed profile and binds its origin", () => {
+    expect(() =>
+      resolveFollowedPublisherFeedTarget({
+        follow: { ...followRecord(), feedProfile: "unsigned" },
+        marketplaces,
+      }),
+    ).toThrow("must require signatures");
+    expect(() =>
+      resolveFollowedPublisherFeedTarget({
+        follow: { ...followRecord(), sourceOrigin: "https://mirror.example" },
+        marketplaces,
+      }),
+    ).toThrow("no longer matches");
+    expect(
+      resolveFollowedPublisherFeedTarget({ follow: followRecord(), marketplaces }),
+    ).toMatchObject({
+      baseUrl: "https://clawhub.ai",
+      publisherId: "publishers:alice",
+      verification: { trustedKeys: [{ keyId: "clawhub-2026-q3" }] },
+    });
+  });
+
+  it("refreshes before persisting a new follow", async () => {
+    const deps = dependencies();
+    const refresh = vi.fn(async () => ({
+      status: "initialized" as const,
+      record: acceptedState(),
+    }));
+    const result = await followPublisherFeed({
+      publisherId: "publishers:alice",
+      feedProfile: "clawhub-signed",
+      deps: { ...deps, refresh },
+    });
+    expect(refresh).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://clawhub.ai",
+        forceSnapshot: true,
+        publisherId: "publishers:alice",
+        store: deps.states,
+      }),
+    );
+    expect(deps.follows.follow).toHaveBeenCalledAfter(refresh);
+    expect(result.follow.publisherId).toBe("publishers:alice");
+  });
+
+  it("lists accepted state, refreshes independently, and unfollows", async () => {
+    const deps = dependencies({ follows: [followRecord()], state: acceptedState() });
+    expect(await listFollowedPublisherFeeds(deps)).toMatchObject([
+      { publisherId: "publishers:alice", acceptedSequence: 7, displayName: "Alice" },
+    ]);
+
+    const refresh = vi.fn(async () => ({ status: "unchanged" as const, record: acceptedState() }));
+    const refreshed = await refreshFollowedPublisherFeeds({ deps: { ...deps, refresh } });
+    expect(refreshed).toMatchObject([{ ok: true, result: { status: "unchanged" } }]);
+    await expect(
+      unfollowPublisherFeed({
+        publisherId: "publishers:alice",
+        feedProfile: "clawhub-signed",
+        deps: { ...deps, marketplaces: undefined },
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("keeps per-follow failures visible without blocking other targets", async () => {
+    const second = { ...followRecord(), publisherId: "publishers:bob" };
+    const deps = dependencies({ follows: [followRecord(), second] });
+    const refresh = vi.fn(async ({ publisherId }: { publisherId: string }) => {
+      if (publisherId === "publishers:alice") {
+        throw new Error("offline");
+      }
+      return { status: "initialized" as const, record: acceptedState() };
+    });
+    const results = await refreshFollowedPublisherFeeds({ deps: { ...deps, refresh } });
+    expect(results).toMatchObject([
+      { ok: false, error: "offline" },
+      { ok: true, result: { status: "initialized" } },
+    ]);
+  });
+});

--- a/src/plugins/publisher-feed-follow-service.ts
+++ b/src/plugins/publisher-feed-follow-service.ts
@@ -1,0 +1,177 @@
+import type { MarketplacesConfig } from "../config/types.marketplaces.js";
+import type {
+  FollowedPublisherFeed,
+  PublisherFeedFollowStore,
+} from "./publisher-feed-follow-store.js";
+import {
+  refreshPublisherFeedState,
+  type PublisherFeedRefreshResult,
+  type PublisherFeedRefreshTarget,
+} from "./publisher-feed-refresh.js";
+import type { PublisherFeedStateStore } from "./publisher-feed-state-store.js";
+
+export type PublisherFeedFollowServiceDependencies = {
+  follows: PublisherFeedFollowStore;
+  states: PublisherFeedStateStore;
+  marketplaces: MarketplacesConfig | undefined;
+  refresh?: typeof refreshPublisherFeedState;
+};
+
+export type FollowedPublisherFeedStatus = FollowedPublisherFeed & {
+  acceptedSequence: number | null;
+  displayName: string | null;
+  verifiedAt: string | null;
+};
+
+function resolveProfile(params: {
+  marketplaces: MarketplacesConfig | undefined;
+  profileName: string;
+}): Omit<PublisherFeedRefreshTarget, "publisherId"> {
+  const profileName = params.profileName.trim();
+  const profile = params.marketplaces?.feeds?.[profileName];
+  if (!profile) {
+    throw new Error(`publisher feed profile ${JSON.stringify(profileName)} is not configured`);
+  }
+  if (profile.verification?.mode !== "signed") {
+    throw new Error(
+      `publisher feed profile ${JSON.stringify(profileName)} must require signatures`,
+    );
+  }
+  let url: URL;
+  try {
+    url = new URL(profile.url);
+  } catch {
+    throw new Error(`publisher feed profile ${JSON.stringify(profileName)} has an invalid URL`);
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      `publisher feed profile ${JSON.stringify(profileName)} must use an HTTPS URL without credentials, query, or fragment`,
+    );
+  }
+  return {
+    baseUrl: url.origin,
+    verification: {
+      trustedKeys: profile.verification.keys,
+      ...(profile.verification.threshold === undefined
+        ? {}
+        : { threshold: profile.verification.threshold }),
+    },
+  };
+}
+
+export function resolveFollowedPublisherFeedTarget(params: {
+  follow: FollowedPublisherFeed;
+  marketplaces: MarketplacesConfig | undefined;
+}): PublisherFeedRefreshTarget {
+  const profile = resolveProfile({
+    marketplaces: params.marketplaces,
+    profileName: params.follow.feedProfile,
+  });
+  if (new URL(profile.baseUrl).origin !== params.follow.sourceOrigin) {
+    throw new Error(
+      `publisher feed profile ${JSON.stringify(params.follow.feedProfile)} no longer matches the followed source origin`,
+    );
+  }
+  return { ...profile, publisherId: params.follow.publisherId };
+}
+
+export async function listFollowedPublisherFeeds(
+  deps: PublisherFeedFollowServiceDependencies,
+): Promise<FollowedPublisherFeedStatus[]> {
+  const follows = await deps.follows.list();
+  return await Promise.all(
+    follows.map(async (follow) => {
+      const state = await deps.states.read(follow.sourceOrigin, follow.publisherId);
+      return {
+        sourceOrigin: follow.sourceOrigin,
+        publisherId: follow.publisherId,
+        feedProfile: follow.feedProfile,
+        createdAtMs: follow.createdAtMs,
+        updatedAtMs: follow.updatedAtMs,
+        acceptedSequence: state?.state.sequence ?? null,
+        displayName: state?.state.displayName ?? null,
+        verifiedAt: state?.verifiedAt ?? null,
+      };
+    }),
+  );
+}
+
+export async function followPublisherFeed(params: {
+  publisherId: string;
+  feedProfile: string;
+  deps: PublisherFeedFollowServiceDependencies;
+}): Promise<{ follow: FollowedPublisherFeed; refresh: PublisherFeedRefreshResult }> {
+  const target = resolveProfile({
+    marketplaces: params.deps.marketplaces,
+    profileName: params.feedProfile,
+  });
+  const refresh = params.deps.refresh ?? refreshPublisherFeedState;
+  const refreshed = await refresh({
+    ...target,
+    publisherId: params.publisherId,
+    store: params.deps.states,
+    forceSnapshot: true,
+  });
+  const follow = await params.deps.follows.follow({
+    sourceOrigin: new URL(target.baseUrl).origin,
+    publisherId: refreshed.record.state.publisherId,
+    feedProfile: params.feedProfile,
+  });
+  return { follow, refresh: refreshed };
+}
+
+export async function unfollowPublisherFeed(params: {
+  publisherId: string;
+  feedProfile: string;
+  deps: PublisherFeedFollowServiceDependencies;
+}): Promise<boolean> {
+  const publisherId = params.publisherId.trim();
+  const feedProfile = params.feedProfile.trim();
+  const matches = (await params.deps.follows.list()).filter(
+    (follow) => follow.publisherId === publisherId && follow.feedProfile === feedProfile,
+  );
+  let removed = false;
+  for (const follow of matches) {
+    removed = (await params.deps.follows.unfollow(follow.sourceOrigin, publisherId)) || removed;
+  }
+  return removed;
+}
+
+export async function refreshFollowedPublisherFeeds(params: {
+  deps: PublisherFeedFollowServiceDependencies;
+  publisherId?: string;
+  feedProfile?: string;
+}): Promise<
+  Array<
+    | { follow: FollowedPublisherFeed; ok: true; result: PublisherFeedRefreshResult }
+    | { follow: FollowedPublisherFeed; ok: false; error: string }
+  >
+> {
+  const follows = (await params.deps.follows.list()).filter(
+    (follow) =>
+      (!params.publisherId || follow.publisherId === params.publisherId.trim()) &&
+      (!params.feedProfile || follow.feedProfile === params.feedProfile.trim()),
+  );
+  const refresh = params.deps.refresh ?? refreshPublisherFeedState;
+  const results = [];
+  for (const follow of follows) {
+    try {
+      const target = resolveFollowedPublisherFeedTarget({
+        follow,
+        marketplaces: params.deps.marketplaces,
+      });
+      results.push({
+        follow,
+        ok: true as const,
+        result: await refresh({ ...target, store: params.deps.states }),
+      });
+    } catch (error) {
+      results.push({
+        follow,
+        ok: false as const,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return results;
+}

--- a/src/plugins/publisher-feed-follow-store.test.ts
+++ b/src/plugins/publisher-feed-follow-store.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { createSqlitePublisherFeedFollowStore } from "./publisher-feed-follow-store.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawStateDatabase();
+  for (const directory of tempDirs.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("publisher feed follow store", () => {
+  it("persists, updates, lists, and removes follows", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publisher-feed-follow-"));
+    tempDirs.push(directory);
+    const store = createSqlitePublisherFeedFollowStore({
+      stateDatabasePath: path.join(directory, "state.sqlite"),
+    });
+
+    expect(await store.list()).toEqual([]);
+    await store.follow({
+      sourceOrigin: "https://clawhub.ai/",
+      publisherId: " publishers:alice ",
+      feedProfile: " clawhub-signed ",
+      nowMs: 10,
+    });
+    await store.follow({
+      sourceOrigin: "https://clawhub.ai",
+      publisherId: "publishers:alice",
+      feedProfile: "clawhub-rotated",
+      nowMs: 20,
+    });
+
+    expect(await store.list()).toEqual([
+      {
+        sourceOrigin: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        feedProfile: "clawhub-rotated",
+        createdAtMs: 10,
+        updatedAtMs: 20,
+      },
+    ]);
+    await expect(store.unfollow("https://clawhub.ai", "publishers:alice")).resolves.toBe(true);
+    await expect(store.unfollow("https://clawhub.ai", "publishers:alice")).resolves.toBe(false);
+    expect(await store.list()).toEqual([]);
+  });
+
+  it("rejects unsafe origins and invalid identities before opening SQLite", async () => {
+    const store = createSqlitePublisherFeedFollowStore({
+      stateDatabasePath: path.join(os.tmpdir(), `missing-${Date.now()}`, "state.sqlite"),
+    });
+    await expect(
+      store.follow({
+        sourceOrigin: "http://clawhub.ai",
+        publisherId: "publishers:alice",
+        feedProfile: "clawhub-signed",
+      }),
+    ).rejects.toThrow("HTTPS origin");
+    await expect(
+      store.follow({
+        sourceOrigin: "https://clawhub.ai",
+        publisherId: " ",
+        feedProfile: "clawhub-signed",
+      }),
+    ).rejects.toThrow("publisher id is invalid");
+  });
+});

--- a/src/plugins/publisher-feed-follow-store.ts
+++ b/src/plugins/publisher-feed-follow-store.ts
@@ -1,0 +1,222 @@
+import { existsSync } from "node:fs";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+
+export type FollowedPublisherFeed = {
+  sourceOrigin: string;
+  publisherId: string;
+  feedProfile: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+};
+
+export type PublisherFeedFollowStore = {
+  list: () => Promise<FollowedPublisherFeed[]>;
+  follow: (params: {
+    sourceOrigin: string;
+    publisherId: string;
+    feedProfile: string;
+    nowMs?: number;
+  }) => Promise<FollowedPublisherFeed>;
+  unfollow: (sourceOrigin: string, publisherId: string) => Promise<boolean>;
+};
+
+type PublisherFeedFollowStoreOptions = {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateDatabasePath?: string;
+};
+
+type PublisherFeedFollowDatabase = Pick<OpenClawStateKyselyDatabase, "publisher_feed_follows">;
+
+type PublisherFeedFollowRow = {
+  source_origin: string;
+  publisher_id: string;
+  feed_profile: string;
+  created_at_ms: number | bigint;
+  updated_at_ms: number | bigint;
+};
+
+function resolveStoreEnv(options: PublisherFeedFollowStoreOptions): NodeJS.ProcessEnv | undefined {
+  if (!options.stateDir) {
+    return options.env;
+  }
+  return { ...(options.env ?? process.env), OPENCLAW_STATE_DIR: options.stateDir };
+}
+
+function resolveDatabaseOptions(
+  options: PublisherFeedFollowStoreOptions,
+): OpenClawStateDatabaseOptions {
+  const env = resolveStoreEnv(options);
+  return {
+    ...(env ? { env } : {}),
+    ...(options.stateDatabasePath ? { path: options.stateDatabasePath } : {}),
+  };
+}
+
+function resolveDatabasePath(options: PublisherFeedFollowStoreOptions): string {
+  return (
+    options.stateDatabasePath ??
+    resolveOpenClawStateSqlitePath(resolveStoreEnv(options) ?? process.env)
+  );
+}
+
+function normalizeSourceOrigin(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("publisher feed source origin is invalid");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "/" && url.pathname !== "")
+  ) {
+    throw new Error("publisher feed source must be an HTTPS origin");
+  }
+  return url.origin;
+}
+
+function normalizeBoundedText(raw: string, label: string, maxBytes: number): string {
+  const value = raw.trim();
+  if (!value || new TextEncoder().encode(value).length > maxBytes) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function normalizePublisherId(raw: string): string {
+  return normalizeBoundedText(raw, "publisher id", 200);
+}
+
+function normalizeFeedProfile(raw: string): string {
+  return normalizeBoundedText(raw, "publisher feed profile", 100);
+}
+
+function normalizeTimestamp(raw: number | bigint, label: string): number {
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`stored publisher feed follow ${label} is invalid`);
+  }
+  return value;
+}
+
+function rowToFollow(row: PublisherFeedFollowRow): FollowedPublisherFeed {
+  return {
+    sourceOrigin: normalizeSourceOrigin(row.source_origin),
+    publisherId: normalizePublisherId(row.publisher_id),
+    feedProfile: normalizeFeedProfile(row.feed_profile),
+    createdAtMs: normalizeTimestamp(row.created_at_ms, "creation time"),
+    updatedAtMs: normalizeTimestamp(row.updated_at_ms, "update time"),
+  };
+}
+
+const SELECT_COLUMNS = [
+  "source_origin",
+  "publisher_id",
+  "feed_profile",
+  "created_at_ms",
+  "updated_at_ms",
+] as const;
+
+export function createSqlitePublisherFeedFollowStore(
+  options: PublisherFeedFollowStoreOptions = {},
+): PublisherFeedFollowStore {
+  return {
+    async list() {
+      const pathname = resolveDatabasePath(options);
+      if (!existsSync(pathname)) {
+        return [];
+      }
+      const database = openOpenClawStateDatabase(resolveDatabaseOptions(options));
+      const stateDb = getNodeSqliteKysely<PublisherFeedFollowDatabase>(database.db);
+      const rows = executeSqliteQuerySync(
+        database.db,
+        stateDb
+          .selectFrom("publisher_feed_follows")
+          .select(SELECT_COLUMNS)
+          .orderBy("source_origin", "asc")
+          .orderBy("publisher_id", "asc"),
+      ).rows as PublisherFeedFollowRow[];
+      return rows.map(rowToFollow);
+    },
+    async follow(params) {
+      const sourceOrigin = normalizeSourceOrigin(params.sourceOrigin);
+      const publisherId = normalizePublisherId(params.publisherId);
+      const feedProfile = normalizeFeedProfile(params.feedProfile);
+      const nowMs = params.nowMs ?? Date.now();
+      if (!Number.isSafeInteger(nowMs) || nowMs < 0) {
+        throw new Error("publisher feed follow time is invalid");
+      }
+      return runOpenClawStateWriteTransaction((database) => {
+        const stateDb = getNodeSqliteKysely<PublisherFeedFollowDatabase>(database.db);
+        executeSqliteQuerySync(
+          database.db,
+          stateDb
+            .insertInto("publisher_feed_follows")
+            .values({
+              source_origin: sourceOrigin,
+              publisher_id: publisherId,
+              feed_profile: feedProfile,
+              created_at_ms: nowMs,
+              updated_at_ms: nowMs,
+            })
+            .onConflict((conflict) =>
+              conflict.columns(["source_origin", "publisher_id"]).doUpdateSet({
+                feed_profile: feedProfile,
+                updated_at_ms: nowMs,
+              }),
+            ),
+        );
+        const row = executeSqliteQuerySync(
+          database.db,
+          stateDb
+            .selectFrom("publisher_feed_follows")
+            .select(SELECT_COLUMNS)
+            .where("source_origin", "=", sourceOrigin)
+            .where("publisher_id", "=", publisherId),
+        ).rows[0] as PublisherFeedFollowRow | undefined;
+        if (!row) {
+          throw new Error("publisher feed follow was not persisted");
+        }
+        return rowToFollow(row);
+      }, resolveDatabaseOptions(options));
+    },
+    async unfollow(sourceOriginInput, publisherIdInput) {
+      const sourceOrigin = normalizeSourceOrigin(sourceOriginInput);
+      const publisherId = normalizePublisherId(publisherIdInput);
+      return runOpenClawStateWriteTransaction((database) => {
+        const stateDb = getNodeSqliteKysely<PublisherFeedFollowDatabase>(database.db);
+        const existing = executeSqliteQuerySync(
+          database.db,
+          stateDb
+            .selectFrom("publisher_feed_follows")
+            .select("publisher_id")
+            .where("source_origin", "=", sourceOrigin)
+            .where("publisher_id", "=", publisherId),
+        ).rows[0];
+        if (!existing) {
+          return false;
+        }
+        executeSqliteQuerySync(
+          database.db,
+          stateDb
+            .deleteFrom("publisher_feed_follows")
+            .where("source_origin", "=", sourceOrigin)
+            .where("publisher_id", "=", publisherId),
+        );
+        return true;
+      }, resolveDatabaseOptions(options));
+    },
+  };
+}

--- a/src/plugins/publisher-feed-projections.test.ts
+++ b/src/plugins/publisher-feed-projections.test.ts
@@ -21,14 +21,12 @@ function signedEnvelope(key: SigningKey, payloadType: string, payload: unknown) 
     payloadBytes,
   ]);
   return {
-    schemaVersion: 1,
     payloadType,
     payload: payloadBytes.toString("base64url"),
     signatures: [
       {
-        keyId: key.keyId,
-        algorithm: "ed25519",
-        signature: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
+        keyid: key.keyId,
+        sig: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
       },
     ],
   };

--- a/src/plugins/publisher-feed-projections.test.ts
+++ b/src/plugins/publisher-feed-projections.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
   PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+  PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE,
   verifyPublisherFeedProjection,
 } from "./publisher-feed-projections.js";
 
@@ -37,7 +38,7 @@ function verification(key: SigningKey) {
     trustedKeys: [
       {
         keyId: key.keyId,
-        publicKey: key.publicKey.export({ type: "spki", format: "pem" }).toString(),
+        publicKey: key.publicKey.export({ type: "spki", format: "pem" }),
       },
     ],
   };
@@ -61,6 +62,33 @@ const projectionBase = {
 };
 
 describe("publisher feed signed projections", () => {
+  it("verifies a complete signed publisher snapshot with distinct authority", () => {
+    const key = signingKey();
+    const payload = {
+      ...projectionBase,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      sequence: 7,
+      entries: [entry],
+    };
+    expect(
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE, payload),
+        { payloadType: PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE, ...verification(key) },
+      ),
+    ).toMatchObject({ payload, signedBy: key.keyId });
+    expect(() =>
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE, {
+          ...payload,
+          entries: [entry, entry],
+        }),
+        { payloadType: PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE, ...verification(key) },
+      ),
+    ).toThrow("projection payload is invalid");
+  });
+
   it("verifies a strict signed query page without treating it as an install catalog", () => {
     const key = signingKey();
     const payload = {
@@ -112,7 +140,7 @@ describe("publisher feed signed projections", () => {
       fromSequence: 1,
       currentSequence: 8,
       resetRequired: true,
-      snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+      snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/snapshot",
     };
 
     expect(

--- a/src/plugins/publisher-feed-projections.test.ts
+++ b/src/plugins/publisher-feed-projections.test.ts
@@ -1,0 +1,170 @@
+import crypto, { type KeyObject } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+  PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+  verifyPublisherFeedProjection,
+} from "./publisher-feed-projections.js";
+
+type SigningKey = { keyId: string; privateKey: KeyObject; publicKey: KeyObject };
+
+function signingKey(): SigningKey {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return { keyId: "clawhub-feed-2026-q3", privateKey, publicKey };
+}
+
+function signedEnvelope(key: SigningKey, payloadType: string, payload: unknown) {
+  const payloadBytes = Buffer.from(JSON.stringify(payload));
+  const typeBytes = Buffer.from(payloadType);
+  const signingInput = Buffer.concat([
+    Buffer.from(`DSSEv1 ${typeBytes.length} ${payloadType} ${payloadBytes.length} `),
+    payloadBytes,
+  ]);
+  return {
+    schemaVersion: 1,
+    payloadType,
+    payload: payloadBytes.toString("base64url"),
+    signatures: [
+      {
+        keyId: key.keyId,
+        algorithm: "ed25519",
+        signature: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
+      },
+    ],
+  };
+}
+
+function verification(key: SigningKey) {
+  return {
+    trustedKeys: [
+      {
+        keyId: key.keyId,
+        publicKey: key.publicKey.export({ type: "spki", format: "pem" }).toString(),
+      },
+    ],
+  };
+}
+
+const entry = {
+  kind: "skill",
+  id: "skills:cuda",
+  name: "cuda-helper",
+  displayName: "CUDA Helper",
+  summary: "GPU tools",
+  url: "/alice/skills/cuda-helper",
+  updatedAt: 2,
+};
+
+const projectionBase = {
+  schemaVersion: 1,
+  feedId: "clawhub.publisher.publishers:alice",
+  generatedAt: "2026-07-16T00:00:00.000Z",
+  expiresAt: "2026-07-16T00:05:00.000Z",
+};
+
+describe("publisher feed signed projections", () => {
+  it("verifies a strict signed query page without treating it as an install catalog", () => {
+    const key = signingKey();
+    const payload = {
+      ...projectionBase,
+      sequence: 7,
+      query: { text: "CUDA Helper", kinds: ["skill"] },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 1,
+      entries: [entry],
+      nextCursor: null,
+    };
+    const result = verifyPublisherFeedProjection(
+      signedEnvelope(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload),
+      { payloadType: PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, ...verification(key) },
+    );
+
+    expect(result).toMatchObject({
+      payload,
+      signedBy: key.keyId,
+      signatureCount: 1,
+      threshold: 1,
+    });
+  });
+
+  it("verifies complete change pages and reset-required responses", () => {
+    const key = signingKey();
+    const changes = {
+      ...projectionBase,
+      fromSequence: 7,
+      toSequence: 8,
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      changeCount: 1,
+      changes: [
+        {
+          sequence: 8,
+          operation: "remove",
+          entryId: "skills:old",
+          entryKind: "skill",
+        },
+      ],
+      nextCursor: null,
+    };
+    const reset = {
+      ...projectionBase,
+      fromSequence: 1,
+      currentSequence: 8,
+      resetRequired: true,
+      snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+    };
+
+    expect(
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, changes),
+        { payloadType: PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, ...verification(key) },
+      ).payload,
+    ).toEqual(changes);
+    expect(
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, reset),
+        { payloadType: PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, ...verification(key) },
+      ).payload,
+    ).toEqual(reset);
+  });
+
+  it("rejects payload type confusion before parsing", () => {
+    const key = signingKey();
+    expect(() =>
+      verifyPublisherFeedProjection(signedEnvelope(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {}), {
+        payloadType: PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+        ...verification(key),
+      }),
+    ).toThrow("payload type is unsupported");
+  });
+
+  it.each([
+    { query: { text: " CUDA" }, reason: "non-normalized query" },
+    { query: { kinds: ["skill", "skill"] }, reason: "duplicate query kinds" },
+    { unexpected: true, reason: "unknown page fields" },
+    { entries: [{ ...entry, url: "//evil.example/skill" }], reason: "unsafe entry URL" },
+  ])("rejects $reason", ({ reason: _reason, ...override }) => {
+    const key = signingKey();
+    const payload = {
+      ...projectionBase,
+      sequence: 7,
+      query: { text: "CUDA" },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 1,
+      entries: [entry],
+      nextCursor: null,
+      ...override,
+    };
+    expect(() =>
+      verifyPublisherFeedProjection(
+        signedEnvelope(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload),
+        { payloadType: PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, ...verification(key) },
+      ),
+    ).toThrow("projection payload is invalid");
+  });
+});

--- a/src/plugins/publisher-feed-projections.ts
+++ b/src/plugins/publisher-feed-projections.ts
@@ -341,10 +341,14 @@ function parseChangePayload(
     value.changes.length > 500 ||
     !value.changes.every(isPublisherFeedChange) ||
     !isNullableString(value.nextCursor) ||
-    value.startIndex + value.changes.length > value.changeCount ||
-    value.changes.some(
-      (change) => change.sequence <= value.fromSequence || change.sequence > value.toSequence,
-    )
+    value.startIndex + value.changes.length > value.changeCount
+  ) {
+    return null;
+  }
+  const fromSequence = value.fromSequence;
+  const toSequence = value.toSequence;
+  if (
+    value.changes.some((change) => change.sequence <= fromSequence || change.sequence > toSequence)
   ) {
     return null;
   }

--- a/src/plugins/publisher-feed-projections.ts
+++ b/src/plugins/publisher-feed-projections.ts
@@ -6,6 +6,7 @@ import {
 
 export const PUBLISHER_FEED_QUERY_PAYLOAD_TYPE = "openclaw.clawhub-publisher-feed-query-results.v1";
 export const PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE = "openclaw.clawhub-publisher-feed-changes.v1";
+export const PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE = "openclaw.clawhub-publisher-feed-snapshot.v1";
 
 export type PublisherFeedEntry = {
   kind: "skill" | "plugin";
@@ -77,13 +78,41 @@ export type PublisherFeedResetRequired = {
   snapshotUrl: string;
 };
 
+export type PublisherFeedSnapshot = {
+  schemaVersion: 1;
+  feedId: string;
+  publisherId: string;
+  handle: string | null;
+  displayName: string;
+  generatedAt: string;
+  expiresAt: string;
+  sequence: number;
+  entries: readonly PublisherFeedEntry[];
+};
+
 export type VerifiedPublisherFeedProjection = {
-  payload: PublisherFeedQueryPage | PublisherFeedChangePage | PublisherFeedResetRequired;
+  payload:
+    | PublisherFeedSnapshot
+    | PublisherFeedQueryPage
+    | PublisherFeedChangePage
+    | PublisherFeedResetRequired;
   signedBy: string;
   signedByKeyIds: readonly string[];
   signatureCount: number;
   threshold: number;
 };
+
+const SNAPSHOT_KEYS = [
+  "schemaVersion",
+  "feedId",
+  "publisherId",
+  "handle",
+  "displayName",
+  "generatedAt",
+  "expiresAt",
+  "sequence",
+  "entries",
+] as const;
 
 const QUERY_PAGE_KEYS = [
   "schemaVersion",
@@ -130,6 +159,14 @@ function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): 
 
 function isSafeNonNegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function hasUtf8Length(value: unknown, minimum: number, maximum: number): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const length = new TextEncoder().encode(value).length;
+  return length >= minimum && length <= maximum;
 }
 
 function isDateString(value: unknown): value is string {
@@ -303,6 +340,34 @@ function parseQueryPage(value: unknown): PublisherFeedQueryPage | null {
   return value as PublisherFeedQueryPage;
 }
 
+function parseSnapshot(value: unknown): PublisherFeedSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, SNAPSHOT_KEYS) ||
+    !hasValidProjectionBase(value) ||
+    !hasUtf8Length(value.publisherId, 1, 200) ||
+    value.feedId !== `clawhub.publisher.${value.publisherId}` ||
+    new TextEncoder().encode(value.feedId).length > 256 ||
+    (value.handle !== null && !hasUtf8Length(value.handle, 1, 64)) ||
+    !hasUtf8Length(value.displayName, 1, 256) ||
+    !isSafeNonNegativeInteger(value.sequence) ||
+    !Array.isArray(value.entries) ||
+    value.entries.length > 400 ||
+    !value.entries.every(isPublisherFeedEntry)
+  ) {
+    return null;
+  }
+  const identities = new Set<string>();
+  for (const entry of value.entries) {
+    const identity = `${entry.kind}\0${entry.id}`;
+    if (identities.has(identity)) {
+      return null;
+    }
+    identities.add(identity);
+  }
+  return value as PublisherFeedSnapshot;
+}
+
 function parseChangePayload(
   value: unknown,
 ): PublisherFeedChangePage | PublisherFeedResetRequired | null {
@@ -359,6 +424,7 @@ export function verifyPublisherFeedProjection(
   raw: unknown,
   params: {
     payloadType:
+      | typeof PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE
       | typeof PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
       | typeof PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE;
     trustedKeys: readonly TrustedFeedSigningKey[];
@@ -381,9 +447,11 @@ export function verifyPublisherFeedProjection(
     throw new Error("publisher feed projection payload is not valid JSON");
   }
   const payload =
-    params.payloadType === PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
-      ? parseQueryPage(rawPayload)
-      : parseChangePayload(rawPayload);
+    params.payloadType === PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE
+      ? parseSnapshot(rawPayload)
+      : params.payloadType === PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+        ? parseQueryPage(rawPayload)
+        : parseChangePayload(rawPayload);
   if (!payload) {
     throw new Error("publisher feed projection payload is invalid");
   }

--- a/src/plugins/publisher-feed-projections.ts
+++ b/src/plugins/publisher-feed-projections.ts
@@ -1,0 +1,393 @@
+import { isRecord } from "../utils.js";
+import {
+  verifySignedFeedEnvelopePayload,
+  type TrustedFeedSigningKey,
+} from "./official-external-plugin-catalog-envelope.js";
+
+export const PUBLISHER_FEED_QUERY_PAYLOAD_TYPE = "openclaw.clawhub-publisher-feed-query-results.v1";
+export const PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE = "openclaw.clawhub-publisher-feed-changes.v1";
+
+export type PublisherFeedEntry = {
+  kind: "skill" | "plugin";
+  id: string;
+  name: string;
+  displayName: string;
+  summary: string | null;
+  url: string;
+  updatedAt: number;
+};
+
+export type PublisherFeedQuery = {
+  text?: string;
+  kinds?: readonly ("skill" | "plugin")[];
+};
+
+export type PublisherFeedChange =
+  | { sequence: number; operation: "upsert"; entry: PublisherFeedEntry }
+  | {
+      sequence: number;
+      operation: "remove";
+      entryId: string;
+      entryKind: "skill" | "plugin";
+    }
+  | {
+      sequence: number;
+      operation: "metadata";
+      metadata: { publisherId: string; handle: string | null; displayName: string };
+    };
+
+export type PublisherFeedQueryPage = {
+  schemaVersion: 1;
+  feedId: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  query: PublisherFeedQuery;
+  requestCursor: string | null;
+  pageIndex: number;
+  startIndex: number;
+  resultCount: number;
+  entries: readonly PublisherFeedEntry[];
+  nextCursor: string | null;
+};
+
+export type PublisherFeedChangePage = {
+  schemaVersion: 1;
+  feedId: string;
+  fromSequence: number;
+  toSequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  requestCursor: string | null;
+  pageIndex: number;
+  startIndex: number;
+  changeCount: number;
+  changes: readonly PublisherFeedChange[];
+  nextCursor: string | null;
+};
+
+export type PublisherFeedResetRequired = {
+  schemaVersion: 1;
+  feedId: string;
+  fromSequence: number;
+  currentSequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  resetRequired: true;
+  snapshotUrl: string;
+};
+
+export type VerifiedPublisherFeedProjection = {
+  payload: PublisherFeedQueryPage | PublisherFeedChangePage | PublisherFeedResetRequired;
+  signedBy: string;
+  signedByKeyIds: readonly string[];
+  signatureCount: number;
+  threshold: number;
+};
+
+const QUERY_PAGE_KEYS = [
+  "schemaVersion",
+  "feedId",
+  "sequence",
+  "generatedAt",
+  "expiresAt",
+  "query",
+  "requestCursor",
+  "pageIndex",
+  "startIndex",
+  "resultCount",
+  "entries",
+  "nextCursor",
+] as const;
+const CHANGE_PAGE_KEYS = [
+  "schemaVersion",
+  "feedId",
+  "fromSequence",
+  "toSequence",
+  "generatedAt",
+  "expiresAt",
+  "requestCursor",
+  "pageIndex",
+  "startIndex",
+  "changeCount",
+  "changes",
+  "nextCursor",
+] as const;
+const RESET_KEYS = [
+  "schemaVersion",
+  "feedId",
+  "fromSequence",
+  "currentSequence",
+  "generatedAt",
+  "expiresAt",
+  "resetRequired",
+  "snapshotUrl",
+] as const;
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).toSorted().join("\0") === keys.toSorted().join("\0");
+}
+
+function isSafeNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isDateString(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function hasValidProjectionBase(value: Record<string, unknown>): boolean {
+  return (
+    value.schemaVersion === 1 &&
+    typeof value.feedId === "string" &&
+    value.feedId.length > 0 &&
+    isDateString(value.generatedAt) &&
+    isDateString(value.expiresAt) &&
+    Date.parse(value.expiresAt) > Date.parse(value.generatedAt)
+  );
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isEntryKind(value: unknown): value is "skill" | "plugin" {
+  return value === "skill" || value === "plugin";
+}
+
+function isPublisherFeedEntry(value: unknown): value is PublisherFeedEntry {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (
+    !(
+      hasExactKeys(value, ["kind", "id", "name", "displayName", "summary", "url", "updatedAt"]) &&
+      isEntryKind(value.kind) &&
+      typeof value.id === "string" &&
+      value.id.length > 0 &&
+      typeof value.name === "string" &&
+      value.name.length > 0 &&
+      typeof value.displayName === "string" &&
+      value.displayName.length > 0 &&
+      isNullableString(value.summary) &&
+      typeof value.url === "string" &&
+      value.url.length > 0 &&
+      typeof value.updatedAt === "number" &&
+      Number.isFinite(value.updatedAt) &&
+      value.updatedAt >= 0
+    )
+  ) {
+    return false;
+  }
+  if (value.url.startsWith("/")) {
+    return (
+      !value.url.startsWith("//") &&
+      !value.url.includes("\\") &&
+      !containsAsciiControlCharacter(value.url)
+    );
+  }
+  try {
+    const url = new URL(value.url);
+    return url.protocol === "https:" && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function containsAsciiControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeQueryTextWhitespace(value: string): string {
+  let result = "";
+  let pendingSpace = false;
+  for (const character of value.normalize("NFC")) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if ((codePoint >= 0x09 && codePoint <= 0x0d) || codePoint === 0x20) {
+      pendingSpace = result.length > 0;
+      continue;
+    }
+    if (pendingSpace) {
+      result += " ";
+    }
+    result += character;
+    pendingSpace = false;
+  }
+  return result;
+}
+
+function isPublisherFeedQuery(value: unknown): value is PublisherFeedQuery {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  if (keys.length === 0 || keys.some((key) => key !== "text" && key !== "kinds")) {
+    return false;
+  }
+  if (
+    value.text !== undefined &&
+    (typeof value.text !== "string" ||
+      !value.text ||
+      new TextEncoder().encode(value.text).length > 256 ||
+      normalizeQueryTextWhitespace(value.text) !== value.text)
+  ) {
+    return false;
+  }
+  if (
+    value.kinds !== undefined &&
+    (!Array.isArray(value.kinds) ||
+      value.kinds.length === 0 ||
+      !value.kinds.every(isEntryKind) ||
+      [...new Set(value.kinds)].toSorted().join("\0") !== value.kinds.join("\0"))
+  ) {
+    return false;
+  }
+  return value.text !== undefined || value.kinds !== undefined;
+}
+
+function isPublisherFeedChange(value: unknown): value is PublisherFeedChange {
+  if (!isRecord(value) || !isSafeNonNegativeInteger(value.sequence)) {
+    return false;
+  }
+  if (value.operation === "upsert") {
+    return (
+      hasExactKeys(value, ["sequence", "operation", "entry"]) && isPublisherFeedEntry(value.entry)
+    );
+  }
+  if (value.operation === "remove") {
+    return (
+      hasExactKeys(value, ["sequence", "operation", "entryId", "entryKind"]) &&
+      typeof value.entryId === "string" &&
+      value.entryId.length > 0 &&
+      isEntryKind(value.entryKind)
+    );
+  }
+  if (value.operation !== "metadata" || !isRecord(value.metadata)) {
+    return false;
+  }
+  return (
+    hasExactKeys(value, ["sequence", "operation", "metadata"]) &&
+    hasExactKeys(value.metadata, ["publisherId", "handle", "displayName"]) &&
+    typeof value.metadata.publisherId === "string" &&
+    value.metadata.publisherId.length > 0 &&
+    isNullableString(value.metadata.handle) &&
+    typeof value.metadata.displayName === "string"
+  );
+}
+
+function parseQueryPage(value: unknown): PublisherFeedQueryPage | null {
+  if (!isRecord(value) || !hasExactKeys(value, QUERY_PAGE_KEYS) || !hasValidProjectionBase(value)) {
+    return null;
+  }
+  if (
+    !isSafeNonNegativeInteger(value.sequence) ||
+    !isPublisherFeedQuery(value.query) ||
+    !isNullableString(value.requestCursor) ||
+    !isSafeNonNegativeInteger(value.pageIndex) ||
+    !isSafeNonNegativeInteger(value.startIndex) ||
+    !isSafeNonNegativeInteger(value.resultCount) ||
+    !Array.isArray(value.entries) ||
+    value.entries.length > 200 ||
+    !value.entries.every(isPublisherFeedEntry) ||
+    !isNullableString(value.nextCursor) ||
+    value.startIndex + value.entries.length > value.resultCount
+  ) {
+    return null;
+  }
+  return value as PublisherFeedQueryPage;
+}
+
+function parseChangePayload(
+  value: unknown,
+): PublisherFeedChangePage | PublisherFeedResetRequired | null {
+  if (!isRecord(value) || !hasValidProjectionBase(value)) {
+    return null;
+  }
+  if (value.resetRequired === true) {
+    if (
+      !hasExactKeys(value, RESET_KEYS) ||
+      !isSafeNonNegativeInteger(value.fromSequence) ||
+      !isSafeNonNegativeInteger(value.currentSequence) ||
+      value.currentSequence < value.fromSequence ||
+      typeof value.snapshotUrl !== "string"
+    ) {
+      return null;
+    }
+    try {
+      if (new URL(value.snapshotUrl).protocol !== "https:") {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    return value as PublisherFeedResetRequired;
+  }
+  if (
+    !hasExactKeys(value, CHANGE_PAGE_KEYS) ||
+    !isSafeNonNegativeInteger(value.fromSequence) ||
+    !isSafeNonNegativeInteger(value.toSequence) ||
+    value.toSequence < value.fromSequence ||
+    !isNullableString(value.requestCursor) ||
+    !isSafeNonNegativeInteger(value.pageIndex) ||
+    !isSafeNonNegativeInteger(value.startIndex) ||
+    !isSafeNonNegativeInteger(value.changeCount) ||
+    !Array.isArray(value.changes) ||
+    value.changes.length > 500 ||
+    !value.changes.every(isPublisherFeedChange) ||
+    !isNullableString(value.nextCursor) ||
+    value.startIndex + value.changes.length > value.changeCount ||
+    value.changes.some(
+      (change) => change.sequence <= value.fromSequence || change.sequence > value.toSequence,
+    )
+  ) {
+    return null;
+  }
+  return value as PublisherFeedChangePage;
+}
+
+export function verifyPublisherFeedProjection(
+  raw: unknown,
+  params: {
+    payloadType:
+      | typeof PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+      | typeof PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE;
+    trustedKeys: readonly TrustedFeedSigningKey[];
+    threshold?: number;
+  },
+): VerifiedPublisherFeedProjection {
+  const verified = verifySignedFeedEnvelopePayload(raw, {
+    expectedPayloadType: params.payloadType,
+    trustedKeys: params.trustedKeys,
+    threshold: params.threshold,
+    context: "publisher feed projection",
+  });
+  if (!verified.ok) {
+    throw new Error(verified.message);
+  }
+  let rawPayload: unknown;
+  try {
+    rawPayload = JSON.parse(verified.payloadBytes.toString("utf8"));
+  } catch {
+    throw new Error("publisher feed projection payload is not valid JSON");
+  }
+  const payload =
+    params.payloadType === PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+      ? parseQueryPage(rawPayload)
+      : parseChangePayload(rawPayload);
+  if (!payload) {
+    throw new Error("publisher feed projection payload is invalid");
+  }
+  return {
+    payload,
+    signedBy: verified.signedBy,
+    signedByKeyIds: verified.signedByKeyIds,
+    signatureCount: verified.signatureCount,
+    threshold: verified.threshold,
+  };
+}

--- a/src/plugins/publisher-feed-refresh.test.ts
+++ b/src/plugins/publisher-feed-refresh.test.ts
@@ -66,6 +66,81 @@ describe("publisher feed durable refresh", () => {
     expect(memory.store.read).toHaveBeenCalledWith("https://clawhub.ai", "publishers:alice");
   });
 
+  it("revalidates complete state when a caller changes trust policy", async () => {
+    const initial = {
+      sourceOrigin: "https://clawhub.ai",
+      state: state(7),
+      verification,
+      verifiedAt: "2026-07-16T00:00:00.000Z",
+    };
+    const memory = memoryStore(initial);
+    const fetchSnapshot = vi.fn(async () => ({
+      state: state(8),
+      expiresAt: "2026-07-16T00:06:00.000Z",
+      verification: {
+        ...verification,
+        signedBy: "clawhub-feed-2026-q4",
+        signedByKeyIds: ["clawhub-feed-2026-q4"],
+      },
+    }));
+    const fetchChanges = vi.fn();
+    const result = await refreshPublisherFeedState({
+      ...target,
+      store: memory.store,
+      forceSnapshot: true,
+      dependencies: { fetchSnapshot, fetchChanges },
+    });
+
+    expect(result).toMatchObject({
+      status: "updated",
+      record: { state: { sequence: 8 }, verification: { signedBy: "clawhub-feed-2026-q4" } },
+    });
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+    expect(fetchChanges).not.toHaveBeenCalled();
+  });
+
+  it("rejects rollback and equivocation during forced revalidation", async () => {
+    const initial = {
+      sourceOrigin: "https://clawhub.ai",
+      state: state(7),
+      verification,
+      verifiedAt: "2026-07-16T00:00:00.000Z",
+    };
+    const stale = memoryStore(initial);
+    await expect(
+      refreshPublisherFeedState({
+        ...target,
+        store: stale.store,
+        forceSnapshot: true,
+        dependencies: {
+          fetchSnapshot: vi.fn(async () => ({
+            state: state(6),
+            expiresAt: "2026-07-16T00:06:00.000Z",
+            verification,
+          })),
+        },
+      }),
+    ).rejects.toThrow("older than accepted");
+    expect(stale.current()).toBe(initial);
+
+    const changed = memoryStore(initial);
+    await expect(
+      refreshPublisherFeedState({
+        ...target,
+        store: changed.store,
+        forceSnapshot: true,
+        dependencies: {
+          fetchSnapshot: vi.fn(async () => ({
+            state: { ...state(7), displayName: "Changed" },
+            expiresAt: "2026-07-16T00:06:00.000Z",
+            verification,
+          })),
+        },
+      }),
+    ).rejects.toThrow("without a sequence increment");
+    expect(changed.current()).toBe(initial);
+  });
+
   it("applies complete deltas and preserves state on transport failure", async () => {
     const initial = {
       sourceOrigin: "https://clawhub.ai",

--- a/src/plugins/publisher-feed-refresh.test.ts
+++ b/src/plugins/publisher-feed-refresh.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  refreshPublisherFeedState,
+  startPublisherFeedRefreshScheduler,
+} from "./publisher-feed-refresh.js";
+import type {
+  PublisherFeedStateStore,
+  StoredPublisherFeedState,
+} from "./publisher-feed-state-store.js";
+
+const verification = {
+  signedBy: "clawhub-feed-2026-q3",
+  signedByKeyIds: ["clawhub-feed-2026-q3"],
+  signatureCount: 1,
+  threshold: 1,
+};
+
+function state(sequence: number) {
+  return {
+    feedId: "clawhub.publisher.publishers:alice",
+    sequence,
+    generatedAt: "2026-07-16T00:00:00.000Z",
+    publisherId: "publishers:alice",
+    handle: "alice",
+    displayName: "Alice",
+    entries: [],
+  };
+}
+
+function memoryStore(initial: StoredPublisherFeedState | null = null) {
+  let current = initial;
+  const store: PublisherFeedStateStore = {
+    read: vi.fn(async () => current),
+    write: vi.fn(async (record) => {
+      current = record;
+    }),
+  };
+  return { store, current: () => current };
+}
+
+const target = {
+  baseUrl: "https://clawhub.ai",
+  publisherId: "publishers:alice",
+  verification: { trustedKeys: [] },
+};
+
+describe("publisher feed durable refresh", () => {
+  it("initializes from a complete signed snapshot", async () => {
+    const memory = memoryStore();
+    const result = await refreshPublisherFeedState({
+      ...target,
+      publisherId: "  publishers:alice  ",
+      store: memory.store,
+      now: () => new Date("2026-07-16T00:01:00.000Z"),
+      dependencies: {
+        fetchSnapshot: vi.fn(async () => ({
+          state: state(7),
+          expiresAt: "2026-07-16T00:05:00.000Z",
+          verification,
+        })),
+      },
+    });
+
+    expect(result).toMatchObject({ status: "initialized", record: { state: { sequence: 7 } } });
+    expect(memory.current()).toEqual(result.record);
+    expect(memory.store.read).toHaveBeenCalledWith("https://clawhub.ai", "publishers:alice");
+  });
+
+  it("applies complete deltas and preserves state on transport failure", async () => {
+    const initial = {
+      sourceOrigin: "https://clawhub.ai",
+      state: state(7),
+      verification,
+      verifiedAt: "2026-07-16T00:00:00.000Z",
+    };
+    const memory = memoryStore(initial);
+    const result = await refreshPublisherFeedState({
+      ...target,
+      store: memory.store,
+      dependencies: {
+        fetchChanges: vi.fn(async () => ({
+          status: "complete" as const,
+          feedId: initial.state.feedId,
+          fromSequence: 7,
+          toSequence: 8,
+          generatedAt: "2026-07-16T00:01:00.000Z",
+          expiresAt: "2026-07-16T00:06:00.000Z",
+          changes: [
+            {
+              sequence: 8,
+              operation: "metadata" as const,
+              metadata: {
+                publisherId: "publishers:alice",
+                handle: "alice-ai",
+                displayName: "Alice AI",
+              },
+            },
+          ],
+          verification,
+        })),
+      },
+    });
+    expect(result).toMatchObject({
+      status: "updated",
+      record: { state: { sequence: 8, handle: "alice-ai" } },
+    });
+
+    const accepted = memory.current();
+    await expect(
+      refreshPublisherFeedState({
+        ...target,
+        store: memory.store,
+        dependencies: {
+          fetchChanges: vi.fn(async () => {
+            throw new Error("offline");
+          }),
+        },
+      }),
+    ).rejects.toThrow("offline");
+    expect(memory.current()).toBe(accepted);
+  });
+
+  it("accepts reset snapshots only at the signed target sequence", async () => {
+    const initial = {
+      sourceOrigin: "https://clawhub.ai",
+      state: state(2),
+      verification,
+      verifiedAt: "2026-07-16T00:00:00.000Z",
+    };
+    const memory = memoryStore(initial);
+    const fetchChanges = vi.fn(async () => ({
+      status: "reset-required" as const,
+      reset: {
+        schemaVersion: 1 as const,
+        feedId: initial.state.feedId,
+        fromSequence: 2,
+        currentSequence: 7,
+        generatedAt: "2026-07-16T00:01:00.000Z",
+        expiresAt: "2026-07-16T00:06:00.000Z",
+        resetRequired: true as const,
+        snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/snapshot",
+      },
+      verification,
+    }));
+    const fetchSnapshot = vi.fn(async () => ({
+      state: state(7),
+      expiresAt: "2026-07-16T00:06:00.000Z",
+      verification,
+    }));
+    const result = await refreshPublisherFeedState({
+      ...target,
+      store: memory.store,
+      dependencies: { fetchChanges, fetchSnapshot },
+    });
+    expect(result.status).toBe("reset");
+    expect(result.record.state.sequence).toBe(7);
+
+    const mismatch = memoryStore(initial);
+    await expect(
+      refreshPublisherFeedState({
+        ...target,
+        store: mismatch.store,
+        dependencies: {
+          fetchChanges,
+          fetchSnapshot: vi.fn(async () => ({
+            state: state(6),
+            expiresAt: "2026-07-16T00:06:00.000Z",
+            verification,
+          })),
+        },
+      }),
+    ).rejects.toThrow("does not match");
+    expect(mismatch.current()).toBe(initial);
+  });
+});
+
+describe("publisher feed refresh scheduler", () => {
+  it("runs targets serially, reports per-target errors, and stops future runs", async () => {
+    vi.useFakeTimers();
+    try {
+      const memory = memoryStore();
+      const calls: string[] = [];
+      const errors: unknown[] = [];
+      const refresh = vi.fn(async ({ publisherId }: { publisherId: string }) => {
+        calls.push(publisherId);
+        if (publisherId === "publishers:bob") {
+          throw new Error("offline");
+        }
+        return {} as never;
+      });
+      const scheduler = startPublisherFeedRefreshScheduler({
+        targets: [target, { ...target, publisherId: "publishers:bob" }],
+        store: memory.store,
+        intervalMs: 60_000,
+        refresh: refresh as typeof refreshPublisherFeedState,
+        onError: (_target, error) => errors.push(error),
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls).toEqual(["publishers:alice", "publishers:bob"]);
+      expect(errors).toHaveLength(1);
+      scheduler.stop();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/plugins/publisher-feed-refresh.ts
+++ b/src/plugins/publisher-feed-refresh.ts
@@ -29,6 +29,21 @@ export type PublisherFeedRefreshResult = {
   record: StoredPublisherFeedState;
 };
 
+function samePublisherFeedState(
+  left: StoredPublisherFeedState["state"],
+  right: StoredPublisherFeedState["state"],
+): boolean {
+  return (
+    left.feedId === right.feedId &&
+    left.sequence === right.sequence &&
+    left.generatedAt === right.generatedAt &&
+    left.publisherId === right.publisherId &&
+    left.handle === right.handle &&
+    left.displayName === right.displayName &&
+    JSON.stringify(left.entries) === JSON.stringify(right.entries)
+  );
+}
+
 function sourceOrigin(raw: string): string {
   const url = new URL(raw);
   if (
@@ -68,6 +83,7 @@ function snapshotRecord(params: {
 export async function refreshPublisherFeedState(
   params: PublisherFeedRefreshTarget & {
     store: PublisherFeedStateStore;
+    forceSnapshot?: boolean;
     now?: () => Date;
     dependencies?: PublisherFeedRefreshDependencies;
   },
@@ -84,11 +100,28 @@ export async function refreshPublisherFeedState(
     verification: params.verification,
     now,
   };
-  if (!current) {
+  if (!current || params.forceSnapshot) {
     const snapshot = await fetchSnapshot(transport);
     const record = snapshotRecord({ origin, snapshot, verifiedAt: now().toISOString() });
+    if (current && record.state.sequence < current.state.sequence) {
+      throw new Error("publisher feed snapshot is older than accepted state");
+    }
+    if (
+      current &&
+      record.state.sequence === current.state.sequence &&
+      !samePublisherFeedState(record.state, current.state)
+    ) {
+      throw new Error("publisher feed snapshot changed without a sequence increment");
+    }
     await params.store.write(record);
-    return { status: "initialized", record };
+    return {
+      status: current
+        ? record.state.sequence === current.state.sequence
+          ? "unchanged"
+          : "updated"
+        : "initialized",
+      record,
+    };
   }
 
   const changes = await fetchChanges({ ...transport, fromSequence: current.state.sequence });

--- a/src/plugins/publisher-feed-refresh.ts
+++ b/src/plugins/publisher-feed-refresh.ts
@@ -1,0 +1,212 @@
+import type { TrustedFeedSigningKey } from "./official-external-plugin-catalog-envelope.js";
+import type {
+  PublisherFeedStateStore,
+  StoredPublisherFeedState,
+} from "./publisher-feed-state-store.js";
+import {
+  applyPublisherFeedChanges,
+  fetchPublisherFeedChanges,
+  fetchPublisherFeedSnapshot,
+  type PublisherFeedSnapshotResult,
+} from "./publisher-feed-transport.js";
+
+export type PublisherFeedRefreshTarget = {
+  baseUrl: string;
+  publisherId: string;
+  verification: {
+    trustedKeys: readonly TrustedFeedSigningKey[];
+    threshold?: number;
+  };
+};
+
+type PublisherFeedRefreshDependencies = {
+  fetchSnapshot?: typeof fetchPublisherFeedSnapshot;
+  fetchChanges?: typeof fetchPublisherFeedChanges;
+};
+
+export type PublisherFeedRefreshResult = {
+  status: "initialized" | "updated" | "unchanged" | "reset";
+  record: StoredPublisherFeedState;
+};
+
+function sourceOrigin(raw: string): string {
+  const url = new URL(raw);
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "/" && url.pathname !== "")
+  ) {
+    throw new Error("publisher feed refresh source must be an HTTPS origin");
+  }
+  return url.origin;
+}
+
+function publisherId(raw: string): string {
+  const normalized = raw.trim();
+  if (!normalized || new TextEncoder().encode(normalized).length > 200) {
+    throw new Error("publisher feed refresh publisher id is invalid");
+  }
+  return normalized;
+}
+
+function snapshotRecord(params: {
+  origin: string;
+  snapshot: PublisherFeedSnapshotResult;
+  verifiedAt: string;
+}): StoredPublisherFeedState {
+  return {
+    sourceOrigin: params.origin,
+    state: params.snapshot.state,
+    verification: params.snapshot.verification,
+    verifiedAt: params.verifiedAt,
+  };
+}
+
+export async function refreshPublisherFeedState(
+  params: PublisherFeedRefreshTarget & {
+    store: PublisherFeedStateStore;
+    now?: () => Date;
+    dependencies?: PublisherFeedRefreshDependencies;
+  },
+): Promise<PublisherFeedRefreshResult> {
+  const origin = sourceOrigin(params.baseUrl);
+  const normalizedPublisherId = publisherId(params.publisherId);
+  const now = params.now ?? (() => new Date());
+  const fetchSnapshot = params.dependencies?.fetchSnapshot ?? fetchPublisherFeedSnapshot;
+  const fetchChanges = params.dependencies?.fetchChanges ?? fetchPublisherFeedChanges;
+  const current = await params.store.read(origin, normalizedPublisherId);
+  const transport = {
+    baseUrl: origin,
+    publisherId: normalizedPublisherId,
+    verification: params.verification,
+    now,
+  };
+  if (!current) {
+    const snapshot = await fetchSnapshot(transport);
+    const record = snapshotRecord({ origin, snapshot, verifiedAt: now().toISOString() });
+    await params.store.write(record);
+    return { status: "initialized", record };
+  }
+
+  const changes = await fetchChanges({ ...transport, fromSequence: current.state.sequence });
+  if (changes.status === "reset-required") {
+    const snapshot = await fetchSnapshot(transport);
+    if (
+      snapshot.state.feedId !== changes.reset.feedId ||
+      snapshot.state.sequence !== changes.reset.currentSequence ||
+      snapshot.state.sequence <= current.state.sequence
+    ) {
+      throw new Error("publisher feed reset snapshot does not match the signed reset instruction");
+    }
+    const record = snapshotRecord({ origin, snapshot, verifiedAt: now().toISOString() });
+    await params.store.write(record);
+    return { status: "reset", record };
+  }
+
+  const applied = applyPublisherFeedChanges(current.state, changes);
+  if (applied.status !== "applied") {
+    throw new Error("publisher feed change application unexpectedly requested reset");
+  }
+  const record: StoredPublisherFeedState = {
+    sourceOrigin: origin,
+    state: applied.state,
+    verification: changes.verification,
+    verifiedAt: now().toISOString(),
+  };
+  await params.store.write(record);
+  return {
+    status: applied.state.sequence === current.state.sequence ? "unchanged" : "updated",
+    record,
+  };
+}
+
+export type PublisherFeedRefreshScheduler = {
+  runNow: () => Promise<void>;
+  stop: () => void;
+};
+
+export function startPublisherFeedRefreshScheduler(params: {
+  targets: readonly PublisherFeedRefreshTarget[];
+  store: PublisherFeedStateStore;
+  intervalMs?: number;
+  initialDelayMs?: number;
+  refresh?: typeof refreshPublisherFeedState;
+  onError?: (target: PublisherFeedRefreshTarget, error: unknown) => void;
+}): PublisherFeedRefreshScheduler {
+  if (params.targets.length > 100) {
+    throw new Error("publisher feed refresh scheduler supports at most 100 targets");
+  }
+  const intervalMs = params.intervalMs ?? 15 * 60 * 1000;
+  const initialDelayMs = params.initialDelayMs ?? 0;
+  if (
+    !Number.isSafeInteger(intervalMs) ||
+    intervalMs < 60_000 ||
+    intervalMs > 24 * 60 * 60 * 1000
+  ) {
+    throw new Error("publisher feed refresh interval must be between 1 minute and 24 hours");
+  }
+  if (!Number.isSafeInteger(initialDelayMs) || initialDelayMs < 0 || initialDelayMs > intervalMs) {
+    throw new Error("publisher feed initial delay is invalid");
+  }
+  const refresh = params.refresh ?? refreshPublisherFeedState;
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let running: Promise<void> | null = null;
+
+  const schedule = (delayMs: number) => {
+    if (stopped || params.targets.length === 0) {
+      return;
+    }
+    timer = setTimeout(() => {
+      timer = null;
+      void run();
+    }, delayMs);
+    timer.unref?.();
+  };
+
+  const execute = async () => {
+    for (const target of params.targets) {
+      if (stopped) {
+        return;
+      }
+      try {
+        await refresh({ ...target, store: params.store });
+      } catch (error) {
+        params.onError?.(target, error);
+      }
+    }
+  };
+
+  const run = (): Promise<void> => {
+    if (stopped) {
+      return Promise.resolve();
+    }
+    if (running) {
+      return running;
+    }
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    running = execute().finally(() => {
+      running = null;
+      schedule(intervalMs);
+    });
+    return running;
+  };
+
+  schedule(initialDelayMs);
+  return {
+    runNow: run,
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/src/plugins/publisher-feed-state-store.test.ts
+++ b/src/plugins/publisher-feed-state-store.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { createSqlitePublisherFeedStateStore } from "./publisher-feed-state-store.js";
+
+const tempDirs: string[] = [];
+
+function makeRecord(sequence = 7) {
+  return {
+    sourceOrigin: "https://clawhub.ai",
+    state: {
+      feedId: "clawhub.publisher.publishers:alice",
+      sequence,
+      generatedAt: `2026-07-16T00:00:0${sequence}.000Z`,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [
+        {
+          kind: "skill" as const,
+          id: "skills:cuda",
+          name: "cuda-helper",
+          displayName: "CUDA Helper",
+          summary: "GPU tools",
+          url: "/alice/skills/cuda-helper",
+          updatedAt: 2,
+        },
+      ],
+    },
+    verification: {
+      signedBy: "clawhub-feed-2026-q3",
+      signedByKeyIds: ["clawhub-feed-2026-q3"],
+      signatureCount: 1,
+      threshold: 1,
+    },
+    verifiedAt: "2026-07-16T00:01:00.000Z",
+  };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabase();
+  for (const directory of tempDirs.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("publisher feed state store", () => {
+  it("persists accepted publisher state and signing evidence", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publisher-feed-state-"));
+    tempDirs.push(directory);
+    const store = createSqlitePublisherFeedStateStore({
+      stateDatabasePath: path.join(directory, "state.sqlite"),
+    });
+
+    expect(await store.read("https://clawhub.ai", "publishers:alice")).toBeNull();
+    await store.write(makeRecord());
+    expect(await store.read("https://clawhub.ai/", "publishers:alice")).toEqual(makeRecord());
+  });
+
+  it("rejects rollback and same-sequence content changes", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publisher-feed-state-"));
+    tempDirs.push(directory);
+    const store = createSqlitePublisherFeedStateStore({
+      stateDatabasePath: path.join(directory, "state.sqlite"),
+    });
+    const unsorted = {
+      ...makeRecord(7),
+      state: {
+        ...makeRecord(7).state,
+        entries: [
+          { ...makeRecord(7).state.entries[0]!, id: "skills:a" },
+          { ...makeRecord(7).state.entries[0]!, id: "skills:Z" },
+        ],
+      },
+    };
+    await store.write(unsorted);
+    await store.write({
+      ...unsorted,
+      state: {
+        ...unsorted.state,
+        entries: unsorted.state.entries.toReversed(),
+      },
+    });
+
+    await expect(store.write(makeRecord(6))).rejects.toThrow("older than accepted");
+    await expect(
+      store.write({
+        ...makeRecord(7),
+        state: { ...makeRecord(7).state, displayName: "Changed" },
+      }),
+    ).rejects.toThrow("without a sequence increment");
+    await store.write(makeRecord(8));
+    expect((await store.read("https://clawhub.ai", "publishers:alice"))?.state.sequence).toBe(8);
+  });
+});

--- a/src/plugins/publisher-feed-state-store.ts
+++ b/src/plugins/publisher-feed-state-store.ts
@@ -1,0 +1,367 @@
+import { existsSync } from "node:fs";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import type { PublisherFeedEntry } from "./publisher-feed-projections.js";
+import type {
+  PublisherFeedState,
+  PublisherFeedVerificationEvidence,
+} from "./publisher-feed-transport.js";
+
+export type StoredPublisherFeedState = {
+  sourceOrigin: string;
+  state: PublisherFeedState;
+  verification: PublisherFeedVerificationEvidence;
+  verifiedAt: string;
+};
+
+export type PublisherFeedStateStore = {
+  read: (sourceOrigin: string, publisherId: string) => Promise<StoredPublisherFeedState | null>;
+  write: (record: StoredPublisherFeedState) => Promise<void>;
+};
+
+type PublisherFeedStateStoreOptions = {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateDatabasePath?: string;
+};
+
+type PublisherFeedStateDatabase = Pick<OpenClawStateKyselyDatabase, "publisher_feed_states">;
+
+type PublisherFeedStateRow = {
+  source_origin: string;
+  publisher_id: string;
+  feed_id: string;
+  sequence: number | bigint;
+  generated_at: string;
+  handle: string | null;
+  display_name: string;
+  entries_json: string;
+  signed_by: string;
+  signed_by_key_ids_json: string;
+  signature_count: number | bigint;
+  threshold: number | bigint;
+  verified_at: string;
+};
+
+function resolveStoreEnv(options: PublisherFeedStateStoreOptions): NodeJS.ProcessEnv | undefined {
+  if (!options.stateDir) {
+    return options.env;
+  }
+  return { ...(options.env ?? process.env), OPENCLAW_STATE_DIR: options.stateDir };
+}
+
+function resolveDatabaseOptions(
+  options: PublisherFeedStateStoreOptions,
+): OpenClawStateDatabaseOptions {
+  const env = resolveStoreEnv(options);
+  return {
+    ...(env ? { env } : {}),
+    ...(options.stateDatabasePath ? { path: options.stateDatabasePath } : {}),
+  };
+}
+
+function resolveDatabasePath(options: PublisherFeedStateStoreOptions): string {
+  return (
+    options.stateDatabasePath ??
+    resolveOpenClawStateSqlitePath(resolveStoreEnv(options) ?? process.env)
+  );
+}
+
+function normalizeSourceOrigin(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("publisher feed source origin is invalid");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "/" && url.pathname !== "")
+  ) {
+    throw new Error("publisher feed source must be an HTTPS origin");
+  }
+  return url.origin;
+}
+
+function isSafeEntryUrl(raw: string): boolean {
+  if (raw.startsWith("/")) {
+    if (raw.startsWith("//") || raw.includes("\\")) {
+      return false;
+    }
+    for (let index = 0; index < raw.length; index += 1) {
+      const codeUnit = raw.charCodeAt(index);
+      if (codeUnit <= 0x1f || codeUnit === 0x7f) {
+        return false;
+      }
+    }
+    return true;
+  }
+  try {
+    const url = new URL(raw);
+    return url.protocol === "https:" && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function isEntry(value: unknown): value is PublisherFeedEntry {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    Object.keys(entry).toSorted().join("\0") ===
+      ["kind", "id", "name", "displayName", "summary", "url", "updatedAt"].toSorted().join("\0") &&
+    (entry.kind === "skill" || entry.kind === "plugin") &&
+    typeof entry.id === "string" &&
+    entry.id.length > 0 &&
+    typeof entry.name === "string" &&
+    entry.name.length > 0 &&
+    typeof entry.displayName === "string" &&
+    entry.displayName.length > 0 &&
+    (entry.summary === null || typeof entry.summary === "string") &&
+    typeof entry.url === "string" &&
+    entry.url.length > 0 &&
+    isSafeEntryUrl(entry.url) &&
+    typeof entry.updatedAt === "number" &&
+    Number.isFinite(entry.updatedAt) &&
+    entry.updatedAt >= 0
+  );
+}
+
+function parseStringArray(raw: string): string[] | null {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseEntries(raw: string): PublisherFeedEntry[] | null {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    return Array.isArray(value) && value.length <= 400 && value.every(isEntry) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareEntries(left: PublisherFeedEntry, right: PublisherFeedEntry): number {
+  return (
+    right.updatedAt - left.updatedAt ||
+    compareCodeUnits(left.kind, right.kind) ||
+    compareCodeUnits(left.id, right.id)
+  );
+}
+
+function assertRecord(record: StoredPublisherFeedState): StoredPublisherFeedState {
+  const sourceOrigin = normalizeSourceOrigin(record.sourceOrigin);
+  if (
+    !record.state.publisherId ||
+    new TextEncoder().encode(record.state.publisherId).length > 200 ||
+    record.state.feedId !== `clawhub.publisher.${record.state.publisherId}` ||
+    !Number.isSafeInteger(record.state.sequence) ||
+    record.state.sequence < 0 ||
+    !Number.isFinite(Date.parse(record.state.generatedAt)) ||
+    (record.state.handle !== null && !record.state.handle) ||
+    !record.state.displayName ||
+    record.state.entries.length > 400 ||
+    !record.state.entries.every(isEntry) ||
+    !record.verification.signedBy ||
+    record.verification.signedByKeyIds.length === 0 ||
+    record.verification.signedByKeyIds.some((keyId) => !keyId) ||
+    !record.verification.signedByKeyIds.includes(record.verification.signedBy) ||
+    !Number.isSafeInteger(record.verification.signatureCount) ||
+    record.verification.signatureCount < 1 ||
+    !Number.isSafeInteger(record.verification.threshold) ||
+    record.verification.threshold < 1 ||
+    record.verification.signatureCount < record.verification.threshold ||
+    !Number.isFinite(Date.parse(record.verifiedAt))
+  ) {
+    throw new Error("publisher feed state record is invalid");
+  }
+  const identities = new Set<string>();
+  for (const entry of record.state.entries) {
+    const identity = `${entry.kind}\0${entry.id}`;
+    if (identities.has(identity)) {
+      throw new Error("publisher feed state contains duplicate entries");
+    }
+    identities.add(identity);
+  }
+  return {
+    ...record,
+    sourceOrigin,
+    state: {
+      ...record.state,
+      entries: [...record.state.entries].toSorted(compareEntries),
+    },
+    verification: {
+      ...record.verification,
+      signedByKeyIds: [...new Set(record.verification.signedByKeyIds)].toSorted(),
+    },
+  };
+}
+
+function rowToRecord(row: PublisherFeedStateRow | undefined): StoredPublisherFeedState | null {
+  if (!row) {
+    return null;
+  }
+  const entries = parseEntries(row.entries_json);
+  const signedByKeyIds = parseStringArray(row.signed_by_key_ids_json);
+  if (!entries || !signedByKeyIds) {
+    throw new Error("stored publisher feed state is corrupt");
+  }
+  return assertRecord({
+    sourceOrigin: row.source_origin,
+    state: {
+      feedId: row.feed_id,
+      sequence: Number(row.sequence),
+      generatedAt: row.generated_at,
+      publisherId: row.publisher_id,
+      handle: row.handle,
+      displayName: row.display_name,
+      entries,
+    },
+    verification: {
+      signedBy: row.signed_by,
+      signedByKeyIds,
+      signatureCount: Number(row.signature_count),
+      threshold: Number(row.threshold),
+    },
+    verifiedAt: row.verified_at,
+  });
+}
+
+function sameAcceptedState(row: PublisherFeedStateRow, record: StoredPublisherFeedState): boolean {
+  return (
+    row.feed_id === record.state.feedId &&
+    row.generated_at === record.state.generatedAt &&
+    row.handle === record.state.handle &&
+    row.display_name === record.state.displayName &&
+    row.entries_json === JSON.stringify(record.state.entries)
+  );
+}
+
+const SELECT_COLUMNS = [
+  "source_origin",
+  "publisher_id",
+  "feed_id",
+  "sequence",
+  "generated_at",
+  "handle",
+  "display_name",
+  "entries_json",
+  "signed_by",
+  "signed_by_key_ids_json",
+  "signature_count",
+  "threshold",
+  "verified_at",
+] as const;
+
+export function createSqlitePublisherFeedStateStore(
+  options: PublisherFeedStateStoreOptions = {},
+): PublisherFeedStateStore {
+  return {
+    async read(sourceOrigin, publisherId) {
+      const normalizedOrigin = normalizeSourceOrigin(sourceOrigin);
+      const pathname = resolveDatabasePath(options);
+      if (!existsSync(pathname)) {
+        return null;
+      }
+      const database = openOpenClawStateDatabase(resolveDatabaseOptions(options));
+      const stateDb = getNodeSqliteKysely<PublisherFeedStateDatabase>(database.db);
+      const row = executeSqliteQueryTakeFirstSync(
+        database.db,
+        stateDb
+          .selectFrom("publisher_feed_states")
+          .select(SELECT_COLUMNS)
+          .where("source_origin", "=", normalizedOrigin)
+          .where("publisher_id", "=", publisherId),
+      ) as PublisherFeedStateRow | undefined;
+      return rowToRecord(row);
+    },
+    async write(input) {
+      const record = assertRecord(input);
+      const entriesJson = JSON.stringify(record.state.entries);
+      const keyIdsJson = JSON.stringify(record.verification.signedByKeyIds);
+      const now = Date.now();
+      runOpenClawStateWriteTransaction((database) => {
+        const stateDb = getNodeSqliteKysely<PublisherFeedStateDatabase>(database.db);
+        const current = executeSqliteQueryTakeFirstSync(
+          database.db,
+          stateDb
+            .selectFrom("publisher_feed_states")
+            .select(SELECT_COLUMNS)
+            .where("source_origin", "=", record.sourceOrigin)
+            .where("publisher_id", "=", record.state.publisherId),
+        ) as PublisherFeedStateRow | undefined;
+        if (current && Number(current.sequence) > record.state.sequence) {
+          throw new Error("publisher feed state sequence is older than accepted state");
+        }
+        if (
+          current &&
+          Number(current.sequence) === record.state.sequence &&
+          !sameAcceptedState(current, record)
+        ) {
+          throw new Error("publisher feed state changed without a sequence increment");
+        }
+        executeSqliteQuerySync(
+          database.db,
+          stateDb
+            .insertInto("publisher_feed_states")
+            .values({
+              source_origin: record.sourceOrigin,
+              publisher_id: record.state.publisherId,
+              feed_id: record.state.feedId,
+              sequence: record.state.sequence,
+              generated_at: record.state.generatedAt,
+              handle: record.state.handle,
+              display_name: record.state.displayName,
+              entries_json: entriesJson,
+              signed_by: record.verification.signedBy,
+              signed_by_key_ids_json: keyIdsJson,
+              signature_count: record.verification.signatureCount,
+              threshold: record.verification.threshold,
+              verified_at: record.verifiedAt,
+              updated_at_ms: now,
+            })
+            .onConflict((conflict) =>
+              conflict.columns(["source_origin", "publisher_id"]).doUpdateSet({
+                feed_id: record.state.feedId,
+                sequence: record.state.sequence,
+                generated_at: record.state.generatedAt,
+                handle: record.state.handle,
+                display_name: record.state.displayName,
+                entries_json: entriesJson,
+                signed_by: record.verification.signedBy,
+                signed_by_key_ids_json: keyIdsJson,
+                signature_count: record.verification.signatureCount,
+                threshold: record.verification.threshold,
+                verified_at: record.verifiedAt,
+                updated_at_ms: now,
+              }),
+            ),
+        );
+      }, resolveDatabaseOptions(options));
+    },
+  };
+}

--- a/src/plugins/publisher-feed-transport.test.ts
+++ b/src/plugins/publisher-feed-transport.test.ts
@@ -13,12 +13,14 @@ import {
   PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
   PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
   PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE,
+  type PublisherFeedEntry,
 } from "./publisher-feed-projections.js";
 import {
   applyPublisherFeedChanges,
   fetchPublisherFeedChanges,
   fetchPublisherFeedQuery,
   fetchPublisherFeedSnapshot,
+  type PublisherFeedState,
 } from "./publisher-feed-transport.js";
 
 type SigningKey = { keyId: string; privateKey: KeyObject; publicKey: KeyObject };
@@ -89,14 +91,14 @@ const entry = {
   summary: "GPU tools",
   url: "/alice/skills/cuda-helper",
   updatedAt: 2,
-};
+} satisfies PublisherFeedEntry;
 
 const base = {
   schemaVersion: 1,
   feedId: "clawhub.publisher.publishers:alice",
   generatedAt: "2026-07-16T00:00:00.000Z",
   expiresAt: "2026-07-16T00:05:00.000Z",
-};
+} as const;
 
 const evidence = {
   signedBy: "clawhub-feed-2026-q3",
@@ -242,11 +244,7 @@ describe("publisher feed projection transport", () => {
     });
     enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
       ...base,
-      sequence: 7,
       query,
-      requestCursor: "next",
-      pageIndex: 1,
-      startIndex: 1,
       resultCount: 2,
       entries: [{ ...entry, id: "skills:two", name: "two" }],
       nextCursor: null,
@@ -308,7 +306,7 @@ describe("publisher feed projection transport", () => {
 
   it("applies a complete change range atomically without mutating current state", () => {
     const currentEntry = { ...entry, id: "skills:old", name: "old", updatedAt: 1 };
-    const current = {
+    const current: PublisherFeedState = {
       feedId: base.feedId,
       sequence: 7,
       generatedAt: "2026-07-15T00:00:00.000Z",
@@ -354,7 +352,7 @@ describe("publisher feed projection transport", () => {
   });
 
   it("orders equal-timestamp entries by locale-independent code units", () => {
-    const current = {
+    const current: PublisherFeedState = {
       feedId: base.feedId,
       sequence: 7,
       generatedAt: base.generatedAt,
@@ -384,7 +382,7 @@ describe("publisher feed projection transport", () => {
   });
 
   it("retains accepted generation time for a no-op change range", () => {
-    const current = {
+    const current: PublisherFeedState = {
       feedId: base.feedId,
       sequence: 7,
       generatedAt: "2026-07-15T00:00:00.000Z",
@@ -411,7 +409,7 @@ describe("publisher feed projection transport", () => {
   });
 
   it("rejects incomplete change ranges before exposing a next state", () => {
-    const current = {
+    const current: PublisherFeedState = {
       feedId: base.feedId,
       sequence: 7,
       generatedAt: base.generatedAt,

--- a/src/plugins/publisher-feed-transport.test.ts
+++ b/src/plugins/publisher-feed-transport.test.ts
@@ -1,0 +1,528 @@
+import crypto, { type KeyObject } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const transportMocks = vi.hoisted(() => ({
+  guardedFetch: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: transportMocks.guardedFetch,
+}));
+
+import {
+  PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+  PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+} from "./publisher-feed-projections.js";
+import {
+  applyPublisherFeedChanges,
+  fetchPublisherFeedChanges,
+  fetchPublisherFeedQuery,
+} from "./publisher-feed-transport.js";
+
+type SigningKey = { keyId: string; privateKey: KeyObject; publicKey: KeyObject };
+type QueuedResponse = { response: Response; finalUrl?: string };
+
+const queuedResponses: QueuedResponse[] = [];
+const release = vi.fn(async () => undefined);
+
+function signingKey(): SigningKey {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  return { keyId: "clawhub-feed-2026-q3", privateKey, publicKey };
+}
+
+function verification(key: SigningKey) {
+  return {
+    trustedKeys: [
+      {
+        keyId: key.keyId,
+        publicKey: key.publicKey.export({ type: "spki", format: "pem" }),
+      },
+    ],
+  };
+}
+
+function signedEnvelope(key: SigningKey, payloadType: string, payload: unknown) {
+  const payloadBytes = Buffer.from(JSON.stringify(payload));
+  const typeBytes = Buffer.from(payloadType);
+  const signingInput = Buffer.concat([
+    Buffer.from(`DSSEv1 ${typeBytes.length} ${payloadType} ${payloadBytes.length} `),
+    payloadBytes,
+  ]);
+  return JSON.stringify({
+    schemaVersion: 1,
+    payloadType,
+    payload: payloadBytes.toString("base64url"),
+    signatures: [
+      {
+        keyId: key.keyId,
+        algorithm: "ed25519",
+        signature: crypto.sign(null, signingInput, key.privateKey).toString("base64url"),
+      },
+    ],
+  });
+}
+
+function enqueueSigned(
+  key: SigningKey,
+  payloadType: string,
+  payload: unknown,
+  status = 200,
+  headers?: HeadersInit,
+) {
+  const responseHeaders = new Headers(headers);
+  if (!responseHeaders.has("content-type")) {
+    responseHeaders.set("content-type", "application/vnd.dsse+json; charset=utf-8");
+  }
+  queuedResponses.push({
+    response: new Response(signedEnvelope(key, payloadType, payload), {
+      status,
+      headers: responseHeaders,
+    }),
+  });
+}
+
+const entry = {
+  kind: "skill",
+  id: "skills:cuda",
+  name: "cuda-helper",
+  displayName: "CUDA Helper",
+  summary: "GPU tools",
+  url: "/alice/skills/cuda-helper",
+  updatedAt: 2,
+};
+
+const base = {
+  schemaVersion: 1,
+  feedId: "clawhub.publisher.publishers:alice",
+  generatedAt: "2026-07-16T00:00:00.000Z",
+  expiresAt: "2026-07-16T00:05:00.000Z",
+};
+
+beforeEach(() => {
+  queuedResponses.length = 0;
+  release.mockClear();
+  transportMocks.guardedFetch.mockReset();
+  transportMocks.guardedFetch.mockImplementation(async ({ url }: { url: string }) => {
+    const queued = queuedResponses.shift();
+    if (!queued) {
+      throw new Error("missing queued publisher feed response");
+    }
+    return {
+      response: queued.response,
+      finalUrl: queued.finalUrl ?? url,
+      release,
+    };
+  });
+});
+
+describe("publisher feed projection transport", () => {
+  it("assembles a complete signed query across revision-bound pages", async () => {
+    const key = signingKey();
+    const query = { text: "CUDA Helper", kinds: ["skill"] };
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query: { kinds: ["skill"], text: "CUDA Helper" },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 2,
+      entries: [entry],
+      nextCursor: "",
+    });
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query,
+      requestCursor: "",
+      pageIndex: 1,
+      startIndex: 1,
+      resultCount: 2,
+      entries: [{ ...entry, id: "skills:cuda-two", name: "cuda-two" }],
+      nextCursor: null,
+    });
+
+    const result = await fetchPublisherFeedQuery({
+      baseUrl: "https://clawhub.ai",
+      publisherId: "publishers:alice",
+      verification: verification(key),
+      query: { text: "  CUDA\tHelper ", kinds: ["skill", "skill"] },
+      limit: 1,
+      now: () => new Date("2026-07-16T00:01:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ sequence: 7, query });
+    expect(result.entries[0]).toMatchObject({ id: "skills:cuda" });
+    expect(result.entries).toHaveLength(2);
+    expect(transportMocks.guardedFetch.mock.calls.map(([args]) => args.url)).toEqual([
+      "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/query?q=CUDA+Helper&kind=skill&limit=1",
+      "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/query?cursor=",
+    ]);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      name: "revision drift",
+      second: { sequence: 8, requestCursor: "next", pageIndex: 1, startIndex: 1 },
+      error: "revision changed",
+    },
+    {
+      name: "cursor replay",
+      second: {
+        sequence: 7,
+        requestCursor: "next",
+        pageIndex: 1,
+        startIndex: 1,
+        nextCursor: "next",
+      },
+      error: "cursor repeated",
+    },
+    {
+      name: "premature terminal page",
+      second: {
+        sequence: 7,
+        requestCursor: "next",
+        pageIndex: 1,
+        startIndex: 1,
+        nextCursor: null,
+        resultCount: 3,
+      },
+      error: "revision changed",
+    },
+  ])("rejects query $name without returning partial entries", async ({ second, error }) => {
+    const key = signingKey();
+    const query = { text: "CUDA" };
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query,
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 2,
+      entries: [entry],
+      nextCursor: "next",
+    });
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, {
+      ...base,
+      sequence: 7,
+      query,
+      requestCursor: "next",
+      pageIndex: 1,
+      startIndex: 1,
+      resultCount: 2,
+      entries: [{ ...entry, id: "skills:two", name: "two" }],
+      nextCursor: null,
+      ...second,
+    });
+
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow(error);
+  });
+
+  it("assembles a complete signed changed-since range", async () => {
+    const key = signingKey();
+    enqueueSigned(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {
+      ...base,
+      fromSequence: 7,
+      toSequence: 9,
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      changeCount: 2,
+      changes: [{ sequence: 8, operation: "remove", entryId: "skills:old", entryKind: "skill" }],
+      nextCursor: "next-change",
+    });
+    enqueueSigned(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {
+      ...base,
+      fromSequence: 7,
+      toSequence: 9,
+      requestCursor: "next-change",
+      pageIndex: 1,
+      startIndex: 1,
+      changeCount: 2,
+      changes: [{ sequence: 9, operation: "upsert", entry }],
+      nextCursor: null,
+    });
+
+    const result = await fetchPublisherFeedChanges({
+      baseUrl: "https://clawhub.ai",
+      publisherId: "publishers:alice",
+      verification: verification(key),
+      fromSequence: 7,
+      limit: 1,
+      now: () => new Date("2026-07-16T00:01:00.000Z"),
+    });
+
+    expect(result).toMatchObject({ status: "complete", fromSequence: 7, toSequence: 9 });
+    if (result.status === "complete") {
+      expect(result.changes).toHaveLength(2);
+    }
+  });
+
+  it("applies a complete change range atomically without mutating current state", () => {
+    const currentEntry = { ...entry, id: "skills:old", name: "old", updatedAt: 1 };
+    const current = {
+      feedId: base.feedId,
+      sequence: 7,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [currentEntry],
+    };
+    const applied = applyPublisherFeedChanges(current, {
+      status: "complete",
+      feedId: base.feedId,
+      fromSequence: 7,
+      toSequence: 9,
+      generatedAt: base.generatedAt,
+      expiresAt: base.expiresAt,
+      changes: [
+        { sequence: 8, operation: "remove", entryId: "skills:old", entryKind: "skill" },
+        { sequence: 9, operation: "upsert", entry },
+        {
+          sequence: 9,
+          operation: "metadata",
+          metadata: {
+            publisherId: "publishers:alice",
+            handle: "alice-ai",
+            displayName: "Alice AI",
+          },
+        },
+      ],
+    });
+
+    expect(applied).toMatchObject({
+      status: "applied",
+      state: {
+        sequence: 9,
+        handle: "alice-ai",
+        displayName: "Alice AI",
+        entries: [{ id: "skills:cuda" }],
+      },
+    });
+    expect(current).toMatchObject({ sequence: 7, handle: "alice", entries: [currentEntry] });
+  });
+
+  it("orders equal-timestamp entries by locale-independent code units", () => {
+    const current = {
+      feedId: base.feedId,
+      sequence: 7,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [],
+    };
+    const applied = applyPublisherFeedChanges(current, {
+      status: "complete",
+      feedId: base.feedId,
+      fromSequence: 7,
+      toSequence: 8,
+      generatedAt: base.generatedAt,
+      expiresAt: base.expiresAt,
+      changes: [
+        { sequence: 8, operation: "upsert", entry: { ...entry, id: "skills:a" } },
+        { sequence: 8, operation: "upsert", entry: { ...entry, id: "skills:Z" } },
+      ],
+    });
+
+    expect(applied).toMatchObject({
+      status: "applied",
+      state: { entries: [{ id: "skills:Z" }, { id: "skills:a" }] },
+    });
+  });
+
+  it("rejects incomplete change ranges before exposing a next state", () => {
+    const current = {
+      feedId: base.feedId,
+      sequence: 7,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [],
+    };
+    expect(() =>
+      applyPublisherFeedChanges(current, {
+        status: "complete",
+        feedId: base.feedId,
+        fromSequence: 7,
+        toSequence: Number.MAX_SAFE_INTEGER,
+        generatedAt: base.generatedAt,
+        expiresAt: base.expiresAt,
+        changes: [{ sequence: 9, operation: "upsert", entry }],
+      }),
+    ).toThrow("omitted a revision");
+    expect(() =>
+      applyPublisherFeedChanges(current, {
+        status: "complete",
+        feedId: base.feedId,
+        fromSequence: 7,
+        toSequence: 9,
+        generatedAt: base.generatedAt,
+        expiresAt: base.expiresAt,
+        changes: [
+          {
+            sequence: 7,
+            operation: "remove",
+            entryId: "skills:old",
+            entryKind: "skill",
+          },
+          { sequence: 8, operation: "upsert", entry },
+        ],
+      }),
+    ).toThrow("not ordered within the signed range");
+  });
+
+  it("rejects reset instructions that do not continue the current state", () => {
+    expect(() =>
+      applyPublisherFeedChanges(
+        {
+          feedId: base.feedId,
+          sequence: 7,
+          publisherId: "publishers:alice",
+          handle: "alice",
+          displayName: "Alice",
+          entries: [],
+        },
+        {
+          status: "reset-required",
+          reset: {
+            ...base,
+            feedId: "clawhub.publisher.publishers:bob",
+            fromSequence: 7,
+            currentSequence: 9,
+            resetRequired: true,
+            snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Abob/feed",
+          },
+        },
+      ),
+    ).toThrow("reset does not continue");
+  });
+
+  it("accepts only a first-page same-origin signed reset response", async () => {
+    const key = signingKey();
+    enqueueSigned(
+      key,
+      PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      {
+        ...base,
+        fromSequence: 1,
+        currentSequence: 9,
+        resetRequired: true,
+        snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+      },
+      409,
+    );
+
+    await expect(
+      fetchPublisherFeedChanges({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        fromSequence: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).resolves.toMatchObject({ status: "reset-required", reset: { currentSequence: 9 } });
+
+    enqueueSigned(
+      key,
+      PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      {
+        ...base,
+        fromSequence: 1,
+        currentSequence: 9,
+        resetRequired: true,
+        snapshotUrl: "https://evil.example/api/v1/publishers/publishers%3Aalice/feed",
+      },
+      409,
+    );
+    await expect(
+      fetchPublisherFeedChanges({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        fromSequence: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow("reset instruction is invalid");
+
+    enqueueSigned(
+      key,
+      PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      {
+        ...base,
+        fromSequence: 1,
+        currentSequence: 9,
+        resetRequired: true,
+        snapshotUrl: "https://user:secret@clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+      },
+      409,
+    );
+    await expect(
+      fetchPublisherFeedChanges({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        fromSequence: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow("reset instruction is invalid");
+  });
+
+  it("rejects redirects, wrong content types, and page-count exhaustion", async () => {
+    const key = signingKey();
+    const payload = {
+      ...base,
+      sequence: 7,
+      query: { text: "CUDA" },
+      requestCursor: null,
+      pageIndex: 0,
+      startIndex: 0,
+      resultCount: 2,
+      entries: [entry],
+      nextCursor: "next",
+    };
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload);
+    queuedResponses[0]!.finalUrl = "https://clawhub.ai/redirected";
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query: { text: "CUDA" },
+      }),
+    ).rejects.toThrow("redirected away");
+
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload, 200, {
+      "content-type": "application/json",
+    });
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query: { text: "CUDA" },
+      }),
+    ).rejects.toThrow("unsupported content type");
+
+    enqueueSigned(key, PUBLISHER_FEED_QUERY_PAYLOAD_TYPE, payload);
+    await expect(
+      fetchPublisherFeedQuery({
+        baseUrl: "https://clawhub.ai",
+        publisherId: "publishers:alice",
+        verification: verification(key),
+        query: { text: "CUDA" },
+        maxPages: 1,
+        now: () => new Date("2026-07-16T00:01:00.000Z"),
+      }),
+    ).rejects.toThrow("exceeded 1 pages");
+  });
+});

--- a/src/plugins/publisher-feed-transport.test.ts
+++ b/src/plugins/publisher-feed-transport.test.ts
@@ -12,11 +12,13 @@ vi.mock("../infra/net/fetch-guard.js", () => ({
 import {
   PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
   PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+  PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE,
 } from "./publisher-feed-projections.js";
 import {
   applyPublisherFeedChanges,
   fetchPublisherFeedChanges,
   fetchPublisherFeedQuery,
+  fetchPublisherFeedSnapshot,
 } from "./publisher-feed-transport.js";
 
 type SigningKey = { keyId: string; privateKey: KeyObject; publicKey: KeyObject };
@@ -25,19 +27,17 @@ type QueuedResponse = { response: Response; finalUrl?: string };
 const queuedResponses: QueuedResponse[] = [];
 const release = vi.fn(async () => undefined);
 
-function signingKey(): SigningKey {
+function signingKey(keyId = "clawhub-feed-2026-q3"): SigningKey {
   const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
-  return { keyId: "clawhub-feed-2026-q3", privateKey, publicKey };
+  return { keyId, privateKey, publicKey };
 }
 
-function verification(key: SigningKey) {
+function verification(...keys: SigningKey[]) {
   return {
-    trustedKeys: [
-      {
-        keyId: key.keyId,
-        publicKey: key.publicKey.export({ type: "spki", format: "pem" }),
-      },
-    ],
+    trustedKeys: keys.map((key) => ({
+      keyId: key.keyId,
+      publicKey: key.publicKey.export({ type: "spki", format: "pem" }),
+    })),
   };
 }
 
@@ -98,6 +98,13 @@ const base = {
   expiresAt: "2026-07-16T00:05:00.000Z",
 };
 
+const evidence = {
+  signedBy: "clawhub-feed-2026-q3",
+  signedByKeyIds: ["clawhub-feed-2026-q3"],
+  signatureCount: 1,
+  threshold: 1,
+};
+
 beforeEach(() => {
   queuedResponses.length = 0;
   release.mockClear();
@@ -116,6 +123,35 @@ beforeEach(() => {
 });
 
 describe("publisher feed projection transport", () => {
+  it("fetches a complete signed snapshot from the canonical route", async () => {
+    const key = signingKey();
+    enqueueSigned(key, PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE, {
+      ...base,
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      sequence: 7,
+      entries: [entry],
+    });
+
+    const result = await fetchPublisherFeedSnapshot({
+      baseUrl: "https://clawhub.ai",
+      publisherId: "publishers:alice",
+      verification: verification(key),
+      now: () => new Date("2026-07-16T00:01:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      state: { publisherId: "publishers:alice", sequence: 7, entries: [entry] },
+      verification: { signedBy: key.keyId, signatureCount: 1, threshold: 1 },
+    });
+    expect(transportMocks.guardedFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/snapshot",
+      }),
+    );
+  });
+
   it("assembles a complete signed query across revision-bound pages", async () => {
     const key = signingKey();
     const query = { text: "CUDA Helper", kinds: ["skill"] };
@@ -230,6 +266,7 @@ describe("publisher feed projection transport", () => {
 
   it("assembles a complete signed changed-since range", async () => {
     const key = signingKey();
+    const rotatedKey = signingKey("clawhub-feed-2026-q4");
     enqueueSigned(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {
       ...base,
       fromSequence: 7,
@@ -241,7 +278,7 @@ describe("publisher feed projection transport", () => {
       changes: [{ sequence: 8, operation: "remove", entryId: "skills:old", entryKind: "skill" }],
       nextCursor: "next-change",
     });
-    enqueueSigned(key, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {
+    enqueueSigned(rotatedKey, PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE, {
       ...base,
       fromSequence: 7,
       toSequence: 9,
@@ -256,7 +293,7 @@ describe("publisher feed projection transport", () => {
     const result = await fetchPublisherFeedChanges({
       baseUrl: "https://clawhub.ai",
       publisherId: "publishers:alice",
-      verification: verification(key),
+      verification: verification(key, rotatedKey),
       fromSequence: 7,
       limit: 1,
       now: () => new Date("2026-07-16T00:01:00.000Z"),
@@ -265,6 +302,7 @@ describe("publisher feed projection transport", () => {
     expect(result).toMatchObject({ status: "complete", fromSequence: 7, toSequence: 9 });
     if (result.status === "complete") {
       expect(result.changes).toHaveLength(2);
+      expect(result.verification.signedBy).toBe(rotatedKey.keyId);
     }
   });
 
@@ -273,6 +311,7 @@ describe("publisher feed projection transport", () => {
     const current = {
       feedId: base.feedId,
       sequence: 7,
+      generatedAt: "2026-07-15T00:00:00.000Z",
       publisherId: "publishers:alice",
       handle: "alice",
       displayName: "Alice",
@@ -298,12 +337,14 @@ describe("publisher feed projection transport", () => {
           },
         },
       ],
+      verification: evidence,
     });
 
     expect(applied).toMatchObject({
       status: "applied",
       state: {
         sequence: 9,
+        generatedAt: base.generatedAt,
         handle: "alice-ai",
         displayName: "Alice AI",
         entries: [{ id: "skills:cuda" }],
@@ -316,6 +357,7 @@ describe("publisher feed projection transport", () => {
     const current = {
       feedId: base.feedId,
       sequence: 7,
+      generatedAt: base.generatedAt,
       publisherId: "publishers:alice",
       handle: "alice",
       displayName: "Alice",
@@ -332,6 +374,7 @@ describe("publisher feed projection transport", () => {
         { sequence: 8, operation: "upsert", entry: { ...entry, id: "skills:a" } },
         { sequence: 8, operation: "upsert", entry: { ...entry, id: "skills:Z" } },
       ],
+      verification: evidence,
     });
 
     expect(applied).toMatchObject({
@@ -340,10 +383,38 @@ describe("publisher feed projection transport", () => {
     });
   });
 
+  it("retains accepted generation time for a no-op change range", () => {
+    const current = {
+      feedId: base.feedId,
+      sequence: 7,
+      generatedAt: "2026-07-15T00:00:00.000Z",
+      publisherId: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      entries: [],
+    };
+    const applied = applyPublisherFeedChanges(current, {
+      status: "complete",
+      feedId: base.feedId,
+      fromSequence: 7,
+      toSequence: 7,
+      generatedAt: base.generatedAt,
+      expiresAt: base.expiresAt,
+      changes: [],
+      verification: evidence,
+    });
+
+    expect(applied).toMatchObject({
+      status: "applied",
+      state: { sequence: 7, generatedAt: current.generatedAt },
+    });
+  });
+
   it("rejects incomplete change ranges before exposing a next state", () => {
     const current = {
       feedId: base.feedId,
       sequence: 7,
+      generatedAt: base.generatedAt,
       publisherId: "publishers:alice",
       handle: "alice",
       displayName: "Alice",
@@ -358,6 +429,7 @@ describe("publisher feed projection transport", () => {
         generatedAt: base.generatedAt,
         expiresAt: base.expiresAt,
         changes: [{ sequence: 9, operation: "upsert", entry }],
+        verification: evidence,
       }),
     ).toThrow("omitted a revision");
     expect(() =>
@@ -377,6 +449,7 @@ describe("publisher feed projection transport", () => {
           },
           { sequence: 8, operation: "upsert", entry },
         ],
+        verification: evidence,
       }),
     ).toThrow("not ordered within the signed range");
   });
@@ -387,6 +460,7 @@ describe("publisher feed projection transport", () => {
         {
           feedId: base.feedId,
           sequence: 7,
+          generatedAt: base.generatedAt,
           publisherId: "publishers:alice",
           handle: "alice",
           displayName: "Alice",
@@ -402,6 +476,7 @@ describe("publisher feed projection transport", () => {
             resetRequired: true,
             snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Abob/feed",
           },
+          verification: evidence,
         },
       ),
     ).toThrow("reset does not continue");
@@ -417,7 +492,7 @@ describe("publisher feed projection transport", () => {
         fromSequence: 1,
         currentSequence: 9,
         resetRequired: true,
-        snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed",
+        snapshotUrl: "https://clawhub.ai/api/v1/publishers/publishers%3Aalice/feed/snapshot",
       },
       409,
     );

--- a/src/plugins/publisher-feed-transport.ts
+++ b/src/plugins/publisher-feed-transport.ts
@@ -1,0 +1,560 @@
+import { readResponseWithLimit } from "../infra/http-body.js";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import type { TrustedFeedSigningKey } from "./official-external-plugin-catalog-envelope.js";
+import {
+  PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+  PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+  verifyPublisherFeedProjection,
+  type PublisherFeedChange,
+  type PublisherFeedChangePage,
+  type PublisherFeedEntry,
+  type PublisherFeedQuery,
+  type PublisherFeedQueryPage,
+  type PublisherFeedResetRequired,
+} from "./publisher-feed-projections.js";
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type PublisherFeedVerification = {
+  trustedKeys: readonly TrustedFeedSigningKey[];
+  threshold?: number;
+};
+
+type PublisherFeedTransportOptions = {
+  baseUrl: string;
+  publisherId: string;
+  verification: PublisherFeedVerification;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  chunkTimeoutMs?: number;
+  maxPages?: number;
+  now?: () => Date;
+};
+
+export type PublisherFeedQueryResult = {
+  feedId: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  query: PublisherFeedQuery;
+  entries: readonly PublisherFeedEntry[];
+};
+
+export type PublisherFeedChangesResult =
+  | {
+      status: "complete";
+      feedId: string;
+      fromSequence: number;
+      toSequence: number;
+      generatedAt: string;
+      expiresAt: string;
+      changes: readonly PublisherFeedChange[];
+    }
+  | { status: "reset-required"; reset: PublisherFeedResetRequired };
+
+export type PublisherFeedState = {
+  feedId: string;
+  sequence: number;
+  publisherId: string;
+  handle: string | null;
+  displayName: string;
+  entries: readonly PublisherFeedEntry[];
+};
+
+export type PublisherFeedApplyResult =
+  | { status: "applied"; state: PublisherFeedState }
+  | { status: "reset-required"; reset: PublisherFeedResetRequired };
+
+const PUBLISHER_FEED_PAGE_MAX_BYTES = 1024 * 1024;
+const PUBLISHER_FEED_DEFAULT_TIMEOUT_MS = 5_000;
+const PUBLISHER_FEED_DEFAULT_MAX_PAGES = 50;
+const PUBLISHER_FEED_MAX_MAX_PAGES = 100;
+const PUBLISHER_FEED_QUERY_MAX_LIMIT = 200;
+const PUBLISHER_FEED_CHANGE_MAX_LIMIT = 500;
+const PUBLISHER_FEED_CONTENT_TYPE = "application/vnd.dsse+json";
+
+function normalizeBaseUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    throw new Error("publisher feed base URL is invalid");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "/" && url.pathname !== "")
+  ) {
+    throw new Error("publisher feed base URL must be an HTTPS origin without credentials");
+  }
+  return new URL(url.origin);
+}
+
+function normalizePublisherId(raw: string): string {
+  const publisherId = raw.trim();
+  if (!publisherId || new TextEncoder().encode(publisherId).length > 200) {
+    throw new Error("publisher feed publisher id is invalid");
+  }
+  return publisherId;
+}
+
+function normalizeLimit(value: number | undefined, fallback: number, maximum: number): number {
+  const limit = value ?? fallback;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximum) {
+    throw new Error(`publisher feed page limit must be between 1 and ${maximum}`);
+  }
+  return limit;
+}
+
+function normalizeMaxPages(value: number | undefined): number {
+  const maxPages = value ?? PUBLISHER_FEED_DEFAULT_MAX_PAGES;
+  if (!Number.isSafeInteger(maxPages) || maxPages < 1 || maxPages > PUBLISHER_FEED_MAX_MAX_PAGES) {
+    throw new Error(
+      `publisher feed max pages must be between 1 and ${PUBLISHER_FEED_MAX_MAX_PAGES}`,
+    );
+  }
+  return maxPages;
+}
+
+function normalizeQueryTextWhitespace(value: string): string {
+  let result = "";
+  let pendingSpace = false;
+  for (const character of value.normalize("NFC")) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if ((codePoint >= 0x09 && codePoint <= 0x0d) || codePoint === 0x20) {
+      pendingSpace = result.length > 0;
+      continue;
+    }
+    if (pendingSpace) {
+      result += " ";
+    }
+    result += character;
+    pendingSpace = false;
+  }
+  return result;
+}
+
+function normalizeQuery(query: PublisherFeedQuery): PublisherFeedQuery {
+  const normalized: PublisherFeedQuery = {};
+  if (query.text !== undefined) {
+    const text = normalizeQueryTextWhitespace(query.text);
+    if (!text || new TextEncoder().encode(text).length > 256) {
+      throw new Error("publisher feed query text must be between 1 and 256 UTF-8 bytes");
+    }
+    normalized.text = text;
+  }
+  if (query.kinds !== undefined) {
+    const kinds = [...new Set(query.kinds)].toSorted();
+    if (kinds.length === 0 || kinds.some((kind) => kind !== "skill" && kind !== "plugin")) {
+      throw new Error("publisher feed query kinds are invalid");
+    }
+    normalized.kinds = kinds;
+  }
+  if (normalized.text === undefined && normalized.kinds === undefined) {
+    throw new Error("publisher feed query must include text or kinds");
+  }
+  return normalized;
+}
+
+function sameQuery(left: PublisherFeedQuery, right: PublisherFeedQuery): boolean {
+  if (left.text !== right.text) {
+    return false;
+  }
+  const leftKinds = left.kinds ?? [];
+  const rightKinds = right.kinds ?? [];
+  return (
+    leftKinds.length === rightKinds.length &&
+    leftKinds.every((kind, index) => kind === rightKinds[index])
+  );
+}
+
+function projectionPath(publisherId: string, operation: "query" | "changes"): string {
+  return `/api/v1/publishers/${encodeURIComponent(publisherId)}/feed/${operation}`;
+}
+
+function initialQueryUrl(
+  baseUrl: URL,
+  publisherId: string,
+  query: PublisherFeedQuery,
+  limit: number,
+) {
+  const url = new URL(projectionPath(publisherId, "query"), baseUrl);
+  if (query.text !== undefined) {
+    url.searchParams.set("q", query.text);
+  }
+  for (const kind of query.kinds ?? []) {
+    url.searchParams.append("kind", kind);
+  }
+  url.searchParams.set("limit", String(limit));
+  return url;
+}
+
+function initialChangesUrl(baseUrl: URL, publisherId: string, fromSequence: number, limit: number) {
+  const url = new URL(projectionPath(publisherId, "changes"), baseUrl);
+  url.searchParams.set("fromSequence", String(fromSequence));
+  url.searchParams.set("limit", String(limit));
+  return url;
+}
+
+function continuationUrl(
+  baseUrl: URL,
+  publisherId: string,
+  operation: "query" | "changes",
+  cursor: string,
+) {
+  const url = new URL(projectionPath(publisherId, operation), baseUrl);
+  url.searchParams.set("cursor", cursor);
+  return url;
+}
+
+function assertContentLength(response: Response): void {
+  const raw = response.headers.get("content-length");
+  if (raw === null) {
+    return;
+  }
+  if (!/^\d+$/u.test(raw)) {
+    throw new Error("publisher feed response has invalid content-length");
+  }
+  const length = Number(raw);
+  if (!Number.isSafeInteger(length) || length > PUBLISHER_FEED_PAGE_MAX_BYTES) {
+    throw new Error(`publisher feed response exceeds ${PUBLISHER_FEED_PAGE_MAX_BYTES} bytes`);
+  }
+}
+
+async function readProjectionEnvelope(params: {
+  url: URL;
+  operation: "query" | "changes";
+  verification: PublisherFeedVerification;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  chunkTimeoutMs?: number;
+}) {
+  const guarded = await fetchWithSsrFGuard({
+    url: params.url.href,
+    fetchImpl: params.fetchImpl,
+    init: { method: "GET", headers: { accept: PUBLISHER_FEED_CONTENT_TYPE } },
+    requireHttps: true,
+    maxRedirects: 2,
+    timeoutMs: params.timeoutMs ?? PUBLISHER_FEED_DEFAULT_TIMEOUT_MS,
+    policy: { hostnameAllowlist: [params.url.hostname] },
+    auditContext: "publisher-feed-projection",
+  });
+  try {
+    if (guarded.finalUrl !== params.url.href) {
+      throw new Error("publisher feed projection redirected away from the requested page");
+    }
+    const allowedStatuses = params.operation === "changes" ? [200, 409] : [200];
+    if (!allowedStatuses.includes(guarded.response.status)) {
+      throw new Error(`publisher feed projection returned HTTP ${guarded.response.status}`);
+    }
+    const contentType = guarded.response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+    if (contentType !== PUBLISHER_FEED_CONTENT_TYPE) {
+      throw new Error("publisher feed projection returned an unsupported content type");
+    }
+    assertContentLength(guarded.response);
+    const body = await readResponseWithLimit(guarded.response, PUBLISHER_FEED_PAGE_MAX_BYTES, {
+      chunkTimeoutMs: params.chunkTimeoutMs ?? PUBLISHER_FEED_DEFAULT_TIMEOUT_MS,
+      onOverflow: ({ maxBytes }) => new Error(`publisher feed response exceeds ${maxBytes} bytes`),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`publisher feed response timed out after ${chunkTimeoutMs}ms`),
+    });
+    let envelope: unknown;
+    try {
+      envelope = JSON.parse(body.toString("utf8"));
+    } catch {
+      throw new Error("publisher feed projection envelope is not valid JSON");
+    }
+    const verified = verifyPublisherFeedProjection(envelope, {
+      payloadType:
+        params.operation === "query"
+          ? PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+          : PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+      ...params.verification,
+    });
+    return { status: guarded.response.status, payload: verified.payload };
+  } finally {
+    if (!guarded.response.bodyUsed) {
+      await guarded.response.body?.cancel().catch(() => undefined);
+    }
+    await guarded.release();
+  }
+}
+
+function assertNotExpired(expiresAt: string, now: () => Date): void {
+  if (Date.parse(expiresAt) <= now().getTime()) {
+    throw new Error("publisher feed projection expired during traversal");
+  }
+}
+
+function assertUniqueEntries(entries: readonly PublisherFeedEntry[]): void {
+  const identities = new Set<string>();
+  for (const entry of entries) {
+    const identity = `${entry.kind}\0${entry.id}`;
+    if (identities.has(identity)) {
+      throw new Error("publisher feed query returned duplicate entries");
+    }
+    identities.add(identity);
+  }
+}
+
+function entryIdentity(entry: Pick<PublisherFeedEntry, "kind" | "id">): string {
+  return `${entry.kind}\0${entry.id}`;
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareEntries(left: PublisherFeedEntry, right: PublisherFeedEntry): number {
+  return (
+    right.updatedAt - left.updatedAt ||
+    compareCodeUnits(left.kind, right.kind) ||
+    compareCodeUnits(left.id, right.id)
+  );
+}
+
+export function applyPublisherFeedChanges(
+  current: PublisherFeedState,
+  result: PublisherFeedChangesResult,
+): PublisherFeedApplyResult {
+  if (result.status === "reset-required") {
+    if (
+      result.reset.feedId !== current.feedId ||
+      result.reset.fromSequence !== current.sequence ||
+      current.feedId !== `clawhub.publisher.${current.publisherId}`
+    ) {
+      throw new Error("publisher feed reset does not continue the current state");
+    }
+    return result;
+  }
+  if (
+    result.feedId !== current.feedId ||
+    result.fromSequence !== current.sequence ||
+    current.feedId !== `clawhub.publisher.${current.publisherId}`
+  ) {
+    throw new Error("publisher feed changes do not continue the current state");
+  }
+  const entries = new Map(current.entries.map((entry) => [entryIdentity(entry), { ...entry }]));
+  if (entries.size !== current.entries.length) {
+    throw new Error("current publisher feed state contains duplicate entries");
+  }
+  let publisherId = current.publisherId;
+  let handle = current.handle;
+  let displayName = current.displayName;
+  let previousSequence = result.fromSequence;
+  const seenSequences = new Set<number>();
+  for (const change of result.changes) {
+    if (
+      !Number.isSafeInteger(change.sequence) ||
+      change.sequence <= result.fromSequence ||
+      change.sequence < previousSequence ||
+      change.sequence > result.toSequence
+    ) {
+      throw new Error("publisher feed changes are not ordered within the signed range");
+    }
+    previousSequence = change.sequence;
+    seenSequences.add(change.sequence);
+    if (change.operation === "upsert") {
+      entries.set(entryIdentity(change.entry), { ...change.entry });
+    } else if (change.operation === "remove") {
+      entries.delete(`${change.entryKind}\0${change.entryId}`);
+    } else {
+      if (
+        change.metadata.publisherId !== current.publisherId ||
+        result.feedId !== `clawhub.publisher.${change.metadata.publisherId}`
+      ) {
+        throw new Error("publisher feed metadata changed stable publisher identity");
+      }
+      publisherId = change.metadata.publisherId;
+      handle = change.metadata.handle;
+      displayName = change.metadata.displayName;
+    }
+  }
+  const expectedSequenceCount = result.toSequence - result.fromSequence;
+  if (seenSequences.size !== expectedSequenceCount) {
+    throw new Error("publisher feed changes omitted a revision from the signed range");
+  }
+  return {
+    status: "applied",
+    state: {
+      feedId: current.feedId,
+      sequence: result.toSequence,
+      publisherId,
+      handle,
+      displayName,
+      entries: [...entries.values()].toSorted(compareEntries),
+    },
+  };
+}
+
+export async function fetchPublisherFeedQuery(
+  params: PublisherFeedTransportOptions & { query: PublisherFeedQuery; limit?: number },
+): Promise<PublisherFeedQueryResult> {
+  const baseUrl = normalizeBaseUrl(params.baseUrl);
+  const publisherId = normalizePublisherId(params.publisherId);
+  const expectedFeedId = `clawhub.publisher.${publisherId}`;
+  const query = normalizeQuery(params.query);
+  const limit = normalizeLimit(params.limit, 50, PUBLISHER_FEED_QUERY_MAX_LIMIT);
+  const maxPages = normalizeMaxPages(params.maxPages);
+  const now = params.now ?? (() => new Date());
+  const entries: PublisherFeedEntry[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | null = null;
+  let first: PublisherFeedQueryPage | null = null;
+
+  for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+    const url =
+      cursor === null
+        ? initialQueryUrl(baseUrl, publisherId, query, limit)
+        : continuationUrl(baseUrl, publisherId, "query", cursor);
+    const response = await readProjectionEnvelope({
+      url,
+      operation: "query",
+      verification: params.verification,
+      fetchImpl: params.fetchImpl,
+      timeoutMs: params.timeoutMs,
+      chunkTimeoutMs: params.chunkTimeoutMs,
+    });
+    const page = response.payload as PublisherFeedQueryPage;
+    if (
+      page.feedId !== expectedFeedId ||
+      page.pageIndex !== pageIndex ||
+      page.startIndex !== entries.length ||
+      page.requestCursor !== cursor ||
+      !sameQuery(page.query, query)
+    ) {
+      throw new Error("publisher feed query page continuity check failed");
+    }
+    assertNotExpired(page.expiresAt, now);
+    if (!first) {
+      first = page;
+    } else if (
+      page.sequence !== first.sequence ||
+      page.generatedAt !== first.generatedAt ||
+      page.expiresAt !== first.expiresAt ||
+      page.resultCount !== first.resultCount
+    ) {
+      throw new Error("publisher feed query revision changed during traversal");
+    }
+    entries.push(...page.entries);
+    cursor = page.nextCursor;
+    if (cursor === null) {
+      if (entries.length !== page.resultCount) {
+        throw new Error("publisher feed query terminated before its signed result count");
+      }
+      assertUniqueEntries(entries);
+      return {
+        feedId: page.feedId,
+        sequence: page.sequence,
+        generatedAt: page.generatedAt,
+        expiresAt: page.expiresAt,
+        query: page.query,
+        entries,
+      };
+    }
+    if (seenCursors.has(cursor)) {
+      throw new Error("publisher feed query cursor repeated during traversal");
+    }
+    seenCursors.add(cursor);
+  }
+  throw new Error(`publisher feed query exceeded ${maxPages} pages`);
+}
+
+export async function fetchPublisherFeedChanges(
+  params: PublisherFeedTransportOptions & { fromSequence: number; limit?: number },
+): Promise<PublisherFeedChangesResult> {
+  const baseUrl = normalizeBaseUrl(params.baseUrl);
+  const publisherId = normalizePublisherId(params.publisherId);
+  const expectedFeedId = `clawhub.publisher.${publisherId}`;
+  if (!Number.isSafeInteger(params.fromSequence) || params.fromSequence < 0) {
+    throw new Error("publisher feed from sequence is invalid");
+  }
+  const limit = normalizeLimit(params.limit, 100, PUBLISHER_FEED_CHANGE_MAX_LIMIT);
+  const maxPages = normalizeMaxPages(params.maxPages);
+  const now = params.now ?? (() => new Date());
+  const changes: PublisherFeedChange[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | null = null;
+  let first: PublisherFeedChangePage | null = null;
+
+  for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+    const url =
+      cursor === null
+        ? initialChangesUrl(baseUrl, publisherId, params.fromSequence, limit)
+        : continuationUrl(baseUrl, publisherId, "changes", cursor);
+    const response = await readProjectionEnvelope({
+      url,
+      operation: "changes",
+      verification: params.verification,
+      fetchImpl: params.fetchImpl,
+      timeoutMs: params.timeoutMs,
+      chunkTimeoutMs: params.chunkTimeoutMs,
+    });
+    if (response.status === 409) {
+      const reset = response.payload as PublisherFeedResetRequired;
+      const expectedSnapshotUrl = new URL(
+        `/api/v1/publishers/${encodeURIComponent(publisherId)}/feed`,
+        baseUrl,
+      );
+      if (
+        pageIndex !== 0 ||
+        !reset.resetRequired ||
+        reset.feedId !== expectedFeedId ||
+        reset.fromSequence !== params.fromSequence ||
+        new URL(reset.snapshotUrl).href !== expectedSnapshotUrl.href
+      ) {
+        throw new Error("publisher feed reset instruction is invalid");
+      }
+      assertNotExpired(reset.expiresAt, now);
+      return { status: "reset-required", reset };
+    }
+    if ((response.payload as PublisherFeedResetRequired).resetRequired) {
+      throw new Error("publisher feed reset instruction used an invalid HTTP status");
+    }
+    const page = response.payload as PublisherFeedChangePage;
+    if (
+      page.feedId !== expectedFeedId ||
+      page.fromSequence !== params.fromSequence ||
+      page.pageIndex !== pageIndex ||
+      page.startIndex !== changes.length ||
+      page.requestCursor !== cursor
+    ) {
+      throw new Error("publisher feed change page continuity check failed");
+    }
+    assertNotExpired(page.expiresAt, now);
+    if (!first) {
+      first = page;
+    } else if (
+      page.toSequence !== first.toSequence ||
+      page.generatedAt !== first.generatedAt ||
+      page.expiresAt !== first.expiresAt ||
+      page.changeCount !== first.changeCount
+    ) {
+      throw new Error("publisher feed change range changed during traversal");
+    }
+    changes.push(...page.changes);
+    cursor = page.nextCursor;
+    if (cursor === null) {
+      if (changes.length !== page.changeCount) {
+        throw new Error("publisher feed changes terminated before their signed change count");
+      }
+      return {
+        status: "complete",
+        feedId: page.feedId,
+        fromSequence: page.fromSequence,
+        toSequence: page.toSequence,
+        generatedAt: page.generatedAt,
+        expiresAt: page.expiresAt,
+        changes,
+      };
+    }
+    if (seenCursors.has(cursor)) {
+      throw new Error("publisher feed change cursor repeated during traversal");
+    }
+    seenCursors.add(cursor);
+  }
+  throw new Error(`publisher feed changes exceeded ${maxPages} pages`);
+}

--- a/src/plugins/publisher-feed-transport.ts
+++ b/src/plugins/publisher-feed-transport.ts
@@ -4,6 +4,7 @@ import type { TrustedFeedSigningKey } from "./official-external-plugin-catalog-e
 import {
   PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
   PUBLISHER_FEED_QUERY_PAYLOAD_TYPE,
+  PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE,
   verifyPublisherFeedProjection,
   type PublisherFeedChange,
   type PublisherFeedChangePage,
@@ -11,6 +12,7 @@ import {
   type PublisherFeedQuery,
   type PublisherFeedQueryPage,
   type PublisherFeedResetRequired,
+  type PublisherFeedSnapshot,
 } from "./publisher-feed-projections.js";
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -38,6 +40,14 @@ export type PublisherFeedQueryResult = {
   expiresAt: string;
   query: PublisherFeedQuery;
   entries: readonly PublisherFeedEntry[];
+  verification: PublisherFeedVerificationEvidence;
+};
+
+export type PublisherFeedVerificationEvidence = {
+  signedBy: string;
+  signedByKeyIds: readonly string[];
+  signatureCount: number;
+  threshold: number;
 };
 
 export type PublisherFeedChangesResult =
@@ -49,21 +59,37 @@ export type PublisherFeedChangesResult =
       generatedAt: string;
       expiresAt: string;
       changes: readonly PublisherFeedChange[];
+      verification: PublisherFeedVerificationEvidence;
     }
-  | { status: "reset-required"; reset: PublisherFeedResetRequired };
+  | {
+      status: "reset-required";
+      reset: PublisherFeedResetRequired;
+      verification: PublisherFeedVerificationEvidence;
+    };
 
 export type PublisherFeedState = {
   feedId: string;
   sequence: number;
+  generatedAt: string;
   publisherId: string;
   handle: string | null;
   displayName: string;
   entries: readonly PublisherFeedEntry[];
 };
 
+export type PublisherFeedSnapshotResult = {
+  state: PublisherFeedState;
+  expiresAt: string;
+  verification: PublisherFeedVerificationEvidence;
+};
+
 export type PublisherFeedApplyResult =
   | { status: "applied"; state: PublisherFeedState }
-  | { status: "reset-required"; reset: PublisherFeedResetRequired };
+  | {
+      status: "reset-required";
+      reset: PublisherFeedResetRequired;
+      verification: PublisherFeedVerificationEvidence;
+    };
 
 const PUBLISHER_FEED_PAGE_MAX_BYTES = 1024 * 1024;
 const PUBLISHER_FEED_DEFAULT_TIMEOUT_MS = 5_000;
@@ -171,7 +197,7 @@ function sameQuery(left: PublisherFeedQuery, right: PublisherFeedQuery): boolean
   );
 }
 
-function projectionPath(publisherId: string, operation: "query" | "changes"): string {
+function projectionPath(publisherId: string, operation: "snapshot" | "query" | "changes"): string {
   return `/api/v1/publishers/${encodeURIComponent(publisherId)}/feed/${operation}`;
 }
 
@@ -226,7 +252,7 @@ function assertContentLength(response: Response): void {
 
 async function readProjectionEnvelope(params: {
   url: URL;
-  operation: "query" | "changes";
+  operation: "snapshot" | "query" | "changes";
   verification: PublisherFeedVerification;
   fetchImpl?: FetchLike;
   timeoutMs?: number;
@@ -269,12 +295,23 @@ async function readProjectionEnvelope(params: {
     }
     const verified = verifyPublisherFeedProjection(envelope, {
       payloadType:
-        params.operation === "query"
-          ? PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
-          : PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
+        params.operation === "snapshot"
+          ? PUBLISHER_FEED_SNAPSHOT_PAYLOAD_TYPE
+          : params.operation === "query"
+            ? PUBLISHER_FEED_QUERY_PAYLOAD_TYPE
+            : PUBLISHER_FEED_CHANGES_PAYLOAD_TYPE,
       ...params.verification,
     });
-    return { status: guarded.response.status, payload: verified.payload };
+    return {
+      status: guarded.response.status,
+      payload: verified.payload,
+      verification: {
+        signedBy: verified.signedBy,
+        signedByKeyIds: verified.signedByKeyIds,
+        signatureCount: verified.signatureCount,
+        threshold: verified.threshold,
+      },
+    };
   } finally {
     if (!guarded.response.bodyUsed) {
       await guarded.response.body?.cancel().catch(() => undefined);
@@ -306,6 +343,42 @@ function entryIdentity(entry: Pick<PublisherFeedEntry, "kind" | "id">): string {
 
 function compareCodeUnits(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export async function fetchPublisherFeedSnapshot(
+  params: PublisherFeedTransportOptions,
+): Promise<PublisherFeedSnapshotResult> {
+  const baseUrl = normalizeBaseUrl(params.baseUrl);
+  const publisherId = normalizePublisherId(params.publisherId);
+  const response = await readProjectionEnvelope({
+    url: new URL(projectionPath(publisherId, "snapshot"), baseUrl),
+    operation: "snapshot",
+    verification: params.verification,
+    fetchImpl: params.fetchImpl,
+    timeoutMs: params.timeoutMs,
+    chunkTimeoutMs: params.chunkTimeoutMs,
+  });
+  const snapshot = response.payload as PublisherFeedSnapshot;
+  if (
+    snapshot.publisherId !== publisherId ||
+    snapshot.feedId !== `clawhub.publisher.${publisherId}`
+  ) {
+    throw new Error("publisher feed snapshot identity check failed");
+  }
+  assertNotExpired(snapshot.expiresAt, params.now ?? (() => new Date()));
+  return {
+    state: {
+      feedId: snapshot.feedId,
+      sequence: snapshot.sequence,
+      generatedAt: snapshot.generatedAt,
+      publisherId: snapshot.publisherId,
+      handle: snapshot.handle,
+      displayName: snapshot.displayName,
+      entries: snapshot.entries,
+    },
+    expiresAt: snapshot.expiresAt,
+    verification: response.verification,
+  };
 }
 
 function compareEntries(left: PublisherFeedEntry, right: PublisherFeedEntry): number {
@@ -382,6 +455,8 @@ export function applyPublisherFeedChanges(
     state: {
       feedId: current.feedId,
       sequence: result.toSequence,
+      generatedAt:
+        result.toSequence === current.sequence ? current.generatedAt : result.generatedAt,
       publisherId,
       handle,
       displayName,
@@ -453,6 +528,7 @@ export async function fetchPublisherFeedQuery(
         expiresAt: page.expiresAt,
         query: page.query,
         entries,
+        verification: response.verification,
       };
     }
     if (seenCursors.has(cursor)) {
@@ -496,7 +572,7 @@ export async function fetchPublisherFeedChanges(
     if (response.status === 409) {
       const reset = response.payload as PublisherFeedResetRequired;
       const expectedSnapshotUrl = new URL(
-        `/api/v1/publishers/${encodeURIComponent(publisherId)}/feed`,
+        `/api/v1/publishers/${encodeURIComponent(publisherId)}/feed/snapshot`,
         baseUrl,
       );
       if (
@@ -509,7 +585,7 @@ export async function fetchPublisherFeedChanges(
         throw new Error("publisher feed reset instruction is invalid");
       }
       assertNotExpired(reset.expiresAt, now);
-      return { status: "reset-required", reset };
+      return { status: "reset-required", reset, verification: response.verification };
     }
     if ((response.payload as PublisherFeedResetRequired).resetRequired) {
       throw new Error("publisher feed reset instruction used an invalid HTTP status");
@@ -549,6 +625,7 @@ export async function fetchPublisherFeedChanges(
         generatedAt: page.generatedAt,
         expiresAt: page.expiresAt,
         changes,
+        verification: response.verification,
       };
     }
     if (seenCursors.has(cursor)) {

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -826,6 +826,23 @@ export interface PluginStateEntries {
   value_json: string;
 }
 
+export interface PublisherFeedStates {
+  display_name: string;
+  entries_json: string;
+  feed_id: string;
+  generated_at: string;
+  handle: string | null;
+  publisher_id: string;
+  sequence: number;
+  signature_count: number;
+  signed_by: string;
+  signed_by_key_ids_json: string;
+  source_origin: string;
+  threshold: number;
+  updated_at_ms: number;
+  verified_at: string;
+}
+
 export interface SandboxRegistryEntries {
   backend_id: string | null;
   cdp_port: number | null;
@@ -1362,6 +1379,7 @@ export interface DB {
   plugin_binding_approvals: PluginBindingApprovals;
   plugin_blob_entries: PluginBlobEntries;
   plugin_state_entries: PluginStateEntries;
+  publisher_feed_states: PublisherFeedStates;
   sandbox_registry_entries: SandboxRegistryEntries;
   schema_meta: SchemaMeta;
   session_groups: SessionGroups;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -826,6 +826,14 @@ export interface PluginStateEntries {
   value_json: string;
 }
 
+export interface PublisherFeedFollows {
+  created_at_ms: number;
+  feed_profile: string;
+  publisher_id: string;
+  source_origin: string;
+  updated_at_ms: number;
+}
+
 export interface PublisherFeedStates {
   display_name: string;
   entries_json: string;
@@ -1379,6 +1387,7 @@ export interface DB {
   plugin_binding_approvals: PluginBindingApprovals;
   plugin_blob_entries: PluginBlobEntries;
   plugin_state_entries: PluginStateEntries;
+  publisher_feed_follows: PublisherFeedFollows;
   publisher_feed_states: PublisherFeedStates;
   sandbox_registry_entries: SandboxRegistryEntries;
   schema_meta: SchemaMeta;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -828,6 +828,27 @@ CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
 CREATE INDEX IF NOT EXISTS idx_official_external_plugin_catalog_snapshots_updated
   ON official_external_plugin_catalog_snapshots(updated_at_ms DESC, feed_url);
 
+CREATE TABLE IF NOT EXISTS publisher_feed_states (
+  source_origin TEXT NOT NULL,
+  publisher_id TEXT NOT NULL,
+  feed_id TEXT NOT NULL,
+  sequence INTEGER NOT NULL,
+  generated_at TEXT NOT NULL,
+  handle TEXT,
+  display_name TEXT NOT NULL,
+  entries_json TEXT NOT NULL,
+  signed_by TEXT NOT NULL,
+  signed_by_key_ids_json TEXT NOT NULL,
+  signature_count INTEGER NOT NULL,
+  threshold INTEGER NOT NULL,
+  verified_at TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (source_origin, publisher_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_publisher_feed_states_updated
+  ON publisher_feed_states(updated_at_ms DESC, source_origin, publisher_id);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -849,6 +849,18 @@ CREATE TABLE IF NOT EXISTS publisher_feed_states (
 CREATE INDEX IF NOT EXISTS idx_publisher_feed_states_updated
   ON publisher_feed_states(updated_at_ms DESC, source_origin, publisher_id);
 
+CREATE TABLE IF NOT EXISTS publisher_feed_follows (
+  source_origin TEXT NOT NULL,
+  publisher_id TEXT NOT NULL,
+  feed_profile TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (source_origin, publisher_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_publisher_feed_follows_updated
+  ON publisher_feed_follows(updated_at_ms DESC, source_origin, publisher_id);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -823,6 +823,27 @@ CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
 CREATE INDEX IF NOT EXISTS idx_official_external_plugin_catalog_snapshots_updated
   ON official_external_plugin_catalog_snapshots(updated_at_ms DESC, feed_url);
 
+CREATE TABLE IF NOT EXISTS publisher_feed_states (
+  source_origin TEXT NOT NULL,
+  publisher_id TEXT NOT NULL,
+  feed_id TEXT NOT NULL,
+  sequence INTEGER NOT NULL,
+  generated_at TEXT NOT NULL,
+  handle TEXT,
+  display_name TEXT NOT NULL,
+  entries_json TEXT NOT NULL,
+  signed_by TEXT NOT NULL,
+  signed_by_key_ids_json TEXT NOT NULL,
+  signature_count INTEGER NOT NULL,
+  threshold INTEGER NOT NULL,
+  verified_at TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (source_origin, publisher_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_publisher_feed_states_updated
+  ON publisher_feed_states(updated_at_ms DESC, source_origin, publisher_id);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -844,6 +844,18 @@ CREATE TABLE IF NOT EXISTS publisher_feed_states (
 CREATE INDEX IF NOT EXISTS idx_publisher_feed_states_updated
   ON publisher_feed_states(updated_at_ms DESC, source_origin, publisher_id);
 
+CREATE TABLE IF NOT EXISTS publisher_feed_follows (
+  source_origin TEXT NOT NULL,
+  publisher_id TEXT NOT NULL,
+  feed_profile TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (source_origin, publisher_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_publisher_feed_follows_updated
+  ON publisher_feed_follows(updated_at_ms DESC, source_origin, publisher_id);
+
 CREATE TABLE IF NOT EXISTS gateway_restart_sentinel (
   sentinel_key TEXT NOT NULL PRIMARY KEY,
   version INTEGER NOT NULL,


### PR DESCRIPTION
## Summary

- persist followed publisher identities in shared OpenClaw SQLite while keeping public keys in marketplace configuration
- add `openclaw publisher follow`, `unfollow`, `list`, and `refresh` lifecycle commands
- require an explicitly configured signed feed profile and re-resolve its keys on every refresh
- verify a complete signed snapshot before a follow becomes durable
- reject rollback and same-sequence equivocation during trust-profile changes
- keep stale follows removable after their profile is deleted or moved

## Stack

- depends on #109378 for durable verified publisher state and refresh
- transport dependency: #109340
- verifier dependency: #109305
- producer dependency: openclaw/clawhub#3117
- protocol contract: openclaw/rfcs#39

## Validation

- exact-commit WSL proof at `ad65875ba88` using Node 24.15.0 / SQLite 3.51.3: 34 tests across 3 shards, including real follow/state SQLite tests
- scoped type-aware oxlint
- scoped oxfmt
- state schema generation verification
- `git diff --check`
- final `codex review --uncommitted`: no actionable correctness issues

Repository-wide TypeScript remains blocked in the Windows worktree by its borrowed stale dependency tree; no changed-file type errors were reported. This PR intentionally stops at explicit CLI lifecycle. Gateway-owned scheduling and Control UI status/actions are the next stacked slice.