### PR TITLE
fix(android): preserve graphemes in compact badges

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -2059,7 +2059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 49,
+      "line": 50,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Messaging surfaces connected to this gateway.",
       "surface": "android",
@@ -2067,7 +2067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 56,
+      "line": 57,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Channels",
       "surface": "android",
@@ -2075,7 +2075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 59,
+      "line": 60,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Issues",
       "surface": "android",
@@ -2083,7 +2083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 64,
+      "line": 65,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -2091,7 +2091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 64,
+      "line": 65,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -2099,7 +2099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 85,
+      "line": 86,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Connect the gateway to load channels.",
       "surface": "android",
@@ -2107,7 +2107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 90,
+      "line": 91,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "No channels found.",
       "surface": "android",
@@ -2115,7 +2115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 91,
+      "line": 92,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Telegram, WhatsApp, email, and other channels appear here after setup.",
       "surface": "android",
@@ -2123,7 +2123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 120,
+      "line": 121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "1 account",
       "surface": "android",
@@ -2131,7 +2131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 121,
+      "line": 122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "${channel.accountCount} accounts",
       "surface": "android",
@@ -2139,7 +2139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 127,
+      "line": 128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Linked",
       "surface": "android",
@@ -2147,7 +2147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 128,
+      "line": 129,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Configured",
       "surface": "android",
@@ -2155,7 +2155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 129,
+      "line": 130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Enabled",
       "surface": "android",
@@ -2163,7 +2163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 137,
+      "line": 138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Issue",
       "surface": "android",
@@ -2171,7 +2171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 138,
+      "line": 139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Connected",
       "surface": "android",
@@ -2179,7 +2179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 139,
+      "line": 140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Running",
       "surface": "android",
@@ -2187,7 +2187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 140,
+      "line": 141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -2195,7 +2195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 141,
+      "line": 142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Setup",
       "surface": "android",
@@ -2203,7 +2203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 142,
+      "line": 143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -2211,7 +2211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 164,
+      "line": 165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Some channel status checks did not complete.",
       "surface": "android",
@@ -3763,7 +3763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 57,
+      "line": 58,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
@@ -3771,7 +3771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 58,
+      "line": 59,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Live nodes, paired phones, and pending device requests.",
       "surface": "android",
@@ -3779,7 +3779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 67,
+      "line": 68,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Admin",
       "surface": "android",
@@ -3787,7 +3787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 67,
+      "line": 68,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Devices",
       "surface": "android",
@@ -3795,7 +3795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 68,
+      "line": 69,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending",
       "surface": "android",
@@ -3803,7 +3803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 73,
+      "line": 74,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -3811,7 +3811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 73,
+      "line": 74,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -3819,7 +3819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 87,
+      "line": 88,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Connect the gateway to load nodes and paired devices.",
       "surface": "android",
@@ -3827,7 +3827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 92,
+      "line": 93,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "No nodes or paired devices.",
       "surface": "android",
@@ -3835,7 +3835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 93,
+      "line": 94,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Linked phones and node hosts will appear here after pairing.",
       "surface": "android",
@@ -3843,7 +3843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 113,
+      "line": 114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node approval required",
       "surface": "android",
@@ -3851,7 +3851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 114,
+      "line": 115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Run on the Gateway host:",
       "surface": "android",
@@ -3859,7 +3859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 129,
+      "line": 130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending Requests",
       "surface": "android",
@@ -3867,7 +3867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 139,
+      "line": 140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes",
       "surface": "android",
@@ -3875,7 +3875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 149,
+      "line": 150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired Devices",
       "surface": "android",
@@ -3883,7 +3883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 200,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "New device",
       "surface": "android",
@@ -3891,7 +3891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 202,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Repair",
       "surface": "android",
@@ -3899,7 +3899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 202,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
@@ -3907,7 +3907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired device",
       "surface": "android",
@@ -3915,7 +3915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 238,
+      "line": 239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node host",
       "surface": "android",
@@ -3923,7 +3923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 240,
+      "line": 241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unpaired",
       "surface": "android",
@@ -3931,7 +3931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 252,
+      "line": 253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs approval",
       "surface": "android",
@@ -3939,7 +3939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 253,
+      "line": 254,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs reapproval",
       "surface": "android",
@@ -3947,7 +3947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 254,
+      "line": 255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unapproved",
       "surface": "android",
@@ -3955,7 +3955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -3963,7 +3963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -3971,7 +3971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 272,
+      "line": 273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Approved",
       "surface": "android",
@@ -3979,7 +3979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 273,
+      "line": 274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability approval pending",
       "surface": "android",
@@ -3987,7 +3987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 274,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability reapproval pending",
       "surface": "android",
@@ -3995,7 +3995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability unapproved",
       "surface": "android",
@@ -4003,7 +4003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 282,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
       "surface": "android",
@@ -4011,7 +4011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 289,
+      "line": 290,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "requested ${relativeDeviceTime(it)}",
       "surface": "android",
@@ -4019,7 +4019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 297,
+      "line": 298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${device.tokens.count { !it.revoked }}/${device.tokens.size} active tokens",
       "surface": "android",
@@ -4027,7 +4027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 307,
+      "line": 308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired",
       "surface": "android",
@@ -4035,7 +4035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 308,
+      "line": 309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Active",
       "surface": "android",
@@ -4043,7 +4043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 309,
+      "line": 310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs Token",
       "surface": "android",
@@ -4051,7 +4051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 333,
+      "line": 334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${values.size} roles",
       "surface": "android",
@@ -4059,7 +4059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${values.size} scopes",
       "surface": "android",
@@ -4067,7 +4067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 352,
+      "line": 353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "now",
       "surface": "android",
@@ -4075,7 +4075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 353,
+      "line": 354,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${minutes}m ago",
       "surface": "android",
@@ -4083,7 +4083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 355,
+      "line": 356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${hours}h ago",
       "surface": "android",
@@ -4091,7 +4091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 357,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${days}d ago",
       "surface": "android",
@@ -5411,7 +5411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 88,
+      "line": 89,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -5419,7 +5419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 91,
+      "line": 92,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Providers & Models",
       "surface": "android",
@@ -5427,7 +5427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 93,
+      "line": 94,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Review provider readiness\nand configured models.",
       "surface": "android",
@@ -5435,7 +5435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 112,
+      "line": 113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Providers and configured models",
       "surface": "android",
@@ -5443,7 +5443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 117,
+      "line": 118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to load provider readiness.",
       "surface": "android",
@@ -5451,7 +5451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 117,
+      "line": 118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5459,7 +5459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 185,
+      "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -5467,7 +5467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 241,
+      "line": 242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Provider catalog",
       "surface": "android",
@@ -5475,7 +5475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Loading",
       "surface": "android",
@@ -5483,7 +5483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No providers",
       "surface": "android",
@@ -5491,7 +5491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -5499,7 +5499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Needs",
       "surface": "android",
@@ -5507,7 +5507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 284,
+      "line": 285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to view provider readiness.",
       "surface": "android",
@@ -5515,7 +5515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 288,
+      "line": 289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -5523,7 +5523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 288,
+      "line": 289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -5531,7 +5531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 329,
+      "line": 330,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No configured models. Refresh to recheck availability.",
       "surface": "android",
@@ -5539,7 +5539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 330,
+      "line": 331,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "1 configured model. Refresh to recheck availability.",
       "surface": "android",
@@ -5547,7 +5547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 331,
+      "line": 332,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "$count configured models. Refresh to recheck availability.",
       "surface": "android",
@@ -5555,7 +5555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 336,
+      "line": 337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No configured models",
       "surface": "android",
@@ -5563,7 +5563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 337,
+      "line": 338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "1 configured model",
       "surface": "android",
@@ -5571,7 +5571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 338,
+      "line": 339,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "$count configured models",
       "surface": "android",
@@ -5579,7 +5579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 382,
+      "line": 383,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Available",
       "surface": "android",
@@ -5587,7 +5587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 383,
+      "line": 384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Unavailable",
       "surface": "android",
@@ -5595,7 +5595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 384,
+      "line": 385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Unknown",
       "surface": "android",
@@ -5603,7 +5603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 396,
+      "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "reasoning",
       "surface": "android",
@@ -5611,7 +5611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 397,
+      "line": 398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "image",
       "surface": "android",
@@ -5619,7 +5619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 398,
+      "line": 399,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "audio",
       "surface": "android",
@@ -5627,7 +5627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 399,
+      "line": 400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "video",
       "surface": "android",
@@ -5635,7 +5635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 400,
+      "line": 401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "document",
       "surface": "android",
@@ -5643,7 +5643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 401,
+      "line": 402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "$context context",
       "surface": "android",
@@ -5651,7 +5651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 404,
+      "line": 405,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "${tokens / 1_000}k",
       "surface": "android",
@@ -6163,7 +6163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 250,
+      "line": 251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -6171,7 +6171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 250,
+      "line": 251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -6179,7 +6179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 254,
+      "line": 255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Providers",
       "surface": "android",
@@ -6187,7 +6187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 270,
+      "line": 271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -6195,7 +6195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -6203,7 +6203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 276,
+      "line": 277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -6211,7 +6211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 315,
+      "line": 316,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -6219,7 +6219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automations",
       "surface": "android",
@@ -6227,7 +6227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 328,
+      "line": 329,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search automations",
       "surface": "android",
@@ -6235,7 +6235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 329,
+      "line": 330,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search",
       "surface": "android",
@@ -6243,7 +6243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open an automation to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it.",
       "surface": "android",
@@ -6251,7 +6251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 355,
+      "line": 356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load automations.",
       "surface": "android",
@@ -6259,7 +6259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No automations yet.",
       "surface": "android",
@@ -6267,7 +6267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled work created on the gateway will appear here.",
       "surface": "android",
@@ -6275,7 +6275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching automations.",
       "surface": "android",
@@ -6283,7 +6283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 465,
+      "line": 466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation",
       "surface": "android",
@@ -6291,7 +6291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 466,
+      "line": 467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect and manage scheduled gateway work.",
       "surface": "android",
@@ -6299,7 +6299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 487,
+      "line": 488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -6307,7 +6307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 495,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation not loaded.",
       "surface": "android",
@@ -6315,7 +6315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 495,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading automation…",
       "surface": "android",
@@ -6323,7 +6323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 546,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -6331,7 +6331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 550,
+      "line": 551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Available",
       "surface": "android",
@@ -6339,7 +6339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 557,
+      "line": 558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -6347,7 +6347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 561,
+      "line": 562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -6355,7 +6355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 588,
+      "line": 589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -6363,7 +6363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 588,
+      "line": 589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -6371,7 +6371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 592,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway Pending",
       "surface": "android",
@@ -6379,7 +6379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session Activity",
       "surface": "android",
@@ -6387,7 +6387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 594,
+      "line": 595,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issues",
       "surface": "android",
@@ -6395,7 +6395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 595,
+      "line": 596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active Runs",
       "surface": "android",
@@ -6403,7 +6403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 599,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -6411,7 +6411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 599,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -6419,7 +6419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 617,
+      "line": 618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -6427,7 +6427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 618,
+      "line": 619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -6435,7 +6435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 624,
+      "line": 625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -6443,7 +6443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -6451,7 +6451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 635,
+      "line": 636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
@@ -6459,7 +6459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 636,
+      "line": 637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
@@ -6467,7 +6467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 650,
+      "line": 651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -6475,7 +6475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 650,
+      "line": 651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -6483,7 +6483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 653,
+      "line": 654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -6491,7 +6491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 654,
+      "line": 655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -6499,7 +6499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 702,
+      "line": 703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure wake words, talk, and playback.",
       "surface": "android",
@@ -6507,7 +6507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 702,
+      "line": 703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice",
       "surface": "android",
@@ -6515,7 +6515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 704,
+      "line": 705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice Wake",
       "surface": "android",
@@ -6523,7 +6523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 709,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Listen for wake words",
       "surface": "android",
@@ -6531,7 +6531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 712,
+      "line": 713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runs on-device while OpenClaw is visible.",
       "surface": "android",
@@ -6539,7 +6539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 714,
+      "line": 715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On-device speech recognition is unavailable.",
       "surface": "android",
@@ -6547,7 +6547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 724,
+      "line": 725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake listener",
       "surface": "android",
@@ -6555,7 +6555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 726,
+      "line": 727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last command: $command",
       "surface": "android",
@@ -6563,7 +6563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 727,
+      "line": 728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pauses during other voice activity.",
       "surface": "android",
@@ -6571,7 +6571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 734,
+      "line": 735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake words",
       "surface": "android",
@@ -6579,7 +6579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 736,
+      "line": 737,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add one wake word or phrase per field. Then say one before your command.",
       "surface": "android",
@@ -6587,7 +6587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 751,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake word or phrase",
       "surface": "android",
@@ -6595,7 +6595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 758,
+      "line": 759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove wake phrase",
       "surface": "android",
@@ -6603,7 +6603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 767,
+      "line": 768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add wake phrase",
       "surface": "android",
@@ -6611,7 +6611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save wake words",
       "surface": "android",
@@ -6619,7 +6619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving…",
       "surface": "android",
@@ -6627,7 +6627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 779,
+      "line": 780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -6635,7 +6635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 784,
+      "line": 785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -6643,7 +6643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 786,
+      "line": 787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -6651,7 +6651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 787,
+      "line": 788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -6659,7 +6659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -6667,7 +6667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -6675,7 +6675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 791,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -6683,7 +6683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 791,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -6691,7 +6691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 793,
+      "line": 794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -6699,7 +6699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 793,
+      "line": 794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -6707,7 +6707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 797,
+      "line": 798,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -6715,7 +6715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 807,
+      "line": 808,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -6723,7 +6723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 808,
+      "line": 809,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -6731,7 +6731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 978,
+      "line": 979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -6739,7 +6739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 978,
+      "line": 979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -6747,7 +6747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 982,
+      "line": 983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -6755,7 +6755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 982,
+      "line": 983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forward Notifications",
       "surface": "android",
@@ -6763,7 +6763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 982,
+      "line": 983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -6771,7 +6771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 984,
+      "line": 985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Quiet Hours",
       "surface": "android",
@@ -6779,7 +6779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 985,
+      "line": 986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$quietStart to $quietEnd",
       "surface": "android",
@@ -6787,7 +6787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 997,
+      "line": 998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Policy",
       "surface": "android",
@@ -6795,7 +6795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 998,
+      "line": 999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected Apps",
       "surface": "android",
@@ -6803,7 +6803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 999,
+      "line": 1000,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Rate Limit",
       "surface": "android",
@@ -6811,7 +6811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1000,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -6819,7 +6819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1000,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -6827,7 +6827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1005,
+      "line": 1006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -6835,7 +6835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1005,
+      "line": 1006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -6843,7 +6843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1014,
+      "line": 1015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -6851,7 +6851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1016,
+      "line": 1017,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -6859,7 +6859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1020,
+      "line": 1021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -6867,7 +6867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1069,
+      "line": 1070,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -6875,7 +6875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1076,
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -6883,7 +6883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1076,
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -6891,7 +6891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1081,
+      "line": 1082,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -6899,7 +6899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1084,
+      "line": 1085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -6907,7 +6907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1085,
+      "line": 1086,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -6915,7 +6915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1092,
+      "line": 1093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -6923,7 +6923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1103,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -6931,7 +6931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1350,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -6939,7 +6939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1350,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -6947,7 +6947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1354,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow camera tools when requested.",
       "surface": "android",
@@ -6955,7 +6955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1354,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Camera",
       "surface": "android",
@@ -6963,7 +6963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1355,
+      "line": 1356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Precise Location",
       "surface": "android",
@@ -6971,7 +6971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1355,
+      "line": 1356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share precise location while location is enabled.",
       "surface": "android",
@@ -6979,7 +6979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1358,
+      "line": 1359,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Photos",
       "surface": "android",
@@ -6987,7 +6987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1359,
+      "line": 1360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -6995,7 +6995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1359,
+      "line": 1360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -7003,7 +7003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1368,
+      "line": 1369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Installed Apps",
       "surface": "android",
@@ -7011,7 +7011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1369,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -7019,7 +7019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1369,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -7027,7 +7027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1374,
+      "line": 1375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep Awake",
       "surface": "android",
@@ -7035,7 +7035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1374,
+      "line": 1375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep the node available during active work.",
       "surface": "android",
@@ -7043,7 +7043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1375,
+      "line": 1376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Canvas Status",
       "surface": "android",
@@ -7051,7 +7051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1375,
+      "line": 1376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show screen-sharing debug state.",
       "surface": "android",
@@ -7059,7 +7059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1380,
+      "line": 1381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -7067,7 +7067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1388,
+      "line": 1389,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -7075,7 +7075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1423,
+      "line": 1424,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -7083,7 +7083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1426,
+      "line": 1427,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
       "surface": "android",
@@ -7091,7 +7091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1440,
+      "line": 1441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -7099,7 +7099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1459,
+      "line": 1460,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share installed app information?",
       "surface": "android",
@@ -7107,7 +7107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1463,
+      "line": 1464,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
       "surface": "android",
@@ -7115,7 +7115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
       "surface": "android",
@@ -7123,7 +7123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1472,
+      "line": 1473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agree and Enable",
       "surface": "android",
@@ -7131,7 +7131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1477,
+      "line": 1478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -7139,7 +7139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1530,
+      "line": 1531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -7147,7 +7147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1545,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -7155,7 +7155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1559,
+      "line": 1560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "this gateway",
       "surface": "android",
@@ -7163,7 +7163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1562,
+      "line": 1563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -7171,7 +7171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1565,
+      "line": 1566,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove $gatewayName and its saved credentials from this phone?",
       "surface": "android",
@@ -7179,7 +7179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1582,
+      "line": 1583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -7187,7 +7187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1620,
+      "line": 1621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -7195,7 +7195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1634,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -7203,7 +7203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1634,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection",
       "surface": "android",
@@ -7211,7 +7211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1634,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -7219,7 +7219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1635,
+      "line": 1636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -7227,7 +7227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1635,
+      "line": 1636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -7235,7 +7235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1637,
+      "line": 1638,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Access",
       "surface": "android",
@@ -7243,7 +7243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1644,
+      "line": 1645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Address",
       "surface": "android",
@@ -7251,7 +7251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1649,
+      "line": 1650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Discovered",
       "surface": "android",
@@ -7259,7 +7259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1650,
+      "line": 1651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default Agent",
       "surface": "android",
@@ -7267,7 +7267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1651,
+      "line": 1652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -7275,7 +7275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1652,
+      "line": 1653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Instance ID",
       "surface": "android",
@@ -7283,7 +7283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1658,
+      "line": 1659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR to Pair",
       "surface": "android",
@@ -7291,7 +7291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1668,
+      "line": 1669,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited Gateway access",
       "surface": "android",
@@ -7299,7 +7299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1681,
+      "line": 1682,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -7307,7 +7307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1682,
+      "line": 1683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -7315,7 +7315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1685,
+      "line": 1686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Diagnose",
       "surface": "android",
@@ -7323,7 +7323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1698,
+      "line": 1699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add Gateway",
       "surface": "android",
@@ -7331,7 +7331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1700,
+      "line": 1701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -7339,7 +7339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1706,
+      "line": 1707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR",
       "surface": "android",
@@ -7347,7 +7347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1707,
+      "line": 1708,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -7355,7 +7355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1710,
+      "line": 1711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Where do I get a setup code?",
       "surface": "android",
@@ -7363,7 +7363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1714,
+      "line": 1715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -7371,7 +7371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1721,
+      "line": 1722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateways found yet. Use manual setup if discovery is blocked.",
       "surface": "android",
@@ -7379,7 +7379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1734,
+      "line": 1735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect",
       "surface": "android",
@@ -7387,7 +7387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1745,
+      "line": 1746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -7395,7 +7395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1747,
+      "line": 1748,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -7403,7 +7403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1767,
+      "line": 1768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -7411,7 +7411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1783,
+      "line": 1784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Manual Gateway",
       "surface": "android",
@@ -7419,7 +7419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1785,
+      "line": 1786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -7427,7 +7427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1786,
+      "line": 1787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -7435,7 +7435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1788,
+      "line": 1789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -7443,7 +7443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1792,
+      "line": 1793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -7451,7 +7451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1796,
+      "line": 1797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -7459,7 +7459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1809,
+      "line": 1810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -7467,7 +7467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1810,
+      "line": 1811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -7475,7 +7475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1812,
+      "line": 1813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -7483,7 +7483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1817,
+      "line": 1818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -7491,7 +7491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1834,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -7499,7 +7499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1855,
+      "line": 1856,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not available",
       "surface": "android",
@@ -7507,7 +7507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1856,
+      "line": 1857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Full",
       "surface": "android",
@@ -7515,7 +7515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1857,
+      "line": 1858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited",
       "surface": "android",
@@ -7523,7 +7523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1861,
+      "line": 1862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Use a secure wss:// or Tailscale Serve Gateway, generate a full-access setup code in the Control UI or with openclaw qr, then scan or paste it below and reconnect to enable settings and upgrades.",
       "surface": "android",
@@ -7531,7 +7531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1875,
+      "line": 1876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -7539,7 +7539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1875,
+      "line": 1876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
@@ -7547,7 +7547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1880,
+      "line": 1881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Language",
       "surface": "android",
@@ -7555,7 +7555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1881,
+      "line": 1882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Contrast",
       "surface": "android",
@@ -7563,7 +7563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1881,
+      "line": 1882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "High",
       "surface": "android",
@@ -7571,7 +7571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1882,
+      "line": 1883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Readable",
       "surface": "android",
@@ -7579,7 +7579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1882,
+      "line": 1883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Typography",
       "surface": "android",
@@ -7587,7 +7587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1887,
+      "line": 1888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -7595,7 +7595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1897,
+      "line": 1898,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
@@ -7603,7 +7603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1931,
+      "line": 1932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
@@ -7611,7 +7611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1943,
+      "line": 1944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System",
       "surface": "android",
@@ -7619,7 +7619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1971,
+      "line": 1972,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -7627,7 +7627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1972,
+      "line": 1973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -7635,7 +7635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1984,
+      "line": 1985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -7643,7 +7643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1985,
+      "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pairing needed",
       "surface": "android",
@@ -7651,7 +7651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1986,
+      "line": 1987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -7659,7 +7659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1987,
+      "line": 1988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -7667,7 +7667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1988,
+      "line": 1989,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -7675,7 +7675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1989,
+      "line": 1990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -7683,7 +7683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1990,
+      "line": 1991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cannot reach gateway",
       "surface": "android",
@@ -7691,7 +7691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2011,
+      "line": 2012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -7699,7 +7699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2011,
+      "line": 2012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -7707,7 +7707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2023,
+      "line": 2024,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Channel",
       "surface": "android",
@@ -7715,7 +7715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2024,
+      "line": 2025,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not connected",
       "surface": "android",
@@ -7723,7 +7723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2029,
+      "line": 2030,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Home Gateway",
       "surface": "android",
@@ -7731,7 +7731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2031,
+      "line": 2032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -7739,7 +7739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2031,
+      "line": 2032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting",
       "surface": "android",
@@ -7747,7 +7747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2034,
+      "line": 2035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -7755,7 +7755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2035,
+      "line": 2036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Up to date",
       "surface": "android",
@@ -7763,7 +7763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2035,
+      "line": 2036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "v$it available",
       "surface": "android",
@@ -7771,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2045,
+      "line": 2046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -7779,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2062,
+      "line": 2063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -7787,7 +7787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2064,
+      "line": 2065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -7795,7 +7795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2065,
+      "line": 2066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -7803,7 +7803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2124,
+      "line": 2125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -7811,7 +7811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2125,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -7819,7 +7819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2134,
+      "line": 2135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -7827,7 +7827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2160,
+      "line": 2161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -7835,7 +7835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2171,
+      "line": 2172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Third-party",
       "surface": "android",
@@ -7843,7 +7843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2172,
+      "line": 2173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unknown",
       "surface": "android",
@@ -7851,7 +7851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2178,
+      "line": 2179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Website",
       "surface": "android",
@@ -7859,7 +7859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2179,
+      "line": 2180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Docs",
       "surface": "android",
@@ -7867,7 +7867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2183,
+      "line": 2184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow all the time",
       "surface": "android",
@@ -7875,7 +7875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2186,
+      "line": 2187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
       "surface": "android",
@@ -7883,7 +7883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2205,
+      "line": 2206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -7891,7 +7891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2212,
+      "line": 2213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
       "surface": "android",
@@ -7899,7 +7899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2214,
+      "line": 2215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
       "surface": "android",
@@ -7907,7 +7907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2239,
+      "line": 2240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -7915,7 +7915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2313,
+      "line": 2314,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command approval",
       "surface": "android",
@@ -7923,7 +7923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2318,
+      "line": 2319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -7931,7 +7931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2378,
+      "line": 2379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -7939,7 +7939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2379,
+      "line": 2380,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Always",
       "surface": "android",
@@ -7947,7 +7947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2380,
+      "line": 2381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -7955,7 +7955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2401,
+      "line": 2402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approval ${notice.approvalId}",
       "surface": "android",
@@ -7963,7 +7963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2408,
+      "line": 2409,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dismiss approval notice",
       "surface": "android",
@@ -7971,7 +7971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2427,
+      "line": 2428,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -7979,7 +7979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2467,
+      "line": 2468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open automation detail",
       "surface": "android",
@@ -7987,7 +7987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2510,
+      "line": 2511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -7995,7 +7995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2510,
+      "line": 2511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Status",
       "surface": "android",
@@ -8003,7 +8003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2511,
+      "line": 2512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule",
       "surface": "android",
@@ -8011,7 +8011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2512,
+      "line": 2513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next Wake",
       "surface": "android",
@@ -8019,7 +8019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2513,
+      "line": 2514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Run",
       "surface": "android",
@@ -8027,7 +8027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2520,
+      "line": 2521,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Description",
       "surface": "android",
@@ -8035,7 +8035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2521,
+      "line": 2522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule Detail",
       "surface": "android",
@@ -8043,7 +8043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2522,
+      "line": 2523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session Target",
       "surface": "android",
@@ -8051,7 +8051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2523,
+      "line": 2524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake Mode",
       "surface": "android",
@@ -8059,7 +8059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2524,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delete After Run",
       "surface": "android",
@@ -8067,7 +8067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2524,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -8075,7 +8075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2524,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -8083,7 +8083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2525,
+      "line": 2526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload",
       "surface": "android",
@@ -8091,7 +8091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2526,
+      "line": 2527,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery",
       "surface": "android",
@@ -8099,7 +8099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2527,
+      "line": 2528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Failure Alert",
       "surface": "android",
@@ -8107,7 +8107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2528,
+      "line": 2529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Created",
       "surface": "android",
@@ -8115,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2529,
+      "line": 2530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Updated",
       "surface": "android",
@@ -8123,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2530,
+      "line": 2531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Running Since",
       "surface": "android",
@@ -8131,7 +8131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2531,
+      "line": 2532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Status",
       "surface": "android",
@@ -8139,7 +8139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2533,
+      "line": 2534,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Duration",
       "surface": "android",
@@ -8147,7 +8147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2534,
+      "line": 2535,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${durationMs}ms",
       "surface": "android",
@@ -8155,7 +8155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2536,
+      "line": 2537,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Errors",
       "surface": "android",
@@ -8163,7 +8163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2537,
+      "line": 2538,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Skips",
       "surface": "android",
@@ -8171,7 +8171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2538,
+      "line": 2539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Status",
       "surface": "android",
@@ -8179,7 +8179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2545,
+      "line": 2546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -8187,7 +8187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2548,
+      "line": 2549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -8195,7 +8195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2564,
+      "line": 2565,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Copy ${row.title}",
       "surface": "android",
@@ -8203,7 +8203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2589,
+      "line": 2590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -8211,7 +8211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2604,
+      "line": 2605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -8219,7 +8219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2642,
+      "line": 2643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -8227,7 +8227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2648,
+      "line": 2649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -8235,7 +8235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2656,
+      "line": 2657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${endpoint.host}:${endpoint.port}",
       "surface": "android",
@@ -8243,7 +8243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2702,
+      "line": 2703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Action Request",
       "surface": "android",
@@ -8251,7 +8251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2710,
+      "line": 2711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -8259,7 +8259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2713,
+      "line": 2714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -8267,7 +8267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2713,
+      "line": 2714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -8275,7 +8275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2724,
+      "line": 2725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node ${nodeId}",
       "surface": "android",
@@ -8283,7 +8283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2726,
+      "line": 2727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node",
       "surface": "android",
@@ -8291,7 +8291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2729,
+      "line": 2730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -8299,7 +8299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2734,
+      "line": 2735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent ${agentId}",
       "surface": "android",
@@ -8307,7 +8307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2739,
+      "line": 2740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${duration}",
       "surface": "android",
@@ -8315,7 +8315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2744,
+      "line": 2745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Expires ${duration}",
       "surface": "android",
@@ -8323,7 +8323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2754,
+      "line": 2755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "soon",
       "surface": "android",
@@ -8331,7 +8331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2762,
+      "line": 2763,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Main",
       "surface": "android",
@@ -8339,7 +8339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2763,
+      "line": 2764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Isolated",
       "surface": "android",
@@ -8347,7 +8347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2764,
+      "line": 2765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Current",
       "surface": "android",
@@ -8355,7 +8355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2770,
+      "line": 2771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -8363,7 +8363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2786,
+      "line": 2787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "All",
       "surface": "android",
@@ -8371,7 +8371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2787,
+      "line": 2788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active",
       "surface": "android",
@@ -8379,7 +8379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2788,
+      "line": 2789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Paused",
       "surface": "android",
@@ -8387,7 +8387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2821,
+      "line": 2822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${remaining}% left ${label}",
       "surface": "android",
@@ -8395,7 +8395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2824,
+      "line": 2825,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -8403,7 +8403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2835,
+      "line": 2836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Never",
       "surface": "android",
@@ -8411,7 +8411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2840,
+      "line": 2841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Now",
       "surface": "android",
@@ -8419,7 +8419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2862,
+      "line": 2863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -8427,7 +8427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2864,
+      "line": 2865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -8435,7 +8435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2866,
+      "line": 2867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Skipped",
       "surface": "android",
@@ -8443,7 +8443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2867,
+      "line": 2868,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -8451,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2883,
+      "line": 2884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -8459,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2884,
+      "line": 2885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -8467,7 +8467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2885,
+      "line": 2886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -8475,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2886,
+      "line": 2887,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -8483,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2916,
+      "line": 2917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps selected. Nothing forwards until you add apps.",
       "surface": "android",
@@ -8491,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2918,
+      "line": 2919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app allowed to forward.",
       "surface": "android",
@@ -8499,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2920,
+      "line": 2921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps allowed to forward.",
       "surface": "android",
@@ -8507,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2924,
+      "line": 2925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps blocked. Apps can forward unless you add blocks.",
       "surface": "android",
@@ -8515,7 +8515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2926,
+      "line": 2927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app blocked from forwarding.",
       "surface": "android",
@@ -8523,7 +8523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2928,
+      "line": 2929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps blocked from forwarding.",
       "surface": "android",
@@ -8531,7 +8531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2954,
+      "line": 2955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Due",
       "surface": "android",
@@ -8539,7 +8539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2959,
+      "line": 2960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${days}d",
       "surface": "android",
@@ -8547,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2960,
+      "line": 2961,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -8555,7 +8555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2961,
+      "line": 2962,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -8563,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2962,
+      "line": 2963,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Soon",
       "surface": "android",
@@ -8571,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2967,
+      "line": 2968,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "None",
       "surface": "android",
@@ -10035,7 +10035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 132,
+      "line": 133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills",
       "surface": "android",
@@ -10043,7 +10043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 133,
+      "line": 134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Manage installed skills and add trusted releases from ClawHub.",
       "surface": "android",
@@ -10051,7 +10051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 147,
+      "line": 148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -10059,7 +10059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 165,
+      "line": 166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill changes require operator.admin. Reconnect with an admin-capable gateway token.",
       "surface": "android",
@@ -10067,7 +10067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 231,
+      "line": 232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Inspect and manage installed skill state.",
       "surface": "android",
@@ -10075,7 +10075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 239,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Status",
       "surface": "android",
@@ -10083,7 +10083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 241,
+      "line": 242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Missing",
       "surface": "android",
@@ -10091,7 +10091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -10099,7 +10099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -10107,7 +10107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 374,
+      "line": 375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search installed skills",
       "surface": "android",
@@ -10115,7 +10115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 392,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skills.",
       "surface": "android",
@@ -10123,7 +10123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 397,
+      "line": 398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No skills installed.",
       "surface": "android",
@@ -10131,7 +10131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 398,
+      "line": 399,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills installed on the gateway will appear here.",
       "surface": "android",
@@ -10139,7 +10139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 403,
+      "line": 404,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No installed skills match this search.",
       "surface": "android",
@@ -10147,7 +10147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 430,
+      "line": 431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Gateway switch",
       "surface": "android",
@@ -10155,7 +10155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 432,
+      "line": 433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Disabled for all agents.",
       "surface": "android",
@@ -10163,7 +10163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 432,
+      "line": 433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Enabled for eligible agents.",
       "surface": "android",
@@ -10171,7 +10171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 463,
+      "line": 464,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skill details.",
       "surface": "android",
@@ -10179,7 +10179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 469,
+      "line": 470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill detail is not available in the current skills status.",
       "surface": "android",
@@ -10187,7 +10187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 476,
+      "line": 477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill Key",
       "surface": "android",
@@ -10195,7 +10195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 477,
+      "line": 478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Display",
       "surface": "android",
@@ -10203,7 +10203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 478,
+      "line": 479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Source",
       "surface": "android",
@@ -10211,7 +10211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 479,
+      "line": 480,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Install Options",
       "surface": "android",
@@ -10219,7 +10219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 485,
+      "line": 486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Description",
       "surface": "android",
@@ -10227,7 +10227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Open skill detail",
       "surface": "android",
@@ -10235,7 +10235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 553,
+      "line": 554,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Find on ClawHub",
       "surface": "android",
@@ -10243,7 +10243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search registry metadata. The Gateway verifies trust again before any download.",
       "surface": "android",
@@ -10251,7 +10251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 574,
+      "line": 575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search ClawHub",
       "surface": "android",
@@ -10259,7 +10259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 579,
+      "line": 580,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -10267,7 +10267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 579,
+      "line": 580,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Searching",
       "surface": "android",
@@ -10275,7 +10275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 605,
+      "line": 606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Version $it",
       "surface": "android",
@@ -10283,7 +10283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 614,
+      "line": 615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installing",
       "surface": "android",
@@ -10291,7 +10291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 615,
+      "line": 616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Loading",
       "surface": "android",
@@ -10299,7 +10299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 675,
+      "line": 676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -10307,7 +10307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 713,
+      "line": 714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
@@ -10315,7 +10315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 719,
+      "line": 720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Dismiss",
       "surface": "android",
@@ -10323,7 +10323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 726,
+      "line": 727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Acknowledge Gateway warning and install",
       "surface": "android",
@@ -10331,7 +10331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 745,
+      "line": 746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Review ClawHub skill",
       "surface": "android",
@@ -10339,7 +10339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 752,
+      "line": 753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Version",
       "surface": "android",
@@ -10347,7 +10347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 753,
+      "line": 754,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Publisher",
       "surface": "android",
@@ -10355,7 +10355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 755,
+      "line": 756,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "The Gateway will verify this exact release with ClawHub before download. If the release needs explicit risk acknowledgement, Android will show the Gateway warning before retrying.",
       "surface": "android",
@@ -10363,7 +10363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 763,
+      "line": 764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Verify and install",
       "surface": "android",
@@ -10371,7 +10371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 768,
+      "line": 769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -10379,7 +10379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 810,
+      "line": 811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "All",
       "surface": "android",
@@ -10387,7 +10387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 812,
+      "line": 813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs Setup",
       "surface": "android",
@@ -10395,7 +10395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 829,
+      "line": 830,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -10403,7 +10403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 830,
+      "line": 831,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Setup",
       "surface": "android",
@@ -10411,7 +10411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 831,
+      "line": 832,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -10419,7 +10419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 844,
+      "line": 845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Disabled",
       "surface": "android",
@@ -10427,7 +10427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 845,
+      "line": 846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Blocked",
       "surface": "android",
@@ -10435,7 +10435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 846,
+      "line": 847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Not available to this agent",
       "surface": "android",
@@ -10443,7 +10443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 848,
+      "line": 849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Needs setup",
       "surface": "android",
@@ -10451,7 +10451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 856,
+      "line": 857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is disabled on the gateway. Enable it here when the current connection has operator.admin.",
       "surface": "android",
@@ -10459,7 +10459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 857,
+      "line": 858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is blocked by the gateway allowlist. Allowlist changes stay on desktop or CLI.",
       "surface": "android",
@@ -10467,7 +10467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 858,
+      "line": 859,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI.",
       "surface": "android",
@@ -10475,7 +10475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 860,
+      "line": 861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill is installed but not currently eligible to run. Use desktop or CLI for configuration changes.",
       "surface": "android",
@@ -10483,7 +10483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 861,
+      "line": 862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Ready on this gateway. Android can enable or disable it globally; setup and configuration stay on desktop or CLI.",
       "surface": "android",
@@ -10491,7 +10491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 866,
+      "line": 867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No missing items",
       "surface": "android",
@@ -10499,7 +10499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 867,
+      "line": 868,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "1 missing item",
       "surface": "android",
@@ -10507,7 +10507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 868,
+      "line": 869,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "$count missing items",
       "surface": "android",
@@ -10515,7 +10515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 873,
+      "line": 874,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill needs 1 setup item. Android shows what is installed; setup/config changes stay on desktop or CLI.",
       "surface": "android",
@@ -10523,7 +10523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 874,
+      "line": 875,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "This skill needs $count setup items. Android shows what is installed; setup/config changes stay on desktop or CLI.",
       "surface": "android",
@@ -10531,7 +10531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 879,
+      "line": 880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Built-in",
       "surface": "android",
@@ -10539,7 +10539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 879,
+      "line": 880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Bundled",
       "surface": "android",
@@ -10547,7 +10547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 880,
+      "line": 881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installed",
       "surface": "android",
@@ -10555,7 +10555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 881,
+      "line": 882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Workspace",
       "surface": "android",
@@ -10563,7 +10563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 882,
+      "line": 883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Extra",
       "surface": "android",
@@ -10571,7 +10571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 883,
+      "line": 884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -7189,7 +7189,7 @@ class NodeRuntime private constructor(
         .split(' ', '-', '_')
         .filter { it.isNotBlank() }
         .take(2)
-        .mapNotNull { token -> token.firstOrNull()?.uppercaseChar()?.toString() }
+        .mapNotNull { token -> token.uppercaseFirstGraphemeOrNull() }
         .joinToString("")
     return if (initials.isNotEmpty()) initials else "OC"
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/Utf16Text.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/Utf16Text.kt
@@ -15,7 +15,13 @@ internal fun String.firstGraphemeOrNull(): String? {
   return if (end == BreakIterator.DONE) null else substring(0, end)
 }
 
-internal fun String.uppercaseFirstGraphemeOrNull(): String? = firstGraphemeOrNull()?.uppercase()
+internal fun String.uppercaseFirstGraphemeOrNull(): String? {
+  val grapheme = firstGraphemeOrNull() ?: return null
+  val firstCodePoint = grapheme.codePointAt(0)
+  val uppercaseCodePoint = Character.toUpperCase(firstCodePoint)
+  // Keep badge width stable while preserving the rest of the grapheme cluster.
+  return String(Character.toChars(uppercaseCodePoint)) + grapheme.substring(Character.charCount(firstCodePoint))
+}
 
 internal fun String.takeUtf16Safe(maxChars: Int): String {
   if (length <= maxChars) return this

--- a/apps/android/app/src/main/java/ai/openclaw/app/Utf16Text.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/Utf16Text.kt
@@ -15,6 +15,8 @@ internal fun String.firstGraphemeOrNull(): String? {
   return if (end == BreakIterator.DONE) null else substring(0, end)
 }
 
+internal fun String.uppercaseFirstGraphemeOrNull(): String? = firstGraphemeOrNull()?.uppercase()
+
 internal fun String.takeUtf16Safe(maxChars: Int): String {
   if (length <= maxChars) return this
   // Keep the code-unit cap without leaving a high surrogate at its boundary.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.GatewayChannelSummary
 import ai.openclaw.app.GatewayChannelsSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.i18n.nativeString
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawListPanel
 import ai.openclaw.app.ui.design.ClawPanel
@@ -156,7 +157,7 @@ private fun channelBadge(label: String): String =
     .split(' ', '-', '_')
     .filter { it.isNotBlank() }
     .take(2)
-    .mapNotNull { it.firstOrNull()?.uppercaseChar()?.toString() }
+    .mapNotNull { it.uppercaseFirstGraphemeOrNull() }
     .joinToString("")
     .ifBlank { "C" }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt
@@ -4,7 +4,6 @@ import ai.openclaw.app.GatewayChannelSummary
 import ai.openclaw.app.GatewayChannelsSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.i18n.nativeString
-import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawListPanel
 import ai.openclaw.app.ui.design.ClawPanel
@@ -13,6 +12,7 @@ import ai.openclaw.app.ui.design.ClawStatus
 import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTextBadge
 import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
@@ -9,6 +9,7 @@ import ai.openclaw.app.GatewayPendingDeviceSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.currentAppLanguage
 import ai.openclaw.app.i18n.nativeString
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawSecondaryButton
@@ -340,7 +341,7 @@ private fun nodeBadge(value: String): String =
     .split(' ', '-', '_')
     .filter { it.isNotBlank() }
     .take(2)
-    .mapNotNull { it.firstOrNull()?.uppercaseChar()?.toString() }
+    .mapNotNull { it.uppercaseFirstGraphemeOrNull() }
     .joinToString("")
     .ifBlank { "N" }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
@@ -9,7 +9,6 @@ import ai.openclaw.app.GatewayPendingDeviceSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.currentAppLanguage
 import ai.openclaw.app.i18n.nativeString
-import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawSecondaryButton
@@ -17,6 +16,7 @@ import ai.openclaw.app.ui.design.ClawStatus
 import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTextBadge
 import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.currentAppLanguage
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.providerDisplayName
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawEmptyState
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawScaffold
@@ -417,7 +418,7 @@ private fun providerInitials(value: String): String =
     .split(' ', '-', '_')
     .filter { it.isNotBlank() }
     .take(2)
-    .mapNotNull { it.firstOrNull()?.uppercaseChar()?.toString() }
+    .mapNotNull { it.uppercaseFirstGraphemeOrNull() }
     .joinToString("")
     .ifBlank { "AI" }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -6,12 +6,12 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.currentAppLanguage
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.providerDisplayName
-import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawEmptyState
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawScaffold
 import ai.openclaw.app.ui.design.ClawSecondaryButton
 import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -43,6 +43,7 @@ import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.reconcileRestoredAction
 import ai.openclaw.app.setAppLanguage
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawAgentAvatar
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconBadge
@@ -2451,7 +2452,7 @@ private fun UsageProviderListRow(provider: GatewayUsageProviderSummary) {
   ClawDetailRow(
     title = provider.displayName,
     subtitle = usageProviderSubtitle(provider),
-    leading = { ClawTextBadge(text = provider.displayName.firstOrNull()?.uppercase() ?: "U") },
+    leading = { ClawTextBadge(text = provider.displayName.uppercaseFirstGraphemeOrNull() ?: "U") },
     trailing = { ClawStatusPill(text = if (hasIssue) nativeString("Issue") else "OK", status = if (hasIssue) ClawStatus.Warning else ClawStatus.Success) },
   )
 }
@@ -2680,7 +2681,7 @@ private fun agentBadge(agent: GatewayAgentSummary): String {
     .split(' ', '-', '_')
     .filter { it.isNotBlank() }
     .take(2)
-    .mapNotNull { it.firstOrNull()?.uppercaseChar()?.toString() }
+    .mapNotNull { it.uppercaseFirstGraphemeOrNull() }
     .joinToString("")
     .ifBlank { "A" }
 }
@@ -2937,7 +2938,7 @@ private fun notificationAppBadge(label: String): String {
       .asSequence()
       .filter { it.isNotBlank() }
       .take(2)
-      .mapNotNull { it.firstOrNull()?.uppercaseChar()?.toString() }
+      .mapNotNull { it.uppercaseFirstGraphemeOrNull() }
       .joinToString("")
   return initials.ifBlank { "A" }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -43,7 +43,6 @@ import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.reconcileRestoredAction
 import ai.openclaw.app.setAppLanguage
-import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawAgentAvatar
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconBadge
@@ -65,6 +64,7 @@ import ai.openclaw.app.ui.design.OpenClawMascot
 import ai.openclaw.app.ui.design.TalkWaveform
 import ai.openclaw.app.ui.design.TalkWaveformPhase
 import ai.openclaw.app.ui.design.agentAvatarSource
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.voice.VoiceWakePreferences
 import android.Manifest
 import android.content.ClipData

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
@@ -9,7 +9,6 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.isClawHubSkillInstalled
 import ai.openclaw.app.isClawHubSkillOperationActive
-import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconButton
 import ai.openclaw.app.ui.design.ClawListPanel
@@ -23,6 +22,7 @@ import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTextBadge
 import ai.openclaw.app.ui.design.ClawTextField
 import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
@@ -9,6 +9,7 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.isClawHubSkillInstalled
 import ai.openclaw.app.isClawHubSkillOperationActive
+import ai.openclaw.app.uppercaseFirstGraphemeOrNull
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconButton
 import ai.openclaw.app.ui.design.ClawListPanel
@@ -893,6 +894,6 @@ private fun skillBadge(name: String): String =
     .split(' ', '-', '_')
     .filter { it.isNotBlank() }
     .take(2)
-    .mapNotNull { it.firstOrNull()?.uppercaseChar()?.toString() }
+    .mapNotNull { it.uppercaseFirstGraphemeOrNull() }
     .joinToString("")
     .ifBlank { "S" }

--- a/apps/android/app/src/test/java/ai/openclaw/app/Utf16TextTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/Utf16TextTest.kt
@@ -29,6 +29,8 @@ class Utf16TextTest {
     assertEquals("👩🏽‍💻", "👩🏽‍💻 Dev".uppercaseFirstGraphemeOrNull())
     assertEquals("A\u0308", "a\u0308lice".uppercaseFirstGraphemeOrNull())
     assertEquals("S", "scout".uppercaseFirstGraphemeOrNull())
+    assertEquals("ß", "ßcout".uppercaseFirstGraphemeOrNull())
+    assertEquals("\uD801\uDC00", "\uD801\uDC28cout".uppercaseFirstGraphemeOrNull())
     assertNull("".uppercaseFirstGraphemeOrNull())
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/Utf16TextTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/Utf16TextTest.kt
@@ -23,6 +23,16 @@ class Utf16TextTest {
   }
 
   @Test
+  fun uppercaseFirstGraphemeOrNullPreservesUserPerceivedCharacters() {
+    assertEquals("🧭", "🧭 Scout".uppercaseFirstGraphemeOrNull())
+    assertEquals("🇺🇸", "🇺🇸 Scout".uppercaseFirstGraphemeOrNull())
+    assertEquals("👩🏽‍💻", "👩🏽‍💻 Dev".uppercaseFirstGraphemeOrNull())
+    assertEquals("A\u0308", "a\u0308lice".uppercaseFirstGraphemeOrNull())
+    assertEquals("S", "scout".uppercaseFirstGraphemeOrNull())
+    assertNull("".uppercaseFirstGraphemeOrNull())
+  }
+
+  @Test
   fun localizedInitialPreservesGraphemesAndLocale() {
     assertEquals("🧭", localizedInitial("🧭 Scout", languageTag = "en", fallbackLocale = Locale.US))
     assertEquals("🇺🇸", localizedInitial("🇺🇸 Scout", languageTag = "en", fallbackLocale = Locale.US))


### PR DESCRIPTION
## What Problem This Solves

Fixes compact Android badges that could render a lone UTF-16 surrogate when a channel, node, model provider, usage provider, agent, installed app, or skill name began with emoji. The same bug also split flags, ZWJ emoji, and combining-character graphemes.

## Why This Change Was Made

All eight remaining badge/initial paths now share a grapheme-aware uppercase helper built on the Android ICU `BreakIterator` utility already used by shell initials. The helper uses a one-to-one Unicode code-point case mapping so compact badges do not expand characters such as `ß` while still casing supplementary-plane letters correctly.

## User Impact

Android status and settings surfaces now preserve the complete first visible character for Unicode names instead of displaying malformed initials.

## Evidence

- Extended `Utf16TextTest` with emoji, flag, ZWJ, combining-mark, ASCII, `ß`, supplementary-plane casing, and empty-input cases.
- Audited all eight remaining `firstOrNull()?.uppercase*` badge paths; no affected renderer remains.
- Regenerated `apps/.i18n/native-source.json` after the import-line shifts.
- `node --import tsx scripts/native-app-i18n.ts check` passed.
- `node --import tsx scripts/android-app-i18n.ts check` passed.
- `git diff --check` and import-order checks passed.
- Two fresh autoreview passes are clean, including a full branch review at 0.85 correctness confidence.
- Exact-head Android CI passed for head `22f2be63225c5ac907c1b58050e59f4e964e0558`.
- [API 36 emulator behavior proof](https://github.com/Leon-SK668/openclaw/actions/runs/29559948128) passed against that immutable head: the production compact-badge component rendered a supplementary-plane emoji, US regional-indicator flag, woman-technologist ZWJ sequence, and combining-mark grapheme. The connected instrumentation lane passed 1/1 test and Gradle completed successfully.
- The uploaded `android-badge-grapheme-proof-22f2be63225c5ac907c1b58050e59f4e964e0558` artifact (`sha256:033ea8d2f065867f068270a312de3e2bfe176441364631c67c9219d0b1b5c102`) contains the 1080×1920 screenshot, UI hierarchy, environment, and machine-readable pixel assertions. All four badges occupy stable 79×79 bounds, have non-background rendered pixels, and contain no U+FFFD accessibility node.
