### PR TITLE
fix(auto-reply): preserve emoji in bash session snippets

### DIFF
--- a/src/auto-reply/reply/bash-command.stop.test.ts
+++ b/src/auto-reply/reply/bash-command.stop.test.ts
@@ -124,6 +124,15 @@ describe("handleBashChatCommand stop", () => {
     expect(killProcessTreeMock).not.toHaveBeenCalled();
   });
 
+  it("does not split boundary emoji in missing session snippets", async () => {
+    getSessionMock.mockReturnValue(undefined);
+    getFinishedSessionMock.mockReturnValue(undefined);
+
+    const result = await handleBashChatCommand(buildParams("/bash stop 1234567😀tail"));
+
+    expect(result.text).toBe("⚙️ No running bash job found for 1234567….");
+  });
+
   it("fails stop when session has no pid", async () => {
     const session = buildRunningSession({ pid: undefined, child: undefined });
     getSessionMock.mockReturnValue(session);

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -3,6 +3,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { getFinishedSession, getSession } from "../../agents/bash-process-registry.js";
 import { createExecTool } from "../../agents/bash-tools.js";
@@ -54,7 +55,7 @@ function formatSessionSnippet(sessionId: string) {
   if (trimmed.length <= 12) {
     return trimmed;
   }
-  return `${trimmed.slice(0, 8)}…`;
+  return `${truncateUtf16Safe(trimmed, 8)}…`;
 }
 
 function formatOutputBlock(text: string) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users polling or stopping an unknown `/bash` session could receive a malformed replacement character when the supplied session ID placed an emoji across the shortened display boundary.

## Why This Change Was Made

The chat reply now shortens session IDs with the shared UTF-16-safe truncation helper, preserving the existing eight-code-unit preview and ellipsis behavior without emitting an isolated surrogate.

## User Impact

Bash status replies remain valid Unicode for arbitrary user-supplied session IDs.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/bash-command.stop.test.ts` (7 tests passed)
- Added a regression case for `/bash stop 1234567😀tail` at the exact truncation boundary.
- Exact-head live proof on `fb143b4b44f` with Node 24.15.0: started a local Gateway and sent `/bash stop 1234567😀tail` through a paired WebChat `chat.send` client.
- The matching final chat event and persisted `chat.history` reply were both `⚙️ No running bash job found for 1234567….`.
- The captured response had no lone surrogate and survived a UTF-8 encode/decode round trip without a replacement character.
- The command completed through the gateway-injected command path with zero model tokens and no external credentials.
- `oxfmt` passed for both changed files.
- `git diff --check` passed.
- Pre-commit autoreview: clean, no actionable findings.
