### PR TITLE
improve: speed up state database race tests

### DIFF
--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -526,8 +526,10 @@ function runConcurrentSchemaProbe(params: {
     const rootDir = ${JSON.stringify(params.rootDir)};
     const mode = ${JSON.stringify(params.mode)};
     const workerSource = ${JSON.stringify(workerSource)};
-    const workerCount = 8;
-    const roundCount = 3;
+    // The barriers deterministically overlap both openers. Two contenders prove
+    // serialization without repeating the same child-process stress.
+    const workerCount = 2;
+    const roundCount = 1;
     const databasePaths = [];
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -2168,7 +2170,7 @@ describe("openclaw state database", () => {
     );
     const { DatabaseSync } = requireNodeSqlite();
 
-    expect(databasePaths).toHaveLength(3);
+    expect(databasePaths).toHaveLength(1);
     for (const [round, databasePath] of databasePaths.entries()) {
       const db = new DatabaseSync(databasePath, { readOnly: true });
       try {
@@ -2202,7 +2204,7 @@ describe("openclaw state database", () => {
     );
     const { DatabaseSync } = requireNodeSqlite();
 
-    expect(databasePaths).toHaveLength(3);
+    expect(databasePaths).toHaveLength(1);
     for (const databasePath of databasePaths) {
       const db = new DatabaseSync(databasePath, { readOnly: true });
       try {


### PR DESCRIPTION
## What Problem This Solves

The state-database concurrency tests repeated the same deterministic process race three times with eight workers, making two tests account for about six seconds of test-body time per focused run.

## Why This Change Was Made

Keep both fresh-initialization and additive-upgrade race cases, but use the minimum two contenders and one deterministic barrier round. The assertions, schema checks, and 78-test file coverage remain intact. No production or CI configuration changes.

## User Impact

No user-visible behavior change. Maintainers get faster state-database test feedback.

## Evidence

- Blacksmith Testbox `tbx_01kxpmtct2sbw6g3rn5kd78jz3`: https://github.com/openclaw/openclaw/actions/runs/29542681528
- Focused command: `pnpm test src/state/openclaw-state-db.test.ts`
- Three-run median target-body time: 5.99s before, 1.25s after (79.2% faster)
- Three-run median file test time: 8.60s before, 4.80s after (44.2% faster)
- 78/78 tests passed on all before and after runs
- Remote `pnpm check:changed`: passed
- Autoreview: clean, no accepted/actionable findings

AI-assisted; reviewed and understood.
