### PR TITLE
fix(logging): retain diagnostic context across short transcript reads

### DIFF
--- a/src/logging/diagnostic-session-context.test.ts
+++ b/src/logging/diagnostic-session-context.test.ts
@@ -1,7 +1,7 @@
 // Diagnostic session context tests cover session context capture for diagnostics.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveCronStore } from "../cron/store.js";
 import {
   createOpenClawTestState,
@@ -98,11 +98,29 @@ describe("diagnostic session context", () => {
       { message: { role: "assistant", content: "newer" } },
     ]);
 
-    expect(
-      resolveCronSessionDiagnosticContext({
-        sessionKey: "agent:clawblocker:cron:job-123:run:run-456",
-      }).lastAssistant,
-    ).toBe("newer");
+    const realReadSync = fs.readSync.bind(fs);
+    let shortReadCalls = 0;
+    const readSpy = vi.spyOn(fs, "readSync").mockImplementation(((
+      fd: number,
+      buffer: NodeJS.ArrayBufferView,
+      offset: number,
+      length: number,
+      position: fs.ReadPosition | null,
+    ) => {
+      shortReadCalls += 1;
+      return realReadSync(fd, buffer, offset, Math.min(length, 16), position);
+    }) as typeof fs.readSync);
+
+    try {
+      expect(
+        resolveCronSessionDiagnosticContext({
+          sessionKey: "agent:clawblocker:cron:job-123:run:run-456",
+        }).lastAssistant,
+      ).toBe("newer");
+      expect(shortReadCalls).toBeGreaterThan(1);
+    } finally {
+      readSpy.mockRestore();
+    }
   });
 
   it("keeps bounded quoted fields UTF-16 safe", () => {

--- a/src/logging/diagnostic-session-context.ts
+++ b/src/logging/diagnostic-session-context.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../config/paths.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
+import { readFileWindowFullySync } from "../infra/file-read.js";
 
 const SESSION_TAIL_BYTES = 64 * 1024;
 const MAX_QUOTED_FIELD_CHARS = 140;
@@ -71,7 +72,7 @@ function readTailText(filePath: string): { text: string; truncated: boolean } | 
     const start = Math.max(0, stat.size - length);
     const buffer = Buffer.alloc(length);
     fd = fs.openSync(filePath, "r");
-    const read = fs.readSync(fd, buffer, 0, length, start);
+    const read = readFileWindowFullySync(fd, buffer, start);
     return { text: buffer.subarray(0, read).toString("utf8"), truncated: start > 0 };
   } catch {
     return undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stalled-session and cron diagnostics could omit the latest assistant context when the bounded transcript-tail read returned fewer bytes than requested. A partial JSONL record was ignored, leaving `lastAssistant` unavailable in diagnostic output and recovery logs.

## Why This Change Was Made

The diagnostic reader now fills its existing bounded 64 KiB tail window with the shared positional-read helper before parsing records. The risk is limited to diagnostic context selection: the same byte cap, truncation flag, malformed-line handling, and output formatting remain in place, while the regression test forces repeated short reads.

## User Impact

Operators investigating stalled cron or agent sessions retain the latest assistant context on filesystems that complete positional reads in multiple chunks.

## Evidence

On Linux 6.8.0 x86_64 with Node v24.18.0, I compiled an `LD_PRELOAD` shim that caps `pread`/`pread64` to 16 bytes only for the target transcript. I then ran the actual `resolveCronSessionDiagnosticContext` production path against exact `upstream/main` `f61a3d46a22e973d0c65fd6d5bc5d1586decdcdf` and this branch:

```text
before: {"lastAssistant":null,"transcript":"/tmp/openclaw-proof-diagnostic/agents/main/sessions/run-1.jsonl"}
after:  {"lastAssistant":"latest diagnostic answer","transcript":"/tmp/openclaw-proof-diagnostic/agents/main/sessions/run-1.jsonl"}
```

The premise matches the Node filesystem contract: a read reports the actual byte count, which may be less than the requested length ([Node.js filesystem documentation](https://nodejs.org/api/fs.html#fsreadsyncfd-buffer-offset-length-position)).

Focused validation:

```text
node scripts/run-vitest.mjs src/logging/diagnostic-session-context.test.ts
Test Files  1 passed (1)
Tests       5 passed (5)

git diff --check
exit 0
```

`CI=1 node scripts/check-changed.mjs -- src/logging/diagnostic-session-context.ts src/logging/diagnostic-session-context.test.ts` passed conflict-marker, max-lines, attribution, wildcard-export, duplicate-coverage, dependency-pin, and formatting checks. It then stopped at an unrelated Plugin SDK baseline mismatch that reproduces on the clean current `main` after #109344; this PR changes no SDK surface. GitHub CI will provide the full clean-check environment.

Autoreview (`.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`) reported no findings and `patch is correct` with 0.98 confidence.

AI-assisted: Codex helped implement and review the change; the filesystem proof and validation commands above were run manually.
