### PR TITLE
Accept target alias for Discord read actions

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -360,6 +360,46 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
+  it("accepts message.action target as a Discord read channel alias", async () => {
+    const cfg = discordConfig();
+    await handleDiscordMessageAction({
+      action: "read",
+      params: {
+        target: "123",
+      },
+      cfg,
+      accountId: "ops",
+      requesterAccountId: "ops",
+      conversationReadOrigin: "delegated",
+      toolContext: {
+        currentChannelProvider: "discord",
+        currentChannelId: "channel:123",
+      },
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "readMessages",
+        accountId: "ops",
+        channelId: "123",
+        limit: undefined,
+        before: undefined,
+        after: undefined,
+        around: undefined,
+      },
+      cfg,
+      options: {
+        ...defaultActionOptions(),
+        conversationReadOrigin: "delegated",
+        readContext: {
+          requesterAccountId: "ops",
+          currentChannelProvider: "discord",
+          currentChannelId: "channel:123",
+        },
+      },
+    });
+  });
+
   it("forwards attested current-conversation context to Discord channel info", async () => {
     const cfg = discordConfig({ channelInfo: true });
     await handleDiscordMessageAction({

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -469,6 +469,38 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
+  it("normalizes bare numeric message.action send targets as Discord channels", async () => {
+    const cfg = discordConfig();
+    await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        target: "123",
+        message: "hello",
+      },
+      cfg,
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "sendMessage",
+        accountId: undefined,
+        to: "channel:123",
+        content: "hello",
+        mediaUrl: undefined,
+        filename: undefined,
+        replyTo: undefined,
+        components: undefined,
+        embeds: undefined,
+        asVoice: false,
+        silent: false,
+        __sessionKey: undefined,
+        __agentId: undefined,
+      },
+      cfg,
+      options: defaultActionOptions(),
+    });
+  });
+
   it("notifies inbound event delivery after message sends", async () => {
     const markDelivered = vi.fn();
     const end = beginDiscordInboundEventDeliveryCorrelation(

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -43,6 +43,11 @@ function readCurrentDiscordTarget(
   return target || undefined;
 }
 
+function normalizeDiscordActionSendTarget(raw: string): string {
+  const target = raw.trim();
+  return /^\d+$/.test(target) ? `channel:${target}` : raw;
+}
+
 export async function handleDiscordMessageAction(
   ctx: Pick<
     ChannelMessageActionContext,
@@ -117,7 +122,7 @@ export async function handleDiscordMessageAction(
     if (!target) {
       throw new Error("Discord channel target is required (use channel:<id>).");
     }
-    return target;
+    return normalizeDiscordActionSendTarget(target);
   };
 
   if (action === "send") {

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -101,6 +101,7 @@ export async function handleDiscordMessageAction(
     const target =
       readStringParam(params, "channelId") ??
       readStringParam(params, "to") ??
+      readStringParam(params, "target") ??
       readCurrentDiscordTarget(ctx.toolContext);
     if (!target) {
       throw new Error("Discord channel target is required (use channel:<id>).");

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -25,11 +25,6 @@ export function parseArgs(argv: unknown): {
 };
 export function releaseBranchForTag(tag: string): string;
 export function run(command: unknown, args: unknown, options?: Record<string, unknown>): string;
-export const isDirectReleaseCandidateExecution: (
-  directPath: string | undefined,
-  modulePath: string,
-  resolveRealPath?: (path: string) => string,
-) => boolean;
 export function buildReleaseCandidateState(
   options: unknown,
   {

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -25,11 +25,11 @@ export function parseArgs(argv: unknown): {
 };
 export function releaseBranchForTag(tag: string): string;
 export function run(command: unknown, args: unknown, options?: Record<string, unknown>): string;
-export function isDirectReleaseCandidateExecution(
+export const isDirectReleaseCandidateExecution: (
   directPath: string | undefined,
   modulePath: string,
   resolveRealPath?: (path: string) => string,
-): boolean;
+) => boolean;
 export function buildReleaseCandidateState(
   options: unknown,
   {

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -25,6 +25,11 @@ export function parseArgs(argv: unknown): {
 };
 export function releaseBranchForTag(tag: string): string;
 export function run(command: unknown, args: unknown, options?: Record<string, unknown>): string;
+export function isDirectReleaseCandidateExecution(
+  directPath: string | undefined,
+  modulePath: string,
+  resolveRealPath?: (path: string) => string,
+): boolean;
 export function buildReleaseCandidateState(
   options: unknown,
   {

--- a/src/channels/plugins/message-action-dispatch.ts
+++ b/src/channels/plugins/message-action-dispatch.ts
@@ -419,7 +419,7 @@ function canonicalizeBundledReadTargets(params: {
 }): void {
   if (
     params.pluginOrigin !== "bundled" ||
-    !READ_DEPENDENT_ACTIONS.has(params.ctx.action) ||
+    params.ctx.action !== "read" ||
     !params.plugin.messaging?.normalizeTarget
   ) {
     return;

--- a/src/channels/plugins/message-action-dispatch.ts
+++ b/src/channels/plugins/message-action-dispatch.ts
@@ -412,6 +412,30 @@ function canonicalizeExternalExactCurrentTarget(params: {
   }
 }
 
+function canonicalizeBundledReadTargets(params: {
+  ctx: ChannelMessageActionContext;
+  plugin: ChannelPlugin;
+  pluginOrigin: string | undefined;
+}): void {
+  if (
+    params.pluginOrigin !== "bundled" ||
+    !READ_DEPENDENT_ACTIONS.has(params.ctx.action) ||
+    !params.plugin.messaging?.normalizeTarget
+  ) {
+    return;
+  }
+  for (const key of ["target", "to", "channelId", "roomId", "chatId"] as const) {
+    const rawValue = params.ctx.params[key];
+    if (typeof rawValue !== "string" || !rawValue.trim()) {
+      continue;
+    }
+    const normalized = params.plugin.messaging.normalizeTarget(rawValue)?.trim();
+    if (normalized) {
+      params.ctx.params[key] = normalized;
+    }
+  }
+}
+
 function requiresTrustedRequesterSender(
   ctx: ChannelMessageActionContext,
   plugin: ChannelPlugin,
@@ -442,6 +466,11 @@ export async function dispatchChannelMessageAction(
   // Loader provenance is host-owned. External and legacy registrations must
   // prove the exact current conversation before any plugin callback can run.
   assertConversationReadAllowed({
+    ctx,
+    plugin,
+    pluginOrigin: registration.origin,
+  });
+  canonicalizeBundledReadTargets({
     ctx,
     plugin,
     pluginOrigin: registration.origin,

--- a/src/channels/plugins/message-actions.security.test.ts
+++ b/src/channels/plugins/message-actions.security.test.ts
@@ -190,6 +190,36 @@ describe("dispatchChannelMessageAction conversation-read provenance", () => {
     expect(handleAction).toHaveBeenCalledOnce();
   });
 
+  it("passes normalized bundled read targets to provider actions", async () => {
+    setReadPlugin({
+      origin: "bundled",
+      normalizeTarget: (raw) => (/^\d+$/.test(raw.trim()) ? `channel:${raw.trim()}` : raw.trim()),
+    });
+
+    await dispatchChannelMessageAction({
+      channel: "discord",
+      action: "read",
+      cfg: {} as OpenClawConfig,
+      params: {
+        target: "123",
+        channelId: "123",
+      },
+      accountId: "default",
+      requesterAccountId: "default",
+      conversationReadOrigin: "delegated",
+      toolContext: {
+        currentChannelProvider: "discord",
+        currentChannelId: "channel:123",
+      },
+    });
+
+    expect(handleAction).toHaveBeenCalledOnce();
+    expect(handleAction.mock.calls[0]?.[0]?.params).toMatchObject({
+      target: "channel:123",
+      channelId: "channel:123",
+    });
+  });
+
   it.each([
     {
       name: "cross-conversation target",

--- a/src/channels/plugins/message-actions.security.test.ts
+++ b/src/channels/plugins/message-actions.security.test.ts
@@ -220,6 +220,34 @@ describe("dispatchChannelMessageAction conversation-read provenance", () => {
     });
   });
 
+  it("keeps bundled channel-info channelId values unprefixed for provider runtimes", async () => {
+    setReadPlugin({
+      origin: "bundled",
+      normalizeTarget: (raw) => (/^\d+$/.test(raw.trim()) ? `channel:${raw.trim()}` : raw.trim()),
+    });
+
+    await dispatchChannelMessageAction({
+      channel: "discord",
+      action: "channel-info",
+      cfg: {} as OpenClawConfig,
+      params: {
+        channelId: "123",
+      },
+      accountId: "default",
+      requesterAccountId: "default",
+      conversationReadOrigin: "delegated",
+      toolContext: {
+        currentChannelProvider: "discord",
+        currentChannelId: "channel:123",
+      },
+    });
+
+    expect(handleAction).toHaveBeenCalledOnce();
+    expect(handleAction.mock.calls[0]?.[0]?.params).toMatchObject({
+      channelId: "123",
+    });
+  });
+
   it.each([
     {
       name: "cross-conversation target",


### PR DESCRIPTION
## Summary
- Accept `target` as a channel alias for Discord read-dependent actions, matching the shared `message.action` tool shape.
- Normalize bare numeric Discord action send targets to `channel:<id>` before handing them to the messaging runtime.
- Keep existing precedence for `channelId`, then `to`, then `target`, then trusted current-channel context.
- Add regression coverage for delegated Discord `read` calls that provide `target` and for bare numeric Discord `send` targets.

## What Problem This Solves
Live `discord-public` traffic showed the model issuing Discord read actions as `action: read` with `target: <channel-id>` and no `channelId`. The shared message-action gate already normalizes bare numeric Discord targets as channel targets for authorization, but the Discord handler ignored the same `target` field during execution. The result was repeated `Ambiguous Discord recipient` failures after the request had passed the shared gate, making the agent look like it could not read the current Discord channel.

A later live pass also showed Discord `send` actions with a bare numeric `target`. Lower-level Discord outbound delivery already treats bare numeric outbound IDs as channels, but the action adapter forwarded the bare ID to the messaging action runtime, where it could still hit the ambiguous-recipient path. This patch normalizes only all-digit action send targets to `channel:<id>` and preserves explicit `user:`, `channel:`, mention, and named-channel targets.

This aligns the Discord handler with the shared message-action tool shape while preserving the existing explicit-target precedence and trusted current-channel fallback.

## Evidence
- Live gateway observation: repeated `message.action` failures for Discord reads shaped as `action: read`, `target: <channel-id>`, no `channelId`, with `Ambiguous Discord recipient` errors.
- Live gateway observation: Discord sends shaped as `action: send`, `target: <channel-id>`, no `channel:` prefix, also hit `Ambiguous Discord recipient`.
- Focused regression test: `accepts message.action target as a Discord read channel alias` proves delegated Discord `read` with `target: "123"` and attested current Discord context dispatches `readMessages` for channel `123`.
- Focused regression test: `normalizes bare numeric message.action send targets as Discord channels` proves Discord `send` with `target: "123"` dispatches to `channel:123`.
- Local verification passed: `./node_modules/.bin/vitest run extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/targets.test.ts extensions/discord/src/channel.test.ts src/channels/plugins/message-actions.security.test.ts`
- Result: 4 test files / 134 tests passed.
