### PR TITLE
fix(cli): bound DNS CLI spawns to prevent system tool stalls

### DIFF
--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -15,12 +15,19 @@ import {
 } from "../infra/widearea-dns.js";
 import { defaultRuntime } from "../runtime.js";
 
+// DNS CLI commands invoke system tools (resolvectl, systemd-resolve, sudo tee)
+// that may stall waiting on dbus or tty input. Bound every spawn with a deadline
+// so a stalled system tool does not block the CLI indefinitely.
+const DNS_CLI_SPAWN_TIMEOUT_MS = 30_000;
+
 type RunOpts = { allowFailure?: boolean; inherit?: boolean };
 
 function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
+    timeout: DNS_CLI_SPAWN_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   });
   if (res.error) {
     throw res.error;
@@ -51,6 +58,8 @@ function writeFileSudoIfNeeded(filePath: string, content: string): void {
     input: content,
     encoding: "utf-8",
     stdio: ["pipe", "ignore", "inherit"],
+    timeout: DNS_CLI_SPAWN_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   });
   if (res.error) {
     throw res.error;


### PR DESCRIPTION
## What Problem This Solves

The `resolvectl`/`systemd-resolve` and `sudo tee` spawns in the DNS CLI had no deadline. A stalled dbus call or tty prompt could block the CLI indefinitely.

## Why This Change Was Made

Add `DNS_CLI_SPAWN_TIMEOUT_MS` (30 seconds) and `killSignal: "SIGKILL"` to both spawnSync calls. The existing error paths already throw on non-zero exit, so timeout failures are surfaced to the user rather than silently swallowed. The 30s bound follows the same pattern as doctor subprocess bounds (#109253).

## User Impact

`openclaw dns setup` and related commands no longer block indefinitely when system DNS tools stall.

## Evidence

- `src/cli/dns-cli.ts` — 2 spawnSync calls bounded with `timeout: 30000, killSignal: "SIGKILL"`
- `oxfmt --check` + `oxlint` on changed file
- `git diff origin/main...HEAD --check` — clean