### PR TITLE
fix: use last valid daemon --port for status, audit, and launchd

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -9,7 +9,7 @@ import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-f
 import { probePortUsage } from "../infra/ports-probe.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
-import { parseTcpPort } from "../infra/tcp-port.js";
+import { parseTcpPort, parseTcpPortFromArgs } from "../infra/tcp-port.js";
 import { getWindowsCmdExePath } from "../infra/windows-install-roots.js";
 import { sleep } from "../utils.js";
 import {
@@ -548,29 +548,14 @@ export async function disableCurrentOpenClawUpdateLaunchdJob(
 function parseGatewayPortFromProgramArguments(
   programArguments: string[] | undefined,
 ): number | null {
+  // Share Commander-style last-valid semantics with status/repair helpers so
+  // launchd stop/restart cleanup probes the same effective gateway port.
   if (!Array.isArray(programArguments) || programArguments.length === 0) {
     return null;
   }
-  for (let index = 0; index < programArguments.length; index += 1) {
-    const current = programArguments[index]?.trim();
-    if (!current) {
-      continue;
-    }
-    if (current === "--port") {
-      const next = parseTcpPort(programArguments[index + 1] ?? "");
-      if (next !== null) {
-        return next;
-      }
-      continue;
-    }
-    if (current.startsWith("--port=")) {
-      const value = parseTcpPort(current.slice("--port=".length));
-      if (value !== null) {
-        return value;
-      }
-    }
-  }
-  return null;
+  // Plist-sourced argv can carry whitespace padding; keep prior trim tolerance.
+  const normalized = programArguments.map((argument) => argument?.trim() ?? "");
+  return parseTcpPortFromArgs(normalized);
 }
 
 async function resolveLaunchAgentGatewayPort(env: GatewayServiceEnv): Promise<number | null> {

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -455,6 +455,74 @@ describe("auditGatewayServiceConfig", () => {
     expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPortMismatch)).toBe(false);
   });
 
+  it("uses the last repeated --port when auditing gateway service port drift", async () => {
+    const matching = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "win32",
+      expectedPort: 19001,
+      command: {
+        programArguments: [
+          "/usr/bin/node",
+          "entry.js",
+          "gateway",
+          "--port",
+          "18789",
+          "--port",
+          "19001",
+        ],
+        environment: {},
+      },
+    });
+    expect(hasIssue(matching, SERVICE_AUDIT_CODES.gatewayPortMismatch)).toBe(false);
+
+    const mismatch = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "win32",
+      expectedPort: 18888,
+      command: {
+        programArguments: ["/usr/bin/node", "entry.js", "gateway", "--port=18789", "--port=19002"],
+        environment: {},
+      },
+    });
+    const issue = mismatch.issues.find(
+      (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayPortMismatch,
+    );
+    expect(issue).toStrictEqual({
+      code: SERVICE_AUDIT_CODES.gatewayPortMismatch,
+      message: "Gateway service port does not match current gateway config.",
+      detail: "19002 -> 18888",
+      level: "recommended",
+    });
+  });
+
+  it("reports invalid state for the last --port occurrence when auditing", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "win32",
+      expectedPort: 18888,
+      command: {
+        programArguments: [
+          "/usr/bin/node",
+          "entry.js",
+          "gateway",
+          "--port",
+          "18789",
+          "--port=65536",
+        ],
+        environment: {},
+      },
+    });
+    const issue = audit.issues.find(
+      (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayPortMismatch,
+    );
+    expect(issue).toStrictEqual({
+      code: SERVICE_AUDIT_CODES.gatewayPortMismatch,
+      message: "Gateway service port does not match current gateway config.",
+      detail: "65536 -> 18888",
+      level: "recommended",
+    });
+  });
+
   it("flags gateway token mismatch when service token is stale", async () => {
     const audit = await createGatewayAudit({
       expectedGatewayToken: "new-token",

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -297,15 +297,19 @@ function readGatewayServiceCommandPortState(
   if (!programArguments || programArguments.length === 0) {
     return { kind: "missing" };
   }
+  // Effective last occurrence (Commander-style). Keep explicit invalid state for
+  // the last flag so audits still surface bad values rather than silent first-match.
+  let last: GatewayServiceCommandPort = { kind: "missing" };
   for (const [index, arg] of programArguments.entries()) {
     if (arg === "--port") {
-      return parseGatewayPortArg(programArguments[index + 1]);
+      last = parseGatewayPortArg(programArguments[index + 1]);
+      continue;
     }
     if (arg.startsWith("--port=")) {
-      return parseGatewayPortArg(arg.slice("--port=".length));
+      last = parseGatewayPortArg(arg.slice("--port=".length));
     }
   }
-  return { kind: "missing" };
+  return last;
 }
 
 function auditGatewayServicePort(params: {

--- a/src/infra/tcp-port.test.ts
+++ b/src/infra/tcp-port.test.ts
@@ -1,6 +1,6 @@
 // Covers TCP port parsing boundaries.
 import { describe, expect, it } from "vitest";
-import { parseTcpPort } from "./tcp-port.js";
+import { parseTcpPort, parseTcpPortFromArgs } from "./tcp-port.js";
 
 describe("parseTcpPort", () => {
   it("accepts valid TCP port values", () => {
@@ -18,5 +18,28 @@ describe("parseTcpPort", () => {
     expect(parseTcpPort("100000")).toBeNull();
     expect(parseTcpPort("8080ms")).toBeNull();
     expect(parseTcpPort("1.5")).toBeNull();
+  });
+});
+
+describe("parseTcpPortFromArgs", () => {
+  it("returns the last valid separated and equals-form --port values", () => {
+    expect(parseTcpPortFromArgs(["gateway", "--port", "18789", "--port", "19001"])).toBe(19001);
+    expect(parseTcpPortFromArgs(["gateway", "--port=18789", "--port=19002"])).toBe(19002);
+    expect(
+      parseTcpPortFromArgs(["gateway", "--port", "18789", "--port=19003", "--port", "19004"]),
+    ).toBe(19004);
+  });
+
+  it("ignores invalid occurrences and keeps the last valid port", () => {
+    expect(parseTcpPortFromArgs(["gateway", "--port", "nope", "--port", "19003"])).toBe(19003);
+    expect(parseTcpPortFromArgs(["gateway", "--port", "19001", "--port", "65536"])).toBe(19001);
+    expect(parseTcpPortFromArgs(["gateway", "--port=nope", "--port=19005"])).toBe(19005);
+  });
+
+  it("returns null when no valid --port is present", () => {
+    expect(parseTcpPortFromArgs(undefined)).toBeNull();
+    expect(parseTcpPortFromArgs([])).toBeNull();
+    expect(parseTcpPortFromArgs(["gateway"])).toBeNull();
+    expect(parseTcpPortFromArgs(["gateway", "--port", "nope"])).toBeNull();
   });
 });

--- a/src/infra/tcp-port.ts
+++ b/src/infra/tcp-port.ts
@@ -16,25 +16,31 @@ export function parseTcpPort(raw: unknown): number | null {
   return parsed;
 }
 
-/** Extract the effective `--port` value from command arguments. */
+/** Extract the effective `--port` value from command arguments.
+ * Commander-style CLIs treat the last occurrence as the effective option value.
+ * Invalid earlier or later values are ignored so status/repair probes stay best-effort.
+ */
 export function parseTcpPortFromArgs(programArguments: string[] | undefined): number | null {
   if (!programArguments?.length) {
     return null;
   }
+  // Last valid wins: wrappers and stale service argv can repeat `--port`.
+  let effectivePort: number | null = null;
   for (let index = 0; index < programArguments.length; index += 1) {
     const argument = programArguments[index];
     if (argument === "--port") {
       const parsed = parseTcpPort(programArguments[index + 1]);
       if (parsed !== null) {
-        return parsed;
+        effectivePort = parsed;
       }
+      continue;
     }
     if (argument?.startsWith("--port=")) {
       const parsed = parseTcpPort(argument.slice("--port=".length));
       if (parsed !== null) {
-        return parsed;
+        effectivePort = parsed;
       }
     }
   }
-  return null;
+  return effectivePort;
 }


### PR DESCRIPTION
Related: #109292

## What Problem This Solves

Fixes an issue where daemon status, service audit, and launchd stop/restart helpers could use the wrong Gateway port when an installed service command contained repeated `--port` flags. Status/repair helpers previously returned the first valid port while Commander-style CLI parsing uses the last occurrence as the effective value.

## Why This Change Was Made

Align all three installed-service argv port readers on Commander-style **effective last** semantics:

- Shared helper `parseTcpPortFromArgs` now keeps the last valid `--port` / `--port=` value (invalid occurrences stay ignored for best-effort probes).
- Launchd lifecycle port resolution reuses that helper so stop/restart cleanup probes the same port as status/repair.
- Service audit evaluates the **last** `--port` occurrence and still reports explicit invalid state for that last value (not a silent first-match).

This matches the sibling-surface guidance on the earlier candidate fix and avoids leaving status on the last port while launchd cleanup/audit still used the first.

Compatibility: no config/API/schema change; only repeated-flag argv interpretation for daemon introspection. Performance: single linear scan, same as before. Usability: operators see consistent port selection across status, audit, and lifecycle cleanup. Security: no auth, secrets, or trust-boundary change.

## User Impact

Operators get accurate Gateway status, audit, and launchd stop/restart port selection when wrappers or stale service definitions include more than one `--port` flag.

## Evidence

Focused tests (local macOS):

```text
node scripts/run-vitest.mjs src/infra/tcp-port.test.ts src/daemon/service-audit.test.ts

[test] passed 2 Vitest shards in 32.54s
- src/infra/tcp-port.test.ts (5 tests)
- src/daemon/service-audit.test.ts (48 tests)
```

Changed-lane checks: format, conflict markers, and other static gates for the touched core files passed. Plugin SDK API baseline reports a pre-existing hash drift on current `main` with no plugin-sdk files in this diff. One `launchd.test.ts` ANSI-sanitize case is environment-sensitive under `FORCE_COLOR` and passes with `NO_COLOR=1`; it is outside this port-parser change.

## Real behavior proof

- Behavior addressed: repeated `--port` flags in service argv resolve to the effective last valid port for shared status/repair parsing, and sibling audit/launchd readers no longer keep first-match semantics for the same argv shape.
- Environment: local macOS, OpenClaw checkout at branch `fix/109292-effective-daemon-port`, Node with `tsx` import of production modules.
- Current-main contrast: on main, `parseTcpPortFromArgs(['gateway','--port','18789','--port','19001'])` returned `18789` (first match). The same probe for equals-form flags also returned the first value.
- Exact steps or command run after this patch:

```sh
node --import tsx -e "import { parseTcpPortFromArgs } from './src/infra/tcp-port.ts'; console.log(parseTcpPortFromArgs(['gateway','--port','18789','--port','19001'])); console.log(parseTcpPortFromArgs(['gateway','--port=18789','--port=19002'])); console.log(parseTcpPortFromArgs(['gateway','--port','nope','--port','19003']));"
```

- Evidence after fix:

```text
["gateway","--port","18789","--port","19001"] => 19001
["gateway","--port=18789","--port=19002"] => 19002
["gateway","--port","nope","--port","19003"] => 19003
```

  Service-audit focused cases also assert last-occurrence match (`19001` matches expected) and last-invalid reporting (`65536` after a valid earlier port).

- Control check: only argv port resolution for daemon introspection is changed; single-port and no-port cases still return the same null/valid results; audit still emits `gateway-port-mismatch` for true drift and invalid last values.
- Observed result after fix: last valid separated and equals-form ports win; invalid values are skipped by the shared helper; audit reports the last flag's invalid state when that is the final occurrence.
- What was not tested: full installed LaunchAgent install/stop/restart against a live launchd unit with deliberately duplicated `--port` flags (unit/source coverage of the three readers is provided instead).

## AI disclosure

This PR was authored with AI assistance (Grok).
