### PR TITLE
docs: define SecretRef failure isolation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,7 @@ Skills own workflows; root owns hard policy and routing.
 
 - Never commit real phone numbers, videos, credentials, live config.
 - Secrets: channel/provider creds in `~/.openclaw/credentials/`; model auth profiles in `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`.
+- SecretRef failures isolate to the smallest known owning surface. Proven-inactive surfaces skip; unknown ownership fails closed. Gateway refuses startup only when its own ingress protection cannot be established, config is structurally invalid, or the owning surface is unknown. Otherwise start, mark the exact capability/account/route configured-unavailable, emit a typed redacted diagnostic, and forbid implicit credential fallback. On reload, retain last-known-good only for an unchanged ref+provider; a changed unresolved ref makes that owner cold. Doctor and status must list every degraded owner.
 - Dependency patches/overrides/vendor changes need explicit approval. `pnpm-workspace.yaml` patched dependencies use exact versions only.
 - Release/package guards: no hard-coded retired-package denylists; use generic artifact/dependency checks or fix build source.
 - Lockfiles/shrinkwrap are security surface: review `pnpm-lock.yaml`, `npm-shrinkwrap.json`, `package-lock.json`; root/plugin npm packages ship shrinkwrap, not package-lock.

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -28,6 +28,10 @@ Plaintext credentials remain agent-readable if they sit in files the agent can i
 
 This keeps secret-provider outages off hot request paths.
 
+<Note>
+Target policy for the SecretRef ownership-isolation migration: failures isolate to the smallest known owner. Only unavailable Gateway ingress protection, structurally invalid config, or unknown ownership will block startup; other affected capabilities, accounts, or routes will become configured-unavailable with typed redacted diagnostics and no implicit credential fallback. Reload will retain last-known-good only for an unchanged ref and provider, while a changed unresolved ref will make that owner cold. Doctor and status will list every degraded owner. This migration is not fully implemented; the current activation rules on this page remain in effect.
+</Note>
+
 ## Egress-time injection (sentinels)
 
 For model-provider credentials backed by SecretRefs, OpenClaw mints an opaque, process-local sentinel during model-auth resolution. Auth storage, stream options, SDK configuration, logs, error objects, and most runtime introspection therefore see a value such as `oc-sent-v1-...`, not the provider credential. The guarded model fetch and managed local-provider health probes replace known sentinels in URL and header values immediately before each request leaves the process.


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's current secrets documentation describes whole-snapshot startup and reload failure behavior, but the repository lacked a durable maintainer rule for isolating SecretRef failures by owning surface. Without that rule, narrow fixes can introduce inconsistent fail-open exceptions without the required owner state, diagnostics, fallback prohibition, or operator visibility.

## Why This Change Was Made

This adds the owner-approved SecretRef failure-isolation policy to the canonical root `AGENTS.md`. It also adds a target-policy note to the secrets guide because that page currently documents the older all-or-nothing activation contract. The note explicitly says the ownership-isolation migration is not fully implemented and that the page's current behavior remains authoritative until it lands.

AI-assisted: yes (Codex).

## User Impact

No runtime behavior changes. Maintainers and contributors now have one explicit target contract for startup, reload, degraded-owner state, typed redacted diagnostics, credential fallback, and doctor/status reporting.

## Evidence

- `git diff --check origin/main...HEAD` — passed.
- `node scripts/docs-list.js` — passed; `gateway/secrets.md` remains indexed with valid front matter.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted ...` — clean; no accepted/actionable findings.
- Source audit covered `src/secrets/runtime.ts`, `src/secrets/resolve.ts`, `src/secrets/runtime-shared.ts`, `src/secrets/runtime-state.ts`, and `src/gateway/server-startup-config.ts`; current resolution is stop-on-first-error and activation remains whole-snapshot, so the docs text is correctly labeled as migration target rather than current behavior.
