### PR TITLE
fix(windows): bound encoding probe spawns to prevent startup hangs

### DIFF
--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -3,6 +3,10 @@ import { spawnSync } from "node:child_process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { getWindowsCmdExePath } from "./windows-install-roots.js";
 
+// These synchronous probes run during gateway startup and first output decode.
+// A stalled encoding probe should not block the process indefinitely.
+const WINDOWS_ENCODING_PROBE_TIMEOUT_MS = 5_000;
+
 const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
   65001: "utf-8",
   54936: "gb18030",
@@ -54,6 +58,8 @@ export function resolveWindowsConsoleEncoding(): string | null {
       windowsHide: true,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      timeout: WINDOWS_ENCODING_PROBE_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
     const codePage = parseWindowsCodePage(raw);
@@ -81,6 +87,8 @@ export function resolveWindowsSystemEncoding(): string | null {
         windowsHide: true,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        timeout: WINDOWS_ENCODING_PROBE_TIMEOUT_MS,
+        killSignal: "SIGKILL",
       },
     );
     const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;


### PR DESCRIPTION
## What Problem This Solves

The chcp and PowerShell code-page probes in `resolveWindowsConsoleEncoding` and `resolveWindowsSystemEncoding` run synchronously during gateway startup and first output decode. Neither `spawnSync` call carried a timeout, so a stalled console or system code-page probe could block the process indefinitely — particularly on CJK systems where encoding detection is load-bearing.

## Why This Change Was Made

Add `WINDOWS_ENCODING_PROBE_TIMEOUT_MS` (5 seconds) and `killSignal: "SIGKILL"` to both spawnSync calls. The existing catch blocks already return `null` (cached fallback) on any error, so the change only makes the timeout path reachable when a probe stalls. Encoding behavior is unchanged for non-stalled probes.

The 5s constant follows the same bounded-probe pattern applied to macOS `sw_vers` lookups (#109241) and Windows console probes (#109319).

## User Impact

Windows gateway startup and first-turn output decoding are no longer blocked indefinitely by a stalled encoding probe. On timeout the cached fallback (`null`) is returned.

## Evidence

- `src/infra/windows-encoding.ts` — 2 spawnSync calls bounded with `timeout: 5000, killSignal: "SIGKILL"`
- `pnpm test src/infra/windows-encoding.test.ts` — 8 passed, 0 regressions
- `oxfmt --check` + `oxlint` on changed file
- `git diff origin/main...HEAD --check` — clean
- Function probe on Windows:
```
$ node --import tsx -e "..."
platform: win32
console encoding: gbk
system encoding: gbk
Timeout constant: WINDOWS_ENCODING_PROBE_TIMEOUT_MS = 5000
```