### PR TITLE
fix(config-cli): reject text/whitespace without separator after bracket segment

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3240,6 +3240,7 @@ describe("config cli", () => {
       await expect(runConfigCommand(args)).rejects.toThrow(
         "Invalid path (missing separator after bracket): agents.list[0]id",
       );
+      );
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expect(mockWriteConfigFile).not.toHaveBeenCalled();

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3240,7 +3240,6 @@ describe("config cli", () => {
       await expect(runConfigCommand(args)).rejects.toThrow(
         "Invalid path (missing separator after bracket): agents.list[0]id",
       );
-      );
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expect(mockWriteConfigFile).not.toHaveBeenCalled();

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -383,9 +383,18 @@ function parsePath(raw: string): PathSegment[] {
   // Tracks whether a bracket segment was emitted since the last "." boundary, so
   // "foo[0].bar" is accepted while empty key segments are rejected.
   let segmentEmitted = false;
+  let postBracket = false;
   let i = 0;
   while (i < trimmed.length) {
     const ch = trimmed[i];
+    if (postBracket) {
+      // After a bracket segment, only "." and "[" are valid continuations.
+      // Reject bare text, whitespace, and escape sequences immediately.
+      if (ch !== "." && ch !== "[") {
+        throw new Error(`Invalid path (missing separator after bracket): ${raw}`);
+      }
+      postBracket = false;
+    }
     if (ch === "\\") {
       const next = trimmed[i + 1];
       if (next) {
@@ -433,6 +442,7 @@ function parsePath(raw: string): PathSegment[] {
         throw new Error(`Invalid path (missing separator after bracket): ${raw}`);
       }
       segmentEmitted = true;
+      postBracket = true;
       i = close + 1;
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

The config path parser silently accepted malformed bracket paths like `agents.list[0]id` as if it were `agents.list[0].id`. When used with config set/unset, a typo can silently modify or remove a different configuration value instead of failing fast.

Related: #109299

## Changes

Added an explicit `postBracket` parser state that rejects any character except `.` and `[` immediately after a bracket segment is emitted. This catches:

- **Bare text**: `foo[0]id` → error
- **Whitespace-prefixed text**: `foo[0] id` → error
- **Whitespace then separator**: `foo[0] .bar` → error (was previously caught as "empty segment")

Valid forms preserved:
- `foo[0].bar` — dot separator
- `foo[0][1]` — consecutive brackets
- `[0]` — root bracket
- `foo[0]` — bracket at end

## Evidence

All 131 config-cli tests pass:

```
 Test Files  1 passed (1)
      Tests  131 passed (131)
```

Existing tests for empty-segment rejection, escaped-dot paths, valid bracket path forms, and prototype-key blocking all continue to pass unchanged.

🤖 Generated with [iCodeMate](https://claude.ai/code)