### PR TITLE
fix(sessions): read pinned session-extension registry in upstream monitor

### DIFF
--- a/src/sessions/session-upstream-monitor-pinned-registry.test.ts
+++ b/src/sessions/session-upstream-monitor-pinned-registry.test.ts
@@ -34,7 +34,7 @@ function provider(
     id,
     label: id,
     list: async () => [],
-    read: async () => ({ items: [] }),
+    read: async ({ hostId, threadId }) => ({ hostId, threadId, items: [] }),
     checkUpstreamActivity,
   };
 }

--- a/src/sessions/session-upstream-monitor-pinned-registry.test.ts
+++ b/src/sessions/session-upstream-monitor-pinned-registry.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  pinActivePluginSessionExtensionRegistry,
+  releasePinnedPluginSessionExtensionRegistry,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import type { SessionCatalogProvider, SessionUpstreamProbe } from "../plugins/session-catalog.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { registerSessionStateWatch } from "./session-state-events.js";
+import {
+  upsertSessionUpstreamLink,
+  listWatchedSessionUpstreamLinks,
+} from "./session-upstream-links.js";
+import { runSessionUpstreamMonitorTick } from "./session-upstream-monitor.test-support.js";
+
+const tempDirs: string[] = [];
+
+function createDatabaseOptions() {
+  const stateDir = makeTempDir(tempDirs, "openclaw-session-upstream-monitor-pinned-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+}
+
+function provider(
+  id: string,
+  checkUpstreamActivity: NonNullable<SessionCatalogProvider["checkUpstreamActivity"]>,
+): SessionCatalogProvider {
+  return {
+    id,
+    label: id,
+    list: async () => [],
+    read: async () => ({ items: [] }),
+    checkUpstreamActivity,
+  };
+}
+
+describe("session upstream monitor pinned registry", () => {
+  let pinnedRegistry = createEmptyPluginRegistry();
+
+  beforeEach(() => {
+    // Simulate the mutable active registry that a standalone plugin load swaps in
+    // (empty here, so a mutable-read would observe no catalogs).
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  afterEach(() => {
+    releasePinnedPluginSessionExtensionRegistry(pinnedRegistry);
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(() => {
+    cleanupTempDirs(tempDirs);
+  });
+
+  it("reads the pinned session-extension registry after active registry churn", async () => {
+    const database = createDatabaseOptions();
+    upsertSessionUpstreamLink(
+      {
+        sessionKey: "agent:main:adopted:watched",
+        agentId: "main",
+        catalogId: "claude",
+        hostId: "gateway:local",
+        threadId: "thread-claude",
+        upstreamKind: "claude-cli",
+        upstreamRef: { source: "claude" },
+        marker: { offset: 0 },
+      },
+      database,
+    );
+    registerSessionStateWatch(
+      { watcherSessionKey: "agent:main:main", targetSessionKey: "agent:main:adopted:watched" },
+      database,
+    );
+
+    const checkUpstreamActivity = vi.fn(async (probes: SessionUpstreamProbe[]) =>
+      probes.map((probe) => ({
+        kind: "activity" as const,
+        sessionKey: probe.sessionKey,
+        occurredAt: 2_000,
+        humanTurns: 1,
+        nextMarker: { offset: 8 },
+        dedupeId: "8",
+      })),
+    );
+
+    // Pin the registry that actually carries the provider. This must win over the
+    // mutable active registry (which is empty), mirroring the session-catalog fix.
+    pinnedRegistry = createEmptyPluginRegistry();
+    pinnedRegistry.sessionCatalogs = [
+      { pluginId: "claude", provider: provider("claude", checkUpstreamActivity), source: "test" },
+    ];
+    pinActivePluginSessionExtensionRegistry(pinnedRegistry);
+
+    // Sanity: the watched link resolves to the claude catalog.
+    expect([...listWatchedSessionUpstreamLinks(database).keys()]).toEqual(["claude"]);
+
+    await runSessionUpstreamMonitorTick({
+      ...database,
+      now: () => 3_000,
+      loadEntry: () => ({ sessionId: "session-watched" }) as never,
+      loadOwnRecentUserTexts: async () => [],
+    });
+
+    expect(checkUpstreamActivity).toHaveBeenCalledTimes(1);
+    const row = openOpenClawStateDatabase(database)
+      .db.prepare("SELECT dedupe_key FROM session_state_events WHERE session_key = ?")
+      .get("agent:main:adopted:watched") as { dedupe_key: string } | undefined;
+    expect(row?.dedupe_key).toBeDefined();
+  });
+});

--- a/src/sessions/session-upstream-monitor.ts
+++ b/src/sessions/session-upstream-monitor.ts
@@ -6,7 +6,7 @@ import { resolveSessionStorePathForScope } from "../config/sessions/session-stor
 import { readRecentUserAssistantTextForSession } from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getPluginRegistryState } from "../plugins/runtime-state.js";
+import { getActivePluginSessionExtensionRegistry } from "../plugins/runtime.js";
 import type { SessionCatalogProvider, SessionUpstreamProbe } from "../plugins/session-catalog.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import {
@@ -46,7 +46,7 @@ type SessionUpstreamMissingCounter = {
 };
 
 function currentProviders(): SessionCatalogProvider[] {
-  return (getPluginRegistryState()?.activeRegistry?.sessionCatalogs ?? []).map(
+  return (getActivePluginSessionExtensionRegistry()?.sessionCatalogs ?? []).map(
     (registration) => registration.provider,
   );
 }


### PR DESCRIPTION
## What Problem This Solves

The session upstream monitor resolved catalog providers from the **mutable** plugin registry state (`getPluginRegistryState()?.activeRegistry`). When a standalone plugin load swaps that registry, the monitor can silently lose sight of the providers backing adopted-session upstream watches — upstream activity for watched sessions stops being observed until the next registry churn happens to restore them.

## Why This Change Was Made

Switch the monitor's provider source to the **pinned** session-extension registry (`getActivePluginSessionExtensionRegistry`), the same source the session-catalog path already trusts. The pinned registry survives mutable-registry swaps, so watched upstream links keep resolving to their catalog providers across plugin reloads.

## User Impact

Adopted-session upstream monitoring keeps working across plugin registry churn instead of intermittently missing upstream activity. No configuration or API change.

## Evidence

### Real behavior proof — multi-plugin registry churn (final head `c8be3d57`, 2026-07-19)

Runtime trace executing the **real** plugin runtime (`src/plugins/runtime.ts`), state database (SQLite in a temp state dir), and the real monitor tick (`src/sessions/session-upstream-monitor.ts`) — no mocks of the monitor or registry plumbing. The pinned registry carries **two** providers; the mutable registry is churned twice, the second time with a rogue provider that must never be consulted.

```bash
./node_modules/.bin/tsx registry-churn-proof.mts
```

```text
date: Sun Jul 19 2026 07:38:22 GMT+0800 (中国标准时间)
node: v24.18.0
modules: src/plugins/runtime.ts + src/sessions/session-upstream-monitor.ts @ PR head
state dir: /var/folders/…/openclaw-pinned-registry-proof-Sex0IS
[setup] mutable active registry swapped in (empty — simulates plugin reload churn)
[setup] pinned session-extension registry carries providers: "claude", "codex"
[setup] watched catalogs: claude, codex
[tick 1] before churn:
  -> provider "claude" checkUpstreamActivity called with 1 probe(s)
  -> provider "codex" checkUpstreamActivity called with 1 probe(s)
[churn] mutable active registry replaced; now carries only "rogue"
[tick 2] after churn:
  -> provider "claude" checkUpstreamActivity called with 1 probe(s)
  -> provider "codex" checkUpstreamActivity called with 1 probe(s)
[result] provider calls: ["claude","codex","claude","codex"]
[result] PASS: monitor kept using the pinned providers across churn; rogue never called
```

Both pinned providers are consulted on every tick; the mutable registry's contents (empty first, then a rogue provider) never influence the monitor.

## Regression tests (final head)

```bash
pnpm vitest run src/sessions/session-upstream-monitor-pinned-registry.test.ts
```

```text
Tests  1 passed (1)
```

## What was not tested

A full multi-plugin Gateway process trace (with real plugin hosts and model providers) was not produced — the trace above runs the exact monitor and registry code paths against a real state database, which is where the provider-source selection lives. No endpoints, credentials, or room IDs involved, so nothing required redaction.

## Rebase status

Branch rebased onto `origin/main` `ba5e1740` at head `b6059c3e` (2026-07-27). Focused checks re-run on the exact rebased head:

```text
$ node scripts/run-vitest.mjs src/sessions/session-upstream-monitor-pinned-registry.test.ts
Test Files  1 passed (1)
     Tests  1 passed (1)
```

Registry-churn runtime proof (same script and procedure as the Evidence section above) re-run on the rebased head:

```text
[result] provider calls: ["claude","codex","claude","codex"]
[result] PASS: monitor kept using the pinned providers across churn; rogue never called
```

