### PR TITLE
fix(qa-lab): unref detached qa cli child and detach stdio listeners

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -59,6 +59,7 @@ function createSpawnedProcess(params: { pid?: number } = {}) {
   child.stdout = createMockEmitter();
   child.stderr = createMockEmitter();
   child.kill = vi.fn();
+  child.unref = vi.fn();
   return child;
 }
 
@@ -119,6 +120,35 @@ describe("qa suite runtime agent process helpers", () => {
     );
     expect((spawnCall?.[2] as { env?: unknown } | undefined)?.env).toEqual({ PATH: "/usr/bin" });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "unrefs the detached child so it cannot keep the parent event loop alive",
+    async () => {
+      const child = createSpawnedProcess();
+      spawnMock.mockReturnValue(child);
+
+      const pending = runQaCli(
+        {
+          repoRoot: "/repo",
+          gateway: { tempRoot: "/tmp/runtime", runtimeEnv: { PATH: "/usr/bin" } },
+          primaryModel: "openai/gpt-5.6-luna",
+          alternateModel: "openai/gpt-5.6-luna-mini",
+          providerMode: "mock-openai",
+        } as never,
+        ["qa", "suite"],
+      );
+
+      await waitForSpawnCount(1);
+      expect(child.unref).toHaveBeenCalledTimes(1);
+      child.stdout.emit("data", Buffer.from("ok\n"));
+      child.emit("close", 0);
+
+      await expect(pending).resolves.toBe("ok");
+      // Listeners must be detached on close so the resolved stream is not retained.
+      expect(child.stdout.listenerCount("data")).toBe(0);
+      expect(child.stderr.listenerCount("data")).toBe(0);
+    },
+  );
 
   it("caps oversized qa cli timeout timers", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -40,6 +40,7 @@ type MockEmitter = {
   emit: (eventName: string | symbol, ...args: unknown[]) => boolean;
   on: (eventName: string | symbol, listener: (...args: unknown[]) => void) => MockEmitter;
   once: (eventName: string | symbol, listener: (...args: unknown[]) => void) => MockEmitter;
+  listenerCount: (eventName: string | symbol) => number;
 };
 
 type MockChildProcess = MockEmitter & {
@@ -47,6 +48,7 @@ type MockChildProcess = MockEmitter & {
   stdout: MockEmitter;
   stderr: MockEmitter;
   kill: ReturnType<typeof vi.fn>;
+  unref: ReturnType<typeof vi.fn>;
 };
 
 function createMockEmitter() {

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -48,7 +48,6 @@ type MockChildProcess = MockEmitter & {
   stdout: MockEmitter;
   stderr: MockEmitter;
   kill: ReturnType<typeof vi.fn>;
-  unref: ReturnType<typeof vi.fn>;
 };
 
 function createMockEmitter() {
@@ -61,7 +60,6 @@ function createSpawnedProcess(params: { pid?: number } = {}) {
   child.stdout = createMockEmitter();
   child.stderr = createMockEmitter();
   child.kill = vi.fn();
-  child.unref = vi.fn();
   return child;
 }
 
@@ -124,7 +122,7 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "unrefs the detached child so it cannot keep the parent event loop alive",
+    "detaches stdout/stderr data listeners on close so the resolved stream is not retained",
     async () => {
       const child = createSpawnedProcess();
       spawnMock.mockReturnValue(child);
@@ -141,7 +139,6 @@ describe("qa suite runtime agent process helpers", () => {
       );
 
       await waitForSpawnCount(1);
-      expect(child.unref).toHaveBeenCalledTimes(1);
       child.stdout.emit("data", Buffer.from("ok\n"));
       child.emit("close", 0);
 

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -272,6 +272,9 @@ async function runQaCli(
       detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
+    // A detached child must not keep the parent's event loop alive once the
+    // promise settles; unref it so the caller can exit without reaping it.
+    child.unref();
     const timeoutMs = resolveTimerTimeoutMs(opts?.timeoutMs, 60_000);
     const timeout = setTimeout(() => {
       signalQaCliProcessTree(child, "SIGKILL");
@@ -279,14 +282,18 @@ async function runQaCli(
         new QaSuiteInfraError("qa_cli_timeout", `qa cli timed out: openclaw ${args.join(" ")}`),
       );
     }, timeoutMs);
-    child.stdout.on("data", (chunk) => appendQaChildOutput(stdout, chunk));
-    child.stderr.on("data", (chunk) => appendQaChildOutputTail(stderr, chunk));
+    const onStdout = (chunk: Buffer) => appendQaChildOutput(stdout, chunk);
+    const onStderr = (chunk: Buffer) => appendQaChildOutputTail(stderr, chunk);
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", onStderr);
     child.once("error", (error) => {
       clearTimeout(timeout);
       reject(error);
     });
     child.once("close", (code) => {
       clearTimeout(timeout);
+      child.stdout.off("data", onStdout);
+      child.stderr.off("data", onStderr);
       if (code === 0) {
         if (stdout.exceeded) {
           reject(

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -272,9 +272,6 @@ async function runQaCli(
       detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
-    // A detached child must not keep the parent's event loop alive once the
-    // promise settles; unref it so the caller can exit without reaping it.
-    child.unref();
     const timeoutMs = resolveTimerTimeoutMs(opts?.timeoutMs, 60_000);
     const timeout = setTimeout(() => {
       signalQaCliProcessTree(child, "SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

`runQaCli` in `extensions/qa-lab/src/suite-runtime-agent-process.ts` spawns the QA CLI as a detached child and attaches `data` listeners to its `stdout`/`stderr`, but never removed them — the listener closures (and the output buffers they capture) stay referenced until the stream objects are garbage collected instead of being released deterministically at `close`.

**Status of the claimed user-visible impact (updated with before/after evidence below):** a controlled pre-change vs PR-head comparison shows **no observable event-loop retention on the baseline** — Node destroys the stdio streams at `close`, so the parent drains either way. This change is therefore presented as deterministic listener hygiene (release closures/buffers at close, matching the lifecycle intent), not as a fix for a demonstrated hang. Maintainers may reasonably prefer to drop it as speculative; see the comparison evidence.

## Why This Change Was Made

On `close`, detach both stdio `data` listeners (`child.stdout.off("data", onStdout)` / `child.stderr.off("data", onStderr)`). The handlers are named functions so the exact references can be removed. An earlier unconditional `child.unref()` was dropped per review feedback (ineffective for the cleanup goal); the close-time detachment is the retained behavior.

## User Impact

No behavior change for QA suite runs (confirmed by the before/after comparison below). The only effect is deterministic release of the two listener closures at `close`.

## Evidence

### Controlled before/after — identical detached-child scenario (2026-07-19)

The identical real-detached-subprocess scenario (production `runQaCli` spawn path, stub CLI entry, success + non-zero-exit cases) was executed against **both** `origin/main` (`cc57514e6`, no close-time detachment) and the PR head, recording exit timing and active handles:

**Baseline (`origin/main`, no listener detachment):**

```text
[success] runQaCli resolved in 49ms: {"ok":true,"argv":["memory","status","--json"]}
[failure] rejected in 44ms: qa cli failed (2): boom
[cleanup] active handles after close: Socket, Socket, Socket, ChildProcess
real    0m1.593s
exit=0
```

**PR head (close-time detachment):**

```text
[success] runQaCli resolved in 47ms: {"ok":true,"argv":["memory","status","--json"]}
[failure] rejected in 44ms: qa cli failed (2): boom
[cleanup] active handles after close: Socket, Socket, Socket, ChildProcess
real    0m0.916s
exit=0
```

**Comparison conclusion:** the pre-change revision shows **no retained live owner** — both versions complete both paths promptly, show the same post-close handle inventory (parent stdio sockets + the already-closed `ChildProcess` object), and exit on their own in <2s. There is no hang for this change to fix; its value is limited to deterministic listener release at close. Per the reviewer's stated fork, maintainers may prefer removing the cleanup as speculative — this PR is left open for that call, with the mocked `listenerCount` regression retained should the detachment be kept.

## Regression tests (final head)

```bash
pnpm vitest run extensions/qa-lab/src/suite-runtime-agent-process.test.ts
```

```text
Test Files  1 passed (1)
     Tests  28 passed (28)
```

(Includes the mocked assertion that both `data` listeners are detached on `close` via `listenerCount`.)

## What was not tested

A full QA lab suite run against a live Gateway (needs model providers); the proof above runs the exact exported spawn/lifecycle function whose listeners this PR changes, on both revisions.

## Rebase status

Rebased onto latest `origin/main`; checks re-run on the exact head.
