### PR TITLE
fix(codex): timed-out native hooks exhaust memory

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -82,6 +82,7 @@ const isSourceCheckoutLauncher = () =>
 const isNodeCompileCacheDisabled = () => process.env.NODE_DISABLE_COMPILE_CACHE !== undefined;
 const isNodeCompileCacheRequested = () =>
   Boolean(process.env.NODE_COMPILE_CACHE) && !isNodeCompileCacheDisabled();
+const isNativeHookRelayInvocation = (argv) => argv[2] === "hooks" && argv[3] === "relay";
 const sanitizeCompileCachePathSegment = (value) => {
   const normalized = value.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
   return normalized.length > 0 ? normalized : "unknown";
@@ -273,8 +274,11 @@ const respawnWithPackagedCompileCacheIfNeeded = () => {
   );
 };
 
+// Codex owns the relay timeout by PID. Keep the launcher as that exact process
+// so a timeout cannot strand a compile-cache respawn child.
 const waitingForCompileCacheRespawn =
-  respawnWithoutCompileCacheIfNeeded() || respawnWithPackagedCompileCacheIfNeeded();
+  !(process.platform !== "win32" && isNativeHookRelayInvocation(process.argv)) &&
+  (respawnWithoutCompileCacheIfNeeded() || respawnWithPackagedCompileCacheIfNeeded());
 
 // https://nodejs.org/api/module.html#module-compile-cache
 if (

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -32,6 +32,8 @@ import {
   resolveNativeHookRelayDeferredToolApproval,
 } from "./native-hook-relay.js";
 
+const NATIVE_HOOK_RELAY_EXEC_PREFIX = process.platform === "win32" ? "" : "exec ";
+
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
@@ -252,15 +254,15 @@ describe("native hook relay registry", () => {
       },
     );
     expect(relay.commandForEvent("pre_tool_use")).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
     expect(relay.commandForEvent("pre_tool_use", { timeoutMs: 900 })).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --timeout 900`,
     );
     expect(relay.commandForEvent("pre_tool_use", { timeoutMs: 2_000 })).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
   });
@@ -547,7 +549,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
     expect(relay.shouldRelayEvent("permission_request")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
     );
   });
@@ -570,7 +572,7 @@ describe("native hook relay registry", () => {
 
     expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
   });
@@ -590,7 +592,7 @@ describe("native hook relay registry", () => {
 
     expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
   });
@@ -639,7 +641,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("post_tool_use")).toBe(true);
     expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
     expect(relay.commandForEvent("post_tool_use")).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event post_tool_use --timeout 1234`,
     );
   });
@@ -661,7 +663,7 @@ describe("native hook relay registry", () => {
 
     expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(true);
     expect(relay.commandForEvent("before_agent_finalize")).toBe(
-      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id ` +
         `${relay.relayId} ${nativeHookRelayStateDbArgForTests()} --generation ${relay.generation} --event before_agent_finalize --timeout 1234`,
     );
   });
@@ -3546,7 +3548,23 @@ describe("native hook relay command builder", () => {
         executable: "openclaw",
       }),
     ).toBe(
-      "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 5000",
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 5000`,
+    );
+  });
+
+  it("execs niced relays so the Codex timeout owns the relay process", () => {
+    const command = buildNativeHookRelayCommand({
+      provider: "codex",
+      relayId: "relay-1",
+      event: "post_tool_use",
+      executable: "openclaw",
+      nice: 10,
+    });
+
+    expect(command).toBe(
+      process.platform === "win32"
+        ? "openclaw hooks relay --provider codex --relay-id relay-1 --event post_tool_use --timeout 5000"
+        : "exec nice -n 10 openclaw hooks relay --provider codex --relay-id relay-1 --event post_tool_use --timeout 5000",
     );
   });
 
@@ -3561,7 +3579,7 @@ describe("native hook relay command builder", () => {
         executable: "openclaw",
       }),
     ).toBe(
-      "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 5000",
+      `${NATIVE_HOOK_RELAY_EXEC_PREFIX}openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 5000`,
     );
   });
 });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -615,7 +615,7 @@ function buildNativeHookRelayCommandWithStateDatabase(params: {
       ? ["openclaw"]
       : [params.nodeExecutable ?? process.execPath, executable];
   const nicePrefix = resolveNativeHookRelayNicePrefix(params.nice);
-  return shellQuoteArgs([
+  const command = shellQuoteArgs([
     ...nicePrefix,
     ...argv,
     "hooks",
@@ -634,6 +634,9 @@ function buildNativeHookRelayCommandWithStateDatabase(params: {
     "--timeout",
     String(timeoutMs),
   ]);
+  // Codex kills the shell process when a hook times out. Replace that shell so
+  // the timeout targets this relay instead of leaving its Node child behind.
+  return process.platform === "win32" ? command : `exec ${command}`;
 }
 
 function nativePreToolUseMayRunLoopDetection(

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -68,6 +68,7 @@ describe("shouldSkipRespawnForArgv", () => {
     { argv: ["node", "openclaw", "tui"] },
     { argv: ["node", "openclaw", "terminal"] },
     { argv: ["node", "openclaw", "chat"] },
+    { argv: ["node", "openclaw", "hooks", "relay", "--relay-id", "relay-1"] },
     { argv: ["node", "openclaw", "gateway"] },
     { argv: ["node", "openclaw", "gateway", "--port", "14720", "--bind", "loopback"] },
     { argv: ["node", "openclaw", "gateway", "run", "--port=14720", "--bind", "loopback"] },
@@ -85,11 +86,21 @@ describe("shouldSkipRespawnForArgv", () => {
   ] as const)("keeps respawn path for argv %j", ({ argv }) => {
     expect(shouldSkipRespawnForArgv([...argv]), argv.join(" ")).toBe(false);
   });
+
+  it("keeps native hook relay respawn behavior unchanged on Windows", () => {
+    expect(
+      shouldSkipRespawnForArgv(
+        ["node", "openclaw", "hooks", "relay", "--relay-id", "relay-1"],
+        "win32",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("shouldSkipStartupEnvironmentRespawnForArgv", () => {
   it.each([
     { argv: ["node", "openclaw", "--help"] },
+    { argv: ["node", "openclaw", "hooks", "relay", "--relay-id", "relay-1"] },
     { argv: ["node", "openclaw", "gateway"] },
     { argv: ["node", "openclaw", "gateway", "run", "--port=14720"] },
   ] as const)("skips startup env respawn for argv %j", ({ argv }) => {
@@ -103,6 +114,15 @@ describe("shouldSkipStartupEnvironmentRespawnForArgv", () => {
     { argv: ["node", "openclaw", "status"] },
   ] as const)("allows startup env respawn for argv %j", ({ argv }) => {
     expect(shouldSkipStartupEnvironmentRespawnForArgv([...argv]), argv.join(" ")).toBe(false);
+  });
+
+  it("keeps native hook relay startup environment respawn on Windows", () => {
+    expect(
+      shouldSkipStartupEnvironmentRespawnForArgv(
+        ["node", "openclaw", "hooks", "relay", "--relay-id", "relay-1"],
+        "win32",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
+  buildNativeHookRelayCommand,
   registerNativeHookRelay,
   testing as nativeHookRelayTesting,
 } from "../agents/harness/native-hook-relay.js";
@@ -109,6 +110,61 @@ async function createLingeringPreloadFixture(): Promise<{
     ].join("\n"),
   );
   return { markerPath, preloadPath, stateDir };
+}
+
+async function createTimeoutOwnershipFixture(): Promise<{
+  nodeWrapperPath: string;
+  pidLogPath: string;
+  preloadPath: string;
+  readyMarkerPath: string;
+  stateDir: string;
+}> {
+  const root = tempDirs.make("openclaw-hooks-timeout-owner-");
+  const nodeWrapperPath = path.join(root, "node-with-tsx");
+  const pidLogPath = path.join(root, "pids");
+  const preloadPath = path.join(root, "track-relay-pid.mjs");
+  const readyMarkerPath = path.join(root, "ready");
+  const stateDir = path.join(root, "state");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(
+    preloadPath,
+    [
+      'import fs from "node:fs";',
+      "fs.appendFileSync(process.env.RELAY_PID_LOG, `${process.pid}\\n`);",
+      "const originalAsyncIterator = process.stdin[Symbol.asyncIterator].bind(process.stdin);",
+      "process.stdin[Symbol.asyncIterator] = function () {",
+      "  fs.writeFileSync(process.env.RELAY_READY_MARKER, `${process.pid}\\n`);",
+      "  return originalAsyncIterator();",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    nodeWrapperPath,
+    ["#!/bin/sh", 'exec "$OPENCLAW_TEST_NODE" --import tsx "$@"', ""].join("\n"),
+  );
+  await fs.chmod(nodeWrapperPath, 0o755);
+  return { nodeWrapperPath, pidLogPath, preloadPath, readyMarkerPath, stateDir };
+}
+
+async function readPidFile(filePath: string): Promise<number[]> {
+  try {
+    return (await fs.readFile(filePath, "utf8"))
+      .split(/\s+/u)
+      .map((value) => Number.parseInt(value, 10))
+      .filter((value) => Number.isSafeInteger(value) && value > 0);
+  } catch {
+    return [];
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function runHooksCli(params: {
@@ -218,6 +274,74 @@ async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; 
 }
 
 describe("hooks CLI process lifecycle", () => {
+  it.runIf(process.platform !== "win32")(
+    "keeps the relay on the timeout-owned shell PID",
+    async () => {
+      const fixture = await createTimeoutOwnershipFixture();
+      const command = buildNativeHookRelayCommand({
+        provider: "codex",
+        relayId: "timeout-owner",
+        event: "post_tool_use",
+        executable: path.resolve("src/entry.ts"),
+        nodeExecutable: fixture.nodeWrapperPath,
+        timeoutMs: 60_000,
+      });
+      const child = spawn("/bin/sh", ["-lc", command], {
+        cwd: path.resolve("."),
+        env: {
+          ...process.env,
+          NODE_ENV: undefined,
+          VITEST: undefined,
+          NODE_OPTIONS: `--import=${pathToFileURL(fixture.preloadPath).href}`,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_STATE_DIR: fixture.stateDir,
+          OPENCLAW_TEST_NODE: process.execPath,
+          RELAY_PID_LOG: fixture.pidLogPath,
+          RELAY_READY_MARKER: fixture.readyMarkerPath,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      activeChildren.add(child);
+      child.once("close", () => activeChildren.delete(child));
+      const timeoutOwnedPid = child.pid;
+      if (!timeoutOwnedPid) {
+        throw new Error("Expected native hook relay shell PID");
+      }
+
+      try {
+        await expect
+          .poll(async () => (await readPidFile(fixture.readyMarkerPath))[0], {
+            interval: 100,
+            timeout: outputTimeoutMs,
+          })
+          .toBe(timeoutOwnedPid);
+        expect(new Set(await readPidFile(fixture.pidLogPath))).toEqual(new Set([timeoutOwnedPid]));
+
+        const closed = once(child, "close");
+        expect(child.kill("SIGKILL")).toBe(true);
+        await closed;
+        await expect
+          .poll(() => isProcessAlive(timeoutOwnedPid), { interval: 50, timeout: 5_000 })
+          .toBe(false);
+        await expect
+          .poll(
+            async () =>
+              (await readPidFile(fixture.pidLogPath)).filter((pid) => isProcessAlive(pid)),
+            { interval: 50, timeout: 5_000 },
+          )
+          .toEqual([]);
+      } finally {
+        await terminateChild(child);
+        for (const pid of await readPidFile(fixture.pidLogPath)) {
+          if (pid !== timeoutOwnedPid && isProcessAlive(pid)) {
+            process.kill(pid, "SIGKILL");
+          }
+        }
+      }
+    },
+    60_000,
+  );
+
   it("uses the explicit relay database when the child has a different state directory", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",

--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -292,6 +292,7 @@ describe("hooks CLI process lifecycle", () => {
           ...process.env,
           NODE_ENV: undefined,
           VITEST: undefined,
+          NODE_COMPILE_CACHE: path.join(fixture.stateDir, "node-compile-cache"),
           NODE_OPTIONS: `--import=${pathToFileURL(fixture.preloadPath).href}`,
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
           OPENCLAW_STATE_DIR: fixture.stateDir,

--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -209,7 +209,6 @@ async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; 
       LINGER_MARKER: fixture.markerPath,
       NODE_OPTIONS: `--import=${pathToFileURL(fixture.preloadPath).href}`,
       OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-      OPENCLAW_NO_RESPAWN: "1",
       OPENCLAW_STATE_DIR: fixture.stateDir,
     },
     stdin: params.stdin,
@@ -254,7 +253,6 @@ describe("hooks CLI process lifecycle", () => {
       label: "hooks relay explicit state database",
       env: {
         OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-        OPENCLAW_NO_RESPAWN: "1",
         OPENCLAW_STATE_DIR: childStateDir,
       },
       stdin: JSON.stringify({ hook_event_name: "PostToolUse" }),

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -29,6 +29,15 @@ const GATEWAY_RUN_VALUE_FLAGS = [
 
 const INTERACTIVE_TTY_COMMANDS = new Set(["tui", "terminal", "chat"]);
 
+function isNativeHookRelayArgv(argv: string[]): boolean {
+  const { commandPath } = resolveCliArgvInvocation(argv);
+  return commandPath[0] === "hooks" && commandPath[1] === "relay";
+}
+
+function shouldKeepNativeHookRelayInProcess(argv: string[], platform: NodeJS.Platform): boolean {
+  return platform !== "win32" && isNativeHookRelayArgv(argv);
+}
+
 function isInteractiveTtyCommandArgv(argv: string[]): boolean {
   const invocation = resolveCliArgvInvocation(argv);
   return invocation.primary !== null && INTERACTIVE_TTY_COMMANDS.has(invocation.primary);
@@ -57,20 +66,30 @@ function isForegroundGatewayRunArgv(argv: string[]): boolean {
 }
 
 /** Returns whether CLI startup should avoid the general respawn wrapper for this argv. */
-export function shouldSkipRespawnForArgv(argv: string[]): boolean {
+export function shouldSkipRespawnForArgv(
+  argv: string[],
+  platform: NodeJS.Platform = process.platform,
+): boolean {
   const invocation = resolveCliArgvInvocation(argv);
   return (
     invocation.hasHelpOrVersion ||
     isInteractiveTtyCommandArgv(argv) ||
+    shouldKeepNativeHookRelayInProcess(argv, platform) ||
     (invocation.primary === "gateway" && isForegroundGatewayRunArgv(argv))
   );
 }
 
 /** Returns whether startup-environment respawn should be skipped without suppressing TUI respawn policy. */
-export function shouldSkipStartupEnvironmentRespawnForArgv(argv: string[]): boolean {
+export function shouldSkipStartupEnvironmentRespawnForArgv(
+  argv: string[],
+  platform: NodeJS.Platform = process.platform,
+): boolean {
   const invocation = resolveCliArgvInvocation(argv);
   return (
     invocation.hasHelpOrVersion ||
+    // Codex owns the relay subprocess timeout. A detached startup respawn can
+    // outlive the launcher when Codex kills it, stranding the relay child.
+    shouldKeepNativeHookRelayInProcess(argv, platform) ||
     (invocation.primary === "gateway" && isForegroundGatewayRunArgv(argv))
   );
 }

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -34,7 +34,10 @@ function isNativeHookRelayArgv(argv: string[]): boolean {
   return commandPath[0] === "hooks" && commandPath[1] === "relay";
 }
 
-function shouldKeepNativeHookRelayInProcess(argv: string[], platform: NodeJS.Platform): boolean {
+export function shouldKeepNativeHookRelayInProcess(
+  argv: string[],
+  platform: NodeJS.Platform,
+): boolean {
   return platform !== "win32" && isNativeHookRelayArgv(argv);
 }
 

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanupTempDirs, makeTempDir } from "../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../test/helpers/temp-dir.js";
 import { resolveEntryInstallRoot } from "./entry.compile-cache.js";
 import {
   buildOpenClawCompileCacheRespawnPlan,
@@ -24,11 +24,7 @@ function requireFirstMockCall(mock: { mock: { calls: unknown[][] } }, label: str
 }
 
 describe("entry compile cache", () => {
-  const tempDirs: string[] = [];
-
-  afterEach(() => {
-    cleanupTempDirs(tempDirs);
-  });
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   it("resolves install roots from source and dist entry paths", () => {
     expect(resolveEntryInstallRoot("/repo/openclaw/src/entry.ts")).toBe("/repo/openclaw");
@@ -37,14 +33,14 @@ describe("entry compile cache", () => {
   });
 
   it("treats git and source entry markers as source checkouts", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-source-");
+    const root = tempDirs.make("openclaw-compile-cache-source-");
     await fs.writeFile(path.join(root, ".git"), "gitdir: .git/worktrees/openclaw\n", "utf8");
 
     expect(isSourceCheckoutInstallRoot(root)).toBe(true);
   });
 
   it("disables compile cache for source-checkout installs", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-src-entry-");
+    const root = tempDirs.make("openclaw-compile-cache-src-entry-");
     await fs.mkdir(path.join(root, "src"), { recursive: true });
     await fs.writeFile(path.join(root, "src", "entry.ts"), "export {};\n", "utf8");
 
@@ -57,7 +53,7 @@ describe("entry compile cache", () => {
   });
 
   it("keeps compile cache enabled for packaged installs unless disabled by env", () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-package-");
+    const root = tempDirs.make("openclaw-compile-cache-package-");
 
     expect(
       shouldEnableOpenClawCompileCache({
@@ -78,7 +74,7 @@ describe("entry compile cache", () => {
   });
 
   it("scopes packaged compile cache by package install metadata", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-package-key-");
+    const root = tempDirs.make("openclaw-compile-cache-package-key-");
     const packageJsonPath = path.join(root, "package.json");
     await fs.writeFile(packageJsonPath, '{"version":"2026.4.29"}\n', "utf8");
 
@@ -93,7 +89,7 @@ describe("entry compile cache", () => {
   });
 
   it("builds a one-shot no-cache respawn plan when source checkout inherits NODE_COMPILE_CACHE", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-respawn-");
+    const root = tempDirs.make("openclaw-compile-cache-respawn-");
     await fs.mkdir(path.join(root, "src"), { recursive: true });
     await fs.writeFile(path.join(root, "src", "entry.ts"), "export {};\n", "utf8");
 
@@ -118,7 +114,7 @@ describe("entry compile cache", () => {
   });
 
   it("keeps POSIX native hook relays on the timeout-owned process", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-relay-");
+    const root = tempDirs.make("openclaw-compile-cache-relay-");
     const entryFile = path.join(root, "src", "entry.ts");
     await fs.mkdir(path.dirname(entryFile), { recursive: true });
     await fs.writeFile(entryFile, "export {};\n", "utf8");
@@ -145,7 +141,7 @@ describe("entry compile cache", () => {
   });
 
   it("keeps interactive no-cache respawn plans attached to the terminal", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-interactive-");
+    const root = tempDirs.make("openclaw-compile-cache-interactive-");
     const entryFile = path.join(root, "dist", "entry.js");
     await fs.mkdir(path.join(root, "src"), { recursive: true });
     await fs.writeFile(path.join(root, "src", "entry.ts"), "export {};\n", "utf8");
@@ -162,7 +158,7 @@ describe("entry compile cache", () => {
   });
 
   it("keeps bare-root no-cache respawn plans attached to the terminal", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-root-");
+    const root = tempDirs.make("openclaw-compile-cache-root-");
     const entryFile = path.join(root, "dist", "entry.js");
     await fs.mkdir(path.join(root, "src"), { recursive: true });
     await fs.writeFile(path.join(root, "src", "entry.ts"), "export {};\n", "utf8");
@@ -179,7 +175,7 @@ describe("entry compile cache", () => {
   });
 
   it("does not respawn unaffected packaged installs when NODE_COMPILE_CACHE is configured", () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-package-respawn-");
+    const root = tempDirs.make("openclaw-compile-cache-package-respawn-");
 
     expect(
       buildOpenClawCompileCacheRespawnPlan({
@@ -193,7 +189,7 @@ describe("entry compile cache", () => {
   });
 
   it("builds a no-cache respawn plan for affected Windows packaged installs", () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-package-win24-");
+    const root = tempDirs.make("openclaw-compile-cache-package-win24-");
     const entryFile = path.join(root, "dist", "entry.js");
 
     const plan = buildOpenClawCompileCacheRespawnPlan({
@@ -219,7 +215,7 @@ describe("entry compile cache", () => {
   });
 
   it("does not respawn source checkouts twice", async () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-respawn-once-");
+    const root = tempDirs.make("openclaw-compile-cache-respawn-once-");
     await fs.mkdir(path.join(root, "src"), { recursive: true });
     await fs.writeFile(path.join(root, "src", "entry.ts"), "export {};\n", "utf8");
 
@@ -352,7 +348,7 @@ describe("entry compile cache", () => {
   });
 
   it("disables compile cache for early Node 24.x versions on Windows", () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-node24-");
+    const root = tempDirs.make("openclaw-compile-cache-node24-");
     expect(
       shouldEnableOpenClawCompileCache({
         env: {},
@@ -372,7 +368,7 @@ describe("entry compile cache", () => {
   });
 
   it("keeps compile cache enabled for early Node 24.x on non-Windows packaged installs", () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-node24-nonwin-");
+    const root = tempDirs.make("openclaw-compile-cache-node24-nonwin-");
     expect(
       shouldEnableOpenClawCompileCache({
         env: {},
@@ -392,7 +388,7 @@ describe("entry compile cache", () => {
   });
 
   it("keeps compile cache enabled for Node 24.15+ and other majors on Windows", () => {
-    const root = makeTempDir(tempDirs, "openclaw-compile-cache-node2415-");
+    const root = tempDirs.make("openclaw-compile-cache-node2415-");
     expect(
       shouldEnableOpenClawCompileCache({
         env: {},

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -117,6 +117,33 @@ describe("entry compile cache", () => {
     });
   });
 
+  it("keeps POSIX native hook relays on the timeout-owned process", async () => {
+    const root = makeTempDir(tempDirs, "openclaw-compile-cache-relay-");
+    const entryFile = path.join(root, "src", "entry.ts");
+    await fs.mkdir(path.dirname(entryFile), { recursive: true });
+    await fs.writeFile(entryFile, "export {};\n", "utf8");
+    const params = {
+      currentFile: entryFile,
+      env: { NODE_COMPILE_CACHE: "/tmp/openclaw-cache" },
+      execPath: "/usr/bin/node",
+      installRoot: root,
+      argv: ["/usr/bin/node", entryFile, "hooks", "relay", "--relay-id", "relay-1"],
+    };
+
+    expect(
+      buildOpenClawCompileCacheRespawnPlan({
+        ...params,
+        platform: "linux",
+      }),
+    ).toBeUndefined();
+    expect(
+      buildOpenClawCompileCacheRespawnPlan({
+        ...params,
+        platform: "win32",
+      }),
+    ).toBeDefined();
+  });
+
   it("keeps interactive no-cache respawn plans attached to the terminal", async () => {
     const root = makeTempDir(tempDirs, "openclaw-compile-cache-interactive-");
     const entryFile = path.join(root, "dist", "entry.js");

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -6,7 +6,10 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { expectDefined } from "@openclaw/normalization-core";
-import { isTerminalInteractiveRespawnArgv } from "./cli/respawn-policy.js";
+import {
+  isTerminalInteractiveRespawnArgv,
+  shouldKeepNativeHookRelayInProcess,
+} from "./cli/respawn-policy.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 import {
   runRespawnChildWithSignalBridge,
@@ -145,9 +148,14 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
   platform?: NodeJS.Platform;
 }): OpenClawCompileCacheRespawnPlan | undefined {
   const env = params.env ?? process.env;
+  const argv = params.argv ?? process.argv;
+  const platform = params.platform ?? process.platform;
+  if (shouldKeepNativeHookRelayInProcess(argv, platform)) {
+    return undefined;
+  }
   const needsDisabledCompileCacheRespawn =
     isSourceCheckoutInstallRoot(params.installRoot) ||
-    ((params.platform ?? process.platform) === "win32" &&
+    (platform === "win32" &&
       isNodeVersionAffectedByCompileCacheDeadlock(params.nodeVersion ?? process.versions.node));
   if (!needsDisabledCompileCacheRespawn) {
     return undefined;
@@ -166,15 +174,9 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
   delete nextEnv.NODE_COMPILE_CACHE;
   return {
     command: params.execPath ?? process.execPath,
-    args: [
-      ...(params.execArgv ?? process.execArgv),
-      params.currentFile,
-      ...(params.argv ?? process.argv).slice(2),
-    ],
+    args: [...(params.execArgv ?? process.execArgv), params.currentFile, ...argv.slice(2)],
     env: nextEnv,
-    detachForProcessTree:
-      (params.platform ?? process.platform) !== "win32" &&
-      !isTerminalInteractiveRespawnArgv(params.argv ?? process.argv),
+    detachForProcessTree: platform !== "win32" && !isTerminalInteractiveRespawnArgv(argv),
   };
 }
 

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -39,6 +39,18 @@ describe("buildCliRespawnPlan", () => {
     ).toBeNull();
   });
 
+  it("does not detach native hook relays through a startup respawn", () => {
+    expect(
+      buildCliRespawnPlan({
+        argv: ["node", "openclaw", "hooks", "relay", "--relay-id", "relay-1"],
+        env: {},
+        execArgv: [],
+        autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+        platform: "linux",
+      }),
+    ).toBeNull();
+  });
+
   it("adds NODE_EXTRA_CA_CERTS and warning suppression in one respawn", () => {
     const plan = buildCliRespawnPlan({
       argv: ["node", "openclaw", "status"],

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -116,7 +116,7 @@ export function buildCliRespawnPlan(
     platform === "win32" ? normalizeWindowsArgv(argv, { platform, execPath }) : argv;
 
   if (
-    shouldSkipStartupEnvironmentRespawnForArgv(normalizedArgv) ||
+    shouldSkipStartupEnvironmentRespawnForArgv(normalizedArgv, platform) ||
     isTruthyEnvValue(env.OPENCLAW_NO_RESPAWN)
   ) {
     return null;
@@ -179,7 +179,7 @@ export function buildCliRespawnPlan(
   }
 
   if (
-    !shouldSkipRespawnForArgv(argv) &&
+    !shouldSkipRespawnForArgv(argv, platform) &&
     !isTruthyEnvValue(env[OPENCLAW_NODE_OPTIONS_READY]) &&
     !hasExperimentalWarningSuppressed({ env, execArgv })
   ) {

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -953,6 +953,34 @@ describe("openclaw launcher", () => {
     expect(result.stdout).toBe("cache:enabled;respawn:0");
   });
 
+  it.runIf(process.platform !== "win32")(
+    "does not respawn native hook relays for packaged compile-cache scoping",
+    async () => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await fs.writeFile(path.join(fixtureRoot, "package.json"), '{"version":"2026.4.29"}\n');
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        'process.stdout.write(process.env.OPENCLAW_PACKAGED_COMPILE_CACHE_RESPAWNED ?? "0");\n',
+        "utf8",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [path.join(fixtureRoot, "openclaw.mjs"), "hooks", "relay"],
+        {
+          cwd: fixtureRoot,
+          env: launcherEnv({
+            NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
+          }),
+          encoding: "utf8",
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("0");
+    },
+  );
+
   it("scopes packaged launcher compile cache inside configured cache roots", async () => {
     const fixtureRoot = await makeLauncherFixture(fixtureRoots);
     await fs.writeFile(path.join(fixtureRoot, "package.json"), '{"version":"2026.4.29"}\n');


### PR DESCRIPTION
Closes #109421

## What Problem This Solves

Fixes an issue where Codex-backed agent jobs could leave timed-out native hook relay processes running on Linux, causing process fanout, multi-gigabyte memory growth, swap pressure, and eventual gateway or host OOM kills.

## Why This Change Was Made

POSIX native hook commands now replace Codex's timeout-owned shell with the relay process via `exec`. The internal `hooks relay` invocation also bypasses OpenClaw's packaged compile-cache, startup-environment, and general CLI respawn layers so the PID Codex terminates remains the relay PID throughout startup.

Windows behavior is unchanged because it needs a separate process-tree-aware termination or parent-watchdog design.

## User Impact

Linux operators running Codex native hooks should no longer accumulate relay children after hook timeouts. Timed-out hooks terminate the actual relay process instead of only an intermediate launcher, reducing task fanout and memory exhaustion during long agent jobs.

## Evidence

### Production incident and current-main reproduction

- Kernel OOM logs from the affected host recorded 19 `openclaw-hooks` processes using 3.84 GiB plus 30 launcher/startup `openclaw` processes using 2.56 GiB.
- The issue contains an independent current-main process-tree reproduction showing the timeout-owned shell dying while the launcher and detached relay survive.
- The same probe against this patch keeps one timeout-owned relay PID and leaves no survivor.

### Live Codex timeout on the final branch

A controlled run used OpenClaw's production `buildCodexNativeHookRelayConfig` through the real Codex 0.144.5 app-server `thread/start` path. Codex started the generated relay command, applied its own one-second hook timeout, emitted `hook/completed`, and left no recorded relay process alive.

Tested OpenClaw head: `a7e2531f0df471f7f79ab3ff09843df2b0953963`.

```text
codex_version=codex-cli 0.144.5
command_has_exec_prefix=true
generated_command=exec nice -n 10 .../node-with-tsx .../src/entry.ts hooks relay   --provider codex --relay-id codex-live-proof-missing   --event pre_tool_use --timeout 8000

before_codex_timeout
timeout_owned_relay_pid=1904306
recorded_relay_count=1

PID      PPID     PGID     SID      STAT  RSS_KiB  COMMAND
1904306  1903641  1903468  1903420  SNl   68420    node ... hooks relay ...

codex hook/completed
source=sessionFlags
event=preToolUse
executionMode=sync
status=failed
durationMs=1001
error="hook timed out after 1s"

after_codex_timeout
codex_exit_code=0
recorded_relay_count=1
surviving_relay_pids=(none)
relay_survived_timeout=false
```

The probe ran in a transient systemd service with `MemoryMax=2G`, `MemorySwapMax=1G`, `TasksMax=80`, and cleanup for every recorded PID.

### Codex dependency contract

Direct source inspection confirms the contract in both the incident version `rust-v0.144.3` and current OpenClaw dependency `rust-v0.144.5`; `command_runner.rs` is identical between those tags:

- The hook command is the directly spawned child with `kill_on_drop(true)`.
- The timeout wraps `child.wait_with_output()`.
- A timeout reports `hook timed out after Ns`.
- POSIX uses `$SHELL -lc`, falling back to `/bin/sh -lc`.

Source: [Codex 0.144.5 command runner](https://github.com/openai/codex/blob/rust-v0.144.5/codex-rs/hooks/src/engine/command_runner.rs).

### Exact-head validation

- Hook CLI process lifecycle: 3 passed.
- Native relay, respawn policy, compile-cache, and launcher suites: 263 passed.
- Production TypeScript check: passed.
- Test TypeScript check: passed.
- Fresh branch autoreview: no actionable findings; correctness confidence 0.93.
- The three-commit head merges cleanly with upstream `main` at `75697ad3bf`.
