### PR TITLE
fix(cron): stop a cron job's own marker from blocking its awaited wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ Docs: https://docs.openclaw.ai
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
-- **Cron main-session wake delivery:** let a `wakeMode: "now"` job ignore only its own active marker so the awaited heartbeat delivers before the run reports success. (#109440) Thanks @harjothkhara.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
 - **iOS fresh-install setup:** atomically redact spent setup credentials before Keychain cleanup so a deferred item deletion no longer disconnects a successfully paired device. Fixes #107591. Thanks @dagmarjeeves-lab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
+- **Cron main-session wake delivery:** let a `wakeMode: "now"` job ignore only its own active marker so the awaited heartbeat delivers before the run reports success. (#109440) Thanks @harjothkhara.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
 - **iOS fresh-install setup:** atomically redact spent setup credentials before Keychain cleanup so a deferred item deletion no longer disconnects a successfully paired device. Fixes #107591. Thanks @dagmarjeeves-lab.

--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   clearCronJobActive,
   hasActiveCronJobs,
-  hasActiveCronJobsExcept,
+  hasActiveCronJobsExceptMarker,
   markCronJobActive,
   resetCronActiveJobs,
 } from "./active-jobs.js";
@@ -12,34 +12,36 @@ afterEach(() => {
   resetCronActiveJobs();
 });
 
-describe("hasActiveCronJobsExcept", () => {
+describe("hasActiveCronJobsExceptMarker", () => {
   it("discounts only the named job's own marker", () => {
-    markCronJobActive("nightly-report");
+    const marker = markCronJobActive("nightly-report");
 
     expect(hasActiveCronJobs()).toBe(true);
-    expect(hasActiveCronJobsExcept("nightly-report")).toBe(false);
+    expect(hasActiveCronJobsExceptMarker(marker!)).toBe(false);
   });
 
   it("still reports busy while an unrelated job is active", () => {
-    markCronJobActive("nightly-report");
+    const marker = markCronJobActive("nightly-report");
     markCronJobActive("different-job");
 
     // The owning job must not be waved through while another run holds a marker:
     // cron executes jobs concurrently (cron.maxConcurrentRuns).
-    expect(hasActiveCronJobsExcept("nightly-report")).toBe(true);
+    expect(hasActiveCronJobsExceptMarker(marker!)).toBe(true);
   });
 
   it("reports idle once the unrelated job clears", () => {
-    markCronJobActive("nightly-report");
+    const marker = markCronJobActive("nightly-report");
     const otherMarker = markCronJobActive("different-job");
     clearCronJobActive("different-job", otherMarker);
 
-    expect(hasActiveCronJobsExcept("nightly-report")).toBe(false);
+    expect(hasActiveCronJobsExceptMarker(marker!)).toBe(false);
   });
 
-  it("falls back to the plain busy check when no job id is given", () => {
-    markCronJobActive("nightly-report");
+  it("does not discount a replacement marker with the same job id", () => {
+    const staleMarker = markCronJobActive("nightly-report");
+    const replacementMarker = markCronJobActive("nightly-report");
 
-    expect(hasActiveCronJobsExcept("")).toBe(true);
+    expect(hasActiveCronJobsExceptMarker(staleMarker!)).toBe(true);
+    expect(hasActiveCronJobsExceptMarker(replacementMarker!)).toBe(false);
   });
 });

--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -1,0 +1,45 @@
+// Unit coverage for the active-job accounting the heartbeat busy guard depends on.
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearCronJobActive,
+  hasActiveCronJobs,
+  hasActiveCronJobsExcept,
+  markCronJobActive,
+  resetCronActiveJobs,
+} from "./active-jobs.js";
+
+afterEach(() => {
+  resetCronActiveJobs();
+});
+
+describe("hasActiveCronJobsExcept", () => {
+  it("discounts only the named job's own marker", () => {
+    markCronJobActive("nightly-report");
+
+    expect(hasActiveCronJobs()).toBe(true);
+    expect(hasActiveCronJobsExcept("nightly-report")).toBe(false);
+  });
+
+  it("still reports busy while an unrelated job is active", () => {
+    markCronJobActive("nightly-report");
+    markCronJobActive("different-job");
+
+    // The owning job must not be waved through while another run holds a marker:
+    // cron executes jobs concurrently (cron.maxConcurrentRuns).
+    expect(hasActiveCronJobsExcept("nightly-report")).toBe(true);
+  });
+
+  it("reports idle once the unrelated job clears", () => {
+    markCronJobActive("nightly-report");
+    const otherMarker = markCronJobActive("different-job");
+    clearCronJobActive("different-job", otherMarker);
+
+    expect(hasActiveCronJobsExcept("nightly-report")).toBe(false);
+  });
+
+  it("falls back to the plain busy check when no job id is given", () => {
+    markCronJobActive("nightly-report");
+
+    expect(hasActiveCronJobsExcept("")).toBe(true);
+  });
+});

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -145,18 +145,15 @@ export function hasActiveCronJobs() {
 }
 
 /**
- * Returns whether any cron run other than `jobId` is active. A job's own marker must
- * not block its own synchronous wake, but every other job's marker still must: cron
- * runs concurrently (cron.maxConcurrentRuns), so discounting all markers would let one
- * job's wake execute while an unrelated job is mid-run.
+ * Ignore only the caller's own marker. Unrelated runs must still block its wake,
+ * because cron jobs may execute concurrently.
  */
-export function hasActiveCronJobsExcept(jobId: string) {
-  if (!jobId) {
-    return hasActiveCronJobs();
-  }
+export function hasActiveCronJobsExceptMarker(markerToIgnore: CronActiveJobMarker) {
   const state = getCronActiveJobState();
   for (const marker of state.activeJobs.values()) {
-    if (marker.jobId !== jobId && isMarkerActiveInGeneration(marker, state.generation)) {
+    const isIgnoredMarker =
+      marker.jobId === markerToIgnore.jobId && marker.token === markerToIgnore.token;
+    if (!isIgnoredMarker && isMarkerActiveInGeneration(marker, state.generation)) {
       return true;
     }
   }

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -144,6 +144,25 @@ export function hasActiveCronJobs() {
   return getActiveCronJobCountForGeneration(getCronActiveJobState()) > 0;
 }
 
+/**
+ * Returns whether any cron run other than `jobId` is active. A job's own marker must
+ * not block its own synchronous wake, but every other job's marker still must: cron
+ * runs concurrently (cron.maxConcurrentRuns), so discounting all markers would let one
+ * job's wake execute while an unrelated job is mid-run.
+ */
+export function hasActiveCronJobsExcept(jobId: string) {
+  if (!jobId) {
+    return hasActiveCronJobs();
+  }
+  const state = getCronActiveJobState();
+  for (const marker of state.activeJobs.values()) {
+    if (marker.jobId !== jobId && isMarkerActiveInGeneration(marker, state.generation)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Returns the number of active cron runs in this process. */
 export function getActiveCronJobCount() {
   return getActiveCronJobCountForGeneration(getCronActiveJobState());

--- a/src/cron/service.wake-now-real-heartbeat.test.ts
+++ b/src/cron/service.wake-now-real-heartbeat.test.ts
@@ -1,0 +1,132 @@
+// Scheduler-level proof for #105257: the real CronService drives the real heartbeat
+// runner, so the job's own active marker (set by the scheduler) meets the real busy
+// guard. Every other cron test stubs runHeartbeatOnce, which hides that interaction:
+// pre-fix the guard self-tripped, cron took its async fallback, and the run was
+// reported ok without the queued event ever being delivered.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
+import {
+  seedMainSessionStore,
+  setupTelegramHeartbeatPluginRuntimeForTests,
+} from "../infra/heartbeat-runner.test-utils.js";
+import {
+  consumeSelectedSystemEventEntries,
+  enqueueSystemEventEntry,
+  resetSystemEventsForTest,
+} from "../infra/system-events.js";
+import { CronService } from "./service.js";
+import type { CronServiceDeps } from "./service/state.js";
+
+setupTelegramHeartbeatPluginRuntimeForTests();
+
+afterEach(() => {
+  resetSystemEventsForTest();
+  vi.restoreAllMocks();
+});
+
+const noopLogger = { debug() {}, info() {}, warn() {}, error() {} };
+
+async function makeSandbox() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-real-heartbeat-"));
+  return {
+    dir,
+    cronStorePath: path.join(dir, "cron", "jobs.json"),
+    sessionStorePath: path.join(dir, "sessions.json"),
+    cleanup: () => fs.rm(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("wakeMode:now main cron with the real heartbeat runner (#105257)", () => {
+  it("runs the turn synchronously instead of falling back to an unconfirmed async wake", async () => {
+    const sandbox = await makeSandbox();
+    const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled the reminder" });
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
+    const requestHeartbeat = vi.fn();
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: sandbox.dir,
+          heartbeat: { every: "5m", target: "telegram" },
+        },
+      },
+      channels: { telegram: { allowFrom: ["*"] } },
+      session: { store: sandbox.sessionStorePath },
+    };
+    await seedMainSessionStore(sandbox.sessionStorePath, cfg, {
+      lastChannel: "telegram",
+      lastProvider: "telegram",
+      lastTo: "-100155462274",
+    });
+
+    // The model call is the only mocked boundary; the busy guard, the active-job
+    // marker, and the system-event queue are all real.
+    const runHeartbeatOnceReal: NonNullable<CronServiceDeps["runHeartbeatOnce"]> = (opts) =>
+      runHeartbeatOnce({
+        ...opts,
+        cfg,
+        deps: { getReplyFromConfig: getReplySpy, telegram: sendTelegram },
+      });
+
+    const cron = new CronService({
+      storePath: sandbox.cronStorePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: (text, opts) => {
+        const event = enqueueSystemEventEntry(text, {
+          sessionKey: opts?.sessionKey as string,
+          contextKey: opts?.contextKey,
+          deliveryContext: opts?.deliveryContext,
+        });
+        return event
+          ? {
+              accepted: true,
+              remove: () =>
+                consumeSelectedSystemEventEntries(opts?.sessionKey as string, [event]).length > 0,
+            }
+          : { accepted: false };
+      },
+      requestHeartbeat,
+      runHeartbeatOnce: runHeartbeatOnceReal,
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok",
+      })) as unknown as CronServiceDeps["runIsolatedAgentJob"],
+    });
+    await cron.start();
+
+    try {
+      // Scheduled far ahead so only the explicit forced run fires: an already-due job
+      // would race the running scheduler's own timer against cron.run below.
+      const job = await cron.add({
+        enabled: true,
+        name: "nightly report",
+        schedule: { kind: "at", at: new Date(Date.now() + 60 * 60_000).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "Reminder: Send the nightly report" },
+      });
+
+      await cron.run(job.id, "force");
+
+      // Pre-fix the job's own marker tripped the guard, so the turn never ran here and
+      // cron queued an unconfirmed async wake instead while still reporting ok.
+      expect(getReplySpy).toHaveBeenCalledTimes(1);
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+
+      // Assert the cron payload actually reached the model on the job's own per-run
+      // session key. A bare heartbeat turn would satisfy the call count above.
+      const [ctx] = getReplySpy.mock.calls[0] ?? [];
+      const replyCtx = ctx as { Provider?: string; SessionKey?: string; Body?: string };
+      expect(replyCtx.Provider).toBe("cron-event");
+      expect(replyCtx.SessionKey).toContain(`:cron:${job.id}:run:`);
+      expect(replyCtx.Body).toContain("Reminder: Send the nightly report");
+    } finally {
+      await cron.stop();
+      await sandbox.cleanup();
+    }
+  });
+});

--- a/src/cron/service.wake-now-real-heartbeat.test.ts
+++ b/src/cron/service.wake-now-real-heartbeat.test.ts
@@ -1,9 +1,8 @@
 // Exercise the scheduler's active marker against the real heartbeat busy guard.
 // Stubbing runHeartbeatOnce hides this cross-owner interaction.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import {
@@ -22,6 +21,7 @@ import { CronService, type CronEvent } from "./service.js";
 import type { CronServiceDeps } from "./service/state.js";
 
 setupTelegramHeartbeatPluginRuntimeForTests();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   resetSystemEventsForTest();
@@ -31,20 +31,19 @@ afterEach(() => {
 
 const noopLogger = { debug() {}, info() {}, warn() {}, error() {} };
 
-async function makeSandbox() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-real-heartbeat-"));
+function makeSandbox() {
+  const dir = tempDirs.make("openclaw-cron-real-heartbeat-");
   return {
     dir,
     cronStorePath: path.join(dir, "cron", "jobs.json"),
     sessionStorePath: path.join(dir, "sessions.json"),
-    cleanup: () => fs.rm(dir, { recursive: true, force: true }),
   };
 }
 
 type WakeNowRunMode = "direct" | "queued" | "scheduled";
 
 async function runWakeNowCase(mode: WakeNowRunMode) {
-  const sandbox = await makeSandbox();
+  const sandbox = makeSandbox();
   const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled the reminder" });
   const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
   const requestHeartbeat = vi.fn();
@@ -153,7 +152,6 @@ async function runWakeNowCase(mode: WakeNowRunMode) {
     const drained = await waitForActiveCronJobs(5_000);
     expect(drained).toEqual({ drained: true, active: 0 });
     await vi.waitFor(() => expect(getQueueSize(CommandLane.Cron)).toBe(0), { timeout: 5_000 });
-    await sandbox.cleanup();
   }
 }
 

--- a/src/cron/service.wake-now-real-heartbeat.test.ts
+++ b/src/cron/service.wake-now-real-heartbeat.test.ts
@@ -1,8 +1,5 @@
-// Scheduler-level proof for #105257: the real CronService drives the real heartbeat
-// runner, so the job's own active marker (set by the scheduler) meets the real busy
-// guard. Every other cron test stubs runHeartbeatOnce, which hides that interaction:
-// pre-fix the guard self-tripped, cron took its async fallback, and the run was
-// reported ok without the queued event ever being delivered.
+// Exercise the scheduler's active marker against the real heartbeat busy guard.
+// Stubbing runHeartbeatOnce hides this cross-owner interaction.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -18,13 +15,17 @@ import {
   enqueueSystemEventEntry,
   resetSystemEventsForTest,
 } from "../infra/system-events.js";
-import { CronService } from "./service.js";
+import { getQueueSize } from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
+import { resetCronActiveJobs, waitForActiveCronJobs } from "./active-jobs.js";
+import { CronService, type CronEvent } from "./service.js";
 import type { CronServiceDeps } from "./service/state.js";
 
 setupTelegramHeartbeatPluginRuntimeForTests();
 
 afterEach(() => {
   resetSystemEventsForTest();
+  resetCronActiveJobs();
   vi.restoreAllMocks();
 });
 
@@ -40,93 +41,132 @@ async function makeSandbox() {
   };
 }
 
-describe("wakeMode:now main cron with the real heartbeat runner (#105257)", () => {
-  it("runs the turn synchronously instead of falling back to an unconfirmed async wake", async () => {
-    const sandbox = await makeSandbox();
-    const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled the reminder" });
-    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
-    const requestHeartbeat = vi.fn();
+type WakeNowRunMode = "direct" | "queued" | "scheduled";
 
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: {
-          workspace: sandbox.dir,
-          heartbeat: { every: "5m", target: "telegram" },
-        },
+async function runWakeNowCase(mode: WakeNowRunMode) {
+  const sandbox = await makeSandbox();
+  const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled the reminder" });
+  const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
+  const requestHeartbeat = vi.fn();
+  let resolveFinished: ((event: CronEvent) => void) | undefined;
+  const finished = new Promise<CronEvent>((resolve) => {
+    resolveFinished = resolve;
+  });
+
+  const cfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        workspace: sandbox.dir,
+        heartbeat: { every: "5m", target: "telegram" },
       },
-      channels: { telegram: { allowFrom: ["*"] } },
-      session: { store: sandbox.sessionStorePath },
-    };
-    await seedMainSessionStore(sandbox.sessionStorePath, cfg, {
-      lastChannel: "telegram",
-      lastProvider: "telegram",
-      lastTo: "-100155462274",
+    },
+    channels: { telegram: { allowFrom: ["*"] } },
+    session: { store: sandbox.sessionStorePath },
+  };
+  await seedMainSessionStore(sandbox.sessionStorePath, cfg, {
+    lastChannel: "telegram",
+    lastProvider: "telegram",
+    lastTo: "-100155462274",
+  });
+
+  const runHeartbeatOnceReal: NonNullable<CronServiceDeps["runHeartbeatOnce"]> = (opts) =>
+    runHeartbeatOnce({
+      ...opts,
+      cfg,
+      deps: { getReplyFromConfig: getReplySpy, telegram: sendTelegram },
     });
 
-    // The model call is the only mocked boundary; the busy guard, the active-job
-    // marker, and the system-event queue are all real.
-    const runHeartbeatOnceReal: NonNullable<CronServiceDeps["runHeartbeatOnce"]> = (opts) =>
-      runHeartbeatOnce({
-        ...opts,
-        cfg,
-        deps: { getReplyFromConfig: getReplySpy, telegram: sendTelegram },
+  const cron = new CronService({
+    storePath: sandbox.cronStorePath,
+    cronEnabled: true,
+    log: noopLogger,
+    enqueueSystemEvent: (text, opts) => {
+      const event = enqueueSystemEventEntry(text, {
+        sessionKey: opts?.sessionKey as string,
+        contextKey: opts?.contextKey,
+        deliveryContext: opts?.deliveryContext,
       });
+      return event
+        ? {
+            accepted: true,
+            remove: () =>
+              consumeSelectedSystemEventEntries(opts?.sessionKey as string, [event]).length > 0,
+          }
+        : { accepted: false };
+    },
+    requestHeartbeat,
+    runHeartbeatOnce: runHeartbeatOnceReal,
+    runIsolatedAgentJob: vi.fn(async () => ({
+      status: "ok",
+    })) as unknown as CronServiceDeps["runIsolatedAgentJob"],
+    onEvent: (event) => {
+      if (event.action === "finished") {
+        resolveFinished?.(event);
+      }
+    },
+  });
+  await cron.start();
 
-    const cron = new CronService({
-      storePath: sandbox.cronStorePath,
-      cronEnabled: true,
-      log: noopLogger,
-      enqueueSystemEvent: (text, opts) => {
-        const event = enqueueSystemEventEntry(text, {
-          sessionKey: opts?.sessionKey as string,
-          contextKey: opts?.contextKey,
-          deliveryContext: opts?.deliveryContext,
-        });
-        return event
-          ? {
-              accepted: true,
-              remove: () =>
-                consumeSelectedSystemEventEntries(opts?.sessionKey as string, [event]).length > 0,
-            }
-          : { accepted: false };
+  try {
+    const job = await cron.add({
+      enabled: true,
+      name: "nightly report",
+      schedule: {
+        kind: "at",
+        at: new Date(Date.now() + (mode === "scheduled" ? 250 : 60 * 60_000)).toISOString(),
       },
-      requestHeartbeat,
-      runHeartbeatOnce: runHeartbeatOnceReal,
-      runIsolatedAgentJob: vi.fn(async () => ({
-        status: "ok",
-      })) as unknown as CronServiceDeps["runIsolatedAgentJob"],
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "Reminder: Send the nightly report" },
     });
-    await cron.start();
 
-    try {
-      // Scheduled far ahead so only the explicit forced run fires: an already-due job
-      // would race the running scheduler's own timer against cron.run below.
-      const job = await cron.add({
-        enabled: true,
-        name: "nightly report",
-        schedule: { kind: "at", at: new Date(Date.now() + 60 * 60_000).toISOString() },
-        sessionTarget: "main",
-        wakeMode: "now",
-        payload: { kind: "systemEvent", text: "Reminder: Send the nightly report" },
-      });
-
+    if (mode === "direct") {
       await cron.run(job.id, "force");
-
-      // Pre-fix the job's own marker tripped the guard, so the turn never ran here and
-      // cron queued an unconfirmed async wake instead while still reporting ok.
-      expect(getReplySpy).toHaveBeenCalledTimes(1);
-      expect(requestHeartbeat).not.toHaveBeenCalled();
-
-      // Assert the cron payload actually reached the model on the job's own per-run
-      // session key. A bare heartbeat turn would satisfy the call count above.
-      const [ctx] = getReplySpy.mock.calls[0] ?? [];
-      const replyCtx = ctx as { Provider?: string; SessionKey?: string; Body?: string };
-      expect(replyCtx.Provider).toBe("cron-event");
-      expect(replyCtx.SessionKey).toContain(`:cron:${job.id}:run:`);
-      expect(replyCtx.Body).toContain("Reminder: Send the nightly report");
-    } finally {
-      cron.stop();
-      await sandbox.cleanup();
+    } else if (mode === "queued") {
+      await expect(cron.enqueueRun(job.id, "force")).resolves.toMatchObject({
+        ok: true,
+        enqueued: true,
+      });
     }
+
+    let finishTimeout: ReturnType<typeof setTimeout> | undefined;
+    const terminal = await Promise.race([
+      finished,
+      new Promise<never>((_, reject) => {
+        finishTimeout = setTimeout(
+          () => reject(new Error(`${mode} cron run did not finish`)),
+          10_000,
+        );
+      }),
+    ]).finally(() => clearTimeout(finishTimeout));
+    expect(terminal.status).toBe("ok");
+    expect(getReplySpy).toHaveBeenCalledTimes(1);
+    expect(requestHeartbeat).not.toHaveBeenCalled();
+
+    const [ctx] = getReplySpy.mock.calls[0] ?? [];
+    const replyCtx = ctx as { Provider?: string; SessionKey?: string; Body?: string };
+    expect(replyCtx.Provider).toBe("cron-event");
+    expect(replyCtx.SessionKey).toContain(`:cron:${job.id}:run:`);
+    expect(replyCtx.Body).toContain("Reminder: Send the nightly report");
+  } finally {
+    cron.stop();
+    const drained = await waitForActiveCronJobs(5_000);
+    expect(drained).toEqual({ drained: true, active: 0 });
+    await vi.waitFor(() => expect(getQueueSize(CommandLane.Cron)).toBe(0), { timeout: 5_000 });
+    await sandbox.cleanup();
+  }
+}
+
+describe("wakeMode:now main cron with the real heartbeat runner", () => {
+  it("delivers during a direct manual run", async () => {
+    await runWakeNowCase("direct");
+  });
+
+  it("delivers before a command-lane queued run finishes", async () => {
+    await runWakeNowCase("queued");
+  });
+
+  it("delivers during a natural scheduled run", async () => {
+    await runWakeNowCase("scheduled");
   });
 });

--- a/src/cron/service.wake-now-real-heartbeat.test.ts
+++ b/src/cron/service.wake-now-real-heartbeat.test.ts
@@ -125,7 +125,7 @@ describe("wakeMode:now main cron with the real heartbeat runner (#105257)", () =
       expect(replyCtx.SessionKey).toContain(`:cron:${job.id}:run:`);
       expect(replyCtx.Body).toContain("Reminder: Send the nightly report");
     } finally {
-      await cron.stop();
+      cron.stop();
       await sandbox.cleanup();
     }
   });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -4,7 +4,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { enqueueCommandInLane, type CommandLaneTaskMarker } from "../../process/command-queue.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
@@ -737,6 +737,7 @@ type PreparedManualRun =
       jobId: string;
       runId?: string;
       terminalTracker?: ManualRunTerminalTracker;
+      owningCronLaneTaskMarker?: CommandLaneTaskMarker;
       reservationAt: number;
       reservationIdentity: object;
       wasEnabled: boolean;
@@ -755,6 +756,7 @@ type ManualRunOptions = {
   runId?: string;
   payload?: CronPayload;
   terminalTracker?: ManualRunTerminalTracker;
+  owningCronLaneTaskMarker?: CommandLaneTaskMarker;
 };
 
 type ManualRunTerminalTracker = { emitted: boolean };
@@ -1009,6 +1011,7 @@ async function prepareManualRun(
       jobId: job.id,
       runId: opts?.runId,
       terminalTracker: opts?.terminalTracker,
+      owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
       reservationAt,
       reservationIdentity,
       wasEnabled: isJobEnabled(job),
@@ -1212,6 +1215,7 @@ async function finishPreparedManualRun(
       coreResult = await executeJobCoreWithTimeout(state, executionJob, {
         runId: taskRunId,
         activeJobMarker: prepared.activeJobMarker,
+        owningCronLaneTaskMarker: prepared.owningCronLaneTaskMarker,
       });
     } catch (err) {
       coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
@@ -1459,8 +1463,12 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
   void runWithGatewayIndependentRootWorkContinuation(() =>
     enqueueCommandInLane(
       CommandLane.Cron,
-      async () => {
-        const result = await run(state, id, mode, { runId, terminalTracker });
+      async (owningCronLaneTaskMarker) => {
+        const result = await run(state, id, mode, {
+          runId,
+          terminalTracker,
+          owningCronLaneTaskMarker,
+        });
         if (result.ok && "ran" in result && !result.ran) {
           if (result.reason !== "invalid-spec") {
             const finishedAt = state.deps.nowMs();

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -2,6 +2,7 @@
 import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult, HeartbeatWakeRequest } from "../../infra/heartbeat-wake.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import type { CronActiveJobMarker } from "../active-jobs.js";
 import type { QuarantinedCronConfigJob } from "../store.js";
 import type {
   CronTriggerEvaluationResult,
@@ -125,8 +126,8 @@ export type CronServiceDeps = {
     reason?: string;
     agentId?: string;
     sessionKey?: string;
-    /** Cron job id whose own active marker must not block its awaited wake. */
-    owningCronJobId?: string;
+    /** Exact cron run marker whose own activity must not block its awaited wake. */
+    owningCronJobMarker?: CronActiveJobMarker;
     /** Optional heartbeat config override (e.g. target: "last" for cron-triggered heartbeats). */
     heartbeat?: HeartbeatWakeRequest["heartbeat"];
   }) => Promise<HeartbeatRunResult>;

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -125,6 +125,8 @@ export type CronServiceDeps = {
     reason?: string;
     agentId?: string;
     sessionKey?: string;
+    /** Cron job id whose own active marker must not block its awaited wake. */
+    owningCronJobId?: string;
     /** Optional heartbeat config override (e.g. target: "last" for cron-triggered heartbeats). */
     heartbeat?: HeartbeatWakeRequest["heartbeat"];
   }) => Promise<HeartbeatRunResult>;

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -1,6 +1,7 @@
 /** Cron service dependency, event, state, and public result types. */
 import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult, HeartbeatWakeRequest } from "../../infra/heartbeat-wake.js";
+import type { CommandLaneTaskMarker } from "../../process/command-queue.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { CronActiveJobMarker } from "../active-jobs.js";
 import type { QuarantinedCronConfigJob } from "../store.js";
@@ -128,6 +129,8 @@ export type CronServiceDeps = {
     sessionKey?: string;
     /** Exact cron run marker whose own activity must not block its awaited wake. */
     owningCronJobMarker?: CronActiveJobMarker;
+    /** Exact command-lane task whose own slot must not block its awaited wake. */
+    owningCronLaneTaskMarker?: CommandLaneTaskMarker;
     /** Optional heartbeat config override (e.g. target: "last" for cron-triggered heartbeats). */
     heartbeat?: HeartbeatWakeRequest["heartbeat"];
   }) => Promise<HeartbeatRunResult>;

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -129,6 +129,7 @@ describe("cron service timer seam coverage", () => {
       reason: "cron:main-heartbeat-job",
       agentId: undefined,
       sessionKey: cronRunSessionKey,
+      owningCronJobId: "main-heartbeat-job",
       heartbeat: { target: "last" },
     });
   });

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -129,7 +129,7 @@ describe("cron service timer seam coverage", () => {
       reason: "cron:main-heartbeat-job",
       agentId: undefined,
       sessionKey: cronRunSessionKey,
-      owningCronJobId: "main-heartbeat-job",
+      owningCronJobMarker: undefined,
       heartbeat: { target: "last" },
     });
   });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -10,6 +10,7 @@ import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
   isRetryableHeartbeatBusySkipReason,
 } from "../../infra/heartbeat-wake.js";
+import type { CommandLaneTaskMarker } from "../../process/command-queue.js";
 import {
   beginGatewayRootWorkAdmissionWhenOpen,
   GatewayDrainingError,
@@ -198,6 +199,7 @@ type StartupCatchupExecution =
 
 type ExecuteJobCoreOptions = {
   activeJobMarker?: CronActiveJobMarker;
+  owningCronLaneTaskMarker?: CommandLaneTaskMarker;
   onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
   onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
   onLaneWait?: (info?: { waiting?: boolean }) => void;
@@ -232,7 +234,11 @@ function cronRunAttributionFromExecution(execution?: CronAgentExecutionStarted):
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
-  opts?: { runId?: string; activeJobMarker?: CronActiveJobMarker },
+  opts?: {
+    runId?: string;
+    activeJobMarker?: CronActiveJobMarker;
+    owningCronLaneTaskMarker?: CommandLaneTaskMarker;
+  },
 ): Promise<CronCoreRunOutcome> {
   const runAbortController = new AbortController();
   const operatorCancellationMarker = Symbol("cron-operator-cancelled");
@@ -278,6 +284,7 @@ export async function executeJobCoreWithTimeout(
       };
       const corePromise = executeJobCore(state, job, runAbortController.signal, {
         activeJobMarker: opts?.activeJobMarker,
+        owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
         onExecutionStarted: accumulateExecution,
         onExecutionPhase: accumulateExecution,
       });
@@ -332,6 +339,7 @@ export async function executeJobCoreWithTimeout(
     };
     const corePromise = executeJobCore(state, job, runAbortController.signal, {
       activeJobMarker: opts?.activeJobMarker,
+      owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
       onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
       onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
       onLaneWait: deferTimeoutUntilExecutionStart ? noteLaneState : undefined,
@@ -2510,6 +2518,7 @@ async function executeJobCore(
       abortSignal,
       waitWithAbort,
       options?.activeJobMarker,
+      options?.owningCronLaneTaskMarker,
     );
     return triggerEval ? { ...result, triggerEval } : result;
   }
@@ -2530,6 +2539,7 @@ async function executeMainSessionCronJob(
   abortSignal: AbortSignal | undefined,
   waitWithAbort: (ms: number) => Promise<void>,
   activeJobMarker?: CronActiveJobMarker,
+  owningCronLaneTaskMarker?: CommandLaneTaskMarker,
 ): Promise<
   CronRunOutcome &
     CronRunTelemetry & {
@@ -2583,6 +2593,7 @@ async function executeMainSessionCronJob(
         agentId: job.agentId,
         sessionKey: cronRunSessionKey,
         owningCronJobMarker: activeJobMarker,
+        owningCronLaneTaskMarker,
         heartbeat: { target: "last" },
       });
       if (abortSignal?.aborted) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -2572,6 +2572,7 @@ async function executeMainSessionCronJob(
         reason,
         agentId: job.agentId,
         sessionKey: cronRunSessionKey,
+        owningCronJobId: job.id,
         heartbeat: { target: "last" },
       });
       if (abortSignal?.aborted) {
@@ -2585,7 +2586,11 @@ async function executeMainSessionCronJob(
         break;
       }
       if (heartbeatResult.reason === HEARTBEAT_SKIP_CRON_IN_PROGRESS) {
-        // The active cron marker blocks direct wake-now until this job returns.
+        // Reached only when something OTHER than this job is busy: a concurrent cron
+        // run's marker, or cron-lane pressure. The owning job's own marker no longer
+        // lands here (#105257). Hand off to the targeted async requeue instead of
+        // waiting in place -- two concurrent jobs would otherwise deadlock on each
+        // other's markers, which are not cleared until finalization.
         state.deps.requestHeartbeat({
           source: "cron",
           intent: "immediate",

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -197,6 +197,7 @@ type StartupCatchupExecution =
   | { ok: false; outcomes: TimedCronRunOutcome[]; error: unknown };
 
 type ExecuteJobCoreOptions = {
+  activeJobMarker?: CronActiveJobMarker;
   onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
   onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
   onLaneWait?: (info?: { waiting?: boolean }) => void;
@@ -276,6 +277,7 @@ export async function executeJobCoreWithTimeout(
         }
       };
       const corePromise = executeJobCore(state, job, runAbortController.signal, {
+        activeJobMarker: opts?.activeJobMarker,
         onExecutionStarted: accumulateExecution,
         onExecutionPhase: accumulateExecution,
       });
@@ -329,6 +331,7 @@ export async function executeJobCoreWithTimeout(
       watchdog.noteLaneWait();
     };
     const corePromise = executeJobCore(state, job, runAbortController.signal, {
+      activeJobMarker: opts?.activeJobMarker,
       onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
       onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
       onLaneWait: deferTimeoutUntilExecutionStart ? noteLaneState : undefined,
@@ -2501,7 +2504,13 @@ async function executeJobCore(
     }
   }
   if (effectiveJob.sessionTarget === "main") {
-    const result = await executeMainSessionCronJob(state, effectiveJob, abortSignal, waitWithAbort);
+    const result = await executeMainSessionCronJob(
+      state,
+      effectiveJob,
+      abortSignal,
+      waitWithAbort,
+      options?.activeJobMarker,
+    );
     return triggerEval ? { ...result, triggerEval } : result;
   }
 
@@ -2520,6 +2529,7 @@ async function executeMainSessionCronJob(
   job: CronJob,
   abortSignal: AbortSignal | undefined,
   waitWithAbort: (ms: number) => Promise<void>,
+  activeJobMarker?: CronActiveJobMarker,
 ): Promise<
   CronRunOutcome &
     CronRunTelemetry & {
@@ -2572,7 +2582,7 @@ async function executeMainSessionCronJob(
         reason,
         agentId: job.agentId,
         sessionKey: cronRunSessionKey,
-        owningCronJobId: job.id,
+        owningCronJobMarker: activeJobMarker,
         heartbeat: { target: "last" },
       });
       if (abortSignal?.aborted) {
@@ -2586,11 +2596,8 @@ async function executeMainSessionCronJob(
         break;
       }
       if (heartbeatResult.reason === HEARTBEAT_SKIP_CRON_IN_PROGRESS) {
-        // Reached only when something OTHER than this job is busy: a concurrent cron
-        // run's marker, or cron-lane pressure. The owning job's own marker no longer
-        // lands here (#105257). Hand off to the targeted async requeue instead of
-        // waiting in place -- two concurrent jobs would otherwise deadlock on each
-        // other's markers, which are not cleared until finalization.
+        // Only another cron run or lane pressure reaches here. Requeue instead of
+        // waiting on markers that cannot clear until both runs finish.
         state.deps.requestHeartbeat({
           source: "cron",
           intent: "immediate",

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1015,10 +1015,8 @@ describe("buildGatewayCronService", () => {
       );
       expect(heartbeatRun.agentId).toBe("main");
       expect(heartbeatRun.sessionKey).toBe("global");
-      // The adapter rebuilds this options object field-by-field, so a dropped
-      // owningCronJobId would silently restore the #105257 self-block: the field is
-      // optional, so nothing but this assertion fails when it goes missing.
-      expect(heartbeatRun.owningCronJobId).toBe(job.id);
+      // The adapter rebuilds this object field-by-field; preserve the optional owner.
+      expect(heartbeatRun.owningCronJobMarker).toMatchObject({ jobId: job.id });
       expect(heartbeatRun.heartbeat).toEqual({
         target: "last",
         to: undefined,

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1107,6 +1107,11 @@ describe("buildGatewayCronService", () => {
                 agentId?: string;
                 sessionKey?: string | null;
                 reason?: string;
+                owningCronLaneTaskMarker?: {
+                  lane: string;
+                  taskId: number;
+                  generation: number;
+                };
                 heartbeat?: { target?: string };
               }) => Promise<unknown>;
             };
@@ -1114,9 +1119,11 @@ describe("buildGatewayCronService", () => {
         }
       ).state?.deps;
 
+      const owningCronLaneTaskMarker = { lane: "cron", taskId: 7, generation: 3 };
       await cronDeps?.runHeartbeatOnce?.({
         reason: "cron:test",
         sessionKey: "telegram:group:123:topic:456",
+        owningCronLaneTaskMarker,
         heartbeat: { target: "last" },
       });
 
@@ -1125,6 +1132,7 @@ describe("buildGatewayCronService", () => {
         "heartbeat run options",
       );
       expect(call.sessionKey).toBe("agent:main:telegram:group:123:topic:456");
+      expect(call.owningCronLaneTaskMarker).toEqual(owningCronLaneTaskMarker);
       expect(call.heartbeat).toEqual({
         every: "1h",
         prompt: "Default heartbeat prompt",

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1015,6 +1015,10 @@ describe("buildGatewayCronService", () => {
       );
       expect(heartbeatRun.agentId).toBe("main");
       expect(heartbeatRun.sessionKey).toBe("global");
+      // The adapter rebuilds this options object field-by-field, so a dropped
+      // owningCronJobId would silently restore the #105257 self-block: the field is
+      // optional, so nothing but this assertion fails when it goes missing.
+      expect(heartbeatRun.owningCronJobId).toBe(job.id);
       expect(heartbeatRun.heartbeat).toEqual({
         target: "last",
         to: undefined,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -529,6 +529,7 @@ export function buildGatewayCronService(params: {
         // Preserve ownership across this adapter so the wake does not self-block on
         // the cron run that is awaiting it.
         owningCronJobMarker: opts?.owningCronJobMarker,
+        owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
         heartbeat: resolveCronHeartbeatOverride({
           runtimeConfig,
           agentId,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -526,10 +526,9 @@ export function buildGatewayCronService(params: {
         reason: opts?.reason,
         agentId,
         sessionKey,
-        // Must forward: without it the owning job's wake self-blocks on its own active
-        // marker and cron falls back to an unconfirmed async wake (#105257). The field is
-        // optional, so dropping it here fails silently rather than at build time.
-        owningCronJobId: opts?.owningCronJobId,
+        // Preserve ownership across this adapter so the wake does not self-block on
+        // the cron run that is awaiting it.
+        owningCronJobMarker: opts?.owningCronJobMarker,
         heartbeat: resolveCronHeartbeatOverride({
           runtimeConfig,
           agentId,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -526,6 +526,10 @@ export function buildGatewayCronService(params: {
         reason: opts?.reason,
         agentId,
         sessionKey,
+        // Must forward: without it the owning job's wake self-blocks on its own active
+        // marker and cron falls back to an unconfirmed async wake (#105257). The field is
+        // optional, so dropping it here fails silently rather than at build time.
+        owningCronJobId: opts?.owningCronJobId,
         heartbeat: resolveCronHeartbeatOverride({
           runtimeConfig,
           agentId,

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import { clearCronJobActive, markCronJobActive, resetCronActiveJobs } from "../cron/active-jobs.js";
+import { enqueueCommandInLane, type CommandLaneTaskMarker } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import {
@@ -192,7 +193,9 @@ describe("Ghost reminder bug (issue #13317)", () => {
     activeCronJobId?: string;
     owningCronJobId?: string;
     replaceOwningCronMarker?: boolean;
+    owningCronLaneTaskMarker?: CommandLaneTaskMarker;
     cronLaneDepth?: number;
+    cronNestedLaneDepth?: number;
   }): Promise<{
     result: Awaited<ReturnType<typeof runHeartbeatOnce>>;
     sendTelegram: ReturnType<typeof vi.fn>;
@@ -235,14 +238,21 @@ describe("Ghost reminder bug (issue #13317)", () => {
             intent: params.intent,
             ...(params.source ? { sessionKey } : {}),
             ...(owningCronJobMarker ? { owningCronJobMarker } : {}),
+            ...(params.owningCronLaneTaskMarker
+              ? { owningCronLaneTaskMarker: params.owningCronLaneTaskMarker }
+              : {}),
             deps: {
               getReplyFromConfig: getReplySpy,
               telegram: sendTelegram,
-              ...(params.cronLaneDepth === undefined
+              ...(params.cronLaneDepth === undefined && params.cronNestedLaneDepth === undefined
                 ? {}
                 : {
                     getQueueSize: (lane?: string) =>
-                      lane === CommandLane.Cron ? (params.cronLaneDepth ?? 0) : 0,
+                      lane === CommandLane.Cron
+                        ? (params.cronLaneDepth ?? 0)
+                        : lane === CommandLane.CronNested
+                          ? (params.cronNestedLaneDepth ?? 0)
+                          : 0,
                   }),
             },
           });
@@ -343,7 +353,6 @@ describe("Ghost reminder bug (issue #13317)", () => {
       intent: "immediate",
       activeCronJobId: "nightly-report",
       owningCronJobId: "nightly-report",
-      cronLaneDepth: 3,
       enqueue: (key) => {
         enqueueSystemEvent("Reminder: Send the nightly report", {
           sessionKey: key,
@@ -355,6 +364,122 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(result.status).toBe("ran");
     expectCronEventPrompt(calledCtx, "Reminder: Send the nightly report");
     expect(peekSystemEvents(sessionKey)).toEqual([]);
+  });
+
+  it("still blocks an owning cron wake while the nested cron lane is busy", async () => {
+    const { result, replyCallCount } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-owner-nested-lane-",
+      replyText: "must not run",
+      reason: "cron:nightly-report",
+      source: "cron",
+      intent: "immediate",
+      owningCronJobId: "nightly-report",
+      cronNestedLaneDepth: 1,
+      enqueue: (key) => {
+        enqueueSystemEvent("Reminder: Send the nightly report", {
+          sessionKey: key,
+          contextKey: "cron:nightly-report",
+        });
+      },
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
+    expect(replyCallCount).toBe(0);
+  });
+
+  it("still blocks an owning cron wake while unrelated cron lane work is queued", async () => {
+    const { result, replyCallCount } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-owner-unrelated-lane-",
+      replyText: "must not run",
+      reason: "cron:nightly-report",
+      source: "cron",
+      intent: "immediate",
+      owningCronJobId: "nightly-report",
+      cronLaneDepth: 1,
+      enqueue: (key) => {
+        enqueueSystemEvent("Reminder: Send the nightly report", {
+          sessionKey: key,
+          contextKey: "cron:nightly-report",
+        });
+      },
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
+    expect(replyCallCount).toBe(0);
+  });
+
+  it("ignores only the exact command lane task that owns the cron wake", async () => {
+    await enqueueCommandInLane(CommandLane.Cron, async (owningCronLaneTaskMarker) => {
+      const ownTaskOnly = await runHeartbeatCase({
+        tmpPrefix: "openclaw-cron-owner-exact-lane-",
+        replyText: "Handled the reminder",
+        reason: "cron:nightly-report",
+        source: "cron",
+        intent: "immediate",
+        owningCronJobId: "nightly-report",
+        owningCronLaneTaskMarker,
+        cronLaneDepth: 1,
+        enqueue: (key) => {
+          enqueueSystemEvent("Reminder: Send the nightly report", {
+            sessionKey: key,
+            contextKey: "cron:nightly-report",
+          });
+        },
+      });
+      expect(ownTaskOnly.result.status).toBe("ran");
+
+      const unrelatedTaskQueued = await runHeartbeatCase({
+        tmpPrefix: "openclaw-cron-owner-second-lane-",
+        replyText: "must not run",
+        reason: "cron:nightly-report",
+        source: "cron",
+        intent: "immediate",
+        owningCronJobId: "nightly-report",
+        owningCronLaneTaskMarker,
+        cronLaneDepth: 2,
+        enqueue: (key) => {
+          enqueueSystemEvent("Reminder: Send the nightly report", {
+            sessionKey: key,
+            contextKey: "cron:nightly-report",
+          });
+        },
+      });
+      expect(unrelatedTaskQueued.result).toEqual({
+        status: "skipped",
+        reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS,
+      });
+      expect(unrelatedTaskQueued.replyCallCount).toBe(0);
+    });
+  });
+
+  it("does not let a stale command lane task marker bypass cron pressure", async () => {
+    let staleMarker: CommandLaneTaskMarker | undefined;
+    await enqueueCommandInLane(CommandLane.Cron, async (marker) => {
+      staleMarker = marker;
+    });
+    if (!staleMarker) {
+      throw new Error("expected command lane marker");
+    }
+
+    const { result, replyCallCount } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-owner-stale-lane-",
+      replyText: "must not run",
+      reason: "cron:nightly-report",
+      source: "cron",
+      intent: "immediate",
+      owningCronJobId: "nightly-report",
+      owningCronLaneTaskMarker: staleMarker,
+      cronLaneDepth: 1,
+      enqueue: (key) => {
+        enqueueSystemEvent("Reminder: Send the nightly report", {
+          sessionKey: key,
+          contextKey: "cron:nightly-report",
+        });
+      },
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
+    expect(replyCallCount).toBe(0);
   });
 
   it("does not let a stale owner marker bypass its replacement", async () => {

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import { clearCronJobActive, markCronJobActive, resetCronActiveJobs } from "../cron/active-jobs.js";
+import { CommandLane } from "../process/lanes.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import {
   seedMainSessionStore,
@@ -190,6 +191,8 @@ describe("Ghost reminder bug (issue #13317)", () => {
     intent?: "immediate";
     activeCronJobId?: string;
     owningCronJobId?: string;
+    replaceOwningCronMarker?: boolean;
+    cronLaneDepth?: number;
   }): Promise<{
     result: Awaited<ReturnType<typeof runHeartbeatOnce>>;
     sendTelegram: ReturnType<typeof vi.fn>;
@@ -211,9 +214,17 @@ describe("Ghost reminder bug (issue #13317)", () => {
           isolatedSession: params.isolatedSession,
         });
         params.enqueue(sessionKey);
-        const activeCronMarker = params.activeCronJobId
-          ? markCronJobActive(params.activeCronJobId)
+        const owningCronJobMarker = params.owningCronJobId
+          ? markCronJobActive(params.owningCronJobId)
           : undefined;
+        const replacementCronJobMarker =
+          params.replaceOwningCronMarker && params.owningCronJobId
+            ? markCronJobActive(params.owningCronJobId)
+            : undefined;
+        const unrelatedCronJobMarker =
+          params.activeCronJobId && params.activeCronJobId !== params.owningCronJobId
+            ? markCronJobActive(params.activeCronJobId)
+            : undefined;
         let result: Awaited<ReturnType<typeof runHeartbeatOnce>>;
         try {
           result = await runHeartbeatOnce({
@@ -223,15 +234,27 @@ describe("Ghost reminder bug (issue #13317)", () => {
             source: params.source,
             intent: params.intent,
             ...(params.source ? { sessionKey } : {}),
-            ...(params.owningCronJobId ? { owningCronJobId: params.owningCronJobId } : {}),
+            ...(owningCronJobMarker ? { owningCronJobMarker } : {}),
             deps: {
               getReplyFromConfig: getReplySpy,
               telegram: sendTelegram,
+              ...(params.cronLaneDepth === undefined
+                ? {}
+                : {
+                    getQueueSize: (lane?: string) =>
+                      lane === CommandLane.Cron ? (params.cronLaneDepth ?? 0) : 0,
+                  }),
             },
           });
         } finally {
-          if (params.activeCronJobId && activeCronMarker) {
-            clearCronJobActive(params.activeCronJobId, activeCronMarker);
+          if (params.activeCronJobId && unrelatedCronJobMarker) {
+            clearCronJobActive(params.activeCronJobId, unrelatedCronJobMarker);
+          }
+          if (params.owningCronJobId && owningCronJobMarker) {
+            if (replacementCronJobMarker) {
+              clearCronJobActive(params.owningCronJobId, replacementCronJobMarker);
+            }
+            clearCronJobActive(params.owningCronJobId, owningCronJobMarker);
           }
         }
         const calledCtx =
@@ -311,7 +334,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(sendTelegram).toHaveBeenCalled();
   });
 
-  it("delivers a targeted cron event while its owning job is active (#105257)", async () => {
+  it("delivers a targeted cron event while its owning job is active", async () => {
     const { result, calledCtx, sessionKey } = await runHeartbeatCase({
       tmpPrefix: "openclaw-cron-active-job-",
       replyText: "Handled the reminder",
@@ -320,6 +343,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
       intent: "immediate",
       activeCronJobId: "nightly-report",
       owningCronJobId: "nightly-report",
+      cronLaneDepth: 3,
       enqueue: (key) => {
         enqueueSystemEvent("Reminder: Send the nightly report", {
           sessionKey: key,
@@ -333,7 +357,28 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(peekSystemEvents(sessionKey)).toEqual([]);
   });
 
-  it("still blocks an owning cron wake while an unrelated job is active (#105257)", async () => {
+  it("does not let a stale owner marker bypass its replacement", async () => {
+    const { result, replyCallCount } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-replaced-owner-",
+      replyText: "must not run",
+      reason: "cron:nightly-report",
+      source: "cron",
+      intent: "immediate",
+      owningCronJobId: "nightly-report",
+      replaceOwningCronMarker: true,
+      enqueue: (key) => {
+        enqueueSystemEvent("Reminder: Send the nightly report", {
+          sessionKey: key,
+          contextKey: "cron:nightly-report",
+        });
+      },
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
+    expect(replyCallCount).toBe(0);
+  });
+
+  it("still blocks an owning cron wake while an unrelated job is active", async () => {
     const { result, replyCallCount } = await runHeartbeatCase({
       tmpPrefix: "openclaw-cron-unrelated-active-job-",
       replyText: "must not run",
@@ -354,7 +399,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(replyCallCount).toBe(0);
   });
 
-  it("still blocks a cron wake that claims no owning job while a job is active (#105257)", async () => {
+  it("still blocks a cron wake that claims no owning job while a job is active", async () => {
     const { result, replyCallCount } = await runHeartbeatCase({
       tmpPrefix: "openclaw-cron-unowned-wake-",
       replyText: "must not run",

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import { clearCronJobActive, markCronJobActive, resetCronActiveJobs } from "../cron/active-jobs.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import {
   seedMainSessionStore,
@@ -9,11 +10,13 @@ import {
   setupTelegramHeartbeatPluginRuntimeForTests,
   withTempHeartbeatSandbox,
 } from "./heartbeat-runner.test-utils.js";
+import { HEARTBEAT_SKIP_CRON_IN_PROGRESS } from "./heartbeat-wake.js";
 import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
 
 beforeEach(() => {
   setupTelegramHeartbeatPluginRuntimeForTests();
   resetSystemEventsForTest();
+  resetCronActiveJobs();
 });
 
 afterEach(() => {
@@ -183,6 +186,10 @@ describe("Ghost reminder bug (issue #13317)", () => {
     enqueue: (sessionKey: string) => void;
     target?: "telegram" | "none";
     isolatedSession?: boolean;
+    source?: "cron";
+    intent?: "immediate";
+    activeCronJobId?: string;
+    owningCronJobId?: string;
   }): Promise<{
     result: Awaited<ReturnType<typeof runHeartbeatOnce>>;
     sendTelegram: ReturnType<typeof vi.fn>;
@@ -204,15 +211,29 @@ describe("Ghost reminder bug (issue #13317)", () => {
           isolatedSession: params.isolatedSession,
         });
         params.enqueue(sessionKey);
-        const result = await runHeartbeatOnce({
-          cfg,
-          agentId: "main",
-          reason: params.reason,
-          deps: {
-            getReplyFromConfig: getReplySpy,
-            telegram: sendTelegram,
-          },
-        });
+        const activeCronMarker = params.activeCronJobId
+          ? markCronJobActive(params.activeCronJobId)
+          : undefined;
+        let result: Awaited<ReturnType<typeof runHeartbeatOnce>>;
+        try {
+          result = await runHeartbeatOnce({
+            cfg,
+            agentId: "main",
+            reason: params.reason,
+            source: params.source,
+            intent: params.intent,
+            ...(params.source ? { sessionKey } : {}),
+            ...(params.owningCronJobId ? { owningCronJobId: params.owningCronJobId } : {}),
+            deps: {
+              getReplyFromConfig: getReplySpy,
+              telegram: sendTelegram,
+            },
+          });
+        } finally {
+          if (params.activeCronJobId && activeCronMarker) {
+            clearCronJobActive(params.activeCronJobId, activeCronMarker);
+          }
+        }
         const calledCtx =
           getReplySpy.mock.calls.length === 0 ? null : getFirstReplyContext(getReplySpy);
         return {
@@ -288,6 +309,69 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(calledCtx?.Body).toContain("Cron: QMD maintenance completed");
     expect(calledCtx?.Body).not.toContain("Read HEARTBEAT.md");
     expect(sendTelegram).toHaveBeenCalled();
+  });
+
+  it("delivers a targeted cron event while its owning job is active (#105257)", async () => {
+    const { result, calledCtx, sessionKey } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-active-job-",
+      replyText: "Handled the reminder",
+      reason: "cron:nightly-report",
+      source: "cron",
+      intent: "immediate",
+      activeCronJobId: "nightly-report",
+      owningCronJobId: "nightly-report",
+      enqueue: (key) => {
+        enqueueSystemEvent("Reminder: Send the nightly report", {
+          sessionKey: key,
+          contextKey: "cron:nightly-report",
+        });
+      },
+    });
+
+    expect(result.status).toBe("ran");
+    expectCronEventPrompt(calledCtx, "Reminder: Send the nightly report");
+    expect(peekSystemEvents(sessionKey)).toEqual([]);
+  });
+
+  it("still blocks an owning cron wake while an unrelated job is active (#105257)", async () => {
+    const { result, replyCallCount } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-unrelated-active-job-",
+      replyText: "must not run",
+      reason: "cron:nightly-report",
+      source: "cron",
+      intent: "immediate",
+      activeCronJobId: "different-job",
+      owningCronJobId: "nightly-report",
+      enqueue: (key) => {
+        enqueueSystemEvent("Reminder: Send the nightly report", {
+          sessionKey: key,
+          contextKey: "cron:nightly-report",
+        });
+      },
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
+    expect(replyCallCount).toBe(0);
+  });
+
+  it("still blocks a cron wake that claims no owning job while a job is active (#105257)", async () => {
+    const { result, replyCallCount } = await runHeartbeatCase({
+      tmpPrefix: "openclaw-cron-unowned-wake-",
+      replyText: "must not run",
+      reason: "cron:nightly-report",
+      source: "cron",
+      intent: "immediate",
+      activeCronJobId: "nightly-report",
+      enqueue: (key) => {
+        enqueueSystemEvent("Reminder: Send the nightly report", {
+          sessionKey: key,
+          contextKey: "cron:nightly-report",
+        });
+      },
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
+    expect(replyCallCount).toBe(0);
   });
 
   it("drains inspected cron events after a successful run so later heartbeats do not replay them", async () => {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -88,7 +88,12 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { hasActiveCronJobs, hasActiveCronJobsExcept } from "../cron/active-jobs.js";
+import {
+  hasActiveCronJobs,
+  hasActiveCronJobsExceptMarker,
+  isCronActiveJobMarkerCurrent,
+  type CronActiveJobMarker,
+} from "../cron/active-jobs.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getActivePluginChannelRegistry } from "../plugins/runtime.js";
@@ -1297,8 +1302,8 @@ export async function runHeartbeatOnce(opts: {
   intent?: HeartbeatWakeIntent;
   reason?: string;
   runScope?: HeartbeatRunScope;
-  /** Cron job id whose own active marker must not block this wake (see the guard below). */
-  owningCronJobId?: string;
+  /** Exact cron run marker whose own activity must not block this wake. */
+  owningCronJobMarker?: CronActiveJobMarker;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? getRuntimeConfig();
@@ -1339,13 +1344,19 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
   }
 
-  // A cron job's own active marker must not block the synchronous wake it is awaiting:
-  // that self-block forces cron onto its async fallback, which reports success before the
-  // queued event is delivered (#105257). Only the caller's own marker is discounted --
-  // every other job's marker still blocks, since cron runs jobs concurrently.
-  const owningCronJobId = normalizeOptionalString(opts.owningCronJobId);
-  const cronBusy = owningCronJobId ? hasActiveCronJobsExcept(owningCronJobId) : hasActiveCronJobs();
-  if (cronBusy || hasQueuedWorkInLanes(HEARTBEAT_ALWAYS_BUSY_LANES, getSize)) {
+  // An exact current owner may ignore itself and queued cron work that cannot advance
+  // until this run finishes. Unrelated active runs remain visible through their markers.
+  const owningCronJobMarker = opts.owningCronJobMarker;
+  const ownsActiveCronRun = owningCronJobMarker
+    ? isCronActiveJobMarkerCurrent(owningCronJobMarker)
+    : false;
+  const cronBusy =
+    ownsActiveCronRun && owningCronJobMarker
+      ? hasActiveCronJobsExceptMarker(owningCronJobMarker)
+      : hasActiveCronJobs();
+  const cronLaneBusy =
+    !ownsActiveCronRun && hasQueuedWorkInLanes(HEARTBEAT_ALWAYS_BUSY_LANES, getSize);
+  if (cronBusy || cronLaneBusy) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -88,7 +88,7 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { hasActiveCronJobs } from "../cron/active-jobs.js";
+import { hasActiveCronJobs, hasActiveCronJobsExcept } from "../cron/active-jobs.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getActivePluginChannelRegistry } from "../plugins/runtime.js";
@@ -1297,6 +1297,8 @@ export async function runHeartbeatOnce(opts: {
   intent?: HeartbeatWakeIntent;
   reason?: string;
   runScope?: HeartbeatRunScope;
+  /** Cron job id whose own active marker must not block this wake (see the guard below). */
+  owningCronJobId?: string;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? getRuntimeConfig();
@@ -1337,7 +1339,13 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
   }
 
-  if (hasActiveCronJobs() || hasQueuedWorkInLanes(HEARTBEAT_ALWAYS_BUSY_LANES, getSize)) {
+  // A cron job's own active marker must not block the synchronous wake it is awaiting:
+  // that self-block forces cron onto its async fallback, which reports success before the
+  // queued event is delivered (#105257). Only the caller's own marker is discounted --
+  // every other job's marker still blocks, since cron runs jobs concurrently.
+  const owningCronJobId = normalizeOptionalString(opts.owningCronJobId);
+  const cronBusy = owningCronJobId ? hasActiveCronJobsExcept(owningCronJobId) : hasActiveCronJobs();
+  if (cronBusy || hasQueuedWorkInLanes(HEARTBEAT_ALWAYS_BUSY_LANES, getSize)) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -100,7 +100,9 @@ import { getActivePluginChannelRegistry } from "../plugins/runtime.js";
 import {
   getCommandLaneSnapshots,
   getQueueSize,
+  isCommandLaneTaskMarkerCurrent,
   type CommandLaneSnapshot,
+  type CommandLaneTaskMarker,
 } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import {
@@ -201,15 +203,7 @@ const loadHeartbeatRunnerRuntime = createLazyRuntimeModule(
   () => import("./heartbeat-runner.runtime.js"),
 );
 
-const HEARTBEAT_ALWAYS_BUSY_LANES = [CommandLane.Cron, CommandLane.CronNested] as const;
 const DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = 10 * 60;
-
-function hasQueuedWorkInLanes(
-  lanes: readonly string[],
-  getSize: (lane?: string) => number,
-): boolean {
-  return lanes.some((lane) => getSize(lane) > 0);
-}
 
 function hasQueuedWorkInLaneSnapshots(
   snapshots: readonly CommandLaneSnapshot[],
@@ -1304,6 +1298,7 @@ export async function runHeartbeatOnce(opts: {
   runScope?: HeartbeatRunScope;
   /** Exact cron run marker whose own activity must not block this wake. */
   owningCronJobMarker?: CronActiveJobMarker;
+  owningCronLaneTaskMarker?: CommandLaneTaskMarker;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? getRuntimeConfig();
@@ -1344,8 +1339,8 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
   }
 
-  // An exact current owner may ignore itself and queued cron work that cannot advance
-  // until this run finishes. Unrelated active runs remain visible through their markers.
+  // Ignore only the exact Cron lane task that owns this wake. Other queued or active
+  // Cron work and all CronNested work remain busy signals.
   const owningCronJobMarker = opts.owningCronJobMarker;
   const ownsActiveCronRun = owningCronJobMarker
     ? isCronActiveJobMarkerCurrent(owningCronJobMarker)
@@ -1354,8 +1349,14 @@ export async function runHeartbeatOnce(opts: {
     ownsActiveCronRun && owningCronJobMarker
       ? hasActiveCronJobsExceptMarker(owningCronJobMarker)
       : hasActiveCronJobs();
+  const owningCronLaneTaskMarker = opts.owningCronLaneTaskMarker;
+  const ownsCronLaneTask =
+    ownsActiveCronRun &&
+    owningCronLaneTaskMarker?.lane === CommandLane.Cron &&
+    isCommandLaneTaskMarkerCurrent(owningCronLaneTaskMarker);
+  const cronLaneDepth = getSize(CommandLane.Cron);
   const cronLaneBusy =
-    !ownsActiveCronRun && hasQueuedWorkInLanes(HEARTBEAT_ALWAYS_BUSY_LANES, getSize);
+    cronLaneDepth > (ownsCronLaneTask ? 1 : 0) || getSize(CommandLane.CronNested) > 0;
   if (cronBusy || cronLaneBusy) {
     emitHeartbeatEvent({
       status: "skipped",

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -76,8 +76,14 @@ export function isCommandLaneTaskTimeoutError(err: unknown, lane?: string): bool
 // low-risk parallelism (e.g. cron jobs) without interleaving stdin / logs for
 // the main auto-reply workflow.
 
+export type CommandLaneTaskMarker = Readonly<{
+  lane: string;
+  taskId: number;
+  generation: number;
+}>;
+
 type QueueEntry = {
-  task: () => Promise<unknown>;
+  task: (marker: CommandLaneTaskMarker) => Promise<unknown>;
   resolve: (value: unknown) => void;
   reject: (reason?: unknown) => void;
   enqueuedAt: number;
@@ -301,8 +307,12 @@ function enqueueLaneEntry(state: LaneState, entry: QueueEntry): void {
   state.queue.splice(insertAt, 0, entry);
 }
 
-async function runQueueEntryTask(lane: string, entry: QueueEntry): Promise<unknown> {
-  const taskPromise = Promise.resolve().then(entry.task);
+async function runQueueEntryTask(
+  lane: string,
+  entry: QueueEntry,
+  marker: CommandLaneTaskMarker,
+): Promise<unknown> {
+  const taskPromise = Promise.resolve().then(() => entry.task(marker));
   const taskTimeoutMs = normalizeTaskTimeoutMs(entry.taskTimeoutMs);
   if (taskTimeoutMs === undefined) {
     return await taskPromise;
@@ -461,7 +471,11 @@ function drainLane(lane: string) {
         void (async () => {
           const startTime = Date.now();
           try {
-            const result = await runQueueEntryTask(lane, entry);
+            const result = await runQueueEntryTask(lane, entry, {
+              lane,
+              taskId,
+              generation: taskGeneration,
+            });
             const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
             if (completedCurrentGeneration) {
               notifyActiveTaskWaiters();
@@ -524,7 +538,7 @@ export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
 
 export function enqueueCommandInLane<T>(
   lane: string,
-  task: () => Promise<T>,
+  task: (marker: CommandLaneTaskMarker) => Promise<T>,
   opts?: CommandQueueEnqueueOptions,
 ): Promise<T> {
   const queueState = getQueueState();
@@ -536,7 +550,7 @@ export function enqueueCommandInLane<T>(
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
     enqueueLaneEntry(state, {
-      task: () => task(),
+      task: (marker) => task(marker),
       resolve: (value) => resolve(value as T),
       reject,
       enqueuedAt: Date.now(),
@@ -589,6 +603,15 @@ export function getCommandLaneSnapshot(lane: string = CommandLane.Main): Command
 export function getCommandLaneActiveTaskIds(lane: string = CommandLane.Main): number[] {
   const state = getQueueState().lanes.get(normalizeLane(lane));
   return state ? [...state.activeTaskIds] : [];
+}
+
+/** Return whether this exact lane task still owns an active queue slot. */
+export function isCommandLaneTaskMarkerCurrent(marker: CommandLaneTaskMarker | undefined): boolean {
+  if (!marker) {
+    return false;
+  }
+  const state = getQueueState().lanes.get(normalizeLane(marker.lane));
+  return state?.generation === marker.generation && state.activeTaskIds.has(marker.taskId);
 }
 
 export function getCommandLaneSnapshots(): CommandLaneSnapshot[] {


### PR DESCRIPTION
## What Problem This Solves

A `wakeMode: "now"` main-session cron job can block the heartbeat it owns. The job installs its active execution marker before awaiting `runHeartbeatOnce`; the heartbeat admission guard then sees cron work in progress and rejects the owning wake. A manual `cron.run` adds a second self-block because its queued `CommandLane.Cron` task also counts as unrelated lane pressure. Cron falls back to an asynchronous request and records success before delivery is confirmed.

This is a deterministic defect found while investigating #105257. It fixes the reproducible self-block; it does not claim to close that broader intermittent report.

## Why This Change Was Made

The cron path now carries two exact, private ownership markers into the heartbeat runner:

- the active cron execution marker `{ jobId, token }`;
- the current Cron command-lane task marker `{ lane, taskId, generation }` for queued Gateway `cron.run` calls.

Heartbeat admission discounts only markers that still match the authoritative active job and lane task. Another cron job, another queued Cron task, any `CronNested` task, a same-ID replacement, or a stale marker still blocks the wake. Scheduled and direct owners receive no lane exemption. The public plugin heartbeat facade cannot supply or forge either internal marker.

Exact identity matters. Broadly discounting a lane count or job ID would let unrelated or superseded work bypass the existing admission fence.

## User Impact

Main-session `wakeMode: "now"` cron runs now wait for their owned heartbeat delivery before recording terminal success. Other cron work continues to enforce the existing concurrency fence. No config, storage, protocol, or public plugin API changes.

## Evidence

Focused regression coverage exercises the full decision surface:

- exact active marker, unrelated marker, same-ID replacement, and stale replacement;
- exact Cron-lane task, a second Cron task, `CronNested`, and stale lane generations;
- direct manual run, Gateway-queued `cron.run`, and natural scheduled firing;
- real heartbeat runner integration and Gateway adapter forwarding;
- marker and command-lane cleanup before sandbox deletion.

Results:

- 100 focused tests passed across the Gateway adapter, heartbeat runner, cron wake integration, and command queue.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox ([run 29632824782](https://github.com/openclaw/openclaw/actions/runs/29632824782)).
- Exact-head hosted CI is green.
- Fresh autoreview found no actionable issue.

Live proof used the official OpenAI API with `openai/gpt-5.6-luna`, an isolated QA state root, and a custom loopback Gateway port (`41103`):

- Natural timer: outbound delivery `1784347997662`, terminal success `1784347997665`.
- Real Gateway `cron.run`: outbound delivery `1784348000474`, terminal success `1784348000476`.
- Both successful one-shots were deleted.

The timestamp ordering is the regression oracle: the old self-block records terminal success before the later asynchronous outbound message; the fixed path delivers first.

## Scope

`next-heartbeat` remains asynchronous by design. Issue #105257 remains open for its broader intermittent payload-loss report.

---

🤖 AI-assisted: original fix by @harjothkhara, reviewed and rewritten with maintainer tests, changed-gate proof, and live OpenAI Gateway verification.
