### PR TITLE
improve: speed up state migration tests

### DIFF
--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -3,7 +3,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as sessionStore from "../config/sessions.js";
@@ -480,12 +480,15 @@ async function createLegacyStateFixture(params?: { includePreKey?: boolean }) {
   };
 }
 
-afterEach(async () => {
+afterEach(() => {
   vi.useRealTimers();
   pluginDoctorStateMigrationEntries.entries = [];
   resetAutoMigrateLegacyStateForTest();
   resetAutoMigrateLegacyStateDirForTest();
   closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(async () => {
   await tempDirs.cleanup();
 });
 


### PR DESCRIPTION
## What Problem This Solves

The state-migration test suite recursively deleted every temporary fixture tree after each of its 50 tests, adding repeated filesystem cleanup work even though each test already receives a unique directory.

## Why This Change Was Made

Keep the per-test timer, migration-state, and SQLite reset boundaries, but defer deletion of the unique temporary directories to one suite-level cleanup.

## User Impact

No user-visible behavior change. The state-migration tests complete faster while preserving test isolation and coverage.

## Evidence

- Blacksmith Testbox `tbx_01kxprae1m94bk35femr7ma6hh`
- Three-run median Vitest test time: 5.119s before, 4.207s after (17.8% faster)
- `pnpm test src/infra/state-migrations.test.ts` — 50/50 passed; final measured run 4.201s test time
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed
- Fresh autoreview — clean, no accepted/actionable findings
