### PR TITLE
fix: model calls fail with provider 400 when tool-call ids repeat across assistant turns

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -668,6 +668,174 @@ describe("repairToolUseResultPairing prefers real result over synthetic error", 
   });
 });
 
+describe("repairToolUseResultPairing repeated per-turn tool-call ids", () => {
+  function makeExecAssistant(...toolCallIds: string[]) {
+    return {
+      role: "assistant" as const,
+      content: toolCallIds.map((id) => ({ type: "toolCall", id, name: "exec", arguments: {} })),
+    };
+  }
+
+  function makeExecResult(toolCallId: string, text: string) {
+    return {
+      role: "toolResult" as const,
+      toolCallId,
+      toolName: "exec",
+      content: [{ type: "text", text }],
+      isError: false,
+    };
+  }
+
+  it("keeps real results when tool-call ids repeat across assistant turns", () => {
+    // Some providers restart tool-call id numbering every assistant turn, so the
+    // same id legitimately recurs; each turn must keep its own real result.
+    const input = castAgentMessages([
+      makeExecAssistant("exec_0", "exec_1"),
+      makeExecResult("exec_0", "turn one first"),
+      makeExecResult("exec_1", "turn one second"),
+      { role: "user", content: "next turn" },
+      makeExecAssistant("exec_0", "exec_1"),
+      makeExecResult("exec_0", "turn two first"),
+      makeExecResult("exec_1", "turn two second"),
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.droppedDuplicateCount).toBe(0);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "toolResult",
+      "user",
+      "assistant",
+      "toolResult",
+      "toolResult",
+    ]);
+    expect(
+      result.messages
+        .filter((message) => message.role === "toolResult")
+        .map(
+          (message) =>
+            (message as { toolCallId?: string; content?: Array<{ text?: string }> }).toolCallId,
+        ),
+    ).toEqual(["exec_0", "exec_1", "exec_0", "exec_1"]);
+    expect(
+      result.messages
+        .filter((message) => message.role === "toolResult")
+        .map((message) => (message as { content?: Array<{ text?: string }> }).content?.[0]?.text),
+    ).toEqual(["turn one first", "turn one second", "turn two first", "turn two second"]);
+  });
+
+  it("synthesizes a missing result for a later turn with a repeated id instead of dropping it", () => {
+    const input = castAgentMessages([
+      makeExecAssistant("exec_0"),
+      makeExecResult("exec_0", "turn one output"),
+      { role: "user", content: "next turn" },
+      makeExecAssistant("exec_0"),
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0]?.toolCallId).toBe("exec_0");
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+    const synthesized = result.messages[4] as { toolCallId?: string; isError?: boolean };
+    expect(synthesized.toolCallId).toBe("exec_0");
+    expect(synthesized.isError).toBe(true);
+  });
+
+  it("leaves an already-valid transcript with unique ids unchanged", () => {
+    const input = castAgentMessages([
+      makeExecAssistant("call_1", "call_2"),
+      makeExecResult("call_1", "first"),
+      makeExecResult("call_2", "second"),
+      makeExecAssistant("call_3"),
+      makeExecResult("call_3", "third"),
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.messages).toBe(input);
+    expect(result.added).toHaveLength(0);
+    expect(result.droppedDuplicateCount).toBe(0);
+    expect(result.droppedOrphanCount).toBe(0);
+    expect(result.moved).toBe(false);
+  });
+
+  it("pairs displaced results with repeated ids by occurrence without re-emitting records", () => {
+    const input = castAgentMessages([
+      makeExecAssistant("exec_0"),
+      makeExecAssistant("exec_0"),
+      {
+        role: "toolResult" as const,
+        toolCallId: "exec_0",
+        toolName: "   ",
+        content: [{ type: "text", text: "late second" }],
+        isError: false,
+      },
+      makeExecResult("exec_0", "late third"),
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "assistant",
+      "toolResult",
+    ]);
+    const first = result.messages[1] as {
+      toolName?: string;
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+    expect(first.toolName).toBe("exec");
+    expect(first.isError).toBe(false);
+    expect(
+      result.messages
+        .filter((message) => message.role === "toolResult")
+        .map((message) => (message as { content?: Array<{ text?: string }> }).content?.[0]?.text),
+    ).toEqual(["late second", "late third"]);
+  });
+
+  it("reserves a later turn's adjacent result when an earlier repeated-id turn is missing its own", () => {
+    const input = castAgentMessages([
+      makeExecAssistant("exec_0"),
+      makeExecResult("exec_0", "turn zero output"),
+      makeExecAssistant("exec_0"),
+      makeExecAssistant("exec_0"),
+      makeExecResult("exec_0", "turn two output"),
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "assistant",
+      "toolResult",
+      "assistant",
+      "toolResult",
+    ]);
+    expect(
+      result.messages
+        .filter((message) => message.role === "toolResult")
+        .map((message) => (message as { content?: Array<{ text?: string }> }).content?.[0]?.text),
+    ).toEqual(["turn zero output", DEFAULT_MISSING_TOOL_RESULT_TEXT, "turn two output"]);
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0]?.toolCallId).toBe("exec_0");
+    expect((result.messages[5] as { isError?: boolean }).isError).toBe(false);
+  });
+});
+
 describe("sanitizeToolCallInputs legacy block filtering", () => {
   it("drops malformed snake_case tool call blocks", () => {
     const input = castAgentMessages([

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -561,24 +561,67 @@ function collectLaterMatchingToolResults(params: {
   startIndex: number;
   toolCalls: Array<{ id: string; name?: string }>;
   toolNamesById: Map<string, string>;
-  seenToolResultIds: Set<string>;
-}): Map<string, Extract<AgentMessage, { role: "toolResult" }>> {
-  const resultsById = new Map<string, Extract<AgentMessage, { role: "toolResult" }>>();
+  emittedToolResultRecords: Set<AgentMessage>;
+}): Map<string, { source: AgentMessage; result: Extract<AgentMessage, { role: "toolResult" }> }> {
+  const resultsById = new Map<
+    string,
+    { source: AgentMessage; result: Extract<AgentMessage, { role: "toolResult" }> }
+  >();
   const toolCallIds = new Set(params.toolCalls.map((toolCall) => toolCall.id));
+  // Tool-call ids can legitimately repeat across assistant turns. Displaced
+  // results are claimed in occurrence order by the last unresolved turns that
+  // call the same id, so this turn may only claim a result when more results
+  // exist than later turns that still need one; otherwise the result is
+  // reserved for the later turn it is adjacent to.
+  const laterTurnCountById = new Map<string, number>();
+  const availableCountById = new Map<string, number>();
+  for (let index = params.startIndex; index < params.messages.length; index += 1) {
+    const candidate = params.messages[index];
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    if (candidate.role === "assistant") {
+      const claimedIds = new Set<string>();
+      for (const toolCall of extractToolCallsFromAssistant(
+        candidate as Extract<AgentMessage, { role: "assistant" }>,
+      )) {
+        if (toolCallIds.has(toolCall.id)) {
+          claimedIds.add(toolCall.id);
+        }
+      }
+      for (const id of claimedIds) {
+        laterTurnCountById.set(id, (laterTurnCountById.get(id) ?? 0) + 1);
+      }
+      continue;
+    }
+    if (candidate.role !== "toolResult" || params.emittedToolResultRecords.has(candidate)) {
+      continue;
+    }
+    const id = extractToolResultId(normalizeLegacyToolResultId(candidate, params.toolCalls));
+    if (id && toolCallIds.has(id)) {
+      availableCountById.set(id, (availableCountById.get(id) ?? 0) + 1);
+    }
+  }
   for (let index = params.startIndex; index < params.messages.length; index += 1) {
     const candidate = params.messages[index];
     if (!candidate || typeof candidate !== "object" || candidate.role !== "toolResult") {
       continue;
     }
-    const normalizedLegacyResult = normalizeLegacyToolResultId(candidate, params.toolCalls);
-    const id = extractToolResultId(normalizedLegacyResult);
-    if (!id || !toolCallIds.has(id) || params.seenToolResultIds.has(id) || resultsById.has(id)) {
+    if (params.emittedToolResultRecords.has(candidate)) {
       continue;
     }
-    resultsById.set(
-      id,
-      normalizeToolResultName(normalizedLegacyResult, params.toolNamesById.get(id)),
-    );
+    const normalizedLegacyResult = normalizeLegacyToolResultId(candidate, params.toolCalls);
+    const id = extractToolResultId(normalizedLegacyResult);
+    if (!id || !toolCallIds.has(id) || resultsById.has(id)) {
+      continue;
+    }
+    if ((availableCountById.get(id) ?? 0) <= (laterTurnCountById.get(id) ?? 0)) {
+      continue;
+    }
+    resultsById.set(id, {
+      source: candidate,
+      result: normalizeToolResultName(normalizedLegacyResult, params.toolNamesById.get(id)),
+    });
   }
   return resultsById;
 }
@@ -601,6 +644,29 @@ export function repairToolUseResultPairing(
   let droppedOrphanCount = 0;
   let moved = false;
   let changed = false;
+
+  // Pair tool results with the current assistant turn before consulting the
+  // global seen-id dedupe, and track emitted records by identity. Tool-call
+  // ids that legitimately repeat across assistant turns (some providers
+  // restart id numbering every turn, e.g. exec_0/exec_1) previously had their
+  // real results dropped as duplicates, and the synthesized replacement was
+  // dropped by the same seen-id check, emitting dangling assistant tool calls
+  // that providers reject (tool_call_id without a matching response).
+  const emittedToolResultRecords = new Set<AgentMessage>();
+  const pushCurrentTurnToolResult = (msg: Extract<AgentMessage, { role: "toolResult" }>) => {
+    if (emittedToolResultRecords.has(msg)) {
+      droppedDuplicateCount += 1;
+      changed = true;
+      return;
+    }
+    const id = extractToolResultId(msg);
+    if (id) {
+      seenToolResultIds.add(id);
+      toolResultPositions.set(id, out.length);
+    }
+    emittedToolResultRecords.add(msg);
+    out.push(msg);
+  };
 
   const pushToolResult = (msg: Extract<AgentMessage, { role: "toolResult" }>) => {
     const id = extractToolResultId(msg);
@@ -693,15 +759,14 @@ export function repairToolUseResultPairing(
       }
 
       if (nextRole === "toolResult") {
+        if (emittedToolResultRecords.has(next)) {
+          continue;
+        }
         const toolResult = normalizeLegacyToolResultId(
           next as Extract<AgentMessage, { role: "toolResult" }>,
           toolCalls,
         );
         const id = extractToolResultId(toolResult);
-        if (id && seenToolResultIds.has(id)) {
-          pushToolResult(normalizeToolResultName(toolResult, toolCallNamesById.get(id)));
-          continue;
-        }
         if (id && toolCallIds.has(id)) {
           if (toolResult !== next) {
             changed = true;
@@ -729,6 +794,10 @@ export function repairToolUseResultPairing(
           }
           continue;
         }
+        if (id && seenToolResultIds.has(id)) {
+          pushToolResult(normalizeToolResultName(toolResult, toolCallNamesById.get(id)));
+          continue;
+        }
       }
 
       // Drop tool results that don't match the current assistant tool calls.
@@ -752,7 +821,7 @@ export function repairToolUseResultPairing(
           if (!result) {
             continue;
           }
-          pushToolResult(result);
+          pushCurrentTurnToolResult(result);
         }
       } else if (spanResultsById.size > 0) {
         changed = true;
@@ -780,19 +849,24 @@ export function repairToolUseResultPairing(
       startIndex: j,
       toolCalls,
       toolNamesById: toolCallNamesById,
-      seenToolResultIds,
+      emittedToolResultRecords,
     });
     for (const call of toolCalls) {
       const existing = spanResultsById.get(call.id);
       if (existing) {
-        pushToolResult(existing);
+        pushCurrentTurnToolResult(existing);
       } else {
         const laterResult = laterResultsById.get(call.id);
         if (laterResult) {
           laterResultsById.delete(call.id);
           moved = true;
           changed = true;
-          pushToolResult(laterResult);
+          if (laterResult.source !== laterResult.result) {
+            // Normalization cloned the displaced record; register the original
+            // too so a later turn cannot re-emit the same physical result.
+            emittedToolResultRecords.add(laterResult.source);
+          }
+          pushCurrentTurnToolResult(laterResult.result);
         } else {
           const missing = makeMissingToolResult({
             toolCallId: call.id,
@@ -801,7 +875,7 @@ export function repairToolUseResultPairing(
           });
           added.push(missing);
           changed = true;
-          pushToolResult(missing);
+          pushCurrentTurnToolResult(missing);
         }
       }
     }


### PR DESCRIPTION
Closes #109443

## What Problem This Solves

Fixes an issue where users who run sessions on a provider that restarts tool-call id numbering every assistant turn (e.g. Kimi for-coding, ids like `exec_0` reused each turn) — or who switch models mid-session from a provider with globally unique ids to such a provider — would see every subsequent model call fail with a provider 400 (`tool_call_ids did not have response messages`), leaving the session permanently broken until a manual `sessions.reset`.

Affected surface: embedded agent runs / session replay across all three replay layers (session sanitize, attempt repair, `anthropic-messages` transport boundary).

## Why This Change Was Made

`repairToolUseResultPairing` deduped tool results with a global `seenToolResultIds` set consulted before per-turn pairing, so legitimately repeated ids across turns lost their real results, and the function's own synthesized gap-fill results were dropped by the same check. The fix pairs tool results with the current assistant turn before the global dedupe runs and tracks emitted records by identity (including normalization clones), claiming displaced results in occurrence order with reservation for later turns that still call the same id. Boundaries: already-valid transcripts are returned unchanged, and genuinely missing results still get synthesized replacements.

## User Impact

Sessions with repeated per-turn tool-call ids keep their real tool results and no longer produce invalid payloads; previously such sessions bricked on every turn with a provider 400 and required a manual session reset. No behavior change for valid transcripts.

## Evidence

- Focused tests: `src/agents/session-transcript-repair.test.ts` — 60/60 pass, including new cases: repeated per-turn ids keep real results; synthesized gap-fill is not self-dropped; valid transcripts returned unchanged; occurrence pairing without re-emitting normalized records; later-turn reservation. The new tests fail against the unfixed source (discrimination verified).
- Consumer suites: 9 related test files (attachments, transport-message-transform, session-tool-result-guard, tool-result-context-guard, replay-history, transcript-repair-runtime-contract, attempt.tool-call-normalization, attempt-context-guards, attempt.transcript-policy) — 200/200 pass.
- `tsgo:core` / `tsgo:test:src` exit 0; targeted `oxlint` exit 0; `oxfmt --check` clean; `check-max-lines-ratchet` OK; `node scripts/tsdown-build.mjs` (dist bundle lane) exit 0.
- `codex review --base origin/main` run locally: 4 rounds; findings addressed (normalization-clone double-emit, occurrence pairing, adjacent-turn reservation); final round reported no actionable regressions.
- End-to-end: the same fix semantics have been running in production against the installed 2026.7.1 dist bundle (via a local post-patch) and repaired a real poisoned session verified against its archived failed-run snapshot.
- Environment note: local runs used Node v22.22.2 (repo engines ask \u003e=22.22.3); all lanes above passed. One unrelated test (`src/config/sessions/transcript.test.ts`) fails environmentally on this Node's SQLite build; CI on a supported Node should be clean.

## AI-assisted disclosure

This PR is AI-assisted: the fix was implemented by an isolated coding worker and reviewed by an orchestrating agent, ported from a hotfix verified in production. Prompts/session logs available on request. We confirm we understand the change and its boundaries (the occurrence-order attribution heuristic for genuinely ambiguous historical data; payloads are structurally valid regardless).