### PR TITLE
fix(qa-lab): avoid hangs before child runs under Bun

### DIFF
--- a/extensions/qa-lab/src/node-exec.test.ts
+++ b/extensions/qa-lab/src/node-exec.test.ts
@@ -1,6 +1,6 @@
 // Qa Lab tests cover node exec plugin behavior.
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { runExecMock } = vi.hoisted(() => ({ runExecMock: vi.fn() }));
 
@@ -11,6 +11,10 @@ import { resolveQaNodeExecPath } from "./node-exec.js";
 describe("resolveQaNodeExecPath", () => {
   beforeEach(() => {
     runExecMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("reuses the current exec path when already running under Node", async () => {
@@ -66,6 +70,7 @@ describe("resolveQaNodeExecPath", () => {
     expect(runExecMock).toHaveBeenCalledWith("which", ["node"], {
       baseEnv: env,
       logOutput: false,
+      timeoutMs: 5_000,
     });
   });
 
@@ -82,6 +87,7 @@ describe("resolveQaNodeExecPath", () => {
           expect(options).toEqual({
             encoding: "utf8",
             env: { SystemRoot: String.raw`D:\Windows` },
+            timeoutMs: 5_000,
           });
           return {
             stdout: String.raw`D:\nodejs\node.exe` + "\r\n",
@@ -90,6 +96,33 @@ describe("resolveQaNodeExecPath", () => {
         },
       }),
     ).resolves.toBe(String.raw`D:\nodejs\node.exe`);
+  });
+
+  it("fails after the lookup timeout when the PATH probe stalls", async () => {
+    vi.useFakeTimers();
+    runExecMock.mockImplementationOnce(
+      (_file: string, _args: string[], options: { timeoutMs: number }): Promise<never> =>
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(new Error("timed out")), options.timeoutMs);
+        }),
+    );
+
+    const lookup = resolveQaNodeExecPath({
+      execPath: "/opt/homebrew/bin/bun",
+      platform: "darwin",
+      versions: { ...process.versions, bun: "1.2.3" },
+    });
+    const rejection = lookup.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(rejection).resolves.toEqual(
+      expect.objectContaining({ message: expect.stringContaining("Node not found in PATH") }),
+    );
+    expect(runExecMock).toHaveBeenCalledWith("which", ["node"], {
+      baseEnv: undefined,
+      logOutput: false,
+      timeoutMs: 5_000,
+    });
   });
 
   it("throws a clear error when node is unavailable", async () => {

--- a/extensions/qa-lab/src/node-exec.ts
+++ b/extensions/qa-lab/src/node-exec.ts
@@ -9,11 +9,18 @@ type ExecFileAsync = (
   options: {
     encoding: "utf8";
     env?: NodeJS.ProcessEnv;
+    timeoutMs: number;
   },
 ) => Promise<{ stdout: string; stderr: string }>;
 
+const NODE_BINARY_LOOKUP_TIMEOUT_MS = 5_000;
+
 const execFileAsync: ExecFileAsync = async (file, args, options) =>
-  await runExec(file, [...args], { baseEnv: options.env, logOutput: false });
+  await runExec(file, [...args], {
+    baseEnv: options.env,
+    logOutput: false,
+    timeoutMs: options.timeoutMs,
+  });
 
 function isNodeExecPath(execPath: string, platform: NodeJS.Platform): boolean {
   const pathModule = platform === "win32" ? path.win32 : path.posix;
@@ -48,6 +55,7 @@ export async function resolveQaNodeExecPath(params?: {
     ({ stdout } = await execFileImpl(locator, ["node"], {
       encoding: "utf8",
       env: params?.env,
+      timeoutMs: NODE_BINARY_LOOKUP_TIMEOUT_MS,
     }));
   } catch {
     throw new Error(


### PR DESCRIPTION
AI-assisted: Codex.

## What Problem This Solves

Fixes an issue where QA Lab users running the parent process under Bun could wait indefinitely before child gateway or CLI startup when the operating-system Node lookup stalls.

## Why This Change Was Made

The QA Lab Node resolver now gives its trusted `which node` / `where.exe node` probe a five-second deadline through the existing plugin SDK process runner. The direct Node fast path and the existing clear lookup failure remain unchanged.

## User Impact

QA Lab startup now fails with an actionable error after a bounded wait instead of hanging before its child-process deadlines are established. Normal successful lookups are unaffected.

## Evidence

- Latest validated base: `05980207c6a455ed0a84c4891c04be62e281c12e`.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/node-exec.test.ts` - 1 file, 7 tests passed.
- `./node_modules/.bin/oxfmt --check extensions/qa-lab/src/node-exec.ts extensions/qa-lab/src/node-exec.test.ts` - passed.
- `./node_modules/.bin/oxlint extensions/qa-lab/src/node-exec.ts extensions/qa-lab/src/node-exec.test.ts` - passed.
- `git diff --check` - passed.
- Controlled stalled `which` proof: a lookup that sleeps for 30 seconds returned after 5,125 ms with `Node not found in PATH. QA live lanes require Node for child gateway and CLI processes.`
- Canonical runner proof: a 100 ms stalled-child budget rejected after 124 ms with `timedOut=true` and `signal=SIGTERM`.
- Independent Codex adversarial review: CLEAN. The repository autoreview helper was also attempted, but its Codex API call was unavailable with HTTP 401 in this environment.

The broader extension lint wrapper could not reach lint because its local declaration-preparation step failed in unchanged `packages/net-policy/src/ip.ts` and `src/infra/push-web.ts`; direct lint of both touched files passed, and CI remains authoritative for the broader lane.
