### PR TITLE
improve: speed up updater process-tree test

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -215,6 +215,9 @@ describe("runGatewayUpdate", () => {
       );
       await fs.chmod(fakeGitPath, 0o755);
 
+      // Keep install-surface candidates on the fixture root so this test exercises
+      // one timed-out process tree instead of repeating the timeout for Vitest's cwd.
+      const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tempDir);
       let childPid: number | null = null;
       let childExited = false;
       try {
@@ -231,6 +234,7 @@ describe("runGatewayUpdate", () => {
         expect(Number.isInteger(childPid) && childPid > 0).toBe(true);
         childExited = await waitForProcessExit(childPid);
       } finally {
+        cwdSpy.mockRestore();
         if (childPid && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
         }


### PR DESCRIPTION
## What Problem This Solves

The updater process-tree timeout test ran the same forced 500ms timeout twice because the fixture directory and Vitest working directory became separate install-surface candidates. The duplicate timeout did not add process-tree coverage.

## Why This Change Was Made

Scope `process.cwd()` to the fixture root for this one test, deduplicating install-surface candidates while preserving the real subprocess timeout, nested child, tree termination, and descendant-exit assertions. No production or CI configuration changes.

## User Impact

No user-visible behavior change. Maintainers get faster updater-test feedback.

## Evidence

- Blacksmith Testbox `tbx_01kxppfzdfks8e7s53h8ttfy1j`: https://github.com/openclaw/openclaw/actions/runs/29543978103
- Focused command: `pnpm test src/infra/update-runner.test.ts -t "kills nested updater subprocesses when a default command times out"`
- Three-run median test-body time: 2.524s before, 1.707s after (32.4% faster)
- Full file: `pnpm test src/infra/update-runner.test.ts`, 62/62 passed; target 1.672s
- Remote `pnpm check:changed`: passed
- Autoreview: clean, no accepted/actionable findings

AI-assisted; reviewed and understood.
