### PR TITLE
fix(sessions): bound git branch resolution probes

### DIFF
--- a/src/agents/sessions/footer-data-provider.ts
+++ b/src/agents/sessions/footer-data-provider.ts
@@ -67,6 +67,13 @@ function findGitPaths(cwd: string): GitPaths | null {
 }
 
 /** Ask git for the current branch. Returns null on detached HEAD or if git is unavailable. */
+
+// `git symbolic-ref` reads a single ref file and exits quickly on healthy
+// repos, but on NFS/CIFS mounts or with a stuck kernel filesystem driver it
+// can block indefinitely. Bound it so the session footer falls back to the
+// HEAD-read path instead of hanging UI rendering.
+const GIT_BRANCH_RESOLVE_TIMEOUT_MS = 2_000;
+
 function resolveBranchWithGitSync(repoDir: string): string | null {
   const result = spawnSync(
     "git",
@@ -75,6 +82,7 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
       cwd: repoDir,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: GIT_BRANCH_RESOLVE_TIMEOUT_MS,
     },
   );
   const branch = result.status === 0 ? result.stdout.trim() : "";


### PR DESCRIPTION
## What Problem This Solves

`resolveBranchWithGitSync()` in the session footer data provider calls `spawnSync("git", ["symbolic-ref", ...])` without a timeout. On NFS/CIFS mounts or with a stuck kernel filesystem driver, `git` can block indefinitely, which hangs the session UI footer rendering.

## Why This Change Was Made

Adds a 2-second timeout (`GIT_BRANCH_RESOLVE_TIMEOUT_MS`) so the footer falls back to the existing HEAD-read path instead of hanging.

This follows the same pattern as other bound probe PRs:
- `fix(daemon): bound Node binary lookup` (#109239)
- `fix(infra): bound macOS process start probes` (#109064)

`git symbolic-ref` is fast on healthy repos (<50ms) — 2 seconds is a generous bound.

## User Impact

Session UI footer no longer hangs when the working directory is on an unresponsive network mount.

## Evidence

- Code change is minimal and single-site: one timeout constant + one option
- The existing fallback path (reading `.git/HEAD` directly) already handles the timeout case gracefully