### PR TITLE
fix(tui): bound run state when terminal events are missing

### DIFF
--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -125,6 +125,20 @@ describe("TuiStreamAssembler", () => {
     expect(second).toBeNull();
   });
 
+  it("does not evict another run when finalizing an already-evicted run id", () => {
+    const assembler = new TuiStreamAssembler();
+    for (let index = 0; index < 200; index += 1) {
+      assembler.ingestDelta(`run-${index}`, messageWithContent([text(`Draft ${index}`)]), false);
+    }
+
+    assembler.ingestDelta("run-200", messageWithContent([text("Newest")]), false);
+
+    expect(assembler.finalize("run-0", messageWithContent([text("Late final")]), false)).toBe(
+      "Late final",
+    );
+    expect(assembler.finalize("run-1", { role: "assistant", content: [] }, false)).toBe("Draft 1");
+  });
+
   it("bounds orphaned run state while retaining recently active runs", () => {
     const assembler = new TuiStreamAssembler();
     for (let index = 0; index < 200; index += 1) {

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -125,6 +125,24 @@ describe("TuiStreamAssembler", () => {
     expect(second).toBeNull();
   });
 
+  it("bounds orphaned run state while retaining recently active runs", () => {
+    const assembler = new TuiStreamAssembler();
+    for (let index = 0; index < 200; index += 1) {
+      assembler.ingestDelta(`run-${index}`, messageWithContent([text(`Draft ${index}`)]), false);
+    }
+
+    assembler.ingestDelta("run-0", messageWithContent([text("Recently active")]), false);
+    assembler.ingestDelta("run-200", messageWithContent([text("Newest")]), false);
+
+    expect(assembler.finalize("run-0", { role: "assistant", content: [] }, false)).toBe(
+      "Recently active",
+    );
+    expect(assembler.finalize("run-1", { role: "assistant", content: [] }, false)).toBe(
+      "(no output)",
+    );
+    expect(assembler.finalize("run-200", { role: "assistant", content: [] }, false)).toBe("Newest");
+  });
+
   it("keeps streamed delta text when incoming tool boundary drops a block", () => {
     const assembler = new TuiStreamAssembler();
     const first = assembler.ingestDelta("run-delta-boundary", TEXT_ONLY_TWO_BLOCKS, false);

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -112,7 +112,17 @@ function shouldPreserveBoundaryDroppedText(params: {
 export class TuiStreamAssembler {
   private runs = new Map<string, RunStreamState>();
 
-  private getOrCreateRun(runId: string): RunStreamState {
+  private createEmptyRunState(): RunStreamState {
+    return {
+      thinkingText: "",
+      contentText: "",
+      contentBlocks: [],
+      sawNonTextContentBlocks: false,
+      displayText: "",
+    };
+  }
+
+  private getTrackedRun(runId: string): RunStreamState {
     let state = this.runs.get(runId);
     if (state) {
       // Refresh insertion order so an active older run survives eviction when newer runs arrive.
@@ -121,16 +131,14 @@ export class TuiStreamAssembler {
       return state;
     }
 
-    state = {
-      thinkingText: "",
-      contentText: "",
-      contentBlocks: [],
-      sawNonTextContentBlocks: false,
-      displayText: "",
-    };
+    state = this.createEmptyRunState();
     this.runs.set(runId, state);
     pruneMapToMaxSize(this.runs, MAX_TRACKED_STREAM_RUNS);
     return state;
+  }
+
+  private getRunForFinalize(runId: string): RunStreamState {
+    return this.runs.get(runId) ?? this.createEmptyRunState();
   }
 
   private updateRunState(
@@ -177,7 +185,7 @@ export class TuiStreamAssembler {
 
   /** Ingests a streaming delta and returns updated display text only when it changed. */
   ingestDelta(runId: string, message: unknown, showThinking: boolean): string | null {
-    const state = this.getOrCreateRun(runId);
+    const state = this.getTrackedRun(runId);
     const previousDisplayText = state.displayText;
     this.updateRunState(state, message, showThinking, {
       boundaryDropMode: "streamed-or-incoming",
@@ -192,7 +200,7 @@ export class TuiStreamAssembler {
 
   /** Finalizes a run, combines any error text, and drops stored stream state. */
   finalize(runId: string, message: unknown, showThinking: boolean, errorMessage?: string): string {
-    const state = this.getOrCreateRun(runId);
+    const state = this.getRunForFinalize(runId);
     const streamedDisplayText = state.displayText;
     const streamedTextBlocks = [...state.contentBlocks];
     const streamedSawNonTextContentBlocks = state.sawNonTextContentBlocks;

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -1,10 +1,13 @@
 // Assembles streamed backend events into TUI-visible messages.
+import { pruneMapToMaxSize } from "../infra/map-size.js";
 import {
   composeThinkingAndContent,
   extractContentFromMessage,
   extractThinkingFromMessage,
   resolveFinalAssistantText,
 } from "./tui-formatters.js";
+
+const MAX_TRACKED_STREAM_RUNS = 200;
 
 // Per-run state used to merge streaming deltas with final assistant messages.
 type RunStreamState = {
@@ -111,16 +114,22 @@ export class TuiStreamAssembler {
 
   private getOrCreateRun(runId: string): RunStreamState {
     let state = this.runs.get(runId);
-    if (!state) {
-      state = {
-        thinkingText: "",
-        contentText: "",
-        contentBlocks: [],
-        sawNonTextContentBlocks: false,
-        displayText: "",
-      };
+    if (state) {
+      // Refresh insertion order so an active older run survives eviction when newer runs arrive.
+      this.runs.delete(runId);
       this.runs.set(runId, state);
+      return state;
     }
+
+    state = {
+      thinkingText: "",
+      contentText: "",
+      contentBlocks: [],
+      sawNonTextContentBlocks: false,
+      displayText: "",
+    };
+    this.runs.set(runId, state);
+    pruneMapToMaxSize(this.runs, MAX_TRACKED_STREAM_RUNS);
     return state;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a long-running TUI session could retain streamed run state indefinitely when a run emitted deltas but its terminal event never arrived, such as after a transport interruption.

## Why This Change Was Made

The stream assembler now keeps at most 200 run states and refreshes insertion order for recently active runs, matching the existing TUI run-bookkeeping ceiling. Normal `final`, `aborted`, and `error` cleanup is unchanged; the bounded fallback only matters when terminal cleanup is missing. The risk is limited to very old orphaned stream state being unavailable if a terminal event arrives after more than 200 other tracked runs.

## User Impact

TUI sessions no longer accumulate unbounded in-memory stream state after missing terminal events, while current and recently active streamed responses continue to assemble normally.

## Evidence

AI-assisted change; I reviewed the lifecycle paths and ran the following evidence locally on Linux with Node 24.18.0.

Real behavior proof used the same script against two isolated worktrees at latest `upstream/main` (`0a19e1ed586`) and the fixed head. The script imported the real exported `TuiStreamAssembler`, ingested 201 distinct run IDs without terminal events, refreshed the oldest active run, and inspected the production object's runtime map only to report its size. No transport or assembler logic was mocked.

Before, latest main retained all 201 entries:

```text
{"trackedRunCount":201,"recentRun":"Recently active","evictedCandidate":"Draft 1","newestRun":"Newest"}
```

After, the fixed head retained 200 entries, preserved the recently active and newest runs, and evicted the oldest orphan:

```text
{"trackedRunCount":200,"recentRun":"Recently active","evictedCandidate":"(no output)","newestRun":"Newest"}
```

Focused regression test:

```text
$ node scripts/run-vitest.mjs src/tui/tui-stream-assembler.test.ts
Test Files  1 passed (1)
Tests  14 passed (14)
```

Static checks:

```text
$ node scripts/run-oxlint.mjs src/tui/tui-stream-assembler.ts src/tui/tui-stream-assembler.test.ts
$ pnpm tsgo:core
$ pnpm tsgo:core:test
$ oxfmt --check src/tui/tui-stream-assembler.ts src/tui/tui-stream-assembler.test.ts
All matched files use the correct format.
$ git diff --check upstream/main..HEAD
```

A live Gateway disconnect was not forced; the direct production-component run exercises the exact state-retention boundary before transport-specific handling. Full repository build and test suites were not run locally and are left to CI.
