### PR TITLE
fix(cli): reject missing separator after config path brackets

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3140,7 +3140,7 @@ describe("config cli", () => {
 
     it("rejects a whitespace-only segment after a bracket before a dot", async () => {
       await expect(runConfigCommand(["config", "get", "agents.list[0] .id"])).rejects.toThrow(
-        "Invalid path (empty segment): agents.list[0] .id",
+        "Invalid path (missing separator after bracket): agents.list[0] .id",
       );
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
@@ -3149,8 +3149,35 @@ describe("config cli", () => {
 
     it("rejects a whitespace-only segment after a bracket before another bracket", async () => {
       await expect(runConfigCommand(["config", "get", "agents.list[0] [1]"])).rejects.toThrow(
-        "Invalid path (empty segment): agents.list[0] [1]",
+        "Invalid path (missing separator after bracket): agents.list[0] [1]",
       );
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-delimited text after a bracket path segment", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "agents.list[0]id", '"renamed"']),
+      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0]id");
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects whitespace-prefixed text after a bracket path segment", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "agents.list[0] id", '"renamed"']),
+      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0] id");
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects escape-prefixed continuations after a bracket path segment", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "agents.list[0]\\id", '"renamed"']),
+      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0]\\id");
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expect(mockWriteConfigFile).not.toHaveBeenCalled();

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -384,9 +384,17 @@ function parsePath(raw: string): PathSegment[] {
   // "foo[0].bar" is accepted while empty key segments (leading/trailing/double dots,
   // whitespace-only segments) are rejected instead of silently collapsed.
   let segmentEmitted = false;
+  // After `]`, only `.`, `[`, or end-of-input are legal. Bare text, whitespace, or
+  // escape continuations would invent a next segment (e.g. `foo[0]id`, `foo[0] id`).
+  let requireSeparatorAfterBracket = false;
   let i = 0;
   while (i < trimmed.length) {
     const ch = trimmed[i];
+    // Reject every post-bracket continuation before escape/text handling so
+    // whitespace and backslash cannot bypass the separator requirement.
+    if (requireSeparatorAfterBracket && ch !== "." && ch !== "[") {
+      throw new Error(`Invalid path (missing separator after bracket): ${raw}`);
+    }
     if (ch === "\\") {
       const next = trimmed[i + 1];
       if (next) {
@@ -396,6 +404,7 @@ function parsePath(raw: string): PathSegment[] {
       continue;
     }
     if (ch === ".") {
+      requireSeparatorAfterBracket = false;
       assertNotWhitespaceSegment(current, raw);
       if (!segmentEmitted && !current.trim()) {
         throw new Error(`Invalid path (empty segment): ${raw}`);
@@ -412,6 +421,8 @@ function parsePath(raw: string): PathSegment[] {
       // A bracket may start the path ("[0]"), follow a key ("foo[0]"), or follow
       // another bracket ("foo[0][1]"), but a bracket right after a "." boundary with
       // no key (e.g. "gateway.[port]") is an empty segment, same as a double dot.
+      // Post-bracket separator requirement is already satisfied by `ch === "["`
+      // above; the flag is re-armed after this bracket closes.
       assertNotWhitespaceSegment(current, raw);
       if (!current.trim() && !segmentEmitted && parts.length > 0) {
         throw new Error(`Invalid path (empty segment): ${raw}`);
@@ -430,6 +441,7 @@ function parsePath(raw: string): PathSegment[] {
       }
       parts.push(parseBracketPathSegment(inside, raw));
       segmentEmitted = true;
+      requireSeparatorAfterBracket = true;
       i = close + 1;
       continue;
     }


### PR DESCRIPTION
Closes #109299

## What Problem This Solves

Fixes an issue where users typing or scripting `openclaw config` paths would accidentally read, set, unset, or patch a different config key when a bracket segment was followed by bare text without a separator (for example `agents.list[0]id` was treated the same as `agents.list[0].id`).

## Why This Change Was Made

After a `]` the shared config path parser only accepts `.`, another `[`, or end-of-input. Bare text, whitespace, and backslash/escape continuations are rejected with a clear error instead of inventing a next path segment.

This completes the separator grammar for the shared `parsePath` / `parseConfigSetPath` boundary used by config get/set/unset/patch: valid forms such as `foo[0].bar`, `foo[0][1]`, and `[0]` stay accepted. Compatibility impact is intentional and limited to previously undocumented malformed bracket paths.

## User Impact

Operators and scripts get a fail-fast error for typoed bracket paths instead of silently targeting a different config location (which can look like data loss or wrong agent/settings updates).

## Evidence

Parser probe after this patch:

```text
agents.list[0]id ERROR Invalid path (missing separator after bracket): agents.list[0]id
agents.list[0] id ERROR Invalid path (missing separator after bracket): agents.list[0] id
agents.list[0]\id ERROR Invalid path (missing separator after bracket): agents.list[0]\id
agents.list[0].id ["agents","list","0","id"]
agents.list[0][1] ["agents","list","0","1"]
[0] ["0"]
```

Focused tests:

```text
node scripts/run-vitest.mjs src/cli/config-cli.test.ts -t "non-delimited text after a bracket|whitespace-prefixed text after a bracket|escape-prefixed|preserves valid bracket|whitespace-only segment after a bracket"

Test Files  1 passed (1)
     Tests  6 passed | 126 skipped (132)
```

Also: `git diff --check` PASS; `oxfmt --check` PASS on touched files; path-scoped `oxlint` PASS (0 errors).

## Real behavior proof

- Behavior addressed: malformed config paths with missing separator after a bracket segment are rejected; valid bracket/dotted forms still parse.
- Environment: local macOS, openclaw checkout at commit after this patch, Node 22+/24, no live channel or paid API required.
- Current-main contrast: on main before this patch, `parseConfigSetPath("agents.list[0]id")`, `"agents.list[0] id"`, and `"agents.list[0]\\id"` all accepted and normalized to the same segment list as the valid dotted path.
- Exact steps or command run after this patch:
  `node --import tsx -e "import { parseConfigSetPath } from './src/cli/config-cli.ts'; for (const p of ['agents.list[0]id','agents.list[0] id','agents.list[0]\\\\id','agents.list[0].id','agents.list[0][1]','[0]']) { try { console.log(p, JSON.stringify(parseConfigSetPath(p))); } catch (err) { console.log(p, 'ERROR', err.message); } }"`
  and focused Vitest above.
- Evidence after fix: malformed cases throw `Invalid path (missing separator after bracket): …`; valid forms return the expected segment arrays (see Evidence).
- Control check: only the post-bracket separator invariant is under test; consecutive brackets and dotted keys after brackets still succeed; escaped dots inside non-bracket key segments remain covered by existing tests.
- Observed result after fix: typos no longer silently map to a different config path; operators see a clear invalid-path error before any config read/write.
- What was not tested: live multi-agent gateway config workflows; other shells of config UX beyond the shared path parser and CLI config tests.

---

This PR was authored with AI assistance (Grok).
