### PR TITLE
fix(gateway): let wizard clients control daemon installation

### DIFF
--- a/packages/gateway-protocol/src/schema/wizard.ts
+++ b/packages/gateway-protocol/src/schema/wizard.ts
@@ -16,6 +16,7 @@ const WizardRunStatusSchema = Type.Union([
 export const WizardStartParamsSchema = closedObject({
   mode: Type.Optional(Type.Union([Type.Literal("local"), Type.Literal("remote")])),
   workspace: Type.Optional(Type.String()),
+  installDaemon: Type.Optional(Type.Boolean()),
   // "setup" (default) runs full onboarding; "channels" runs the guided
   // channel-setup flow (openclaw channels add) over the same step protocol.
   flow: Type.Optional(Type.Union([Type.Literal("setup"), Type.Literal("channels")])),

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OnboardOptions } from "../../commands/onboard-types.js";
+import type { WizardSession } from "../../wizard/session.js";
+import { type SetupWizardRunner, wizardHandlers } from "./wizard.js";
+
+type ProjectedOptions = Pick<
+  OnboardOptions,
+  "installDaemon" | "skipUi" | "suppressGatewayTokenOutput"
+>;
+
+describe("wizard.start", () => {
+  it.each([
+    { label: "false", params: { installDaemon: false }, expected: false },
+    { label: "true", params: { installDaemon: true }, expected: true },
+    { label: "omitted", params: {}, expected: undefined },
+  ])("projects installDaemon when $label", async ({ params, expected }) => {
+    let receivedOptions: ProjectedOptions | undefined;
+    const wizardSessions = new Map<string, WizardSession>();
+    const respond = vi.fn();
+    const wizardRunner: SetupWizardRunner = async (opts, _runtime, prompter) => {
+      receivedOptions = {
+        installDaemon: opts.installDaemon,
+        skipUi: opts.skipUi,
+        suppressGatewayTokenOutput: opts.suppressGatewayTokenOutput,
+      };
+      await prompter.note("ready");
+    };
+    const context = {
+      findRunningWizard: () => null,
+      wizardSessions,
+      purgeWizardSession: vi.fn(),
+      wizardRunner,
+    };
+
+    const startWizard = wizardHandlers["wizard.start"];
+    if (!startWizard) {
+      throw new Error("wizard.start handler is not registered");
+    }
+
+    await startWizard({
+      params: { mode: "local", ...params },
+      respond,
+      context,
+    } as never);
+
+    expect(receivedOptions).toEqual({
+      installDaemon: expected,
+      skipUi: true,
+      suppressGatewayTokenOutput: true,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ done: false, status: "running" }),
+      undefined,
+    );
+
+    for (const session of wizardSessions.values()) {
+      session.cancel();
+    }
+  });
+});

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -98,6 +98,9 @@ export const wizardHandlers: GatewayRequestHandlers = {
               {
                 mode: params.mode,
                 workspace: readStringValue(params.workspace),
+                installDaemon: params.installDaemon,
+                skipUi: true,
+                suppressGatewayTokenOutput: true,
               },
               defaultRuntime,
               prompter,


### PR DESCRIPTION
## What Problem This Solves

Remote wizard clients can already express whether onboarding should install a daemon through `OnboardOptions.installDaemon`, but the Gateway RPC contract rejected that field and `wizard.start` did not forward it.

This blocks clients that own the service lifecycle themselves, including the Windows Companion setup flow. Passing `installDaemon=false` must prevent the Gateway-hosted wizard from installing a competing daemon inside the managed environment.

Related Windows Companion work:
- openclaw/openclaw-windows-node#1000
- openclaw/openclaw-windows-node#999

## Why This Change Was Made

This keeps ownership at the existing native boundary:

- add the optional boolean to the closed `WizardStartParamsSchema`;
- forward the exact value, preserving explicit `false`, `true`, and omission;
- keep Gateway-hosted wizard runs headless with `skipUi=true`;
- suppress token-bearing terminal output with `suppressGatewayTokenOutput=true`.

No new lifecycle mechanism or client-specific branch is introduced.

## User Impact

Wizard RPC clients can now explicitly opt out of daemon installation while retaining the existing default when the field is omitted.

This lets a Companion-managed installation own service creation without changing CLI onboarding behavior.

## Evidence

- Focused `wizard.start` regression: 6/6 executions passed across the configured Vitest projects.
- Cases cover `installDaemon=false`, `true`, and omitted.
- The same test verifies `skipUi=true` and `suppressGatewayTokenOutput=true`.
- Focused `tsgo`, `oxfmt --check`, and `oxlint` passed.
- `git diff --check` passed.
- Scoped Codex Auto-review on current head returned zero findings: `patch is correct`, confidence 0.96.

Failed-first evidence was retained during development: a broad Gateway WebSocket test exceeded its inherited 90-second limit, so the PR uses a dedicated handler-level regression rather than claiming that timeout as proof. The first focused typecheck also caught a potentially absent indexed handler; the test now asserts registration before invocation.

## Scope

This PR changes only the Gateway wizard protocol projection and its focused regression test. It does not modify Windows Companion code, service defaults, packaging, migrations, or unrelated beta fixes.

The PR remains draft until the paired Windows Companion flow is validated against an official OpenClaw artifact containing this change.