### PR TITLE
improve: speed up cron process-group timeout test

### DIFF
--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -139,9 +139,8 @@ describe("runCronCommandJob", () => {
   it.skipIf(process.platform === "win32")("kills shell process groups on timeout", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-command-"));
     const childPidPath = path.join(tempDir, "child.pid");
-    const childScript = "setInterval(() => {}, 1000)";
     const shellCommand = [
-      `${JSON.stringify(process.execPath)} -e ${JSON.stringify(childScript)} &`,
+      "sleep 60 &",
       "child_pid=$!",
       `printf '%s' "$child_pid" > ${JSON.stringify(childPidPath)}`,
       'wait "$child_pid"',
@@ -151,7 +150,7 @@ describe("runCronCommandJob", () => {
       job: makeCommandJob({
         kind: "command",
         argv: ["sh", "-lc", shellCommand],
-        timeoutSeconds: 1,
+        timeoutSeconds: 0.5,
       }),
     });
 


### PR DESCRIPTION
## What Problem This Solves

The cron process-group timeout test waited a full second and launched a Node runtime merely to keep a descendant alive. Those costs did not add coverage to the shell process-group termination contract.

## Why This Change Was Made

Use the POSIX `sleep` utility as the real shell descendant and retain a conservative 500ms startup margin before timeout. The test still records the child PID, observes a timeout error, and verifies the descendant is gone. No production or CI configuration changes.

## User Impact

No user-visible behavior change. Maintainers get faster cron test feedback.

## Evidence

- Blacksmith Testbox `tbx_01kxpq76j9z9d09mq50669yd5h`: https://github.com/openclaw/openclaw/actions/runs/29544578373
- Focused command: `pnpm test src/cron/command-runner.test.ts -t "kills shell process groups on timeout"`
- Three-run median body: 1.405s before, 0.853s after (39.3% faster)
- Full file: `pnpm test src/cron/command-runner.test.ts`, 8/8 passed
- Remote `pnpm check:changed`: passed
- Autoreview cycle: initial 100ms margin finding accepted; raised to 500ms; final review clean

AI-assisted; reviewed and understood.
