### PR TITLE
fix(usage-bar): clear dead watcher reference after transient error

### DIFF
--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -214,7 +214,9 @@ describe("loadUsageBarTemplate", () => {
       // entry.template = undefined.
       writeFileSync(path, "{ not json");
       // Wait for the watcher to deliver the change event.
-      await new Promise((r) => setTimeout(r, 200));
+      await new Promise((r) => {
+        setTimeout(r, 200);
+      });
 
       // The template is now invalid — served as DEFAULT.
       expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -227,9 +227,26 @@ describe("loadUsageBarTemplate", () => {
       // Write valid content to disk.
       writeFileSync(path, JSON.stringify(tplB));
 
-      // With the fix, entry.watcher is undefined → cacheTemplateFile re-reads.
-      // Without the fix, entry.watcher is a closed FSWatcher (truthy) →
-      // returns undefined → DEFAULT.
+      expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
+    });
+
+    it("reloads a still-valid template after watcher error", async () => {
+      const path = tmpFile("t.json", JSON.stringify(tplA));
+
+      // Load valid template → creates a watcher in the cache.
+      expect(loadUsageBarTemplate(path)).toMatchObject(tplA);
+      expect(capturedWatchers.length).toBe(1);
+
+      // Simulate a transient watcher error while the template is still valid.
+      capturedWatchers[0]?.emit("error", new Error("simulated watcher error"));
+
+      // Without the fix (entry.template cleared): the stale tplA is still
+      // served from cache because entry.template is truthy.  File edits
+      // are never observed because the dead watcher doesn't fire and
+      // loadUsageBarTemplate never calls cacheTemplateFile() again.
+      // With the fix: entry.template is also cleared, so the next load
+      // re-reads from disk and creates a fresh watcher.
+      writeFileSync(path, JSON.stringify(tplB));
       expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
     });
 

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -13,6 +13,21 @@ vi.mock("../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => ({ warn: warnSpy }),
 }));
 
+const capturedWatchers = vi.hoisted(() => [] as Array<ReturnType<typeof import("node:fs").watch>>);
+
+vi.mock("node:fs", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("node:fs")>();
+  const origWatch = orig.watch;
+  return {
+    ...orig,
+    watch: ((path: unknown, opts: unknown, cb: unknown) => {
+      const w = origWatch(path as never, opts as never, cb as never);
+      capturedWatchers.push(w);
+      return w;
+    }) as typeof orig.watch,
+  };
+});
+
 const tplA = { segments: [{ text: "A" }] };
 const tplB = { output: { default: [{ text: "B" }] } };
 
@@ -21,6 +36,7 @@ const cleanups: Array<() => void> = [];
 afterEach(() => {
   clearUsageBarTemplateCacheForTest();
   warnSpy.mockClear();
+  capturedWatchers.splice(0);
   for (const fn of cleanups.splice(0)) {
     fn();
   }
@@ -185,6 +201,36 @@ describe("loadUsageBarTemplate", () => {
       expect(loadUsageBarTemplate(paths[0])).toMatchObject({
         segments: [{ text: "v2-0" }],
       });
+    });
+
+    it("recovers after watcher error by clearing the dead watcher reference", async () => {
+      const path = tmpFile("t.json", JSON.stringify(tplA));
+
+      // Load valid template → creates a watcher in the cache.
+      expect(loadUsageBarTemplate(path)).toMatchObject(tplA);
+      expect(capturedWatchers.length).toBe(1);
+
+      // Write invalid JSON to trigger the change handler, which sets
+      // entry.template = undefined.
+      writeFileSync(path, "{ not json");
+      // Wait for the watcher to deliver the change event.
+      await new Promise((r) => setTimeout(r, 200));
+
+      // The template is now invalid — served as DEFAULT.
+      expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+
+      // Simulate a transient watcher error.
+      // Without the fix: entry.watcher stays truthy → permanent DEFAULT.
+      // With the fix: entry.watcher is cleared → recovery on next access.
+      capturedWatchers[0]?.emit("error", new Error("simulated watcher error"));
+
+      // Write valid content to disk.
+      writeFileSync(path, JSON.stringify(tplB));
+
+      // With the fix, entry.watcher is undefined → cacheTemplateFile re-reads.
+      // Without the fix, entry.watcher is a closed FSWatcher (truthy) →
+      // returns undefined → DEFAULT.
+      expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
     });
 
     it("does not evict when retrying the same key after a prior miss", () => {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -157,6 +157,7 @@ function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
       watcher.on("error", () => {
         watcher.close();
         entry.watcher = undefined;
+        entry.template = undefined;
       });
       entry.watcher = watcher;
     } catch {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -156,6 +156,7 @@ function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
       });
       watcher.on("error", () => {
         watcher.close();
+        entry.watcher = undefined;
       });
       entry.watcher = watcher;
     } catch {


### PR DESCRIPTION

## Summary
Clear both `entry.watcher` and `entry.template` when a usage bar template file watcher hits a transient error, so the next access re-reads from disk and creates a fresh watcher — whether the template was valid or invalid at the time of the error.

## What Problem This Solves
After a usage bar template file watcher (`src/auto-reply/usage-bar/template.ts`) hits a transient filesystem error, the error handler called `watcher.close()` but left the cache entry intact. `loadUsageBarTemplate` at line 184 checks `cached.template ?? (cached.watcher ? undefined : cacheTemplateFile(path))` — a truthy cached template short-circuits the re-read, so edits after the watcher error are never observed.

The original fix (PR head `2da5c8f`) cleared only `entry.watcher`. This recovered the case where the template was already `undefined` (invalidated by a prior change event before the error), but left the common case unaddressed: a valid cached template that stays stale indefinitely after its watcher dies.

**Code evidence**: [template.ts:157-160](https://github.com/openclaw/openclaw/blob/main/src/auto-reply/usage-bar/template.ts#L157-L160)

## Root Cause
- Bug present since the watcher was added in [#98990](https://github.com/openclaw/openclaw/pull/98990)
- Invariant violated: a closed FSWatcher must not be treated as "still watching." The cache logic at line 184 uses truthiness of both `entry.template` and `entry.watcher` — both must be cleared for recovery.
- Trigger: any transient inotify/kqueue watcher error, regardless of the template's current cached state.

## Why This Fix
Clear `entry.template = undefined` alongside `entry.watcher = undefined`. This makes the cache entry eligible for full re-read on the next access:
- **Valid template case**: File was valid → watcher errors → file is edited → next load re-reads → picks up the edit
- **Invalid template case** (already covered): File was invalidated → watcher errors → next load re-reads → picks up new content

This matches the recovery pattern from [#109682](https://github.com/openclaw/openclaw/pull/109682) (config hot-reload watcher recovery, 🦞).

## User Impact
- **Before**: After a transient watcher error, users see stale usage bar footer content indefinitely. Only cache eviction (64 other paths loaded) or gateway restart recovers.
- **After**: The next `loadUsageBarTemplate` call re-reads from disk and creates a fresh watcher. Template edits are picked up within one access.

## Evidence
- **Before**: Watcher error → stale template served forever
- **After**: Watcher error → `entry.template = undefined` + `entry.watcher = undefined` → next load re-reads from disk
- Two regression tests: invalid-template recovery AND valid-template recovery after watcher error

## Real Behavior Proof

### Valid-template recovery after watcher error (new test)

```bash
$ node --require ./scripts/proof-watcher-patch.cjs --import tsx scripts/proof-usage-bar-watcher-error.mjs
Step 1: Load valid template
  PASS: valid template loaded
  watchers captured: 1
Step 2: Inject transient watcher error (template still valid)
  error emitted on captured watcher
Step 3: Write new content and reload
  PASS: template recovery after watcher error  ← new: valid-cache path
  Template: {"segments":[{"text":"CUSTOM-B-RECOVERED"}]}
VERDICT: PASS — template recovers after watcher error
```

### Test results

```bash
$ node scripts/run-vitest.mjs src/auto-reply/usage-bar/template.test.ts
 ✓ 15/15 passed
     ✓ recovers after watcher error by clearing the dead watcher reference
     ✓ reloads a still-valid template after watcher error
$ node scripts/run-vitest.mjs src/auto-reply/usage-bar/template.watcher-proof.test.ts
 ✓ 1/1 passed (0 watchers leaked)
```

## Tests and Validation
- `node scripts/run-vitest.mjs src/auto-reply/usage-bar/template.test.ts` — 15/15 passed
- `node scripts/run-vitest.mjs src/auto-reply/usage-bar/template.watcher-proof.test.ts` — 1/1 passed (0 leaked)
- `git diff --check` clean
