### PR TITLE
fix(infra): add .catch() to redirect response body cancel to prevent unhandled rejection

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -698,7 +698,7 @@ async function fetchWithSsrFGuardInternal(
           throw new Error("Redirect loop detected");
         }
         visited.add(nextVisitKey);
-        void response.body?.cancel();
+        void response.body?.cancel().catch(() => undefined);
         await closeDispatcher(dispatcher);
         currentUrl = nextUrl;
         continue;


### PR DESCRIPTION
## Summary
Add `.catch(() => undefined)` to `void response.body?.cancel()` in redirect handling.

## What Problem This Solves
`void response.body?.cancel()` in the redirect path discards the return value but NOT Promise rejections. If the stream is already errored, `cancel()` rejects as unhandled.

**Code evidence**: [fetch-guard.ts:701](src/infra/net/fetch-guard.ts#L701)

## Evidence
- **Before**: `void response.body?.cancel()` — unhandled rejection on errored stream
- **After**: `void response.body?.cancel().catch(() => undefined)` — safe

## Real Behavior Proof

```diff
-        void response.body?.cancel();
+        void response.body?.cancel().catch(() => undefined);
```

Matches established codebase pattern (15+ existing instances).