### PR TITLE
fix(sessions): bound git branch probe to prevent gateway footer stalls

### DIFF
--- a/src/agents/sessions/footer-data-provider.ts
+++ b/src/agents/sessions/footer-data-provider.ts
@@ -68,7 +68,7 @@ function findGitPaths(cwd: string): GitPaths | null {
 
 // This synchronous probe runs during gateway prompt footer assembly. A stalled
 // git symbolic-ref call should not block the gateway process indefinitely.
-const GIT_SYMBOLIC_REF_TIMEOUT_MS = 5_000;
+export const GIT_SYMBOLIC_REF_TIMEOUT_MS = 5_000;
 
 /** Ask git for the current branch. Returns null on detached HEAD or if git is unavailable. */
 function resolveBranchWithGitSync(repoDir: string): string | null {

--- a/src/agents/sessions/footer-data-provider.ts
+++ b/src/agents/sessions/footer-data-provider.ts
@@ -66,6 +66,10 @@ function findGitPaths(cwd: string): GitPaths | null {
   }
 }
 
+// This synchronous probe runs during gateway prompt footer assembly. A stalled
+// git symbolic-ref call should not block the gateway process indefinitely.
+const GIT_SYMBOLIC_REF_TIMEOUT_MS = 5_000;
+
 /** Ask git for the current branch. Returns null on detached HEAD or if git is unavailable. */
 function resolveBranchWithGitSync(repoDir: string): string | null {
   const result = spawnSync(
@@ -75,6 +79,8 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
       cwd: repoDir,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: GIT_SYMBOLIC_REF_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     },
   );
   const branch = result.status === 0 ? result.stdout.trim() : "";


### PR DESCRIPTION
## What Problem This Solves

The synchronous `git symbolic-ref` probe in `resolveBranchWithGitSync` runs during gateway prompt footer assembly. The `spawnSync` call had no timeout, so a stalled git process could block the gateway indefinitely.

## Why This Change Was Made

Add `GIT_SYMBOLIC_REF_TIMEOUT_MS` (5 seconds) and `killSignal: "SIGKILL"` to the spawnSync call. The caller already returns `null` when git is unavailable or on non-zero exit, so the timeout path is safe — a stalled probe falls back to the same `null` result.

The 5s bound follows the same pattern as macOS system probes (#109241) and other synchronous gateway probes.

## User Impact

Gateway prompt footer assembly is no longer blocked indefinitely by a stalled git symbolic-ref call. `getGitBranch()` returns `null` on timeout.

## Evidence

- `src/agents/sessions/footer-data-provider.ts` — one spawnSync call bounded with `timeout: 5000, killSignal: "SIGKILL"`
- `oxfmt --check` + `oxlint` on changed file
- `git diff origin/main...HEAD --check` — clean