### PR TITLE
improve: speed up large transcript regression test

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -478,9 +478,10 @@ describe("SQLite active transcript event projection", () => {
         JSON.stringify({ id: scope.sessionId, type: "session", version: 3 }),
         0,
       );
+      // Cardinality and parent links drive this bound; keep unrelated payload bytes minimal.
       for (let index = 1; index <= 100_000; index += 1) {
-        const eventId = `message-${index}`;
-        const parentId = index === 1 ? null : `message-${index - 1}`;
+        const eventId = `m${index}`;
+        const parentId = index === 1 ? null : `m${index - 1}`;
         insertEvent.run(
           scope.sessionId,
           index,
@@ -488,7 +489,7 @@ describe("SQLite active transcript event projection", () => {
             type: "message",
             id: eventId,
             parentId,
-            message: { role: "toolResult", content: `payload-${index}` },
+            message: { role: "toolResult", content: "x" },
           }),
           index,
         );
@@ -501,7 +502,7 @@ describe("SQLite active transcript event projection", () => {
             INSERT INTO session_transcript_index_state
               (session_id, indexed_seq, leaf_event_id, needs_rebuild,
                active_event_count, active_message_count, updated_at)
-            VALUES (?, 100000, 'message-100000', 0, 100000, 100000, 100000)
+            VALUES (?, 100000, 'm100000', 0, 100000, 100000, 100000)
           `,
         )
         .run(scope.sessionId);
@@ -527,10 +528,10 @@ describe("SQLite active transcript event projection", () => {
       maxLines: 3,
       maxMessages: 10,
     });
-    const byId = readSessionTranscriptMessageEventById(scope, "message-100000");
+    const byId = readSessionTranscriptMessageEventById(scope, "m100000");
     const anchor = readSessionTranscriptMessageAnchorPage(scope, {
       maxMessages: 5,
-      messageId: "message-100000",
+      messageId: "m100000",
     });
 
     expect(page.totalMessages).toBe(100_000);
@@ -559,9 +560,9 @@ describe("SQLite active transcript event projection", () => {
       .run(
         JSON.stringify({
           type: "message",
-          id: "message-1",
+          id: "m1",
           parentId: null,
-          message: { role: "toolResult", content: "payload-1" },
+          message: { role: "toolResult", content: "x" },
         }),
         scope.sessionId,
       );
@@ -589,8 +590,8 @@ describe("SQLite active transcript event projection", () => {
     const liveWrite = await persistSessionTranscriptTurn(scope, {
       messages: [
         {
-          eventId: "message-100001",
-          parentId: "message-100000",
+          eventId: "m100001",
+          parentId: "m100000",
           message: { role: "toolResult", content: "live-write" },
         },
       ],


### PR DESCRIPTION
## What Problem This Solves

The 100k-message transcript performance test spent avoidable time constructing and parsing long per-row IDs and payload strings that do not contribute to its cardinality, bounded-read, branch-chain, or concurrent-rebuild assertions.

## Why This Change Was Made

Keep the complete 100k-row parent chain and all existing read, lookup, rebuild, event-loop responsiveness, and live-write checks, while using compact IDs and constant payload text for irrelevant fixture data.

## User Impact

No user-visible behavior change. The large transcript regression test completes faster without reducing its 100k-message coverage.

## Evidence

- Blacksmith Testbox `tbx_01kxpshyzh4e17yv9xh4q2n8qy`
- Three-run median target time: 2.968s before, 2.563s after (13.6% faster)
- `pnpm test src/config/sessions/session-accessor.sqlite-active-events.test.ts` — 8/8 passed; target 2.598s in final full-file run
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed
- Fresh autoreview — clean, no accepted/actionable findings
