### PR TITLE
fix(anthropic): complete transcript reverse-scan windows across short reads

### DIFF
--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import type { FileHandle } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -349,13 +348,48 @@ function sdkCliMessage(sessionId: string, text: string): Record<string, unknown>
   };
 }
 
-// Fault-injects short positional reads on the target transcript's FileHandle so
-// tests can drive the reverse-scan pager through partial reads deterministically
-// (production short reads are non-deterministic and cannot be induced reliably).
-// `plan` returns the byte count each read is allowed to satisfy; returning 0
-// simulates a genuine mid-window EOF (truncation). Forward metadata-scan handles
-// (first read at position 0) and the reverse pager handle (first read at a high
-// offset) are distinguishable via `firstPosition`.
+async function writeLongPagedTranscript(params: {
+  home: string;
+  sessionId: string;
+  truncated?: boolean;
+}): Promise<string> {
+  const oldUser = "old user ".repeat(20_000);
+  await writeProject({
+    home: params.home,
+    entries: [
+      {
+        sessionId: params.sessionId,
+        fullPath: path.join(
+          params.home,
+          ".claude",
+          "projects",
+          "-workspace",
+          `${params.sessionId}.jsonl`,
+        ),
+        summary: "Transcript",
+        modified: "2026-07-04T00:00:00.000Z",
+        isSidechain: false,
+      },
+    ],
+    transcripts: {
+      [params.sessionId]: params.truncated
+        ? [
+            message(params.sessionId, "user", oldUser, 1),
+            message(params.sessionId, "assistant", "new assistant", 2),
+          ]
+        : [
+            { type: "queue-operation", sessionId: params.sessionId },
+            message(params.sessionId, "user", oldUser, 1),
+            message(params.sessionId, "assistant", "old assistant", 2),
+            message(params.sessionId, "user", "new user", 3),
+            message(params.sessionId, "assistant", "new assistant", 4),
+          ],
+    },
+  });
+  return oldUser;
+}
+
+// Cap positional reads on one transcript; a zero cap simulates mid-window EOF.
 function injectTranscriptShortReads(
   sessionId: string,
   plan: (input: {
@@ -366,8 +400,9 @@ function injectTranscriptShortReads(
   }) => number,
 ): void {
   const realOpen = fs.open.bind(fs);
-  vi.spyOn(fs, "open").mockImplementation((async (target: unknown, ...rest: unknown[]) => {
-    const handle = await (realOpen as (...args: unknown[]) => Promise<FileHandle>)(target, ...rest);
+  vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+    const handle = await realOpen(...args);
+    const [target] = args;
     if (typeof target === "string" && target.endsWith(`${sessionId}.jsonl`)) {
       const realRead = handle.read.bind(handle) as (
         buffer: Buffer,
@@ -377,22 +412,20 @@ function injectTranscriptShortReads(
       ) => Promise<{ bytesRead: number; buffer: Buffer }>;
       let call = 0;
       let firstPosition = -1;
-      (handle as { read: unknown }).read = (
-        buffer: Buffer,
-        offset: number,
-        length: number,
-        position: number,
-      ) => {
-        if (firstPosition < 0) {
-          firstPosition = position;
-        }
-        const allowed = plan({ length, position, call, firstPosition });
-        call += 1;
-        return realRead(buffer, offset, allowed, position);
-      };
+      Object.defineProperty(handle, "read", {
+        configurable: true,
+        value: (buffer: Buffer, offset: number, length: number, position: number) => {
+          if (firstPosition < 0) {
+            firstPosition = position;
+          }
+          const allowed = plan({ length, position, call, firstPosition });
+          call += 1;
+          return realRead(buffer, offset, allowed, position);
+        },
+      });
     }
     return handle;
-  }) as typeof fs.open);
+  });
 }
 
 afterEach(async () => {
@@ -1466,28 +1499,7 @@ describe("Claude session catalog", () => {
   it("reads newest transcript messages first by page while returning each page chronologically", async () => {
     const home = await createHome();
     const sessionId = "transcript-session";
-    const oldUser = "old user ".repeat(20_000);
-    await writeProject({
-      home,
-      entries: [
-        {
-          sessionId,
-          fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
-          summary: "Transcript",
-          modified: "2026-07-04T00:00:00.000Z",
-          isSidechain: false,
-        },
-      ],
-      transcripts: {
-        [sessionId]: [
-          { type: "queue-operation", sessionId },
-          message(sessionId, "user", oldUser, 1),
-          message(sessionId, "assistant", "old assistant", 2),
-          message(sessionId, "user", "new user", 3),
-          message(sessionId, "assistant", "new assistant", 4),
-        ],
-      },
-    });
+    const oldUser = await writeLongPagedTranscript({ home, sessionId });
 
     const latest = await readLocalClaudeTranscriptPage({ threadId: sessionId, limit: 2 }, home);
     expect(latest.items.map((item) => item.text)).toEqual(["new assistant", "new user"]);
@@ -1597,34 +1609,9 @@ describe("Claude session catalog", () => {
   it("pages transcripts identically when every reverse-scan read returns short", async () => {
     const home = await createHome();
     const sessionId = "short-read-session";
-    // > TRANSCRIPT_READ_CHUNK_BYTES (128 KiB) so the reverse scan spans multiple
-    // windows, each of which is now split into many consecutive short reads.
-    const oldUser = "old user ".repeat(20_000);
-    await writeProject({
-      home,
-      entries: [
-        {
-          sessionId,
-          fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
-          summary: "Transcript",
-          modified: "2026-07-04T00:00:00.000Z",
-          isSidechain: false,
-        },
-      ],
-      transcripts: {
-        [sessionId]: [
-          { type: "queue-operation", sessionId },
-          message(sessionId, "user", oldUser, 1),
-          message(sessionId, "assistant", "old assistant", 2),
-          message(sessionId, "user", "new user", 3),
-          message(sessionId, "assistant", "new assistant", 4),
-        ],
-      },
-    });
+    const oldUser = await writeLongPagedTranscript({ home, sessionId });
 
-    // Every read satisfies at most 4 KiB, so each 128 KiB window is completed
-    // across dozens of non-zero short reads. Fails before the fill-loop fix: the
-    // first short read tripped the "transcript changed" throw.
+    // The fixture spans multiple 128 KiB windows; each is filled in 4 KiB reads.
     injectTranscriptShortReads(sessionId, ({ length }) => Math.min(length, 4096));
 
     const latest = await readLocalClaudeTranscriptPage({ threadId: sessionId, limit: 2 }, home);
@@ -1642,30 +1629,9 @@ describe("Claude session catalog", () => {
   it("still reports a truncated transcript when a reverse-scan read hits EOF mid-window", async () => {
     const home = await createHome();
     const sessionId = "truncated-read-session";
-    const oldUser = "old user ".repeat(20_000);
-    await writeProject({
-      home,
-      entries: [
-        {
-          sessionId,
-          fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
-          summary: "Transcript",
-          modified: "2026-07-04T00:00:00.000Z",
-          isSidechain: false,
-        },
-      ],
-      transcripts: {
-        [sessionId]: [
-          message(sessionId, "user", oldUser, 1),
-          message(sessionId, "assistant", "new assistant", 2),
-        ],
-      },
-    });
+    await writeLongPagedTranscript({ home, sessionId, truncated: true });
 
-    // Reverse pager handle (first read at a high offset): return a partial read,
-    // then a 0-byte read = the file was truncated out from under us mid-window,
-    // which must still surface the hard error. Forward metadata-scan handles
-    // (first read at position 0) read normally so the session still resolves.
+    // Return one partial reverse read, then simulate truncation with zero bytes.
     injectTranscriptShortReads(sessionId, ({ length, call, firstPosition }) =>
       firstPosition === 0 ? length : call === 0 ? Math.min(length, 8) : 0,
     );

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -346,6 +347,52 @@ function sdkCliMessage(sessionId: string, text: string): Record<string, unknown>
     cwd: `/work/${sessionId}`,
     version: "2.1.204",
   };
+}
+
+// Fault-injects short positional reads on the target transcript's FileHandle so
+// tests can drive the reverse-scan pager through partial reads deterministically
+// (production short reads are non-deterministic and cannot be induced reliably).
+// `plan` returns the byte count each read is allowed to satisfy; returning 0
+// simulates a genuine mid-window EOF (truncation). Forward metadata-scan handles
+// (first read at position 0) and the reverse pager handle (first read at a high
+// offset) are distinguishable via `firstPosition`.
+function injectTranscriptShortReads(
+  sessionId: string,
+  plan: (input: {
+    length: number;
+    position: number;
+    call: number;
+    firstPosition: number;
+  }) => number,
+): void {
+  const realOpen = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation((async (target: unknown, ...rest: unknown[]) => {
+    const handle = await (realOpen as (...args: unknown[]) => Promise<FileHandle>)(target, ...rest);
+    if (typeof target === "string" && target.endsWith(`${sessionId}.jsonl`)) {
+      const realRead = handle.read.bind(handle) as (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number,
+      ) => Promise<{ bytesRead: number; buffer: Buffer }>;
+      let call = 0;
+      let firstPosition = -1;
+      (handle as { read: unknown }).read = (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number,
+      ) => {
+        if (firstPosition < 0) {
+          firstPosition = position;
+        }
+        const allowed = plan({ length, position, call, firstPosition });
+        call += 1;
+        return realRead(buffer, offset, allowed, position);
+      };
+    }
+    return handle;
+  }) as typeof fs.open);
 }
 
 afterEach(async () => {
@@ -1545,6 +1592,87 @@ describe("Claude session catalog", () => {
     await expect(
       provider.read({ hostId: "node:node-a", threadId: "session-a", limit: 1 }),
     ).rejects.toThrow("Claude node returned an invalid transcript page");
+  });
+
+  it("pages transcripts identically when every reverse-scan read returns short", async () => {
+    const home = await createHome();
+    const sessionId = "short-read-session";
+    // > TRANSCRIPT_READ_CHUNK_BYTES (128 KiB) so the reverse scan spans multiple
+    // windows, each of which is now split into many consecutive short reads.
+    const oldUser = "old user ".repeat(20_000);
+    await writeProject({
+      home,
+      entries: [
+        {
+          sessionId,
+          fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
+          summary: "Transcript",
+          modified: "2026-07-04T00:00:00.000Z",
+          isSidechain: false,
+        },
+      ],
+      transcripts: {
+        [sessionId]: [
+          { type: "queue-operation", sessionId },
+          message(sessionId, "user", oldUser, 1),
+          message(sessionId, "assistant", "old assistant", 2),
+          message(sessionId, "user", "new user", 3),
+          message(sessionId, "assistant", "new assistant", 4),
+        ],
+      },
+    });
+
+    // Every read satisfies at most 4 KiB, so each 128 KiB window is completed
+    // across dozens of non-zero short reads. Fails before the fill-loop fix: the
+    // first short read tripped the "transcript changed" throw.
+    injectTranscriptShortReads(sessionId, ({ length }) => Math.min(length, 4096));
+
+    const latest = await readLocalClaudeTranscriptPage({ threadId: sessionId, limit: 2 }, home);
+    expect(latest.items.map((item) => item.text)).toEqual(["new assistant", "new user"]);
+    expect(latest.nextCursor).toEqual(expect.any(String));
+
+    const older = await readLocalClaudeTranscriptPage(
+      { threadId: sessionId, limit: 2, cursor: latest.nextCursor },
+      home,
+    );
+    expect(older.items.map((item) => item.text)).toEqual(["old assistant", oldUser]);
+    expect(older.nextCursor).toBeUndefined();
+  });
+
+  it("still reports a truncated transcript when a reverse-scan read hits EOF mid-window", async () => {
+    const home = await createHome();
+    const sessionId = "truncated-read-session";
+    const oldUser = "old user ".repeat(20_000);
+    await writeProject({
+      home,
+      entries: [
+        {
+          sessionId,
+          fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
+          summary: "Transcript",
+          modified: "2026-07-04T00:00:00.000Z",
+          isSidechain: false,
+        },
+      ],
+      transcripts: {
+        [sessionId]: [
+          message(sessionId, "user", oldUser, 1),
+          message(sessionId, "assistant", "new assistant", 2),
+        ],
+      },
+    });
+
+    // Reverse pager handle (first read at a high offset): return a partial read,
+    // then a 0-byte read = the file was truncated out from under us mid-window,
+    // which must still surface the hard error. Forward metadata-scan handles
+    // (first read at position 0) read normally so the session still resolves.
+    injectTranscriptShortReads(sessionId, ({ length, call, firstPosition }) =>
+      firstPosition === 0 ? length : call === 0 ? Math.min(length, 8) : 0,
+    );
+
+    await expect(
+      readLocalClaudeTranscriptPage({ threadId: sessionId, limit: 2 }, home),
+    ).rejects.toThrow("Claude transcript changed while it was being read");
   });
 
   it("advertises terminal resume only when the store and Claude binary exist", async () => {

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -769,12 +769,8 @@ export async function readLocalClaudeTranscriptPage(
       );
       position -= size;
       const chunk = Buffer.allocUnsafe(size);
-      // Positional reads can return fewer bytes than requested even inside a
-      // stat'd, unchanged file, so fill the whole window across short reads
-      // (mirrors the forward metadata scan above). Advance both the buffer
-      // offset and the file position each retry. A zero-byte read before the
-      // window is filled is a genuine premature EOF = the transcript was
-      // truncated mid-read, which stays a hard error.
+      // Positional reads may return short, so complete the bounded window.
+      // A zero-byte read before it fills means the file changed after stat.
       let filled = 0;
       while (filled < size) {
         const { bytesRead } = await handle.read(chunk, filled, size - filled, position + filled);

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -769,13 +769,23 @@ export async function readLocalClaudeTranscriptPage(
       );
       position -= size;
       const chunk = Buffer.allocUnsafe(size);
-      const { bytesRead } = await handle.read(chunk, 0, size, position);
-      if (bytesRead !== size) {
-        throw new Error("Claude transcript changed while it was being read");
+      // Positional reads can return fewer bytes than requested even inside a
+      // stat'd, unchanged file, so fill the whole window across short reads
+      // (mirrors the forward metadata scan above). Advance both the buffer
+      // offset and the file position each retry. A zero-byte read before the
+      // window is filled is a genuine premature EOF = the transcript was
+      // truncated mid-read, which stays a hard error.
+      let filled = 0;
+      while (filled < size) {
+        const { bytesRead } = await handle.read(chunk, filled, size - filled, position + filled);
+        if (bytesRead === 0) {
+          throw new Error("Claude transcript changed while it was being read");
+        }
+        filled += bytesRead;
       }
-      scanned += bytesRead;
-      let right = bytesRead;
-      for (let index = bytesRead - 1; index >= 0; index -= 1) {
+      scanned += filled;
+      let right = filled;
+      for (let index = filled - 1; index >= 0; index -= 1) {
         if (chunk[index] !== 0x0a) {
           continue;
         }


### PR DESCRIPTION
## What Problem This Solves

Opening a Claude session transcript could fail with `Claude transcript changed while it was being read` even when the file was unchanged. The reverse pager required one positional read to fill an entire 128 KiB window, but Node permits a successful read to return fewer positive bytes than requested.

## Why This Change Was Made

The Anthropic plugin now completes each already-bounded reverse window across positive short reads, advancing both the buffer and file offsets. A zero-byte read before the stat-sized window is full remains a premature-EOF error, so concurrent truncation still fails closed.

The implementation stays plugin-local because bundled plugins may not import core `src/infra` helpers across the Plugin SDK boundary. It mirrors the established bounded-read loop used by core readers without adding API, config, dependency, or storage surface.

## User Impact

Claude transcript pagination no longer fails spuriously on filesystems that return positive short positional reads. Real truncation during a page read still reports the existing error.

## Evidence

- `node scripts/run-vitest.mjs extensions/anthropic/session-catalog.test.ts` — 37 passed.
- The short-read regression spans multiple 128 KiB windows and produces the same two-page items/order/cursor as normal reads.
- A first-position-discriminated fault injects one short reverse read followed by zero bytes and preserves the premature-EOF error.
- `node scripts/check-changed.mjs -- extensions/anthropic/session-catalog.ts extensions/anthropic/session-catalog.test.ts` — passed on Blacksmith Testbox `tbx_01ky1m69ad5sftt2jpfnpybfgw`, run 29805682398.
- Full-branch AutoReview — clean, no accepted/actionable findings (0.98 confidence).
- `git diff --check` — passed.

Contributor credit is preserved in Masato Hoshino's original commit.
