### PR TITLE
fix(infra): retain Git commit identity after partial file reads

### DIFF
--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -1,4 +1,5 @@
 // Covers git commit helper behavior in fake repositories.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
@@ -54,6 +55,23 @@ async function makeFakeGitRepo(
 async function makeFakeOpenClawPackage(root: string) {
   await fs.mkdir(path.join(root, "src"), { recursive: true });
   await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+}
+
+function limitPositionalReads(maxBytes: number) {
+  const realReadSync = fsSync.readSync.bind(fsSync);
+  let totalBytesRead = 0;
+  vi.spyOn(fsSync, "readSync").mockImplementation(((
+    fd: number,
+    buffer: NodeJS.ArrayBufferView,
+    offset: number,
+    length: number,
+    position: number | null,
+  ) => {
+    const bytesRead = realReadSync(fd, buffer, offset, Math.min(length, maxBytes), position);
+    totalBytesRead += bytesRead;
+    return bytesRead;
+  }) as typeof fsSync.readSync);
+  return () => totalBytesRead;
 }
 
 describe("git commit resolution", () => {
@@ -210,7 +228,7 @@ describe("git commit resolution", () => {
     expect(resolveCommitHash({ cwd: repoA, env: {} })).toBe("0123456");
   });
 
-  it("reads packed refs from the common git dir for worktree-style checkouts", async () => {
+  it("reads packed refs after short commondir reads in worktree-style checkouts", async () => {
     const temp = await makeTempDir("git-commit-packed-refs");
     const checkoutRoot = path.join(temp, "checkout");
     const commonGitDir = path.join(temp, "git-common");
@@ -224,6 +242,7 @@ describe("git commit resolution", () => {
         "refs/heads/main": "0123456789abcdef0123456789abcdef01234567",
       },
     });
+    limitPositionalReads(4);
 
     expect(resolveCommitHash({ cwd: checkoutRoot, env: {} })).toBe("0123456");
   });
@@ -379,6 +398,57 @@ describe("git commit resolution", () => {
     });
 
     expect(resolveCommitHash({ cwd: repoRootValue, env: {} })).toBe("bbbbbbb");
+  });
+
+  it("fills short positional reads for loose refs", async () => {
+    const temp = await makeTempDir("git-commit-short-ref");
+    const repoRoot = path.join(temp, "repo");
+    await makeFakeGitRepo(repoRoot, {
+      head: "ref: refs/heads/main\n",
+      refs: {
+        "refs/heads/main": "abcdef0123456789abcdef0123456789abcdef01",
+      },
+    });
+    limitPositionalReads(4);
+
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBe("abcdef0");
+  });
+
+  it("keeps short-read retries within the bounded metadata window", async () => {
+    const temp = await makeTempDir("git-commit-bounded-ref");
+    const repoRoot = path.join(temp, "repo");
+    await makeFakeGitRepo(repoRoot, {
+      head: "ref: refs/heads/main\n",
+      refs: {
+        "refs/heads/main": `${"x".repeat(256)}abcdef0123456789`,
+      },
+    });
+    const totalBytesRead = limitPositionalReads(4);
+
+    expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBeNull();
+    expect(totalBytesRead()).toBe(256);
+  });
+
+  it("falls back to baked metadata when a bounded Git metadata read errors", async () => {
+    const temp = await makeTempDir("git-commit-read-error");
+    const repoRoot = path.join(temp, "repo");
+    await makeFakeGitRepo(repoRoot, {
+      head: "ref: refs/heads/main\n",
+      refs: {
+        "refs/heads/main": "abcdef0123456789abcdef0123456789abcdef01",
+      },
+    });
+    vi.spyOn(fsSync, "readSync").mockImplementationOnce((() => {
+      throw Object.assign(new Error("EIO: forced read failure"), { code: "EIO" });
+    }) as typeof fsSync.readSync);
+
+    expect(
+      resolveCommitHash({
+        cwd: repoRoot,
+        env: {},
+        readers: { readBuildInfoCommit: () => "deadbee" },
+      }),
+    ).toBe("deadbee");
   });
 
   it("reads full HEAD refs before parsing long branch names", async () => {

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { readFileWindowFullySync } from "./file-read.js";
 import { resolveGitHeadPath } from "./git-root.js";
 import { pruneMapToMaxSize } from "./map-size.js";
 import { resolveOpenClawPackageRootSync } from "./openclaw-root.js";
@@ -59,7 +60,7 @@ const safeReadFilePrefix = (filePath: string, limit = 256) => {
   const fd = fs.openSync(filePath, "r");
   try {
     const buf = Buffer.alloc(limit);
-    const bytesRead = fs.readSync(fd, buf, 0, limit, 0);
+    const bytesRead = readFileWindowFullySync(fd, buf, 0);
     return buf.subarray(0, bytesRead).toString("utf-8");
   } finally {
     fs.closeSync(fd);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where live checkout metadata could lose the current Git commit when a bounded loose-ref or linked-worktree `commondir` read returned fewer bytes than requested. Version banners, status output, trajectories, and diagnostics could then omit the checkout commit identity even though the metadata file was valid.

## Why This Change Was Made

The bounded prefix reader now uses the existing full-window positional-read helper, which continues until the fixed-size buffer is full or the file reaches EOF. The 256-byte bound, metadata fallback order, path validation, and cache behavior are unchanged.

## User Impact

Operators and developers get stable seven-character commit identities from live checkouts, including linked worktrees, on filesystems that legally return short positional reads.

## Evidence

I ran the same proof harness on Linux with Node v24.18.0 against the real exported `resolveCommitHash()`. It created real temporary Git metadata files and used real kernel reads; the only injected seam capped each `fs.readSync` call at 4 bytes.

Before, on `upstream/main` (`23de5c297d1`):

```text
{"plainLooseRef":null,"linkedWorktree":null,"kernelReadCapBytes":4,"positionalReadCalls":2}
Error: short positional reads lost Git commit metadata
before_exit=1
```

Node's `fs.read()` contract, which `fs.readSync()` references for detailed behavior, states that `length` is a maximum and the actual `bytesRead` can be lower; callers that require more data may need to loop: https://nodejs.org/api/fs.html#fsreadfd-buffer-offset-length-position-callback

After, on this branch with the identical harness:

```text
{"plainLooseRef":"abcdef0","linkedWorktree":"abcdef0","kernelReadCapBytes":4,"positionalReadCalls":29}
after_exit=0
```

An uncapped read from this real linked worktree also matched its actual HEAD:

```text
{"cwd":"/srv/projects/openclaw-pr-git-commit","commit":"23de5c2"}
23de5c2
```

Focused validation on the accepted landing head `4c90626e1c914309d69180ecb8aefc91f47d707f`:

```text
$ node scripts/run-vitest.mjs src/infra/git-commit.test.ts
Test Files  1 passed (1)
Tests  19 passed (19)

$ ./node_modules/.bin/oxfmt --check src/infra/git-commit.ts src/infra/git-commit.test.ts
All matched files use the correct format.

$ ./node_modules/.bin/oxlint src/infra/git-commit.ts src/infra/git-commit.test.ts
```

A fresh Codex autoreview of the accepted head against current `origin/main` reported no accepted or actionable findings. The repository lint wrapper was also attempted on the contributor head, but that checkout's then-current `upstream/main` package-boundary generation stopped on unrelated existing type errors in `packages/net-policy/src/ip.ts`; the two touched files passed direct targeted lint. Full repository gates are covered by exact-head GitHub Actions.

AI-assisted: Codex helped implement and review this change; all proof and validation commands above were run manually.
