### PR TITLE
fix(signal): bound container receive WebSocket handshake with timeout

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -35,7 +35,7 @@ function bodyStream(text: string): { body: ReadableStream<Uint8Array> } {
   };
 }
 const wsMockState = vi.hoisted(() => ({
-  behavior: "close" as "close" | "open" | "error" | "unexpected-response",
+  behavior: "close" as "close" | "open" | "error" | "unexpected-response" | "hang",
   urls: [] as string[],
   options: [] as Array<{ maxPayload?: number } | undefined>,
 }));
@@ -96,6 +96,8 @@ vi.mock("ws", () => ({
           this.emit("error", new Error("WebSocket failed"));
         } else if (wsMockState.behavior === "unexpected-response") {
           this.emit("unexpected-response", {}, { statusCode: 200, statusMessage: "OK" });
+        } else if (wsMockState.behavior === "hang") {
+          // Never fire any event — used for connect-timeout tests.
         } else {
           this.emit("close", 1000, Buffer.from("done"));
         }
@@ -1173,6 +1175,39 @@ describe("streamContainerEvents", () => {
     const abortHandler = addEventListener.mock.calls.find((call) => call[0] === "abort")?.[1];
     expect(abortHandler).toBeTypeOf("function");
     expect(removeEventListener).toHaveBeenCalledWith("abort", abortHandler);
+  });
+
+  it("rejects after the connect timeout when the server never responds", async () => {
+    wsMockState.behavior = "hang";
+    const promise = streamContainerEvents({
+      baseUrl: "http://localhost:8080",
+      account: "+14259798283",
+      timeoutMs: 100,
+      onEvent: vi.fn(),
+    });
+    await expect(promise).rejects.toThrow(
+      "Signal container receive WebSocket connection timed out",
+    );
+  });
+
+  it("uses DEFAULT_TIMEOUT_MS when timeoutMs is not provided", async () => {
+    wsMockState.behavior = "hang";
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const promise = streamContainerEvents({
+      baseUrl: "http://localhost:8080",
+      account: "+14259798283",
+      onEvent: vi.fn(),
+    });
+    // The connect timer should fire after the default 10s.
+    const connectTimer = setTimeoutSpy.mock.results.find((r) => {
+      const ms = setTimeoutSpy.mock.calls[setTimeoutSpy.mock.results.indexOf(r)]?.[1];
+      return ms === 10_000;
+    });
+    expect(connectTimer).toBeDefined();
+    await expect(promise).rejects.toThrow(
+      "Signal container receive WebSocket connection timed out",
+    );
+    setTimeoutSpy.mockRestore();
   });
 });
 

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -319,6 +319,8 @@ export async function streamContainerEvents(params: {
 
   log(`[signal-ws] connecting to ${redactedWsUrl}`);
 
+  const handshakeTimeoutMs = resolveTimerTimeoutMs(params.timeoutMs, DEFAULT_TIMEOUT_MS);
+
   return new Promise((resolve, reject) => {
     let ws: WebSocket;
     let resolved = false;
@@ -329,15 +331,24 @@ export async function streamContainerEvents(params: {
         return;
       }
       resolved = true;
+      clearTimeout(connectTimer);
       if (abortHandler) {
         params.abortSignal?.removeEventListener("abort", abortHandler);
         abortHandler = undefined;
       }
     };
 
+    const connectTimer = setTimeout(() => {
+      cleanup();
+      ws?.terminate();
+      reject(new Error("Signal container receive WebSocket connection timed out"));
+    }, handshakeTimeoutMs);
+    connectTimer.unref?.();
+
     try {
       ws = new WebSocket(wsUrl, { maxPayload: SIGNAL_CONTAINER_WS_MAX_PAYLOAD_BYTES });
     } catch (err) {
+      clearTimeout(connectTimer);
       logError(
         `[signal-ws] failed to create WebSocket: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -346,6 +357,7 @@ export async function streamContainerEvents(params: {
     }
 
     ws.on("open", () => {
+      clearTimeout(connectTimer);
       log("[signal-ws] connected");
     });
 


### PR DESCRIPTION
## What Problem This Solves

The `streamContainerEvents` path created a WebSocket without a connect deadline, so an unreachable Signal container server would leave the connection unresolved indefinitely.

The sibling `containerReceiveCheck` already protects its probe WebSocket with a timer, and `streamContainerEvents` already accepted a `timeoutMs` parameter — it was simply not applied to the handshake.

This is the same WebSocket-handshake-timeout class fixed for sibling channel gateways (mattermost #105553, qqbot #106484, clickclack #106485).

## Why This Change Was Made

- Resolve a handshake timeout from `params.timeoutMs` (default 10s via `resolveTimerTimeoutMs`).
- Reject with a descriptive error and terminate the socket on timeout.
- Clear the timer on open, error-close, or abort.
- Follow the same pattern used by `containerReceiveCheck` in the same file.

## User Impact

- Before: unreachable Signal container left the gateway stream hanging forever.
- After: connection fails fast with a clear timeout error, allowing the outer reconnect loop to retry.

## Evidence

```text
$ node scripts/run-vitest.mjs extensions/signal/src/client-container.test.ts
Test Files  1 passed (1)
Tests  42 passed (42)
```

Added tests verify:
- Timeout rejects with the expected error message
- DEFAULT_TIMEOUT_MS (10s) is used when timeoutMs is not provided

## Risk / Compatibility

Low. The timeout defaults to 10s (same as `containerReceiveCheck`), and the Signal adapter already passes `timeoutMs` through from its caller. No config, persistence, or dependency surface changes.

AI-assisted: contributor patch used coding agents.