### PR TITLE
docs(clickclack): refresh generated navigation map

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -311,6 +311,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /channels/clickclack
 - Headings:
   - H2: Quick setup
+  - H3: Alternative: manual token
   - H3: Alternative: env-based token
   - H3: JSON5 reference
   - H3: Account config keys


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the generated docs navigation map omitted the new manual-token heading on the ClickClack setup page, causing the docs consistency gate to fail on main.

## Why This Change Was Made

Regenerates the canonical docs map after commit 2090f9da81f8 added the heading.

## User Impact

No runtime behavior change. Docs navigation metadata is complete and the main docs gate is restored.

## Evidence

- `node scripts/generate-docs-map.mjs --check` — pass
- `git diff --check` — pass
- fresh autoreview — clean, confidence 0.99
