### PR TITLE
fix(node-host): preserve native binary approvals after short reads

### DIFF
--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -714,6 +714,47 @@ describe("hardenApprovedExecutionPaths", () => {
     expect(prepared.plan.mutableFileOperand).toBeUndefined();
   });
 
+  it("recognizes native binary headers across short positional reads", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const binaryPath = resolveNativeBinaryFixturePath();
+    if (canMutateNativeBinaryFixturePath(binaryPath)) {
+      return;
+    }
+    const realReadSync = fs.readSync.bind(fs);
+    let shortReadCalls = 0;
+    const readSpy = vi.spyOn(fs, "readSync").mockImplementation(((
+      fd: number,
+      buffer: NodeJS.ArrayBufferView,
+      offset: number,
+      length: number,
+      position: fs.ReadPosition | null,
+    ) => {
+      const cappedLength = typeof position === "number" ? Math.min(length, 1) : length;
+      if (cappedLength < length) {
+        shortReadCalls += 1;
+      }
+      return realReadSync(fd, buffer, offset, cappedLength, position);
+    }) as typeof fs.readSync);
+    try {
+      const prepared = buildSystemRunApprovalPlan({
+        command: ["/bin/sh", "-lc", binaryPath],
+        rawCommand: binaryPath,
+        cwd: process.cwd(),
+      });
+
+      expect(shortReadCalls).toBeGreaterThan(1);
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) {
+        throw new Error("unreachable");
+      }
+      expect(prepared.plan.mutableFileOperand).toBeUndefined();
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
   it("keeps fail-closed behavior for relative native-binary shell payloads", () => {
     if (process.platform === "win32") {
       return;

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -20,6 +20,7 @@ import {
   unwrapKnownDispatchWrapperInvocation,
   unwrapKnownShellMultiplexerInvocation,
 } from "../infra/exec-wrapper-resolution.js";
+import { readFileWindowFullySync } from "../infra/file-read.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { parseInlineOptionToken } from "../infra/inline-option-token.js";
 import {
@@ -337,7 +338,7 @@ function isLikelyScriptLikePathSync(targetPath: string): boolean {
     const fd = fs.openSync(targetPath, "r");
     try {
       header = Buffer.alloc(1024);
-      const bytesRead = fs.readSync(fd, header, 0, header.length, 0);
+      const bytesRead = readFileWindowFullySync(fd, header, 0);
       header = header.subarray(0, bytesRead);
     } finally {
       fs.closeSync(fd);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users approving a shell command that invokes a stable native binary could receive `SYSTEM_RUN_DENIED` when the filesystem returned a short positional read for the binary header. This can affect supported filesystems where a successful read returns fewer bytes than requested.

## Why This Change Was Made

The node-host approval planner now fills its bounded 1 KiB binary-header window with the existing shared short-read helper before classifying the executable. The change remains fail-closed for unreadable, mutable, relative, script-like, or ambiguous paths and does not alter approval policy or protocol shapes.

## User Impact

Stable absolute native binaries invoked through approved shell commands are no longer misclassified as scripts solely because their header arrived across multiple reads.

## Evidence

**Real-machine before / premise / after / negative control**

Environment: Linux 6.8.0-134-generic x86_64, Node v24.18.0.

I ran the same exported production planner against the real `/bin/ls` binary from a clean latest-main worktree and this branch. The harness caps each positional `fs.readSync` call at one byte, then calls `buildSystemRunApprovalPlan()` for `/bin/sh -lc /bin/ls`:

```bash
node --import tsx --input-type=module -e 'import fs from "node:fs"; import { buildSystemRunApprovalPlan } from "./src/node-host/invoke-system-run-plan.ts"; const binary="/bin/ls"; const real=fs.readSync.bind(fs); let cappedReads=0; fs.readSync=((fd,buffer,offset,length,position)=>{const capped=typeof position==="number"?Math.min(length,1):length;if(capped<length)cappedReads+=1;return real(fd,buffer,offset,capped,position);}); const result=buildSystemRunApprovalPlan({command:["/bin/sh","-lc",binary],rawCommand:binary,cwd:process.cwd()}); console.log(JSON.stringify({binary,cappedReads,result},null,2));'
```

Negative control / before (`upstream/main` at `0f1b0e6679793dc64b4b4ac5e913e6c4bc5c0f4f`):

```json
{
  "binary": "/bin/ls",
  "cappedReads": 1,
  "result": {
    "ok": false,
    "message": "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command"
  }
}
```

Premise: Node's `fs.readSync` contract returns the actual byte count. Latest main performs one 1024-byte request, receives one byte in this control, and therefore cannot match the four-byte ELF signature even though the real file is a native binary.

After (`da72119c68c7188553a704125d35a0ca06b6340e`):

```json
{
  "binary": "/bin/ls",
  "cappedReads": 1023,
  "result": {
    "ok": true,
    "plan": {
      "argv": ["/bin/sh", "-lc", "/bin/ls"],
      "commandText": "/bin/sh -lc /bin/ls",
      "commandPreview": "/bin/ls"
    }
  }
}
```

The repeated capped reads are the causal control: the production planner now fills the same bounded header window and recognizes the real ELF binary. Existing tests continue to verify that mutable, relative, script-like, unreadable, and ambiguous payloads remain denied.

Focused validation:

```text
node scripts/run-vitest.mjs src/node-host/invoke-system-run-plan.test.ts
Test Files  1 passed (1)
Tests       18 passed (18)

./node_modules/.bin/oxlint src/node-host/invoke-system-run-plan.ts src/node-host/invoke-system-run-plan.test.ts
exit 0

./node_modules/.bin/oxfmt --write src/node-host/invoke-system-run-plan.ts src/node-host/invoke-system-run-plan.test.ts
Finished on 2 files

git diff --check upstream/main...HEAD
exit 0
```

Full build and full typecheck were not run locally; fork GitHub Actions are expected to cover the wider repository gates. This is a non-visual node-host behavior change, so no screenshot is applicable.

**AI-assisted:** Yes. I reviewed the complete classifier and approval-planning call path, sibling bounded-read helper and adopters, adjacent tests, Node `fs.readSync` types, and the real-machine evidence.
