### PR TITLE
fix(qqbot): ignore blank app id fallbacks

### DIFF
--- a/extensions/qqbot/src/engine/config/resolve.test.ts
+++ b/extensions/qqbot/src/engine/config/resolve.test.ts
@@ -1,11 +1,15 @@
 // Qqbot tests cover resolve plugin behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_ACCOUNT_ID,
   listAccountIds,
   resolveDefaultAccountId,
   resolveAccountBase,
 } from "./resolve.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("engine/config/resolve", () => {
   it("returns empty list when no accounts configured", () => {
@@ -19,6 +23,32 @@ describe("engine/config/resolve", () => {
       },
     };
     expect(listAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
+  });
+
+  it("ignores blank app IDs when discovering configured accounts", () => {
+    vi.stubEnv("QQBOT_APP_ID", "   ");
+    const cfg = {
+      channels: {
+        qqbot: {
+          appId: "   ",
+          accounts: {
+            bot2: { appId: "   " },
+          },
+        },
+      },
+    };
+
+    expect(listAccountIds(cfg)).toEqual([]);
+    expect(resolveDefaultAccountId(cfg)).toBe(DEFAULT_ACCOUNT_ID);
+    expect(resolveAccountBase(cfg, DEFAULT_ACCOUNT_ID).appId).toBe("");
+  });
+
+  it("uses non-blank QQBOT_APP_ID as an implicit default account", () => {
+    vi.stubEnv("QQBOT_APP_ID", " 123456 ");
+
+    expect(listAccountIds({})).toEqual([DEFAULT_ACCOUNT_ID]);
+    expect(resolveDefaultAccountId({})).toBe(DEFAULT_ACCOUNT_ID);
+    expect(resolveAccountBase({}, DEFAULT_ACCOUNT_ID).appId).toBe("123456");
   });
 
   it("lists named accounts", () => {

--- a/extensions/qqbot/src/engine/config/resolve.ts
+++ b/extensions/qqbot/src/engine/config/resolve.ts
@@ -12,6 +12,7 @@ import { getPlatformAdapter } from "../adapter/index.js";
 import {
   asOptionalObjectRecord as asRecord,
   normalizeOptionalLowercaseString,
+  normalizeOptionalString,
   normalizeStringifiedEntries,
   readStringField as readString,
 } from "../utils/string-normalize.js";
@@ -51,14 +52,19 @@ interface ResolvedAccountBase {
   config: Record<string, unknown>;
 }
 
-function normalizeAppId(raw: unknown): string {
-  if (typeof raw === "string") {
-    return raw.trim();
-  }
+function normalizeOptionalAppId(raw: unknown): string | undefined {
   if (typeof raw === "number") {
     return String(raw);
   }
-  return "";
+  return normalizeOptionalString(raw);
+}
+
+function normalizeAppId(raw: unknown): string {
+  return normalizeOptionalAppId(raw) ?? "";
+}
+
+function hasAppId(raw: unknown): boolean {
+  return normalizeOptionalAppId(raw) !== undefined;
 }
 
 function normalizeAccountConfig(
@@ -87,13 +93,13 @@ export function listAccountIds(cfg: Record<string, unknown>): string[] {
   const ids = new Set<string>();
   const qqbot = readQQBotSection(cfg);
 
-  if (qqbot?.appId || process.env.QQBOT_APP_ID) {
+  if (hasAppId(qqbot?.appId) || hasAppId(process.env.QQBOT_APP_ID)) {
     ids.add(DEFAULT_ACCOUNT_ID);
   }
 
   if (qqbot?.accounts) {
     for (const accountId of Object.keys(qqbot.accounts)) {
-      if (qqbot.accounts[accountId]?.appId) {
+      if (hasAppId(qqbot.accounts[accountId]?.appId)) {
         ids.add(accountId);
       }
     }
@@ -112,16 +118,16 @@ export function resolveDefaultAccountId(cfg: Record<string, unknown>): string {
   if (
     configuredDefaultAccountId &&
     (configuredDefaultAccountId === DEFAULT_ACCOUNT_ID ||
-      Boolean(qqbot?.accounts?.[configuredDefaultAccountId]?.appId))
+      hasAppId(qqbot?.accounts?.[configuredDefaultAccountId]?.appId))
   ) {
     return configuredDefaultAccountId;
   }
-  if (qqbot?.appId || process.env.QQBOT_APP_ID) {
+  if (hasAppId(qqbot?.appId) || hasAppId(process.env.QQBOT_APP_ID)) {
     return DEFAULT_ACCOUNT_ID;
   }
   if (qqbot?.accounts) {
     const ids = Object.keys(qqbot.accounts);
-    const firstId = ids.at(0);
+    const firstId = ids.find((id) => hasAppId(qqbot.accounts?.[id]?.appId));
     if (firstId !== undefined) {
       return firstId;
     }
@@ -158,7 +164,7 @@ export function resolveAccountBase(
     appId = normalizeAppId(asRecord(account)?.appId);
   }
 
-  if (!appId && process.env.QQBOT_APP_ID && resolvedAccountId === DEFAULT_ACCOUNT_ID) {
+  if (!appId && hasAppId(process.env.QQBOT_APP_ID) && resolvedAccountId === DEFAULT_ACCOUNT_ID) {
     appId = normalizeAppId(process.env.QQBOT_APP_ID);
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QQBot users with whitespace-only app IDs could have empty default or named accounts discovered as configured.

## Why This Change Was Made

QQBot account discovery and default selection now normalize app IDs before treating them as configured, reusing the existing string normalization helper while preserving numeric app IDs. Non-blank `QQBOT_APP_ID` values still provide the implicit default account.

## User Impact

Users no longer see blank QQBot account entries selected from whitespace-only config or environment values.

## Evidence

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/config/resolve.test.ts`: 1 file passed, 13 tests passed.
- Real production-module proof: `pnpm exec tsx proof-live.ts` imports `extensions/qqbot/src/engine/config/resolve.ts` and exercises blank and non-blank env fallbacks.

```text
Before fix from origin/main:
entrypoint: extensions/qqbot/src/engine/config/resolve.ts
blank.ids: ["default","bot2"]
blank.default: default
blank.resolvedAppId: ""
valid-env.ids: ["default"]
valid-env.default: default
valid-env.resolvedAppId: "123456"

After fix on this branch:
entrypoint: extensions/qqbot/src/engine/config/resolve.ts
blank.ids: []
blank.default: default
blank.resolvedAppId: ""
valid-env.ids: ["default"]
valid-env.default: default
valid-env.resolvedAppId: "123456"
```

<details>
<summary>proof-live.ts</summary>

```ts
const repo = process.env.REPO_UNDER_TEST ?? process.cwd();

async function main() {
  const mod = await import(`${repo}/extensions/qqbot/src/engine/config/resolve.ts`);

  const cfgWithBlankIds = {
    channels: {
      qqbot: {
        appId: "   ",
        accounts: {
          bot2: { appId: "   " },
        },
      },
    },
  };

  process.env.QQBOT_APP_ID = "   ";
  console.log(`blank.ids: ${JSON.stringify(mod.listAccountIds(cfgWithBlankIds))}`);
  console.log(`blank.default: ${mod.resolveDefaultAccountId(cfgWithBlankIds)}`);
  console.log(
    `blank.resolvedAppId: ${JSON.stringify(mod.resolveAccountBase(cfgWithBlankIds, mod.DEFAULT_ACCOUNT_ID).appId)}`,
  );

  process.env.QQBOT_APP_ID = " 123456 ";
  console.log(`valid-env.ids: ${JSON.stringify(mod.listAccountIds({}))}`);
  console.log(`valid-env.default: ${mod.resolveDefaultAccountId({})}`);
  console.log(
    `valid-env.resolvedAppId: ${JSON.stringify(mod.resolveAccountBase({}, mod.DEFAULT_ACCOUNT_ID).appId)}`,
  );
}

void main();
```

</details>

AI-assisted: built with Codex
