### PR TITLE
fix(scripts): preserve emoji in issue label prompts

### DIFF
--- a/scripts/label-open-issues.ts
+++ b/scripts/label-open-issues.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isRecord } from "../src/utils.js";
 import { readBoundedResponseText as readBoundedBodyText } from "./lib/bounded-response.ts";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
@@ -644,7 +645,7 @@ function truncateBody(body: string): string {
   if (body.length <= MAX_BODY_CHARS) {
     return body;
   }
-  return `${body.slice(0, MAX_BODY_CHARS)}\n\n[truncated]`;
+  return `${truncateUtf16Safe(body, MAX_BODY_CHARS)}\n\n[truncated]`;
 }
 
 function buildItemPrompt(item: LabelItem, kind: "issue" | "pull request"): string {

--- a/test/scripts/label-open-issues.test.ts
+++ b/test/scripts/label-open-issues.test.ts
@@ -226,4 +226,41 @@ describe("label-open-issues helpers", () => {
       /OPENCLAW_LABEL_OPEN_ISSUES_OPENAI_TIMEOUT_MS must be an integer/u,
     );
   });
+
+  it("does not split boundary emoji in model prompts", async () => {
+    let requestBody = "";
+    const response = new Response(
+      JSON.stringify({
+        output_text: JSON.stringify({
+          category: "bug",
+          isSupport: false,
+          isSkillOnly: false,
+        }),
+      }),
+      { status: 200 },
+    );
+
+    await testing.classifyItem(
+      {
+        ...labelItem,
+        body: `${"a".repeat(5999)}😀tail`,
+      },
+      "issue",
+      {
+        apiKey: "placeholder",
+        model: "test-model",
+        timeoutMs: 50,
+        fetchImpl: ((_url, init) => {
+          requestBody = String(init?.body ?? "");
+          return Promise.resolve(response);
+        }) as typeof fetch,
+      },
+    );
+
+    const payload = JSON.parse(requestBody) as { input: Array<{ content: string }> };
+    const prompt = payload.input[1]?.content ?? "";
+    expect(prompt).toContain(`${"a".repeat(5999)}\n\n[truncated]`);
+    expect(prompt).not.toContain("\uD83D");
+    expect(prompt).not.toContain("tail");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where automated issue and pull-request classification could send a malformed Unicode character to the model when a long GitHub body placed an emoji across the 6000-character prompt boundary.

## Why This Change Was Made

The labeler now applies the shared UTF-16-safe truncation helper while retaining its current body budget and visible `[truncated]` marker.

## User Impact

Repository operators can classify long GitHub items containing emoji without corrupting the model input at the truncation boundary.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/label-open-issues.test.ts` (11 tests passed)
- The regression test captures and decodes the actual fake `/v1/responses` request body, verifies the truncation marker, and rejects a lone high surrogate or leaked tail text.
- `oxfmt` passed for both changed files.
- `git diff --check` passed.
- Pre-commit autoreview: clean, no actionable findings.

### Exact-head real CLI proof

- Node 24.15.0 ran `scripts/label-open-issues.ts --dry-run --limit 1 --model proof-offline` at exact head `12bc3e5ca696` through the actual CLI path: `fetchOpenIssueBatches` -> `classifyItem` -> global `fetch` -> dry-run label application. A fail-closed offline transport supplied one GitHub item whose body was 5,999 ASCII code units followed by `😀tail`, captured the real `/v1/responses` request, and returned an offline structured response. No test export, injected `fetchImpl`, live label mutation, or paid/model request was used.
- Captured prompt: `ascii_prefix_code_units=5999`, `body_code_units=6012`, `body_tail_json="aaaaaaaaaaaaaaaaaaa\n\n[truncated]"`, `truncated_marker=true`, `emoji_leaked=false`, `tail_leaked=false`, `lone_surrogate=false`, `utf8_replacement=false`, and `utf8_roundtrip_equal=true`.
- The real CLI completed classification and printed `Would add labels: bug`; the isolated dry-run state directory remained empty.
