### PR TITLE
fix(cli): bound DNS setup system command probes

### DIFF
--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -15,12 +15,19 @@ import {
 } from "../infra/widearea-dns.js";
 import { defaultRuntime } from "../runtime.js";
 
-type RunOpts = { allowFailure?: boolean; inherit?: boolean };
+type RunOpts = { allowFailure?: boolean; inherit?: boolean; timeout?: number };
+
+// Quick system probes (brew --prefix, brew list, sudo mkdir, sudo tee) resolve
+// in well under a second on healthy hosts. Bound every spawned command so a
+// stuck NFS mount, unresponsive daemon, or hung sudo prompt does not block the
+// CLI indefinitely.
+const DEFAULT_SYSTEM_CMD_TIMEOUT_MS = 10_000;
 
 function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
+    ...(opts?.timeout !== undefined ? { timeout: opts.timeout } : {}),
   });
   if (res.error) {
     throw res.error;
@@ -51,6 +58,7 @@ function writeFileSudoIfNeeded(filePath: string, content: string): void {
     input: content,
     encoding: "utf-8",
     stdio: ["pipe", "ignore", "inherit"],
+    timeout: DEFAULT_SYSTEM_CMD_TIMEOUT_MS,
   });
   if (res.error) {
     throw res.error;
@@ -87,7 +95,7 @@ function zoneFileNeedsBootstrap(zonePath: string): boolean {
 }
 
 function detectBrewPrefix(): string {
-  const out = run("brew", ["--prefix"]);
+  const out = run("brew", ["--prefix"], { timeout: DEFAULT_SYSTEM_CMD_TIMEOUT_MS });
   const prefix = out.trim();
   if (!prefix) {
     throw new Error("failed to resolve Homebrew prefix");
@@ -201,7 +209,10 @@ export function registerDnsCli(program: Command) {
       const importGlob = path.join(confDir, "*.server");
       const serverPath = path.join(confDir, `${wideAreaDomain.replace(/\.$/, "")}.server`);
 
-      run("brew", ["list", "coredns"], { allowFailure: true });
+      run("brew", ["list", "coredns"], {
+        allowFailure: true,
+        timeout: DEFAULT_SYSTEM_CMD_TIMEOUT_MS,
+      });
       run("brew", ["install", "coredns"], {
         inherit: true,
         allowFailure: true,


### PR DESCRIPTION
## What Problem This Solves

The `dns setup` CLI helper in `src/cli/dns-cli.ts` invokes `spawnSync` for `brew` (`--prefix`, `list`) and `sudo tee` without a timeout. A stuck Homebrew daemon, unresponsive NFS mount, or hung sudo password prompt can block the CLI indefinitely.

## Why This Change Was Made

- Adds `timeout?: number` to `RunOpts` type and passes it through to `spawnSync`
- Adds a 10-second timeout (`DEFAULT_SYSTEM_CMD_TIMEOUT_MS`) to quick metadata probes:
  - `brew --prefix` (Homebrew prefix detection)
  - `brew list` (package presence check)
  - `sudo tee` (privileged file writes)
- Interactive/long-running commands (`brew install`, `sudo brew services restart`) intentionally keep no timeout — the user is watching and can Ctrl+C

This follows the same pattern as other bound probe PRs:
- `fix(infra): bound macOS metadata probes` (#109241)
- `fix(doctor): bound launchctl environment probes` (#109115)

## User Impact

The `openclaw dns setup --apply` command no longer hangs on unresponsive system daemons.

## Evidence

- Code change is localized to `dns-cli.ts` only
- Timeout is only applied to quick probes, not user-watched interactive commands