### PR TITLE
fix(canvas): stop stalled Git blocking A2UI builds

### DIFF
--- a/extensions/canvas/scripts/bundle-a2ui.mjs
+++ b/extensions/canvas/scripts/bundle-a2ui.mjs
@@ -22,6 +22,7 @@ const outputFile =
   process.env.OPENCLAW_A2UI_BUNDLE_OUT ??
   path.join(pluginDir, "src", "host", "a2ui", "a2ui.bundle.js");
 const a2uiAppDir = path.join(pluginDir, "src", "host", "a2ui-app");
+const GIT_INPUT_DISCOVERY_TIMEOUT_MS = 1_000;
 const repoInputPaths = getBundleHashRepoInputPaths(rootDir);
 const relativeRepoInputPaths = repoInputPaths.map((inputPath) =>
   normalizePath(path.relative(rootDir, inputPath)),
@@ -111,7 +112,9 @@ function listTrackedInputFiles() {
   const result = spawnSync("git", ["ls-files", "--", ...relativeRepoInputPaths], {
     cwd: rootDir,
     encoding: "utf8",
+    killSignal: "SIGKILL",
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: GIT_INPUT_DISCOVERY_TIMEOUT_MS,
   });
   if (result.status !== 0) {
     return null;

--- a/extensions/canvas/scripts/bundle-a2ui.mjs
+++ b/extensions/canvas/scripts/bundle-a2ui.mjs
@@ -22,7 +22,7 @@ const outputFile =
   process.env.OPENCLAW_A2UI_BUNDLE_OUT ??
   path.join(pluginDir, "src", "host", "a2ui", "a2ui.bundle.js");
 const a2uiAppDir = path.join(pluginDir, "src", "host", "a2ui-app");
-const GIT_INPUT_DISCOVERY_TIMEOUT_MS = 1_000;
+const GIT_INPUT_DISCOVERY_TIMEOUT_MS = 5_000;
 const repoInputPaths = getBundleHashRepoInputPaths(rootDir);
 const relativeRepoInputPaths = repoInputPaths.map((inputPath) =>
   normalizePath(path.relative(rootDir, inputPath)),

--- a/extensions/canvas/scripts/bundle-a2ui.test.ts
+++ b/extensions/canvas/scripts/bundle-a2ui.test.ts
@@ -1,5 +1,8 @@
 // Canvas tests cover bundle a2ui plugin behavior.
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
 import path from "node:path";
+import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { describe, expect, it } from "vitest";
 import {
   compareNormalizedPaths,
@@ -58,4 +61,46 @@ describe("scripts/bundle-a2ui.mjs", () => {
       path.join(repoRoot, "ui", "node_modules", "lit", "package.json"),
     );
   });
+
+  it.skipIf(process.platform === "win32")(
+    "falls back when tracked-input discovery stalls",
+    async () => {
+      await withTempWorkspace(
+        { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "openclaw-a2ui-git-timeout-" },
+        async ({ dir }) => {
+          const fakeBinDir = path.join(dir, "bin");
+          const fakeGitPath = path.join(fakeBinDir, "git");
+          const outputFile = path.join(dir, "a2ui.bundle.js");
+          const hashFile = path.join(dir, "a2ui.bundle.hash");
+          await fs.mkdir(fakeBinDir, { recursive: true });
+          await fs.writeFile(
+            fakeGitPath,
+            `#!${process.execPath}\nsetTimeout(() => {}, 30_000);\n`,
+            "utf8",
+          );
+          await fs.chmod(fakeGitPath, 0o755);
+
+          execFileSync(
+            process.execPath,
+            [path.resolve("extensions/canvas/scripts/bundle-a2ui.mjs")],
+            {
+              cwd: process.cwd(),
+              encoding: "utf8",
+              env: {
+                ...process.env,
+                OPENCLAW_A2UI_BUNDLE_HASH_FILE: hashFile,
+                OPENCLAW_A2UI_BUNDLE_OUT: outputFile,
+                PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+              },
+              killSignal: "SIGKILL",
+              timeout: 12_000,
+            },
+          );
+
+          await expect(fs.stat(outputFile)).resolves.toBeDefined();
+          await expect(fs.stat(hashFile)).resolves.toBeDefined();
+        },
+      );
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

The Canvas A2UI bundler synchronously runs `git ls-files` before calculating its input hash. That probe had no deadline, so a stalled Git process could block `canvas:a2ui:bundle`, bundled plugin asset builds, and native A2UI sync indefinitely.

## Why This Change Was Made

Tracked-input discovery now has a one-second hard timeout with `SIGKILL`. A timeout produces the same non-success result as any existing Git failure, so the script continues through its established filesystem-walk fallback instead of changing the hash policy or failing the build.

## User Impact

Canvas A2UI builds no longer wait forever on a wedged Git metadata probe. Healthy Git discovery remains the fast path, while stalled discovery still produces the bundle and hash through the existing fallback.

## Evidence

- Regression-first process test ran the real `bundle-a2ui.mjs` with an isolated stalled `git`; before the fix, its 12-second outer deadline expired with `ETIMEDOUT`.
- Independent before proof: the real bundler exceeded a 6-second external guard (`exit_status=124`).
- After: the same real bundler with stalled Git completed a temporary 394.90 kB bundle and hash in 1.37 seconds (`exit_status=0`).
- Control: the same bundler with normal Git completed the temporary bundle and hash in 0.37 seconds (`exit_status=0`).
- `node scripts/run-vitest.mjs run extensions/canvas/scripts/bundle-a2ui.test.ts extensions/canvas/scripts/copy-a2ui.test.ts` on Node 24.15.0: 12 tests passed.
- `oxfmt --check` for both changed files: passed.
- Type-aware oxlint and TypeScript checking for both changed files: passed.
- `codex review --base origin/main`: no actionable findings.

Not exercised: a live Windows host. The process-level regression and live proof ran on Linux with test-only local executables and temporary output files.
