### PR TITLE
fix: honor null inbound conversation rejection in claim mappers

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -517,6 +517,42 @@ describe("message hook mappers", () => {
     });
   });
 
+  it("does not fall back when a channel resolver rejects an inbound claim conversation", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "reject-claim-chat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "reject-claim-chat",
+              label: "Reject claim chat",
+            }),
+            messaging: {
+              resolveInboundConversation: () => null,
+            },
+          },
+        },
+      ]),
+    );
+
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        Provider: "reject-claim-chat",
+        Surface: "reject-claim-chat",
+        OriginatingChannel: "reject-claim-chat",
+        To: "channel:room-123",
+        OriginatingTo: "channel:room-123",
+        GroupChannel: "ops",
+        GroupSubject: "guild",
+      }),
+    );
+
+    // Explicit null must leave conversationId unset (no stripChannelPrefix fallback).
+    expect(toPluginInboundClaimContext(canonical).conversationId).toBeUndefined();
+    expect(toPluginInboundClaimEvent(canonical).conversationId).toBeUndefined();
+  });
+
   it("maps transcribed and preprocessed internal payloads", () => {
     const cfg = {} as OpenClawConfig;
     const canonical = deriveInboundMessageHookContext(makeInboundCtx({ Transcript: undefined }));

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -314,21 +314,31 @@ function resolveInboundConversation(canonical: CanonicalInboundMessageHookContex
   parentConversationId?: string;
 } {
   const channelId = normalizeChannelId(canonical.channelId);
-  const pluginResolved = channelId
-    ? getChannelPlugin(channelId)?.messaging?.resolveInboundConversation?.({
-        from: canonical.from,
-        to: canonical.to ?? canonical.originatingTo,
-        conversationId: canonical.conversationId,
-        threadId: canonical.threadId,
-        threadParentId: canonical.threadParentId,
-        isGroup: canonical.isGroup,
-      })
-    : null;
-  if (pluginResolved) {
-    return {
-      conversationId: normalizeOptionalString(pluginResolved.conversationId),
-      parentConversationId: normalizeOptionalString(pluginResolved.parentConversationId),
-    };
+  // Only call a channel-owned resolver when the plugin exposes one. Missing
+  // resolvers still fall through to generic target parsing; explicit `null` does not.
+  const resolveInbound = channelId
+    ? getChannelPlugin(channelId)?.messaging?.resolveInboundConversation
+    : undefined;
+  if (resolveInbound) {
+    const pluginResolved = resolveInbound({
+      from: canonical.from,
+      to: canonical.to ?? canonical.originatingTo,
+      conversationId: canonical.conversationId,
+      threadId: canonical.threadId,
+      threadParentId: canonical.threadParentId,
+      isGroup: canonical.isGroup,
+    });
+    // Match resolveInboundConversationResolution: null is an explicit rejection,
+    // not a signal to stripChannelPrefix / generic fallback for the same target.
+    if (pluginResolved === null) {
+      return {};
+    }
+    if (pluginResolved !== undefined) {
+      return {
+        conversationId: normalizeOptionalString(pluginResolved.conversationId),
+        parentConversationId: normalizeOptionalString(pluginResolved.parentConversationId),
+      };
+    }
   }
   const baseConversationId = stripChannelPrefix(
     canonical.to ?? canonical.originatingTo ?? canonical.conversationId,


### PR DESCRIPTION
Fixes #109300

## What Problem This Solves

Fixes an issue where `inbound_claim` hook payloads could fall back to generic conversation parsing after a channel plugin explicitly rejected inbound conversation resolution by returning `null` from `messaging.resolveInboundConversation()`.

## Why This Change Was Made

The shared channel conversation resolver already treats `null` as an explicit rejection and does not fall through to bundled/generic parsing. The hook claim mapper used a truthy check (`if (pluginResolved)`), so `null` was treated like a missing resolver and fell through to `stripChannelPrefix`.

This change only calls a plugin resolver when one is present, returns an empty conversation mapping when the resolver returns `null`, and keeps the previous generic fallback when no resolver is provided. Object results still map `conversationId` / `parentConversationId` as before.

Compatibility: matches the existing `resolveInboundConversationResolution` contract; no config or public API shape change. Performance: negligible (resolver function lookup once). Usability: channel plugins can reject mapping without inventing a synthetic id. Security: no auth/session gate changes.

## User Impact

Plugin-owned inbound claim payloads no longer receive a generic conversation id when the channel integration deliberately rejects conversation mapping. Missing resolvers continue to use generic target parsing.

## Evidence

Focused regression test on local macOS (Crabbox not used):

```text
$ node scripts/run-vitest.mjs src/hooks/message-hook-mappers.test.ts -t "does not fall back when a channel resolver rejects"

 ✓ |hooks| src/hooks/message-hook-mappers.test.ts (16 tests | 15 skipped)
     ✓ does not fall back when a channel resolver rejects an inbound claim conversation

 Test Files  1 passed (1)
      Tests  1 passed | 15 skipped (16)
```

Full file suite:

```text
$ node scripts/run-vitest.mjs src/hooks/message-hook-mappers.test.ts
 ✓ |hooks| src/hooks/message-hook-mappers.test.ts (16 tests)
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Static: `oxfmt --check` on the two touched files passed. `pnpm check:changed` also passed format/conflict/dup/pin lanes for the diff; Plugin SDK API baseline failed the same way on clean `origin/main` without this patch (pre-existing drift, unrelated to hooks mappers).

## Real behavior proof

- Behavior addressed: When a channel plugin's `resolveInboundConversation()` returns `null`, `toPluginInboundClaimContext` / `toPluginInboundClaimEvent` leave `conversationId` unset instead of inventing one via generic `To` parsing.
- Environment: local macOS, openclaw checkout at this PR head, focused Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: On main, a truthy check treats resolver `null` like “no result”, so a `To` such as `channel:room-123` becomes a fallback conversation id. Sibling `resolveInboundConversationResolution` already documents that `null` is an explicit rejection.
- Exact steps or command run after this patch:
  1. Register a test channel plugin whose `messaging.resolveInboundConversation` returns `null`.
  2. Build a canonical inbound claim context with `To` / `OriginatingTo` = `channel:room-123`.
  3. Run `node scripts/run-vitest.mjs src/hooks/message-hook-mappers.test.ts -t "does not fall back when a channel resolver rejects"`.
- Evidence after fix: The focused test passes; both claim context and claim event assert `conversationId` is `undefined`.
- Control check: Existing claim-chat / thread-claim-chat cases still pass (full file suite 16/16), proving object results and missing-resolver fallbacks remain intact.
- Observed result after fix: Explicit null rejection no longer synthesizes a conversation id from the transport target string.
- What was not tested: Live multi-channel gateway traffic with a production plugin returning null; sibling channel resolution path was already covered by `src/channels/conversation-resolution.test.ts` and was not changed.

## AI disclosure

This PR was authored with AI assistance (Grok).
