### PR TITLE
fix(infra): bound filesystem mount table probes

### DIFF
--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -340,6 +340,10 @@ describe("sqlite WAL maintenance", () => {
         databasePath: path.join(tempDir, "openclaw.sqlite"),
       });
 
+      expect(childProcess.execFileSync).toHaveBeenCalledWith("mount", [], {
+        encoding: "utf8",
+        timeout: 5_000,
+      });
       expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -7,6 +7,12 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { isSqliteLockError } from "./sqlite-transaction.js";
 
+// The `mount` command reads kernel filesystem tables synchronously. If a
+// remote/NFS mount point is unresponsive, the command can block indefinitely
+// while the kernel waits on the filesystem server. Bound it so WAL checks
+// fail closed instead of hanging gateway startup.
+const MOUNT_PROBE_TIMEOUT_MS = 5_000;
+
 // WAL maintenance configures SQLite write-ahead logging and schedules bounded
 // checkpoints so state databases do not accumulate unbounded WAL files.
 const DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
@@ -172,7 +178,14 @@ function readMountEntries(): MountEntry[] {
     // Linux superblock magic, so keep this fallback for named filesystem types.
   }
   try {
-    return parseMountCommandEntries(String(childProcess.execFileSync("mount", [])));
+    return parseMountCommandEntries(
+      String(
+        childProcess.execFileSync("mount", [], {
+          encoding: "utf8",
+          timeout: MOUNT_PROBE_TIMEOUT_MS,
+        }),
+      ),
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

The `mount` command in `readMountEntries()` (`src/infra/sqlite-wal.ts`) is called via `childProcess.execFileSync` without a timeout. If a remote/NFS mount point is unresponsive, the kernel can block the `mount` command indefinitely while waiting on the filesystem server. This blocks gateway startup during WAL maintenance configuration.

## Why This Change Was Made

Adds a 5-second timeout (`MOUNT_PROBE_TIMEOUT_MS`) to the `execFileSync("mount", [])` call so WAL filesystem checks fail closed instead of hanging the process.

This follows the same pattern as other bound probe PRs:
- `fix(infra): bound macOS metadata probes` (#109241)
- `fix(infra): bound macOS process start probes` (#109064)
- `fix(daemon): bound Node binary lookup` (#109239)

## User Impact

Gateway startup no longer hangs on machines with unresponsive NFS/remote mounts during SQLite WAL maintenance.

## Evidence

- All 37 existing tests pass (vitest infra config)
- Added assertion verifying `execFileSync` receives `{ encoding: "utf8", timeout: 5_000 }`