### PR TITLE
fix(gateway): worker workspaces recover after stalled process probes

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -592,7 +592,7 @@ struct PortGuardianRecordStoreTests {
         try store.upsert(existing)
         try JSONEncoder().encode([existing]).write(to: fixture.legacyURL, options: [.atomic])
 
-        try Self.execute(fixture.databaseURL, "PRAGMA user_version = 7")
+        try Self.execute(fixture.databaseURL, "PRAGMA user_version = 9")
 
         #expect(throws: PortGuardianStoreError.self) {
             try store.upsert(Self.record(pid: 4243, port: 18790, timestamp: 43))

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7458,6 +7458,7 @@ public struct FailedSessionPlacement: Codable, Sendable {
     public let terminalreason: String?
     public let terminalatms: Int?
     public let recoveryerror: String
+    public let terminalrecovery: [String: AnyCodable]?
 
     public init(
         state: String,
@@ -7475,7 +7476,8 @@ public struct FailedSessionPlacement: Codable, Sendable {
         workspaceresultconflict: [String: AnyCodable]? = nil,
         terminalreason: String? = nil,
         terminalatms: Int? = nil,
-        recoveryerror: String)
+        recoveryerror: String,
+        terminalrecovery: [String: AnyCodable]? = nil)
     {
         self.state = state
         self.generation = generation
@@ -7493,6 +7495,7 @@ public struct FailedSessionPlacement: Codable, Sendable {
         self.terminalreason = terminalreason
         self.terminalatms = terminalatms
         self.recoveryerror = recoveryerror
+        self.terminalrecovery = terminalrecovery
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -7512,6 +7515,7 @@ public struct FailedSessionPlacement: Codable, Sendable {
         case terminalreason = "terminalReason"
         case terminalatms = "terminalAtMs"
         case recoveryerror = "recoveryError"
+        case terminalrecovery = "terminalRecovery"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/session-placement.test.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.test.ts
@@ -314,6 +314,34 @@ describe("session dispatch protocol schemas", () => {
         ...basePlacement,
       }),
     ).toBe(false);
+    expect(
+      Value.Check(SessionPlacementSchema, {
+        ...failed,
+        terminalRecovery: {
+          action: "force-destroy-environment",
+          dataLoss: "unreconciled-workspace-result",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(SessionPlacementSchema, {
+        ...failed,
+        terminalRecovery: {
+          action: "retry",
+          dataLoss: "unreconciled-workspace-result",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      Value.Check(SessionPlacementSchema, {
+        state: "reclaimed",
+        ...basePlacement,
+        terminalRecovery: {
+          action: "force-destroy-environment",
+          dataLoss: "unreconciled-workspace-result",
+        },
+      }),
+    ).toBe(false);
   });
 
   it("rejects unknown placement fields", () => {

--- a/packages/gateway-protocol/src/schema/session-placement.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.ts
@@ -82,6 +82,11 @@ const WorkspaceResultConflictSchema = closedObject({
   totalCount: Type.Optional(Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER })),
 });
 
+const TerminalRecoverySchema = closedObject({
+  action: Type.Literal("force-destroy-environment"),
+  dataLoss: Type.Literal("unreconciled-workspace-result"),
+});
+
 const SessionPlacementConflictProperties = {
   workspaceResultConflict: Type.Optional(WorkspaceResultConflictSchema),
 };
@@ -159,6 +164,7 @@ const FailedSessionPlacementSchema = closedObject({
   ...SessionPlacementTimingProperties,
   ...TerminalSessionPlacementProperties,
   recoveryError: NonEmptyString,
+  terminalRecovery: Type.Optional(TerminalRecoverySchema),
 });
 
 /** Gateway-visible placement projection; `state` remains the closed discriminator. */

--- a/src/gateway/server-methods/environments.test.ts
+++ b/src/gateway/server-methods/environments.test.ts
@@ -76,6 +76,7 @@ function mockContext(
       connectedAtMs: 123,
     },
   ],
+  teardownFenced = false,
 ) {
   return {
     logGateway: {
@@ -85,6 +86,10 @@ function mockContext(
       listConnectedForPairingStates: () => connectedNodes,
     },
     workerEnvironmentService,
+    workerSessionPlacementService: {
+      getMany: () => new Map(),
+      isEnvironmentTeardownFenced: vi.fn(() => teardownFenced),
+    },
     getRuntimeConfig: () => ({
       cloudWorkers: {
         profiles: {
@@ -171,6 +176,7 @@ async function callEnvironmentMethod(
       onCleanupError?: (error: unknown) => void,
     ) => Promise<TestWorkerRecord>;
     connectedNodes?: unknown[];
+    teardownFenced?: boolean;
   } = {},
 ) {
   const respond = vi.fn();
@@ -182,6 +188,7 @@ async function callEnvironmentMethod(
       options.reconcileActive,
       options.forceDestroyEnvironment,
       options.connectedNodes,
+      options.teardownFenced,
     ),
   } as never);
   const call = respond.mock.calls.at(0);
@@ -850,6 +857,24 @@ describe("environment gateway methods", () => {
       code: ErrorCodes.INVALID_REQUEST,
       message: "Attached cloud workers must be stopped through sessions.reclaim",
     });
+  });
+
+  it("names forced abandonment and data loss for a retained workspace result", async () => {
+    const service = workerService();
+
+    const [ok, , error] = await callEnvironmentMethod(
+      "environments.destroy",
+      { environmentId: "worker-1" },
+      { service, teardownFenced: true },
+    );
+
+    expect(ok).toBe(false);
+    expect(error).toEqual({
+      code: ErrorCodes.INVALID_REQUEST,
+      message:
+        "This cloud worker retains an unreconciled workspace result. Retry environments.destroy with force=true only to abandon that result and permanently lose its remote workspace changes.",
+    });
+    expect(service.destroyUnattached).not.toHaveBeenCalled();
   });
 
   it("durably abandons placement ownership before forced destruction", async () => {

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -492,6 +492,17 @@ export const environmentsHandlers: GatewayRequestHandlers = {
         if (params.force && !placementService?.forceDestroyEnvironment) {
           throw new Error("cloud worker placement control is unavailable");
         }
+        if (
+          !params.force &&
+          context.workerSessionPlacementService?.isEnvironmentTeardownFenced?.(params.environmentId)
+        ) {
+          throw Object.assign(
+            new Error(
+              "This cloud worker retains an unreconciled workspace result. Retry environments.destroy with force=true only to abandon that result and permanently lose its remote workspace changes.",
+            ),
+            { code: "invalid_state" },
+          );
+        }
         const destroyed = params.force
           ? await placementService!.forceDestroyEnvironment!(params.environmentId, (error) => {
               context.logGateway.warn(

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -35,6 +35,9 @@ type InternalTransitionDispatchService = {
   ): ReturnType<WorkerPlacementDispatchContract["dispatch"]>;
 };
 
+const TERMINAL_RECOVERY_INSTRUCTION =
+  "cloud worker retains unreconciled workspace changes; call environments.destroy with force=true (or use Stop cloud worker and confirm permanent abandonment) before reclaim or redispatch";
+
 function respondInvalidWorkerSession(respond: RespondFn, message: string): void {
   respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
 }
@@ -182,10 +185,7 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
     }
     const existingPlacement = placementReader.getMany([sessionId]).get(sessionId);
     if (existingPlacement?.state === "failed" && existingPlacement.terminalRecovery) {
-      respondInvalidWorkerSession(
-        respond,
-        "cloud worker retains unreconciled workspace changes; use Stop cloud worker and confirm permanent abandonment before redispatch",
-      );
+      respondInvalidWorkerSession(respond, TERMINAL_RECOVERY_INSTRUCTION);
       return;
     }
     if (
@@ -271,6 +271,10 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
     }
     const { target, entry, sessionId } = resolved;
     const existingPlacement = placementReader.getMany([sessionId]).get(sessionId);
+    if (existingPlacement?.state === "failed" && existingPlacement.terminalRecovery) {
+      respondInvalidWorkerSession(respond, TERMINAL_RECOVERY_INSTRUCTION);
+      return;
+    }
     if (existingPlacement?.state === "reclaimed") {
       respondWorkerPlacement({
         respond,

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -181,6 +181,13 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       return;
     }
     const existingPlacement = placementReader.getMany([sessionId]).get(sessionId);
+    if (existingPlacement?.state === "failed" && existingPlacement.terminalRecovery) {
+      respondInvalidWorkerSession(
+        respond,
+        "cloud worker retains unreconciled workspace changes; use Stop cloud worker and confirm permanent abandonment before redispatch",
+      );
+      return;
+    }
     if (
       existingPlacement?.state === "failed" &&
       !isFailedWorkerPlacementEnvironmentGone({

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -368,7 +368,7 @@ describe("sessions.dispatch", () => {
       expect.objectContaining({
         code: ErrorCodes.INVALID_REQUEST,
         message:
-          "cloud worker retains unreconciled workspace changes; use Stop cloud worker and confirm permanent abandonment before redispatch",
+          "cloud worker retains unreconciled workspace changes; call environments.destroy with force=true (or use Stop cloud worker and confirm permanent abandonment) before reclaim or redispatch",
       }),
     );
   });

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -343,6 +343,36 @@ describe("sessions.dispatch", () => {
     );
   });
 
+  it("requires permanent abandonment before redispatching retained workspace recovery", async () => {
+    mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
+    const dispatch = vi.fn();
+    const placement = failedPlacementRecord();
+    placement.terminalRecovery = {
+      action: "force-destroy-environment",
+      dataLoss: "unreconciled-workspace-result",
+    };
+
+    const respond = await invoke(
+      makeContext({
+        workerPlacementDispatchService: { dispatch },
+        workerSessionPlacementService: {
+          getMany: () => new Map([[sessionId, placement]]),
+        },
+      }),
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message:
+          "cloud worker retains unreconciled workspace changes; use Stop cloud worker and confirm permanent abandonment before redispatch",
+      }),
+    );
+  });
+
   it("rejects failed-placement redispatch while its environment remains live", async () => {
     mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
     const dispatch = vi.fn();

--- a/src/gateway/server-methods/sessions.reclaim.test.ts
+++ b/src/gateway/server-methods/sessions.reclaim.test.ts
@@ -129,6 +129,39 @@ describe("sessions.reclaim", () => {
     );
   });
 
+  it("requires permanent abandonment before reclaiming retained workspace recovery", async () => {
+    const reclaim = vi.fn();
+    const failed = {
+      ...makeReclaimedPlacement(),
+      state: "failed",
+      recoveryError: "workspace recovery requires operator action",
+      terminalReason: "workspace recovery requires operator action",
+      terminalRecovery: {
+        action: "force-destroy-environment",
+        dataLoss: "unreconciled-workspace-result",
+      },
+    } as WorkerSessionPlacementRecord;
+    const respond = await invokeSessionReclaim(
+      makeDispatchTestContext({
+        workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+        workerSessionPlacementService: {
+          getMany: () => new Map([[dispatchTestSessionId, failed]]),
+        },
+      }),
+    );
+
+    expect(reclaim).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message:
+          "cloud worker retains unreconciled workspace changes; call environments.destroy with force=true (or use Stop cloud worker and confirm permanent abandonment) before reclaim or redispatch",
+      }),
+    );
+  });
+
   it("rejects a missing placement", async () => {
     const reclaim = vi.fn();
     const respond = await invokeSessionReclaim(

--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -42,12 +42,18 @@ describe("gateway worker environment startup", () => {
         environmentId: "worker-retention-startup",
         ownerEpoch: 1,
       });
+      if (active.state !== "active") {
+        throw new Error("expected active placement");
+      }
       const draining = placements.startDrain({
         sessionId: active.sessionId,
         environmentId: active.environmentId,
         ownerEpoch: active.activeOwnerEpoch,
         expectedGeneration: active.generation,
       });
+      if (draining.state !== "draining") {
+        throw new Error("expected draining placement");
+      }
       const reconciling = placements.startReconcile({
         sessionId: draining.sessionId,
         environmentId: draining.environmentId,

--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { createDesktopSessionRegistry } from "./desktop/session-registry.js";
 import {
@@ -14,6 +18,11 @@ import {
   DEVICE_WORKER_PROVIDER_ID,
   reconcileDeviceWorker,
 } from "./worker-environments/device-provider.js";
+import {
+  REQUEST,
+  seedActivePlacement,
+} from "./worker-environments/placement-dispatch-test-fixtures.js";
+import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 
 const DEVICE_ID = "revoked-device";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -23,6 +32,53 @@ afterEach(() => {
 });
 
 describe("gateway worker environment startup", () => {
+  it("installs the lazy retention column before projecting failed placements", async () => {
+    const stateDir = tempDirs.make("openclaw-worker-retention-startup-");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const database = openOpenClawStateDatabase();
+      const placements = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+      const active = seedActivePlacement(placements, {
+        environmentId: "worker-retention-startup",
+        ownerEpoch: 1,
+      });
+      const draining = placements.startDrain({
+        sessionId: active.sessionId,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        expectedGeneration: active.generation,
+      });
+      const reconciling = placements.startReconcile({
+        sessionId: draining.sessionId,
+        environmentId: draining.environmentId,
+        ownerEpoch: draining.activeOwnerEpoch,
+        expectedGeneration: draining.generation,
+      });
+      placements.fail({
+        sessionId: REQUEST.sessionId,
+        expectedGeneration: reconciling.generation,
+        recoveryError: "worker recovery interrupted",
+      });
+      database.db.exec(
+        "ALTER TABLE worker_workspace_reconciliations DROP COLUMN forced_abandonment_retained;",
+      );
+      expect(database.db.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+      });
+
+      const startup = await loadGatewayWorkerEnvironmentStartupState();
+
+      expect(startup.hasNonlocalPlacementRecords).toBe(true);
+      expect(
+        database.db
+          .prepare(
+            "SELECT name FROM pragma_table_info('worker_workspace_reconciliations') WHERE name = 'forced_abandonment_retained'",
+          )
+          .get(),
+      ).toEqual({ name: "forced_abandonment_retained" });
+    });
+  });
+
   it("cleans transfer scratch before serving and removes it on shutdown", async () => {
     const stateDir = tempDirs.make("openclaw-worker-transfer-startup-");
     const transferRoot = path.join(stateDir, "tmp", "node-workspace-transfer");

--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -23,6 +23,7 @@ import {
   seedActivePlacement,
 } from "./worker-environments/placement-dispatch-test-fixtures.js";
 import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
+import { BOOTSTRAP_RECEIPT, SSH_ENDPOINT } from "./worker-environments/service.test-support.js";
 
 const DEVICE_ID = "revoked-device";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -111,6 +112,64 @@ describe("gateway worker environment startup", () => {
         await service.stop();
       }
       await expect(fs.stat(transferRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("invalidates persisted SSH host isolation before creating tunnel managers", async () => {
+    const stateDir = tempDirs.make("openclaw-worker-isolation-startup-");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const startup = await loadGatewayWorkerEnvironmentStartupState();
+      const intent = startup.store.createIntent({
+        environmentId: "worker-isolation-startup",
+        providerId: "fake",
+        profileId: "development",
+        profileSnapshot: { settings: { region: "test" } },
+        provisionOperationId: "provision:worker-isolation-startup",
+      });
+      const provisioning = startup.store.transition({
+        environmentId: intent.environmentId,
+        from: intent.state,
+        to: "provisioning",
+      });
+      const bootstrapping = startup.store.transition({
+        environmentId: intent.environmentId,
+        from: provisioning.state,
+        to: "bootstrapping",
+        patch: { leaseId: "lease-isolation", sshEndpoint: SSH_ENDPOINT, sharedHost: false },
+      });
+      startup.store.transition({
+        environmentId: intent.environmentId,
+        from: bootstrapping.state,
+        to: "ready",
+        patch: {
+          bootstrapReceipt: BOOTSTRAP_RECEIPT,
+          credential: {
+            credentialHash: hashWorkerCredential("startup-isolation-credential"),
+            sessionId: null,
+            rpcSetVersion: 1,
+            expiresAtMs: Date.now() + 60_000,
+          },
+        },
+      });
+      expect(startup.store.get(intent.environmentId)?.sharedHost).toBe(false);
+
+      const runtime = await createGatewayWorkerEnvironmentRuntime({
+        getPluginRegistry: () => ({ workerProviders: new Map() }),
+        resolveWorkerGateway: () => undefined,
+        desktopSessionRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
+        startup,
+        log: { child: () => ({ warn: () => {} }) },
+      });
+      const service = runtime.workerEnvironmentService;
+      if (!service) {
+        throw new Error("worker environment service was not created");
+      }
+      try {
+        expect(startup.store.get(intent.environmentId)?.sharedHost).toBeNull();
+      } finally {
+        await service.stop();
+      }
     });
   });
 

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -145,6 +145,18 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
   params.startup.placementStore.recoverWorkerSessionToolOperationsAfterRestart();
   // A crashed gateway can leak local turn claims; drop them before workers re-admit turns.
   params.startup.placementStore.clearLocalTurnClaimsAfterRestart();
+  // SSH isolation is a provider observation scoped to one Gateway process. Invalidate it before
+  // creating tunnel managers; provider reconciliation must publish a fresh fact for this lease.
+  for (const record of params.startup.store.listForReconcile()) {
+    if (record.sshEndpoint && record.sharedHost !== null) {
+      params.startup.store.reconcileSharedHost({
+        environmentId: record.environmentId,
+        state: record.state,
+        leaseId: record.leaseId,
+        sharedHost: null,
+      });
+    }
+  }
   const placementGate = createWorkerSessionPlacementGate(params.startup.placementStore);
   const workerEnvironmentLog = params.log.child("worker-environments");
   const listRetainedBundleHashes = () =>

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -16,11 +16,7 @@ import { createWorkerPlacementSessionEvidenceResolver } from "./server-worker-pl
 import { createNodeWorkspaceRetainCoordinator } from "./worker-environments/node-workspace-retain-coordinator.js";
 import { createWorkerPlacementDiskSpaceMonitor } from "./worker-environments/placement-disk-space.js";
 import { coordinateWorkerPlacementDispatch } from "./worker-environments/placement-dispatch-coordinator.js";
-import {
-  createWorkerPlacementDispatchService,
-  type WorkerPlacementDispatchService,
-} from "./worker-environments/placement-dispatch.js";
-import { FORCED_WORKER_ABANDONMENT_ERROR } from "./worker-environments/placement-force-abandon.js";
+import { createWorkerPlacementDispatchService } from "./worker-environments/placement-dispatch.js";
 import { createPlacementSessionRetirement } from "./worker-environments/placement-session-retirement.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import { createReclaimedPlacementRedispatch } from "./worker-environments/reclaimed-placement-redispatch.js";

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -16,7 +16,10 @@ import { createWorkerPlacementSessionEvidenceResolver } from "./server-worker-pl
 import { createNodeWorkspaceRetainCoordinator } from "./worker-environments/node-workspace-retain-coordinator.js";
 import { createWorkerPlacementDiskSpaceMonitor } from "./worker-environments/placement-disk-space.js";
 import { coordinateWorkerPlacementDispatch } from "./worker-environments/placement-dispatch-coordinator.js";
-import { createWorkerPlacementDispatchService } from "./worker-environments/placement-dispatch.js";
+import {
+  createWorkerPlacementDispatchService,
+  type WorkerPlacementDispatchService,
+} from "./worker-environments/placement-dispatch.js";
 import { FORCED_WORKER_ABANDONMENT_ERROR } from "./worker-environments/placement-force-abandon.js";
 import { createPlacementSessionRetirement } from "./worker-environments/placement-session-retirement.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
@@ -433,15 +436,16 @@ export function createGatewayWorkerPlacementRuntime(params: GatewayWorkerPlaceme
     workspaceOperations,
   });
   const recoverPendingWorkspaceReconciliations = async (): Promise<void> => {
-    const orphanedJournals = params.placements.pruneOrphanedWorkspaceReconciliations({
-      retainFailedOwner: (recoveryError) =>
-        recoveryError.startsWith(FORCED_WORKER_ABANDONMENT_ERROR),
-    });
+    const orphanedJournals = params.placements.pruneOrphanedWorkspaceReconciliations();
     for (const owner of orphanedJournals) {
       workerPlacementLog.warn(`discarded orphaned cloud workspace journal for ${owner.sessionId}`);
     }
     for (const owner of params.placements.listWorkspaceReconciliationOwners()) {
       try {
+        if (params.placements.isWorkspaceReconciliationRetainedForPendingResult(owner)) {
+          // Terminal pending results own their journal until explicit forced abandonment.
+          continue;
+        }
         const placement = params.placements.get(owner.sessionId);
         if (
           (placement?.state !== "active" && placement?.state !== "draining") ||

--- a/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
+++ b/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
@@ -312,6 +312,43 @@ test("sessions.delete rejects failed placement while its worker lease remains", 
   expect(placementService.retireSessionPlacement).not.toHaveBeenCalled();
 });
 
+test("sessions.delete directs retained failed recovery through explicit forced abandonment", async () => {
+  await createSessionStoreDir();
+  const sessionKey = "discord:group:retained-worker-session";
+  const sessionId = "sess-retained-worker-delete";
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
+  const placement = terminalPlacementRecord(sessionId, "failed");
+  if (placement.state !== "failed") {
+    throw new Error("expected failed placement fixture");
+  }
+  placement.terminalRecovery = {
+    action: "force-destroy-environment",
+    dataLoss: "unreconciled-workspace-result",
+  };
+  const placementService = sequencedPlacementService([placement]);
+
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    { key: sessionKey },
+    {
+      context: {
+        workerEnvironmentService: {
+          get: () => ({ state: "destroyed" }),
+          hasInferenceForSession: () => false,
+          resolveInferenceSessionForRunId: () => undefined,
+        } as never,
+        workerSessionPlacementService: placementService,
+      },
+    },
+  );
+
+  expect(deleted.ok).toBe(false);
+  expect(deleted.error?.message).toContain("environments.destroy with force=true");
+  expect(deleted.error?.message).toContain("permanently abandon its remote workspace changes");
+  expect(loadSessionEntry(sessionKey).entry?.sessionId).toBe(sessionId);
+  expect(placementService.retireSessionPlacement).not.toHaveBeenCalled();
+});
+
 test.each([
   { name: "local", state: "local" as const },
   { name: "reclaimed", state: "reclaimed" as const },

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -96,7 +96,7 @@ describe("worker environment service", () => {
 
     await expect(workerService.startTunnel({ environmentId, ownerEpoch: 1 })).rejects.toMatchObject(
       {
-        code: "invalid_state",
+        code: prepareError ? "invalid_state" : "worker_build_mismatch",
         message: prepareError
           ? "Current worker build identity is unavailable"
           : STALE_WORKER_BUILD_REASON,

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -105,7 +105,67 @@ describe("worker environment service", () => {
     expect(tunnelManager.start).not.toHaveBeenCalled();
   });
 
+  it("opens stale SSH bundles only through a workspace recovery handle", async () => {
+    const environmentId = "worker-stale-workspace-recovery";
+    const staleBundleHash = "c".repeat(64);
+    const bootstrapping = support.seedBootstrapping(environmentId, undefined, true);
+    support.testState.store.transition({
+      environmentId,
+      from: bootstrapping.state,
+      to: "ready",
+      patch: support.readyPatch(environmentId, {
+        ...support.BOOTSTRAP_RECEIPT,
+        bundleHash: staleBundleHash,
+      }),
+    });
+    const launchTurn = vi.fn();
+    const tunnelManager = {
+      status: () => "stopped" as const,
+      start: vi.fn(async (request) => ({
+        environmentId: request.environmentId,
+        ownerEpoch: request.ownerEpoch,
+        launchTurn,
+        runWorkspaceCommand: vi.fn(),
+        quiesceWorkspace: vi.fn(),
+        reconcileWorkspace: vi.fn(),
+        syncWorkspace: vi.fn(),
+        stop: vi.fn(async () => {}),
+      })),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const workerService = support.createService(support.createProvider(), { tunnelManager });
+    const prepareInstallation = vi.mocked(support.testState.prepareInstallation);
+    const prepareCallsBeforeRecovery = prepareInstallation.mock.calls.length;
+
+    await expect(
+      workerService.startRecoveryTunnel({
+        environmentId,
+        ownerEpoch: 1,
+        workerBuild: "current",
+      }),
+    ).rejects.toMatchObject({ code: "worker_build_mismatch" });
+    expect(tunnelManager.start).not.toHaveBeenCalled();
+
+    const recovery = await workerService.startRecoveryTunnel({
+      environmentId,
+      ownerEpoch: 1,
+      workerBuild: "installed",
+    });
+
+    expect(tunnelManager.start).toHaveBeenCalledWith(
+      expect.objectContaining({ bundleHash: staleBundleHash }),
+    );
+    expect(prepareInstallation).toHaveBeenCalledTimes(prepareCallsBeforeRecovery + 1);
+    expect(recovery).not.toHaveProperty("launchTurn");
+    expect(launchTurn).not.toHaveBeenCalled();
+  });
+
   it("starts a Gateway-bundle node tunnel without entering SSH", async () => {
+    let currentBundle = support.BUNDLE_ARTIFACT;
+    support.testState.prepareInstallation = vi.fn(async (install) =>
+      install === "bundle" ? currentBundle : support.NPM_ARTIFACT,
+    );
     const tunnelManager = {
       status: () => "stopped" as const,
       start: vi.fn(),
@@ -175,6 +235,16 @@ describe("worker environment service", () => {
         expectedBuild: expect.objectContaining({ bundleHash: support.BUNDLE_HASH }),
       }),
     );
+
+    currentBundle = { ...support.BUNDLE_ARTIFACT, bundleHash: "c".repeat(64) };
+    await expect(
+      workerService.startRecoveryTunnel({
+        environmentId: environment.environmentId,
+        ownerEpoch: credential.ownerEpoch,
+        workerBuild: "installed",
+      }),
+    ).rejects.toMatchObject({ code: "worker_build_mismatch" });
+    expect(nodeTunnelManager.start).toHaveBeenCalledTimes(1);
   });
 
   it("stops the node transport that owns a timed-out start", async () => {

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -45,7 +45,7 @@ describe("worker environment service", () => {
 
     await expect(
       workerService.startTunnel({ environmentId: "worker-tunnel", ownerEpoch: 0 }),
-    ).rejects.toThrow("owner credential is not current");
+    ).rejects.toThrow("environment owner is not current");
     expect(tunnelManager.start).not.toHaveBeenCalled();
 
     await workerService.startTunnel({

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -6,7 +6,7 @@ import {
 import { STALE_WORKER_BUILD_REASON } from "./admission.js";
 import * as support from "./service.test-support.js";
 import { createWorkerEnvironmentStore } from "./store.js";
-import type { WorkerTunnelManager } from "./tunnel.js";
+import type { WorkerTunnelHandle, WorkerTunnelManager } from "./tunnel.js";
 
 type WorkerEnvironmentServiceError = support.WorkerEnvironmentServiceError;
 
@@ -147,10 +147,30 @@ describe("worker environment service", () => {
     ).rejects.toMatchObject({ code: "worker_build_mismatch" });
     expect(tunnelManager.start).not.toHaveBeenCalled();
 
+    const authorizePendingResult = vi.fn(() => false);
+    support.testState.nowMs += 10_001;
+    await expect(
+      workerService.startRecoveryTunnel({
+        environmentId,
+        ownerEpoch: 1,
+        workerBuild: "installed",
+        authorizePendingResult,
+      }),
+    ).rejects.toThrow("workspace recovery authority is not current");
+    expect(tunnelManager.start).not.toHaveBeenCalled();
+
+    authorizePendingResult.mockReturnValue(true);
+    support.testState.store.requestDestroy({
+      environmentId,
+      state: "ready",
+      terminalState: "failed",
+      lastError: "stale worker build",
+    });
     const recovery = await workerService.startRecoveryTunnel({
       environmentId,
       ownerEpoch: 1,
       workerBuild: "installed",
+      authorizePendingResult,
     });
 
     expect(tunnelManager.start).toHaveBeenCalledWith(
@@ -159,6 +179,64 @@ describe("worker environment service", () => {
     expect(prepareInstallation).toHaveBeenCalledTimes(prepareCallsBeforeRecovery + 1);
     expect(recovery).not.toHaveProperty("launchTurn");
     expect(launchTurn).not.toHaveBeenCalled();
+    expect(support.testState.store.get(environmentId)?.destroyRequestedAtMs).toBe(
+      support.testState.nowMs,
+    );
+  });
+
+  it("revalidates installed workspace recovery authority across SSH startup", async () => {
+    const environmentId = "worker-workspace-recovery-authority";
+    support.seedReady(environmentId, undefined, true);
+    let resolveStart!: (handle: WorkerTunnelHandle) => void;
+    const startPending = new Promise<WorkerTunnelHandle>((resolve) => {
+      resolveStart = resolve;
+    });
+    const stop = vi.fn(async () => {});
+    const tunnelManager = {
+      status: () => "connecting" as const,
+      start: vi.fn(() => startPending),
+      stop,
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const workerService = support.createService(support.createProvider(), { tunnelManager });
+    let authorized = true;
+    const authorizePendingResult = vi.fn(() => authorized);
+
+    await expect(
+      workerService.startRecoveryTunnel({
+        environmentId,
+        ownerEpoch: 0,
+        workerBuild: "installed",
+        authorizePendingResult,
+      }),
+    ).rejects.toThrow("environment owner is not current");
+    expect(tunnelManager.start).not.toHaveBeenCalled();
+
+    const recovery = workerService.startRecoveryTunnel({
+      environmentId,
+      ownerEpoch: 1,
+      workerBuild: "installed",
+      authorizePendingResult,
+    });
+    const rejected = expect(recovery).rejects.toThrow(
+      "workspace recovery authority is not current",
+    );
+    await support.waitForFast(() => expect(tunnelManager.start).toHaveBeenCalledOnce());
+    authorized = false;
+    resolveStart({
+      environmentId,
+      ownerEpoch: 1,
+      launchTurn: vi.fn(),
+      quiesceWorkspace: vi.fn(),
+      reconcileWorkspace: vi.fn(),
+      runWorkspaceCommand: vi.fn(),
+      stop: vi.fn(async () => {}),
+      syncWorkspace: vi.fn(),
+    });
+
+    await rejected;
+    expect(stop).toHaveBeenCalledWith(environmentId, 1);
+    expect(authorizePendingResult).toHaveBeenCalledTimes(2);
   });
 
   it("starts a Gateway-bundle node tunnel without entering SSH", async () => {
@@ -242,6 +320,7 @@ describe("worker environment service", () => {
         environmentId: environment.environmentId,
         ownerEpoch: credential.ownerEpoch,
         workerBuild: "installed",
+        authorizePendingResult: () => true,
       }),
     ).rejects.toMatchObject({ code: "worker_build_mismatch" });
     expect(nodeTunnelManager.start).toHaveBeenCalledTimes(1);

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -8,7 +8,11 @@ import type { NodeWorkerTunnelManager } from "./node-worker-tunnel.js";
 import type { WorkerDesktopLaunchResult, WorkerDesktopObserveResult } from "./service-contract.js";
 import type { WorkerEnvironmentState } from "./state.js";
 import type { WorkerEnvironmentRecord, WorkerEnvironmentStore } from "./store.js";
-import type { WorkerTunnelRequest } from "./tunnel-contract.js";
+import type {
+  WorkerRecoveryTunnelRequest,
+  WorkerTunnelRequest,
+  WorkerWorkspaceRecoveryTunnelHandle,
+} from "./tunnel-contract.js";
 import type { WorkerTunnelHandle, WorkerTunnelManager } from "./tunnel.js";
 import { boundedWorkerError as boundedError } from "./worker-error.js";
 
@@ -75,7 +79,10 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     };
   };
 
-  const startTunnel = async (request: WorkerTunnelRequest): Promise<WorkerTunnelHandle> => {
+  const startTunnelAccess = async (
+    request: WorkerTunnelRequest,
+    access: "current-worker" | "workspace-recovery",
+  ): Promise<WorkerTunnelHandle> => {
     let stopping = options.isStopping();
     if (stopping) {
       throw serviceError("invalid_state", "Worker environment service is stopping");
@@ -121,23 +128,31 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       ) {
         throw serviceError("invalid_state", "Worker tunnel owner credential is not current");
       }
-      let currentBundle: ExpectedWorkerBuild;
-      try {
-        currentBundle = await options.prepareCurrentBundle();
-      } catch {
-        throw serviceError("invalid_state", "Current worker build identity is unavailable");
-      }
-      if (!verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle)) {
-        throw serviceError(
-          "worker_build_mismatch",
-          "Worker must bootstrap the current build before continuing",
-        );
+      let tunnelBundleHash = record.bootstrapReceipt.bundleHash;
+      let currentBundle: ExpectedWorkerBuild | undefined;
+      const usesInstalledSshBundle = access === "workspace-recovery" && record.sshEndpoint !== null;
+      if (!usesInstalledSshBundle) {
+        try {
+          currentBundle = await options.prepareCurrentBundle();
+        } catch {
+          throw serviceError("invalid_state", "Current worker build identity is unavailable");
+        }
+        if (!verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle)) {
+          throw serviceError(
+            "worker_build_mismatch",
+            "Worker must bootstrap the current build before continuing",
+          );
+        }
+        tunnelBundleHash = currentBundle.bundleHash;
       }
       const nodeBundle =
         record.providerId === DEVICE_WORKER_PROVIDER_ID &&
         !record.sshEndpoint &&
         record.bootstrapReceipt.installKind === "bundle";
       if (nodeBundle) {
+        if (!currentBundle) {
+          throw serviceError("invalid_state", "Current worker build identity is unavailable");
+        }
         const profileSettings = record.profileSnapshot.settings;
         const deviceId = isRecord(profileSettings) ? profileSettings.device : undefined;
         const sessionId = record.attachedSessionIds[0];
@@ -173,7 +188,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       // lock while SSH connects so drain/destroy can fence an indefinitely reconnecting start.
       startup = tunnels.start({
         ...request,
-        bundleHash: currentBundle.bundleHash,
+        bundleHash: tunnelBundleHash,
         gateway,
         ssh: record.sshEndpoint,
         sharedHost: record.sharedHost,
@@ -202,6 +217,28 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       void stopStartup?.().catch(() => undefined);
       throw timeoutError;
     }
+  };
+
+  const startTunnel = async (request: WorkerTunnelRequest): Promise<WorkerTunnelHandle> =>
+    await startTunnelAccess(request, "current-worker");
+
+  const startRecoveryTunnel = async (
+    request: WorkerRecoveryTunnelRequest,
+  ): Promise<WorkerWorkspaceRecoveryTunnelHandle> => {
+    const { workerBuild, ...tunnelRequest } = request;
+    const tunnel = await startTunnelAccess(
+      tunnelRequest,
+      workerBuild === "current" ? "current-worker" : "workspace-recovery",
+    );
+    return {
+      environmentId: tunnel.environmentId,
+      ownerEpoch: tunnel.ownerEpoch,
+      quiesceWorkspace: tunnel.quiesceWorkspace,
+      reconcileWorkspace: tunnel.reconcileWorkspace,
+      runWorkspaceCommand: tunnel.runWorkspaceCommand,
+      stop: tunnel.stop,
+      syncWorkspace: tunnel.syncWorkspace,
+    };
   };
 
   const observeDesktop = async (request: {
@@ -401,6 +438,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     list: () => store.list().map(project),
     observeDesktop,
     project,
+    startRecoveryTunnel,
     startTunnel,
     stopAllTunnels: async () => {
       await Promise.all([tunnels?.stopAll(), nodeTunnels?.stopAll()]);

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -272,11 +272,11 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     return {
       environmentId: tunnel.environmentId,
       ownerEpoch: tunnel.ownerEpoch,
-      quiesceWorkspace: tunnel.quiesceWorkspace,
-      reconcileWorkspace: tunnel.reconcileWorkspace,
-      runWorkspaceCommand: tunnel.runWorkspaceCommand,
-      stop: tunnel.stop,
-      syncWorkspace: tunnel.syncWorkspace,
+      quiesceWorkspace: (remoteWorkspaceDir) => tunnel.quiesceWorkspace(remoteWorkspaceDir),
+      reconcileWorkspace: (reconcileRequest) => tunnel.reconcileWorkspace(reconcileRequest),
+      runWorkspaceCommand: (command) => tunnel.runWorkspaceCommand(command),
+      stop: () => tunnel.stop(),
+      syncWorkspace: (syncRequest) => tunnel.syncWorkspace(syncRequest),
     };
   };
 

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -18,6 +18,10 @@ import { boundedWorkerError as boundedError } from "./worker-error.js";
 
 const TUNNEL_START_TIMEOUT_MS = 3 * 60_000;
 
+type WorkerTunnelAccess =
+  | { kind: "current-worker" }
+  | { kind: "workspace-recovery"; authorizePendingResult: () => boolean };
+
 type WorkerEnvironmentAccessOptions = {
   store: WorkerEnvironmentStore;
   getConfig: () => OpenClawConfig;
@@ -81,7 +85,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
 
   const startTunnelAccess = async (
     request: WorkerTunnelRequest,
-    access: "current-worker" | "workspace-recovery",
+    access: WorkerTunnelAccess,
   ): Promise<WorkerTunnelHandle> => {
     let stopping = options.isStopping();
     if (stopping) {
@@ -92,6 +96,15 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     }
     let startup: Promise<WorkerTunnelHandle> | undefined;
     let stopStartup: (() => Promise<void>) | undefined;
+    const hasWorkspaceRecoveryAuthority = (record: WorkerEnvironmentRecord | undefined): boolean =>
+      access.kind === "workspace-recovery" &&
+      Boolean(
+        record &&
+        inState(record, "ready", "idle", "attached") &&
+        record.leaseId &&
+        record.ownerEpoch === request.ownerEpoch &&
+        access.authorizePendingResult(),
+      );
     await withLock(request.environmentId, async () => {
       stopping = options.isStopping();
       if (stopping) {
@@ -104,9 +117,10 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
           `Unknown worker environment: ${request.environmentId}`,
         );
       }
+      const workspaceRecoveryAuthorized = hasWorkspaceRecoveryAuthority(record);
       if (
         !inState(record, "ready", "idle", "attached") ||
-        record.destroyRequestedAtMs !== null ||
+        (record.destroyRequestedAtMs !== null && !workspaceRecoveryAuthorized) ||
         !record.leaseId
       ) {
         throw serviceError("invalid_state", `Cannot start tunnel in state: ${record.state}`);
@@ -114,23 +128,31 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       if (!record.bootstrapReceipt) {
         throw serviceError("invalid_state", `Cannot start tunnel in state: ${record.state}`);
       }
+      if (record.ownerEpoch !== request.ownerEpoch) {
+        throw serviceError("invalid_state", "Worker tunnel environment owner is not current");
+      }
       if (record.sharedHost === null) {
         throw serviceError(
           "provider_failure",
           "Worker lease isolation is not reconciled; retry after provider inspection",
         );
       }
-      const credential = store.getCredential(request.environmentId);
-      if (
-        !credential ||
-        credential.ownerEpoch !== request.ownerEpoch ||
-        credential.expiresAtMs <= now()
-      ) {
-        throw serviceError("invalid_state", "Worker tunnel owner credential is not current");
+      if (access.kind === "current-worker") {
+        const credential = store.getCredential(request.environmentId);
+        if (
+          !credential ||
+          credential.ownerEpoch !== request.ownerEpoch ||
+          credential.expiresAtMs <= now()
+        ) {
+          throw serviceError("invalid_state", "Worker tunnel owner credential is not current");
+        }
+      } else if (!workspaceRecoveryAuthorized) {
+        throw serviceError("invalid_state", "Worker workspace recovery authority is not current");
       }
       let tunnelBundleHash = record.bootstrapReceipt.bundleHash;
       let currentBundle: ExpectedWorkerBuild | undefined;
-      const usesInstalledSshBundle = access === "workspace-recovery" && record.sshEndpoint !== null;
+      const usesInstalledSshBundle =
+        access.kind === "workspace-recovery" && record.sshEndpoint !== null;
       if (!usesInstalledSshBundle) {
         try {
           currentBundle = await options.prepareCurrentBundle();
@@ -204,9 +226,19 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       "Worker tunnel did not connect within 3 minutes; check worker SSH reachability and retry",
     );
     try {
-      return await withTimeout(startup, TUNNEL_START_TIMEOUT_MS, {
+      const tunnel = await withTimeout(startup, TUNNEL_START_TIMEOUT_MS, {
         createError: () => timeoutError,
       });
+      if (access.kind === "workspace-recovery") {
+        const recoveryAuthorized = await withLock(request.environmentId, async () =>
+          hasWorkspaceRecoveryAuthority(store.get(request.environmentId)),
+        );
+        if (!recoveryAuthorized) {
+          await stopStartup?.().catch(() => undefined);
+          throw serviceError("invalid_state", "Worker workspace recovery authority is not current");
+        }
+      }
+      return tunnel;
     } catch (error) {
       if (error !== timeoutError) {
         throw error;
@@ -220,16 +252,23 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
   };
 
   const startTunnel = async (request: WorkerTunnelRequest): Promise<WorkerTunnelHandle> =>
-    await startTunnelAccess(request, "current-worker");
+    await startTunnelAccess(request, { kind: "current-worker" });
 
   const startRecoveryTunnel = async (
     request: WorkerRecoveryTunnelRequest,
   ): Promise<WorkerWorkspaceRecoveryTunnelHandle> => {
-    const { workerBuild, ...tunnelRequest } = request;
-    const tunnel = await startTunnelAccess(
-      tunnelRequest,
-      workerBuild === "current" ? "current-worker" : "workspace-recovery",
-    );
+    const tunnelRequest = {
+      environmentId: request.environmentId,
+      ownerEpoch: request.ownerEpoch,
+    };
+    const access: WorkerTunnelAccess =
+      request.workerBuild === "current"
+        ? { kind: "current-worker" }
+        : {
+            kind: "workspace-recovery",
+            authorizePendingResult: request.authorizePendingResult,
+          };
+    const tunnel = await startTunnelAccess(tunnelRequest, access);
     return {
       environmentId: tunnel.environmentId,
       ownerEpoch: tunnel.ownerEpoch,

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -2,11 +2,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../../config/types.js";
 import { withTimeout } from "../../infra/fs-safe.js";
 import type { WorkerProvider } from "../../plugins/types.js";
-import {
-  StaleWorkerBuildError,
-  verifyWorkerAdmissionHandshake,
-  type ExpectedWorkerBuild,
-} from "./admission.js";
+import { verifyWorkerAdmissionHandshake, type ExpectedWorkerBuild } from "./admission.js";
 import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider.js";
 import type { NodeWorkerTunnelManager } from "./node-worker-tunnel.js";
 import type { WorkerDesktopLaunchResult, WorkerDesktopObserveResult } from "./service-contract.js";
@@ -41,6 +37,7 @@ type WorkerEnvironmentAccessOptions = {
       | "invalid_state"
       | "launcher_failure"
       | "provider_failure"
+      | "worker_build_mismatch"
       | "unsupported_platform",
     message: string,
   ) => Error;
@@ -131,7 +128,10 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
         throw serviceError("invalid_state", "Current worker build identity is unavailable");
       }
       if (!verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle)) {
-        throw new StaleWorkerBuildError();
+        throw serviceError(
+          "worker_build_mismatch",
+          "Worker must bootstrap the current build before continuing",
+        );
       }
       const nodeBundle =
         record.providerId === DEVICE_WORKER_PROVIDER_ID &&

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -109,9 +109,9 @@ export function coordinateWorkerPlacementDispatch(
         }
       }
     },
-    forceDestroyEnvironment: (environmentId, onCleanupError) =>
+    forceDestroyEnvironment: (environmentId, onCleanupError, authorizeAbandonment) =>
       runExclusivePlacementOperation(() =>
-        service.forceDestroyEnvironment(environmentId, onCleanupError),
+        service.forceDestroyEnvironment(environmentId, onCleanupError, authorizeAbandonment),
       ),
     reclaim: async (request) => await runPlacementOperation(() => service.reclaim(request)),
     reconcile: () => runReconciliation(service.reconcile),

--- a/src/gateway/worker-environments/placement-dispatch-device.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-device.test.ts
@@ -131,7 +131,7 @@ describe("device worker placement dispatch", () => {
 
     await harness.service.reconcile();
 
-    expect(harness.log).toEqual(["workspace", "environment:reconcile", "placement:adopted"]);
+    expect(harness.log).toEqual(["environment:reconcile", "workspace", "placement:adopted"]);
     expect(harness.placements.current()).toMatchObject({ state: "active" });
     expect(harness.environments.startTunnel).not.toHaveBeenCalled();
     expect(harness.environments.destroy).not.toHaveBeenCalled();

--- a/src/gateway/worker-environments/placement-dispatch-device.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-device.test.ts
@@ -131,7 +131,7 @@ describe("device worker placement dispatch", () => {
 
     await harness.service.reconcile();
 
-    expect(harness.log).toEqual(["environment:reconcile", "workspace", "placement:adopted"]);
+    expect(harness.log).toEqual(["workspace", "environment:reconcile", "placement:adopted"]);
     expect(harness.placements.current()).toMatchObject({ state: "active" });
     expect(harness.environments.startTunnel).not.toHaveBeenCalled();
     expect(harness.environments.destroy).not.toHaveBeenCalled();

--- a/src/gateway/worker-environments/placement-dispatch-device.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-device.test.ts
@@ -119,7 +119,7 @@ describe("device worker placement dispatch", () => {
   });
 
   it("adopts an offline paired-device placement without eagerly starting its tunnel", async () => {
-    const harness = createHarness(placementStore);
+    const harness = createHarness(placementStore, { providerInspection: "dormant" });
     await harness.environments.attachSession({
       environmentId: harness.ready.environmentId,
       ownerEpoch: harness.ready.ownerEpoch,

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -55,6 +55,7 @@ export type WorkerDispatchPlacementStore = Pick<
   | "validateWorkspaceResultClaim"
   | "recordStagedWorkspaceResult"
   | "recordWorkspaceResultConflict"
+  | "retireWorkspaceResultConflict"
   | "acceptWorkspaceResult"
   | "cancelWorkspaceResultAndReleaseTurn"
   | "completeWorkspaceResultAndReleaseTurn"

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -126,6 +126,7 @@ export function createPlacementFailureActions(deps: {
   const cleanupEnvironment = async (params: {
     environmentId: string;
     ownerEpoch: number | null;
+    authorizeTeardown?: () => boolean;
   }): Promise<string[]> => {
     const teardownErrors: string[] = [];
     try {
@@ -134,7 +135,11 @@ export function createPlacementFailureActions(deps: {
       teardownErrors.push(`tunnel stop: ${boundedError(error)}`);
     }
     try {
-      await environments.destroy(params.environmentId);
+      if (params.authorizeTeardown) {
+        await environments.destroyOwned(params.environmentId, params.authorizeTeardown);
+      } else {
+        await environments.destroy(params.environmentId);
+      }
     } catch (error) {
       teardownErrors.push(`environment destroy: ${boundedError(error)}`);
     }
@@ -162,10 +167,11 @@ export function createPlacementFailureActions(deps: {
   };
 
   const retryFailedTeardown = async (placement: WorkerFailedDispatchPlacement): Promise<void> => {
-    if (!placement.environmentId) {
+    const environmentId = placement.environmentId;
+    if (!environmentId) {
       return;
     }
-    const environment = environments.get(placement.environmentId);
+    const environment = environments.get(environmentId);
     if (
       !environment ||
       environment.state === "destroyed" ||
@@ -175,8 +181,11 @@ export function createPlacementFailureActions(deps: {
       return;
     }
     const teardownErrors = await cleanupEnvironment({
-      environmentId: placement.environmentId,
+      environmentId,
       ownerEpoch: placement.activeOwnerEpoch,
+      authorizeTeardown: placements.canDestroyForceAbandonedEnvironment(environmentId)
+        ? () => placements.canDestroyForceAbandonedEnvironment(environmentId)
+        : undefined,
     });
     if (teardownErrors.length > 0) {
       const recoveryError = [placement.recoveryError, ...teardownErrors].filter(Boolean).join("; ");

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -34,11 +34,19 @@ export type WorkerDispatchPlacementStore = Pick<
   | "claimTurn"
   | "closeWorkerTurnToolState"
   | "fail"
+  | "failPendingWorkspaceResult"
+  | "forceAbandonPendingWorkspaceResult"
+  | "forceAbandonWorkerTurn"
   | "finishReclaim"
   | "get"
   | "loadWorkspaceReconciliation"
   | "beginWorkspaceReconciliation"
   | "abortWorkspaceReconciliation"
+  | "canDestroyAcceptedWorkspaceResult"
+  | "canDestroyForceAbandonedEnvironment"
+  | "isWorkspaceReconciliationRetainedForForcedAbandonment"
+  | "retainWorkspaceReconciliationForForcedAbandonment"
+  | "listEnvironmentTeardownFences"
   | "listWorkspaceReconciliationOwners"
   | "list"
   | "listPendingWorkspaceResults"
@@ -67,6 +75,7 @@ export type WorkerDispatchEnvironmentService = Pick<
   | "create"
   | "createFromProfileSnapshot"
   | "destroy"
+  | "destroyOwned"
   | "get"
   | "reconcileOnce"
   | "startTunnel"
@@ -83,6 +92,8 @@ export type WorkerActivationBarrier = (params: {
 
 const RECOVERY_ERROR_LIMIT = 1_024;
 const boundedError = boundedWorkerError;
+const RETAINED_WORKSPACE_RESULT_RECOVERY_GUIDANCE =
+  "Use Stop cloud worker and confirm abandoning the result to destroy the environment; unreconciled remote workspace changes will be permanently lost";
 
 export function isUnavailableEnvironment(
   environment: NonNullable<ReturnType<WorkerEnvironmentService["get"]>>,
@@ -175,6 +186,29 @@ export function createPlacementFailureActions(deps: {
         recoveryError: truncateUtf16Safe(recoveryError, RECOVERY_ERROR_LIMIT),
       });
     }
+  };
+
+  const recordRetainedResultFailure = async (
+    placement: WorkerActiveDispatchPlacement | WorkerDrainingDispatchPlacement,
+    error: unknown,
+  ): Promise<void> => {
+    const pending = placements
+      .listPendingWorkspaceResults()
+      .find(
+        (candidate) =>
+          candidate.sessionId === placement.sessionId &&
+          candidate.environmentId === placement.environmentId &&
+          candidate.ownerEpoch === placement.activeOwnerEpoch,
+      );
+    if (!pending) {
+      throw new Error(`Pending cloud workspace result disappeared for ${placement.sessionId}`);
+    }
+    await placements.failPendingWorkspaceResult({
+      pending,
+      recoveryError: boundedError(
+        new Error(`${boundedError(error)}. ${RETAINED_WORKSPACE_RESULT_RECOVERY_GUIDANCE}.`),
+      ),
+    });
   };
 
   const startDrain = (
@@ -301,6 +335,7 @@ export function createPlacementFailureActions(deps: {
   return {
     failActive,
     failDraining,
+    recordRetainedResultFailure,
     reclaimActive,
     retryFailedTeardown,
     teardownEnvironment,

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -77,8 +77,8 @@ export type WorkerDispatchEnvironmentService = Pick<
   | "destroy"
   | "destroyOwned"
   | "get"
-  | "isWorkerBuildMismatchError"
   | "reconcileOnce"
+  | "startRecoveryTunnel"
   | "startTunnel"
   | "stopTunnel"
 >;

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -77,6 +77,7 @@ export type WorkerDispatchEnvironmentService = Pick<
   | "destroy"
   | "destroyOwned"
   | "get"
+  | "isWorkerBuildMismatchError"
   | "reconcileOnce"
   | "startTunnel"
   | "stopTunnel"

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -7,7 +7,9 @@ import type {
   WorkerDrainingDispatchPlacement,
 } from "./placement-dispatch-failure.js";
 import { placementTurnOwner } from "./placement-record.js";
+import { isRetainedFailedWorkspaceResultOwner } from "./placement-teardown-fence.js";
 import type { WorkerEnvironmentService } from "./service.js";
+import { findWorkerWorkspaceOperatorRecoveryError } from "./tunnel-contract.js";
 import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import { verifyReconciledWorkspaceFinal } from "./workspace-finalize.js";
 import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
@@ -95,10 +97,10 @@ export async function recoverPendingWorkspaceResults(
   environmentId?: string,
 ): Promise<Set<string>> {
   const { environments, failure, placements } = deps;
-  const stagedResultOwners = new Set<string>();
+  const retainedResultOwners = new Set<string>();
   for (const pending of placements.listPendingWorkspaceResults()) {
     if (pending.stagedResultRef) {
-      stagedResultOwners.add(pending.sessionId);
+      retainedResultOwners.add(pending.sessionId);
     }
     const sameGatewayInstance =
       pending.gatewayInstanceId === placements.workspaceResultInstanceId();
@@ -107,6 +109,12 @@ export async function recoverPendingWorkspaceResults(
     }
     const placement = placements.get(pending.sessionId);
     if (environmentId !== undefined && placement?.environmentId !== environmentId) {
+      continue;
+    }
+    if (isRetainedFailedWorkspaceResultOwner(placement, pending)) {
+      // A failed placement plus its matching pending row is the durable
+      // operator-recovery owner. Only explicit forced abandonment may clear it.
+      retainedResultOwners.add(pending.sessionId);
       continue;
     }
     try {
@@ -169,7 +177,7 @@ export async function recoverPendingWorkspaceResults(
       ) {
         placements.recordStagedWorkspaceResult(turnClaim, canonicalStagedResultRef);
         stagedResultRef = canonicalStagedResultRef;
-        stagedResultOwners.add(pending.sessionId);
+        retainedResultOwners.add(pending.sessionId);
       }
       if (stagedResultRef && pending.workspaceAcceptedAtMs !== null) {
         const canonicalExists = await hasWorkerWorkspaceResultRef({
@@ -218,7 +226,9 @@ export async function recoverPendingWorkspaceResults(
           environment.state !== "destroyed" &&
           environment.ownerEpoch === active.activeOwnerEpoch
         ) {
-          await environments.destroy(active.environmentId);
+          await environments.destroyOwned(active.environmentId, () =>
+            placements.canDestroyAcceptedWorkspaceResult(turnClaim),
+          );
         }
         const reclaimed = placements.completeWorkspaceResultAndReleaseTurn(turnClaim, {
           reclaim: true,
@@ -308,7 +318,9 @@ export async function recoverPendingWorkspaceResults(
                 currentEnvironment.state !== "destroyed" &&
                 currentEnvironment.ownerEpoch === active.activeOwnerEpoch
               ) {
-                await environments.destroy(active.environmentId);
+                await environments.destroyOwned(active.environmentId, () =>
+                  placements.canDestroyAcceptedWorkspaceResult(turnClaim),
+                );
               }
             },
             validateCompleted: (completed) => {
@@ -419,7 +431,9 @@ export async function recoverPendingWorkspaceResults(
               if (sameGatewayInstance) {
                 await quiescence.resume();
               } else {
-                await environments.destroy(active.environmentId);
+                await environments.destroyOwned(active.environmentId, () =>
+                  placements.canDestroyAcceptedWorkspaceResult(turnClaim),
+                );
               }
               quiescenceHandled = true;
             },
@@ -442,7 +456,14 @@ export async function recoverPendingWorkspaceResults(
           }
         }
       });
-    } catch {
+    } catch (error) {
+      const operatorRecoveryError = findWorkerWorkspaceOperatorRecoveryError(error);
+      if (
+        operatorRecoveryError &&
+        (placement?.state === "active" || placement?.state === "draining")
+      ) {
+        await failure.recordRetainedResultFailure(placement, operatorRecoveryError);
+      }
       // Keep the result, claim, and environment fenced. The next sweep retries.
     }
   }
@@ -471,7 +492,7 @@ export async function recoverPendingWorkspaceResults(
     }
   }
   return new Set([
-    ...stagedResultOwners,
+    ...retainedResultOwners,
     ...placements.listPendingWorkspaceResults().map((pending) => pending.sessionId),
   ]);
 }

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -95,6 +95,7 @@ export async function recoverPendingWorkspaceResults(
   deps: PlacementRecoveryDeps,
   cleanupOrphans: boolean,
   environmentId?: string,
+  freshHostIsolationEnvironmentIds: ReadonlySet<string> = new Set(),
 ): Promise<Set<string>> {
   const { environments, failure, placements } = deps;
   const retainedResultOwners = new Set<string>();
@@ -163,6 +164,15 @@ export async function recoverPendingWorkspaceResults(
         }
         continue;
       }
+      const environment = environments.get(active.environmentId);
+      if (
+        sameActiveEnvironment(active, environment) &&
+        !freshHostIsolationEnvironmentIds.has(active.environmentId)
+      ) {
+        // Provider inspection owns the host-isolation fact consumed by tunnel
+        // creation. A failed inspection must not reuse a stale dedicated-host scope.
+        continue;
+      }
       const localPath = await deps.resolveWorkspacePath(active);
       const priorWorkspaceResultConflict =
         active.workspaceResultConflict ?? (await deps.resolveWorkspaceResultConflict(active));
@@ -197,7 +207,6 @@ export async function recoverPendingWorkspaceResults(
           root: localPath,
           stagedResultRef: preparedWorkerWorkspaceResultRef(canonicalStagedResultRef),
         }));
-      const environment = environments.get(active.environmentId);
       if (
         environment?.state === "attached" &&
         environment.attachedSessionIds.includes(active.sessionId) &&

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -165,14 +165,6 @@ export async function recoverPendingWorkspaceResults(
         continue;
       }
       const environment = environments.get(active.environmentId);
-      if (
-        sameActiveEnvironment(active, environment) &&
-        !freshHostIsolationEnvironmentIds.has(active.environmentId)
-      ) {
-        // Provider inspection owns the host-isolation fact consumed by tunnel
-        // creation. A failed inspection must not reuse a stale dedicated-host scope.
-        continue;
-      }
       const localPath = await deps.resolveWorkspacePath(active);
       const priorWorkspaceResultConflict =
         active.workspaceResultConflict ?? (await deps.resolveWorkspaceResultConflict(active));
@@ -361,6 +353,11 @@ export async function recoverPendingWorkspaceResults(
         if (failed.state === "failed") {
           await failure.retryFailedTeardown(failed);
         }
+        continue;
+      }
+      if (!freshHostIsolationEnvironmentIds.has(active.environmentId)) {
+        // Provider inspection owns the host-isolation fact consumed by tunnel
+        // creation. A failed inspection must not reuse a stale dedicated-host scope.
         continue;
       }
       const owner = {

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -60,6 +60,7 @@ export type PlacementRecoveryDeps = {
 
 export type WorkerWorkspaceRecoveryTunnelStarter = (
   request: WorkerTunnelRequest,
+  authorizePendingResult: () => boolean,
 ) => Promise<WorkerWorkspaceRecoveryTunnelHandle>;
 
 export type WorkerWorkspaceRecoveryTunnelResolver = (
@@ -376,10 +377,13 @@ export async function recoverPendingWorkspaceResults(
           placements.updateWorkspaceBaseManifest({ claim: turnClaim, manifestRef }),
         abort: () => placements.abortWorkspaceReconciliation(owner),
       };
-      const tunnel = await startRecoveryTunnel({
-        environmentId: active.environmentId,
-        ownerEpoch: active.activeOwnerEpoch,
-      });
+      const tunnel = await startRecoveryTunnel(
+        {
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+        },
+        () => placements.validateWorkspaceResultClaim(turnClaim),
+      );
       await deps.workspaceOperations.run(active.environmentId, async () => {
         if (!placements.validateWorkspaceResultClaim(turnClaim)) {
           throw new Error("Recovered workspace result lost its placement owner");

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -6,7 +6,7 @@ import type {
   WorkerDispatchPlacementStore,
   WorkerDrainingDispatchPlacement,
 } from "./placement-dispatch-failure.js";
-import { placementTurnOwner } from "./placement-record.js";
+import { placementWorkspaceResultClaim } from "./placement-record.js";
 import { isRetainedFailedWorkspaceResultOwner } from "./placement-teardown-fence.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import { findWorkerWorkspaceOperatorRecoveryError } from "./tunnel-contract.js";
@@ -121,18 +121,7 @@ export async function recoverPendingWorkspaceResults(
     try {
       const active =
         placement?.state === "active" || placement?.state === "draining" ? placement : undefined;
-      const turnClaim =
-        active &&
-        active.environmentId === pending.environmentId &&
-        active.activeOwnerEpoch === pending.ownerEpoch
-          ? {
-              sessionId: active.sessionId,
-              claimId: pending.claimId,
-              runId: pending.runId,
-              placementGeneration: pending.placementGeneration,
-              owner: placementTurnOwner(active),
-            }
-          : undefined;
+      const turnClaim = placementWorkspaceResultClaim(active, pending);
       if (!active || !turnClaim || !placements.validateWorkspaceResultClaim(turnClaim)) {
         if (pending.stagedResultRef && pending.workspaceAcceptedAtMs === null) {
           // A staged unaccepted result outlives stale placement ownership. Only
@@ -464,13 +453,17 @@ export async function recoverPendingWorkspaceResults(
       });
     } catch (error) {
       const operatorRecoveryError = findWorkerWorkspaceOperatorRecoveryError(error);
+      const terminalRecoveryError =
+        operatorRecoveryError ??
+        (environments.isWorkerBuildMismatchError(error) ? error : undefined);
       if (
-        operatorRecoveryError &&
+        terminalRecoveryError &&
         (placement?.state === "active" || placement?.state === "draining")
       ) {
-        await failure.recordRetainedResultFailure(placement, operatorRecoveryError);
+        await failure.recordRetainedResultFailure(placement, terminalRecoveryError);
       }
-      // Keep the result, claim, and environment fenced. The next sweep retries.
+      // Retryable failures remain fenced for the next sweep; classified terminal
+      // failures retain the result behind the explicit operator recovery action.
     }
   }
   if (cleanupOrphans) {

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -58,7 +58,7 @@ export type PlacementRecoveryDeps = {
   }) => Promise<WorkerWorkspaceResultConflict | undefined>;
 };
 
-export type WorkerWorkspaceRecoveryTunnelStarter = (
+type WorkerWorkspaceRecoveryTunnelStarter = (
   request: WorkerTunnelRequest,
   authorizePendingResult: () => boolean,
 ) => Promise<WorkerWorkspaceRecoveryTunnelHandle>;

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -9,7 +9,11 @@ import type {
 import { placementWorkspaceResultClaim } from "./placement-record.js";
 import { isRetainedFailedWorkspaceResultOwner } from "./placement-teardown-fence.js";
 import type { WorkerEnvironmentService } from "./service.js";
-import { findWorkerWorkspaceOperatorRecoveryError } from "./tunnel-contract.js";
+import {
+  findWorkerWorkspaceOperatorRecoveryError,
+  type WorkerTunnelRequest,
+  type WorkerWorkspaceRecoveryTunnelHandle,
+} from "./tunnel-contract.js";
 import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import { verifyReconciledWorkspaceFinal } from "./workspace-finalize.js";
 import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
@@ -54,6 +58,14 @@ export type PlacementRecoveryDeps = {
   }) => Promise<WorkerWorkspaceResultConflict | undefined>;
 };
 
+export type WorkerWorkspaceRecoveryTunnelStarter = (
+  request: WorkerTunnelRequest,
+) => Promise<WorkerWorkspaceRecoveryTunnelHandle>;
+
+export type WorkerWorkspaceRecoveryTunnelResolver = (
+  environmentId: string,
+) => WorkerWorkspaceRecoveryTunnelStarter | undefined;
+
 function sameActiveEnvironment(
   placement: WorkerActiveDispatchPlacement | WorkerDrainingDispatchPlacement,
   environment: ReturnType<WorkerEnvironmentService["get"]>,
@@ -95,7 +107,7 @@ export async function recoverPendingWorkspaceResults(
   deps: PlacementRecoveryDeps,
   cleanupOrphans: boolean,
   environmentId?: string,
-  freshHostIsolationEnvironmentIds: ReadonlySet<string> = new Set(),
+  recoveryTunnelFor?: WorkerWorkspaceRecoveryTunnelResolver,
 ): Promise<Set<string>> {
   const { environments, failure, placements } = deps;
   const retainedResultOwners = new Set<string>();
@@ -344,7 +356,8 @@ export async function recoverPendingWorkspaceResults(
         }
         continue;
       }
-      if (!freshHostIsolationEnvironmentIds.has(active.environmentId)) {
+      const startRecoveryTunnel = recoveryTunnelFor?.(active.environmentId);
+      if (!startRecoveryTunnel) {
         // Provider inspection owns the host-isolation fact consumed by tunnel
         // creation. A failed inspection must not reuse a stale dedicated-host scope.
         continue;
@@ -363,7 +376,7 @@ export async function recoverPendingWorkspaceResults(
           placements.updateWorkspaceBaseManifest({ claim: turnClaim, manifestRef }),
         abort: () => placements.abortWorkspaceReconciliation(owner),
       };
-      const tunnel = await environments.startTunnel({
+      const tunnel = await startRecoveryTunnel({
         environmentId: active.environmentId,
         ownerEpoch: active.activeOwnerEpoch,
       });
@@ -453,17 +466,14 @@ export async function recoverPendingWorkspaceResults(
       });
     } catch (error) {
       const operatorRecoveryError = findWorkerWorkspaceOperatorRecoveryError(error);
-      const terminalRecoveryError =
-        operatorRecoveryError ??
-        (environments.isWorkerBuildMismatchError(error) ? error : undefined);
       if (
-        terminalRecoveryError &&
+        operatorRecoveryError &&
         (placement?.state === "active" || placement?.state === "draining")
       ) {
-        await failure.recordRetainedResultFailure(placement, terminalRecoveryError);
+        await failure.recordRetainedResultFailure(placement, operatorRecoveryError);
       }
-      // Retryable failures remain fenced for the next sweep; classified terminal
-      // failures retain the result behind the explicit operator recovery action.
+      // Retryable failures remain fenced for the next sweep; operator recovery
+      // failures retain the result behind the explicit recovery action.
     }
   }
   if (cleanupOrphans) {

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -307,7 +307,7 @@ describe("worker placement dispatch reclaim", () => {
   });
 
   it.each(["pending result", "retained workspace journal"] as const)(
-    "refuses to retire a failed placement with a %s owner",
+    "refuses to retire, reclaim, or redispatch a failed placement with a %s owner",
     async (recoveryOwner) => {
       const harness = createHarness(placementStore);
       const active = harness.placements.seedActive(7);
@@ -387,6 +387,22 @@ describe("worker placement dispatch reclaim", () => {
       expect(placementStore.listWorkspaceReconciliationOwners().length).toBe(
         recoveryOwner === "retained workspace journal" ? 1 : 0,
       );
+
+      harness.markEnvironmentDestroyed();
+      await expect(
+        harness.service.reclaim({
+          sessionId: REQUEST.sessionId,
+          sessionKey: REQUEST.sessionKey,
+          agentId: REQUEST.agentId,
+        }),
+      ).rejects.toThrow("must be force-abandoned before reclaim");
+      expect(() => placementStore.startDispatch(REQUEST)).toThrow(
+        "must be force-abandoned before redispatch",
+      );
+      expect(placementStore.get(active.sessionId)).toMatchObject({
+        state: "failed",
+        terminalRecovery: { action: "force-destroy-environment" },
+      });
     },
   );
 

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -357,6 +357,9 @@ describe("worker placement dispatch reclaim", () => {
           ownerEpoch: active.activeOwnerEpoch,
           expectedGeneration: active.generation,
         });
+        if (draining.state !== "draining") {
+          throw new Error("expected draining worker placement");
+        }
         const reconciling = placementStore.startReconcile({
           sessionId: draining.sessionId,
           environmentId: draining.environmentId,

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -306,6 +306,87 @@ describe("worker placement dispatch reclaim", () => {
     expect(placementStore.get(active.sessionId)).not.toHaveProperty("workspaceResultConflict");
   });
 
+  it.each(["pending result", "retained workspace journal"] as const)(
+    "refuses to retire a failed placement with a %s owner",
+    async (recoveryOwner) => {
+      const harness = createHarness(placementStore);
+      const active = harness.placements.seedActive(7);
+      if (active.state !== "active") {
+        throw new Error("expected active worker placement");
+      }
+      const owner = {
+        sessionId: active.sessionId,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        placementGeneration: active.generation,
+      };
+      let failed;
+      if (recoveryOwner === "pending result") {
+        const claim = placementStore.claimTurn({
+          ...REQUEST,
+          owner: {
+            kind: "worker",
+            environmentId: active.environmentId,
+            ownerEpoch: active.activeOwnerEpoch,
+          },
+          claimId: "retirement-pending-claim",
+          runId: "retirement-pending-run",
+        });
+        placementStore.markWorkspaceResultPending(claim);
+        failed = await placementStore.failPendingWorkspaceResult({
+          pending: placementStore.listPendingWorkspaceResults()[0]!,
+          recoveryError: "workspace recovery requires operator action",
+        });
+      } else {
+        const basePack = Buffer.from("retained retirement base pack");
+        placementStore.beginWorkspaceReconciliation(owner, {
+          version: 1,
+          temporaryNonce: "c".repeat(32),
+          baseManifestRef: active.workspaceBaseManifestRef,
+          currentManifestRef: `sha256:${"d".repeat(64)}`,
+          baseEntries: [],
+          appliedEntries: [],
+          baseTree: "e".repeat(40),
+          basePackSha256: createHash("sha256").update(basePack).digest("hex"),
+          basePack,
+        });
+        placementStore.retainWorkspaceReconciliationForForcedAbandonment(owner);
+        const draining = placementStore.startDrain({
+          sessionId: active.sessionId,
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+          expectedGeneration: active.generation,
+        });
+        const reconciling = placementStore.startReconcile({
+          sessionId: draining.sessionId,
+          environmentId: draining.environmentId,
+          ownerEpoch: draining.activeOwnerEpoch,
+          expectedGeneration: draining.generation,
+        });
+        failed = placementStore.fail({
+          sessionId: reconciling.sessionId,
+          expectedGeneration: reconciling.generation,
+          recoveryError: "workspace recovery requires operator action",
+        });
+      }
+
+      expect(() =>
+        placementStore.retireSessionPlacement({
+          sessionId: failed.sessionId,
+          expectedState: "failed",
+          expectedGeneration: failed.generation,
+        }),
+      ).toThrow("must be force-abandoned before retirement");
+      expect(placementStore.get(active.sessionId)).toMatchObject({ state: "failed" });
+      expect(placementStore.listPendingWorkspaceResults().length).toBe(
+        recoveryOwner === "pending result" ? 1 : 0,
+      );
+      expect(placementStore.listWorkspaceReconciliationOwners().length).toBe(
+        recoveryOwner === "retained workspace journal" ? 1 : 0,
+      );
+    },
+  );
+
   it("applies a prepared staged result before requiring its manifest commit", async () => {
     const harness = createHarness(placementStore, {
       reconcileCommitsManifest: false,

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -104,6 +104,25 @@ describe("worker placement dispatch reclaim", () => {
     ]);
   });
 
+  it("reclaims an accepted remote-exec workspace result with its local claim", async () => {
+    const harness = createHarness(placementStore);
+    await harness.service.dispatch({ ...REQUEST, executionMode: "remote-exec" });
+
+    const reclaimed = await harness.service.reclaim({
+      sessionId: REQUEST.sessionId,
+      sessionKey: REQUEST.sessionKey,
+      agentId: REQUEST.agentId,
+    });
+
+    expect(reclaimed).toMatchObject({
+      state: "reclaimed",
+      executionMode: "remote-exec",
+      turnClaim: null,
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+  });
+
   it("reclaims an environment-free failed placement back to clean local state", async () => {
     const harness = createHarness(placementStore);
     const requested = placementStore.startDispatch(REQUEST);

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { WorkerInstallationArtifact } from "./bundle.js";
-import { seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { seedActivePlacement, seedStartingPlacement } from "./placement-dispatch-test-fixtures.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
@@ -11,16 +11,20 @@ import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation
 describe("worker placement restart recovery", () => {
   support.setupWorkerEnvironmentServiceSuite();
 
-  it.each(["bundle", "provider"] as const)(
-    "keeps stale pending recovery fenced when %s recovery is unavailable",
-    async (failure) => {
-      let currentBundle: WorkerInstallationArtifact = support.BUNDLE_ARTIFACT;
-      const recoveryState = { started: false };
-      support.testState.prepareInstallation = vi.fn(async (install) => {
-        if (install === "bundle" && recoveryState.started && failure === "bundle") {
-          throw new Error("bundle unavailable");
-        }
-        return install === "bundle" ? currentBundle : support.NPM_ARTIFACT;
+  it.each(["active", "starting"] as const)(
+    "keeps a restarted %s placement fenced when host isolation inspection is unavailable",
+    async (state) => {
+      let providerSharedHost = false;
+      let recoveryStarted = false;
+      const destroy = vi.fn(async () => {});
+      const provider = support.createProvider({
+        destroy,
+        inspect: async () => {
+          if (recoveryStarted) {
+            throw new Error("provider unavailable");
+          }
+          return { status: "active", sharedHost: providerSharedHost };
+        },
       });
       const tunnelManager = {
         status: () => "stopped" as const,
@@ -28,14 +32,6 @@ describe("worker placement restart recovery", () => {
         stop: vi.fn(async () => {}),
         stopAll: vi.fn(async () => {}),
       } as unknown as WorkerTunnelManager;
-      const provider = support.createProvider({
-        inspect: async () => {
-          if (recoveryState.started && failure === "provider") {
-            throw new Error("provider unavailable");
-          }
-          return { status: "active" };
-        },
-      });
       const workerService = support.createService(provider, { tunnelManager });
       const placements = createWorkerSessionPlacementStore({
         database: support.testState.stateDb,
@@ -52,62 +48,119 @@ describe("worker placement restart recovery", () => {
         reportWorkspaceResultConflict: async () => {},
         resolveWorkspaceResultConflict: async () => undefined,
       });
-      const environmentId = "worker-stale-recovery";
-      support.seedReady(environmentId);
-      const attached = await workerService.attachSession({
-        environmentId,
-        ownerEpoch: 1,
-        sessionId: "session-1",
-      });
-      const active = seedActivePlacement(placements, {
-        environmentId,
-        ownerEpoch: attached.ownerEpoch,
-      });
-      if (active.state !== "active") {
-        throw new Error("active placement fixture was not active");
+      const environmentId = `worker-stale-isolation-${state}`;
+      support.seedReady(environmentId, undefined, false);
+      if (state === "active") {
+        const attached = await workerService.attachSession({
+          environmentId,
+          ownerEpoch: 1,
+          sessionId: "session-1",
+        });
+        seedActivePlacement(placements, { environmentId, ownerEpoch: attached.ownerEpoch });
+      } else {
+        seedStartingPlacement(placements, environmentId);
       }
-      const claim = placements.claimTurn({
-        sessionId: active.sessionId,
-        sessionKey: active.sessionKey,
-        agentId: active.agentId,
-        claimId: "claim-stale-recovery",
-        runId: "run-stale-recovery",
-        owner: {
-          kind: "worker",
-          environmentId: active.environmentId,
-          ownerEpoch: active.activeOwnerEpoch,
-        },
-      });
-      placements.markWorkspaceResultPending(claim);
-      placements.handoffWorkspaceResultRecovery(claim);
-      if (failure === "bundle") {
-        currentBundle = { ...support.BUNDLE_ARTIFACT, bundleHash: "c".repeat(64) };
-      }
-      recoveryState.started = true;
+      expect(workerService.get(environmentId)?.sharedHost).toBe(false);
+      providerSharedHost = true;
+      recoveryStarted = true;
 
       await recovery.reconcile();
 
-      expect(placements.get(active.sessionId)).toMatchObject({
-        state: "active",
-        turnClaim: { claimId: claim.claimId, runId: claim.runId },
-      });
-      expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
-      expect(workerService.get(active.environmentId)).toMatchObject({
-        state: "attached",
-        destroyRequestedAtMs: null,
+      expect(placements.get("session-1")).toMatchObject({
+        state: "failed",
+        recoveryError: "Worker host isolation could not be verified after gateway restart",
       });
       expect(tunnelManager.start).not.toHaveBeenCalled();
+      expect(destroy).toHaveBeenCalledOnce();
     },
   );
 
-  it("projects a stale worker bundle as terminal retained-result recovery", async () => {
+  it("keeps stale pending recovery fenced when provider recovery is unavailable", async () => {
+    const recoveryState = { started: false };
+    const tunnelManager = {
+      status: () => "stopped" as const,
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const provider = support.createProvider({
+      inspect: async () => {
+        if (recoveryState.started) {
+          throw new Error("provider unavailable");
+        }
+        return { status: "active" };
+      },
+    });
+    const workerService = support.createService(provider, { tunnelManager });
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const recovery = createWorkerPlacementDispatchService({
+      placements,
+      environments: workerService,
+      workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+      runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+      runActivationBarrier: async ({ activate }) => activate(),
+      runReclaimBarrier: async ({ reclaim }) => await reclaim("/gateway/workspace"),
+      resolveWorkspacePath: async () => "/gateway/workspace",
+      reportWorkspaceResultConflict: async () => {},
+      resolveWorkspaceResultConflict: async () => undefined,
+    });
+    const environmentId = "worker-stale-recovery";
+    support.seedReady(environmentId);
+    const attached = await workerService.attachSession({
+      environmentId,
+      ownerEpoch: 1,
+      sessionId: "session-1",
+    });
+    const active = seedActivePlacement(placements, {
+      environmentId,
+      ownerEpoch: attached.ownerEpoch,
+    });
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = placements.claimTurn({
+      sessionId: active.sessionId,
+      sessionKey: active.sessionKey,
+      agentId: active.agentId,
+      claimId: "claim-stale-recovery",
+      runId: "run-stale-recovery",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    placements.markWorkspaceResultPending(claim);
+    placements.handoffWorkspaceResultRecovery(claim);
+    recoveryState.started = true;
+
+    await recovery.reconcile();
+
+    expect(placements.get(active.sessionId)).toMatchObject({
+      state: "active",
+      turnClaim: { claimId: claim.claimId, runId: claim.runId },
+    });
+    expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(workerService.get(active.environmentId)).toMatchObject({
+      state: "attached",
+      destroyRequestedAtMs: null,
+    });
+    expect(tunnelManager.start).not.toHaveBeenCalled();
+  });
+
+  it("keeps stale worker bundle recovery retryable through its installed workspace receiver", async () => {
     let currentBundle: WorkerInstallationArtifact = support.BUNDLE_ARTIFACT;
     support.testState.prepareInstallation = vi.fn(async (install) =>
       install === "bundle" ? currentBundle : support.NPM_ARTIFACT,
     );
     const tunnelManager = {
       status: () => "stopped" as const,
-      start: vi.fn(),
+      start: vi.fn(async () => {
+        throw new Error("SSH transport unavailable");
+      }),
       stop: vi.fn(async () => {}),
       stopAll: vi.fn(async () => {}),
     } as unknown as WorkerTunnelManager;
@@ -163,18 +216,17 @@ describe("worker placement restart recovery", () => {
     await recovery.reconcile();
 
     expect(placements.get(active.sessionId)).toMatchObject({
-      state: "failed",
-      turnClaim: null,
-      terminalRecovery: {
-        action: "force-destroy-environment",
-        dataLoss: "unreconciled-workspace-result",
-      },
+      state: "active",
+      turnClaim: { claimId: claim.claimId, runId: claim.runId },
     });
+    expect(placements.get(active.sessionId)).not.toHaveProperty("terminalRecovery");
     expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
     expect(workerService.get(active.environmentId)).toMatchObject({
       state: "attached",
       destroyRequestedAtMs: null,
     });
-    expect(tunnelManager.start).not.toHaveBeenCalled();
+    expect(tunnelManager.start).toHaveBeenCalledWith(
+      expect.objectContaining({ bundleHash: support.BUNDLE_HASH }),
+    );
   });
 });

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -3,6 +3,7 @@ import type { WorkerInstallationArtifact } from "./bundle.js";
 import { seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import * as support from "./service.test-support.js";
 import type { WorkerTunnelManager } from "./tunnel.js";
 import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
@@ -98,4 +99,82 @@ describe("worker placement restart recovery", () => {
       expect(tunnelManager.start).not.toHaveBeenCalled();
     },
   );
+
+  it("projects a stale worker bundle as terminal retained-result recovery", async () => {
+    let currentBundle: WorkerInstallationArtifact = support.BUNDLE_ARTIFACT;
+    support.testState.prepareInstallation = vi.fn(async (install) =>
+      install === "bundle" ? currentBundle : support.NPM_ARTIFACT,
+    );
+    const tunnelManager = {
+      status: () => "stopped" as const,
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const workerService = support.createService(support.createProvider(), {
+      placementStore: createWorkerSessionPlacementGate(placements),
+      tunnelManager,
+    });
+    const recovery = createWorkerPlacementDispatchService({
+      placements,
+      environments: workerService,
+      workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+      runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+      runActivationBarrier: async ({ activate }) => activate(),
+      runReclaimBarrier: async ({ reclaim }) => await reclaim("/gateway/workspace"),
+      resolveWorkspacePath: async () => "/gateway/workspace",
+      reportWorkspaceResultConflict: async () => {},
+      resolveWorkspaceResultConflict: async () => undefined,
+    });
+    const environmentId = "worker-stale-bundle-recovery";
+    support.seedReady(environmentId);
+    const attached = await workerService.attachSession({
+      environmentId,
+      ownerEpoch: 1,
+      sessionId: "session-1",
+    });
+    const active = seedActivePlacement(placements, {
+      environmentId,
+      ownerEpoch: attached.ownerEpoch,
+    });
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = placements.claimTurn({
+      sessionId: active.sessionId,
+      sessionKey: active.sessionKey,
+      agentId: active.agentId,
+      claimId: "claim-stale-bundle-recovery",
+      runId: "run-stale-bundle-recovery",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    placements.markWorkspaceResultPending(claim);
+    placements.handoffWorkspaceResultRecovery(claim);
+    currentBundle = { ...support.BUNDLE_ARTIFACT, bundleHash: "c".repeat(64) };
+
+    await recovery.reconcile();
+
+    expect(placements.get(active.sessionId)).toMatchObject({
+      state: "failed",
+      turnClaim: null,
+      terminalRecovery: {
+        action: "force-destroy-environment",
+        dataLoss: "unreconciled-workspace-result",
+      },
+    });
+    expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(workerService.get(active.environmentId)).toMatchObject({
+      state: "attached",
+      destroyRequestedAtMs: null,
+    });
+    expect(tunnelManager.start).not.toHaveBeenCalled();
+  });
 });

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
 import { seedActivePlacement, seedStartingPlacement } from "./placement-dispatch-test-fixtures.js";
+import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
@@ -12,8 +14,13 @@ describe("worker placement restart recovery", () => {
   support.setupWorkerEnvironmentServiceSuite();
 
   it.each(["active", "starting"] as const)(
-    "keeps a restarted %s placement fenced when host isolation inspection is unavailable",
+    "retries a restarted %s placement after host isolation inspection recovers",
     async (state) => {
+      const protocolFeatures = [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE];
+      support.testState.prepareInstallation = vi.fn(async (install) => ({
+        ...(install === "bundle" ? support.BUNDLE_ARTIFACT : support.NPM_ARTIFACT),
+        protocolFeatures,
+      }));
       let providerSharedHost = false;
       let recoveryStarted = false;
       const destroy = vi.fn(async () => {});
@@ -28,7 +35,16 @@ describe("worker placement restart recovery", () => {
       });
       const tunnelManager = {
         status: () => "stopped" as const,
-        start: vi.fn(),
+        start: vi.fn(async (request) => ({
+          environmentId: request.environmentId,
+          ownerEpoch: request.ownerEpoch,
+          launchTurn: vi.fn(),
+          quiesceWorkspace: vi.fn(),
+          reconcileWorkspace: vi.fn(),
+          runWorkspaceCommand: vi.fn(),
+          stop: vi.fn(async () => {}),
+          syncWorkspace: vi.fn(),
+        })),
         stop: vi.fn(async () => {}),
         stopAll: vi.fn(async () => {}),
       } as unknown as WorkerTunnelManager;
@@ -49,7 +65,16 @@ describe("worker placement restart recovery", () => {
         resolveWorkspaceResultConflict: async () => undefined,
       });
       const environmentId = `worker-stale-isolation-${state}`;
-      support.seedReady(environmentId, undefined, false);
+      const bootstrapping = support.seedBootstrapping(environmentId, undefined, false);
+      support.testState.store.transition({
+        environmentId,
+        from: bootstrapping.state,
+        to: "ready",
+        patch: support.readyPatch(environmentId, {
+          ...support.BOOTSTRAP_RECEIPT,
+          protocolFeatures,
+        }),
+      });
       if (state === "active") {
         const attached = await workerService.attachSession({
           environmentId,
@@ -61,17 +86,48 @@ describe("worker placement restart recovery", () => {
         seedStartingPlacement(placements, environmentId);
       }
       expect(workerService.get(environmentId)?.sharedHost).toBe(false);
+      const persisted = workerService.get(environmentId);
+      if (!persisted?.leaseId) {
+        throw new Error("worker recovery fixture has no provider lease");
+      }
+      support.testState.store.reconcileSharedHost({
+        environmentId,
+        state: persisted.state,
+        leaseId: persisted.leaseId,
+        sharedHost: null,
+      });
       providerSharedHost = true;
       recoveryStarted = true;
 
       await recovery.reconcile();
 
-      expect(placements.get("session-1")).toMatchObject({
-        state: "failed",
-        recoveryError: "Worker host isolation could not be verified after gateway restart",
-      });
+      expect(placements.get("session-1")).toMatchObject({ state });
+      expect(workerService.get(environmentId)?.sharedHost).toBeNull();
       expect(tunnelManager.start).not.toHaveBeenCalled();
-      expect(destroy).toHaveBeenCalledOnce();
+      expect(destroy).not.toHaveBeenCalled();
+      await expect(
+        workerService.startTunnel({
+          environmentId,
+          ownerEpoch: workerService.get(environmentId)!.ownerEpoch,
+        }),
+      ).rejects.toThrow("isolation is not reconciled");
+
+      recoveryStarted = false;
+      await recovery.reconcileActive();
+      if (state === "active") {
+        await workerService.startTunnel({
+          environmentId,
+          ownerEpoch: workerService.get(environmentId)!.ownerEpoch,
+        });
+      }
+
+      expect(placements.get("session-1")).toMatchObject({ state: "active" });
+      expect(workerService.get(environmentId)?.sharedHost).toBe(true);
+      expect(tunnelManager.start).toHaveBeenCalledOnce();
+      expect(tunnelManager.start).toHaveBeenCalledWith(
+        expect.objectContaining({ sharedHost: true }),
+      );
+      expect(destroy).not.toHaveBeenCalled();
     },
   );
 
@@ -212,6 +268,11 @@ describe("worker placement restart recovery", () => {
     placements.markWorkspaceResultPending(claim);
     placements.handoffWorkspaceResultRecovery(claim);
     currentBundle = { ...support.BUNDLE_ARTIFACT, bundleHash: "c".repeat(64) };
+    const expiredCredential = support.testState.store.getCredential(environmentId);
+    if (!expiredCredential) {
+      throw new Error("worker recovery fixture has no credential");
+    }
+    support.testState.nowMs = expiredCredential.expiresAtMs + 1;
 
     await recovery.reconcile();
 
@@ -223,10 +284,32 @@ describe("worker placement restart recovery", () => {
     expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
     expect(workerService.get(active.environmentId)).toMatchObject({
       state: "attached",
-      destroyRequestedAtMs: null,
+      destroyRequestedAtMs: support.testState.nowMs,
     });
+    expect(support.testState.store.getCredential(environmentId)?.expiresAtMs).toBe(
+      expiredCredential.expiresAtMs,
+    );
     expect(tunnelManager.start).toHaveBeenCalledWith(
       expect.objectContaining({ bundleHash: support.BUNDLE_HASH }),
     );
+  });
+
+  it("fails startup-deferred preparation after authoritative environment destruction", async () => {
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const harness = createHarness(placements);
+    harness.placements.seedStarting();
+    harness.markEnvironmentDestroyed();
+
+    await harness.service.reconcileActive();
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: "Interrupted worker dispatch cannot safely resume",
+    });
+    expect(harness.environments.attachSession).not.toHaveBeenCalled();
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -79,7 +79,9 @@ describe("worker placement restart recovery", () => {
       });
       placements.markWorkspaceResultPending(claim);
       placements.handoffWorkspaceResultRecovery(claim);
-      currentBundle = { ...support.BUNDLE_ARTIFACT, bundleHash: "c".repeat(64) };
+      if (failure === "bundle") {
+        currentBundle = { ...support.BUNDLE_ARTIFACT, bundleHash: "c".repeat(64) };
+      }
       recoveryState.started = true;
 
       await recovery.reconcile();

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -216,8 +216,10 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   };
 
   const reconcile = async (): Promise<void> => {
-    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, true);
+    // Provider inspection owns host-isolation facts. Refresh them before any
+    // recovery tunnel snapshots shared-host versus dedicated-host behavior.
     await environments.reconcileOnce();
+    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, true);
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
       if (journalOwners.has(placement.sessionId) || pendingResultOwners.has(placement.sessionId)) {
@@ -255,8 +257,8 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   // Runtime sweeps must not classify a live dispatch preparation as a crash. They only repair
   // durable active ownership and retry teardown already fenced by a previous failure.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
-    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, false, environmentId);
     await environments.reconcileOnce();
+    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, false, environmentId);
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
       if (journalOwners.has(placement.sessionId) || pendingResultOwners.has(placement.sessionId)) {

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -11,6 +11,8 @@ import {
 import {
   recoverPendingWorkspaceResults,
   type PlacementRecoveryDeps,
+  type WorkerWorkspaceRecoveryTunnelResolver,
+  type WorkerWorkspaceRecoveryTunnelStarter,
 } from "./placement-dispatch-pending-results.js";
 import type { WorkerEnvironmentService } from "./service.js";
 
@@ -92,7 +94,20 @@ function blockingWorkspaceJournalSessions(
 export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   const { environments, failure, placements } = deps;
 
-  const adoptActive = async (placement: WorkerActiveDispatchPlacement): Promise<void> => {
+  const recoveryTunnelResolver =
+    (
+      freshEnvironmentIds: ReadonlySet<string>,
+      workerBuild: "current" | "installed",
+    ): WorkerWorkspaceRecoveryTunnelResolver =>
+    (environmentId) =>
+      freshEnvironmentIds.has(environmentId)
+        ? (request) => environments.startRecoveryTunnel({ ...request, workerBuild })
+        : undefined;
+
+  const adoptActive = async (
+    placement: WorkerActiveDispatchPlacement,
+    startRecoveryTunnel: WorkerWorkspaceRecoveryTunnelStarter,
+  ): Promise<void> => {
     // Worker turns are one-shot SSH children owned by the previous gateway process. A durable
     // claim cannot prove that child remains live after restart, so fence the whole placement.
     if (placement.turnClaim) {
@@ -127,7 +142,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       // dormant lease remains authoritative while offline; validate and create
       // the reconnect-scoped tunnel lazily when the next turn actually launches.
       if (environment.providerId !== DEVICE_WORKER_PROVIDER_ID) {
-        await environments.startTunnel({
+        await startRecoveryTunnel({
           environmentId: environment.environmentId,
           ownerEpoch: environment.ownerEpoch,
         });
@@ -143,7 +158,10 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
     }
   };
 
-  const resumeStarting = async (placement: WorkerStartingDispatchPlacement): Promise<void> => {
+  const resumeStarting = async (
+    placement: WorkerStartingDispatchPlacement,
+    startRecoveryTunnel: WorkerWorkspaceRecoveryTunnelStarter,
+  ): Promise<void> => {
     const environment = placement.environmentId
       ? environments.get(placement.environmentId)
       : undefined;
@@ -185,7 +203,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       if (ownerEpoch === undefined) {
         throw new Error(`Worker environment cannot resume dispatch from ${environment.state}`);
       }
-      await environments.startTunnel({ environmentId: environment.environmentId, ownerEpoch });
+      await startRecoveryTunnel({ environmentId: environment.environmentId, ownerEpoch });
       await deps.runActivationBarrier({
         sessionId: placement.sessionId,
         sessionKey: placement.sessionKey,
@@ -224,11 +242,19 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         .filter((result) => result.hostIsolation === "fresh")
         .map((result) => result.environmentId),
     );
+    const workspaceRecoveryTunnelFor = recoveryTunnelResolver(
+      freshHostIsolationEnvironmentIds,
+      "installed",
+    );
+    const currentRecoveryTunnelFor = recoveryTunnelResolver(
+      freshHostIsolationEnvironmentIds,
+      "current",
+    );
     const pendingResultOwners = await recoverPendingWorkspaceResults(
       deps,
       true,
       undefined,
-      freshHostIsolationEnvironmentIds,
+      workspaceRecoveryTunnelFor,
     );
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
@@ -239,7 +265,16 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         continue;
       }
       if (placement.state === "active") {
-        await adoptActive(placement);
+        const startRecoveryTunnel = currentRecoveryTunnelFor(placement.environmentId);
+        if (startRecoveryTunnel) {
+          await adoptActive(placement, startRecoveryTunnel);
+        } else {
+          await failure.failActive(
+            placement,
+            new Error("Worker host isolation could not be verified after gateway restart"),
+            { forceClaimFence: placement.turnClaim !== null },
+          );
+        }
         continue;
       }
       if (isFailedPlacement(placement)) {
@@ -247,7 +282,21 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         continue;
       }
       if (isStartingPlacement(placement)) {
-        await resumeStarting(placement);
+        const startRecoveryTunnel = placement.environmentId
+          ? currentRecoveryTunnelFor(placement.environmentId)
+          : undefined;
+        if (startRecoveryTunnel) {
+          await resumeStarting(placement, startRecoveryTunnel);
+        } else {
+          await failure.teardownEnvironment({
+            placement,
+            environmentId: placement.environmentId,
+            ownerEpoch: null,
+            primaryError: new Error(
+              "Worker host isolation could not be verified after gateway restart",
+            ),
+          });
+        }
         continue;
       }
       const error = new Error(`Worker dispatch interrupted in ${placement.state}`);
@@ -273,11 +322,15 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         .filter((result) => result.hostIsolation === "fresh")
         .map((result) => result.environmentId),
     );
+    const workspaceRecoveryTunnelFor = recoveryTunnelResolver(
+      freshHostIsolationEnvironmentIds,
+      "installed",
+    );
     const pendingResultOwners = await recoverPendingWorkspaceResults(
       deps,
       false,
       environmentId,
-      freshHostIsolationEnvironmentIds,
+      workspaceRecoveryTunnelFor,
     );
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -218,8 +218,18 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   const reconcile = async (): Promise<void> => {
     // Provider inspection owns host-isolation facts. Refresh them before any
     // recovery tunnel snapshots shared-host versus dedicated-host behavior.
-    await environments.reconcileOnce();
-    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, true);
+    const providerFacts = await environments.reconcileOnce();
+    const freshHostIsolationEnvironmentIds = new Set(
+      providerFacts
+        .filter((result) => result.hostIsolation === "fresh")
+        .map((result) => result.environmentId),
+    );
+    const pendingResultOwners = await recoverPendingWorkspaceResults(
+      deps,
+      true,
+      undefined,
+      freshHostIsolationEnvironmentIds,
+    );
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
       if (journalOwners.has(placement.sessionId) || pendingResultOwners.has(placement.sessionId)) {
@@ -257,8 +267,18 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   // Runtime sweeps must not classify a live dispatch preparation as a crash. They only repair
   // durable active ownership and retry teardown already fenced by a previous failure.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
-    await environments.reconcileOnce();
-    const pendingResultOwners = await recoverPendingWorkspaceResults(deps, false, environmentId);
+    const providerFacts = await environments.reconcileOnce();
+    const freshHostIsolationEnvironmentIds = new Set(
+      providerFacts
+        .filter((result) => result.hostIsolation === "fresh")
+        .map((result) => result.environmentId),
+    );
+    const pendingResultOwners = await recoverPendingWorkspaceResults(
+      deps,
+      false,
+      environmentId,
+      freshHostIsolationEnvironmentIds,
+    );
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
       if (journalOwners.has(placement.sessionId) || pendingResultOwners.has(placement.sessionId)) {

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -12,9 +12,16 @@ import {
   recoverPendingWorkspaceResults,
   type PlacementRecoveryDeps,
   type WorkerWorkspaceRecoveryTunnelResolver,
-  type WorkerWorkspaceRecoveryTunnelStarter,
 } from "./placement-dispatch-pending-results.js";
 import type { WorkerEnvironmentService } from "./service.js";
+import type {
+  WorkerTunnelRequest,
+  WorkerWorkspaceRecoveryTunnelHandle,
+} from "./tunnel-contract.js";
+
+type WorkerCurrentRecoveryTunnelStarter = (
+  request: WorkerTunnelRequest,
+) => Promise<WorkerWorkspaceRecoveryTunnelHandle>;
 
 function supportsCurrentWorkerLaunch(
   environment: ReturnType<WorkerEnvironmentService["get"]>,
@@ -94,19 +101,41 @@ function blockingWorkspaceJournalSessions(
 export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   const { environments, failure, placements } = deps;
 
-  const recoveryTunnelResolver =
-    (
-      freshEnvironmentIds: ReadonlySet<string>,
-      workerBuild: "current" | "installed",
-    ): WorkerWorkspaceRecoveryTunnelResolver =>
-    (environmentId) =>
+  const recoveryTunnelResolvers = (
+    providerFacts: Awaited<ReturnType<WorkerEnvironmentService["reconcileOnce"]>>,
+  ) => {
+    const freshEnvironmentIds = new Set(
+      providerFacts
+        .filter((result) => result.hostIsolation === "fresh")
+        .map((result) => result.environmentId),
+    );
+    const dormantEnvironmentIds = new Set(
+      providerFacts
+        .filter((result) => result.inspection === "dormant")
+        .map((result) => result.environmentId),
+    );
+    const currentTunnelFor = (
+      environmentId: string,
+    ): WorkerCurrentRecoveryTunnelStarter | undefined =>
       freshEnvironmentIds.has(environmentId)
-        ? (request) => environments.startRecoveryTunnel({ ...request, workerBuild })
+        ? (request) => environments.startRecoveryTunnel({ ...request, workerBuild: "current" })
         : undefined;
+    const workspaceTunnelFor: WorkerWorkspaceRecoveryTunnelResolver = (environmentId) =>
+      freshEnvironmentIds.has(environmentId)
+        ? (request, authorizePendingResult) =>
+            environments.startRecoveryTunnel({
+              ...request,
+              workerBuild: "installed",
+              authorizePendingResult,
+            })
+        : undefined;
+    return { currentTunnelFor, dormantEnvironmentIds, workspaceTunnelFor };
+  };
 
   const adoptActive = async (
     placement: WorkerActiveDispatchPlacement,
-    startRecoveryTunnel: WorkerWorkspaceRecoveryTunnelStarter,
+    startRecoveryTunnel: WorkerCurrentRecoveryTunnelStarter | undefined,
+    dormantInspection: boolean,
   ): Promise<void> => {
     // Worker turns are one-shot SSH children owned by the previous gateway process. A durable
     // claim cannot prove that child remains live after restart, so fence the whole placement.
@@ -137,11 +166,21 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       );
       return;
     }
+    if (environment.providerId === DEVICE_WORKER_PROVIDER_ID) {
+      if (!dormantInspection && !startRecoveryTunnel) {
+        return;
+      }
+    } else if (!startRecoveryTunnel) {
+      return;
+    }
     try {
       // Paired nodes are persistent runners, not one-shot SSH children. Their
       // dormant lease remains authoritative while offline; validate and create
       // the reconnect-scoped tunnel lazily when the next turn actually launches.
       if (environment.providerId !== DEVICE_WORKER_PROVIDER_ID) {
+        if (!startRecoveryTunnel) {
+          return;
+        }
         await startRecoveryTunnel({
           environmentId: environment.environmentId,
           ownerEpoch: environment.ownerEpoch,
@@ -160,7 +199,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
 
   const resumeStarting = async (
     placement: WorkerStartingDispatchPlacement,
-    startRecoveryTunnel: WorkerWorkspaceRecoveryTunnelStarter,
+    startRecoveryTunnel: WorkerCurrentRecoveryTunnelStarter | undefined,
   ): Promise<void> => {
     const environment = placement.environmentId
       ? environments.get(placement.environmentId)
@@ -169,12 +208,21 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
     const hasSyncedWorkspace = Boolean(
       placement.workspaceBaseManifestRef && placement.remoteWorkspaceDir,
     );
+    const hasResumableOwner = Boolean(
+      environment &&
+      ((environment.state === "attached" &&
+        environment.attachedSessionIds.length === 1 &&
+        environment.attachedSessionIds[0] === placement.sessionId) ||
+        environment.state === "ready" ||
+        environment.state === "idle"),
+    );
     const canResume =
       environment &&
       expectedBundle &&
       environment.bootstrapReceipt?.bundleHash === expectedBundle &&
       supportsCurrentWorkerLaunch(environment) &&
-      hasSyncedWorkspace;
+      hasSyncedWorkspace &&
+      hasResumableOwner;
     if (!canResume) {
       const error = new Error("Interrupted worker dispatch cannot safely resume");
       await failure.teardownEnvironment({
@@ -183,6 +231,9 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         ownerEpoch: environment?.ownerEpoch ?? null,
         primaryError: error,
       });
+      return;
+    }
+    if (!startRecoveryTunnel) {
       return;
     }
     try {
@@ -237,24 +288,13 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
     // Provider inspection owns host-isolation facts. Refresh them before any
     // recovery tunnel snapshots shared-host versus dedicated-host behavior.
     const providerFacts = await environments.reconcileOnce();
-    const freshHostIsolationEnvironmentIds = new Set(
-      providerFacts
-        .filter((result) => result.hostIsolation === "fresh")
-        .map((result) => result.environmentId),
-    );
-    const workspaceRecoveryTunnelFor = recoveryTunnelResolver(
-      freshHostIsolationEnvironmentIds,
-      "installed",
-    );
-    const currentRecoveryTunnelFor = recoveryTunnelResolver(
-      freshHostIsolationEnvironmentIds,
-      "current",
-    );
+    const { currentTunnelFor, dormantEnvironmentIds, workspaceTunnelFor } =
+      recoveryTunnelResolvers(providerFacts);
     const pendingResultOwners = await recoverPendingWorkspaceResults(
       deps,
       true,
       undefined,
-      workspaceRecoveryTunnelFor,
+      workspaceTunnelFor,
     );
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
@@ -265,16 +305,11 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         continue;
       }
       if (placement.state === "active") {
-        const startRecoveryTunnel = currentRecoveryTunnelFor(placement.environmentId);
-        if (startRecoveryTunnel) {
-          await adoptActive(placement, startRecoveryTunnel);
-        } else {
-          await failure.failActive(
-            placement,
-            new Error("Worker host isolation could not be verified after gateway restart"),
-            { forceClaimFence: placement.turnClaim !== null },
-          );
-        }
+        await adoptActive(
+          placement,
+          currentTunnelFor(placement.environmentId),
+          dormantEnvironmentIds.has(placement.environmentId),
+        );
         continue;
       }
       if (isFailedPlacement(placement)) {
@@ -283,20 +318,9 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       }
       if (isStartingPlacement(placement)) {
         const startRecoveryTunnel = placement.environmentId
-          ? currentRecoveryTunnelFor(placement.environmentId)
+          ? currentTunnelFor(placement.environmentId)
           : undefined;
-        if (startRecoveryTunnel) {
-          await resumeStarting(placement, startRecoveryTunnel);
-        } else {
-          await failure.teardownEnvironment({
-            placement,
-            environmentId: placement.environmentId,
-            ownerEpoch: null,
-            primaryError: new Error(
-              "Worker host isolation could not be verified after gateway restart",
-            ),
-          });
-        }
+        await resumeStarting(placement, startRecoveryTunnel);
         continue;
       }
       const error = new Error(`Worker dispatch interrupted in ${placement.state}`);
@@ -313,24 +337,16 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
     }
   };
 
-  // Runtime sweeps must not classify a live dispatch preparation as a crash. They only repair
-  // durable active ownership and retry teardown already fenced by a previous failure.
+  // The coordinator runs runtime sweeps only after live dispatches are idle. They can therefore
+  // resume startup-deferred starting rows without classifying active preparation as a crash.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
     const providerFacts = await environments.reconcileOnce();
-    const freshHostIsolationEnvironmentIds = new Set(
-      providerFacts
-        .filter((result) => result.hostIsolation === "fresh")
-        .map((result) => result.environmentId),
-    );
-    const workspaceRecoveryTunnelFor = recoveryTunnelResolver(
-      freshHostIsolationEnvironmentIds,
-      "installed",
-    );
+    const { currentTunnelFor, workspaceTunnelFor } = recoveryTunnelResolvers(providerFacts);
     const pendingResultOwners = await recoverPendingWorkspaceResults(
       deps,
       false,
       environmentId,
-      workspaceRecoveryTunnelFor,
+      workspaceTunnelFor,
     );
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
@@ -342,6 +358,13 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       }
       if (isFailedPlacement(placement)) {
         await failure.retryFailedTeardown(placement);
+        continue;
+      }
+      if (isStartingPlacement(placement)) {
+        const startRecoveryTunnel = placement.environmentId
+          ? currentTunnelFor(placement.environmentId)
+          : undefined;
+        await resumeStarting(placement, startRecoveryTunnel);
         continue;
       }
       if (placement.state !== "active") {

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -216,8 +216,8 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   };
 
   const reconcile = async (): Promise<void> => {
-    await environments.reconcileOnce();
     const pendingResultOwners = await recoverPendingWorkspaceResults(deps, true);
+    await environments.reconcileOnce();
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
       if (journalOwners.has(placement.sessionId) || pendingResultOwners.has(placement.sessionId)) {
@@ -255,8 +255,8 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   // Runtime sweeps must not classify a live dispatch preparation as a crash. They only repair
   // durable active ownership and retry teardown already fenced by a previous failure.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
-    await environments.reconcileOnce();
     const pendingResultOwners = await recoverPendingWorkspaceResults(deps, false, environmentId);
+    await environments.reconcileOnce();
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     for (const placement of placements.listForReconcile()) {
       if (journalOwners.has(placement.sessionId) || pendingResultOwners.has(placement.sessionId)) {

--- a/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
@@ -94,12 +94,13 @@ describe("staged worker placement result recovery", () => {
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
   });
-  it("applies a staged pending result without a tunnel and reclaims the worker", async () => {
+  it("applies a staged pending result without fresh provider facts or a tunnel", async () => {
     const workspacePath = path.join(root, "same-worker-staged-result");
     const priorConflictRef = "refs/openclaw/worker-results/prior-conflict";
     const harness = createHarness(placementStore, {
       workspacePath,
       priorWorkspaceResultConflict: { paths: ["old.txt"], stagedResultRef: priorConflictRef },
+      hostIsolationFresh: false,
     });
     const active = harness.placements.seedActive(2);
     harness.markEnvironmentOwnerEpoch(2);

--- a/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
@@ -100,7 +100,7 @@ describe("staged worker placement result recovery", () => {
     const harness = createHarness(placementStore, {
       workspacePath,
       priorWorkspaceResultConflict: { paths: ["old.txt"], stagedResultRef: priorConflictRef },
-      hostIsolationFresh: false,
+      providerInspection: "unavailable",
     });
     const active = harness.placements.seedActive(2);
     harness.markEnvironmentOwnerEpoch(2);

--- a/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
@@ -28,8 +28,6 @@ export type DispatchStage =
 
 export const BUNDLE_HASH = "a".repeat(64);
 export const MANIFEST_REF = `sha256:${"b".repeat(64)}`;
-export const FORCED_WORKER_ABANDONMENT_ERROR =
-  "Cloud worker result abandoned by forced operator teardown";
 export const REQUEST: WorkerDispatchRequest = {
   sessionId: "session-1",
   sessionKey: "agent:main:session-1",

--- a/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
@@ -28,6 +28,8 @@ export type DispatchStage =
 
 export const BUNDLE_HASH = "a".repeat(64);
 export const MANIFEST_REF = `sha256:${"b".repeat(64)}`;
+export const FORCED_WORKER_ABANDONMENT_ERROR =
+  "Cloud worker result abandoned by forced operator teardown";
 export const REQUEST: WorkerDispatchRequest = {
   sessionId: "session-1",
   sessionKey: "agent:main:session-1",
@@ -36,7 +38,7 @@ export const REQUEST: WorkerDispatchRequest = {
   executionMode: "worker-turn",
 };
 
-export function seedSyncingPlacement(
+function seedSyncingPlacement(
   store: PlacementStore,
   environmentId: string,
   executionMode: WorkerDispatchRequest["executionMode"] = REQUEST.executionMode,

--- a/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
@@ -28,6 +28,8 @@ export type DispatchStage =
 
 export const BUNDLE_HASH = "a".repeat(64);
 export const MANIFEST_REF = `sha256:${"b".repeat(64)}`;
+export const FORCED_WORKER_ABANDONMENT_ERROR =
+  "Cloud worker result abandoned by forced operator teardown";
 export const REQUEST: WorkerDispatchRequest = {
   sessionId: "session-1",
   sessionKey: "agent:main:session-1",

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -370,6 +370,9 @@ export function createHarness(
     }),
     reconcileOnce: vi.fn(async () => {
       log.push("environment:reconcile");
+      return currentEnvironment
+        ? [{ environmentId: currentEnvironment.environmentId, hostIsolation: "fresh" as const }]
+        : [];
     }),
   };
   const service = createWorkerPlacementDispatchService({

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -95,6 +95,7 @@ export function createHarness(
       placementStore.recordStagedWorkspaceResult(claim, ref),
     recordWorkspaceResultConflict: (claim, conflict) =>
       placementStore.recordWorkspaceResultConflict(claim, conflict),
+    retireWorkspaceResultConflict: (input) => placementStore.retireWorkspaceResultConflict(input),
     claimTurn: (params) => placementStore.claimTurn(params),
     claimReclaimWorkspaceResult: (params) => placementStore.claimReclaimWorkspaceResult(params),
     closeWorkerTurnToolState: (claim) => placementStore.closeWorkerTurnToolState(claim),

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -37,8 +37,11 @@ export function createHarness(
     verifyFailureCall?: number;
     leaseFails?: boolean;
     leaseFailureCount?: number;
+    leaseError?: Error;
+    leaseBarrier?: Promise<void>;
     localVerifyFails?: boolean;
     resumeFails?: boolean;
+    resumeError?: Error;
     workspacePath?: string;
     priorWorkspaceResultConflict?: { paths: string[]; stagedResultRef: string };
     reconcileConflictPaths?: string[];
@@ -47,6 +50,7 @@ export function createHarness(
     terminalizeReclaimOnTunnelDrop?: boolean;
     terminalizedReclaimError?: Error;
     environmentGeneration?: number;
+    destroyPendingOwnerDuringEnvironmentReconcile?: boolean;
   } = {},
 ) {
   const reconciledManifestRef = MANIFEST_REF.replaceAll("b", "c");
@@ -73,7 +77,17 @@ export function createHarness(
       placementStore.beginWorkspaceReconciliation(owner, journal),
     abortWorkspaceReconciliation: (owner, abortOptions) =>
       placementStore.abortWorkspaceReconciliation(owner, abortOptions),
+    isWorkspaceReconciliationRetainedForForcedAbandonment: (owner) =>
+      placementStore.isWorkspaceReconciliationRetainedForForcedAbandonment(owner),
+    retainWorkspaceReconciliationForForcedAbandonment: (owner) =>
+      placementStore.retainWorkspaceReconciliationForForcedAbandonment(owner),
     listWorkspaceReconciliationOwners: () => placementStore.listWorkspaceReconciliationOwners(),
+    listEnvironmentTeardownFences: (environmentId) =>
+      placementStore.listEnvironmentTeardownFences(environmentId),
+    canDestroyAcceptedWorkspaceResult: (claim) =>
+      placementStore.canDestroyAcceptedWorkspaceResult(claim),
+    canDestroyForceAbandonedEnvironment: (environmentId) =>
+      placementStore.canDestroyForceAbandonedEnvironment(environmentId),
     listPendingWorkspaceResults: () => placementStore.listPendingWorkspaceResults(),
     workspaceResultInstanceId: () => placementStore.workspaceResultInstanceId(),
     validateWorkspaceResultClaim: (claim) => placementStore.validateWorkspaceResultClaim(claim),
@@ -107,6 +121,9 @@ export function createHarness(
       return placementStore.failWorkspaceResultAndReleaseTurn(pending, error);
     },
     abandonWorkspaceResult: (pending) => placementStore.abandonWorkspaceResult(pending),
+    forceAbandonPendingWorkspaceResult: (params) =>
+      placementStore.forceAbandonPendingWorkspaceResult(params),
+    forceAbandonWorkerTurn: (params) => placementStore.forceAbandonWorkerTurn(params),
     releaseTurn: (claim) => placementStore.releaseTurn(claim),
     updateWorkspaceBaseManifest: (params) => placementStore.updateWorkspaceBaseManifest(params),
     acceptIdleWorkspaceReconciliation: (params) =>
@@ -122,6 +139,10 @@ export function createHarness(
     fail: (params) => {
       log.push("placement:failed");
       return placementStore.fail(params);
+    },
+    failPendingWorkspaceResult: (params) => {
+      log.push("placement:failed");
+      return placementStore.failPendingWorkspaceResult(params);
     },
     finishReclaim: (params) => {
       log.push("placement:reclaimed");
@@ -182,6 +203,10 @@ export function createHarness(
       return {
         assertActive: vi.fn(async () => {
           log.push("workspace:lease");
+          await options.leaseBarrier;
+          if (options.leaseError) {
+            throw options.leaseError;
+          }
           if (options.leaseFails || remainingLeaseFailures > 0) {
             remainingLeaseFailures -= 1;
             throw new Error("workspace quiescence expired");
@@ -189,6 +214,9 @@ export function createHarness(
         }),
         resume: vi.fn(async () => {
           log.push("workspace:resume");
+          if (options.resumeError) {
+            throw options.resumeError;
+          }
           if (options.resumeFails) {
             throw new Error("workspace resume failed");
           }
@@ -293,6 +321,22 @@ export function createHarness(
     ownerEpoch: 2,
     expiresAtMs: 10_000,
   };
+  const destroy = vi.fn(async (_environmentId: string) => {
+    log.push("teardown:destroy");
+    if (options.destroyFails) {
+      if (options.destroyFailureState) {
+        currentEnvironment = {
+          ...attached,
+          state: options.destroyFailureState,
+          tunnelStatus: "stopped",
+        };
+      }
+      throw new Error("destroy pending");
+    }
+    const destroyed = destroyedEnvironment((currentEnvironment?.ownerEpoch ?? 1) + 1);
+    currentEnvironment = destroyed;
+    return destroyed;
+  });
   const environments: WorkerDispatchEnvironmentService = {
     create: vi.fn(async () => {
       fail("create");
@@ -318,24 +362,27 @@ export function createHarness(
     stopTunnel: vi.fn(async () => {
       log.push("teardown:stop");
     }),
-    destroy: vi.fn(async () => {
-      log.push("teardown:destroy");
-      if (options.destroyFails) {
-        if (options.destroyFailureState) {
-          currentEnvironment = {
-            ...attached,
-            state: options.destroyFailureState,
-            tunnelStatus: "stopped",
-          };
-        }
-        throw new Error("destroy pending");
+    destroy,
+    destroyOwned: vi.fn(async (ownedEnvironmentId, authorizeTeardown) => {
+      if (!authorizeTeardown()) {
+        throw new Error("owned teardown authorization changed");
       }
-      const destroyed = destroyedEnvironment((currentEnvironment?.ownerEpoch ?? 1) + 1);
-      currentEnvironment = destroyed;
-      return destroyed;
+      return await destroy(ownedEnvironmentId);
     }),
     reconcileOnce: vi.fn(async () => {
       log.push("environment:reconcile");
+      if (
+        options.destroyPendingOwnerDuringEnvironmentReconcile &&
+        currentEnvironment?.state === "attached" &&
+        placementStore
+          .listPendingWorkspaceResults()
+          .some((pending) => currentEnvironment?.attachedSessionIds.includes(pending.sessionId))
+      ) {
+        // Model stale-bundle provider reconciliation: destroying the attached
+        // lease here loses an unstaged result unless placement recovery ran first.
+        log.push("environment:stale-bundle-destroy");
+        currentEnvironment = destroyedEnvironment(currentEnvironment.ownerEpoch + 1);
+      }
     }),
   };
   const service = createWorkerPlacementDispatchService({

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -50,7 +50,6 @@ export function createHarness(
     terminalizeReclaimOnTunnelDrop?: boolean;
     terminalizedReclaimError?: Error;
     environmentGeneration?: number;
-    destroyPendingOwnerDuringEnvironmentReconcile?: boolean;
   } = {},
 ) {
   const reconciledManifestRef = MANIFEST_REF.replaceAll("b", "c");
@@ -371,18 +370,6 @@ export function createHarness(
     }),
     reconcileOnce: vi.fn(async () => {
       log.push("environment:reconcile");
-      if (
-        options.destroyPendingOwnerDuringEnvironmentReconcile &&
-        currentEnvironment?.state === "attached" &&
-        placementStore
-          .listPendingWorkspaceResults()
-          .some((pending) => currentEnvironment?.attachedSessionIds.includes(pending.sessionId))
-      ) {
-        // Model stale-bundle provider reconciliation: destroying the attached
-        // lease here loses an unstaged result unless placement recovery ran first.
-        log.push("environment:stale-bundle-destroy");
-        currentEnvironment = destroyedEnvironment(currentEnvironment.ownerEpoch + 1);
-      }
     }),
   };
   const service = createWorkerPlacementDispatchService({

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -50,7 +50,7 @@ export function createHarness(
     terminalizeReclaimOnTunnelDrop?: boolean;
     terminalizedReclaimError?: Error;
     environmentGeneration?: number;
-    hostIsolationFresh?: boolean;
+    providerInspection?: "active" | "dormant" | "unavailable";
   } = {},
 ) {
   const reconciledManifestRef = MANIFEST_REF.replaceAll("b", "c");
@@ -375,14 +375,25 @@ export function createHarness(
     }),
     reconcileOnce: vi.fn(async () => {
       log.push("environment:reconcile");
-      return currentEnvironment
+      if (!currentEnvironment) {
+        return [];
+      }
+      const inspection = options.providerInspection ?? "active";
+      return inspection === "active"
         ? [
             {
               environmentId: currentEnvironment.environmentId,
-              hostIsolation: options.hostIsolationFresh === false ? "unavailable" : "fresh",
+              inspection,
+              hostIsolation: "fresh",
             } as const,
           ]
-        : [];
+        : [
+            {
+              environmentId: currentEnvironment.environmentId,
+              inspection,
+              hostIsolation: "unavailable",
+            } as const,
+          ];
     }),
   };
   const service = createWorkerPlacementDispatchService({

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -50,6 +50,7 @@ export function createHarness(
     terminalizeReclaimOnTunnelDrop?: boolean;
     terminalizedReclaimError?: Error;
     environmentGeneration?: number;
+    hostIsolationFresh?: boolean;
   } = {},
 ) {
   const reconciledManifestRef = MANIFEST_REF.replaceAll("b", "c");
@@ -371,7 +372,12 @@ export function createHarness(
     reconcileOnce: vi.fn(async () => {
       log.push("environment:reconcile");
       return currentEnvironment
-        ? [{ environmentId: currentEnvironment.environmentId, hostIsolation: "fresh" as const }]
+        ? [
+            {
+              environmentId: currentEnvironment.environmentId,
+              hostIsolation: options.hostIsolationFresh === false ? "unavailable" : "fresh",
+            } as const,
+          ]
         : [];
     }),
   };

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -337,6 +337,15 @@ export function createHarness(
     currentEnvironment = destroyed;
     return destroyed;
   });
+  const startTunnel = vi.fn(
+    async ({ ownerEpoch }: Parameters<WorkerDispatchEnvironmentService["startTunnel"]>[0]) => {
+      fail("tunnel:attached");
+      if (ownerEpoch !== currentEnvironment?.ownerEpoch) {
+        throw new Error("tunnel fixture received a stale owner epoch");
+      }
+      return tunnelHandle(ownerEpoch);
+    },
+  );
   const environments: WorkerDispatchEnvironmentService = {
     create: vi.fn(async () => {
       fail("create");
@@ -347,19 +356,13 @@ export function createHarness(
       return ready;
     }),
     get: vi.fn(() => currentEnvironment),
-    isWorkerBuildMismatchError: vi.fn(() => false),
     attachSession: vi.fn(async () => {
       fail("attach");
       currentEnvironment = attached;
       return minted;
     }),
-    startTunnel: vi.fn(async ({ ownerEpoch }) => {
-      fail("tunnel:attached");
-      if (ownerEpoch !== currentEnvironment?.ownerEpoch) {
-        throw new Error("tunnel fixture received a stale owner epoch");
-      }
-      return tunnelHandle(ownerEpoch);
-    }),
+    startTunnel,
+    startRecoveryTunnel: startTunnel,
     stopTunnel: vi.fn(async () => {
       log.push("teardown:stop");
     }),

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -347,6 +347,7 @@ export function createHarness(
       return ready;
     }),
     get: vi.fn(() => currentEnvironment),
+    isWorkerBuildMismatchError: vi.fn(() => false),
     attachSession: vi.fn(async () => {
       fail("attach");
       currentEnvironment = attached;

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -1110,16 +1110,22 @@ describe("worker placement dispatch", () => {
     ]);
   });
 
-  it("leaves in-flight dispatch preparation untouched during runtime reconciliation", async () => {
+  it("resumes startup-deferred preparation during serialized runtime reconciliation", async () => {
     const harness = createHarness(placementStore);
     harness.placements.seedStarting();
     harness.log.length = 0;
 
     await harness.service.reconcileActive();
 
-    expect(harness.placements.current()).toMatchObject({ state: "starting" });
-    expect(harness.log).toEqual(["environment:reconcile"]);
-    expect(harness.environments.attachSession).not.toHaveBeenCalled();
+    expect(harness.placements.current()).toMatchObject({ state: "active" });
+    expect(harness.log).toEqual([
+      "environment:reconcile",
+      "attach",
+      "tunnel:attached",
+      "activation",
+      "placement:active",
+    ]);
+    expect(harness.environments.attachSession).toHaveBeenCalledOnce();
     expect(harness.environments.destroy).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -109,44 +109,44 @@ describe("worker placement dispatch", () => {
     expect(restartedHarness.log).not.toContain("workspace:resume");
   });
 
-  it("recovers an unstaged pending result before stale-bundle provider reconciliation", async () => {
-    const originalHarness = createHarness(placementStore);
-    const active = originalHarness.placements.seedActive(2);
-    originalHarness.markEnvironmentOwnerEpoch(2);
-    if (active.state !== "active") {
-      throw new Error("active placement fixture was not active");
-    }
-    const claim = placementStore.claimTurn({
-      ...REQUEST,
-      claimId: "stale-bundle-pending-claim",
-      runId: "stale-bundle-pending-run",
-      owner: {
-        kind: "worker",
-        environmentId: active.environmentId,
-        ownerEpoch: active.activeOwnerEpoch,
-      },
-    });
-    placementStore.markWorkspaceResultPending(claim);
+  it.each(["reconcile", "reconcileActive"] as const)(
+    "%s refreshes provider facts before recovering an unstaged pending result",
+    async (reconcile) => {
+      const originalHarness = createHarness(placementStore);
+      const active = originalHarness.placements.seedActive(2);
+      originalHarness.markEnvironmentOwnerEpoch(2);
+      if (active.state !== "active") {
+        throw new Error("active placement fixture was not active");
+      }
+      const claim = placementStore.claimTurn({
+        ...REQUEST,
+        claimId: "stale-bundle-pending-claim",
+        runId: "stale-bundle-pending-run",
+        owner: {
+          kind: "worker",
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+        },
+      });
+      placementStore.markWorkspaceResultPending(claim);
 
-    const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
-    const restartedHarness = createHarness(restartedStore, {
-      destroyPendingOwnerDuringEnvironmentReconcile: true,
-    });
-    restartedHarness.markEnvironmentOwnerEpoch(2);
+      const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+      const restartedHarness = createHarness(restartedStore);
+      restartedHarness.markEnvironmentOwnerEpoch(2);
 
-    await restartedHarness.service.reconcile();
+      await restartedHarness.service[reconcile]();
 
-    expect(restartedHarness.log.indexOf("workspace:reconcile")).toBeLessThan(
-      restartedHarness.log.indexOf("environment:reconcile"),
-    );
-    expect(restartedHarness.log).not.toContain("environment:stale-bundle-destroy");
-    expect(restartedHarness.placements.current()).toMatchObject({
-      state: "reclaimed",
-      turnClaim: null,
-      workspaceBaseManifestRef: restartedHarness.reconciledManifestRef,
-    });
-    expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
-  });
+      expect(restartedHarness.log.indexOf("environment:reconcile")).toBeLessThan(
+        restartedHarness.log.indexOf("workspace:reconcile"),
+      );
+      expect(restartedHarness.placements.current()).toMatchObject({
+        state: "reclaimed",
+        turnClaim: null,
+        workspaceBaseManifestRef: restartedHarness.reconciledManifestRef,
+      });
+      expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
+    },
+  );
 
   it("keeps a previous-instance pending result fenced when another session is attached", async () => {
     const originalHarness = createHarness(placementStore);
@@ -748,8 +748,8 @@ describe("worker placement dispatch", () => {
     await harness.service.reconcile();
 
     expect(harness.log).toEqual([
-      "workspace",
       "environment:reconcile",
+      "workspace",
       "tunnel:attached",
       "placement:adopted",
     ]);
@@ -791,8 +791,8 @@ describe("worker placement dispatch", () => {
       terminalAtMs: expect.any(Number),
     });
     expect(harness.log).toEqual([
-      "workspace",
       "environment:reconcile",
+      "workspace",
       "placement:draining",
       "placement:reconciling",
       "placement:failed",
@@ -865,8 +865,8 @@ describe("worker placement dispatch", () => {
       recoveryError: "Active worker turn claim cannot be proven live after gateway restart",
     });
     expect(harness.log).toEqual([
-      "workspace",
       "environment:reconcile",
+      "workspace",
       "placement:draining",
       "placement:reconciling",
       "teardown:stop",
@@ -889,8 +889,8 @@ describe("worker placement dispatch", () => {
       activeOwnerEpoch: harness.attached.ownerEpoch,
     });
     expect(harness.log).toEqual([
-      "workspace",
       "environment:reconcile",
+      "workspace",
       "attach",
       "tunnel:attached",
       "activation",
@@ -927,8 +927,8 @@ describe("worker placement dispatch", () => {
       recoveryError: "Worker dispatch interrupted in draining",
     });
     expect(harness.log).toEqual([
-      "workspace",
       "environment:reconcile",
+      "workspace",
       "placement:reconciling",
       "teardown:stop",
       "teardown:destroy",
@@ -946,8 +946,8 @@ describe("worker placement dispatch", () => {
       state: "reclaimed",
     });
     expect(harness.log).toEqual([
-      "workspace",
       "environment:reconcile",
+      "workspace",
       "placement:draining",
       "placement:reconciling",
       "teardown:stop",

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WORKER_LAUNCH_V2_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -12,12 +12,15 @@ import {
 import {
   type DispatchStage,
   type PlacementStore,
+  FORCED_WORKER_ABANDONMENT_ERROR,
   REQUEST,
-  seedSyncingPlacement,
 } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
-import { deriveEnvironmentIntent } from "./service-contract.js";
+import { WorkerWorkspaceOperatorRecoveryError } from "./tunnel-contract.js";
+
+const OPERATOR_RECOVERY_GUIDANCE =
+  "Use Stop cloud worker and confirm abandoning the result to destroy the environment; unreconciled remote workspace changes will be permanently lost";
 
 describe("worker placement dispatch", () => {
   let root: string;
@@ -33,50 +36,6 @@ describe("worker placement dispatch", () => {
   afterEach(async () => {
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
-  });
-
-  it("reports every durable startup transition without letting reporting break dispatch", async () => {
-    const harness = createHarness(placementStore);
-    const states: string[] = [];
-
-    const placement = await harness.service.dispatch(REQUEST, (current) => {
-      states.push(current.state);
-      throw new Error("reporting failed");
-    });
-
-    expect(placement.state).toBe("active");
-    expect(states).toEqual(["requested", "provisioning", "syncing", "starting", "active"]);
-  });
-
-  it("provisions an inherited dispatch from the exact durable profile snapshot", async () => {
-    const harness = createHarness(placementStore);
-    const inheritedProfile = {
-      providerId: "fake",
-      profileSnapshot: { install: "bundle" as const, settings: { region: "parent" } },
-    };
-
-    await harness.service.dispatch({ ...REQUEST, inheritedProfile });
-
-    expect(harness.environments.create).not.toHaveBeenCalled();
-    expect(harness.environments.createFromProfileSnapshot).toHaveBeenCalledWith(
-      { profileId: REQUEST.profileId, ...inheritedProfile },
-      expect.stringMatching(/^session-dispatch:/u),
-    );
-  });
-
-  it("reports the final durable placement after startup failure teardown", async () => {
-    const harness = createHarness(placementStore, { failAt: "sync" });
-    const states: string[] = [];
-
-    await expect(
-      harness.service.dispatch(REQUEST, (placement) => states.push(placement.state)),
-    ).rejects.toThrow("sync failed");
-
-    expect(states).toEqual(["requested", "provisioning", "syncing", "failed"]);
-    expect(harness.environments.stopTunnel).toHaveBeenCalledWith(
-      harness.attached.environmentId,
-      harness.attached.ownerEpoch,
-    );
   });
 
   it("recovers a completed turn's durable pending workspace result before stale-claim teardown", async () => {
@@ -106,55 +65,6 @@ describe("worker placement dispatch", () => {
 
     placementStore.handoffWorkspaceResultRecovery(claim);
 
-    const otherRequest = {
-      ...REQUEST,
-      sessionId: "session-2",
-      sessionKey: "agent:main:session-2",
-    };
-    let otherPlacement = placementStore.startDispatch(otherRequest);
-    otherPlacement = placementStore.transition({
-      sessionId: otherRequest.sessionId,
-      from: "requested",
-      to: "provisioning",
-      expectedGeneration: otherPlacement.generation,
-      patch: { environmentId: active.environmentId },
-    });
-    otherPlacement = placementStore.transition({
-      sessionId: otherRequest.sessionId,
-      from: "provisioning",
-      to: "syncing",
-      expectedGeneration: otherPlacement.generation,
-      patch: { workerBundleHash: active.workerBundleHash },
-    });
-    otherPlacement = placementStore.transition({
-      sessionId: otherRequest.sessionId,
-      from: "syncing",
-      to: "starting",
-      expectedGeneration: otherPlacement.generation,
-      patch: {
-        workspaceBaseManifestRef: active.workspaceBaseManifestRef,
-        remoteWorkspaceDir: active.remoteWorkspaceDir,
-      },
-    });
-    placementStore.transition({
-      sessionId: otherRequest.sessionId,
-      from: "starting",
-      to: "active",
-      expectedGeneration: otherPlacement.generation,
-      patch: { activeOwnerEpoch: active.activeOwnerEpoch },
-    });
-    const otherClaim = placementStore.claimTurn({
-      ...otherRequest,
-      claimId: "other-session-claim",
-      runId: "other-session-run",
-      owner: {
-        kind: "worker",
-        environmentId: active.environmentId,
-        ownerEpoch: active.activeOwnerEpoch,
-      },
-    });
-    placementStore.markWorkspaceResultPending(otherClaim);
-
     await harness.service.reconcile();
 
     expect(harness.placements.current()).toMatchObject({
@@ -162,9 +72,7 @@ describe("worker placement dispatch", () => {
       turnClaim: null,
       workspaceBaseManifestRef: harness.reconciledManifestRef,
     });
-    expect(placementStore.listPendingWorkspaceResults()).toMatchObject([
-      { sessionId: otherRequest.sessionId, claimId: otherClaim.claimId },
-    ]);
+    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
     expect(harness.environments.destroy).not.toHaveBeenCalled();
   });
 
@@ -201,6 +109,45 @@ describe("worker placement dispatch", () => {
     expect(restartedHarness.log).not.toContain("workspace:resume");
   });
 
+  it("recovers an unstaged pending result before stale-bundle provider reconciliation", async () => {
+    const originalHarness = createHarness(placementStore);
+    const active = originalHarness.placements.seedActive(2);
+    originalHarness.markEnvironmentOwnerEpoch(2);
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = placementStore.claimTurn({
+      ...REQUEST,
+      claimId: "stale-bundle-pending-claim",
+      runId: "stale-bundle-pending-run",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    placementStore.markWorkspaceResultPending(claim);
+
+    const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    const restartedHarness = createHarness(restartedStore, {
+      destroyPendingOwnerDuringEnvironmentReconcile: true,
+    });
+    restartedHarness.markEnvironmentOwnerEpoch(2);
+
+    await restartedHarness.service.reconcile();
+
+    expect(restartedHarness.log.indexOf("workspace:reconcile")).toBeLessThan(
+      restartedHarness.log.indexOf("environment:reconcile"),
+    );
+    expect(restartedHarness.log).not.toContain("environment:stale-bundle-destroy");
+    expect(restartedHarness.placements.current()).toMatchObject({
+      state: "reclaimed",
+      turnClaim: null,
+      workspaceBaseManifestRef: restartedHarness.reconciledManifestRef,
+    });
+    expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
+  });
+
   it("keeps a previous-instance pending result fenced when another session is attached", async () => {
     const originalHarness = createHarness(placementStore);
     const active = originalHarness.placements.seedActive(2);
@@ -230,6 +177,9 @@ describe("worker placement dispatch", () => {
     });
     expect(restartedStore.listPendingWorkspaceResults()).toHaveLength(1);
     expect(restartedHarness.environments.destroy).not.toHaveBeenCalled();
+
+    await restartedHarness.service.forceDestroyEnvironment(active.environmentId);
+    expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
   });
 
   it("recovers a draining turn result using the admitted claim generation", async () => {
@@ -301,6 +251,151 @@ describe("worker placement dispatch", () => {
     });
     expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
     expect(harness.environments.destroy).not.toHaveBeenCalled();
+
+    await harness.service.reconcile();
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "active",
+      turnClaim: { claimId: claim.claimId },
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+  });
+
+  it("retains final-fence terminal recovery until forced abandonment after restart", async () => {
+    const terminalMessage =
+      "Worker workspace sync failed: workspace quiescence recovery timed out; lease retained for operator recovery";
+    const harness = createHarness(placementStore, {
+      leaseError: new Error("Worker workspace quiescence renewal failed", {
+        cause: new WorkerWorkspaceOperatorRecoveryError(new Error(terminalMessage)),
+      }),
+    });
+    const active = harness.placements.seedActive(2);
+    harness.markEnvironmentOwnerEpoch(2);
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = placementStore.claimTurn({
+      ...REQUEST,
+      claimId: "terminal-resume-failure-claim",
+      runId: "terminal-resume-failure-run",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    placementStore.markWorkspaceResultPending(claim);
+    placementStore.handoffWorkspaceResultRecovery(claim);
+
+    await harness.service.reconcile();
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: expect.stringContaining(OPERATOR_RECOVERY_GUIDANCE),
+      turnClaim: null,
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+
+    await harness.service.reconcile();
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: expect.stringContaining(OPERATOR_RECOVERY_GUIDANCE),
+      turnClaim: null,
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+
+    const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    const restartedHarness = createHarness(restartedStore);
+    await restartedHarness.service.reconcile();
+
+    expect(restartedHarness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: expect.stringContaining(OPERATOR_RECOVERY_GUIDANCE),
+      turnClaim: null,
+    });
+    expect(restartedStore.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(restartedHarness.environments.destroy).not.toHaveBeenCalled();
+
+    await restartedHarness.service.forceDestroyEnvironment(active.environmentId);
+
+    expect(restartedHarness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+      turnClaim: null,
+    });
+    expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
+  });
+
+  it("drains a running nested session operation before retaining terminal recovery", async () => {
+    const terminalMessage =
+      "Worker workspace sync failed: workspace quiescence recovery timed out; lease retained for operator recovery";
+    const harness = createHarness(placementStore, {
+      leaseError: new WorkerWorkspaceOperatorRecoveryError(new Error(terminalMessage)),
+    });
+    const active = harness.placements.seedActive(2);
+    harness.markEnvironmentOwnerEpoch(2);
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = placementStore.claimTurn({
+      ...REQUEST,
+      claimId: "terminal-running-operation-claim",
+      runId: "terminal-running-operation-run",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    placementStore.markWorkspaceResultPending(claim);
+    placementStore.authorizeWorkerTurnTools(claim, ["sessions_send"]);
+    const binding = {
+      sessionId: claim.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      runId: claim.runId,
+    };
+    expect(
+      placementStore.beginWorkerSessionToolOperation({
+        binding,
+        toolName: "sessions_send",
+        toolCallId: "terminal-running-operation-call",
+        requestDigest: "terminal-running-operation-digest",
+      }),
+    ).toMatchObject({ kind: "execute" });
+    placementStore.handoffWorkspaceResultRecovery(claim);
+
+    const reconciliation = harness.service.reconcile();
+
+    await vi.waitFor(() => {
+      expect(placementStore.isWorkerTurnToolAuthorized(binding, "sessions_send")).toBe(false);
+    });
+    expect(harness.placements.current()).toMatchObject({
+      state: "active",
+      turnClaim: { claimId: claim.claimId },
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
+
+    expect(
+      placementStore.completeWorkerSessionToolOperation({
+        sourceSessionId: claim.sessionId,
+        sourceClaimId: claim.claimId,
+        toolCallId: "terminal-running-operation-call",
+        requestDigest: "terminal-running-operation-digest",
+        resultJson: '{"status":"ok"}',
+      }),
+    ).toBe(true);
+    await reconciliation;
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      turnClaim: null,
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
   });
 
   it("fails a pending result with diagnostics when its worker is proven lost", async () => {
@@ -443,6 +538,111 @@ describe("worker placement dispatch", () => {
     expect(harness.log).toContain("workspace:resume");
   });
 
+  it("records terminal operator recovery from explicit reclaim", async () => {
+    const terminalMessage =
+      "Worker workspace sync failed: workspace quiescence recovery timed out; lease retained for operator recovery";
+    const harness = createHarness(placementStore, {
+      leaseError: new Error("Worker workspace quiescence renewal failed", {
+        cause: new WorkerWorkspaceOperatorRecoveryError(new Error(terminalMessage)),
+      }),
+    });
+    await harness.service.dispatch(REQUEST);
+    const request = {
+      sessionId: REQUEST.sessionId,
+      sessionKey: REQUEST.sessionKey,
+      agentId: REQUEST.agentId,
+    };
+
+    await expect(harness.service.reclaim(request)).rejects.toThrow(
+      "Worker workspace quiescence renewal failed",
+    );
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: expect.stringContaining(OPERATOR_RECOVERY_GUIDANCE),
+      turnClaim: null,
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+    await expect(harness.service.reclaim(request)).rejects.toThrow(
+      "Failed cloud worker environment must be stopped before reclaim",
+    );
+  });
+
+  it("waits for a running nested operation before explicit reclaim returns", async () => {
+    const leaseBarrier = createDeferred();
+    const terminalMessage =
+      "Worker workspace sync failed: workspace quiescence recovery timed out; lease retained for operator recovery";
+    const harness = createHarness(placementStore, {
+      leaseBarrier: leaseBarrier.promise,
+      leaseError: new WorkerWorkspaceOperatorRecoveryError(new Error(terminalMessage)),
+    });
+    await harness.service.dispatch(REQUEST);
+    const reclaim = harness.service.reclaim({
+      sessionId: REQUEST.sessionId,
+      sessionKey: REQUEST.sessionKey,
+      agentId: REQUEST.agentId,
+    });
+
+    await vi.waitFor(() => {
+      expect(placementStore.listPendingWorkspaceResults()).toHaveLength(1);
+    });
+    const pending = placementStore.listPendingWorkspaceResults()[0]!;
+    const claim = {
+      sessionId: pending.sessionId,
+      claimId: pending.claimId,
+      runId: pending.runId,
+      placementGeneration: pending.placementGeneration,
+      owner: {
+        kind: "worker" as const,
+        environmentId: pending.environmentId,
+        ownerEpoch: pending.ownerEpoch,
+      },
+    };
+    const binding = {
+      sessionId: claim.sessionId,
+      environmentId: claim.owner.environmentId,
+      ownerEpoch: claim.owner.ownerEpoch,
+      runId: claim.runId,
+    };
+    placementStore.authorizeWorkerTurnTools(claim, ["sessions_send"]);
+    expect(
+      placementStore.beginWorkerSessionToolOperation({
+        binding,
+        toolName: "sessions_send",
+        toolCallId: "explicit-reclaim-running-call",
+        requestDigest: "explicit-reclaim-running-digest",
+      }),
+    ).toMatchObject({ kind: "execute" });
+    let settled = false;
+    void reclaim.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    leaseBarrier.resolve();
+    await vi.waitFor(() => {
+      expect(placementStore.isWorkerTurnToolAuthorized(binding, "sessions_send")).toBe(false);
+    });
+    expect(settled).toBe(false);
+    expect(
+      placementStore.completeWorkerSessionToolOperation({
+        sourceSessionId: claim.sessionId,
+        sourceClaimId: claim.claimId,
+        toolCallId: "explicit-reclaim-running-call",
+        requestDigest: "explicit-reclaim-running-digest",
+        resultJson: '{"status":"ok"}',
+      }),
+    ).toBe(true);
+
+    await expect(reclaim).rejects.toThrow(terminalMessage);
+    expect(harness.placements.current()).toMatchObject({ state: "failed", turnClaim: null });
+  });
+
   it("keeps the active worker when the accepted local result changes", async () => {
     const harness = createHarness(placementStore, { localVerifyFails: true });
     await harness.service.dispatch(REQUEST);
@@ -483,30 +683,6 @@ describe("worker placement dispatch", () => {
     expect(harness.log).toContain("workspace:resume");
   });
 
-  it("preserves a provider destroy failure after teardown owns the stopped tunnel", async () => {
-    const harness = createHarness(placementStore, {
-      destroyFails: true,
-      destroyFailureState: "destroying",
-      resumeFails: true,
-    });
-    const active = await harness.service.dispatch(REQUEST);
-
-    await expect(harness.service.reclaim(REQUEST)).rejects.toThrow("destroy pending");
-
-    expect(harness.environments.get(active.environmentId)).toMatchObject({
-      state: "destroying",
-      ownerEpoch: active.activeOwnerEpoch,
-    });
-    expect(harness.placements.current()).toMatchObject({
-      state: "active",
-      turnClaim: { owner: "worker" },
-    });
-    expect(placementStore.listPendingWorkspaceResults()).toMatchObject([
-      { workspaceAcceptedAtMs: expect.any(Number) },
-    ]);
-    expect(harness.log).not.toContain("workspace:resume");
-  });
-
   it.each<DispatchStage>([
     "barrier",
     "workspace",
@@ -534,105 +710,6 @@ describe("worker placement dispatch", () => {
     }
   });
 
-  it("rejects workspace preflight before allocation and allows a corrected redispatch", async () => {
-    const rejectedHarness = createHarness(placementStore, { failAt: "preflight" });
-
-    await expect(rejectedHarness.service.dispatch(REQUEST)).rejects.toMatchObject({
-      code: "invalid_state",
-      message: "preflight failed",
-    });
-
-    expect(rejectedHarness.placements.current()).toBeUndefined();
-    expect(rejectedHarness.log).toEqual(["barrier", "preflight"]);
-    expect(rejectedHarness.environments.create).not.toHaveBeenCalled();
-
-    const correctedHarness = createHarness(placementStore);
-    const active = await correctedHarness.service.dispatch(REQUEST);
-
-    expect(active.state).toBe("active");
-    expect(correctedHarness.log.indexOf("preflight")).toBeLessThan(
-      correctedHarness.log.indexOf("placement:requested"),
-    );
-  });
-
-  it.each(["requested", "provisioning", "syncing"] as const)(
-    "allows explicit redispatch after restart recovery fails an interrupted %s placement",
-    async (interruptedState) => {
-      let interrupted = placementStore.startDispatch(REQUEST);
-      if (interruptedState !== "requested") {
-        interrupted = placementStore.transition({
-          sessionId: REQUEST.sessionId,
-          from: "requested",
-          to: "provisioning",
-          expectedGeneration: interrupted.generation,
-          patch: {
-            environmentId: deriveEnvironmentIntent(
-              `session-dispatch:${REQUEST.sessionId}:${interrupted.generation}`,
-            ).environmentId,
-          },
-        });
-      }
-      if (interruptedState === "syncing") {
-        interrupted = placementStore.transition({
-          sessionId: REQUEST.sessionId,
-          from: "provisioning",
-          to: "syncing",
-          expectedGeneration: interrupted.generation,
-          patch: { workerBundleHash: "a".repeat(64) },
-        });
-      }
-      const interruptedEnvironmentId = interrupted.environmentId;
-      const restartedHarness = createHarness(placementStore);
-
-      await restartedHarness.service.reconcile();
-      const failed = restartedHarness.placements.current();
-      expect(failed).toMatchObject({
-        state: "failed",
-        recoveryError: `Worker dispatch interrupted in ${interruptedState}`,
-      });
-      if (failed?.state !== "failed") {
-        throw new Error("restart recovery did not fail the interrupted placement");
-      }
-      const environmentOwned = interruptedState !== "requested";
-      expect(restartedHarness.environments.stopTunnel).toHaveBeenCalledTimes(
-        environmentOwned ? 1 : 0,
-      );
-      expect(restartedHarness.environments.destroy).toHaveBeenCalledTimes(environmentOwned ? 1 : 0);
-      const redispatchHarness = createHarness(placementStore, {
-        environmentGeneration: failed.generation + 1,
-      });
-
-      const active = await redispatchHarness.service.dispatch(REQUEST);
-
-      expect(active).toMatchObject({
-        state: "active",
-        environmentId: redispatchHarness.ready.environmentId,
-      });
-      expect(active.generation).toBeGreaterThan(failed.generation);
-      expect(active.environmentId).not.toBe(interruptedEnvironmentId);
-      expect(redispatchHarness.log).toContain("placement:requested");
-    },
-  );
-
-  it("tears down the attached owner after restart interrupts workspace sync", async () => {
-    const harness = createHarness(placementStore);
-    const interrupted = seedSyncingPlacement(placementStore, harness.attached.environmentId);
-    harness.markEnvironmentOwnerEpoch(harness.attached.ownerEpoch);
-
-    await harness.service.reconcile();
-
-    expect(harness.placements.current()).toMatchObject({
-      state: "failed",
-      recoveryError: "Worker dispatch interrupted in syncing",
-    });
-    expect(harness.environments.attachSession).not.toHaveBeenCalled();
-    expect(harness.environments.stopTunnel).toHaveBeenCalledWith(
-      interrupted.environmentId,
-      undefined,
-    );
-    expect(harness.environments.destroy).toHaveBeenCalledOnce();
-  });
-
   it("does not fail or tear down a dispatch owned by another invocation", async () => {
     placementStore.startDispatch(REQUEST);
     const harness = createHarness(placementStore);
@@ -644,19 +721,6 @@ describe("worker placement dispatch", () => {
     expect(harness.placements.current()).toMatchObject({ state: "requested" });
     expect(harness.log).not.toContain("placement:failed");
     expect(harness.log).not.toContain("teardown:destroy");
-  });
-
-  it("rejects and tears down a freshly provisioned bundle without execution context", async () => {
-    const harness = createHarness(placementStore);
-    harness.markEnvironmentProtocolFeatures([WORKER_LAUNCH_V2_PROTOCOL_FEATURE]);
-
-    await expect(harness.service.dispatch(REQUEST)).rejects.toThrow(
-      "current execution-context contract",
-    );
-
-    expect(harness.placements.current()).toMatchObject({ state: "failed" });
-    expect(harness.environments.startTunnel).not.toHaveBeenCalled();
-    expect(harness.environments.destroy).toHaveBeenCalledOnce();
   });
 
   it("persists pending teardown evidence after placement is fenced", async () => {
@@ -684,8 +748,8 @@ describe("worker placement dispatch", () => {
     await harness.service.reconcile();
 
     expect(harness.log).toEqual([
-      "environment:reconcile",
       "workspace",
+      "environment:reconcile",
       "tunnel:attached",
       "placement:adopted",
     ]);
@@ -693,7 +757,7 @@ describe("worker placement dispatch", () => {
     expect(harness.environments.destroy).not.toHaveBeenCalled();
   });
 
-  it("reclaims an active worker missing execution context instead of adopting it", async () => {
+  it("reclaims an active pre-v2 worker instead of adopting its stale launch contract", async () => {
     const harness = createHarness(placementStore);
     await harness.environments.attachSession({
       environmentId: harness.ready.environmentId,
@@ -701,7 +765,7 @@ describe("worker placement dispatch", () => {
       sessionId: REQUEST.sessionId,
     });
     harness.placements.seedActive(harness.attached.ownerEpoch);
-    harness.markEnvironmentProtocolFeatures([WORKER_LAUNCH_V2_PROTOCOL_FEATURE]);
+    harness.markEnvironmentProtocolFeatures([]);
 
     await harness.service.reconcile();
 
@@ -710,10 +774,10 @@ describe("worker placement dispatch", () => {
     expect(harness.environments.destroy).toHaveBeenCalledOnce();
   });
 
-  it("fails an active placement whose environment disappeared before restart", async () => {
+  it("fails an active placement whose environment is already terminal after restart", async () => {
     const harness = createHarness(placementStore);
     harness.placements.seedActive(harness.attached.ownerEpoch);
-    harness.markEnvironmentFailed();
+    harness.markEnvironmentDestroyed();
     harness.log.length = 0;
 
     await harness.service.reconcile();
@@ -722,15 +786,13 @@ describe("worker placement dispatch", () => {
       state: "failed",
       environmentId: harness.ready.environmentId,
       activeOwnerEpoch: harness.attached.ownerEpoch,
-      recoveryError:
-        "cloud worker disappeared: Worker environment disappeared before teardown was requested",
-      terminalReason:
-        "cloud worker disappeared: Worker environment disappeared before teardown was requested",
+      recoveryError: "cloud worker disappeared: environment state destroyed",
+      terminalReason: "cloud worker disappeared: environment state destroyed",
       terminalAtMs: expect.any(Number),
     });
     expect(harness.log).toEqual([
-      "environment:reconcile",
       "workspace",
+      "environment:reconcile",
       "placement:draining",
       "placement:reconciling",
       "placement:failed",
@@ -803,8 +865,8 @@ describe("worker placement dispatch", () => {
       recoveryError: "Active worker turn claim cannot be proven live after gateway restart",
     });
     expect(harness.log).toEqual([
-      "environment:reconcile",
       "workspace",
+      "environment:reconcile",
       "placement:draining",
       "placement:reconciling",
       "teardown:stop",
@@ -827,8 +889,8 @@ describe("worker placement dispatch", () => {
       activeOwnerEpoch: harness.attached.ownerEpoch,
     });
     expect(harness.log).toEqual([
-      "environment:reconcile",
       "workspace",
+      "environment:reconcile",
       "attach",
       "tunnel:attached",
       "activation",
@@ -837,37 +899,10 @@ describe("worker placement dispatch", () => {
     expect(harness.environments.create).not.toHaveBeenCalled();
   });
 
-  it("resumes a synced starting placement with its existing attached owner", async () => {
+  it("tears down a starting pre-v2 worker instead of resuming its stale launch contract", async () => {
     const harness = createHarness(placementStore);
     harness.placements.seedStarting();
-    harness.markEnvironmentOwnerEpoch(harness.attached.ownerEpoch);
-    harness.log.length = 0;
-
-    await harness.service.reconcile();
-
-    expect(harness.placements.current()).toMatchObject({
-      state: "active",
-      environmentId: harness.attached.environmentId,
-      activeOwnerEpoch: harness.attached.ownerEpoch,
-    });
-    expect(harness.log).toEqual([
-      "environment:reconcile",
-      "workspace",
-      "tunnel:attached",
-      "activation",
-      "placement:active",
-    ]);
-    expect(harness.environments.attachSession).not.toHaveBeenCalled();
-    expect(harness.environments.startTunnel).toHaveBeenCalledWith({
-      environmentId: harness.attached.environmentId,
-      ownerEpoch: harness.attached.ownerEpoch,
-    });
-  });
-
-  it("tears down a starting worker missing execution context instead of resuming it", async () => {
-    const harness = createHarness(placementStore);
-    harness.placements.seedStarting();
-    harness.markEnvironmentProtocolFeatures([WORKER_LAUNCH_V2_PROTOCOL_FEATURE]);
+    harness.markEnvironmentProtocolFeatures([]);
 
     await harness.service.reconcile();
 
@@ -892,8 +927,8 @@ describe("worker placement dispatch", () => {
       recoveryError: "Worker dispatch interrupted in draining",
     });
     expect(harness.log).toEqual([
-      "environment:reconcile",
       "workspace",
+      "environment:reconcile",
       "placement:reconciling",
       "teardown:stop",
       "teardown:destroy",
@@ -911,8 +946,8 @@ describe("worker placement dispatch", () => {
       state: "reclaimed",
     });
     expect(harness.log).toEqual([
-      "environment:reconcile",
       "workspace",
+      "environment:reconcile",
       "placement:draining",
       "placement:reconciling",
       "teardown:stop",
@@ -968,7 +1003,7 @@ describe("worker placement dispatch", () => {
       sessionId: REQUEST.sessionId,
     });
     harness.placements.seedActive(harness.attached.ownerEpoch);
-    const claim = placementStore.claimTurn({
+    placementStore.claimTurn({
       ...REQUEST,
       claimId: "claim-1",
       runId: "run-1",
@@ -978,44 +1013,10 @@ describe("worker placement dispatch", () => {
         ownerEpoch: harness.attached.ownerEpoch,
       },
     });
-    const binding = {
-      sessionId: claim.sessionId,
-      environmentId: harness.attached.environmentId,
-      ownerEpoch: harness.attached.ownerEpoch,
-      runId: claim.runId,
-    };
-    placementStore.authorizeWorkerTurnTools(claim, ["sessions_send"]);
-    expect(
-      placementStore.beginWorkerSessionToolOperation({
-        binding,
-        toolName: "sessions_send",
-        toolCallId: "call-owner-mismatch",
-        requestDigest: "digest-owner-mismatch",
-      }),
-    ).toMatchObject({ kind: "execute" });
     harness.markEnvironmentOwnerEpoch(harness.attached.ownerEpoch + 1);
     harness.log.length = 0;
 
-    const reconciliation = harness.service.reconcileActive();
-
-    await vi.waitFor(() => {
-      expect(placementStore.isWorkerTurnToolAuthorized(binding, "sessions_send")).toBe(false);
-    });
-    expect(harness.environments.destroy).not.toHaveBeenCalled();
-    expect(harness.placements.current()).toMatchObject({
-      state: "draining",
-      turnClaim: { claimId: claim.claimId },
-    });
-    expect(
-      placementStore.completeWorkerSessionToolOperation({
-        sourceSessionId: claim.sessionId,
-        sourceClaimId: claim.claimId,
-        toolCallId: "call-owner-mismatch",
-        requestDigest: "digest-owner-mismatch",
-        resultJson: '{"status":"ok"}',
-      }),
-    ).toBe(true);
-    await reconciliation;
+    await harness.service.reconcileActive();
 
     expect(harness.placements.current()).toMatchObject({
       state: "failed",
@@ -1032,20 +1033,18 @@ describe("worker placement dispatch", () => {
     ]);
   });
 
-  it("fails an active placement when its environment disappears", async () => {
+  it("fails a terminal active environment during runtime reconciliation", async () => {
     const harness = createHarness(placementStore);
     harness.placements.seedActive(harness.attached.ownerEpoch);
-    harness.markEnvironmentFailed();
+    harness.markEnvironmentDestroyed();
     harness.log.length = 0;
 
     await harness.service.reconcileActive();
 
     expect(harness.placements.current()).toMatchObject({
       state: "failed",
-      recoveryError:
-        "cloud worker disappeared: Worker environment disappeared before teardown was requested",
-      terminalReason:
-        "cloud worker disappeared: Worker environment disappeared before teardown was requested",
+      recoveryError: "cloud worker disappeared: environment state destroyed",
+      terminalReason: "cloud worker disappeared: environment state destroyed",
     });
     expect(harness.log).toEqual([
       "environment:reconcile",
@@ -1059,7 +1058,7 @@ describe("worker placement dispatch", () => {
   it("limits requested runtime reconciliation to one environment", async () => {
     const harness = createHarness(placementStore);
     harness.placements.seedActive(harness.attached.ownerEpoch);
-    harness.markEnvironmentFailed();
+    harness.markEnvironmentDestroyed();
     harness.log.length = 0;
 
     await harness.service.reconcileActive("worker-other");
@@ -1071,8 +1070,7 @@ describe("worker placement dispatch", () => {
 
     expect(harness.placements.current()).toMatchObject({
       state: "failed",
-      recoveryError:
-        "cloud worker disappeared: Worker environment disappeared before teardown was requested",
+      recoveryError: "cloud worker disappeared: environment state destroyed",
     });
   });
 
@@ -1092,7 +1090,7 @@ describe("worker placement dispatch", () => {
   it("fences a turn admitted immediately before runtime drain", async () => {
     const harness = createHarness(placementStore, { claimOnDrain: true });
     harness.placements.seedActive(harness.attached.ownerEpoch);
-    harness.markEnvironmentFailed();
+    harness.markEnvironmentDestroyed();
     harness.log.length = 0;
 
     await harness.service.reconcileActive();
@@ -1100,8 +1098,7 @@ describe("worker placement dispatch", () => {
     expect(harness.placements.current()).toMatchObject({
       state: "failed",
       turnClaim: null,
-      recoveryError:
-        "cloud worker disappeared: Worker environment disappeared before teardown was requested",
+      recoveryError: "cloud worker disappeared: environment state destroyed",
     });
     expect(harness.log).toEqual([
       "environment:reconcile",

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -12,10 +12,10 @@ import {
 import {
   type DispatchStage,
   type PlacementStore,
+  FORCED_WORKER_ABANDONMENT_ERROR,
   REQUEST,
 } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
-import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { WorkerWorkspaceOperatorRecoveryError } from "./tunnel-contract.js";
 

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -12,10 +12,10 @@ import {
 import {
   type DispatchStage,
   type PlacementStore,
-  FORCED_WORKER_ABANDONMENT_ERROR,
   REQUEST,
 } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { WorkerWorkspaceOperatorRecoveryError } from "./tunnel-contract.js";
 

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -589,13 +589,18 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
 
   return {
     dispatch,
-    forceDestroyEnvironment: (environmentId: string, onCleanupError?: (error: unknown) => void) =>
+    forceDestroyEnvironment: (
+      environmentId: string,
+      onCleanupError?: (error: unknown) => void,
+      authorizeAbandonment?: () => boolean,
+    ) =>
       options.workspaceOperations.run(environmentId, async () => {
         await forceAbandonWorkerEnvironment({
           placements,
           environmentId,
           resolveWorkspacePath: options.resolveWorkspacePath,
           onCleanupError,
+          authorizeAbandonment,
         });
         try {
           return await environments.destroyOwned(environmentId, () =>

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -599,7 +599,6 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           placements,
           environmentId,
           resolveWorkspacePath: options.resolveWorkspacePath,
-          resolveWorkspaceResultConflict: options.resolveWorkspaceResultConflict,
           reportWorkspaceResultConflict: options.reportWorkspaceResultConflict,
           onCleanupError,
           authorizeAbandonment,

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -20,7 +20,10 @@ import type {
 import { deriveEnvironmentIntent } from "./service-contract.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-lifecycle.js";
-import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
+import {
+  findWorkerWorkspaceOperatorRecoveryError,
+  WorkerTunnelOwnerDisconnectedError,
+} from "./tunnel-contract.js";
 import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import {
   verifyReconciledWorkspaceFinal,
@@ -466,7 +469,9 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                   conflictRetained: finalized.conflictRetained,
                   reclaim: true,
                   beforeComplete: async () => {
-                    await environments.destroy(current.environmentId);
+                    await environments.destroyOwned(current.environmentId, () =>
+                      placements.canDestroyAcceptedWorkspaceResult(reclaimClaim),
+                    );
                     destroyed = true;
                   },
                   validateCompleted: (completed) => {
@@ -495,6 +500,29 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
         try {
           return await finishReclaim();
         } catch (error) {
+          const operatorRecoveryError = findWorkerWorkspaceOperatorRecoveryError(error);
+          if (operatorRecoveryError) {
+            const owned = placements.get(current.sessionId);
+            const retainsReclaimResult = placements
+              .listPendingWorkspaceResults()
+              .some(
+                (pending) =>
+                  pending.sessionId === reclaimClaim.sessionId &&
+                  pending.claimId === reclaimClaim.claimId &&
+                  pending.runId === reclaimClaim.runId,
+              );
+            if (
+              owned?.state === "active" &&
+              owned.generation === current.generation &&
+              owned.environmentId === current.environmentId &&
+              owned.activeOwnerEpoch === current.activeOwnerEpoch &&
+              owned.turnClaim?.claimId === reclaimClaim.claimId &&
+              retainsReclaimResult
+            ) {
+              await failure.recordRetainedResultFailure(owned, operatorRecoveryError);
+            }
+            throw error;
+          }
           // An unstaged final-fence failure is retryable even after an unchanged
           // manifest commit; the journal remains authoritative for the next attempt.
           await cancelUnstagedFailedReclaim(
@@ -570,7 +598,9 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           onCleanupError,
         });
         try {
-          return await environments.destroy(environmentId);
+          return await environments.destroyOwned(environmentId, () =>
+            placements.canDestroyForceAbandonedEnvironment(environmentId),
+          );
         } catch (error) {
           const current = environments.get(environmentId);
           if (!current || !isUnavailableEnvironment(current)) {

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -73,7 +73,7 @@ type WorkerPlacementDispatchOptions = {
   reportWorkspaceResultConflict: (
     params: { sessionId: string; sessionKey: string; agentId: string } & (
       | { paths: string[]; stagedResultRef: string; totalCount: number }
-      | { cleared: true }
+      | { cleared: true; stagedResultRef?: string }
     ),
   ) => Promise<void>;
   resolveWorkspaceResultConflict: (params: {
@@ -599,6 +599,8 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           placements,
           environmentId,
           resolveWorkspacePath: options.resolveWorkspacePath,
+          resolveWorkspaceResultConflict: options.resolveWorkspaceResultConflict,
+          reportWorkspaceResultConflict: options.reportWorkspaceResultConflict,
           onCleanupError,
           authorizeAbandonment,
         });

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -19,7 +19,7 @@ import {
   seedActivePlacement,
 } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
-import { forceAbandonWorkerEnvironment } from "./placement-force-abandon.js";
+import { forceAbandonWorkerEnvironment as forceAbandonWorkerEnvironmentOwner } from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import {
@@ -32,6 +32,46 @@ import {
 const effects = vi.hoisted(() => ({
   workerPlacementError: vi.fn(),
 }));
+
+async function createWorkspaceResultRefs(workspacePath: string, refs: readonly string[]) {
+  await fs.mkdir(workspacePath);
+  const initialized = await runCommandWithTimeout(["git", "-C", workspacePath, "init", "--quiet"], {
+    timeoutMs: 10_000,
+  });
+  expect(initialized.code).toBe(0);
+  const artifactPath = path.join(workspacePath, "artifact");
+  await fs.writeFile(artifactPath, "retained terminal result\n");
+  const hashed = await runCommandWithTimeout(
+    ["git", "-C", workspacePath, "hash-object", "-w", artifactPath],
+    { timeoutMs: 10_000 },
+  );
+  expect(hashed.code).toBe(0);
+  for (const ref of refs) {
+    const updated = await runCommandWithTimeout(
+      ["git", "-C", workspacePath, "update-ref", ref, hashed.stdout.trim()],
+      { timeoutMs: 10_000 },
+    );
+    expect(updated.code).toBe(0);
+  }
+}
+
+type ForceAbandonParams = Parameters<typeof forceAbandonWorkerEnvironmentOwner>[0];
+
+async function forceAbandonWorkerEnvironment(
+  params: Omit<
+    ForceAbandonParams,
+    "reportWorkspaceResultConflict" | "resolveWorkspaceResultConflict"
+  > &
+    Partial<
+      Pick<ForceAbandonParams, "reportWorkspaceResultConflict" | "resolveWorkspaceResultConflict">
+    >,
+) {
+  return await forceAbandonWorkerEnvironmentOwner({
+    reportWorkspaceResultConflict: async () => {},
+    resolveWorkspaceResultConflict: async () => undefined,
+    ...params,
+  });
+}
 
 vi.mock("../../logging/subsystem.js", async () => {
   const actual = await vi.importActual<typeof import("../../logging/subsystem.js")>(
@@ -395,6 +435,11 @@ describe("forced worker environment abandonment", () => {
       claim,
       "refs/openclaw/worker-results/forced-missing-workspace-claim",
     );
+    store.recordWorkspaceResultConflict(claim, {
+      paths: ["artifact"],
+      stagedResultRef: "refs/openclaw/worker-results/forced-missing-workspace-claim",
+    });
+    const reportWorkspaceResultConflict = vi.fn(async () => {});
 
     await forceAbandonWorkerEnvironment({
       placements: store,
@@ -402,14 +447,69 @@ describe("forced worker environment abandonment", () => {
       resolveWorkspacePath: async () => {
         throw new Error("session-owned managed worktree is missing");
       },
+      reportWorkspaceResultConflict,
     });
 
     expect(store.get(REQUEST.sessionId)).toMatchObject({
       state: "failed",
       turnClaim: null,
       recoveryError: "Cloud worker result abandoned by forced operator teardown",
+      workspaceResultConflict: {
+        paths: ["artifact"],
+        stagedResultRef: "refs/openclaw/worker-results/forced-missing-workspace-claim",
+      },
     });
     expect(store.listPendingWorkspaceResults()).toEqual([]);
+    expect(reportWorkspaceResultConflict).not.toHaveBeenCalled();
+  });
+
+  it("retires the conflict projection after deleting every staged result ref", async () => {
+    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const { environmentId } = createDispatchEnvironmentFixtures();
+    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = store.claimTurn({
+      ...REQUEST,
+      claimId: "forced-conflict-claim",
+      runId: "forced-conflict-run",
+      owner: { kind: "worker", environmentId, ownerEpoch: 2 },
+    });
+    store.markWorkspaceResultPending(claim);
+    const finalRef = workerWorkspaceResultRef(claim.claimId);
+    const preparedRef = preparedWorkerWorkspaceResultRef(finalRef);
+    const cleanupRef = cleanupWorkerWorkspaceResultRef(finalRef);
+    store.recordStagedWorkspaceResult(claim, finalRef);
+    store.recordWorkspaceResultConflict(claim, {
+      paths: ["artifact"],
+      stagedResultRef: finalRef,
+    });
+    const workspacePath = path.join(root, "forced-conflict-workspace");
+    await createWorkspaceResultRefs(workspacePath, [finalRef, preparedRef, cleanupRef]);
+    const reportWorkspaceResultConflict = vi.fn(async () => {});
+
+    await forceAbandonWorkerEnvironment({
+      placements: store,
+      environmentId,
+      resolveWorkspacePath: async () => workspacePath,
+      reportWorkspaceResultConflict,
+    });
+
+    for (const ref of [finalRef, preparedRef, cleanupRef]) {
+      await expect(
+        hasWorkerWorkspaceResultRef({ root: workspacePath, stagedResultRef: ref }),
+      ).resolves.toBe(false);
+    }
+    expect(store.get(REQUEST.sessionId)).not.toHaveProperty("workspaceResultConflict");
+    expect(reportWorkspaceResultConflict).toHaveBeenCalledOnce();
+    expect(reportWorkspaceResultConflict).toHaveBeenCalledWith({
+      sessionId: REQUEST.sessionId,
+      sessionKey: REQUEST.sessionKey,
+      agentId: REQUEST.agentId,
+      cleared: true,
+      stagedResultRef: finalRef,
+    });
   });
 
   it("cleans a retained terminal result and journal after restart", async () => {
@@ -432,26 +532,7 @@ describe("forced worker environment abandonment", () => {
     store.recordStagedWorkspaceResult(claim, finalRef);
 
     const workspacePath = path.join(root, "retained-terminal-workspace");
-    await fs.mkdir(workspacePath);
-    const initialized = await runCommandWithTimeout(
-      ["git", "-C", workspacePath, "init", "--quiet"],
-      { timeoutMs: 10_000 },
-    );
-    expect(initialized.code).toBe(0);
-    const artifactPath = path.join(workspacePath, "artifact");
-    await fs.writeFile(artifactPath, "retained terminal result\n");
-    const hashed = await runCommandWithTimeout(
-      ["git", "-C", workspacePath, "hash-object", "-w", artifactPath],
-      { timeoutMs: 10_000 },
-    );
-    expect(hashed.code).toBe(0);
-    for (const ref of [finalRef, preparedRef, cleanupRef]) {
-      const updated = await runCommandWithTimeout(
-        ["git", "-C", workspacePath, "update-ref", ref, hashed.stdout.trim()],
-        { timeoutMs: 10_000 },
-      );
-      expect(updated.code).toBe(0);
-    }
+    await createWorkspaceResultRefs(workspacePath, [finalRef, preparedRef, cleanupRef]);
 
     const owner = {
       sessionId: active.sessionId,

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -169,6 +169,87 @@ describe("forced worker environment abandonment", () => {
     expect(store.listPendingWorkspaceResults()).toEqual([]);
   });
 
+  it("abandons a restarted remote-exec result after local authority was revoked", async () => {
+    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const harness = createHarness(store);
+    await harness.service.dispatch({ ...REQUEST, executionMode: "remote-exec" });
+    const active = store.get(REQUEST.sessionId);
+    if (active?.state !== "active") {
+      throw new Error("active remote-exec placement fixture was not active");
+    }
+    const claimId = "reclaim-restarted-forced-local";
+    const claim = store.claimReclaimWorkspaceResult({
+      ...REQUEST,
+      claimId,
+      runId: claimId,
+      owner: {
+        kind: "local",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    store.acceptWorkspaceResult(claim);
+    const closed = vi.fn();
+    const unregister = store.registerTurnClaimClosedHandler(closed);
+    expect(store.clearLocalTurnClaimsAfterRestart()).toBe(1);
+
+    await forceAbandonWorkerEnvironment({
+      placements: store,
+      environmentId: active.environmentId,
+      resolveWorkspacePath: async () => root,
+    });
+
+    expect(store.get(REQUEST.sessionId)).toMatchObject({
+      state: "failed",
+      executionMode: "remote-exec",
+      turnClaim: null,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+    expect(store.listPendingWorkspaceResults()).toEqual([]);
+    expect(closed).not.toHaveBeenCalled();
+    unregister();
+  });
+
+  it("records terminal recovery for a restarted remote-exec result", async () => {
+    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const harness = createHarness(store);
+    await harness.service.dispatch({ ...REQUEST, executionMode: "remote-exec" });
+    const active = store.get(REQUEST.sessionId);
+    if (active?.state !== "active") {
+      throw new Error("active remote-exec placement fixture was not active");
+    }
+    const claimId = "reclaim-restarted-terminal-local";
+    store.claimReclaimWorkspaceResult({
+      ...REQUEST,
+      claimId,
+      runId: claimId,
+      owner: {
+        kind: "local",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    const pending = store.listPendingWorkspaceResults()[0]!;
+    const closed = vi.fn();
+    const unregister = store.registerTurnClaimClosedHandler(closed);
+    expect(store.clearLocalTurnClaimsAfterRestart()).toBe(1);
+
+    const failed = await store.failPendingWorkspaceResult({
+      pending,
+      recoveryError: "Workspace recovery requires operator action",
+    });
+
+    expect(failed).toMatchObject({
+      state: "failed",
+      executionMode: "remote-exec",
+      turnClaim: null,
+      recoveryError: "Workspace recovery requires operator action",
+    });
+    expect(store.listPendingWorkspaceResults()).toEqual([pending]);
+    expect(closed).not.toHaveBeenCalled();
+    unregister();
+  });
+
   it("drains nested operations before forced teardown without a pending result", async () => {
     const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
     const { environmentId } = createDispatchEnvironmentFixtures();

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -14,14 +14,12 @@ import {
 import { createGatewayWorkerPlacementRuntime } from "../server-worker-placement-startup.js";
 import {
   createDispatchEnvironmentFixtures,
+  FORCED_WORKER_ABANDONMENT_ERROR,
   REQUEST,
   seedActivePlacement,
 } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
-import {
-  FORCED_WORKER_ABANDONMENT_ERROR,
-  forceAbandonWorkerEnvironment,
-} from "./placement-force-abandon.js";
+import { forceAbandonWorkerEnvironment } from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import {

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -3,24 +3,55 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { createGatewayWorkerPlacementRuntime } from "../server-worker-placement-startup.js";
 import {
   createDispatchEnvironmentFixtures,
+  FORCED_WORKER_ABANDONMENT_ERROR,
   REQUEST,
   seedActivePlacement,
 } from "./placement-dispatch-test-fixtures.js";
+import { createHarness } from "./placement-dispatch-test-harness.js";
 import { forceAbandonWorkerEnvironment } from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import type { WorkerEnvironmentService } from "./service.js";
+import {
+  cleanupWorkerWorkspaceResultRef,
+  hasWorkerWorkspaceResultRef,
+  preparedWorkerWorkspaceResultRef,
+  workerWorkspaceResultRef,
+} from "./workspace-result-staging.js";
+
+const effects = vi.hoisted(() => ({
+  workerPlacementError: vi.fn(),
+}));
+
+vi.mock("../../logging/subsystem.js", async () => {
+  const actual = await vi.importActual<typeof import("../../logging/subsystem.js")>(
+    "../../logging/subsystem.js",
+  );
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/worker-placement"
+        ? { ...logger, error: effects.workerPlacementError }
+        : logger;
+    },
+  };
+});
 
 describe("forced worker environment abandonment", () => {
   let root: string;
   let database: OpenClawStateDatabase;
 
   beforeEach(async () => {
+    effects.workerPlacementError.mockClear();
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-force-worker-"));
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
   });
@@ -43,6 +74,8 @@ describe("forced worker environment abandonment", () => {
       runId: "forced-run",
       owner: { kind: "worker", environmentId, ownerEpoch: 2 },
     });
+    const closed = vi.fn();
+    const unregister = store.registerTurnClaimClosedHandler(closed);
     store.markWorkspaceResultPending(claim);
     const binding = {
       sessionId: claim.sessionId,
@@ -90,6 +123,136 @@ describe("forced worker environment abandonment", () => {
       recoveryError: "Cloud worker result abandoned by forced operator teardown",
     });
     expect(store.listPendingWorkspaceResults()).toEqual([]);
+    expect(closed).toHaveBeenCalledOnce();
+    expect(closed).toHaveBeenCalledWith(claim);
+    unregister();
+  });
+
+  it("drains nested operations before forced teardown without a pending result", async () => {
+    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const { environmentId } = createDispatchEnvironmentFixtures();
+    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = store.claimTurn({
+      ...REQUEST,
+      claimId: "forced-operation-claim",
+      runId: "forced-operation-run",
+      owner: { kind: "worker", environmentId, ownerEpoch: 2 },
+    });
+    const binding = {
+      sessionId: claim.sessionId,
+      environmentId,
+      ownerEpoch: 2,
+      runId: claim.runId,
+    };
+    store.authorizeWorkerTurnTools(claim, ["sessions_send"]);
+    expect(
+      store.beginWorkerSessionToolOperation({
+        binding,
+        toolName: "sessions_send",
+        toolCallId: "forced-operation-send",
+        requestDigest: "forced-operation-digest",
+      }),
+    ).toMatchObject({ kind: "execute" });
+
+    const abandonment = forceAbandonWorkerEnvironment({
+      placements: store,
+      environmentId,
+      resolveWorkspacePath: async () => root,
+    });
+
+    await vi.waitFor(() => {
+      expect(store.isWorkerTurnToolAuthorized(binding, "sessions_send")).toBe(false);
+    });
+    expect(
+      store.completeWorkerSessionToolOperation({
+        sourceSessionId: claim.sessionId,
+        sourceClaimId: claim.claimId,
+        toolCallId: "forced-operation-send",
+        requestDigest: "forced-operation-digest",
+        resultJson: '{"status":"ok"}',
+      }),
+    ).toBe(true);
+    await abandonment;
+
+    expect(store.get(REQUEST.sessionId)).toMatchObject({
+      state: "failed",
+      turnClaim: null,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+  });
+
+  it("atomically abandons a terminal result ACKed while nested operations drain", async () => {
+    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const { environmentId } = createDispatchEnvironmentFixtures();
+    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = store.claimTurn({
+      ...REQUEST,
+      claimId: "forced-racing-result-claim",
+      runId: "forced-racing-result-run",
+      owner: { kind: "worker", environmentId, ownerEpoch: 2 },
+    });
+    const closed = vi.fn();
+    const unregister = store.registerTurnClaimClosedHandler(closed);
+    const binding = {
+      sessionId: claim.sessionId,
+      environmentId,
+      ownerEpoch: 2,
+      runId: claim.runId,
+    };
+    store.authorizeWorkerTurnTools(claim, ["sessions_send"]);
+    expect(
+      store.beginWorkerSessionToolOperation({
+        binding,
+        toolName: "sessions_send",
+        toolCallId: "forced-racing-result-send",
+        requestDigest: "forced-racing-result-digest",
+      }),
+    ).toMatchObject({ kind: "execute" });
+
+    const abandonment = forceAbandonWorkerEnvironment({
+      placements: store,
+      environmentId,
+      resolveWorkspacePath: async () => root,
+    });
+
+    await vi.waitFor(() => {
+      expect(store.isWorkerTurnToolAuthorized(binding, "sessions_send")).toBe(false);
+    });
+    expect(store.get(REQUEST.sessionId)).toMatchObject({
+      state: "draining",
+      turnClaim: { claimId: claim.claimId },
+    });
+    store.updateAckCursors({ claim, liveEvent: 1 });
+    expect(store.listPendingWorkspaceResults()).toMatchObject([
+      { sessionId: claim.sessionId, claimId: claim.claimId },
+    ]);
+    expect(
+      store.completeWorkerSessionToolOperation({
+        sourceSessionId: claim.sessionId,
+        sourceClaimId: claim.claimId,
+        toolCallId: "forced-racing-result-send",
+        requestDigest: "forced-racing-result-digest",
+        resultJson: '{"status":"ok"}',
+      }),
+    ).toBe(true);
+
+    await abandonment;
+
+    expect(store.get(REQUEST.sessionId)).toMatchObject({
+      state: "failed",
+      turnClaim: null,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+    expect(store.listPendingWorkspaceResults()).toEqual([]);
+    expect(closed).toHaveBeenCalledOnce();
+    expect(closed).toHaveBeenCalledWith(claim);
+    unregister();
   });
 
   it("releases a pending worker claim when its workspace is already gone", async () => {
@@ -123,6 +286,171 @@ describe("forced worker environment abandonment", () => {
       state: "failed",
       turnClaim: null,
       recoveryError: "Cloud worker result abandoned by forced operator teardown",
+    });
+    expect(store.listPendingWorkspaceResults()).toEqual([]);
+  });
+
+  it("cleans a retained terminal result and journal after restart", async () => {
+    let store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const { environmentId } = createDispatchEnvironmentFixtures();
+    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = store.claimTurn({
+      ...REQUEST,
+      claimId: "retained-terminal-claim",
+      runId: "retained-terminal-run",
+      owner: { kind: "worker", environmentId, ownerEpoch: 2 },
+    });
+    store.markWorkspaceResultPending(claim);
+    const finalRef = workerWorkspaceResultRef(claim.claimId);
+    const preparedRef = preparedWorkerWorkspaceResultRef(finalRef);
+    const cleanupRef = cleanupWorkerWorkspaceResultRef(finalRef);
+    store.recordStagedWorkspaceResult(claim, finalRef);
+
+    const workspacePath = path.join(root, "retained-terminal-workspace");
+    await fs.mkdir(workspacePath);
+    const initialized = await runCommandWithTimeout(
+      ["git", "-C", workspacePath, "init", "--quiet"],
+      { timeoutMs: 10_000 },
+    );
+    expect(initialized.code).toBe(0);
+    const artifactPath = path.join(workspacePath, "artifact");
+    await fs.writeFile(artifactPath, "retained terminal result\n");
+    const hashed = await runCommandWithTimeout(
+      ["git", "-C", workspacePath, "hash-object", "-w", artifactPath],
+      { timeoutMs: 10_000 },
+    );
+    expect(hashed.code).toBe(0);
+    for (const ref of [finalRef, preparedRef, cleanupRef]) {
+      const updated = await runCommandWithTimeout(
+        ["git", "-C", workspacePath, "update-ref", ref, hashed.stdout.trim()],
+        { timeoutMs: 10_000 },
+      );
+      expect(updated.code).toBe(0);
+    }
+
+    const owner = {
+      sessionId: active.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      placementGeneration: active.generation,
+    };
+    const appliedManifestRef = `sha256:${"d".repeat(64)}`;
+    store.beginWorkspaceReconciliation(owner, {
+      version: 1,
+      temporaryNonce: "e".repeat(32),
+      baseManifestRef: active.workspaceBaseManifestRef,
+      currentManifestRef: appliedManifestRef,
+      baseEntries: [],
+      appliedEntries: [],
+      baseTree: "f".repeat(40),
+      basePackSha256: createHash("sha256").update("").digest("hex"),
+      basePack: Buffer.alloc(0),
+    });
+    store.updateWorkspaceBaseManifest({ claim, manifestRef: appliedManifestRef });
+    const terminalMessage = "Worker workspace sync failed: lease retained for operator recovery";
+    await store.failPendingWorkspaceResult({
+      pending: store.listPendingWorkspaceResults()[0]!,
+      recoveryError: terminalMessage,
+    });
+
+    closeOpenClawStateDatabaseForTest();
+    database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    store = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    const restartedHarness = createHarness(store, { workspacePath });
+    const environments = {
+      ...restartedHarness.environments,
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+    } as unknown as WorkerEnvironmentService;
+    const runtime = createGatewayWorkerPlacementRuntime({
+      placements: store,
+      environments,
+      admitNewPlacements: false,
+      revokeSessionAuthority: vi.fn(),
+      warn: vi.fn(),
+    });
+    const sidecar = await runtime.startRuntime({
+      isClosePreludeStarted: () => false,
+      registerSidecar: vi.fn(),
+    });
+    expect(store.get(active.sessionId)).toMatchObject({
+      state: "failed",
+      recoveryError: terminalMessage,
+      turnClaim: null,
+    });
+    expect(store.listPendingWorkspaceResults()).toHaveLength(1);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+    expect(effects.workerPlacementError).not.toHaveBeenCalledWith(
+      expect.stringContaining(`cloud workspace recovery deferred for ${active.sessionId}`),
+    );
+    await sidecar?.stop();
+
+    await forceAbandonWorkerEnvironment({
+      placements: store,
+      environmentId,
+      resolveWorkspacePath: async () => workspacePath,
+    });
+
+    expect(store.get(active.sessionId)).toMatchObject({
+      state: "failed",
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+      turnClaim: null,
+    });
+    expect(store.listPendingWorkspaceResults()).toEqual([]);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([]);
+    for (const ref of [finalRef, preparedRef, cleanupRef]) {
+      await expect(
+        hasWorkerWorkspaceResultRef({ root: workspacePath, stagedResultRef: ref }),
+      ).resolves.toBe(false);
+    }
+  });
+
+  it("atomically rolls back forced terminal abandonment when the pending identity changed", async () => {
+    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const { environmentId } = createDispatchEnvironmentFixtures();
+    const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
+    if (active.state !== "active") {
+      throw new Error("active placement fixture was not active");
+    }
+    const claim = store.claimTurn({
+      ...REQUEST,
+      claimId: "atomic-terminal-claim",
+      runId: "atomic-terminal-run",
+      owner: { kind: "worker", environmentId, ownerEpoch: 2 },
+    });
+    store.markWorkspaceResultPending(claim);
+    const terminalMessage = "Worker workspace sync failed: lease retained for operator recovery";
+    await store.failPendingWorkspaceResult({
+      pending: store.listPendingWorkspaceResults()[0]!,
+      recoveryError: terminalMessage,
+    });
+    const pending = store.listPendingWorkspaceResults()[0]!;
+
+    expect(() =>
+      store.forceAbandonPendingWorkspaceResult({
+        pending: { ...pending, claimId: "changed-claim" },
+        recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+      }),
+    ).toThrow(`Worker workspace result changed for ${active.sessionId}`);
+
+    expect(store.get(active.sessionId)).toMatchObject({
+      state: "failed",
+      recoveryError: terminalMessage,
+      turnClaim: null,
+    });
+    expect(store.listPendingWorkspaceResults()).toEqual([pending]);
+
+    store.forceAbandonPendingWorkspaceResult({
+      pending,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+    expect(store.get(active.sessionId)).toMatchObject({
+      state: "failed",
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+      turnClaim: null,
     });
     expect(store.listPendingWorkspaceResults()).toEqual([]);
   });
@@ -220,6 +548,7 @@ describe("forced worker environment abandonment", () => {
 
     expect(store.get(REQUEST.sessionId)).toMatchObject({ state: "failed" });
     expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+    expect(store.canDestroyForceAbandonedEnvironment(environmentId)).toBe(true);
     expect(resolveWorkspacePath).toHaveBeenCalledTimes(2);
     expect(onCleanupError).toHaveBeenCalledWith(
       expect.objectContaining({ message: "workspace temporarily unavailable" }),
@@ -267,6 +596,7 @@ describe("forced worker environment abandonment", () => {
 
     expect(store.get(REQUEST.sessionId)).toMatchObject({ state: "failed" });
     expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+    expect(store.canDestroyForceAbandonedEnvironment(environmentId)).toBe(true);
     expect(resolveWorkspacePath).not.toHaveBeenCalled();
     expect(onCleanupError).toHaveBeenCalledWith(
       expect.objectContaining({ message: "journal temporarily unreadable" }),

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -58,17 +58,11 @@ async function createWorkspaceResultRefs(workspacePath: string, refs: readonly s
 type ForceAbandonParams = Parameters<typeof forceAbandonWorkerEnvironmentOwner>[0];
 
 async function forceAbandonWorkerEnvironment(
-  params: Omit<
-    ForceAbandonParams,
-    "reportWorkspaceResultConflict" | "resolveWorkspaceResultConflict"
-  > &
-    Partial<
-      Pick<ForceAbandonParams, "reportWorkspaceResultConflict" | "resolveWorkspaceResultConflict">
-    >,
+  params: Omit<ForceAbandonParams, "reportWorkspaceResultConflict"> &
+    Partial<Pick<ForceAbandonParams, "reportWorkspaceResultConflict">>,
 ) {
   return await forceAbandonWorkerEnvironmentOwner({
     reportWorkspaceResultConflict: async () => {},
-    resolveWorkspaceResultConflict: async () => undefined,
     ...params,
   });
 }
@@ -487,13 +481,18 @@ describe("forced worker environment abandonment", () => {
     });
     const workspacePath = path.join(root, "forced-conflict-workspace");
     await createWorkspaceResultRefs(workspacePath, [finalRef, preparedRef, cleanupRef]);
-    const reportWorkspaceResultConflict = vi.fn(async () => {});
+    const transcriptError = new Error("transcript unavailable");
+    const reportWorkspaceResultConflict = vi.fn(async () => {
+      throw transcriptError;
+    });
+    const onCleanupError = vi.fn();
 
     await forceAbandonWorkerEnvironment({
       placements: store,
       environmentId,
       resolveWorkspacePath: async () => workspacePath,
       reportWorkspaceResultConflict,
+      onCleanupError,
     });
 
     for (const ref of [finalRef, preparedRef, cleanupRef]) {
@@ -510,6 +509,7 @@ describe("forced worker environment abandonment", () => {
       cleared: true,
       stagedResultRef: finalRef,
     });
+    expect(onCleanupError).toHaveBeenCalledWith(transcriptError);
   });
 
   it("cleans a retained terminal result and journal after restart", async () => {

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -53,11 +55,14 @@ describe("forced worker environment abandonment", () => {
   beforeEach(async () => {
     effects.workerPlacementError.mockClear();
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-force-worker-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", root);
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
   });
 
   afterEach(async () => {
     closeOpenClawStateDatabaseForTest();
+    closeOpenClawAgentDatabasesForTest();
+    vi.unstubAllEnvs();
     await fs.rm(root, { recursive: true, force: true });
   });
 
@@ -359,6 +364,10 @@ describe("forced worker environment abandonment", () => {
     closeOpenClawStateDatabaseForTest();
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     store = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    await upsertSessionEntryCore(
+      { agentId: active.agentId, sessionKey: active.sessionKey },
+      { sessionId: active.sessionId, updatedAt: 2_000 },
+    );
     const restartedHarness = createHarness(store, { workspacePath });
     const environments = {
       ...restartedHarness.environments,
@@ -368,7 +377,7 @@ describe("forced worker environment abandonment", () => {
     const runtime = createGatewayWorkerPlacementRuntime({
       placements: store,
       environments,
-      admitNewPlacements: false,
+      gatewayNamespace: "gateway-test",
       revokeSessionAuthority: vi.fn(),
       warn: vi.fn(),
     });

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -133,6 +133,42 @@ describe("forced worker environment abandonment", () => {
     unregister();
   });
 
+  it("abandons a remote-exec pending result owned by a local claim", async () => {
+    const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+    const harness = createHarness(store);
+    await harness.service.dispatch({ ...REQUEST, executionMode: "remote-exec" });
+    const active = store.get(REQUEST.sessionId);
+    if (active?.state !== "active") {
+      throw new Error("active remote-exec placement fixture was not active");
+    }
+    const claimId = "reclaim-forced-local-claim";
+    const claim = store.claimReclaimWorkspaceResult({
+      ...REQUEST,
+      claimId,
+      runId: claimId,
+      owner: {
+        kind: "local",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    store.acceptWorkspaceResult(claim);
+
+    await forceAbandonWorkerEnvironment({
+      placements: store,
+      environmentId: active.environmentId,
+      resolveWorkspacePath: async () => root,
+    });
+
+    expect(store.get(REQUEST.sessionId)).toMatchObject({
+      state: "failed",
+      executionMode: "remote-exec",
+      turnClaim: null,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+    expect(store.listPendingWorkspaceResults()).toEqual([]);
+  });
+
   it("drains nested operations before forced teardown without a pending result", async () => {
     const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
     const { environmentId } = createDispatchEnvironmentFixtures();

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -14,12 +14,14 @@ import {
 import { createGatewayWorkerPlacementRuntime } from "../server-worker-placement-startup.js";
 import {
   createDispatchEnvironmentFixtures,
-  FORCED_WORKER_ABANDONMENT_ERROR,
   REQUEST,
   seedActivePlacement,
 } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
-import { forceAbandonWorkerEnvironment } from "./placement-force-abandon.js";
+import {
+  FORCED_WORKER_ABANDONMENT_ERROR,
+  forceAbandonWorkerEnvironment,
+} from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import {

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -1,5 +1,5 @@
 import type { WorkerDispatchPlacementStore } from "./placement-dispatch-failure.js";
-import { placementTurnOwner } from "./placement-record.js";
+import { placementTurnOwner, type WorkerSessionTurnClaim } from "./placement-record.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   cleanupWorkerWorkspaceResultRef,
@@ -177,7 +177,7 @@ export async function forceAbandonWorkerEnvironment(params: {
           runId: current.turnClaim.runId,
           placementGeneration: current.turnClaim.generation,
           owner: placementTurnOwner(current),
-        };
+        } satisfies WorkerSessionTurnClaim;
         await placements.closeWorkerTurnToolState(claim);
         const abandoned = placements.forceAbandonWorkerTurn({
           claim,

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -9,8 +9,7 @@ import {
   workerWorkspaceResultRef,
 } from "./workspace-result-staging.js";
 
-export const FORCED_WORKER_ABANDONMENT_ERROR =
-  "Cloud worker result abandoned by forced operator teardown";
+const FORCED_WORKER_ABANDONMENT_ERROR = "Cloud worker result abandoned by forced operator teardown";
 
 export class WorkerForcedAbandonmentBlockedError extends Error {
   constructor(environmentId: string) {

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -12,6 +12,14 @@ import {
 export const FORCED_WORKER_ABANDONMENT_ERROR =
   "Cloud worker result abandoned by forced operator teardown";
 
+export class WorkerForcedAbandonmentBlockedError extends Error {
+  constructor(environmentId: string) {
+    super(
+      `Workspace recovery still owns ${environmentId}; explicit forced abandonment is required`,
+    );
+  }
+}
+
 async function tryResolveWorkspacePath(
   resolveWorkspacePath: (placement: {
     sessionId: string;
@@ -51,8 +59,15 @@ export async function forceAbandonWorkerEnvironment(params: {
     agentId: string;
   }) => Promise<string>;
   onCleanupError?: (error: unknown) => void;
+  authorizeAbandonment?: () => boolean;
 }): Promise<void> {
   const { environmentId, placements } = params;
+  const assertAbandonmentAllowed = (): void => {
+    if (params.authorizeAbandonment && !params.authorizeAbandonment()) {
+      throw new WorkerForcedAbandonmentBlockedError(environmentId);
+    }
+  };
+  assertAbandonmentAllowed();
   const recoveryError = FORCED_WORKER_ABANDONMENT_ERROR;
   const pendingResults = placements
     .listPendingWorkspaceResults()
@@ -148,6 +163,7 @@ export async function forceAbandonWorkerEnvironment(params: {
           },
         });
       }
+      assertAbandonmentAllowed();
       placements.forceAbandonPendingWorkspaceResult({
         pending,
         recoveryError,
@@ -162,6 +178,7 @@ export async function forceAbandonWorkerEnvironment(params: {
     }
     let current = placements.get(placement.sessionId);
     if (current?.state === "active") {
+      assertAbandonmentAllowed();
       current = placements.startDrain({
         sessionId: current.sessionId,
         environmentId: current.environmentId,
@@ -179,6 +196,7 @@ export async function forceAbandonWorkerEnvironment(params: {
           owner: placementTurnOwner(current),
         } satisfies WorkerSessionTurnClaim;
         await placements.closeWorkerTurnToolState(claim);
+        assertAbandonmentAllowed();
         const abandoned = placements.forceAbandonWorkerTurn({
           claim,
           expectedGeneration: current.generation,
@@ -197,6 +215,7 @@ export async function forceAbandonWorkerEnvironment(params: {
         }
         current = abandoned.record;
       } else {
+        assertAbandonmentAllowed();
         current = placements.startReconcile({
           sessionId: current.sessionId,
           environmentId: current.environmentId,
@@ -206,6 +225,7 @@ export async function forceAbandonWorkerEnvironment(params: {
       }
     }
     if (current && current.state !== "failed") {
+      assertAbandonmentAllowed();
       placements.fail({
         sessionId: current.sessionId,
         expectedGeneration: current.generation,

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -5,6 +5,7 @@ import {
   placementWorkspaceResultClaim,
   type WorkerSessionTurnClaim,
 } from "./placement-record.js";
+import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   cleanupWorkerWorkspaceResultRef,
@@ -64,6 +65,18 @@ export async function forceAbandonWorkerEnvironment(params: {
   }) => Promise<string>;
   onCleanupError?: (error: unknown) => void;
   authorizeAbandonment?: () => boolean;
+  resolveWorkspaceResultConflict: (placement: {
+    sessionId: string;
+    sessionKey: string;
+    agentId: string;
+  }) => Promise<WorkerWorkspaceResultConflict | undefined>;
+  reportWorkspaceResultConflict: (placement: {
+    sessionId: string;
+    sessionKey: string;
+    agentId: string;
+    cleared: true;
+    stagedResultRef: string;
+  }) => Promise<void>;
 }): Promise<void> {
   const { environmentId, placements } = params;
   const assertAbandonmentAllowed = (): void => {
@@ -129,7 +142,13 @@ export async function forceAbandonWorkerEnvironment(params: {
     }
   }
   const stagedResultCleanups: Array<{
-    placement: { sessionId: string; sessionKey: string; agentId: string };
+    placement: {
+      sessionId: string;
+      sessionKey: string;
+      agentId: string;
+      workspaceResultConflict?: WorkerWorkspaceResultConflict;
+    };
+    finalRef: string;
     refs: string[];
   }> = [];
   for (const pending of pendingResults) {
@@ -146,10 +165,11 @@ export async function forceAbandonWorkerEnvironment(params: {
       const finalRef = pending.stagedResultRef ?? workerWorkspaceResultRef(pending.claimId);
       stagedResultCleanups.push({
         placement,
+        finalRef,
         refs: [
-          finalRef,
-          preparedWorkerWorkspaceResultRef(finalRef),
           cleanupWorkerWorkspaceResultRef(finalRef),
+          preparedWorkerWorkspaceResultRef(finalRef),
+          finalRef,
         ],
       });
     }
@@ -206,10 +226,11 @@ export async function forceAbandonWorkerEnvironment(params: {
           const finalRef = abandoned.stagedResultRef ?? workerWorkspaceResultRef(claim.claimId);
           stagedResultCleanups.push({
             placement: abandoned.record,
+            finalRef,
             refs: [
-              finalRef,
-              preparedWorkerWorkspaceResultRef(finalRef),
               cleanupWorkerWorkspaceResultRef(finalRef),
+              preparedWorkerWorkspaceResultRef(finalRef),
+              finalRef,
             ],
           });
         }
@@ -258,6 +279,9 @@ export async function forceAbandonWorkerEnvironment(params: {
   }
   for (const cleanup of stagedResultCleanups) {
     try {
+      const conflict =
+        cleanup.placement.workspaceResultConflict ??
+        (await params.resolveWorkspaceResultConflict(cleanup.placement));
       const root = await tryResolveWorkspacePath(
         params.resolveWorkspacePath,
         cleanup.placement,
@@ -270,6 +294,19 @@ export async function forceAbandonWorkerEnvironment(params: {
         if (await hasWorkerWorkspaceResultRef({ root, stagedResultRef })) {
           await deleteStagedWorkerWorkspaceResult({ root, stagedResultRef });
         }
+      }
+      if (conflict?.stagedResultRef === cleanup.finalRef) {
+        await params.reportWorkspaceResultConflict({
+          sessionId: cleanup.placement.sessionId,
+          sessionKey: cleanup.placement.sessionKey,
+          agentId: cleanup.placement.agentId,
+          cleared: true,
+          stagedResultRef: cleanup.finalRef,
+        });
+        placements.retireWorkspaceResultConflict({
+          sessionId: cleanup.placement.sessionId,
+          stagedResultRef: cleanup.finalRef,
+        });
       }
     } catch (error) {
       reportCleanupError(params.onCleanupError, error);

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -14,8 +14,7 @@ import {
   workerWorkspaceResultRef,
 } from "./workspace-result-staging.js";
 
-export const FORCED_WORKER_ABANDONMENT_ERROR =
-  "Cloud worker result abandoned by forced operator teardown";
+const FORCED_WORKER_ABANDONMENT_ERROR = "Cloud worker result abandoned by forced operator teardown";
 
 export class WorkerForcedAbandonmentBlockedError extends Error {
   constructor(environmentId: string) {

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -1,5 +1,9 @@
 import type { WorkerDispatchPlacementStore } from "./placement-dispatch-failure.js";
-import { placementTurnOwner, type WorkerSessionTurnClaim } from "./placement-record.js";
+import {
+  placementTurnOwner,
+  placementWorkspaceResultClaim,
+  type WorkerSessionTurnClaim,
+} from "./placement-record.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   cleanupWorkerWorkspaceResultRef,
@@ -9,7 +13,8 @@ import {
   workerWorkspaceResultRef,
 } from "./workspace-result-staging.js";
 
-const FORCED_WORKER_ABANDONMENT_ERROR = "Cloud worker result abandoned by forced operator teardown";
+export const FORCED_WORKER_ABANDONMENT_ERROR =
+  "Cloud worker result abandoned by forced operator teardown";
 
 export class WorkerForcedAbandonmentBlockedError extends Error {
   constructor(environmentId: string) {
@@ -150,17 +155,11 @@ export async function forceAbandonWorkerEnvironment(params: {
     }
     if (fence) {
       if (fence.ownerState === "current") {
-        await placements.closeWorkerTurnToolState({
-          sessionId: pending.sessionId,
-          claimId: pending.claimId,
-          runId: pending.runId,
-          placementGeneration: pending.placementGeneration,
-          owner: {
-            kind: "worker",
-            environmentId: pending.environmentId,
-            ownerEpoch: pending.ownerEpoch,
-          },
-        });
+        const claim = placementWorkspaceResultClaim(placement, pending);
+        if (!claim || !placements.validateWorkspaceResultClaim(claim)) {
+          throw new Error(`Pending workspace result lost its claim for ${pending.sessionId}`);
+        }
+        await placements.closeWorkerTurnToolState(claim);
       }
       assertAbandonmentAllowed();
       placements.forceAbandonPendingWorkspaceResult({

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -2,6 +2,7 @@ import type { WorkerDispatchPlacementStore } from "./placement-dispatch-failure.
 import { placementTurnOwner } from "./placement-record.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
+  cleanupWorkerWorkspaceResultRef,
   deleteStagedWorkerWorkspaceResult,
   hasWorkerWorkspaceResultRef,
   preparedWorkerWorkspaceResultRef,
@@ -53,6 +54,13 @@ export async function forceAbandonWorkerEnvironment(params: {
 }): Promise<void> {
   const { environmentId, placements } = params;
   const recoveryError = FORCED_WORKER_ABANDONMENT_ERROR;
+  const pendingResults = placements
+    .listPendingWorkspaceResults()
+    .filter((pending) => pending.environmentId === environmentId);
+  const pendingResultsBySession = new Map(
+    pendingResults.map((pending) => [pending.sessionId, pending] as const),
+  );
+  const teardownFences = placements.listEnvironmentTeardownFences(environmentId);
   const journalOwners = params.placements
     .listWorkspaceReconciliationOwners()
     .filter((owner) => owner.environmentId === environmentId);
@@ -64,23 +72,33 @@ export async function forceAbandonWorkerEnvironment(params: {
   const retainedJournalSessions = new Set<string>();
   for (const owner of journalOwners) {
     const placement = placements.get(owner.sessionId);
-    const isCurrentOwner =
-      (placement?.state === "active" || placement?.state === "draining") &&
-      placement.generation === owner.placementGeneration;
-    const isForceFailedOwner =
-      placement?.state === "failed" &&
-      placement.recoveryError.startsWith(recoveryError) &&
-      placement.generation > owner.placementGeneration;
-    if (
-      placement &&
-      (isCurrentOwner || isForceFailedOwner) &&
-      placement.environmentId === owner.environmentId &&
-      placement.activeOwnerEpoch === owner.ownerEpoch
-    ) {
+    const fence = teardownFences.find(
+      (candidate) =>
+        candidate.kind === "workspace-reconciliation" &&
+        candidate.sessionId === owner.sessionId &&
+        candidate.environmentId === owner.environmentId &&
+        candidate.ownerEpoch === owner.ownerEpoch &&
+        candidate.placementGeneration === owner.placementGeneration,
+    );
+    const pending = pendingResultsBySession.get(owner.sessionId);
+    const pendingFence = pending
+      ? teardownFences.find(
+          (candidate) =>
+            candidate.kind === "pending-workspace-result" &&
+            candidate.sessionId === pending.sessionId &&
+            candidate.environmentId === pending.environmentId &&
+            candidate.ownerEpoch === pending.ownerEpoch &&
+            candidate.placementGeneration === pending.placementGeneration,
+        )
+      : undefined;
+    if (placement && (fence || pendingFence)) {
+      placements.retainWorkspaceReconciliationForForcedAbandonment(owner);
       try {
         const journal = placements.loadWorkspaceReconciliation(
           owner,
-          isForceFailedOwner ? { allowFailedOwner: true } : undefined,
+          fence?.ownerState === "retained-failed" || pendingFence?.ownerState === "retained-failed"
+            ? { allowFailedOwner: true }
+            : undefined,
         );
         if (journal) {
           journalCleanups.push({ owner, placement, journal });
@@ -95,37 +113,47 @@ export async function forceAbandonWorkerEnvironment(params: {
     placement: { sessionId: string; sessionKey: string; agentId: string };
     refs: string[];
   }> = [];
-  for (const pending of placements.listPendingWorkspaceResults()) {
-    if (pending.environmentId === environmentId) {
-      const placement = placements.get(pending.sessionId);
-      if (
-        (placement?.state === "active" || placement?.state === "draining") &&
-        placement.environmentId === pending.environmentId &&
-        placement.activeOwnerEpoch === pending.ownerEpoch &&
-        placement.generation ===
-          (placement.state === "active"
-            ? pending.placementGeneration
-            : pending.placementGeneration + 1)
-      ) {
-        const finalRef = pending.stagedResultRef ?? workerWorkspaceResultRef(pending.claimId);
-        stagedResultCleanups.push({
-          placement,
-          refs: [finalRef, preparedWorkerWorkspaceResultRef(finalRef)],
+  for (const pending of pendingResults) {
+    const placement = placements.get(pending.sessionId);
+    const fence = teardownFences.find(
+      (candidate) =>
+        candidate.kind === "pending-workspace-result" &&
+        candidate.sessionId === pending.sessionId &&
+        candidate.environmentId === pending.environmentId &&
+        candidate.ownerEpoch === pending.ownerEpoch &&
+        candidate.placementGeneration === pending.placementGeneration,
+    );
+    if (placement && fence) {
+      const finalRef = pending.stagedResultRef ?? workerWorkspaceResultRef(pending.claimId);
+      stagedResultCleanups.push({
+        placement,
+        refs: [
+          finalRef,
+          preparedWorkerWorkspaceResultRef(finalRef),
+          cleanupWorkerWorkspaceResultRef(finalRef),
+        ],
+      });
+    }
+    if (fence) {
+      if (fence.ownerState === "current") {
+        await placements.closeWorkerTurnToolState({
+          sessionId: pending.sessionId,
+          claimId: pending.claimId,
+          runId: pending.runId,
+          placementGeneration: pending.placementGeneration,
+          owner: {
+            kind: "worker",
+            environmentId: pending.environmentId,
+            ownerEpoch: pending.ownerEpoch,
+          },
         });
-        const claim = placement.turnClaim;
-        if (claim && claim.claimId === pending.claimId && claim.runId === pending.runId) {
-          await placements.closeWorkerTurnToolState({
-            sessionId: placement.sessionId,
-            claimId: claim.claimId,
-            runId: claim.runId,
-            placementGeneration: claim.generation,
-            owner: placementTurnOwner(placement),
-          });
-        }
-        placements.failWorkspaceResultAndReleaseTurn(pending, recoveryError);
-      } else {
-        placements.abandonWorkspaceResult(pending);
       }
+      placements.forceAbandonPendingWorkspaceResult({
+        pending,
+        recoveryError,
+      });
+    } else {
+      placements.abandonWorkspaceResult(pending);
     }
   }
   for (const placement of placements.listForReconcile()) {
@@ -143,20 +171,39 @@ export async function forceAbandonWorkerEnvironment(params: {
     }
     if (current?.state === "draining") {
       if (current.turnClaim) {
-        await placements.closeWorkerTurnToolState({
+        const claim = {
           sessionId: current.sessionId,
           claimId: current.turnClaim.claimId,
           runId: current.turnClaim.runId,
           placementGeneration: current.turnClaim.generation,
           owner: placementTurnOwner(current),
+        };
+        await placements.closeWorkerTurnToolState(claim);
+        const abandoned = placements.forceAbandonWorkerTurn({
+          claim,
+          expectedGeneration: current.generation,
+          recoveryError,
+        });
+        if (abandoned.record.state === "failed") {
+          const finalRef = abandoned.stagedResultRef ?? workerWorkspaceResultRef(claim.claimId);
+          stagedResultCleanups.push({
+            placement: abandoned.record,
+            refs: [
+              finalRef,
+              preparedWorkerWorkspaceResultRef(finalRef),
+              cleanupWorkerWorkspaceResultRef(finalRef),
+            ],
+          });
+        }
+        current = abandoned.record;
+      } else {
+        current = placements.startReconcile({
+          sessionId: current.sessionId,
+          environmentId: current.environmentId,
+          ownerEpoch: current.activeOwnerEpoch,
+          expectedGeneration: current.generation,
         });
       }
-      current = placements.startReconcile({
-        sessionId: current.sessionId,
-        environmentId: current.environmentId,
-        ownerEpoch: current.activeOwnerEpoch,
-        expectedGeneration: current.generation,
-      });
     }
     if (current && current.state !== "failed") {
       placements.fail({

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -1,5 +1,6 @@
 import type { WorkerDispatchPlacementStore } from "./placement-dispatch-failure.js";
 import {
+  isCurrentPlacementTurnClaim,
   placementTurnOwner,
   placementWorkspaceResultClaim,
   type WorkerSessionTurnClaim,
@@ -159,7 +160,9 @@ export async function forceAbandonWorkerEnvironment(params: {
         if (!claim || !placements.validateWorkspaceResultClaim(claim)) {
           throw new Error(`Pending workspace result lost its claim for ${pending.sessionId}`);
         }
-        await placements.closeWorkerTurnToolState(claim);
+        if (placement && isCurrentPlacementTurnClaim(placement, claim)) {
+          await placements.closeWorkerTurnToolState(claim);
+        }
       }
       assertAbandonmentAllowed();
       placements.forceAbandonPendingWorkspaceResult({

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -5,7 +5,6 @@ import {
   placementWorkspaceResultClaim,
   type WorkerSessionTurnClaim,
 } from "./placement-record.js";
-import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   cleanupWorkerWorkspaceResultRef,
@@ -65,11 +64,6 @@ export async function forceAbandonWorkerEnvironment(params: {
   }) => Promise<string>;
   onCleanupError?: (error: unknown) => void;
   authorizeAbandonment?: () => boolean;
-  resolveWorkspaceResultConflict: (placement: {
-    sessionId: string;
-    sessionKey: string;
-    agentId: string;
-  }) => Promise<WorkerWorkspaceResultConflict | undefined>;
   reportWorkspaceResultConflict: (placement: {
     sessionId: string;
     sessionKey: string;
@@ -142,12 +136,7 @@ export async function forceAbandonWorkerEnvironment(params: {
     }
   }
   const stagedResultCleanups: Array<{
-    placement: {
-      sessionId: string;
-      sessionKey: string;
-      agentId: string;
-      workspaceResultConflict?: WorkerWorkspaceResultConflict;
-    };
+    placement: { sessionId: string; sessionKey: string; agentId: string };
     finalRef: string;
     refs: string[];
   }> = [];
@@ -279,9 +268,6 @@ export async function forceAbandonWorkerEnvironment(params: {
   }
   for (const cleanup of stagedResultCleanups) {
     try {
-      const conflict =
-        cleanup.placement.workspaceResultConflict ??
-        (await params.resolveWorkspaceResultConflict(cleanup.placement));
       const root = await tryResolveWorkspacePath(
         params.resolveWorkspacePath,
         cleanup.placement,
@@ -295,21 +281,24 @@ export async function forceAbandonWorkerEnvironment(params: {
           await deleteStagedWorkerWorkspaceResult({ root, stagedResultRef });
         }
       }
-      if (conflict?.stagedResultRef === cleanup.finalRef) {
-        await params.reportWorkspaceResultConflict({
-          sessionId: cleanup.placement.sessionId,
-          sessionKey: cleanup.placement.sessionKey,
-          agentId: cleanup.placement.agentId,
-          cleared: true,
-          stagedResultRef: cleanup.finalRef,
-        });
-        placements.retireWorkspaceResultConflict({
-          sessionId: cleanup.placement.sessionId,
-          stagedResultRef: cleanup.finalRef,
-        });
-      }
+    } catch (error) {
+      reportCleanupError(params.onCleanupError, error);
+      continue;
+    }
+    try {
+      await params.reportWorkspaceResultConflict({
+        sessionId: cleanup.placement.sessionId,
+        sessionKey: cleanup.placement.sessionKey,
+        agentId: cleanup.placement.agentId,
+        cleared: true,
+        stagedResultRef: cleanup.finalRef,
+      });
     } catch (error) {
       reportCleanupError(params.onCleanupError, error);
     }
+    placements.retireWorkspaceResultConflict({
+      sessionId: cleanup.placement.sessionId,
+      stagedResultRef: cleanup.finalRef,
+    });
   }
 }

--- a/src/gateway/worker-environments/placement-force-destroy.test.ts
+++ b/src/gateway/worker-environments/placement-force-destroy.test.ts
@@ -155,6 +155,13 @@ describe("forced worker environment destruction", () => {
       harness.service.forceDestroyEnvironment(active.environmentId),
     ).resolves.toMatchObject({ state: "destroying" });
     expect(placementStore.listWorkspaceReconciliationOwners()).toEqual([owner]);
+    expect(placementStore.get(active.sessionId)).toMatchObject({
+      state: "failed",
+      terminalRecovery: {
+        action: "force-destroy-environment",
+        dataLoss: "unreconciled-workspace-result",
+      },
+    });
     vi.mocked(harness.environments.destroy).mockClear();
 
     await harness.service.reconcileActive(active.environmentId);

--- a/src/gateway/worker-environments/placement-force-destroy.test.ts
+++ b/src/gateway/worker-environments/placement-force-destroy.test.ts
@@ -160,5 +160,15 @@ describe("forced worker environment destruction", () => {
     await harness.service.reconcileActive(active.environmentId);
 
     expect(harness.environments.destroy).toHaveBeenCalledExactlyOnceWith(active.environmentId);
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: expect.stringContaining("destroy pending"),
+    });
+
+    closeOpenClawStateDatabaseForTest();
+    database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    placementStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    expect(placementStore.pruneOrphanedWorkspaceReconciliations()).toEqual([]);
+    expect(placementStore.listWorkspaceReconciliationOwners()).toEqual([owner]);
   });
 });

--- a/src/gateway/worker-environments/placement-pending-failure.ts
+++ b/src/gateway/worker-environments/placement-pending-failure.ts
@@ -188,10 +188,16 @@ export function createPlacementPendingFailureOps(
       if (!claim) {
         throw new Error(`Cannot fail stale pending worker result for session ${pending.sessionId}`);
       }
-      await dependencies.closeWorkerTurnToolState(claim);
+      if (isCurrentPlacementTurnClaim(beforeDrain, claim)) {
+        await dependencies.closeWorkerTurnToolState(claim);
+      }
       const outcome = write((db) => {
         const current = getRequired(db, pending.sessionId);
         const currentClaim = placementWorkspaceResultClaim(current, pending);
+        const liveClaim =
+          currentClaim && isCurrentPlacementTurnClaim(current, currentClaim)
+            ? currentClaim
+            : undefined;
         const durablePending = executeSqliteQuerySync(
           db,
           getNodeSqliteKysely<Pick<StateDatabase, "worker_workspace_pending_results">>(db)
@@ -227,22 +233,35 @@ export function createPlacementPendingFailureOps(
           ownerEpoch: pending.ownerEpoch,
           placementGeneration: current.generation,
         });
-        const claimedUpdate = query(db)
+        const placementUpdate = query(db)
           .updateTable("worker_session_placements")
           .set(values)
           .where("session_id", "=", pending.sessionId)
           .where("state", "=", current.state)
           .where("transition_generation", "=", current.generation)
           .where("environment_id", "=", pending.environmentId)
-          .where("active_owner_epoch", "=", pending.ownerEpoch)
-          .where("turn_claim_owner", "=", currentClaim.owner.kind)
-          .where("turn_claim_id", "=", pending.claimId)
-          .where("turn_claim_run_id", "=", pending.runId)
-          .where("turn_claim_generation", "=", pending.placementGeneration);
+          .where("active_owner_epoch", "=", pending.ownerEpoch);
         const update =
-          currentClaim.owner.kind === "worker"
-            ? claimedUpdate.where("turn_claim_owner_epoch", "=", pending.ownerEpoch)
-            : claimedUpdate.where("turn_claim_owner_epoch", "is", null);
+          liveClaim?.owner.kind === "worker"
+            ? placementUpdate
+                .where("turn_claim_owner", "=", "worker")
+                .where("turn_claim_id", "=", pending.claimId)
+                .where("turn_claim_run_id", "=", pending.runId)
+                .where("turn_claim_generation", "=", pending.placementGeneration)
+                .where("turn_claim_owner_epoch", "=", pending.ownerEpoch)
+            : liveClaim
+              ? placementUpdate
+                  .where("turn_claim_owner", "=", "local")
+                  .where("turn_claim_id", "=", pending.claimId)
+                  .where("turn_claim_run_id", "=", pending.runId)
+                  .where("turn_claim_generation", "=", pending.placementGeneration)
+                  .where("turn_claim_owner_epoch", "is", null)
+              : placementUpdate
+                  .where("turn_claim_owner", "is", null)
+                  .where("turn_claim_id", "is", null)
+                  .where("turn_claim_run_id", "is", null)
+                  .where("turn_claim_generation", "is", null)
+                  .where("turn_claim_owner_epoch", "is", null);
         const result = executeSqliteQuerySync(db, update);
         if (result.numAffectedRows !== 1n) {
           throw new Error(
@@ -251,10 +270,12 @@ export function createPlacementPendingFailureOps(
         }
         return {
           record: getRequired(db, pending.sessionId),
-          releasedClaim: currentClaim,
+          releasedClaim: liveClaim,
         };
       });
-      signalWorkerTurnClaimClosed(path, outcome.releasedClaim);
+      if (outcome.releasedClaim) {
+        signalWorkerTurnClaimClosed(path, outcome.releasedClaim);
+      }
       return outcome.record;
     },
   };

--- a/src/gateway/worker-environments/placement-pending-failure.ts
+++ b/src/gateway/worker-environments/placement-pending-failure.ts
@@ -3,6 +3,7 @@ import type { DB as StateDatabase } from "../../state/openclaw-state-db.generate
 import {
   isCurrentPlacementTurnClaim,
   placementTurnOwner,
+  placementWorkspaceResultClaim,
   required,
   type WorkerSessionPlacementRecord,
   type WorkerSessionTurnClaim,
@@ -13,7 +14,6 @@ import {
   assertNoRunningWorkerSessionToolOperations,
   clearWorkerTurnToolState,
 } from "./placement-session-tool-operations.js";
-import { classifyPendingWorkspaceResultOwner } from "./placement-teardown-fence.js";
 import { signalWorkerTurnClaimClosed } from "./placement-turn-claims.js";
 import { retainWorkerWorkspaceReconciliation } from "./placement-workspace-journal.js";
 import type { WorkerWorkspacePendingResult } from "./placement-workspace-result.js";
@@ -184,24 +184,14 @@ export function createPlacementPendingFailureOps(
       const { pending } = input;
       const recoveryError = boundedWorkerError(input.recoveryError);
       const beforeDrain = getRequired(read(), pending.sessionId);
-      if (classifyPendingWorkspaceResultOwner(beforeDrain, pending) !== "current") {
+      const claim = placementWorkspaceResultClaim(beforeDrain, pending);
+      if (!claim) {
         throw new Error(`Cannot fail stale pending worker result for session ${pending.sessionId}`);
       }
-      const claim: WorkerSessionTurnClaim = {
-        sessionId: pending.sessionId,
-        claimId: pending.claimId,
-        runId: pending.runId,
-        placementGeneration: pending.placementGeneration,
-        owner: {
-          kind: "worker",
-          environmentId: pending.environmentId,
-          ownerEpoch: pending.ownerEpoch,
-        },
-      };
       await dependencies.closeWorkerTurnToolState(claim);
       const outcome = write((db) => {
         const current = getRequired(db, pending.sessionId);
-        const persisted = current.turnClaim;
+        const currentClaim = placementWorkspaceResultClaim(current, pending);
         const durablePending = executeSqliteQuerySync(
           db,
           getNodeSqliteKysely<Pick<StateDatabase, "worker_workspace_pending_results">>(db)
@@ -210,8 +200,7 @@ export function createPlacementPendingFailureOps(
             .where("session_id", "=", pending.sessionId),
         ).rows[0];
         if (
-          classifyPendingWorkspaceResultOwner(current, pending) !== "current" ||
-          persisted?.owner !== "worker" ||
+          !currentClaim ||
           !durablePending ||
           durablePending.environment_id !== pending.environmentId ||
           durablePending.owner_epoch !== pending.ownerEpoch ||
@@ -238,22 +227,23 @@ export function createPlacementPendingFailureOps(
           ownerEpoch: pending.ownerEpoch,
           placementGeneration: current.generation,
         });
-        const result = executeSqliteQuerySync(
-          db,
-          query(db)
-            .updateTable("worker_session_placements")
-            .set(values)
-            .where("session_id", "=", pending.sessionId)
-            .where("state", "=", current.state)
-            .where("transition_generation", "=", current.generation)
-            .where("environment_id", "=", pending.environmentId)
-            .where("active_owner_epoch", "=", pending.ownerEpoch)
-            .where("turn_claim_owner", "=", "worker")
-            .where("turn_claim_id", "=", pending.claimId)
-            .where("turn_claim_run_id", "=", pending.runId)
-            .where("turn_claim_generation", "=", pending.placementGeneration)
-            .where("turn_claim_owner_epoch", "=", pending.ownerEpoch),
-        );
+        const claimedUpdate = query(db)
+          .updateTable("worker_session_placements")
+          .set(values)
+          .where("session_id", "=", pending.sessionId)
+          .where("state", "=", current.state)
+          .where("transition_generation", "=", current.generation)
+          .where("environment_id", "=", pending.environmentId)
+          .where("active_owner_epoch", "=", pending.ownerEpoch)
+          .where("turn_claim_owner", "=", currentClaim.owner.kind)
+          .where("turn_claim_id", "=", pending.claimId)
+          .where("turn_claim_run_id", "=", pending.runId)
+          .where("turn_claim_generation", "=", pending.placementGeneration);
+        const update =
+          currentClaim.owner.kind === "worker"
+            ? claimedUpdate.where("turn_claim_owner_epoch", "=", pending.ownerEpoch)
+            : claimedUpdate.where("turn_claim_owner_epoch", "is", null);
+        const result = executeSqliteQuerySync(db, update);
         if (result.numAffectedRows !== 1n) {
           throw new Error(
             `Pending worker result owner changed during failure for ${pending.sessionId}`,
@@ -261,7 +251,7 @@ export function createPlacementPendingFailureOps(
         }
         return {
           record: getRequired(db, pending.sessionId),
-          releasedClaim: claim,
+          releasedClaim: currentClaim,
         };
       });
       signalWorkerTurnClaimClosed(path, outcome.releasedClaim);

--- a/src/gateway/worker-environments/placement-pending-failure.ts
+++ b/src/gateway/worker-environments/placement-pending-failure.ts
@@ -13,12 +13,19 @@ import {
   assertNoRunningWorkerSessionToolOperations,
   clearWorkerTurnToolState,
 } from "./placement-session-tool-operations.js";
+import { classifyPendingWorkspaceResultOwner } from "./placement-teardown-fence.js";
 import { signalWorkerTurnClaimClosed } from "./placement-turn-claims.js";
+import { retainWorkerWorkspaceReconciliation } from "./placement-workspace-journal.js";
 import type { WorkerWorkspacePendingResult } from "./placement-workspace-result.js";
 import { boundedWorkerError } from "./worker-error.js";
 
-export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime) {
-  const { now, path, write } = runtime;
+export function createPlacementPendingFailureOps(
+  runtime: PlacementStoreRuntime,
+  dependencies: {
+    closeWorkerTurnToolState: (claim: WorkerSessionTurnClaim) => Promise<void>;
+  },
+) {
+  const { now, path, read, write } = runtime;
   return {
     failWorkspaceResultAndReleaseTurn(
       pending: WorkerWorkspacePendingResult,
@@ -167,6 +174,97 @@ export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime)
       if (outcome.releasedClaim) {
         signalWorkerTurnClaimClosed(path, outcome.releasedClaim);
       }
+      return outcome.record;
+    },
+
+    async failPendingWorkspaceResult(input: {
+      pending: WorkerWorkspacePendingResult;
+      recoveryError: string;
+    }): Promise<WorkerSessionPlacementRecord> {
+      const { pending } = input;
+      const recoveryError = boundedWorkerError(input.recoveryError);
+      const beforeDrain = getRequired(read(), pending.sessionId);
+      if (classifyPendingWorkspaceResultOwner(beforeDrain, pending) !== "current") {
+        throw new Error(`Cannot fail stale pending worker result for session ${pending.sessionId}`);
+      }
+      const claim: WorkerSessionTurnClaim = {
+        sessionId: pending.sessionId,
+        claimId: pending.claimId,
+        runId: pending.runId,
+        placementGeneration: pending.placementGeneration,
+        owner: {
+          kind: "worker",
+          environmentId: pending.environmentId,
+          ownerEpoch: pending.ownerEpoch,
+        },
+      };
+      await dependencies.closeWorkerTurnToolState(claim);
+      const outcome = write((db) => {
+        const current = getRequired(db, pending.sessionId);
+        const persisted = current.turnClaim;
+        const durablePending = executeSqliteQuerySync(
+          db,
+          getNodeSqliteKysely<Pick<StateDatabase, "worker_workspace_pending_results">>(db)
+            .selectFrom("worker_workspace_pending_results")
+            .selectAll()
+            .where("session_id", "=", pending.sessionId),
+        ).rows[0];
+        if (
+          classifyPendingWorkspaceResultOwner(current, pending) !== "current" ||
+          persisted?.owner !== "worker" ||
+          !durablePending ||
+          durablePending.environment_id !== pending.environmentId ||
+          durablePending.owner_epoch !== pending.ownerEpoch ||
+          durablePending.placement_generation !== pending.placementGeneration ||
+          durablePending.claim_id !== pending.claimId ||
+          durablePending.run_id !== pending.runId
+        ) {
+          throw new Error(
+            `Cannot fail stale pending worker result for session ${pending.sessionId}`,
+          );
+        }
+        assertNoRunningWorkerSessionToolOperations(db, {
+          sessionId: pending.sessionId,
+          claimId: pending.claimId,
+        });
+        clearWorkerTurnToolState(db, {
+          sessionId: pending.sessionId,
+          claimId: pending.claimId,
+        });
+        const values = transitionValues(current, "failed", { recoveryError }, now());
+        retainWorkerWorkspaceReconciliation(db, {
+          sessionId: pending.sessionId,
+          environmentId: pending.environmentId,
+          ownerEpoch: pending.ownerEpoch,
+          placementGeneration: current.generation,
+        });
+        const result = executeSqliteQuerySync(
+          db,
+          query(db)
+            .updateTable("worker_session_placements")
+            .set(values)
+            .where("session_id", "=", pending.sessionId)
+            .where("state", "=", current.state)
+            .where("transition_generation", "=", current.generation)
+            .where("environment_id", "=", pending.environmentId)
+            .where("active_owner_epoch", "=", pending.ownerEpoch)
+            .where("turn_claim_owner", "=", "worker")
+            .where("turn_claim_id", "=", pending.claimId)
+            .where("turn_claim_run_id", "=", pending.runId)
+            .where("turn_claim_generation", "=", pending.placementGeneration)
+            .where("turn_claim_owner_epoch", "=", pending.ownerEpoch),
+        );
+        if (result.numAffectedRows !== 1n) {
+          throw new Error(
+            `Pending worker result owner changed during failure for ${pending.sessionId}`,
+          );
+        }
+        return {
+          record: getRequired(db, pending.sessionId),
+          releasedClaim: claim,
+        };
+      });
+      signalWorkerTurnClaimClosed(path, outcome.releasedClaim);
       return outcome.record;
     },
   };

--- a/src/gateway/worker-environments/placement-projector.test.ts
+++ b/src/gateway/worker-environments/placement-projector.test.ts
@@ -84,7 +84,11 @@ describe("worker placement projection", () => {
         recoveryError: "worker unavailable",
         terminalReason: "worker unavailable",
         terminalAtMs: 260,
-      },
+        terminalRecovery: {
+          action: "force-destroy-environment",
+          dataLoss: "unreconciled-workspace-result",
+        },
+      } as WorkerSessionPlacementRecord,
     ] satisfies WorkerSessionPlacementRecord[];
 
     const projected = records.map((record) => projectWorkerSessionPlacement(record));
@@ -133,6 +137,10 @@ describe("worker placement projection", () => {
         recoveryError: "worker unavailable",
         terminalReason: "worker unavailable",
         terminalAtMs: 260,
+        terminalRecovery: {
+          action: "force-destroy-environment",
+          dataLoss: "unreconciled-workspace-result",
+        },
       },
     ]);
     for (const placement of projected) {

--- a/src/gateway/worker-environments/placement-projector.ts
+++ b/src/gateway/worker-environments/placement-projector.ts
@@ -6,6 +6,7 @@ import type { WorkerSessionPlacementRecord } from "./placement-store.js";
 
 export type WorkerSessionPlacementReader = {
   getMany(sessionIds: readonly string[]): ReadonlyMap<string, WorkerSessionPlacementRecord>;
+  isEnvironmentTeardownFenced?(environmentId: string): boolean;
 };
 
 export type WorkerPlacementDiskSpaceReader = {
@@ -149,6 +150,7 @@ export function projectWorkerSessionPlacement(
           : {}),
         ...conflict,
         recoveryError: record.recoveryError,
+        ...(record.terminalRecovery ? { terminalRecovery: record.terminalRecovery } : {}),
         ...terminal,
       };
   }

--- a/src/gateway/worker-environments/placement-record.ts
+++ b/src/gateway/worker-environments/placement-record.ts
@@ -23,7 +23,7 @@ export type WorkerSessionTurnClaim = {
   owner: WorkerSessionTurnOwner;
 };
 
-export type WorkerWorkspaceResultClaimIdentity = {
+type WorkerWorkspaceResultClaimIdentity = {
   sessionId: string;
   environmentId: string;
   ownerEpoch: number;

--- a/src/gateway/worker-environments/placement-record.ts
+++ b/src/gateway/worker-environments/placement-record.ts
@@ -23,6 +23,15 @@ export type WorkerSessionTurnClaim = {
   owner: WorkerSessionTurnOwner;
 };
 
+export type WorkerWorkspaceResultClaimIdentity = {
+  sessionId: string;
+  environmentId: string;
+  ownerEpoch: number;
+  placementGeneration: number;
+  claimId: string;
+  runId: string;
+};
+
 export function placementTurnOwner(placement: {
   executionMode: WorkerPlacementExecutionMode;
   environmentId: string;
@@ -507,6 +516,37 @@ export function isCurrentPlacementTurnClaim(
     claim.owner.environmentId === undefined &&
     claim.owner.ownerEpoch === undefined
   );
+}
+
+export function placementWorkspaceResultClaim(
+  record: WorkerSessionPlacementRecord | undefined,
+  result: WorkerWorkspaceResultClaimIdentity,
+): WorkerSessionTurnClaim | undefined {
+  if (record?.state !== "active" && record?.state !== "draining") {
+    return undefined;
+  }
+  const expectedGeneration = result.placementGeneration + (record.state === "draining" ? 1 : 0);
+  if (
+    record.sessionId !== result.sessionId ||
+    record.environmentId !== result.environmentId ||
+    record.activeOwnerEpoch !== result.ownerEpoch ||
+    record.generation !== expectedGeneration
+  ) {
+    return undefined;
+  }
+  const claim: WorkerSessionTurnClaim = {
+    sessionId: result.sessionId,
+    claimId: result.claimId,
+    runId: result.runId,
+    placementGeneration: result.placementGeneration,
+    owner: placementTurnOwner(record),
+  };
+  if (isCurrentPlacementTurnClaim(record, claim)) {
+    return claim;
+  }
+  // Restart revokes local authority; only an exact durable workspace result
+  // may retain the remote-exec placement owner needed to finish recovery.
+  return record.turnClaim === null && claim.owner.kind === "local" ? claim : undefined;
 }
 
 export function resolvePlacementTurnEnvironment(

--- a/src/gateway/worker-environments/placement-record.ts
+++ b/src/gateway/worker-environments/placement-record.ts
@@ -57,6 +57,11 @@ export type WorkerWorkspaceResultConflict = {
   totalCount?: number;
 };
 
+export type WorkerTerminalRecovery = {
+  action: "force-destroy-environment";
+  dataLoss: "unreconciled-workspace-result";
+};
+
 type PersistedLocalTurnClaim = Extract<PersistedTurnClaim, { owner: "local" }>;
 
 type PlacementRecordBase<TurnClaim extends PersistedTurnClaim | null> =
@@ -69,6 +74,8 @@ type PlacementRecordBase<TurnClaim extends PersistedTurnClaim | null> =
     stateChangedAtMs: number;
     /** Process-local UI projection; deliberately absent from SQLite. */
     workspaceResultConflict?: WorkerWorkspaceResultConflict;
+    /** Durable-owner projection for the one explicitly destructive recovery path. */
+    terminalRecovery?: WorkerTerminalRecovery;
   };
 
 type UnclaimedPlacementRecordBase = PlacementRecordBase<null>;

--- a/src/gateway/worker-environments/placement-session-retirement.test.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.test.ts
@@ -350,7 +350,7 @@ describe("placement session retirement", () => {
         placements,
         environments: { get: () => ({ state: "attached" }) as never },
         forceDestroyEnvironment,
-        resolveSessionEvidence: async () => "absent",
+        createSessionEvidenceResolver: async () => async () => "absent",
         warn,
       });
 

--- a/src/gateway/worker-environments/placement-session-retirement.test.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.test.ts
@@ -10,6 +10,7 @@ import type { WorkerSessionPlacementRecord } from "./placement-record.js";
 import { createPlacementSessionRetirement } from "./placement-session-retirement.js";
 import {
   createWorkerSessionPlacementStore,
+  WorkerSessionPlacementRetirementBlockedError,
   type WorkerSessionPlacementRetirement,
 } from "./placement-store.js";
 
@@ -282,5 +283,34 @@ describe("placement session retirement", () => {
     expect(harness.resolveSessionEvidence.mock.calls.map(([placement]) => placement)).toEqual(
       placements,
     );
+  });
+
+  it("reports automatic retirement deferred by retained workspace recovery", async () => {
+    const placement = failedPlacement(activePlacement("session-retained"));
+    const warn = vi.fn();
+    const retirement = createPlacementSessionRetirement({
+      placements: {
+        get: () => placement,
+        list: () => [placement],
+        retireSessionPlacement: () => {
+          throw new WorkerSessionPlacementRetirementBlockedError(placement.sessionId);
+        },
+      },
+      environments: {
+        get: () => ({ state: "destroyed" }) as never,
+      },
+      forceDestroyEnvironment: async () => {
+        throw new Error("must not destroy an already terminal environment");
+      },
+      createSessionEvidenceResolver: async () => async () => "absent",
+      warn,
+    });
+
+    await retirement.reconcile();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Worker placement session retirement deferred for session-retained"),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("force-abandoned"));
   });
 });

--- a/src/gateway/worker-environments/placement-session-retirement.test.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.test.ts
@@ -192,6 +192,7 @@ describe("placement session retirement", () => {
     const retirement = createPlacementSessionRetirement({
       placements: {
         get: (sessionId) => placements.get(sessionId),
+        isEnvironmentTeardownFenced: () => false,
         list: () => placements.list(),
         retireSessionPlacement,
       },

--- a/src/gateway/worker-environments/placement-session-retirement.test.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.test.ts
@@ -6,6 +6,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
 import type { WorkerSessionPlacementRecord } from "./placement-record.js";
 import { createPlacementSessionRetirement } from "./placement-session-retirement.js";
 import {
@@ -125,6 +126,7 @@ function createHarness(records: WorkerSessionPlacementRecord[]) {
         placements.delete(input.sessionId);
         retired.push(input);
       },
+      isEnvironmentTeardownFenced: () => false,
     },
     environments: {
       get: (environmentId) => environments.get(environmentId) as never,
@@ -236,6 +238,7 @@ describe("placement session retirement", () => {
     expect(harness.forceDestroyEnvironment).toHaveBeenCalledWith(
       "environment:session-active",
       expect.any(Function),
+      expect.any(Function),
     );
     expect(harness.retired).toEqual([
       {
@@ -257,6 +260,7 @@ describe("placement session retirement", () => {
         retireSessionPlacement: () => {
           throw new Error("must not retire");
         },
+        isEnvironmentTeardownFenced: () => false,
       },
       environments: { get: () => undefined },
       forceDestroyEnvironment: async () => {
@@ -295,6 +299,7 @@ describe("placement session retirement", () => {
         retireSessionPlacement: () => {
           throw new WorkerSessionPlacementRetirementBlockedError(placement.sessionId);
         },
+        isEnvironmentTeardownFenced: () => true,
       },
       environments: {
         get: () => ({ state: "destroyed" }) as never,
@@ -312,5 +317,57 @@ describe("placement session retirement", () => {
       expect.stringContaining("Worker placement session retirement deferred for session-retained"),
     );
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("force-abandoned"));
+  });
+
+  it("defers automatic teardown while a real pending result owns the active orphan", async () => {
+    const root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-retire-"));
+    try {
+      const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+      const placements = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+      const active = seedActivePlacement(placements, {
+        environmentId: "environment:session-pending",
+        ownerEpoch: 2,
+      });
+      if (active.state !== "active") {
+        throw new Error("expected active placement fixture");
+      }
+      const claim = placements.claimTurn({
+        sessionId: active.sessionId,
+        sessionKey: active.sessionKey,
+        agentId: active.agentId,
+        claimId: "claim-pending-retirement",
+        runId: "run-pending-retirement",
+        owner: {
+          kind: "worker",
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+        },
+      });
+      placements.markWorkspaceResultPending(claim);
+      const forceDestroyEnvironment = vi.fn(async () => {});
+      const warn = vi.fn();
+      const retirement = createPlacementSessionRetirement({
+        placements,
+        environments: { get: () => ({ state: "attached" }) as never },
+        forceDestroyEnvironment,
+        resolveSessionEvidence: async () => "absent",
+        warn,
+      });
+
+      await retirement.reconcile();
+
+      expect(forceDestroyEnvironment).not.toHaveBeenCalled();
+      expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
+      expect(placements.get(active.sessionId)).toMatchObject({
+        state: "active",
+        turnClaim: { claimId: claim.claimId },
+      });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("explicit forced abandonment is required"),
+      );
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/gateway/worker-environments/placement-session-retirement.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.ts
@@ -1,5 +1,8 @@
 import type { WorkerSessionPlacementRecord } from "./placement-record.js";
-import type { WorkerSessionPlacementStore } from "./placement-store.js";
+import {
+  WorkerSessionPlacementRetirementBlockedError,
+  type WorkerSessionPlacementStore,
+} from "./placement-store.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-lifecycle.js";
 
@@ -22,6 +25,12 @@ type PlacementSessionRetirementDeps = {
 };
 
 export function createPlacementSessionRetirement(deps: PlacementSessionRetirementDeps) {
+  const reportRetirementError = (sessionId: string, error: unknown): void => {
+    if (error instanceof WorkerSessionPlacementRetirementBlockedError) {
+      deps.warn(`Worker placement session retirement deferred for ${sessionId}: ${error.message}`);
+    }
+  };
+
   const retireCurrent = (placement: WorkerSessionPlacementRecord): boolean => {
     if (placement.turnClaim) {
       return false;
@@ -71,7 +80,8 @@ export function createPlacementSessionRetirement(deps: PlacementSessionRetiremen
       if (retireCurrent(current)) {
         return;
       }
-    } catch {
+    } catch (error) {
+      reportRetirementError(current.sessionId, error);
       return;
     }
 
@@ -98,8 +108,9 @@ export function createPlacementSessionRetirement(deps: PlacementSessionRetiremen
     }
     try {
       retireCurrent(current);
-    } catch {
+    } catch (error) {
       // A concurrent placement transition owns the next reconciliation pass.
+      reportRetirementError(current.sessionId, error);
     }
   };
 

--- a/src/gateway/worker-environments/placement-session-retirement.ts
+++ b/src/gateway/worker-environments/placement-session-retirement.ts
@@ -1,3 +1,4 @@
+import { WorkerForcedAbandonmentBlockedError } from "./placement-force-abandon.js";
 import type { WorkerSessionPlacementRecord } from "./placement-record.js";
 import {
   WorkerSessionPlacementRetirementBlockedError,
@@ -12,11 +13,15 @@ export type PlacementSessionEvidenceResolver = (
 ) => Promise<PlacementSessionEvidence>;
 
 type PlacementSessionRetirementDeps = {
-  placements: Pick<WorkerSessionPlacementStore, "get" | "list" | "retireSessionPlacement">;
+  placements: Pick<
+    WorkerSessionPlacementStore,
+    "get" | "isEnvironmentTeardownFenced" | "list" | "retireSessionPlacement"
+  >;
   environments: Pick<WorkerEnvironmentService, "get">;
   forceDestroyEnvironment: (
     environmentId: string,
     onCleanupError?: (error: unknown) => void,
+    authorizeAbandonment?: () => boolean,
   ) => Promise<unknown>;
   createSessionEvidenceResolver: (
     placements: readonly WorkerSessionPlacementRecord[],
@@ -89,13 +94,29 @@ export function createPlacementSessionRetirement(deps: PlacementSessionRetiremen
     if (!environmentId) {
       return;
     }
+    if (deps.placements.isEnvironmentTeardownFenced(environmentId)) {
+      deps.warn(
+        `Worker placement orphan cleanup deferred for ${current.sessionId}: workspace recovery still owns ${environmentId}; explicit forced abandonment is required`,
+      );
+      return;
+    }
     try {
-      await deps.forceDestroyEnvironment(environmentId, (error) => {
-        deps.warn(
-          `Worker placement orphan cleanup deferred for ${current?.sessionId ?? placement.sessionId}: ${String(error)}`,
-        );
-      });
+      await deps.forceDestroyEnvironment(
+        environmentId,
+        (error) => {
+          deps.warn(
+            `Worker placement orphan cleanup deferred for ${current?.sessionId ?? placement.sessionId}: ${String(error)}`,
+          );
+        },
+        () => !deps.placements.isEnvironmentTeardownFenced(environmentId),
+      );
     } catch (error) {
+      if (error instanceof WorkerForcedAbandonmentBlockedError) {
+        deps.warn(
+          `Worker placement orphan cleanup deferred for ${current.sessionId}: ${error.message}`,
+        );
+        return;
+      }
       deps.warn(
         `Worker placement orphan teardown failed for ${current.sessionId}: ${String(error)}`,
       );

--- a/src/gateway/worker-environments/placement-store-terminal.test.ts
+++ b/src/gateway/worker-environments/placement-store-terminal.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -33,6 +34,7 @@ describe("worker placement terminal persistence", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -244,6 +246,49 @@ describe("worker placement terminal persistence", () => {
       terminalReason: null,
       terminalAtMs: null,
     });
+  });
+
+  it("batches terminal recovery facts for bulk placement reads", () => {
+    const sessionIds = Array.from({ length: 20 }, (_, index) => {
+      const identity = {
+        sessionId: `session-placement-bulk-${index}`,
+        agentId: "main",
+        sessionKey: `agent:main:placement-bulk-${index}`,
+      };
+      const active = advanceToActive(identity);
+      const draining = store.startDrain({
+        sessionId: identity.sessionId,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        expectedGeneration: active.generation,
+      });
+      const reconciling = store.startReconcile({
+        sessionId: identity.sessionId,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        expectedGeneration: draining.generation,
+      });
+      store.fail({
+        sessionId: identity.sessionId,
+        expectedGeneration: reconciling.generation,
+        recoveryError: "cloud worker disappeared",
+      });
+      return identity.sessionId;
+    });
+    const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+
+    const records = store.getMany(sessionIds);
+    const statements = prepare.mock.calls.map(([sql]) => sql);
+    prepare.mockRestore();
+
+    expect(records).toHaveLength(sessionIds.length);
+    expect([...records.values()].every((record) => !record.terminalRecovery)).toBe(true);
+    const placementSelects = statements.filter((sql) =>
+      /from "(?:worker_session_placements|worker_workspace_pending_results|worker_workspace_reconciliations)"/iu.test(
+        sql,
+      ),
+    );
+    expect(placementSelects).toHaveLength(4);
   });
 
   it("rolls back placement failure when pending-result removal aborts", () => {

--- a/src/gateway/worker-environments/placement-store.redispatch.test.ts
+++ b/src/gateway/worker-environments/placement-store.redispatch.test.ts
@@ -8,7 +8,10 @@ import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import type { WorkerSessionPlacementIdentity } from "./placement-record.js";
+import type {
+  WorkerSessionPlacementIdentity,
+  WorkerSessionPlacementRecord,
+} from "./placement-record.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,
@@ -65,7 +68,7 @@ describe("failed worker placement redispatch", () => {
     return placement;
   }
 
-  function advanceToActive() {
+  function advanceToActive(): Extract<WorkerSessionPlacementRecord, { state: "active" }> {
     const placement = advanceToStarting();
     const active = store.transition({
       sessionId: SESSION.sessionId,

--- a/src/gateway/worker-environments/placement-store.redispatch.test.ts
+++ b/src/gateway/worker-environments/placement-store.redispatch.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -35,7 +36,7 @@ describe("failed worker placement redispatch", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it("uses the canonical generation and identity reset", () => {
+  function advanceToStarting() {
     let placement = store.startDispatch(SESSION);
     placement = store.transition({
       sessionId: SESSION.sessionId,
@@ -61,6 +62,26 @@ describe("failed worker placement redispatch", () => {
         remoteWorkspaceDir: "/workspace/failed-dispatch",
       },
     });
+    return placement;
+  }
+
+  function advanceToActive() {
+    const placement = advanceToStarting();
+    const active = store.transition({
+      sessionId: SESSION.sessionId,
+      from: "starting",
+      to: "active",
+      expectedGeneration: placement.generation,
+      patch: { activeOwnerEpoch: 7 },
+    });
+    if (active.state !== "active") {
+      throw new Error("expected active worker placement");
+    }
+    return active;
+  }
+
+  it("uses the canonical generation and identity reset", () => {
+    const placement = advanceToStarting();
     const failed = store.fail({
       sessionId: SESSION.sessionId,
       expectedGeneration: placement.generation,
@@ -82,4 +103,83 @@ describe("failed worker placement redispatch", () => {
       terminalAtMs: null,
     });
   });
+
+  it.each(["pending result", "retained workspace journal"] as const)(
+    "blocks redispatch while a %s owns terminal recovery",
+    async (recoveryOwner) => {
+      const active = advanceToActive();
+      if (recoveryOwner === "pending result") {
+        const claim = store.claimTurn({
+          ...SESSION,
+          owner: {
+            kind: "worker",
+            environmentId: active.environmentId,
+            ownerEpoch: active.activeOwnerEpoch,
+          },
+          claimId: "redispatch-pending-claim",
+          runId: "redispatch-pending-run",
+        });
+        store.markWorkspaceResultPending(claim);
+        await store.failPendingWorkspaceResult({
+          pending: store.listPendingWorkspaceResults()[0]!,
+          recoveryError: "workspace recovery requires operator action",
+        });
+      } else {
+        const owner = {
+          sessionId: active.sessionId,
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+          placementGeneration: active.generation,
+        };
+        const basePack = Buffer.from("retained redispatch base pack");
+        store.beginWorkspaceReconciliation(owner, {
+          version: 1,
+          temporaryNonce: "c".repeat(32),
+          baseManifestRef: active.workspaceBaseManifestRef,
+          currentManifestRef: `sha256:${"d".repeat(64)}`,
+          baseEntries: [],
+          appliedEntries: [],
+          baseTree: "e".repeat(40),
+          basePackSha256: createHash("sha256").update(basePack).digest("hex"),
+          basePack,
+        });
+        store.retainWorkspaceReconciliationForForcedAbandonment(owner);
+        const draining = store.startDrain({
+          sessionId: active.sessionId,
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+          expectedGeneration: active.generation,
+        });
+        const reconciling = store.startReconcile({
+          sessionId: draining.sessionId,
+          environmentId: draining.environmentId,
+          ownerEpoch: draining.activeOwnerEpoch,
+          expectedGeneration: draining.generation,
+        });
+        store.fail({
+          sessionId: reconciling.sessionId,
+          expectedGeneration: reconciling.generation,
+          recoveryError: "workspace recovery requires operator action",
+        });
+      }
+
+      expect(store.get(SESSION.sessionId)).toMatchObject({
+        state: "failed",
+        terminalRecovery: { action: "force-destroy-environment" },
+      });
+      expect(() => store.startDispatch(SESSION)).toThrow(
+        "must be force-abandoned before redispatch",
+      );
+      expect(store.get(SESSION.sessionId)).toMatchObject({
+        state: "failed",
+        terminalRecovery: { action: "force-destroy-environment" },
+      });
+      expect(store.listPendingWorkspaceResults()).toHaveLength(
+        recoveryOwner === "pending result" ? 1 : 0,
+      );
+      expect(store.listWorkspaceReconciliationOwners()).toHaveLength(
+        recoveryOwner === "retained workspace journal" ? 1 : 0,
+      );
+    },
+  );
 });

--- a/src/gateway/worker-environments/placement-store.redispatch.test.ts
+++ b/src/gateway/worker-environments/placement-store.redispatch.test.ts
@@ -153,6 +153,9 @@ describe("failed worker placement redispatch", () => {
           ownerEpoch: active.activeOwnerEpoch,
           expectedGeneration: active.generation,
         });
+        if (draining.state !== "draining") {
+          throw new Error("expected draining worker placement");
+        }
         const reconciling = store.startReconcile({
           sessionId: draining.sessionId,
           environmentId: draining.environmentId,

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -50,6 +50,7 @@ import {
 import {
   clearWorkerWorkspaceReconciliation,
   createPlacementWorkspaceJournalOps,
+  hasWorkerWorkspaceReconciliation,
 } from "./placement-workspace-journal.js";
 import {
   createPlacementWorkspaceResultOps,
@@ -67,6 +68,17 @@ export type WorkerSessionPlacementRetirement = {
   expectedState: (typeof RETIRABLE_PLACEMENT_STATES)[number];
   expectedGeneration: number;
 };
+
+export class WorkerSessionPlacementRetirementBlockedError extends Error {
+  constructor(
+    readonly sessionId: string,
+    readonly environmentId?: string,
+  ) {
+    super(
+      `Worker session placement ${sessionId} retains cloud workspace recovery that must be force-abandoned before retirement`,
+    );
+  }
+}
 
 function exactConflictPath(value: string): string {
   if (typeof value !== "string" || value.length === 0) {
@@ -228,6 +240,20 @@ export function createWorkerSessionPlacementStore(
         throw new Error(`Cannot retire worker session placement from ${input.expectedState}`);
       }
       write((db) => {
+        const current = find(db, sessionId);
+        if (
+          input.expectedState === "failed" &&
+          current?.state === "failed" &&
+          current.generation === input.expectedGeneration &&
+          current.turnClaim === null &&
+          (hasWorkerWorkspacePendingResult(db, sessionId) ||
+            hasWorkerWorkspaceReconciliation(db, sessionId))
+        ) {
+          throw new WorkerSessionPlacementRetirementBlockedError(
+            sessionId,
+            current.environmentId ?? undefined,
+          );
+        }
         const result = executeSqliteQuerySync(
           db,
           query(db)

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -40,7 +40,7 @@ import {
 } from "./placement-state.js";
 import {
   createPlacementTeardownFenceOps,
-  findWorkerTerminalRecovery,
+  findWorkerTerminalRecoveries,
 } from "./placement-teardown-fence.js";
 import {
   createPlacementTurnClaimOps,
@@ -138,14 +138,13 @@ export function createWorkerSessionPlacementStore(
   const { read, write } = runtime;
   const workspaceResultConflicts = new Map<string, WorkerWorkspaceResultConflict>();
   const withPlacementProjectionFacts = (
-    db: DatabaseSync,
     record: WorkerSessionPlacementRecord | undefined,
+    terminalRecovery?: WorkerSessionPlacementRecord["terminalRecovery"],
   ): WorkerSessionPlacementRecord | undefined => {
     if (!record) {
       return undefined;
     }
     const conflict = workspaceResultConflicts.get(record.sessionId);
-    const terminalRecovery = findWorkerTerminalRecovery(db, record);
     return conflict || terminalRecovery
       ? {
           ...record,
@@ -187,7 +186,11 @@ export function createWorkerSessionPlacementStore(
 
     get(sessionId: string): WorkerSessionPlacementRecord | undefined {
       const db = read();
-      return withPlacementProjectionFacts(db, find(db, required(sessionId, "session id")));
+      const record = find(db, required(sessionId, "session id"));
+      const terminalRecovery = record
+        ? findWorkerTerminalRecoveries(db, [record]).get(record.sessionId)
+        : undefined;
+      return withPlacementProjectionFacts(record, terminalRecovery);
     },
 
     getMany(sessionIds: readonly string[]): ReadonlyMap<string, WorkerSessionPlacementRecord> {
@@ -206,8 +209,15 @@ export function createWorkerSessionPlacementStore(
             .where("session_id", "in", chunk),
         ).rows) {
           const record = fromRow(row);
-          records.set(record.sessionId, withPlacementProjectionFacts(db, record)!);
+          records.set(record.sessionId, record);
         }
+      }
+      const terminalRecoveries = findWorkerTerminalRecoveries(db, [...records.values()]);
+      for (const [sessionId, record] of records) {
+        records.set(
+          sessionId,
+          withPlacementProjectionFacts(record, terminalRecoveries.get(sessionId))!,
+        );
       }
       return records;
     },
@@ -625,7 +635,7 @@ export function createWorkerSessionPlacementStore(
 
     listForReconcile(): WorkerSessionPlacementRecord[] {
       const db = read();
-      return executeSqliteQuerySync(
+      const records = executeSqliteQuerySync(
         db,
         query(db)
           .selectFrom("worker_session_placements")
@@ -633,15 +643,23 @@ export function createWorkerSessionPlacementStore(
           .where("state", "not in", ["local", "reclaimed"])
           .orderBy("updated_at_ms")
           .orderBy("session_id"),
-      ).rows.map((row) => withPlacementProjectionFacts(db, fromRow(row))!);
+      ).rows.map(fromRow);
+      const terminalRecoveries = findWorkerTerminalRecoveries(db, records);
+      return records.map((record) =>
+        withPlacementProjectionFacts(record, terminalRecoveries.get(record.sessionId))!,
+      );
     },
 
     list(): WorkerSessionPlacementRecord[] {
       const db = read();
-      return executeSqliteQuerySync(
+      const records = executeSqliteQuerySync(
         db,
         query(db).selectFrom("worker_session_placements").selectAll().orderBy("session_id"),
-      ).rows.map((row) => withPlacementProjectionFacts(db, fromRow(row))!);
+      ).rows.map(fromRow);
+      const terminalRecoveries = findWorkerTerminalRecoveries(db, records);
+      return records.map((record) =>
+        withPlacementProjectionFacts(record, terminalRecoveries.get(record.sessionId))!,
+      );
     },
   };
 }

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -80,12 +80,12 @@ export class WorkerSessionPlacementRetirementBlockedError extends Error {
   }
 }
 
-class WorkerSessionPlacementRedispatchBlockedError extends Error {
+class WorkerSessionPlacementRecoveryBlockedError extends Error {
   readonly code = "invalid_state";
 
-  constructor(sessionId: string) {
+  constructor(sessionId: string, operation: "reclaim" | "redispatch") {
     super(
-      `Worker session placement ${sessionId} retains cloud workspace recovery that must be force-abandoned before redispatch; use Stop cloud worker and confirm permanent abandonment`,
+      `Worker session placement ${sessionId} retains cloud workspace recovery that must be force-abandoned before ${operation}; call environments.destroy with force=true`,
     );
   }
 }
@@ -330,7 +330,7 @@ export function createWorkerSessionPlacementStore(
         if (current.state === "failed" && hasWorkerWorkspaceRecovery(db, identity.sessionId)) {
           // Redispatch cannot replace the placement generation while its durable
           // recovery rows still own the only copy of unreconciled workspace changes.
-          throw new WorkerSessionPlacementRedispatchBlockedError(identity.sessionId);
+          throw new WorkerSessionPlacementRecoveryBlockedError(identity.sessionId, "redispatch");
         }
         const updatedAtMs = now();
         // Preserve an in-flight local claim while closing admission. Reclaimed
@@ -397,6 +397,15 @@ export function createWorkerSessionPlacementStore(
         }
         if (current.turnClaim) {
           throw new Error(`Cannot transition session ${sessionId} during an active turn`);
+        }
+        if (
+          current.state === "failed" &&
+          input.to === "local" &&
+          hasWorkerWorkspaceRecovery(db, sessionId)
+        ) {
+          // Reclaim must not erase the environment owner needed by explicit
+          // forced abandonment of unreconciled workspace changes.
+          throw new WorkerSessionPlacementRecoveryBlockedError(sessionId, "reclaim");
         }
         return updateTransition(db, current, input.to, input.patch ?? {}, now());
       });

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -80,6 +80,23 @@ export class WorkerSessionPlacementRetirementBlockedError extends Error {
   }
 }
 
+class WorkerSessionPlacementRedispatchBlockedError extends Error {
+  readonly code = "invalid_state";
+
+  constructor(sessionId: string) {
+    super(
+      `Worker session placement ${sessionId} retains cloud workspace recovery that must be force-abandoned before redispatch; use Stop cloud worker and confirm permanent abandonment`,
+    );
+  }
+}
+
+function hasWorkerWorkspaceRecovery(db: DatabaseSync, sessionId: string): boolean {
+  return (
+    hasWorkerWorkspacePendingResult(db, sessionId) ||
+    hasWorkerWorkspaceReconciliation(db, sessionId)
+  );
+}
+
 function exactConflictPath(value: string): string {
   if (typeof value !== "string" || value.length === 0) {
     throw new Error("Worker placement conflict path is required");
@@ -246,8 +263,7 @@ export function createWorkerSessionPlacementStore(
           current?.state === "failed" &&
           current.generation === input.expectedGeneration &&
           current.turnClaim === null &&
-          (hasWorkerWorkspacePendingResult(db, sessionId) ||
-            hasWorkerWorkspaceReconciliation(db, sessionId))
+          hasWorkerWorkspaceRecovery(db, sessionId)
         ) {
           throw new WorkerSessionPlacementRetirementBlockedError(
             sessionId,
@@ -310,6 +326,11 @@ export function createWorkerSessionPlacementStore(
           throw new Error(
             `Cannot dispatch session ${identity.sessionId} from placement ${current.state}`,
           );
+        }
+        if (current.state === "failed" && hasWorkerWorkspaceRecovery(db, identity.sessionId)) {
+          // Redispatch cannot replace the placement generation while its durable
+          // recovery rows still own the only copy of unreconciled workspace changes.
+          throw new WorkerSessionPlacementRedispatchBlockedError(identity.sessionId);
         }
         const updatedAtMs = now();
         // Preserve an in-flight local claim while closing admission. Reclaimed

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -39,6 +39,10 @@ import {
   type WorkerSessionPlacementState,
 } from "./placement-state.js";
 import {
+  createPlacementTeardownFenceOps,
+  findWorkerTerminalRecovery,
+} from "./placement-teardown-fence.js";
+import {
   createPlacementTurnClaimOps,
   registerWorkerTurnClaimClosedHandler,
   signalWorkerTurnClaimClosed,
@@ -50,6 +54,7 @@ import {
 import {
   createPlacementWorkspaceResultOps,
   hasCurrentWorkspaceResultClaim,
+  hasMatchingRetainedFailedWorkspaceResultOwner,
   hasWorkerWorkspacePendingResult,
 } from "./placement-workspace-result.js";
 import { boundedWorkerError } from "./worker-error.js";
@@ -132,14 +137,22 @@ export function createWorkerSessionPlacementStore(
   };
   const { read, write } = runtime;
   const workspaceResultConflicts = new Map<string, WorkerWorkspaceResultConflict>();
-  const withWorkspaceResultConflict = (
+  const withPlacementProjectionFacts = (
+    db: DatabaseSync,
     record: WorkerSessionPlacementRecord | undefined,
   ): WorkerSessionPlacementRecord | undefined => {
     if (!record) {
       return undefined;
     }
     const conflict = workspaceResultConflicts.get(record.sessionId);
-    return conflict ? { ...record, workspaceResultConflict: conflict } : record;
+    const terminalRecovery = findWorkerTerminalRecovery(db, record);
+    return conflict || terminalRecovery
+      ? {
+          ...record,
+          ...(conflict ? { workspaceResultConflict: conflict } : {}),
+          ...(terminalRecovery ? { terminalRecovery } : {}),
+        }
+      : record;
   };
 
   const requireClaimOwner = (claim: WorkerSessionTurnClaim): void => {
@@ -153,18 +166,28 @@ export function createWorkerSessionPlacementStore(
     }
   };
 
+  const turnClaimOps = createPlacementTurnClaimOps(runtime);
+
   return {
-    ...createPlacementTurnClaimOps(runtime),
-    ...createPlacementPendingFailureOps(runtime),
-    ...createPlacementWorkspaceJournalOps(runtime),
-    ...createPlacementWorkspaceResultOps(runtime),
+    ...turnClaimOps,
+    ...createPlacementPendingFailureOps(runtime, {
+      closeWorkerTurnToolState: (claim) => turnClaimOps.closeWorkerTurnToolState(claim),
+    }),
+    ...createPlacementTeardownFenceOps(runtime),
+    ...createPlacementWorkspaceJournalOps(runtime, {
+      hasMatchingRetainedFailedResultOwner: hasMatchingRetainedFailedWorkspaceResultOwner,
+    }),
+    ...createPlacementWorkspaceResultOps(runtime, {
+      signalTurnClaimClosed: signalWorkerTurnClaimClosed,
+    }),
 
     registerTurnClaimClosedHandler(handler: (claim: WorkerSessionTurnClaim) => void): () => void {
       return registerWorkerTurnClaimClosedHandler(path, handler);
     },
 
     get(sessionId: string): WorkerSessionPlacementRecord | undefined {
-      return withWorkspaceResultConflict(find(read(), required(sessionId, "session id")));
+      const db = read();
+      return withPlacementProjectionFacts(db, find(db, required(sessionId, "session id")));
     },
 
     getMany(sessionIds: readonly string[]): ReadonlyMap<string, WorkerSessionPlacementRecord> {
@@ -183,7 +206,7 @@ export function createWorkerSessionPlacementStore(
             .where("session_id", "in", chunk),
         ).rows) {
           const record = fromRow(row);
-          records.set(record.sessionId, withWorkspaceResultConflict(record)!);
+          records.set(record.sessionId, withPlacementProjectionFacts(db, record)!);
         }
       }
       return records;
@@ -610,7 +633,7 @@ export function createWorkerSessionPlacementStore(
           .where("state", "not in", ["local", "reclaimed"])
           .orderBy("updated_at_ms")
           .orderBy("session_id"),
-      ).rows.map((row) => withWorkspaceResultConflict(fromRow(row))!);
+      ).rows.map((row) => withPlacementProjectionFacts(db, fromRow(row))!);
     },
 
     list(): WorkerSessionPlacementRecord[] {
@@ -618,7 +641,7 @@ export function createWorkerSessionPlacementStore(
       return executeSqliteQuerySync(
         db,
         query(db).selectFrom("worker_session_placements").selectAll().orderBy("session_id"),
-      ).rows.map((row) => withWorkspaceResultConflict(fromRow(row))!);
+      ).rows.map((row) => withPlacementProjectionFacts(db, fromRow(row))!);
     },
   };
 }

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -313,6 +313,16 @@ export function createWorkerSessionPlacementStore(
       );
     },
 
+    retireWorkspaceResultConflict(input: { sessionId: string; stagedResultRef: string }): boolean {
+      const sessionId = required(input.sessionId, "session id");
+      const stagedResultRef = required(input.stagedResultRef, "staged result ref");
+      if (workspaceResultConflicts.get(sessionId)?.stagedResultRef !== stagedResultRef) {
+        return false;
+      }
+      workspaceResultConflicts.delete(sessionId);
+      return true;
+    },
+
     startDispatch(input: WorkerSessionPlacementDispatchIdentity): WorkerSessionPlacementRecord {
       const identity = normalizeIdentity(input);
       const executionMode = normalizeWorkerPlacementExecutionMode(input.executionMode);

--- a/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
+++ b/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
@@ -113,3 +113,30 @@ it("emits exact worker claim closure after release and owner fencing", () => {
   expect(closed).toHaveBeenCalledTimes(2);
   unregister();
 });
+
+it("emits exact worker claim closure for a terminal pending result", async () => {
+  const closed = vi.fn();
+  const unregister = store.registerTurnClaimClosedHandler(closed);
+  const active = advanceToActive();
+  const claim = store.claimTurn({
+    ...SESSION,
+    owner: {
+      kind: "worker",
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+    },
+    claimId: "claim-terminal-result",
+    runId: "run-terminal-result",
+  });
+  store.markWorkspaceResultPending(claim);
+
+  const pending = store.listPendingWorkspaceResults()[0]!;
+  await store.failPendingWorkspaceResult({
+    pending,
+    recoveryError: "workspace recovery retained for operator action",
+  });
+
+  expect(closed).toHaveBeenCalledOnce();
+  expect(closed).toHaveBeenCalledWith(claim);
+  unregister();
+});

--- a/src/gateway/worker-environments/placement-teardown-fence.ts
+++ b/src/gateway/worker-environments/placement-teardown-fence.ts
@@ -291,8 +291,8 @@ export function findWorkerTerminalRecovery(
       ])
       .where("session_id", "=", placement.sessionId),
   ).rows[0];
-  if (
-    !pending ||
+  const retainedPendingOwner =
+    pending &&
     classifyPendingWorkspaceResultOwner(placement, {
       sessionId: pending.session_id,
       environmentId: pending.environment_id,
@@ -300,8 +300,17 @@ export function findWorkerTerminalRecovery(
       placementGeneration: pending.placement_generation,
       claimId: pending.claim_id,
       runId: pending.run_id,
-    }) !== "retained-failed"
-  ) {
+    }) === "retained-failed";
+  const retainedJournalOwner =
+    !retainedPendingOwner &&
+    canDestroyForceAbandonedEnvironment(db, placement.environmentId) &&
+    listEnvironmentTeardownFences(db, placement.environmentId).some(
+      (fence) =>
+        fence.kind === "workspace-reconciliation" &&
+        fence.ownerState === "retained-failed" &&
+        fence.sessionId === placement.sessionId,
+    );
+  if (!retainedPendingOwner && !retainedJournalOwner) {
     return undefined;
   }
   return {

--- a/src/gateway/worker-environments/placement-teardown-fence.ts
+++ b/src/gateway/worker-environments/placement-teardown-fence.ts
@@ -6,7 +6,7 @@ import type {
   WorkerSessionTurnClaim,
   WorkerTerminalRecovery,
 } from "./placement-record.js";
-import { find as findPlacement } from "./placement-row-codec.js";
+import { find as findPlacement, fromRow } from "./placement-row-codec.js";
 import type { PlacementStoreRuntime } from "./placement-runtime.js";
 
 type TeardownFenceDatabase = Pick<
@@ -34,6 +34,26 @@ type WorkerEnvironmentTeardownFence = WorkerWorkspaceOwnerIdentity & {
   kind: "pending-workspace-result" | "workspace-reconciliation";
   ownerState: "current" | "retained-failed";
 };
+
+type WorkerWorkspaceJournalOwner = WorkerWorkspaceOwnerIdentity & {
+  retained: boolean;
+};
+
+type EnvironmentTeardownFacts = {
+  fencesByEnvironment: ReadonlyMap<string, readonly WorkerEnvironmentTeardownFence[]>;
+  pendingEnvironmentIds: ReadonlySet<string>;
+  pendingOwnersBySession: ReadonlyMap<string, WorkerPendingResultOwnerIdentity>;
+  relatedPlacementsByEnvironment: ReadonlyMap<string, readonly WorkerSessionPlacementRecord[]>;
+};
+
+function appendGrouped<K, V>(groups: Map<K, V[]>, key: K, value: V): void {
+  const group = groups.get(key);
+  if (group) {
+    group.push(value);
+    return;
+  }
+  groups.set(key, [value]);
+}
 
 export function classifyPendingWorkspaceResultOwner(
   placement: WorkerSessionPlacementRecord | undefined,
@@ -102,41 +122,96 @@ export function classifyWorkspaceJournalOwner(
     : undefined;
 }
 
-function listEnvironmentTeardownFences(
+function loadEnvironmentTeardownFacts(
   db: DatabaseSync,
-  environmentId: string,
-): WorkerEnvironmentTeardownFence[] {
-  const fences: WorkerEnvironmentTeardownFence[] = [];
-  const pendingRows = executeSqliteQuerySync(
-    db,
-    query(db)
-      .selectFrom("worker_workspace_pending_results")
-      .select([
-        "session_id",
-        "environment_id",
-        "owner_epoch",
-        "placement_generation",
-        "claim_id",
-        "run_id",
-      ])
-      .where("environment_id", "=", environmentId)
-      .orderBy("session_id"),
-  ).rows;
-  for (const row of pendingRows) {
-    const owner = {
-      sessionId: row.session_id,
-      environmentId: row.environment_id,
-      ownerEpoch: row.owner_epoch,
-      placementGeneration: row.placement_generation,
-      claimId: row.claim_id,
-      runId: row.run_id,
-    };
+  environmentIds: readonly string[],
+): EnvironmentTeardownFacts {
+  // Keep bulk placement projection on one bounded fact load. Per-row discovery here
+  // synchronously amplifies sessions.list latency for every failed placement.
+  const uniqueEnvironmentIds = [...new Set(environmentIds)];
+  const pendingOwners: WorkerPendingResultOwnerIdentity[] = [];
+  const journalOwners: WorkerWorkspaceJournalOwner[] = [];
+  const relatedPlacementsByEnvironment = new Map<string, WorkerSessionPlacementRecord[]>();
+  const placementsBySession = new Map<string, WorkerSessionPlacementRecord>();
+  for (let offset = 0; offset < uniqueEnvironmentIds.length; offset += 250) {
+    const chunk = uniqueEnvironmentIds.slice(offset, offset + 250);
+    for (const row of executeSqliteQuerySync(
+      db,
+      query(db)
+        .selectFrom("worker_workspace_pending_results")
+        .select([
+          "session_id",
+          "environment_id",
+          "owner_epoch",
+          "placement_generation",
+          "claim_id",
+          "run_id",
+        ])
+        .where("environment_id", "in", chunk)
+        .orderBy("environment_id")
+        .orderBy("session_id"),
+    ).rows) {
+      pendingOwners.push({
+        sessionId: row.session_id,
+        environmentId: row.environment_id,
+        ownerEpoch: row.owner_epoch,
+        placementGeneration: row.placement_generation,
+        claimId: row.claim_id,
+        runId: row.run_id,
+      });
+    }
+    for (const row of executeSqliteQuerySync(
+      db,
+      query(db)
+        .selectFrom("worker_workspace_reconciliations")
+        .select([
+          "session_id",
+          "environment_id",
+          "owner_epoch",
+          "placement_generation",
+          "forced_abandonment_retained",
+        ])
+        .where("environment_id", "in", chunk)
+        .orderBy("environment_id")
+        .orderBy("session_id"),
+    ).rows) {
+      journalOwners.push({
+        sessionId: row.session_id,
+        environmentId: row.environment_id,
+        ownerEpoch: row.owner_epoch,
+        placementGeneration: row.placement_generation,
+        retained: row.forced_abandonment_retained === 1,
+      });
+    }
+    for (const row of executeSqliteQuerySync(
+      db,
+      query(db)
+        .selectFrom("worker_session_placements")
+        .selectAll()
+        .where("environment_id", "in", chunk)
+        .where("state", "not in", ["local", "reclaimed"]),
+    ).rows) {
+      const placement = fromRow(row);
+      if (!placement.environmentId) {
+        throw new Error(`Worker placement ${placement.sessionId} lost its environment ownership`);
+      }
+      placementsBySession.set(placement.sessionId, placement);
+      appendGrouped(relatedPlacementsByEnvironment, placement.environmentId, placement);
+    }
+  }
+
+  const pendingOwnersBySession = new Map<string, WorkerPendingResultOwnerIdentity>();
+  const pendingEnvironmentIds = new Set<string>();
+  const fencesByEnvironment = new Map<string, WorkerEnvironmentTeardownFence[]>();
+  for (const owner of pendingOwners) {
+    pendingOwnersBySession.set(owner.sessionId, owner);
+    pendingEnvironmentIds.add(owner.environmentId);
     const ownerState = classifyPendingWorkspaceResultOwner(
-      findPlacement(db, owner.sessionId),
+      placementsBySession.get(owner.sessionId),
       owner,
     );
     if (ownerState) {
-      fences.push({
+      appendGrouped(fencesByEnvironment, owner.environmentId, {
         kind: "pending-workspace-result",
         ownerState,
         sessionId: owner.sessionId,
@@ -146,37 +221,36 @@ function listEnvironmentTeardownFences(
       });
     }
   }
-  const journalRows = executeSqliteQuerySync(
-    db,
-    query(db)
-      .selectFrom("worker_workspace_reconciliations")
-      .select([
-        "session_id",
-        "environment_id",
-        "owner_epoch",
-        "placement_generation",
-        "forced_abandonment_retained",
-      ])
-      .where("environment_id", "=", environmentId)
-      .orderBy("session_id"),
-  ).rows;
-  for (const row of journalRows) {
-    const owner = {
-      sessionId: row.session_id,
-      environmentId: row.environment_id,
-      ownerEpoch: row.owner_epoch,
-      placementGeneration: row.placement_generation,
-    };
+  for (const { retained, ...owner } of journalOwners) {
     const ownerState = classifyWorkspaceJournalOwner(
-      findPlacement(db, owner.sessionId),
+      placementsBySession.get(owner.sessionId),
       owner,
-      row.forced_abandonment_retained === 1,
+      retained,
     );
     if (ownerState) {
-      fences.push({ kind: "workspace-reconciliation", ownerState, ...owner });
+      appendGrouped(fencesByEnvironment, owner.environmentId, {
+        kind: "workspace-reconciliation",
+        ownerState,
+        ...owner,
+      });
     }
   }
-  return fences;
+  return {
+    fencesByEnvironment,
+    pendingEnvironmentIds,
+    pendingOwnersBySession,
+    relatedPlacementsByEnvironment,
+  };
+}
+
+function listEnvironmentTeardownFences(
+  db: DatabaseSync,
+  environmentId: string,
+): WorkerEnvironmentTeardownFence[] {
+  return [
+    ...(loadEnvironmentTeardownFacts(db, [environmentId]).fencesByEnvironment.get(environmentId) ??
+      []),
+  ];
 }
 
 function isExactFenceOwner(
@@ -238,85 +312,68 @@ function canDestroyAcceptedWorkspaceResult(
   return fences.length > 0 && fences.every((fence) => isExactFenceOwner(fence, owner));
 }
 
-function canDestroyForceAbandonedEnvironment(db: DatabaseSync, environmentId: string): boolean {
-  const pending = executeSqliteQuerySync(
-    db,
-    query(db)
-      .selectFrom("worker_workspace_pending_results")
-      .select("session_id")
-      .where("environment_id", "=", environmentId)
-      .limit(1),
-  ).rows[0];
-  if (pending) {
-    return false;
-  }
-  const relatedPlacements = executeSqliteQuerySync(
-    db,
-    query(db)
-      .selectFrom("worker_session_placements")
-      .select(["session_id", "state", "turn_claim_owner"])
-      .where("environment_id", "=", environmentId)
-      .where("state", "not in", ["local", "reclaimed"]),
-  ).rows;
+function canDestroyForceAbandonedEnvironmentFromFacts(
+  facts: EnvironmentTeardownFacts,
+  environmentId: string,
+): boolean {
   if (
-    relatedPlacements.some(
-      (placement) => placement.state !== "failed" || placement.turn_claim_owner !== null,
+    facts.pendingEnvironmentIds.has(environmentId) ||
+    (facts.relatedPlacementsByEnvironment.get(environmentId) ?? []).some(
+      (placement) => placement.state !== "failed" || placement.turnClaim !== null,
     )
   ) {
     return false;
   }
-  return listEnvironmentTeardownFences(db, environmentId).every(
+  return (facts.fencesByEnvironment.get(environmentId) ?? []).every(
     (fence) => fence.kind === "workspace-reconciliation" && fence.ownerState === "retained-failed",
   );
 }
 
-export function findWorkerTerminalRecovery(
+function canDestroyForceAbandonedEnvironment(db: DatabaseSync, environmentId: string): boolean {
+  return canDestroyForceAbandonedEnvironmentFromFacts(
+    loadEnvironmentTeardownFacts(db, [environmentId]),
+    environmentId,
+  );
+}
+
+export function findWorkerTerminalRecoveries(
   db: DatabaseSync,
-  placement: WorkerSessionPlacementRecord,
-): WorkerTerminalRecovery | undefined {
-  if (placement.state !== "failed" || !placement.environmentId) {
-    return undefined;
+  placements: readonly WorkerSessionPlacementRecord[],
+): ReadonlyMap<string, WorkerTerminalRecovery> {
+  const failedPlacements = placements.filter(
+    (placement) => placement.state === "failed" && placement.environmentId,
+  );
+  const recoveries = new Map<string, WorkerTerminalRecovery>();
+  if (failedPlacements.length === 0) {
+    return recoveries;
   }
-  const pending = executeSqliteQuerySync(
+  const facts = loadEnvironmentTeardownFacts(
     db,
-    query(db)
-      .selectFrom("worker_workspace_pending_results")
-      .select([
-        "session_id",
-        "environment_id",
-        "owner_epoch",
-        "placement_generation",
-        "claim_id",
-        "run_id",
-      ])
-      .where("session_id", "=", placement.sessionId),
-  ).rows[0];
-  const retainedPendingOwner =
-    pending &&
-    classifyPendingWorkspaceResultOwner(placement, {
-      sessionId: pending.session_id,
-      environmentId: pending.environment_id,
-      ownerEpoch: pending.owner_epoch,
-      placementGeneration: pending.placement_generation,
-      claimId: pending.claim_id,
-      runId: pending.run_id,
-    }) === "retained-failed";
-  const retainedJournalOwner =
-    !retainedPendingOwner &&
-    canDestroyForceAbandonedEnvironment(db, placement.environmentId) &&
-    listEnvironmentTeardownFences(db, placement.environmentId).some(
-      (fence) =>
-        fence.kind === "workspace-reconciliation" &&
-        fence.ownerState === "retained-failed" &&
-        fence.sessionId === placement.sessionId,
-    );
-  if (!retainedPendingOwner && !retainedJournalOwner) {
-    return undefined;
+    failedPlacements.map((placement) => placement.environmentId!),
+  );
+  for (const placement of failedPlacements) {
+    const environmentId = placement.environmentId!;
+    const pendingOwner = facts.pendingOwnersBySession.get(placement.sessionId);
+    const retainedPendingOwner =
+      pendingOwner &&
+      classifyPendingWorkspaceResultOwner(placement, pendingOwner) === "retained-failed";
+    const retainedJournalOwner =
+      !retainedPendingOwner &&
+      canDestroyForceAbandonedEnvironmentFromFacts(facts, environmentId) &&
+      (facts.fencesByEnvironment.get(environmentId) ?? []).some(
+        (fence) =>
+          fence.kind === "workspace-reconciliation" &&
+          fence.ownerState === "retained-failed" &&
+          fence.sessionId === placement.sessionId,
+      );
+    if (retainedPendingOwner || retainedJournalOwner) {
+      recoveries.set(placement.sessionId, {
+        action: "force-destroy-environment",
+        dataLoss: "unreconciled-workspace-result",
+      });
+    }
   }
-  return {
-    action: "force-destroy-environment",
-    dataLoss: "unreconciled-workspace-result",
-  };
+  return recoveries;
 }
 
 export function createPlacementTeardownFenceOps(runtime: PlacementStoreRuntime) {

--- a/src/gateway/worker-environments/placement-teardown-fence.ts
+++ b/src/gateway/worker-environments/placement-teardown-fence.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { ensureWorkspaceRetentionSchema } from "../../state/openclaw-state-db-schema-additive.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
 import type {
   WorkerSessionPlacementRecord,
@@ -126,6 +127,7 @@ function loadEnvironmentTeardownFacts(
   db: DatabaseSync,
   environmentIds: readonly string[],
 ): EnvironmentTeardownFacts {
+  ensureWorkspaceRetentionSchema(db);
   // Keep bulk placement projection on one bounded fact load. Per-row discovery here
   // synchronously amplifies sessions.list latency for every failed placement.
   const uniqueEnvironmentIds = [...new Set(environmentIds)];

--- a/src/gateway/worker-environments/placement-teardown-fence.ts
+++ b/src/gateway/worker-environments/placement-teardown-fence.ts
@@ -1,0 +1,332 @@
+import type { DatabaseSync } from "node:sqlite";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
+import type {
+  WorkerSessionPlacementRecord,
+  WorkerSessionTurnClaim,
+  WorkerTerminalRecovery,
+} from "./placement-record.js";
+import { find as findPlacement } from "./placement-row-codec.js";
+import type { PlacementStoreRuntime } from "./placement-runtime.js";
+
+type TeardownFenceDatabase = Pick<
+  StateDatabase,
+  | "worker_session_placements"
+  | "worker_workspace_pending_results"
+  | "worker_workspace_reconciliations"
+>;
+
+const query = (db: DatabaseSync) => getNodeSqliteKysely<TeardownFenceDatabase>(db);
+
+type WorkerWorkspaceOwnerIdentity = {
+  sessionId: string;
+  environmentId: string;
+  ownerEpoch: number;
+  placementGeneration: number;
+};
+
+type WorkerPendingResultOwnerIdentity = WorkerWorkspaceOwnerIdentity & {
+  claimId: string;
+  runId: string;
+};
+
+type WorkerEnvironmentTeardownFence = WorkerWorkspaceOwnerIdentity & {
+  kind: "pending-workspace-result" | "workspace-reconciliation";
+  ownerState: "current" | "retained-failed";
+};
+
+export function classifyPendingWorkspaceResultOwner(
+  placement: WorkerSessionPlacementRecord | undefined,
+  pending: WorkerPendingResultOwnerIdentity,
+): WorkerEnvironmentTeardownFence["ownerState"] | undefined {
+  const claim = placement?.turnClaim;
+  const expectedGeneration =
+    pending.placementGeneration + (placement?.state === "draining" ? 1 : 0);
+  if (
+    (placement?.state === "active" || placement?.state === "draining") &&
+    placement.environmentId === pending.environmentId &&
+    placement.activeOwnerEpoch === pending.ownerEpoch &&
+    placement.generation === expectedGeneration &&
+    claim?.owner === "worker" &&
+    claim.claimId === pending.claimId &&
+    claim.runId === pending.runId &&
+    claim.generation === pending.placementGeneration &&
+    claim.ownerEpoch === pending.ownerEpoch
+  ) {
+    return "current";
+  }
+  return placement?.state === "failed" &&
+    placement.turnClaim === null &&
+    placement.environmentId === pending.environmentId &&
+    placement.activeOwnerEpoch === pending.ownerEpoch &&
+    placement.generation > pending.placementGeneration
+    ? "retained-failed"
+    : undefined;
+}
+
+export function isRetainedFailedWorkspaceResultOwner(
+  placement: WorkerSessionPlacementRecord | undefined,
+  pending: Pick<
+    WorkerWorkspaceOwnerIdentity,
+    "environmentId" | "ownerEpoch" | "placementGeneration"
+  >,
+): placement is Extract<WorkerSessionPlacementRecord, { state: "failed" }> {
+  return (
+    placement?.state === "failed" &&
+    placement.turnClaim === null &&
+    placement.environmentId === pending.environmentId &&
+    placement.activeOwnerEpoch === pending.ownerEpoch &&
+    placement.generation > pending.placementGeneration
+  );
+}
+
+export function classifyWorkspaceJournalOwner(
+  placement: WorkerSessionPlacementRecord | undefined,
+  owner: WorkerWorkspaceOwnerIdentity,
+  retained: boolean,
+): WorkerEnvironmentTeardownFence["ownerState"] | undefined {
+  if (
+    (placement?.state === "active" || placement?.state === "draining") &&
+    placement.environmentId === owner.environmentId &&
+    placement.activeOwnerEpoch === owner.ownerEpoch &&
+    placement.generation === owner.placementGeneration
+  ) {
+    return "current";
+  }
+  return retained &&
+    placement?.state === "failed" &&
+    placement.environmentId === owner.environmentId &&
+    placement.activeOwnerEpoch === owner.ownerEpoch &&
+    placement.generation > owner.placementGeneration
+    ? "retained-failed"
+    : undefined;
+}
+
+function listEnvironmentTeardownFences(
+  db: DatabaseSync,
+  environmentId: string,
+): WorkerEnvironmentTeardownFence[] {
+  const fences: WorkerEnvironmentTeardownFence[] = [];
+  const pendingRows = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_workspace_pending_results")
+      .select([
+        "session_id",
+        "environment_id",
+        "owner_epoch",
+        "placement_generation",
+        "claim_id",
+        "run_id",
+      ])
+      .where("environment_id", "=", environmentId)
+      .orderBy("session_id"),
+  ).rows;
+  for (const row of pendingRows) {
+    const owner = {
+      sessionId: row.session_id,
+      environmentId: row.environment_id,
+      ownerEpoch: row.owner_epoch,
+      placementGeneration: row.placement_generation,
+      claimId: row.claim_id,
+      runId: row.run_id,
+    };
+    const ownerState = classifyPendingWorkspaceResultOwner(
+      findPlacement(db, owner.sessionId),
+      owner,
+    );
+    if (ownerState) {
+      fences.push({
+        kind: "pending-workspace-result",
+        ownerState,
+        sessionId: owner.sessionId,
+        environmentId: owner.environmentId,
+        ownerEpoch: owner.ownerEpoch,
+        placementGeneration: owner.placementGeneration,
+      });
+    }
+  }
+  const journalRows = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_workspace_reconciliations")
+      .select([
+        "session_id",
+        "environment_id",
+        "owner_epoch",
+        "placement_generation",
+        "forced_abandonment_retained",
+      ])
+      .where("environment_id", "=", environmentId)
+      .orderBy("session_id"),
+  ).rows;
+  for (const row of journalRows) {
+    const owner = {
+      sessionId: row.session_id,
+      environmentId: row.environment_id,
+      ownerEpoch: row.owner_epoch,
+      placementGeneration: row.placement_generation,
+    };
+    const ownerState = classifyWorkspaceJournalOwner(
+      findPlacement(db, owner.sessionId),
+      owner,
+      row.forced_abandonment_retained === 1,
+    );
+    if (ownerState) {
+      fences.push({ kind: "workspace-reconciliation", ownerState, ...owner });
+    }
+  }
+  return fences;
+}
+
+function isExactFenceOwner(
+  fence: WorkerEnvironmentTeardownFence,
+  owner: WorkerPendingResultOwnerIdentity,
+): boolean {
+  return (
+    fence.sessionId === owner.sessionId &&
+    fence.environmentId === owner.environmentId &&
+    fence.ownerEpoch === owner.ownerEpoch &&
+    fence.placementGeneration === owner.placementGeneration
+  );
+}
+
+function canDestroyAcceptedWorkspaceResult(
+  db: DatabaseSync,
+  claim: WorkerSessionTurnClaim,
+): boolean {
+  if (claim.owner.kind !== "worker") {
+    return false;
+  }
+  const pending = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_workspace_pending_results")
+      .select([
+        "session_id",
+        "environment_id",
+        "owner_epoch",
+        "placement_generation",
+        "claim_id",
+        "run_id",
+      ])
+      .where("session_id", "=", claim.sessionId)
+      .where("environment_id", "=", claim.owner.environmentId)
+      .where("owner_epoch", "=", claim.owner.ownerEpoch)
+      .where("placement_generation", "=", claim.placementGeneration)
+      .where("claim_id", "=", claim.claimId)
+      .where("run_id", "=", claim.runId)
+      .where("workspace_accepted_at_ms", "is not", null),
+  ).rows[0];
+  if (!pending) {
+    return false;
+  }
+  const owner = {
+    sessionId: pending.session_id,
+    environmentId: pending.environment_id,
+    ownerEpoch: pending.owner_epoch,
+    placementGeneration: pending.placement_generation,
+    claimId: pending.claim_id,
+    runId: pending.run_id,
+  };
+  if (
+    classifyPendingWorkspaceResultOwner(findPlacement(db, owner.sessionId), owner) !== "current"
+  ) {
+    return false;
+  }
+  const fences = listEnvironmentTeardownFences(db, owner.environmentId);
+  return fences.length > 0 && fences.every((fence) => isExactFenceOwner(fence, owner));
+}
+
+function canDestroyForceAbandonedEnvironment(db: DatabaseSync, environmentId: string): boolean {
+  const pending = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_workspace_pending_results")
+      .select("session_id")
+      .where("environment_id", "=", environmentId)
+      .limit(1),
+  ).rows[0];
+  if (pending) {
+    return false;
+  }
+  const relatedPlacements = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_session_placements")
+      .select(["session_id", "state", "turn_claim_owner"])
+      .where("environment_id", "=", environmentId)
+      .where("state", "not in", ["local", "reclaimed"]),
+  ).rows;
+  if (
+    relatedPlacements.some(
+      (placement) => placement.state !== "failed" || placement.turn_claim_owner !== null,
+    )
+  ) {
+    return false;
+  }
+  return listEnvironmentTeardownFences(db, environmentId).every(
+    (fence) => fence.kind === "workspace-reconciliation" && fence.ownerState === "retained-failed",
+  );
+}
+
+export function findWorkerTerminalRecovery(
+  db: DatabaseSync,
+  placement: WorkerSessionPlacementRecord,
+): WorkerTerminalRecovery | undefined {
+  if (placement.state !== "failed" || !placement.environmentId) {
+    return undefined;
+  }
+  const pending = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_workspace_pending_results")
+      .select([
+        "session_id",
+        "environment_id",
+        "owner_epoch",
+        "placement_generation",
+        "claim_id",
+        "run_id",
+      ])
+      .where("session_id", "=", placement.sessionId),
+  ).rows[0];
+  if (
+    !pending ||
+    classifyPendingWorkspaceResultOwner(placement, {
+      sessionId: pending.session_id,
+      environmentId: pending.environment_id,
+      ownerEpoch: pending.owner_epoch,
+      placementGeneration: pending.placement_generation,
+      claimId: pending.claim_id,
+      runId: pending.run_id,
+    }) !== "retained-failed"
+  ) {
+    return undefined;
+  }
+  return {
+    action: "force-destroy-environment",
+    dataLoss: "unreconciled-workspace-result",
+  };
+}
+
+export function createPlacementTeardownFenceOps(runtime: PlacementStoreRuntime) {
+  const { read } = runtime;
+  return {
+    listEnvironmentTeardownFences(environmentId: string): WorkerEnvironmentTeardownFence[] {
+      return listEnvironmentTeardownFences(read(), environmentId);
+    },
+
+    isEnvironmentTeardownFenced(environmentId: string): boolean {
+      return listEnvironmentTeardownFences(read(), environmentId).length > 0;
+    },
+
+    canDestroyAcceptedWorkspaceResult(claim: WorkerSessionTurnClaim): boolean {
+      return canDestroyAcceptedWorkspaceResult(read(), claim);
+    },
+
+    canDestroyForceAbandonedEnvironment(environmentId: string): boolean {
+      return canDestroyForceAbandonedEnvironment(read(), environmentId);
+    },
+  };
+}

--- a/src/gateway/worker-environments/placement-teardown-fence.ts
+++ b/src/gateway/worker-environments/placement-teardown-fence.ts
@@ -2,10 +2,11 @@ import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { ensureWorkspaceRetentionSchema } from "../../state/openclaw-state-db-schema-additive.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
-import type {
-  WorkerSessionPlacementRecord,
-  WorkerSessionTurnClaim,
-  WorkerTerminalRecovery,
+import {
+  placementWorkspaceResultClaim,
+  type WorkerSessionPlacementRecord,
+  type WorkerSessionTurnClaim,
+  type WorkerTerminalRecovery,
 } from "./placement-record.js";
 import { find as findPlacement, fromRow } from "./placement-row-codec.js";
 import type { PlacementStoreRuntime } from "./placement-runtime.js";
@@ -26,7 +27,7 @@ type WorkerWorkspaceOwnerIdentity = {
   placementGeneration: number;
 };
 
-type WorkerPendingResultOwnerIdentity = WorkerWorkspaceOwnerIdentity & {
+export type WorkerPendingResultOwnerIdentity = WorkerWorkspaceOwnerIdentity & {
   claimId: string;
   runId: string;
 };
@@ -60,20 +61,7 @@ export function classifyPendingWorkspaceResultOwner(
   placement: WorkerSessionPlacementRecord | undefined,
   pending: WorkerPendingResultOwnerIdentity,
 ): WorkerEnvironmentTeardownFence["ownerState"] | undefined {
-  const claim = placement?.turnClaim;
-  const expectedGeneration =
-    pending.placementGeneration + (placement?.state === "draining" ? 1 : 0);
-  if (
-    (placement?.state === "active" || placement?.state === "draining") &&
-    placement.environmentId === pending.environmentId &&
-    placement.activeOwnerEpoch === pending.ownerEpoch &&
-    placement.generation === expectedGeneration &&
-    claim?.owner === "worker" &&
-    claim.claimId === pending.claimId &&
-    claim.runId === pending.runId &&
-    claim.generation === pending.placementGeneration &&
-    claim.ownerEpoch === pending.ownerEpoch
-  ) {
+  if (placementWorkspaceResultClaim(placement, pending)) {
     return "current";
   }
   return placement?.state === "failed" &&
@@ -271,7 +259,8 @@ function canDestroyAcceptedWorkspaceResult(
   db: DatabaseSync,
   claim: WorkerSessionTurnClaim,
 ): boolean {
-  if (claim.owner.kind !== "worker") {
+  const { environmentId, ownerEpoch } = claim.owner;
+  if (!environmentId || ownerEpoch === undefined) {
     return false;
   }
   const pending = executeSqliteQuerySync(
@@ -287,8 +276,8 @@ function canDestroyAcceptedWorkspaceResult(
         "run_id",
       ])
       .where("session_id", "=", claim.sessionId)
-      .where("environment_id", "=", claim.owner.environmentId)
-      .where("owner_epoch", "=", claim.owner.ownerEpoch)
+      .where("environment_id", "=", environmentId)
+      .where("owner_epoch", "=", ownerEpoch)
       .where("placement_generation", "=", claim.placementGeneration)
       .where("claim_id", "=", claim.claimId)
       .where("run_id", "=", claim.runId)

--- a/src/gateway/worker-environments/placement-teardown-fence.ts
+++ b/src/gateway/worker-environments/placement-teardown-fence.ts
@@ -27,7 +27,7 @@ type WorkerWorkspaceOwnerIdentity = {
   placementGeneration: number;
 };
 
-export type WorkerPendingResultOwnerIdentity = WorkerWorkspaceOwnerIdentity & {
+type WorkerPendingResultOwnerIdentity = WorkerWorkspaceOwnerIdentity & {
   claimId: string;
   runId: string;
 };
@@ -57,7 +57,7 @@ function appendGrouped<K, V>(groups: Map<K, V[]>, key: K, value: V): void {
   groups.set(key, [value]);
 }
 
-export function classifyPendingWorkspaceResultOwner(
+function classifyPendingWorkspaceResultOwner(
   placement: WorkerSessionPlacementRecord | undefined,
   pending: WorkerPendingResultOwnerIdentity,
 ): WorkerEnvironmentTeardownFence["ownerState"] | undefined {

--- a/src/gateway/worker-environments/placement-worker-gate.test.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.test.ts
@@ -7,7 +7,10 @@ import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import type { WorkerSessionPlacementIdentity } from "./placement-record.js";
+import type {
+  WorkerPlacementExecutionMode,
+  WorkerSessionPlacementIdentity,
+} from "./placement-record.js";
 import { MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS } from "./placement-session-tool-operations.js";
 import {
   createWorkerSessionPlacementStore,
@@ -39,8 +42,8 @@ describe("worker session placement gate", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  function activate() {
-    let placement = store.startDispatch(SESSION);
+  function activate(executionMode: WorkerPlacementExecutionMode = "worker-turn") {
+    let placement = store.startDispatch({ ...SESSION, executionMode });
     placement = store.transition({
       sessionId: SESSION.sessionId,
       from: "requested",
@@ -74,15 +77,18 @@ describe("worker session placement gate", () => {
     });
   }
 
-  function preclaim(runId: string) {
-    const placement = activate();
+  function preclaim(runId: string, owner: "local" | "worker" = "worker") {
+    const placement = activate(owner === "worker" ? "worker-turn" : "remote-exec");
     return store.claimTurn({
       sessionId: placement.sessionId,
       agentId: placement.agentId,
       sessionKey: placement.sessionKey,
       claimId: `claim:${runId}`,
       runId,
-      owner: { kind: "worker", environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
+      owner:
+        owner === "worker"
+          ? { kind: "worker", environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH }
+          : { kind: "local", environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
     });
   }
 
@@ -411,40 +417,43 @@ describe("worker session placement gate", () => {
     expect(() => restarted.releaseTurn(claim)).not.toThrow();
   });
 
-  it("fences an environment only for an exact placement-owned recovery record", async () => {
-    const claim = preclaim("run-worker-terminal");
-    store.markWorkspaceResultPending(claim);
-    const active = store.get(SESSION.sessionId);
-    if (active?.state !== "active") {
-      throw new Error("expected active placement");
-    }
-    const gate = createWorkerSessionPlacementGate(store);
-    expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(true);
-    expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(false);
-    store.acceptWorkspaceResult(claim);
-    expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(true);
-    const pending = store.listPendingWorkspaceResults()[0]!;
-    await store.failPendingWorkspaceResult({
-      pending,
-      recoveryError: "workspace recovery retained for operator action",
-    });
-    expect(store.get(SESSION.sessionId)).toMatchObject({
-      state: "failed",
-      terminalRecovery: {
-        action: "force-destroy-environment",
-        dataLoss: "unreconciled-workspace-result",
-      },
-    });
-    expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(true);
-    expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(false);
-    expect(store.canDestroyForceAbandonedEnvironment(ENVIRONMENT_ID)).toBe(false);
-    expect(gate.isEnvironmentTeardownFenced("environment-other")).toBe(false);
+  it.each(["worker", "local"] as const)(
+    "fences an environment for an exact %s placement-owned recovery record",
+    async (owner) => {
+      const claim = preclaim(`run-${owner}-terminal`, owner);
+      store.markWorkspaceResultPending(claim);
+      const active = store.get(SESSION.sessionId);
+      if (active?.state !== "active") {
+        throw new Error("expected active placement");
+      }
+      const gate = createWorkerSessionPlacementGate(store);
+      expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(true);
+      expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(false);
+      store.acceptWorkspaceResult(claim);
+      expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(true);
+      const pending = store.listPendingWorkspaceResults()[0]!;
+      await store.failPendingWorkspaceResult({
+        pending,
+        recoveryError: "workspace recovery retained for operator action",
+      });
+      expect(store.get(SESSION.sessionId)).toMatchObject({
+        state: "failed",
+        terminalRecovery: {
+          action: "force-destroy-environment",
+          dataLoss: "unreconciled-workspace-result",
+        },
+      });
+      expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(true);
+      expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(false);
+      expect(store.canDestroyForceAbandonedEnvironment(ENVIRONMENT_ID)).toBe(false);
+      expect(gate.isEnvironmentTeardownFenced("environment-other")).toBe(false);
 
-    store.forceAbandonPendingWorkspaceResult({
-      pending,
-      recoveryError: "forced abandonment",
-    });
-    expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(false);
-    expect(store.canDestroyForceAbandonedEnvironment(ENVIRONMENT_ID)).toBe(true);
-  });
+      store.forceAbandonPendingWorkspaceResult({
+        pending,
+        recoveryError: "forced abandonment",
+      });
+      expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(false);
+      expect(store.canDestroyForceAbandonedEnvironment(ENVIRONMENT_ID)).toBe(true);
+    },
+  );
 });

--- a/src/gateway/worker-environments/placement-worker-gate.test.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.test.ts
@@ -410,4 +410,41 @@ describe("worker session placement gate", () => {
     ).toEqual({ kind: "unknown" });
     expect(() => restarted.releaseTurn(claim)).not.toThrow();
   });
+
+  it("fences an environment only for an exact placement-owned recovery record", async () => {
+    const claim = preclaim("run-worker-terminal");
+    store.markWorkspaceResultPending(claim);
+    const active = store.get(SESSION.sessionId);
+    if (active?.state !== "active") {
+      throw new Error("expected active placement");
+    }
+    const gate = createWorkerSessionPlacementGate(store);
+    expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(true);
+    expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(false);
+    store.acceptWorkspaceResult(claim);
+    expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(true);
+    const pending = store.listPendingWorkspaceResults()[0]!;
+    await store.failPendingWorkspaceResult({
+      pending,
+      recoveryError: "workspace recovery retained for operator action",
+    });
+    expect(store.get(SESSION.sessionId)).toMatchObject({
+      state: "failed",
+      terminalRecovery: {
+        action: "force-destroy-environment",
+        dataLoss: "unreconciled-workspace-result",
+      },
+    });
+    expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(true);
+    expect(store.canDestroyAcceptedWorkspaceResult(claim)).toBe(false);
+    expect(store.canDestroyForceAbandonedEnvironment(ENVIRONMENT_ID)).toBe(false);
+    expect(gate.isEnvironmentTeardownFenced("environment-other")).toBe(false);
+
+    store.forceAbandonPendingWorkspaceResult({
+      pending,
+      recoveryError: "forced abandonment",
+    });
+    expect(gate.isEnvironmentTeardownFenced(ENVIRONMENT_ID)).toBe(false);
+    expect(store.canDestroyForceAbandonedEnvironment(ENVIRONMENT_ID)).toBe(true);
+  });
 });

--- a/src/gateway/worker-environments/placement-worker-gate.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.ts
@@ -17,6 +17,7 @@ export type WorkerPlacementTurnBinding = WorkerPlacementBinding &
 
 export type WorkerSessionPlacementGate = {
   hasWorkerTurn(binding: WorkerPlacementBinding): boolean;
+  isEnvironmentTeardownFenced(environmentId: string): boolean;
   validateWorkerTurn(binding: WorkerPlacementTurnBinding): boolean;
   isWorkerTurnToolAuthorized(binding: WorkerPlacementTurnBinding, toolName: string): boolean;
   updateAckCursors(
@@ -69,6 +70,8 @@ export function createWorkerSessionPlacementGate(
       const claim = claimForBinding(store.get(binding.sessionId), binding);
       return claim ? store.validateTurnClaim(claim) : false;
     },
+    isEnvironmentTeardownFenced: (environmentId) =>
+      store.isEnvironmentTeardownFenced(environmentId),
 
     validateWorkerTurn,
 

--- a/src/gateway/worker-environments/placement-workspace-journal.test.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.test.ts
@@ -6,8 +6,11 @@ import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
-import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
+import {
+  FORCED_WORKER_ABANDONMENT_ERROR,
+  REQUEST,
+  seedActivePlacement,
+} from "./placement-dispatch-test-fixtures.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,
@@ -30,11 +33,7 @@ describe("worker placement workspace journal", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
-  const prune = () =>
-    store.pruneOrphanedWorkspaceReconciliations({
-      retainFailedOwner: (recoveryError) =>
-        recoveryError.startsWith(FORCED_WORKER_ABANDONMENT_ERROR),
-    });
+  const prune = () => store.pruneOrphanedWorkspaceReconciliations();
 
   const seedJournal = () => {
     const active = seedActivePlacement(store, { environmentId: "worker-1", ownerEpoch: 7 });
@@ -65,6 +64,7 @@ describe("worker placement workspace journal", () => {
   it("prunes a workspace journal only after its exact owner is gone", () => {
     const { active, owner } = seedJournal();
 
+    expect(store.isEnvironmentTeardownFenced(active.environmentId)).toBe(true);
     expect(prune()).toEqual([]);
     const draining = store.startDrain({
       sessionId: REQUEST.sessionId,
@@ -83,11 +83,15 @@ describe("worker placement workspace journal", () => {
     });
 
     expect(prune()).toEqual([owner]);
+    expect(store.isEnvironmentTeardownFenced(active.environmentId)).toBe(false);
     expect(store.listWorkspaceReconciliationOwners()).toEqual([]);
   });
 
   it("retains a failed owner whose forced rollback is retryable", () => {
     const { active, owner } = seedJournal();
+    expect(store.isWorkspaceReconciliationRetainedForForcedAbandonment(owner)).toBe(false);
+    store.retainWorkspaceReconciliationForForcedAbandonment(owner);
+    expect(store.isWorkspaceReconciliationRetainedForForcedAbandonment(owner)).toBe(true);
     const draining = store.startDrain({
       sessionId: active.sessionId,
       environmentId: active.environmentId,
@@ -109,7 +113,122 @@ describe("worker placement workspace journal", () => {
       recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
     });
 
+    expect(store.isWorkspaceReconciliationRetainedForPendingResult(owner)).toBe(false);
+    const databasePath = database.path;
+    closeOpenClawStateDatabaseForTest();
+    database = openOpenClawStateDatabase({ path: databasePath });
+    store = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    expect(store.isWorkspaceReconciliationRetainedForForcedAbandonment(owner)).toBe(true);
     expect(prune()).toEqual([]);
     expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+  });
+
+  it("retains a terminal failed owner with its matching pending result", async () => {
+    const { active, owner } = seedJournal();
+    const claim = store.claimTurn({
+      ...REQUEST,
+      claimId: "terminal-result-claim",
+      runId: "terminal-result-run",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    store.markWorkspaceResultPending(claim);
+    await store.failPendingWorkspaceResult({
+      pending: store.listPendingWorkspaceResults()[0]!,
+      recoveryError:
+        "workspace quiescence recovery timed out; lease retained for operator recovery",
+    });
+
+    expect(store.isWorkspaceReconciliationRetainedForPendingResult(owner)).toBe(true);
+    expect(prune()).toEqual([]);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+  });
+
+  it("retains a draining journal owned by a terminal pending result after restart", async () => {
+    const active = seedActivePlacement(store, { environmentId: "worker-1", ownerEpoch: 7 });
+    if (active.state !== "active") {
+      throw new Error("expected active placement");
+    }
+    const claim = store.claimTurn({
+      ...REQUEST,
+      claimId: "draining-result-claim",
+      runId: "draining-result-run",
+      owner: {
+        kind: "worker",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+    });
+    const draining = store.startDrain({
+      sessionId: active.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: active.generation,
+    });
+    if (draining.state !== "draining") {
+      throw new Error("expected draining placement");
+    }
+    const owner = {
+      sessionId: draining.sessionId,
+      environmentId: draining.environmentId,
+      ownerEpoch: draining.activeOwnerEpoch,
+      placementGeneration: draining.generation,
+    };
+    const basePack = Buffer.from("draining workspace base pack");
+    store.beginWorkspaceReconciliation(owner, {
+      version: 1,
+      temporaryNonce: "a".repeat(32),
+      baseManifestRef: draining.workspaceBaseManifestRef,
+      currentManifestRef: `sha256:${"b".repeat(64)}`,
+      baseEntries: [],
+      appliedEntries: [],
+      baseTree: "c".repeat(40),
+      basePackSha256: createHash("sha256").update(basePack).digest("hex"),
+      basePack,
+    });
+    store.markWorkspaceResultPending(claim);
+    await store.failPendingWorkspaceResult({
+      pending: store.listPendingWorkspaceResults()[0]!,
+      recoveryError: "terminal recovery retained for operator action",
+    });
+
+    expect(store.isWorkspaceReconciliationRetainedForPendingResult(owner)).toBe(true);
+    const databasePath = database.path;
+    closeOpenClawStateDatabaseForTest();
+    database = openOpenClawStateDatabase({ path: databasePath });
+    store = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    expect(store.isWorkspaceReconciliationRetainedForPendingResult(owner)).toBe(true);
+    expect(prune()).toEqual([]);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+  });
+
+  it("prunes an ordinary failed owner without a pending result", () => {
+    const { active, owner } = seedJournal();
+    const draining = store.startDrain({
+      sessionId: active.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: active.generation,
+    });
+    if (draining.state !== "draining") {
+      throw new Error("expected draining placement");
+    }
+    const reconciling = store.startReconcile({
+      sessionId: draining.sessionId,
+      environmentId: draining.environmentId,
+      ownerEpoch: draining.activeOwnerEpoch,
+      expectedGeneration: draining.generation,
+    });
+    store.fail({
+      sessionId: reconciling.sessionId,
+      expectedGeneration: reconciling.generation,
+      recoveryError: "ordinary placement failure",
+    });
+
+    expect(prune()).toEqual([owner]);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([]);
   });
 });

--- a/src/gateway/worker-environments/placement-workspace-journal.test.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -120,6 +121,48 @@ describe("worker placement workspace journal", () => {
     store = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
     expect(store.isWorkspaceReconciliationRetainedForForcedAbandonment(owner)).toBe(true);
     expect(prune()).toEqual([]);
+    expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
+  });
+
+  it("retains a migrated v6 forced-abandonment journal during startup pruning", () => {
+    const { active, owner } = seedJournal();
+    const draining = store.startDrain({
+      sessionId: active.sessionId,
+      environmentId: active.environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: active.generation,
+    });
+    if (draining.state !== "draining") {
+      throw new Error("expected draining placement");
+    }
+    const reconciling = store.startReconcile({
+      sessionId: draining.sessionId,
+      environmentId: draining.environmentId,
+      ownerEpoch: draining.activeOwnerEpoch,
+      expectedGeneration: draining.generation,
+    });
+    store.fail({
+      sessionId: reconciling.sessionId,
+      expectedGeneration: reconciling.generation,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+
+    const databasePath = database.path;
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy.exec(`
+      ALTER TABLE worker_workspace_reconciliations
+        DROP COLUMN forced_abandonment_retained;
+      PRAGMA user_version = 6;
+      UPDATE schema_meta SET schema_version = 6 WHERE meta_key = 'primary';
+    `);
+    legacy.close();
+
+    database = openOpenClawStateDatabase({ path: databasePath });
+    store = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    expect(prune()).toEqual([]);
+    expect(store.isWorkspaceReconciliationRetainedForForcedAbandonment(owner)).toBe(true);
     expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
   });
 

--- a/src/gateway/worker-environments/placement-workspace-journal.test.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.test.ts
@@ -7,11 +7,8 @@ import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import {
-  FORCED_WORKER_ABANDONMENT_ERROR,
-  REQUEST,
-  seedActivePlacement,
-} from "./placement-dispatch-test-fixtures.js";
+import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,

--- a/src/gateway/worker-environments/placement-workspace-journal.test.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.test.ts
@@ -161,7 +161,21 @@ describe("worker placement workspace journal", () => {
 
     database = openOpenClawStateDatabase({ path: databasePath });
     store = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+    expect(
+      database.db
+        .prepare(
+          "SELECT name FROM pragma_table_info('worker_workspace_reconciliations') WHERE name = 'forced_abandonment_retained'",
+        )
+        .get(),
+    ).toBeUndefined();
     expect(prune()).toEqual([]);
+    expect(
+      database.db
+        .prepare(
+          "SELECT forced_abandonment_retained FROM worker_workspace_reconciliations WHERE session_id = ?",
+        )
+        .get(owner.sessionId),
+    ).toEqual({ forced_abandonment_retained: 1 });
     expect(store.isWorkspaceReconciliationRetainedForForcedAbandonment(owner)).toBe(true);
     expect(store.listWorkspaceReconciliationOwners()).toEqual([owner]);
   });

--- a/src/gateway/worker-environments/placement-workspace-journal.test.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.test.ts
@@ -7,8 +7,11 @@ import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
-import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
+import {
+  FORCED_WORKER_ABANDONMENT_ERROR,
+  REQUEST,
+  seedActivePlacement,
+} from "./placement-dispatch-test-fixtures.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,

--- a/src/gateway/worker-environments/placement-workspace-journal.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.ts
@@ -5,6 +5,7 @@ import type { DB as StateDatabase } from "../../state/openclaw-state-db.generate
 import type { WorkerSessionPlacementRecord } from "./placement-record.js";
 import { find, getRequired } from "./placement-row-codec.js";
 import type { PlacementStoreRuntime } from "./placement-runtime.js";
+import { classifyWorkspaceJournalOwner } from "./placement-teardown-fence.js";
 import {
   parseWorkerWorkspaceReconciliationPlan,
   serializeWorkerWorkspaceReconciliationPlan,
@@ -25,36 +26,20 @@ type WorkerWorkspaceJournalOwner = {
   placementGeneration: number;
 };
 
-function isCurrentJournalOwner(
-  placement: WorkerSessionPlacementRecord | undefined,
-  owner: WorkerWorkspaceJournalOwner,
-): boolean {
-  // Only the original active/draining generation may apply these rollback bytes.
-  // Drain/reconcile advances generation, making the prior journal permanently stale.
-  return (
-    (placement?.state === "active" || placement?.state === "draining") &&
-    placement.environmentId === owner.environmentId &&
-    placement.activeOwnerEpoch === owner.ownerEpoch &&
-    placement.generation === owner.placementGeneration
-  );
-}
-
 function assertJournalOwner(
   db: DatabaseSync,
   owner: WorkerWorkspaceJournalOwner,
   options: { allowFailedOwner?: boolean } = {},
 ) {
   const placement = getRequired(db, owner.sessionId);
-  const isCurrentOwner = isCurrentJournalOwner(placement, owner);
   // Forced teardown advances the exact owner to failed before best-effort
   // rollback. Admit that state without weakening the manifest checks below.
-  const isAllowedFailedOwner =
-    options.allowFailedOwner === true &&
-    placement.state === "failed" &&
-    placement.generation > owner.placementGeneration &&
-    placement.environmentId === owner.environmentId &&
-    placement.activeOwnerEpoch === owner.ownerEpoch;
-  if (!isCurrentOwner && !isAllowedFailedOwner) {
+  const ownerState = classifyWorkspaceJournalOwner(
+    placement,
+    owner,
+    options.allowFailedOwner === true,
+  );
+  if (!ownerState) {
     throw new Error(`Cannot reconcile stale worker workspace for session ${owner.sessionId}`);
   }
   return placement;
@@ -81,7 +66,32 @@ export function clearWorkerWorkspaceReconciliation(
   );
 }
 
-export function createPlacementWorkspaceJournalOps(runtime: PlacementStoreRuntime) {
+export function retainWorkerWorkspaceReconciliation(
+  db: DatabaseSync,
+  owner: WorkerWorkspaceJournalOwner,
+): void {
+  executeSqliteQuerySync(
+    db,
+    query(db)
+      .updateTable("worker_workspace_reconciliations")
+      .set({ forced_abandonment_retained: 1 })
+      .where("session_id", "=", owner.sessionId)
+      .where("environment_id", "=", owner.environmentId)
+      .where("owner_epoch", "=", owner.ownerEpoch)
+      .where("placement_generation", "=", owner.placementGeneration),
+  );
+}
+
+export function createPlacementWorkspaceJournalOps(
+  runtime: PlacementStoreRuntime,
+  deps: {
+    hasMatchingRetainedFailedResultOwner: (
+      db: DatabaseSync,
+      placement: WorkerSessionPlacementRecord | undefined,
+      owner: WorkerWorkspaceJournalOwner,
+    ) => boolean;
+  },
+) {
   const { now, read, write } = runtime;
   return {
     listWorkspaceReconciliationOwners(): WorkerWorkspaceJournalOwner[] {
@@ -100,15 +110,94 @@ export function createPlacementWorkspaceJournalOps(runtime: PlacementStoreRuntim
       }));
     },
 
-    pruneOrphanedWorkspaceReconciliations(options: {
-      retainFailedOwner: (recoveryError: string) => boolean;
-    }): WorkerWorkspaceJournalOwner[] {
+    isWorkspaceReconciliationRetainedForForcedAbandonment(
+      owner: WorkerWorkspaceJournalOwner,
+    ): boolean {
+      const db = read();
+      const row = executeSqliteQuerySync(
+        db,
+        query(db)
+          .selectFrom("worker_workspace_reconciliations")
+          .select("forced_abandonment_retained")
+          .where("session_id", "=", owner.sessionId)
+          .where("environment_id", "=", owner.environmentId)
+          .where("owner_epoch", "=", owner.ownerEpoch)
+          .where("placement_generation", "=", owner.placementGeneration),
+      ).rows[0];
+      return row?.forced_abandonment_retained === 1;
+    },
+
+    isWorkspaceReconciliationRetainedForPendingResult(owner: WorkerWorkspaceJournalOwner): boolean {
+      const db = read();
+      const row = executeSqliteQuerySync(
+        db,
+        query(db)
+          .selectFrom("worker_workspace_reconciliations")
+          .select("forced_abandonment_retained")
+          .where("session_id", "=", owner.sessionId)
+          .where("environment_id", "=", owner.environmentId)
+          .where("owner_epoch", "=", owner.ownerEpoch)
+          .where("placement_generation", "=", owner.placementGeneration),
+      ).rows[0];
+      return (
+        row?.forced_abandonment_retained === 1 &&
+        deps.hasMatchingRetainedFailedResultOwner(db, find(db, owner.sessionId), owner)
+      );
+    },
+
+    retainWorkspaceReconciliationForForcedAbandonment(owner: WorkerWorkspaceJournalOwner): void {
+      write((db) => {
+        const placement = find(db, owner.sessionId);
+        const row = executeSqliteQuerySync(
+          db,
+          query(db)
+            .selectFrom("worker_workspace_reconciliations")
+            .select("forced_abandonment_retained")
+            .where("session_id", "=", owner.sessionId)
+            .where("environment_id", "=", owner.environmentId)
+            .where("owner_epoch", "=", owner.ownerEpoch)
+            .where("placement_generation", "=", owner.placementGeneration),
+        ).rows[0];
+        const retainedFailedResultOwner =
+          row?.forced_abandonment_retained === 1 &&
+          deps.hasMatchingRetainedFailedResultOwner(db, placement, owner);
+        const ownerState = classifyWorkspaceJournalOwner(
+          placement,
+          owner,
+          row?.forced_abandonment_retained === 1,
+        );
+        if (!row || (!ownerState && !retainedFailedResultOwner)) {
+          throw new Error(`Cannot retain stale worker workspace for session ${owner.sessionId}`);
+        }
+        const updated = executeSqliteQuerySync(
+          db,
+          query(db)
+            .updateTable("worker_workspace_reconciliations")
+            .set({ forced_abandonment_retained: 1 })
+            .where("session_id", "=", owner.sessionId)
+            .where("environment_id", "=", owner.environmentId)
+            .where("owner_epoch", "=", owner.ownerEpoch)
+            .where("placement_generation", "=", owner.placementGeneration),
+        );
+        if (updated.numAffectedRows !== 1n) {
+          throw new Error(`Worker workspace journal changed for ${owner.sessionId}`);
+        }
+      });
+    },
+
+    pruneOrphanedWorkspaceReconciliations(): WorkerWorkspaceJournalOwner[] {
       return write((db) => {
         const rows = executeSqliteQuerySync(
           db,
           query(db)
             .selectFrom("worker_workspace_reconciliations")
-            .select(["session_id", "environment_id", "owner_epoch", "placement_generation"])
+            .select([
+              "session_id",
+              "environment_id",
+              "owner_epoch",
+              "placement_generation",
+              "forced_abandonment_retained",
+            ])
             .orderBy("session_id"),
         ).rows;
         const pruned: WorkerWorkspaceJournalOwner[] = [];
@@ -120,14 +209,15 @@ export function createPlacementWorkspaceJournalOps(runtime: PlacementStoreRuntim
             placementGeneration: row.placement_generation,
           };
           const placement = find(db, owner.sessionId);
-          const stillOwned = isCurrentJournalOwner(placement, owner);
-          const retainedFailedOwner =
-            placement?.state === "failed" &&
-            placement.environmentId === owner.environmentId &&
-            placement.activeOwnerEpoch === owner.ownerEpoch &&
-            placement.generation > owner.placementGeneration &&
-            options.retainFailedOwner(placement.recoveryError);
-          if (stillOwned || retainedFailedOwner) {
+          const retainedFailedResultOwner =
+            row.forced_abandonment_retained === 1 &&
+            deps.hasMatchingRetainedFailedResultOwner(db, placement, owner);
+          const ownerState = classifyWorkspaceJournalOwner(
+            placement,
+            owner,
+            row.forced_abandonment_retained === 1,
+          );
+          if (ownerState || retainedFailedResultOwner) {
             continue;
           }
           // Generation and owner epoch only advance, so a mismatched exact owner cannot rebind.

--- a/src/gateway/worker-environments/placement-workspace-journal.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.ts
@@ -67,6 +67,18 @@ export function clearWorkerWorkspaceReconciliation(
   );
 }
 
+export function hasWorkerWorkspaceReconciliation(db: DatabaseSync, sessionId: string): boolean {
+  return Boolean(
+    executeSqliteQuerySync(
+      db,
+      query(db)
+        .selectFrom("worker_workspace_reconciliations")
+        .select("session_id")
+        .where("session_id", "=", sessionId),
+    ).rows[0],
+  );
+}
+
 export function retainWorkerWorkspaceReconciliation(
   db: DatabaseSync,
   owner: WorkerWorkspaceJournalOwner,

--- a/src/gateway/worker-environments/placement-workspace-journal.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { ensureWorkspaceRetentionSchema } from "../../state/openclaw-state-db-schema-additive.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
 import type { WorkerSessionPlacementRecord } from "./placement-record.js";
 import { find, getRequired } from "./placement-row-codec.js";
@@ -70,6 +71,7 @@ export function retainWorkerWorkspaceReconciliation(
   db: DatabaseSync,
   owner: WorkerWorkspaceJournalOwner,
 ): void {
+  ensureWorkspaceRetentionSchema(db);
   executeSqliteQuerySync(
     db,
     query(db)
@@ -114,6 +116,7 @@ export function createPlacementWorkspaceJournalOps(
       owner: WorkerWorkspaceJournalOwner,
     ): boolean {
       const db = read();
+      ensureWorkspaceRetentionSchema(db);
       const row = executeSqliteQuerySync(
         db,
         query(db)
@@ -129,6 +132,7 @@ export function createPlacementWorkspaceJournalOps(
 
     isWorkspaceReconciliationRetainedForPendingResult(owner: WorkerWorkspaceJournalOwner): boolean {
       const db = read();
+      ensureWorkspaceRetentionSchema(db);
       const row = executeSqliteQuerySync(
         db,
         query(db)
@@ -147,6 +151,7 @@ export function createPlacementWorkspaceJournalOps(
 
     retainWorkspaceReconciliationForForcedAbandonment(owner: WorkerWorkspaceJournalOwner): void {
       write((db) => {
+        ensureWorkspaceRetentionSchema(db);
         const placement = find(db, owner.sessionId);
         const row = executeSqliteQuerySync(
           db,
@@ -187,6 +192,7 @@ export function createPlacementWorkspaceJournalOps(
 
     pruneOrphanedWorkspaceReconciliations(): WorkerWorkspaceJournalOwner[] {
       return write((db) => {
+        ensureWorkspaceRetentionSchema(db);
         const rows = executeSqliteQuerySync(
           db,
           query(db)

--- a/src/gateway/worker-environments/placement-workspace-result.ts
+++ b/src/gateway/worker-environments/placement-workspace-result.ts
@@ -8,8 +8,13 @@ import {
   type WorkerSessionPlacementRecord,
   type WorkerSessionTurnClaim,
 } from "./placement-record.js";
-import { getRequired } from "./placement-row-codec.js";
+import { getRequired, query as placementQuery, transitionValues } from "./placement-row-codec.js";
 import type { PlacementStoreRuntime } from "./placement-runtime.js";
+import {
+  assertNoRunningWorkerSessionToolOperations,
+  clearWorkerTurnToolState,
+} from "./placement-session-tool-operations.js";
+import { isRetainedFailedWorkspaceResultOwner } from "./placement-teardown-fence.js";
 import { clearWorkerWorkspaceReconciliation } from "./placement-workspace-journal.js";
 
 type WorkspaceResultDatabase = Pick<
@@ -78,11 +83,62 @@ export function hasCurrentWorkspaceResultClaim(
   return Boolean(row && matchesWorkspaceResultClaim(placement, row, claim));
 }
 
+type WorkerWorkspaceResultOwnerIdentity = Pick<
+  WorkerWorkspacePendingResult,
+  "environmentId" | "ownerEpoch" | "placementGeneration"
+>;
+
+export function hasMatchingRetainedFailedWorkspaceResultOwner(
+  db: DatabaseSync,
+  placement: WorkerSessionPlacementRecord | undefined,
+  owner: WorkerWorkspaceResultOwnerIdentity & { sessionId: string },
+): boolean {
+  const pending = executeSqliteQuerySync(
+    db,
+    query(db)
+      .selectFrom("worker_workspace_pending_results")
+      .select(["environment_id", "owner_epoch", "placement_generation"])
+      .where("session_id", "=", owner.sessionId)
+      .where("environment_id", "=", owner.environmentId)
+      .where("owner_epoch", "=", owner.ownerEpoch),
+  ).rows[0];
+  return Boolean(
+    pending &&
+    (owner.placementGeneration === pending.placement_generation ||
+      owner.placementGeneration === pending.placement_generation + 1) &&
+    isRetainedFailedWorkspaceResultOwner(placement, {
+      environmentId: pending.environment_id,
+      ownerEpoch: pending.owner_epoch,
+      placementGeneration: pending.placement_generation,
+    }),
+  );
+}
+
 export function clearWorkerWorkspacePendingResult(db: DatabaseSync, sessionId: string): void {
   executeSqliteQuerySync(
     db,
     query(db).deleteFrom("worker_workspace_pending_results").where("session_id", "=", sessionId),
   );
+}
+
+function deleteWorkerWorkspacePendingResult(
+  db: DatabaseSync,
+  pending: WorkerWorkspacePendingResult,
+): void {
+  const result = executeSqliteQuerySync(
+    db,
+    query(db)
+      .deleteFrom("worker_workspace_pending_results")
+      .where("session_id", "=", pending.sessionId)
+      .where("environment_id", "=", pending.environmentId)
+      .where("owner_epoch", "=", pending.ownerEpoch)
+      .where("placement_generation", "=", pending.placementGeneration)
+      .where("claim_id", "=", pending.claimId)
+      .where("run_id", "=", pending.runId),
+  );
+  if (result.numAffectedRows !== 1n) {
+    throw new Error(`Worker workspace result changed for ${pending.sessionId}`);
+  }
 }
 
 export function hasWorkerWorkspacePendingResult(db: DatabaseSync, sessionId: string): boolean {
@@ -195,8 +251,13 @@ function markWorkerWorkspacePendingResultAccepted(
   }
 }
 
-export function createPlacementWorkspaceResultOps(runtime: PlacementStoreRuntime) {
-  const { instanceId, now, read, write } = runtime;
+export function createPlacementWorkspaceResultOps(
+  runtime: PlacementStoreRuntime,
+  deps: {
+    signalTurnClaimClosed: (path: string, claim: WorkerSessionTurnClaim) => void;
+  },
+) {
+  const { instanceId, now, path, read, write } = runtime;
   const assertPendingClaim = (db: DatabaseSync, claim: WorkerSessionTurnClaim) => {
     const placement = getRequired(db, claim.sessionId);
     const row = executeSqliteQuerySync(
@@ -318,22 +379,186 @@ export function createPlacementWorkspaceResultOps(runtime: PlacementStoreRuntime
       });
     },
 
-    abandonWorkspaceResult(pending: WorkerWorkspacePendingResult): void {
-      write((db) => {
-        const result = executeSqliteQuerySync(
+    forceAbandonPendingWorkspaceResult(input: {
+      pending: WorkerWorkspacePendingResult;
+      recoveryError: string;
+    }): WorkerSessionPlacementRecord {
+      const { pending } = input;
+      const recoveryError = input.recoveryError.trim();
+      if (!recoveryError) {
+        throw new Error("Forced worker workspace abandonment error is required");
+      }
+      const outcome = write((db) => {
+        const current = getRequired(db, pending.sessionId);
+        const claim = current.turnClaim;
+        const expectedGeneration =
+          pending.placementGeneration + (current.state === "draining" ? 1 : 0);
+        const isCurrentOwner =
+          (current.state === "active" || current.state === "draining") &&
+          current.environmentId === pending.environmentId &&
+          current.activeOwnerEpoch === pending.ownerEpoch &&
+          current.generation === expectedGeneration &&
+          claim?.owner === "worker" &&
+          claim.claimId === pending.claimId &&
+          claim.runId === pending.runId &&
+          claim.generation === pending.placementGeneration &&
+          claim.ownerEpoch === pending.ownerEpoch;
+        const isRetainedFailedOwner = isRetainedFailedWorkspaceResultOwner(current, pending);
+        if (!isCurrentOwner && !isRetainedFailedOwner) {
+          throw new Error(
+            `Cannot force-abandon stale worker workspace result for ${pending.sessionId}`,
+          );
+        }
+
+        const updatedAtMs = now();
+        const update =
+          current.state === "failed"
+            ? placementQuery(db)
+                .updateTable("worker_session_placements")
+                .set({ recovery_error: recoveryError, updated_at_ms: updatedAtMs })
+                .where("session_id", "=", pending.sessionId)
+                .where("state", "=", "failed")
+                .where("transition_generation", "=", current.generation)
+                .where("environment_id", "=", pending.environmentId)
+                .where("active_owner_epoch", "=", pending.ownerEpoch)
+                .where("turn_claim_owner", "is", null)
+            : placementQuery(db)
+                .updateTable("worker_session_placements")
+                .set(transitionValues(current, "failed", { recoveryError }, updatedAtMs))
+                .where("session_id", "=", pending.sessionId)
+                .where("state", "=", current.state)
+                .where("transition_generation", "=", current.generation)
+                .where("environment_id", "=", pending.environmentId)
+                .where("active_owner_epoch", "=", pending.ownerEpoch)
+                .where("turn_claim_owner", "=", "worker")
+                .where("turn_claim_id", "=", pending.claimId)
+                .where("turn_claim_run_id", "=", pending.runId)
+                .where("turn_claim_generation", "=", pending.placementGeneration)
+                .where("turn_claim_owner_epoch", "=", pending.ownerEpoch);
+        const result = executeSqliteQuerySync(db, update);
+        if (result.numAffectedRows !== 1n) {
+          throw new Error(
+            `Pending worker result owner changed during forced abandonment for ${pending.sessionId}`,
+          );
+        }
+        deleteWorkerWorkspacePendingResult(db, pending);
+        return {
+          record: getRequired(db, pending.sessionId),
+          releasedClaim: isCurrentOwner
+            ? {
+                sessionId: pending.sessionId,
+                claimId: pending.claimId,
+                runId: pending.runId,
+                placementGeneration: pending.placementGeneration,
+                owner: {
+                  kind: "worker" as const,
+                  environmentId: pending.environmentId,
+                  ownerEpoch: pending.ownerEpoch,
+                },
+              }
+            : undefined,
+        };
+      });
+      if (outcome.releasedClaim) {
+        deps.signalTurnClaimClosed(path, outcome.releasedClaim);
+      }
+      return outcome.record;
+    },
+
+    forceAbandonWorkerTurn(input: {
+      claim: WorkerSessionTurnClaim;
+      expectedGeneration: number;
+      recoveryError: string;
+    }): { record: WorkerSessionPlacementRecord; stagedResultRef?: string } {
+      const { claim } = input;
+      const recoveryError = input.recoveryError.trim();
+      if (claim.owner.kind !== "worker" || !recoveryError) {
+        throw new Error("Forced worker turn abandonment requires a worker claim and error");
+      }
+      const owner = claim.owner;
+      const outcome = write((db) => {
+        const current = getRequired(db, claim.sessionId);
+        const persisted = current.turnClaim;
+        if (
+          current.state !== "draining" ||
+          current.generation !== input.expectedGeneration ||
+          current.environmentId !== owner.environmentId ||
+          current.activeOwnerEpoch !== owner.ownerEpoch ||
+          persisted?.owner !== "worker" ||
+          persisted.claimId !== claim.claimId ||
+          persisted.runId !== claim.runId ||
+          persisted.generation !== claim.placementGeneration ||
+          persisted.ownerEpoch !== owner.ownerEpoch
+        ) {
+          throw new Error(`Cannot force-abandon stale worker turn for ${claim.sessionId}`);
+        }
+        assertNoRunningWorkerSessionToolOperations(db, {
+          sessionId: claim.sessionId,
+          claimId: claim.claimId,
+        });
+        const pending = executeSqliteQuerySync(
           db,
           query(db)
-            .deleteFrom("worker_workspace_pending_results")
-            .where("session_id", "=", pending.sessionId)
-            .where("environment_id", "=", pending.environmentId)
-            .where("owner_epoch", "=", pending.ownerEpoch)
-            .where("placement_generation", "=", pending.placementGeneration)
-            .where("claim_id", "=", pending.claimId)
-            .where("run_id", "=", pending.runId),
+            .selectFrom("worker_workspace_pending_results")
+            .select([
+              "environment_id",
+              "owner_epoch",
+              "placement_generation",
+              "claim_id",
+              "run_id",
+              "staged_result_ref",
+            ])
+            .where("session_id", "=", claim.sessionId),
+        ).rows[0];
+        if (
+          pending &&
+          (pending.environment_id !== owner.environmentId ||
+            pending.owner_epoch !== owner.ownerEpoch ||
+            pending.placement_generation !== claim.placementGeneration ||
+            pending.claim_id !== claim.claimId ||
+            pending.run_id !== claim.runId)
+        ) {
+          throw new Error(`Cannot force-abandon mismatched worker result for ${claim.sessionId}`);
+        }
+        clearWorkerTurnToolState(db, { sessionId: claim.sessionId, claimId: claim.claimId });
+        if (pending) {
+          clearWorkerWorkspacePendingResult(db, claim.sessionId);
+        }
+        const result = executeSqliteQuerySync(
+          db,
+          placementQuery(db)
+            .updateTable("worker_session_placements")
+            .set(
+              pending
+                ? transitionValues(current, "failed", { recoveryError }, now())
+                : transitionValues(current, "reconciling", {}, now()),
+            )
+            .where("session_id", "=", claim.sessionId)
+            .where("state", "=", "draining")
+            .where("transition_generation", "=", current.generation)
+            .where("environment_id", "=", owner.environmentId)
+            .where("active_owner_epoch", "=", owner.ownerEpoch)
+            .where("turn_claim_owner", "=", "worker")
+            .where("turn_claim_id", "=", claim.claimId)
+            .where("turn_claim_run_id", "=", claim.runId)
+            .where("turn_claim_generation", "=", claim.placementGeneration)
+            .where("turn_claim_owner_epoch", "=", owner.ownerEpoch),
         );
         if (result.numAffectedRows !== 1n) {
-          throw new Error(`Worker workspace result changed for ${pending.sessionId}`);
+          throw new Error(`Worker turn owner changed during abandonment for ${claim.sessionId}`);
         }
+        return {
+          record: getRequired(db, claim.sessionId),
+          stagedResultRef: pending?.staged_result_ref ?? undefined,
+        };
+      });
+      deps.signalTurnClaimClosed(path, claim);
+      return outcome;
+    },
+
+    abandonWorkspaceResult(pending: WorkerWorkspacePendingResult): void {
+      write((db) => {
+        deleteWorkerWorkspacePendingResult(db, pending);
       });
     },
   };

--- a/src/gateway/worker-environments/placement-workspace-result.ts
+++ b/src/gateway/worker-environments/placement-workspace-result.ts
@@ -2,8 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
-  isCurrentPlacementTurnClaim,
-  placementTurnOwner,
+  placementWorkspaceResultClaim,
   resolvePlacementTurnEnvironment,
   type WorkerSessionPlacementRecord,
   type WorkerSessionTurnClaim,
@@ -42,29 +41,23 @@ function matchesWorkspaceResultClaim(
   row: StateDatabase["worker_workspace_pending_results"],
   claim: WorkerSessionTurnClaim,
 ): boolean {
-  const recoveryOwner =
-    placement.state === "active" || placement.state === "draining"
-      ? placementTurnOwner(placement)
-      : undefined;
-  const recoveryGenerationMatches =
-    placement.state === "active"
-      ? placement.generation === claim.placementGeneration
-      : placement.state === "draining" && placement.generation === claim.placementGeneration + 1;
-  return (
-    row.session_id === claim.sessionId &&
-    row.environment_id === placement.environmentId &&
-    row.owner_epoch === placement.activeOwnerEpoch &&
-    row.placement_generation === claim.placementGeneration &&
-    row.claim_id === claim.claimId &&
-    row.run_id === claim.runId &&
-    (isCurrentPlacementTurnClaim(placement, claim) ||
-      // Restart revokes local authority; only the exact durable result may finish.
-      (recoveryGenerationMatches &&
-        placement.turnClaim === null &&
-        recoveryOwner?.kind === "local" &&
-        claim.owner.kind === "local" &&
-        claim.owner.environmentId === recoveryOwner.environmentId &&
-        claim.owner.ownerEpoch === recoveryOwner.ownerEpoch))
+  const currentClaim = placementWorkspaceResultClaim(placement, {
+    sessionId: row.session_id,
+    environmentId: row.environment_id,
+    ownerEpoch: row.owner_epoch,
+    placementGeneration: row.placement_generation,
+    claimId: row.claim_id,
+    runId: row.run_id,
+  });
+  return Boolean(
+    currentClaim &&
+    currentClaim.sessionId === claim.sessionId &&
+    currentClaim.claimId === claim.claimId &&
+    currentClaim.runId === claim.runId &&
+    currentClaim.placementGeneration === claim.placementGeneration &&
+    currentClaim.owner.kind === claim.owner.kind &&
+    currentClaim.owner.environmentId === claim.owner.environmentId &&
+    currentClaim.owner.ownerEpoch === claim.owner.ownerEpoch,
   );
 }
 
@@ -390,19 +383,8 @@ export function createPlacementWorkspaceResultOps(
       }
       const outcome = write((db) => {
         const current = getRequired(db, pending.sessionId);
-        const claim = current.turnClaim;
-        const expectedGeneration =
-          pending.placementGeneration + (current.state === "draining" ? 1 : 0);
-        const isCurrentOwner =
-          (current.state === "active" || current.state === "draining") &&
-          current.environmentId === pending.environmentId &&
-          current.activeOwnerEpoch === pending.ownerEpoch &&
-          current.generation === expectedGeneration &&
-          claim?.owner === "worker" &&
-          claim.claimId === pending.claimId &&
-          claim.runId === pending.runId &&
-          claim.generation === pending.placementGeneration &&
-          claim.ownerEpoch === pending.ownerEpoch;
+        const currentClaim = placementWorkspaceResultClaim(current, pending);
+        const isCurrentOwner = Boolean(currentClaim);
         const isRetainedFailedOwner = isRetainedFailedWorkspaceResultOwner(current, pending);
         if (!isCurrentOwner && !isRetainedFailedOwner) {
           throw new Error(
@@ -411,30 +393,38 @@ export function createPlacementWorkspaceResultOps(
         }
 
         const updatedAtMs = now();
-        const update =
-          current.state === "failed"
-            ? placementQuery(db)
-                .updateTable("worker_session_placements")
-                .set({ recovery_error: recoveryError, updated_at_ms: updatedAtMs })
-                .where("session_id", "=", pending.sessionId)
-                .where("state", "=", "failed")
-                .where("transition_generation", "=", current.generation)
-                .where("environment_id", "=", pending.environmentId)
-                .where("active_owner_epoch", "=", pending.ownerEpoch)
-                .where("turn_claim_owner", "is", null)
-            : placementQuery(db)
-                .updateTable("worker_session_placements")
-                .set(transitionValues(current, "failed", { recoveryError }, updatedAtMs))
-                .where("session_id", "=", pending.sessionId)
-                .where("state", "=", current.state)
-                .where("transition_generation", "=", current.generation)
-                .where("environment_id", "=", pending.environmentId)
-                .where("active_owner_epoch", "=", pending.ownerEpoch)
-                .where("turn_claim_owner", "=", "worker")
-                .where("turn_claim_id", "=", pending.claimId)
-                .where("turn_claim_run_id", "=", pending.runId)
-                .where("turn_claim_generation", "=", pending.placementGeneration)
-                .where("turn_claim_owner_epoch", "=", pending.ownerEpoch);
+        let update;
+        if (current.state === "failed") {
+          update = placementQuery(db)
+            .updateTable("worker_session_placements")
+            .set({ recovery_error: recoveryError, updated_at_ms: updatedAtMs })
+            .where("session_id", "=", pending.sessionId)
+            .where("state", "=", "failed")
+            .where("transition_generation", "=", current.generation)
+            .where("environment_id", "=", pending.environmentId)
+            .where("active_owner_epoch", "=", pending.ownerEpoch)
+            .where("turn_claim_owner", "is", null);
+        } else {
+          if (!currentClaim) {
+            throw new Error(`Pending worker result lost its claim for ${pending.sessionId}`);
+          }
+          const claimedUpdate = placementQuery(db)
+            .updateTable("worker_session_placements")
+            .set(transitionValues(current, "failed", { recoveryError }, updatedAtMs))
+            .where("session_id", "=", pending.sessionId)
+            .where("state", "=", current.state)
+            .where("transition_generation", "=", current.generation)
+            .where("environment_id", "=", pending.environmentId)
+            .where("active_owner_epoch", "=", pending.ownerEpoch)
+            .where("turn_claim_owner", "=", currentClaim.owner.kind)
+            .where("turn_claim_id", "=", pending.claimId)
+            .where("turn_claim_run_id", "=", pending.runId)
+            .where("turn_claim_generation", "=", pending.placementGeneration);
+          update =
+            currentClaim.owner.kind === "worker"
+              ? claimedUpdate.where("turn_claim_owner_epoch", "=", pending.ownerEpoch)
+              : claimedUpdate.where("turn_claim_owner_epoch", "is", null);
+        }
         const result = executeSqliteQuerySync(db, update);
         if (result.numAffectedRows !== 1n) {
           throw new Error(
@@ -444,19 +434,7 @@ export function createPlacementWorkspaceResultOps(
         deleteWorkerWorkspacePendingResult(db, pending);
         return {
           record: getRequired(db, pending.sessionId),
-          releasedClaim: isCurrentOwner
-            ? {
-                sessionId: pending.sessionId,
-                claimId: pending.claimId,
-                runId: pending.runId,
-                placementGeneration: pending.placementGeneration,
-                owner: {
-                  kind: "worker" as const,
-                  environmentId: pending.environmentId,
-                  ownerEpoch: pending.ownerEpoch,
-                },
-              }
-            : undefined,
+          releasedClaim: isCurrentOwner ? currentClaim : undefined,
         };
       });
       if (outcome.releasedClaim) {
@@ -472,23 +450,16 @@ export function createPlacementWorkspaceResultOps(
     }): { record: WorkerSessionPlacementRecord; stagedResultRef?: string } {
       const { claim } = input;
       const recoveryError = input.recoveryError.trim();
-      if (claim.owner.kind !== "worker" || !recoveryError) {
-        throw new Error("Forced worker turn abandonment requires a worker claim and error");
+      if (!recoveryError) {
+        throw new Error("Forced worker turn abandonment requires a turn claim and error");
       }
-      const owner = claim.owner;
       const outcome = write((db) => {
         const current = getRequired(db, claim.sessionId);
-        const persisted = current.turnClaim;
+        const environment = resolvePlacementTurnEnvironment(current, claim);
         if (
           current.state !== "draining" ||
           current.generation !== input.expectedGeneration ||
-          current.environmentId !== owner.environmentId ||
-          current.activeOwnerEpoch !== owner.ownerEpoch ||
-          persisted?.owner !== "worker" ||
-          persisted.claimId !== claim.claimId ||
-          persisted.runId !== claim.runId ||
-          persisted.generation !== claim.placementGeneration ||
-          persisted.ownerEpoch !== owner.ownerEpoch
+          !environment
         ) {
           throw new Error(`Cannot force-abandon stale worker turn for ${claim.sessionId}`);
         }
@@ -512,8 +483,8 @@ export function createPlacementWorkspaceResultOps(
         ).rows[0];
         if (
           pending &&
-          (pending.environment_id !== owner.environmentId ||
-            pending.owner_epoch !== owner.ownerEpoch ||
+          (pending.environment_id !== environment.environmentId ||
+            pending.owner_epoch !== environment.ownerEpoch ||
             pending.placement_generation !== claim.placementGeneration ||
             pending.claim_id !== claim.claimId ||
             pending.run_id !== claim.runId)
@@ -524,26 +495,27 @@ export function createPlacementWorkspaceResultOps(
         if (pending) {
           clearWorkerWorkspacePendingResult(db, claim.sessionId);
         }
-        const result = executeSqliteQuerySync(
-          db,
-          placementQuery(db)
-            .updateTable("worker_session_placements")
-            .set(
-              pending
-                ? transitionValues(current, "failed", { recoveryError }, now())
-                : transitionValues(current, "reconciling", {}, now()),
-            )
-            .where("session_id", "=", claim.sessionId)
-            .where("state", "=", "draining")
-            .where("transition_generation", "=", current.generation)
-            .where("environment_id", "=", owner.environmentId)
-            .where("active_owner_epoch", "=", owner.ownerEpoch)
-            .where("turn_claim_owner", "=", "worker")
-            .where("turn_claim_id", "=", claim.claimId)
-            .where("turn_claim_run_id", "=", claim.runId)
-            .where("turn_claim_generation", "=", claim.placementGeneration)
-            .where("turn_claim_owner_epoch", "=", owner.ownerEpoch),
-        );
+        const claimedUpdate = placementQuery(db)
+          .updateTable("worker_session_placements")
+          .set(
+            pending
+              ? transitionValues(current, "failed", { recoveryError }, now())
+              : transitionValues(current, "reconciling", {}, now()),
+          )
+          .where("session_id", "=", claim.sessionId)
+          .where("state", "=", "draining")
+          .where("transition_generation", "=", current.generation)
+          .where("environment_id", "=", environment.environmentId)
+          .where("active_owner_epoch", "=", environment.ownerEpoch)
+          .where("turn_claim_owner", "=", claim.owner.kind)
+          .where("turn_claim_id", "=", claim.claimId)
+          .where("turn_claim_run_id", "=", claim.runId)
+          .where("turn_claim_generation", "=", claim.placementGeneration);
+        const update =
+          claim.owner.kind === "worker"
+            ? claimedUpdate.where("turn_claim_owner_epoch", "=", environment.ownerEpoch)
+            : claimedUpdate.where("turn_claim_owner_epoch", "is", null);
+        const result = executeSqliteQuerySync(db, update);
         if (result.numAffectedRows !== 1n) {
           throw new Error(`Worker turn owner changed during abandonment for ${claim.sessionId}`);
         }

--- a/src/gateway/worker-environments/placement-workspace-result.ts
+++ b/src/gateway/worker-environments/placement-workspace-result.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
+  isCurrentPlacementTurnClaim,
   placementWorkspaceResultClaim,
   resolvePlacementTurnEnvironment,
   type WorkerSessionPlacementRecord,
@@ -384,6 +385,10 @@ export function createPlacementWorkspaceResultOps(
       const outcome = write((db) => {
         const current = getRequired(db, pending.sessionId);
         const currentClaim = placementWorkspaceResultClaim(current, pending);
+        const liveClaim =
+          currentClaim && isCurrentPlacementTurnClaim(current, currentClaim)
+            ? currentClaim
+            : undefined;
         const isCurrentOwner = Boolean(currentClaim);
         const isRetainedFailedOwner = isRetainedFailedWorkspaceResultOwner(current, pending);
         if (!isCurrentOwner && !isRetainedFailedOwner) {
@@ -408,22 +413,35 @@ export function createPlacementWorkspaceResultOps(
           if (!currentClaim) {
             throw new Error(`Pending worker result lost its claim for ${pending.sessionId}`);
           }
-          const claimedUpdate = placementQuery(db)
+          const placementUpdate = placementQuery(db)
             .updateTable("worker_session_placements")
             .set(transitionValues(current, "failed", { recoveryError }, updatedAtMs))
             .where("session_id", "=", pending.sessionId)
             .where("state", "=", current.state)
             .where("transition_generation", "=", current.generation)
             .where("environment_id", "=", pending.environmentId)
-            .where("active_owner_epoch", "=", pending.ownerEpoch)
-            .where("turn_claim_owner", "=", currentClaim.owner.kind)
-            .where("turn_claim_id", "=", pending.claimId)
-            .where("turn_claim_run_id", "=", pending.runId)
-            .where("turn_claim_generation", "=", pending.placementGeneration);
+            .where("active_owner_epoch", "=", pending.ownerEpoch);
           update =
-            currentClaim.owner.kind === "worker"
-              ? claimedUpdate.where("turn_claim_owner_epoch", "=", pending.ownerEpoch)
-              : claimedUpdate.where("turn_claim_owner_epoch", "is", null);
+            liveClaim?.owner.kind === "worker"
+              ? placementUpdate
+                  .where("turn_claim_owner", "=", "worker")
+                  .where("turn_claim_id", "=", pending.claimId)
+                  .where("turn_claim_run_id", "=", pending.runId)
+                  .where("turn_claim_generation", "=", pending.placementGeneration)
+                  .where("turn_claim_owner_epoch", "=", pending.ownerEpoch)
+              : liveClaim
+                ? placementUpdate
+                    .where("turn_claim_owner", "=", "local")
+                    .where("turn_claim_id", "=", pending.claimId)
+                    .where("turn_claim_run_id", "=", pending.runId)
+                    .where("turn_claim_generation", "=", pending.placementGeneration)
+                    .where("turn_claim_owner_epoch", "is", null)
+                : placementUpdate
+                    .where("turn_claim_owner", "is", null)
+                    .where("turn_claim_id", "is", null)
+                    .where("turn_claim_run_id", "is", null)
+                    .where("turn_claim_generation", "is", null)
+                    .where("turn_claim_owner_epoch", "is", null);
         }
         const result = executeSqliteQuerySync(db, update);
         if (result.numAffectedRows !== 1n) {
@@ -434,7 +452,7 @@ export function createPlacementWorkspaceResultOps(
         deleteWorkerWorkspacePendingResult(db, pending);
         return {
           record: getRequired(db, pending.sessionId),
-          releasedClaim: isCurrentOwner ? currentClaim : undefined,
+          releasedClaim: isCurrentOwner ? liveClaim : undefined,
         };
       });
       if (outcome.releasedClaim) {

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -87,10 +87,9 @@ type WorkerProviderLifecycleOptions = {
 
 export type WorkerEnvironmentTeardownAuthorization = () => boolean;
 
-export type WorkerProviderFactReconciliation = {
-  environmentId: string;
-  hostIsolation: "fresh" | "unavailable";
-};
+export type WorkerProviderFactReconciliation =
+  | { environmentId: string; inspection: "active"; hostIsolation: "fresh" }
+  | { environmentId: string; inspection: "dormant" | "unavailable"; hostIsolation: "unavailable" };
 
 function requireProviderProvisionTimeoutMs(timeoutMs: number | undefined): number | undefined {
   if (timeoutMs === undefined) {
@@ -413,10 +412,9 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     return finishProvenDestroy(destroying);
   };
 
-  const recordStaleBuildDestroy = (record: WorkerEnvironmentRecord) => {
-    // Attached sessions need the build cause after teardown so placement reconciliation can
-    // persist an actionable terminal reason instead of inferring from destroyed environment state.
-    return record.state === "attached"
+  const recordStaleBuildDestroy = (record: WorkerEnvironmentRecord) =>
+    // Persist the stale-build cause so attached placements retain an actionable terminal reason.
+    record.state === "attached"
       ? store.requestDestroy({
           environmentId: record.environmentId,
           state: record.state,
@@ -424,11 +422,10 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
           lastError: STALE_WORKER_BUILD_REASON,
         })
       : record;
-  };
 
   const reconcileRecordState = async (
     initialRecord: WorkerEnvironmentRecord,
-    markHostIsolationFresh: () => void,
+    recordInspection: (inspection: "active" | "dormant") => void,
   ): Promise<void> => {
     let record = initialRecord;
     if (record.state === "requested" && record.destroyRequestedAtMs !== null) {
@@ -512,6 +509,8 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     if (status === "dormant") {
       if (teardownExpected) {
         await finishDestroy(record, provider).catch(() => undefined);
+      } else {
+        recordInspection("dormant");
       }
       // A paired device may be offline without losing its lease. Keep that authoritative
       // holding state out of the unknown/orphan path until pairing itself is removed.
@@ -529,7 +528,7 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       leaseId,
       sharedHost: inspectedSharedHost,
     });
-    markHostIsolationFresh();
+    recordInspection("active");
     if (record.destroyRequestedAtMs !== null) {
       await finishDestroy(record, provider).catch(() => undefined);
       return;
@@ -609,11 +608,17 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
   const reconcileRecord = async (
     initialRecord: WorkerEnvironmentRecord,
   ): Promise<WorkerProviderFactReconciliation> => {
-    let hostIsolation: WorkerProviderFactReconciliation["hostIsolation"] = "unavailable";
-    await reconcileRecordState(initialRecord, () => {
-      hostIsolation = "fresh";
+    let inspection: "active" | "dormant" | undefined;
+    await reconcileRecordState(initialRecord, (current) => {
+      inspection = current;
     });
-    return { environmentId: initialRecord.environmentId, hostIsolation };
+    return inspection === "active"
+      ? { environmentId: initialRecord.environmentId, inspection, hostIsolation: "fresh" }
+      : {
+          environmentId: initialRecord.environmentId,
+          inspection: inspection ?? "unavailable",
+          hostIsolation: "unavailable",
+        };
   };
 
   const createWithProfile = async (
@@ -705,8 +710,7 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       authorizeTeardown?: WorkerEnvironmentTeardownAuthorization;
     } = {},
   ) => {
-    const stopping = options.isStopping();
-    if (stopping) {
+    if (options.isStopping()) {
       throw serviceError("invalid_state", "Worker environment service is stopping");
     }
     return withLock(environmentId, async () => {

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -514,9 +514,6 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       // Workspace actions capture isolation at tunnel creation. Fence the old actions before
       // committing a provider-owned change so no reconciliation can use stale host scope.
       await tunnels?.stop(record.environmentId);
-      if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
-        return;
-      }
     }
     record = store.reconcileSharedHost({
       environmentId: record.environmentId,

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -87,6 +87,11 @@ type WorkerProviderLifecycleOptions = {
 
 export type WorkerEnvironmentTeardownAuthorization = () => boolean;
 
+export type WorkerProviderFactReconciliation = {
+  environmentId: string;
+  hostIsolation: "fresh" | "unavailable";
+};
+
 function requireProviderProvisionTimeoutMs(timeoutMs: number | undefined): number | undefined {
   if (timeoutMs === undefined) {
     return undefined;
@@ -421,7 +426,10 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       : record;
   };
 
-  const reconcileRecord = async (initialRecord: WorkerEnvironmentRecord): Promise<void> => {
+  const reconcileRecordState = async (
+    initialRecord: WorkerEnvironmentRecord,
+    markHostIsolationFresh: () => void,
+  ): Promise<void> => {
     let record = initialRecord;
     if (record.state === "requested" && record.destroyRequestedAtMs !== null) {
       return void cancelRequested(record);
@@ -521,6 +529,7 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       leaseId,
       sharedHost: inspectedSharedHost,
     });
+    markHostIsolationFresh();
     if (record.destroyRequestedAtMs !== null) {
       await finishDestroy(record, provider).catch(() => undefined);
       return;
@@ -595,6 +604,16 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     if (inState(record, "draining", "destroying")) {
       await finishDestroy(record, provider).catch(() => undefined);
     }
+  };
+
+  const reconcileRecord = async (
+    initialRecord: WorkerEnvironmentRecord,
+  ): Promise<WorkerProviderFactReconciliation> => {
+    let hostIsolation: WorkerProviderFactReconciliation["hostIsolation"] = "unavailable";
+    await reconcileRecordState(initialRecord, () => {
+      hostIsolation = "fresh";
+    });
+    return { environmentId: initialRecord.environmentId, hostIsolation };
   };
 
   const createWithProfile = async (

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -53,6 +53,9 @@ type WorkerProviderLifecycleOptions = {
   ensureNodeWorkerBundle?: (deviceId: string) => Promise<WorkerAdmissionHandshake>;
   providerCallTimeoutMs?: number;
   tunnelManager?: Pick<WorkerTunnelManager, "stop">;
+  placementStore?: {
+    isEnvironmentTeardownFenced(environmentId: string): boolean;
+  };
   credentialBroker: WorkerCredentialBroker;
   callBootstrap: <T>(
     installation: WorkerInstallationArtifact,
@@ -81,6 +84,8 @@ type WorkerProviderLifecycleOptions = {
   ) => Error;
   withLock: <T>(environmentId: string, task: () => Promise<T>) => Promise<T>;
 };
+
+export type WorkerEnvironmentTeardownAuthorization = () => boolean;
 
 function requireProviderProvisionTimeoutMs(timeoutMs: number | undefined): number | undefined {
   if (timeoutMs === undefined) {
@@ -363,15 +368,37 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     throw serviceError("invalid_state", `Cannot destroy worker in state: ${record.state}`);
   };
 
-  const finishDestroy = async (r: WorkerEnvironmentRecord, provider?: WorkerProvider) => {
+  const assertTeardownAllowed = (
+    environmentId: string,
+    authorizeTeardown?: WorkerEnvironmentTeardownAuthorization,
+  ): void => {
+    const allowed = authorizeTeardown
+      ? authorizeTeardown()
+      : !options.placementStore?.isEnvironmentTeardownFenced(environmentId);
+    if (!allowed) {
+      throw serviceError(
+        "invalid_state",
+        "Worker environment teardown is fenced by a pending workspace result",
+      );
+    }
+  };
+
+  const finishDestroy = async (
+    r: WorkerEnvironmentRecord,
+    provider?: WorkerProvider,
+    authorizeTeardown?: WorkerEnvironmentTeardownAuthorization,
+  ) => {
     if (!r.leaseId) {
       throw serviceError("invalid_state", "Worker environment has no lease");
     }
+    assertTeardownAllowed(r.environmentId, authorizeTeardown);
     const leaseId = r.leaseId;
-    const draining = beginDrain(r);
     await tunnels?.stop(r.environmentId);
+    // Authorization is operational authority, not a bearer token. Re-read its
+    // exact SQLite owner after the awaited tunnel stop before provider teardown.
+    assertTeardownAllowed(r.environmentId, authorizeTeardown);
     const owningProvider = provider ?? providerFor(r.providerId);
-    const destroying = beginDestroy(draining);
+    const destroying = beginDestroy(r);
     try {
       await callProvider(r.environmentId, () => owningProvider.destroy(lifecycleLease(r, leaseId)));
     } catch (error) {
@@ -396,6 +423,9 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
 
   const reconcileRecord = async (initialRecord: WorkerEnvironmentRecord): Promise<void> => {
     let record = initialRecord;
+    if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
+      return;
+    }
     if (record.state === "requested" && record.destroyRequestedAtMs !== null) {
       return void cancelRequested(record);
     }
@@ -442,6 +472,11 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     if (!inspection) {
       return;
     }
+    // Provider inspection and bundle preparation are awaited above. Re-read the
+    // placement-owned fence before any cleanup can destroy the only remote result.
+    if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
+      return;
+    }
     const { status } = inspection;
     const teardownExpected = record.destroyRequestedAtMs !== null || record.state === "destroying";
     if (status === "destroyed" || (status === "unknown" && teardownExpected)) {
@@ -469,6 +504,9 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
           ? record
           : move(record, "draining", { lastError: ORPHANED_LEASE_ERROR });
       await tunnels?.stop(record.environmentId);
+      if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
+        return;
+      }
       move(draining, "orphaned", { lastError: ORPHANED_LEASE_ERROR });
       return;
     }
@@ -485,6 +523,9 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       // Workspace actions capture isolation at tunnel creation. Fence the old actions before
       // committing a provider-owned change so no reconciliation can use stale host scope.
       await tunnels?.stop(record.environmentId);
+      if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
+        return;
+      }
     }
     record = store.reconcileSharedHost({
       environmentId: record.environmentId,
@@ -525,6 +566,9 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     if (record.state === "draining" && record.destroyRequestedAtMs === null) {
       // Draining without destroy intent is durable provider-loss cleanup.
       await tunnels?.stop(record.environmentId);
+      if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
+        return;
+      }
       move(record, "orphaned", { lastError: record.lastError ?? ORPHANED_LEASE_ERROR });
       return;
     }
@@ -652,7 +696,10 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
 
   const destroy = async (
     environmentId: string,
-    destroyOptions: { requireUnattached?: boolean } = {},
+    destroyOptions: {
+      requireUnattached?: boolean;
+      authorizeTeardown?: WorkerEnvironmentTeardownAuthorization;
+    } = {},
   ) => {
     const stopping = options.isStopping();
     if (stopping) {
@@ -672,6 +719,7 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
           "Attached cloud workers must be stopped through sessions.reclaim",
         );
       }
+      assertTeardownAllowed(environmentId, destroyOptions.authorizeTeardown);
       record = store.requestDestroy({ environmentId, state: record.state });
       if (record.state === "requested") {
         return cancelRequested(record);
@@ -682,9 +730,9 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       if (!record.leaseId) {
         const provider = providerFor(record.providerId);
         record = await resumeProvision(record, provider);
-        return finishDestroy(record, provider);
+        return finishDestroy(record, provider, destroyOptions.authorizeTeardown);
       }
-      return finishDestroy(record);
+      return finishDestroy(record, undefined, destroyOptions.authorizeTeardown);
     });
   };
 

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -63,7 +63,7 @@ type WorkerProviderLifecycleOptions = {
   ) => Promise<T>;
   callProvider: <T>(environmentId: string, run: () => Promise<T>, timeoutMs?: number) => Promise<T>;
   inState: (record: WorkerEnvironmentRecord, ...states: WorkerEnvironmentState[]) => boolean;
-  isServiceError: (error: unknown, code: string) => boolean;
+  isServiceError: (error: unknown, code: "invalid_profile") => boolean;
   isStopping: () => boolean;
   move: (
     record: WorkerEnvironmentRecord,

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -423,9 +423,6 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
 
   const reconcileRecord = async (initialRecord: WorkerEnvironmentRecord): Promise<void> => {
     let record = initialRecord;
-    if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
-      return;
-    }
     if (record.state === "requested" && record.destroyRequestedAtMs !== null) {
       return void cancelRequested(record);
     }
@@ -472,11 +469,8 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     if (!inspection) {
       return;
     }
-    // Provider inspection and bundle preparation are awaited above. Re-read the
-    // placement-owned fence before any cleanup can destroy the only remote result.
-    if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
-      return;
-    }
+    // Provider inspection is authoritative observation, not teardown authority. Project
+    // provider-proven loss even while a workspace result fences the mutation paths below.
     const { status } = inspection;
     const teardownExpected = record.destroyRequestedAtMs !== null || record.state === "destroying";
     if (status === "destroyed" || (status === "unknown" && teardownExpected)) {
@@ -504,9 +498,6 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
           ? record
           : move(record, "draining", { lastError: ORPHANED_LEASE_ERROR });
       await tunnels?.stop(record.environmentId);
-      if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
-        return;
-      }
       move(draining, "orphaned", { lastError: ORPHANED_LEASE_ERROR });
       return;
     }
@@ -566,9 +557,6 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
     if (record.state === "draining" && record.destroyRequestedAtMs === null) {
       // Draining without destroy intent is durable provider-loss cleanup.
       await tunnels?.stop(record.environmentId);
-      if (options.placementStore?.isEnvironmentTeardownFenced(record.environmentId)) {
-        return;
-      }
       move(record, "orphaned", { lastError: record.lastError ?? ORPHANED_LEASE_ERROR });
       return;
     }

--- a/src/gateway/worker-environments/provider-reconciliation.test.ts
+++ b/src/gateway/worker-environments/provider-reconciliation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { STALE_WORKER_BUILD_REASON } from "./admission.js";
+import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import * as support from "./service.test-support.js";
 import type { WorkerTunnelManager } from "./tunnel.js";
 
@@ -208,6 +211,100 @@ describe("worker environment service", () => {
       attachedSessionIds: [],
       lastError: STALE_WORKER_BUILD_REASON,
     });
+  it("rechecks the placement teardown fence after stale-bundle preparation", async () => {
+    const environmentId = "worker-attached-stale-pending-result";
+    support.seedBootstrapping(environmentId);
+    const ready = support.testState.store.transition({
+      environmentId,
+      from: "bootstrapping",
+      to: "ready",
+      patch: support.readyPatch(environmentId, {
+        ...support.BOOTSTRAP_RECEIPT,
+        bundleHash: "b".repeat(64),
+      }),
+    });
+    support.testState.store.transition({
+      environmentId,
+      from: ready.state,
+      to: "attached",
+      patch: support.attachedPatch(environmentId, "session-1"),
+    });
+    let fenced = false;
+    support.testState.prepareInstallation = vi.fn(async () => {
+      fenced = true;
+      return support.BUNDLE_ARTIFACT;
+    });
+    const placementStore = {
+      hasWorkerTurn: vi.fn(() => false),
+      isEnvironmentTeardownFenced: vi.fn(() => fenced),
+      validateWorkerTurn: vi.fn(() => false),
+      isWorkerTurnToolAuthorized: vi.fn(() => false),
+      updateAckCursors: vi.fn(),
+    };
+    const destroy = vi.fn(async () => {});
+
+    await support
+      .createService(support.createProvider({ destroy }), { placementStore })
+      .reconcileOnce();
+
+    expect(placementStore.isEnvironmentTeardownFenced).toHaveBeenCalledTimes(2);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(support.testState.store.get(environmentId)).toMatchObject({
+      state: "attached",
+      attachedSessionIds: ["session-1"],
+    });
+  });
+
+  it("lets the exact accepted placement owner destroy through the real service fence", async () => {
+    const environmentId = "worker-attached-owned-result";
+    const ready = support.seedReady(environmentId);
+    const attached = support.testState.store.transition({
+      environmentId,
+      from: ready.state,
+      to: "attached",
+      patch: support.attachedPatch(environmentId, REQUEST.sessionId),
+    });
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const active = seedActivePlacement(placements, {
+      environmentId,
+      ownerEpoch: attached.ownerEpoch,
+    });
+    if (active.state !== "active") {
+      throw new Error("expected active placement owner");
+    }
+    const claim = placements.claimReclaimWorkspaceResult({
+      ...REQUEST,
+      claimId: "reclaim-owned-result",
+      runId: "reclaim-owned-result",
+      owner: {
+        kind: "worker",
+        environmentId,
+        ownerEpoch: attached.ownerEpoch,
+      },
+    });
+    placements.acceptWorkspaceResult(claim);
+    const destroy = vi.fn(async () => {});
+    const workerService = support.createService(support.createProvider({ destroy }), {
+      placementStore: createWorkerSessionPlacementGate(placements),
+    });
+
+    await expect(workerService.destroy(environmentId)).rejects.toMatchObject({
+      code: "invalid_state",
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    expect(support.testState.store.get(environmentId)?.state).toBe("attached");
+    const authorizeTeardown = vi.fn(() => placements.canDestroyAcceptedWorkspaceResult(claim));
+    await expect(
+      workerService.destroyOwned(environmentId, authorizeTeardown),
+    ).resolves.toMatchObject({ state: "destroyed" });
+
+    expect(authorizeTeardown.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(
+      placements.completeWorkspaceResultAndReleaseTurn(claim, { reclaim: true }),
+    ).toMatchObject({ state: "reclaimed", turnClaim: null });
   });
 
   it("does not resolve npm while an admitted receipt matches the local bundle", async () => {

--- a/src/gateway/worker-environments/provider-reconciliation.test.ts
+++ b/src/gateway/worker-environments/provider-reconciliation.test.ts
@@ -1,6 +1,9 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import { STALE_WORKER_BUILD_REASON } from "./admission.js";
+import { createPlacementFailureActions } from "./placement-dispatch-failure.js";
 import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import * as support from "./service.test-support.js";
@@ -339,6 +342,92 @@ describe("worker environment service", () => {
     expect(
       placements.completeWorkspaceResultAndReleaseTurn(claim, { reclaim: true }),
     ).toMatchObject({ state: "reclaimed", turnClaim: null });
+  });
+
+  it("retries force-abandoned teardown through the real service fence", async () => {
+    const environmentId = "worker-force-abandoned-retry";
+    const ready = support.seedReady(environmentId);
+    const attached = support.testState.store.transition({
+      environmentId,
+      from: ready.state,
+      to: "attached",
+      patch: support.attachedPatch(environmentId, REQUEST.sessionId),
+    });
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const active = seedActivePlacement(placements, {
+      environmentId,
+      ownerEpoch: attached.ownerEpoch,
+    });
+    if (active.state !== "active") {
+      throw new Error("expected active placement owner");
+    }
+    const owner = {
+      sessionId: active.sessionId,
+      environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      placementGeneration: active.generation,
+    };
+    placements.beginWorkspaceReconciliation(owner, {
+      version: 1,
+      temporaryNonce: "f".repeat(32),
+      baseManifestRef: active.workspaceBaseManifestRef,
+      currentManifestRef: `sha256:${"f".repeat(64)}`,
+      baseEntries: [],
+      appliedEntries: [],
+      baseTree: "f".repeat(40),
+      basePackSha256: createHash("sha256").update("").digest("hex"),
+      basePack: Buffer.alloc(0),
+    });
+    placements.retainWorkspaceReconciliationForForcedAbandonment(owner);
+    const draining = placements.startDrain({
+      sessionId: active.sessionId,
+      environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: active.generation,
+    });
+    const reconciling = placements.startReconcile({
+      sessionId: active.sessionId,
+      environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: draining.generation,
+    });
+    const failed = placements.fail({
+      sessionId: active.sessionId,
+      expectedGeneration: reconciling.generation,
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+    if (failed.state !== "failed") {
+      throw new Error("expected failed force-abandoned placement");
+    }
+
+    let providerFails = true;
+    const destroy = vi.fn(async () => {
+      if (providerFails) {
+        throw new Error("provider teardown timed out");
+      }
+    });
+    const workerService = support.createService(support.createProvider({ destroy }), {
+      placementStore: createWorkerSessionPlacementGate(placements),
+    });
+    await expect(
+      workerService.destroyOwned(environmentId, () =>
+        placements.canDestroyForceAbandonedEnvironment(environmentId),
+      ),
+    ).rejects.toMatchObject({
+      code: "provider_failure",
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    expect(support.testState.store.get(environmentId)?.state).toBe("destroying");
+
+    providerFails = false;
+    const failure = createPlacementFailureActions({ placements, environments: workerService });
+    await failure.retryFailedTeardown(failed);
+
+    expect(destroy).toHaveBeenCalledTimes(2);
+    expect(support.testState.store.get(environmentId)?.state).toBe("destroyed");
+    expect(placements.listWorkspaceReconciliationOwners()).toEqual([owner]);
   });
 
   it("does not resolve npm while an admitted receipt matches the local bundle", async () => {

--- a/src/gateway/worker-environments/provider-reconciliation.test.ts
+++ b/src/gateway/worker-environments/provider-reconciliation.test.ts
@@ -2,8 +2,11 @@ import { createHash } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import { STALE_WORKER_BUILD_REASON } from "./admission.js";
 import { createPlacementFailureActions } from "./placement-dispatch-failure.js";
-import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
-import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
+import {
+  FORCED_WORKER_ABANDONMENT_ERROR,
+  REQUEST,
+  seedActivePlacement,
+} from "./placement-dispatch-test-fixtures.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import * as support from "./service.test-support.js";

--- a/src/gateway/worker-environments/provider-reconciliation.test.ts
+++ b/src/gateway/worker-environments/provider-reconciliation.test.ts
@@ -737,7 +737,13 @@ describe("worker environment service", () => {
       { tunnelManager },
     );
 
-    await workerService.reconcileOnce();
+    await expect(workerService.reconcileOnce()).resolves.toEqual([
+      {
+        environmentId: "worker-dormant",
+        inspection: "dormant",
+        hostIsolation: "unavailable",
+      },
+    ]);
     await workerService.reconcileOnce();
 
     expect(support.testState.store.get("worker-dormant")).toMatchObject({ state: "ready" });

--- a/src/gateway/worker-environments/provider-reconciliation.test.ts
+++ b/src/gateway/worker-environments/provider-reconciliation.test.ts
@@ -258,6 +258,35 @@ describe("worker environment service", () => {
     });
   });
 
+  it("persists provider-owned host isolation while placement teardown is fenced", async () => {
+    const environmentId = "worker-fenced-isolation-change";
+    support.seedReady(environmentId, undefined, false);
+    const placementStore = {
+      hasWorkerTurn: vi.fn(() => false),
+      isEnvironmentTeardownFenced: vi.fn(() => true),
+      validateWorkerTurn: vi.fn(() => false),
+      isWorkerTurnToolAuthorized: vi.fn(() => false),
+      updateAckCursors: vi.fn(),
+    };
+    const stop = vi.fn(async () => {
+      expect(support.testState.store.get(environmentId)?.sharedHost).toBe(false);
+    });
+    const tunnelManager = {
+      status: () => "connected" as const,
+      start: vi.fn(),
+      stop,
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const provider = support.createProvider({
+      inspect: async () => ({ status: "active", sharedHost: true }),
+    });
+
+    await support.createService(provider, { placementStore, tunnelManager }).reconcileOnce();
+
+    expect(stop).toHaveBeenCalledWith(environmentId, undefined);
+    expect(support.testState.store.get(environmentId)?.sharedHost).toBe(true);
+  });
+
   it.each([
     { status: "destroyed" as const, expectedState: "failed" },
     { status: "unknown" as const, expectedState: "orphaned" },

--- a/src/gateway/worker-environments/provider-reconciliation.test.ts
+++ b/src/gateway/worker-environments/provider-reconciliation.test.ts
@@ -247,13 +247,47 @@ describe("worker environment service", () => {
       .createService(support.createProvider({ destroy }), { placementStore })
       .reconcileOnce();
 
-    expect(placementStore.isEnvironmentTeardownFenced).toHaveBeenCalledTimes(2);
+    expect(placementStore.isEnvironmentTeardownFenced).toHaveBeenCalledOnce();
     expect(destroy).not.toHaveBeenCalled();
     expect(support.testState.store.get(environmentId)).toMatchObject({
       state: "attached",
       attachedSessionIds: ["session-1"],
     });
   });
+
+  it.each([
+    { status: "destroyed" as const, expectedState: "failed" },
+    { status: "unknown" as const, expectedState: "orphaned" },
+  ])(
+    "projects provider-reported $status loss while placement teardown is fenced",
+    async ({ status, expectedState }) => {
+      const environmentId = `worker-fenced-${status}`;
+      const ready = support.seedReady(environmentId);
+      support.testState.store.transition({
+        environmentId,
+        from: ready.state,
+        to: "attached",
+        patch: support.attachedPatch(environmentId, "session-1"),
+      });
+      const placementStore = {
+        hasWorkerTurn: vi.fn(() => false),
+        isEnvironmentTeardownFenced: vi.fn(() => true),
+        validateWorkerTurn: vi.fn(() => false),
+        isWorkerTurnToolAuthorized: vi.fn(() => false),
+        updateAckCursors: vi.fn(),
+      };
+      const inspect = vi.fn(async () => ({ status }));
+      const destroy = vi.fn(async () => {});
+
+      await support
+        .createService(support.createProvider({ inspect, destroy }), { placementStore })
+        .reconcileOnce();
+
+      expect(inspect).toHaveBeenCalledOnce();
+      expect(destroy).not.toHaveBeenCalled();
+      expect(support.testState.store.get(environmentId)?.state).toBe(expectedState);
+    },
+  );
 
   it("lets the exact accepted placement owner destroy through the real service fence", async () => {
     const environmentId = "worker-attached-owned-result";

--- a/src/gateway/worker-environments/provider-reconciliation.test.ts
+++ b/src/gateway/worker-environments/provider-reconciliation.test.ts
@@ -217,6 +217,8 @@ describe("worker environment service", () => {
       attachedSessionIds: [],
       lastError: STALE_WORKER_BUILD_REASON,
     });
+  });
+
   it("rechecks the placement teardown fence after stale-bundle preparation", async () => {
     const environmentId = "worker-attached-stale-pending-result";
     support.seedBootstrapping(environmentId);

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, vi } from "vitest";
+import type { WorkerAdmissionHandshake } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import type {
   WorkerDesktopEndpoint,
@@ -69,7 +70,7 @@ export const NPM_ARTIFACT: WorkerInstallationArtifact = {
   protocolFeatures: [],
   packageSpec: "openclaw@2026.7.2",
 };
-export const BOOTSTRAP_RECEIPT = {
+export const BOOTSTRAP_RECEIPT: WorkerAdmissionHandshake = {
   bundleHash: BUNDLE_HASH,
   openclawVersion: "2026.7.2",
   protocolFeatures: [],

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -452,6 +452,7 @@ export function placementHarness(
   const identity = seedAttachedIdentity(environmentId, sessionId);
   const placementStore = {
     hasWorkerTurn: vi.fn(() => true),
+    isEnvironmentTeardownFenced: vi.fn(() => false),
     validateWorkerTurn: vi.fn(() => true),
     isWorkerTurnToolAuthorized: vi.fn(() => true),
     updateAckCursors: vi.fn(),

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -58,7 +58,8 @@ type WorkerEnvironmentServiceErrorCode =
   | "unsupported_platform"
   | "launcher_failure"
   | "provider_failure"
-  | "bootstrap_failure";
+  | "bootstrap_failure"
+  | "worker_build_mismatch";
 
 class WorkerEnvironmentServiceError extends Error {
   constructor(
@@ -71,6 +72,9 @@ class WorkerEnvironmentServiceError extends Error {
 
 const serviceError = (code: WorkerEnvironmentServiceErrorCode, message: string) =>
   new WorkerEnvironmentServiceError(code, message);
+
+const isServiceError = (error: unknown, code: WorkerEnvironmentServiceErrorCode): boolean =>
+  error instanceof WorkerEnvironmentServiceError && error.code === code;
 
 type WorkerEnvironmentServiceOptions = {
   store: WorkerEnvironmentStore;
@@ -291,8 +295,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     callBootstrap,
     callProvider,
     inState,
-    isServiceError: (error, code) =>
-      error instanceof WorkerEnvironmentServiceError && error.code === code,
+    isServiceError,
     isStopping: () => stopping,
     move,
     saveError,
@@ -479,6 +482,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     takeMintedCredential: credentialBroker.takeMintedCredential,
     acquireTurnCredential: credentialBroker.acquireTurnCredential,
     acknowledgeCredentialDelivery: credentialBroker.acknowledgeCredentialDelivery,
+    isWorkerBuildMismatchError: (error: unknown) => isServiceError(error, "worker_build_mismatch"),
     startTunnel: environmentAccess.startTunnel,
     stopTunnel: environmentAccess.stopTunnel,
     reconcileEnvironment,

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -334,6 +334,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
 
   const unavailableProviderFacts = (environmentId: string): WorkerProviderFactReconciliation => ({
     environmentId,
+    inspection: "unavailable",
     hostIsolation: "unavailable",
   });
 

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -482,7 +482,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     takeMintedCredential: credentialBroker.takeMintedCredential,
     acquireTurnCredential: credentialBroker.acquireTurnCredential,
     acknowledgeCredentialDelivery: credentialBroker.acknowledgeCredentialDelivery,
-    isWorkerBuildMismatchError: (error: unknown) => isServiceError(error, "worker_build_mismatch"),
+    startRecoveryTunnel: environmentAccess.startRecoveryTunnel,
     startTunnel: environmentAccess.startTunnel,
     stopTunnel: environmentAccess.stopTunnel,
     reconcileEnvironment,

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -34,6 +34,7 @@ import type { WorkerLiveEventReceiver } from "./live-events.js";
 import type { NodeWorkerTunnelManager } from "./node-worker-tunnel.js";
 import type { WorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import { createWorkerProviderLifecycle } from "./provider-lifecycle.js";
+import type { WorkerEnvironmentTeardownAuthorization } from "./provider-lifecycle.js";
 import type { WorkerEnvironmentState } from "./state.js";
 import type {
   WorkerEnvironmentRecord,
@@ -282,6 +283,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     ensureNodeWorkerBundle: options.ensureNodeWorkerBundle,
     providerCallTimeoutMs: options.providerCallTimeoutMs,
     tunnelManager: tunnelLifecycle,
+    placementStore: options.placementStore,
     credentialBroker,
     callBootstrap,
     callProvider,
@@ -422,6 +424,13 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       ),
     destroy: async (environmentId: string) =>
       environmentAccess.project(await providerLifecycle.destroy(environmentId)),
+    destroyOwned: async (
+      environmentId: string,
+      authorizeTeardown: WorkerEnvironmentTeardownAuthorization,
+    ) =>
+      environmentAccess.project(
+        await providerLifecycle.destroy(environmentId, { authorizeTeardown }),
+      ),
     destroyUnattached: async (environmentId: string) =>
       environmentAccess.project(
         await providerLifecycle.destroy(environmentId, { requireUnattached: true }),

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -34,7 +34,10 @@ import type { WorkerLiveEventReceiver } from "./live-events.js";
 import type { NodeWorkerTunnelManager } from "./node-worker-tunnel.js";
 import type { WorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import { createWorkerProviderLifecycle } from "./provider-lifecycle.js";
-import type { WorkerEnvironmentTeardownAuthorization } from "./provider-lifecycle.js";
+import type {
+  WorkerEnvironmentTeardownAuthorization,
+  WorkerProviderFactReconciliation,
+} from "./provider-lifecycle.js";
 import type { WorkerEnvironmentState } from "./state.js";
 import type {
   WorkerEnvironmentRecord,
@@ -159,7 +162,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   const inferenceWithDrain = inference as typeof inference & {
     beginSessionDrain(sessionId: string): WorkerInferenceSessionDrain;
   };
-  let reconcileInFlight: Promise<void> | undefined;
+  let reconcileInFlight: Promise<WorkerProviderFactReconciliation[]> | undefined;
   let interval: ReturnType<typeof setInterval> | undefined;
   let unsubscribeSessionIdentityMutation: (() => void) | undefined;
   let stopping = false;
@@ -326,37 +329,44 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     withLock,
   });
 
-  const reconcileEnvironment = async (environmentId: string) => {
+  const unavailableProviderFacts = (environmentId: string): WorkerProviderFactReconciliation => ({
+    environmentId,
+    hostIsolation: "unavailable",
+  });
+
+  const reconcileEnvironment = async (
+    environmentId: string,
+  ): Promise<WorkerProviderFactReconciliation> => {
     if (stopping) {
-      return;
+      return unavailableProviderFacts(environmentId);
     }
-    await withLock(environmentId, async () => {
+    return await withLock(environmentId, async () => {
       const current = store.get(environmentId);
       if (!current || inState(current, "destroyed", "failed", "orphaned")) {
-        return;
+        return unavailableProviderFacts(environmentId);
       }
-      await providerLifecycle.reconcileRecord(current);
+      return await providerLifecycle.reconcileRecord(current);
     });
   };
 
   const reconcilePass = async () => {
-    const tasks = store
-      .listForReconcile()
-      .map(
-        (candidate) => () =>
-          reconcileEnvironment(candidate.environmentId).catch(() =>
-            warn(
-              `Worker environment reconcile failed (${candidate.environmentId}, ${candidate.providerId})`,
-            ),
-          ),
-      );
-    await runTasksWithConcurrency({ tasks, limit: 8 });
+    const tasks = store.listForReconcile().map(
+      (candidate) => async () =>
+        await reconcileEnvironment(candidate.environmentId).catch(() => {
+          warn(
+            `Worker environment reconcile failed (${candidate.environmentId}, ${candidate.providerId})`,
+          );
+          return unavailableProviderFacts(candidate.environmentId);
+        }),
+    );
+    const { results } = await runTasksWithConcurrency({ tasks, limit: 8 });
     store.pruneTerminalEnvironments();
+    return results;
   };
 
   const reconcileOnce = () => {
     if (stopping) {
-      return Promise.resolve();
+      return Promise.resolve([]);
     }
     return (reconcileInFlight ??= reconcilePass().finally(() => {
       reconcileInFlight = undefined;

--- a/src/gateway/worker-environments/session-placement-lifecycle.ts
+++ b/src/gateway/worker-environments/session-placement-lifecycle.ts
@@ -1,7 +1,8 @@
 import type { WorkerSessionPlacementRecord } from "./placement-record.js";
-import type {
-  WorkerSessionPlacementRetirement,
-  WorkerSessionPlacementStore,
+import {
+  WorkerSessionPlacementRetirementBlockedError,
+  type WorkerSessionPlacementRetirement,
+  type WorkerSessionPlacementStore,
 } from "./placement-store.js";
 import type {
   WorkerEnvironmentServiceContract,
@@ -20,8 +21,17 @@ type Placement = WorkerSessionPlacementRecord;
 type PlacementState = Placement["state"];
 
 export class SessionWorkerPlacementMutationError extends Error {
-  constructor(state: PlacementState, action: PlacementMutationAction, key: string) {
-    super(`Session ${key} cannot ${action} while cloud worker placement is ${state}.`);
+  constructor(
+    state: PlacementState,
+    action: PlacementMutationAction,
+    key: string,
+    forceAbandonEnvironmentId?: string,
+  ) {
+    super(
+      forceAbandonEnvironmentId
+        ? `Session ${key} cannot ${action} while its failed cloud worker retains an unreconciled workspace result. Run environments.destroy with force=true for environment ${forceAbandonEnvironmentId} only to permanently abandon its remote workspace changes, then retry.`
+        : `Session ${key} cannot ${action} while cloud worker placement is ${state}.`,
+    );
   }
 }
 
@@ -107,6 +117,20 @@ function resolveSessionWorkerPlacementMutationGuard(
     return retirementGuard(placement);
   }
   if (params.action === "delete" && placement.state === "failed") {
+    if (
+      placement.environmentId &&
+      placement.terminalRecovery?.action === "force-destroy-environment"
+    ) {
+      return {
+        status: "blocked",
+        error: new SessionWorkerPlacementMutationError(
+          placement.state,
+          params.action,
+          params.key,
+          placement.environmentId,
+        ),
+      };
+    }
     // Failed environments retain their lease until teardown is proven, so they stay fenced.
     if (
       isFailedWorkerPlacementEnvironmentGone({
@@ -134,7 +158,19 @@ export function retireSessionWorkerPlacementBeforeMutation(
   if (!retirementService?.retireSessionPlacement) {
     throw new Error("Worker session placement retirement service is unavailable");
   }
-  retirementService.retireSessionPlacement(guard);
+  try {
+    retirementService.retireSessionPlacement(guard);
+  } catch (error) {
+    if (error instanceof WorkerSessionPlacementRetirementBlockedError) {
+      return new SessionWorkerPlacementMutationError(
+        guard.expectedState,
+        params.action,
+        params.key,
+        error.environmentId,
+      );
+    }
+    throw error;
+  }
   return undefined;
 }
 

--- a/src/gateway/worker-environments/store.ts
+++ b/src/gateway/worker-environments/store.ts
@@ -920,7 +920,7 @@ export function createWorkerEnvironmentStore(
       environmentId: string;
       state: WorkerEnvironmentState;
       leaseId: string;
-      sharedHost: boolean;
+      sharedHost: boolean | null;
     }): WorkerEnvironmentRecord {
       const environmentId = required(input.environmentId, "id");
       const leaseId = required(input.leaseId, "lease id");
@@ -932,10 +932,10 @@ export function createWorkerEnvironmentStore(
         if (current.sharedHost === input.sharedHost) {
           return current;
         }
-        // Provider inspection owns facts that may predate their durable column. Persist an
-        // explicit value before tunnel startup so upgraded leases cannot keep stale isolation.
+        // Provider inspection records exact isolation before tunnel startup. Gateway restart
+        // records null before creating tunnel managers so persisted scope cannot cross processes.
         return update(db, environmentId, current.state, {
-          shared_host: input.sharedHost ? 1 : 0,
+          shared_host: input.sharedHost === null ? null : input.sharedHost ? 1 : 0,
           updated_at_ms: now(),
         });
       });

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -64,6 +64,10 @@ export type WorkerTunnelRequest = {
   ownerEpoch: number;
 };
 
+export type WorkerRecoveryTunnelRequest = WorkerTunnelRequest & {
+  workerBuild: "current" | "installed";
+};
+
 export type WorkerWorkspaceCommand = {
   argv: readonly string[];
   transportRetry: "idempotent" | "never";
@@ -140,3 +144,5 @@ export type WorkerTunnelHandle = {
   ): Promise<WorkerWorkspaceReconcileResult>;
   stop(): Promise<void>;
 };
+
+export type WorkerWorkspaceRecoveryTunnelHandle = Omit<WorkerTunnelHandle, "launchTurn">;

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -64,9 +64,12 @@ export type WorkerTunnelRequest = {
   ownerEpoch: number;
 };
 
-export type WorkerRecoveryTunnelRequest = WorkerTunnelRequest & {
-  workerBuild: "current" | "installed";
-};
+export type WorkerRecoveryTunnelRequest =
+  | (WorkerTunnelRequest & { workerBuild: "current" })
+  | (WorkerTunnelRequest & {
+      workerBuild: "installed";
+      authorizePendingResult: () => boolean;
+    });
 
 export type WorkerWorkspaceCommand = {
   argv: readonly string[];

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -37,6 +37,28 @@ export class WorkerRunnerCapacityError extends Error {
   }
 }
 
+export class WorkerWorkspaceOperatorRecoveryError extends Error {
+  constructor(cause: Error) {
+    super(cause.message, { cause });
+    this.name = "WorkerWorkspaceOperatorRecoveryError";
+  }
+}
+
+export function findWorkerWorkspaceOperatorRecoveryError(
+  error: unknown,
+): WorkerWorkspaceOperatorRecoveryError | undefined {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current instanceof Error && !seen.has(current)) {
+    if (current instanceof WorkerWorkspaceOperatorRecoveryError) {
+      return current;
+    }
+    seen.add(current);
+    current = current.cause;
+  }
+  return undefined;
+}
+
 export type WorkerTunnelRequest = {
   environmentId: string;
   ownerEpoch: number;

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -602,6 +602,24 @@ describe("worker tunnel manager", () => {
     await handle.stop();
   });
 
+  it("rejects same-epoch reuse across worker bundle identities", async () => {
+    const fake = fakeRunner();
+    const { manager, handle } = await startConnectedTunnel(fake, "worker:bundle-owner", 4);
+
+    await expect(
+      manager.start({
+        bundleHash: "c".repeat(64),
+        environmentId: "worker:bundle-owner",
+        ownerEpoch: 4,
+        ssh: SSH,
+        gateway: { host: "127.0.0.1", port: 18789 },
+        resolveIdentity,
+      }),
+    ).rejects.toThrow("bundle changed without an owner epoch change");
+    expect(fake.starts).toHaveLength(1);
+    await handle.stop();
+  });
+
   it("publishes a replacement epoch before awaiting prior teardown", async () => {
     const fake = fakeRunner();
     const manager = createWorkerTunnelManager({ runner: fake.runner, sleep: async () => {} });

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -4,6 +4,10 @@ import {
   WORKER_RPC_SET_VERSION,
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { parseWorkerLaunchPlan } from "../../worker/launch-descriptor.js";
+import {
+  findWorkerWorkspaceOperatorRecoveryError,
+  WorkerWorkspaceOperatorRecoveryError,
+} from "./tunnel-contract.js";
 import { createWorkerSshRunner } from "./tunnel-ssh-runner.js";
 import { createWorkerTunnelManager } from "./tunnel.js";
 import {
@@ -20,6 +24,7 @@ import {
   waitForStarts,
 } from "./tunnel.test-support.js";
 import { sshArgvPort } from "./worker-ssh-argv.test-support.js";
+import { WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE } from "./workspace-quiescence-scripts.js";
 
 describe("worker tunnel manager", () => {
   it("cascades only an epoch-matched environment stop into the desktop tunnel owner", async () => {
@@ -141,7 +146,7 @@ describe("worker tunnel manager", () => {
     vi.useFakeTimers();
     try {
       const quiescence = await handle.quiesceWorkspace("/home/worker/workspace");
-      await vi.advanceTimersByTimeAsync(4 * 60_000);
+      await vi.advanceTimersByTimeAsync(3 * 60_000);
       expect(
         fake.runs.filter((entry) => entry.argv.at(-1)?.includes('process.stdout.write("renewed "')),
       ).toHaveLength(1);
@@ -179,6 +184,73 @@ describe("worker tunnel manager", () => {
     );
     await quiescence.resume();
     await handle.stop();
+  });
+
+  it("preserves operator recovery classification from heartbeat renewal", async () => {
+    const nonce = "c".repeat(32);
+    const fake = fakeRunner((argv) => {
+      const remoteCommand = argv.at(-1) ?? "";
+      if (remoteCommand.includes('process.stdout.write("quiesced "')) {
+        return success(`quiesced ${nonce}\n`);
+      }
+      if (
+        remoteCommand.includes('process.stdout.write("renewed "') ||
+        remoteCommand.includes("async function resume()")
+      ) {
+        return {
+          ...success(),
+          code: WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
+          stderr: "workspace quiescence recovery timed out; lease retained for operator recovery\n",
+        };
+      }
+      return undefined;
+    });
+    const { handle } = await startConnectedTunnel(fake, "worker:quiescence-terminal-renewal", 3);
+
+    vi.useFakeTimers();
+    try {
+      const quiescence = await handle.quiesceWorkspace("/home/worker/workspace");
+      await vi.advanceTimersByTimeAsync(3 * 60_000);
+      const error = await quiescence.assertActive().catch((cause: unknown) => cause);
+      expect(findWorkerWorkspaceOperatorRecoveryError(error)).toBeInstanceOf(
+        WorkerWorkspaceOperatorRecoveryError,
+      );
+      const resumeError = await quiescence.resume().catch((cause: unknown) => cause);
+      expect(findWorkerWorkspaceOperatorRecoveryError(resumeError)).toBeInstanceOf(
+        WorkerWorkspaceOperatorRecoveryError,
+      );
+    } finally {
+      vi.useRealTimers();
+      await handle.stop();
+    }
+  });
+
+  it("keeps matching command prose retryable without the quiescence outcome code", async () => {
+    const nonce = "d".repeat(32);
+    const fake = fakeRunner((argv) => {
+      const remoteCommand = argv.at(-1) ?? "";
+      if (remoteCommand.includes('process.stdout.write("quiesced "')) {
+        return success(`quiesced ${nonce}\n`);
+      }
+      if (remoteCommand.includes("async function resume()")) {
+        return {
+          ...success(),
+          code: 1,
+          stderr: "workspace quiescence recovery timed out; lease retained for operator recovery\n",
+        };
+      }
+      return undefined;
+    });
+    const { handle } = await startConnectedTunnel(fake, "worker:quiescence-retryable-prose", 3);
+
+    try {
+      const quiescence = await handle.quiesceWorkspace("/home/worker/workspace");
+      const error = await quiescence.resume().catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(WorkerWorkspaceOperatorRecoveryError);
+    } finally {
+      await handle.stop();
+    }
   });
 
   it("reconnects with capped backoff after unexpected exits and failed attempts", async () => {

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -493,6 +493,9 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
         throw new Error("Worker tunnel owner epoch is stale");
       }
       if (request.ownerEpoch === current.ownerEpoch) {
+        if (request.bundleHash !== current.bundleHash) {
+          throw new Error("Worker tunnel bundle changed without an owner epoch change");
+        }
         return await current.readiness.promise;
       }
     }

--- a/src/gateway/worker-environments/workspace-conflicts.ts
+++ b/src/gateway/worker-environments/workspace-conflicts.ts
@@ -6,6 +6,8 @@ export type WorkerWorkspaceResultConflict = {
 
 export const WORKSPACE_CONFLICT_TRANSCRIPT_TYPE = "cloud-workspace-conflict";
 export const WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE = "cloud-workspace-conflict-cleared";
+export const WORKSPACE_CONFLICT_CLEARED_MESSAGE =
+  "The cloud workspace conflict is no longer active.";
 
 const MAX_PROJECTED_CONFLICT_PATHS = 256;
 const MAX_PROJECTED_CONFLICT_PATH_BYTES = 32 * 1024;

--- a/src/gateway/worker-environments/workspace-quiescence-resume-deadline.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-deadline.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import {
+  REMOTE_WORKSPACE_RESUME_JS,
+  WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
+} from "./workspace-quiescence-scripts.js";
+import { fixture, leasePath } from "./workspace-quiescence-scripts.test-support.js";
+
+describe("remote workspace quiescence resume deadline", () => {
+  it("keeps a maximum-size stalled recovery within the fixed pass budget", async () => {
+    const input = await fixture();
+    const nonce = "a".repeat(32);
+    const leaseFile = leasePath(input.home, input.workspace, nonce);
+    const processReference = { pid: process.pid, start: "stalled process" };
+    await fs.mkdir(path.dirname(leaseFile), { recursive: true });
+    await fs.writeFile(
+      leaseFile,
+      JSON.stringify({
+        version: 1,
+        nonce,
+        processes: Array.from({ length: 4_096 }, () => processReference),
+        watchdog: null,
+        expiresAtMs: Date.now() + 60_000,
+      }),
+    );
+    await fs.writeFile(input.stalledAllProcessProbePath, "stall all identity probes\n");
+
+    const startedAt = Date.now();
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+      { timeoutMs: 10_000, baseEnv: input.env, killProcessTree: true },
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.termination).toBe("exit");
+    expect(result.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+    expect(result.stderr).toContain(
+      "workspace quiescence recovery timed out; lease retained for operator recovery",
+    );
+    expect(elapsedMs).toBeGreaterThanOrEqual(4_000);
+    expect(elapsedMs).toBeLessThan(8_000);
+    const retained = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+      processes: Array<{ pid: number }>;
+      recovery?: { state: string };
+    };
+    expect(retained.processes).toHaveLength(4_096);
+    expect(retained.recovery?.state).toBe("probe-timeout");
+  }, 14_000);
+});

--- a/src/gateway/worker-environments/workspace-quiescence-resume-deadline.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-deadline.test.ts
@@ -9,7 +9,7 @@ import {
 import { fixture, leasePath } from "./workspace-quiescence-scripts.test-support.js";
 
 describe("remote workspace quiescence resume deadline", () => {
-  it("keeps a maximum-size stalled recovery within the fixed pass budget", async () => {
+  it("bounds a stalled pass while allowing healthy high-cardinality progress", async () => {
     const input = await fixture();
     const nonce = "a".repeat(32);
     const leaseFile = leasePath(input.home, input.workspace, nonce);
@@ -47,5 +47,56 @@ describe("remote workspace quiescence resume deadline", () => {
     };
     expect(retained.processes).toHaveLength(4_096);
     expect(retained.recovery?.state).toBe("probe-timeout");
-  }, 14_000);
+
+    await fs.rm(input.stalledAllProcessProbePath, { force: true });
+    const healthyNonce = "b".repeat(32);
+    const healthyLeaseFile = leasePath(input.home, input.workspace, healthyNonce);
+    const preloadPath = path.join(input.home, "healthy-process-probe.cjs");
+    await fs.writeFile(
+      healthyLeaseFile,
+      JSON.stringify({
+        version: 1,
+        nonce: healthyNonce,
+        processes: Array.from({ length: 64 }, () => ({
+          pid: process.pid,
+          start: "healthy process",
+        })),
+        watchdog: null,
+        expiresAtMs: Date.now() + 60_000,
+      }),
+    );
+    await fs.writeFile(
+      preloadPath,
+      `const childProcess = require("node:child_process");
+const originalExecFile = childProcess.execFile;
+childProcess.execFile = function (file, args, options, callback) {
+  if (file === "ps" && args[0] === "-o" && args[1] === "stat=,lstart=") {
+    const timer = setTimeout(() => callback(null, "T healthy process\\n", ""), 700);
+    return { stdout: null, stderr: null, kill: () => { clearTimeout(timer); return true; }, unref: () => {} };
+  }
+  return originalExecFile.call(this, file, args, options, callback);
+};
+`,
+    );
+
+    const healthyStartedAt = Date.now();
+    const healthyResult = await runCommandWithTimeout(
+      [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, healthyNonce],
+      {
+        timeoutMs: 10_000,
+        baseEnv: {
+          ...input.env,
+          NODE_OPTIONS: `${input.env.NODE_OPTIONS ?? ""} --require=${preloadPath}`.trim(),
+        },
+        killProcessTree: true,
+      },
+    );
+    const healthyElapsedMs = Date.now() - healthyStartedAt;
+
+    expect(healthyResult.termination).toBe("exit");
+    expect(healthyResult.code, healthyResult.stderr).toBe(0);
+    expect(healthyElapsedMs).toBeGreaterThan(5_000);
+    expect(healthyElapsedMs).toBeLessThan(8_000);
+    await expect(fs.access(healthyLeaseFile)).rejects.toThrow();
+  }, 22_000);
 });

--- a/src/gateway/worker-environments/workspace-quiescence-resume-deadline.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-deadline.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -6,97 +7,60 @@ import {
   REMOTE_WORKSPACE_RESUME_JS,
   WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
 } from "./workspace-quiescence-scripts.js";
-import { fixture, leasePath } from "./workspace-quiescence-scripts.test-support.js";
+import {
+  fixture,
+  leasePath,
+  processStart,
+  terminate,
+} from "./workspace-quiescence-scripts.test-support.js";
 
 describe("remote workspace quiescence resume deadline", () => {
-  it("bounds a stalled pass while allowing healthy high-cardinality progress", async () => {
+  it("bounds a maximum-size recovery after partial progress", async () => {
     const input = await fixture();
+    const stalledProcess = spawn("sleep", ["30"], { stdio: "ignore" });
+    const stalledPid = stalledProcess.pid!;
     const nonce = "a".repeat(32);
     const leaseFile = leasePath(input.home, input.workspace, nonce);
-    const processReference = { pid: process.pid, start: "stalled process" };
-    await fs.mkdir(path.dirname(leaseFile), { recursive: true });
-    await fs.writeFile(
-      leaseFile,
-      JSON.stringify({
-        version: 1,
-        nonce,
-        processes: Array.from({ length: 4_096 }, () => processReference),
-        watchdog: null,
-        expiresAtMs: Date.now() + 60_000,
-      }),
-    );
-    await fs.writeFile(input.stalledAllProcessProbePath, "stall all identity probes\n");
+    try {
+      const healthyReference = { pid: process.pid, start: await processStart(process.pid) };
+      const stalledReference = { pid: stalledPid, start: await processStart(stalledPid) };
+      await fs.mkdir(path.dirname(leaseFile), { recursive: true });
+      await fs.writeFile(
+        leaseFile,
+        JSON.stringify({
+          version: 1,
+          nonce,
+          processes: [healthyReference, ...Array.from({ length: 4_095 }, () => stalledReference)],
+          watchdog: null,
+          expiresAtMs: Date.now() + 60_000,
+        }),
+      );
+      await fs.writeFile(input.stalledProcessProbeTargetPath, `${stalledPid}\n`);
 
-    const startedAt = Date.now();
-    const result = await runCommandWithTimeout(
-      [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
-      { timeoutMs: 10_000, baseEnv: input.env, killProcessTree: true },
-    );
-    const elapsedMs = Date.now() - startedAt;
+      const startedAt = Date.now();
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+        { timeoutMs: 10_000, baseEnv: input.env, killProcessTree: true },
+      );
+      const elapsedMs = Date.now() - startedAt;
 
-    expect(result.termination).toBe("exit");
-    expect(result.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
-    expect(result.stderr).toContain(
-      "workspace quiescence recovery timed out; lease retained for operator recovery",
-    );
-    expect(elapsedMs).toBeGreaterThanOrEqual(4_000);
-    expect(elapsedMs).toBeLessThan(8_000);
-    const retained = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
-      processes: Array<{ pid: number }>;
-      recovery?: { state: string };
-    };
-    expect(retained.processes).toHaveLength(4_096);
-    expect(retained.recovery?.state).toBe("probe-timeout");
-
-    await fs.rm(input.stalledAllProcessProbePath, { force: true });
-    const healthyNonce = "b".repeat(32);
-    const healthyLeaseFile = leasePath(input.home, input.workspace, healthyNonce);
-    const preloadPath = path.join(input.home, "healthy-process-probe.cjs");
-    await fs.writeFile(
-      healthyLeaseFile,
-      JSON.stringify({
-        version: 1,
-        nonce: healthyNonce,
-        processes: Array.from({ length: 64 }, () => ({
-          pid: process.pid,
-          start: "healthy process",
-        })),
-        watchdog: null,
-        expiresAtMs: Date.now() + 60_000,
-      }),
-    );
-    await fs.writeFile(
-      preloadPath,
-      `const childProcess = require("node:child_process");
-const originalExecFile = childProcess.execFile;
-childProcess.execFile = function (file, args, options, callback) {
-  if (file === "ps" && args[0] === "-o" && args[1] === "stat=,lstart=") {
-    const timer = setTimeout(() => callback(null, "T healthy process\\n", ""), 700);
-    return { stdout: null, stderr: null, kill: () => { clearTimeout(timer); return true; }, unref: () => {} };
-  }
-  return originalExecFile.call(this, file, args, options, callback);
-};
-`,
-    );
-
-    const healthyStartedAt = Date.now();
-    const healthyResult = await runCommandWithTimeout(
-      [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, healthyNonce],
-      {
-        timeoutMs: 10_000,
-        baseEnv: {
-          ...input.env,
-          NODE_OPTIONS: `${input.env.NODE_OPTIONS ?? ""} --require=${preloadPath}`.trim(),
-        },
-        killProcessTree: true,
-      },
-    );
-    const healthyElapsedMs = Date.now() - healthyStartedAt;
-
-    expect(healthyResult.termination).toBe("exit");
-    expect(healthyResult.code, healthyResult.stderr).toBe(0);
-    expect(healthyElapsedMs).toBeGreaterThan(5_000);
-    expect(healthyElapsedMs).toBeLessThan(8_000);
-    await expect(fs.access(healthyLeaseFile)).rejects.toThrow();
-  }, 22_000);
+      expect(result.termination).toBe("exit");
+      expect(result.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+      expect(result.stderr).toContain(
+        "workspace quiescence recovery timed out; lease retained for operator recovery",
+      );
+      expect(elapsedMs).toBeGreaterThanOrEqual(4_000);
+      expect(elapsedMs).toBeLessThan(8_000);
+      const retained = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        processes: Array<{ pid: number }>;
+        recovery?: { state: string };
+      };
+      expect(retained.processes).toHaveLength(4_095);
+      expect(retained.processes.every((entry) => entry.pid === stalledPid)).toBe(true);
+      expect(retained.recovery?.state).toBe("probe-timeout");
+    } finally {
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      await terminate(stalledProcess);
+    }
+  }, 14_000);
 });

--- a/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
@@ -36,7 +36,6 @@ async function resume() {
   const recovery = await recoverProcessReferences(
     references,
     ${options.processProbeConcurrency},
-    processReferenceDeadlineMs(references.length),
   );
   if (recovery.remaining.length > 0) {
     const watchdog = recovery.remaining.find((entry) => entry.signal === "SIGTERM") ?? null;

--- a/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
@@ -1,6 +1,7 @@
 type WorkspaceQuiescenceResumeScriptOptions = {
   processScript: string;
   leaseScript: string;
+  processRecoveryTimeoutMs: number;
   processProbeConcurrency: number;
   operatorRecoveryExitCode: number;
 };
@@ -33,17 +34,12 @@ async function resume() {
     ...(input.watchdog === null ? [] : [{ ...input.watchdog, signal: "SIGTERM" }]),
     ...input.processes.map((entry) => ({ ...entry, signal: "SIGCONT" })),
   ];
-  let recovery = { remaining: references, failed: false };
-  while (recovery.remaining.length > 0) {
-    const priorCount = recovery.remaining.length;
-    recovery = await recoverProcessReferences(
-      recovery.remaining,
-      ${options.processProbeConcurrency},
-    );
-    // Continue only while a fixed-budget pass shrinks the lease. A fully stalled
-    // pass still reaches operator recovery within the default five-second deadline.
-    if (recovery.failed || recovery.remaining.length === priorCount) break;
-  }
+  const recoveryDeadlineMs = Date.now() + ${options.processRecoveryTimeoutMs};
+  const recovery = await recoverProcessReferences(
+    references,
+    ${options.processProbeConcurrency},
+    recoveryDeadlineMs,
+  );
   if (recovery.remaining.length > 0) {
     const watchdog = recovery.remaining.find((entry) => entry.signal === "SIGTERM") ?? null;
     const processes = recovery.remaining

--- a/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
@@ -33,10 +33,17 @@ async function resume() {
     ...(input.watchdog === null ? [] : [{ ...input.watchdog, signal: "SIGTERM" }]),
     ...input.processes.map((entry) => ({ ...entry, signal: "SIGCONT" })),
   ];
-  const recovery = await recoverProcessReferences(
-    references,
-    ${options.processProbeConcurrency},
-  );
+  let recovery = { remaining: references, failed: false };
+  while (recovery.remaining.length > 0) {
+    const priorCount = recovery.remaining.length;
+    recovery = await recoverProcessReferences(
+      recovery.remaining,
+      ${options.processProbeConcurrency},
+    );
+    // Continue only while a fixed-budget pass shrinks the lease. A fully stalled
+    // pass still reaches operator recovery within the default five-second deadline.
+    if (recovery.failed || recovery.remaining.length === priorCount) break;
+  }
   if (recovery.remaining.length > 0) {
     const watchdog = recovery.remaining.find((entry) => entry.signal === "SIGTERM") ?? null;
     const processes = recovery.remaining

--- a/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
@@ -1,0 +1,80 @@
+type WorkspaceQuiescenceResumeScriptOptions = {
+  processScript: string;
+  leaseScript: string;
+  recoveryTimeoutMs: number;
+  processProbeConcurrency: number;
+  operatorRecoveryExitCode: number;
+};
+
+export function createWorkspaceQuiescenceResumeScript(
+  options: WorkspaceQuiescenceResumeScriptOptions,
+): string {
+  return String.raw`const childProcess = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+if (typeof process.getuid !== "function") throw new Error("workspace quiescence requires POSIX");
+const root = fs.realpathSync(process.argv[1]);
+const nonce = process.argv[2];
+if (!/^[a-f0-9]{32}$/.test(nonce || "")) throw new Error("invalid workspace quiescence nonce");
+const leasePath = path.join(os.homedir(), ".openclaw-worker", "quiescence", crypto.createHash("sha256").update(root).digest("hex") + "." + nonce + ".json");
+${options.processScript}
+${options.leaseScript}
+async function resume() {
+  let raw;
+  try {
+    raw = fs.readFileSync(leasePath, "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") return;
+    throw error;
+  }
+  const input = parseLease(raw, nonce); if (input.recovery !== undefined) throw new WorkspaceOperatorRecoveryError("workspace quiescence recovery " + (input.recovery.state === "recovery-failed" ? "failed" : "timed out") + "; lease retained for operator recovery");
+  const recoveryDeadlineMs = Date.now() + ${options.recoveryTimeoutMs};
+  const references = [
+    ...(input.watchdog === null ? [] : [{ ...input.watchdog, signal: "SIGTERM" }]),
+    ...input.processes.map((entry) => ({ ...entry, signal: "SIGCONT" })),
+  ];
+  const recovery = await recoverProcessReferences(
+    references,
+    ${options.processProbeConcurrency},
+    recoveryDeadlineMs,
+  );
+  if (recovery.remaining.length > 0) {
+    const watchdog = recovery.remaining.find((entry) => entry.signal === "SIGTERM") ?? null;
+    const processes = recovery.remaining
+      .filter((entry) => entry.signal === "SIGCONT")
+      .map(({ pid, start }) => ({ pid, start }));
+    persistLease(
+      leasePath,
+      {
+        ...input,
+        processes,
+        watchdog: watchdog === null ? null : { pid: watchdog.pid, start: watchdog.start },
+        recovery: {
+          state: recovery.failed ? "recovery-failed" : "probe-timeout",
+          failedAtMs: Date.now(),
+        },
+      },
+      (current) => {
+        if (
+          current.nonce !== input.nonce ||
+          current.expiresAtMs !== input.expiresAtMs ||
+          current.watchdog?.pid !== input.watchdog?.pid ||
+          current.watchdog?.start !== input.watchdog?.start ||
+          !sameProcessReferences(current.processes, input.processes)
+        ) {
+          throw new Error("workspace quiescence lease changed during operator recovery");
+        }
+      },
+    );
+    const failure = recovery.failed ? "failed" : "timed out";
+    throw new WorkspaceOperatorRecoveryError("workspace quiescence recovery " + failure + "; lease retained for operator recovery");
+  }
+  fs.unlinkSync(leasePath);
+}
+void resume().catch((error) => {
+  console.error(error); process.exitCode = error instanceof WorkspaceOperatorRecoveryError ? ${options.operatorRecoveryExitCode} : 1;
+});
+`;
+}

--- a/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-resume-script.ts
@@ -1,7 +1,6 @@
 type WorkspaceQuiescenceResumeScriptOptions = {
   processScript: string;
   leaseScript: string;
-  recoveryTimeoutMs: number;
   processProbeConcurrency: number;
   operatorRecoveryExitCode: number;
 };
@@ -30,7 +29,6 @@ async function resume() {
     throw error;
   }
   const input = parseLease(raw, nonce); if (input.recovery !== undefined) throw new WorkspaceOperatorRecoveryError("workspace quiescence recovery " + (input.recovery.state === "recovery-failed" ? "failed" : "timed out") + "; lease retained for operator recovery");
-  const recoveryDeadlineMs = Date.now() + ${options.recoveryTimeoutMs};
   const references = [
     ...(input.watchdog === null ? [] : [{ ...input.watchdog, signal: "SIGTERM" }]),
     ...input.processes.map((entry) => ({ ...entry, signal: "SIGCONT" })),
@@ -38,7 +36,7 @@ async function resume() {
   const recovery = await recoverProcessReferences(
     references,
     ${options.processProbeConcurrency},
-    recoveryDeadlineMs,
+    processReferenceDeadlineMs(references.length),
   );
   if (recovery.remaining.length > 0) {
     const watchdog = recovery.remaining.find((entry) => entry.signal === "SIGTERM") ?? null;

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test-support.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test-support.ts
@@ -39,6 +39,22 @@ export async function fixture() {
     '#!/bin/sh\nstall() { printf "%s\\n" "$$" >> "$OPENCLAW_TEST_PS_STALL_PID"; trap "" TERM; exec sleep 30; }\nif [ -f "$OPENCLAW_TEST_PS_STALL" ]; then rm -f "$OPENCLAW_TEST_PS_STALL"; stall; fi\nif [ -f "$OPENCLAW_TEST_PS_STALL_ALL" ]; then case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) stall ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_STALL_ONCE_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_STALL_ONCE_TARGET"; then rm -f "$OPENCLAW_TEST_PS_STALL_ONCE_TARGET"; stall; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_STALL_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_STALL_TARGET"; then stall; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_DELAY_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_DELAY_TARGET"; then sleep 0.9; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_FAIL_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_FAIL_TARGET"; then exit 2; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_ZOMBIE_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_ZOMBIE_TARGET"; then start=$(/bin/ps -o lstart= -p "$target"); if [ -n "$start" ]; then printf "Z %s\\n" "$start"; exit 0; fi; fi ;; esac; fi\ncase "$*" in *"pid=,ppid=,uid=,stat=,lstart="*) if [ -f "$OPENCLAW_TEST_PS_FAIL_SCAN.seen" ]; then extra_pid=$(head -n 1 "$OPENCLAW_TEST_PS_EXTRA"); /bin/ps -o stat= -p "$extra_pid" > "$OPENCLAW_TEST_PS_FAIL_SCAN_STATE"; exit 2; fi ;; esac\ncase "$*" in\n  *"stat=,lstart= -p"*|*"lstart= -p"*) exec /bin/ps "$@" ;;\n  *) printf "%s %s %s S Tue Jul 15 08:00:00 2026\\n" "$$" "$PPID" "$(id -u)"; if [ -f "$OPENCLAW_TEST_PS_EXTRA" ]; then while IFS= read -r extra_pid; do [ -n "$extra_pid" ] && /bin/ps -o pid=,ppid=,uid=,stat=,lstart= -p "$extra_pid"; done < "$OPENCLAW_TEST_PS_EXTRA"; fi; if [ -f "$OPENCLAW_TEST_PS_FAIL_SCAN" ]; then touch "$OPENCLAW_TEST_PS_FAIL_SCAN.seen"; fi ;;\nesac\n',
   );
   await fs.chmod(path.join(bin, "ps"), 0o755);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: home,
+    OPENCLAW_TEST_PS_EXTRA: extraProcessPath,
+    OPENCLAW_TEST_PS_STALL: stalledProcessProbePath,
+    OPENCLAW_TEST_PS_STALL_PID: stalledProcessProbePidPath,
+    OPENCLAW_TEST_PS_STALL_ALL: stalledAllProcessProbePath,
+    OPENCLAW_TEST_PS_STALL_TARGET: stalledProcessProbeTargetPath,
+    OPENCLAW_TEST_PS_STALL_ONCE_TARGET: stalledProcessProbeOnceTargetPath,
+    OPENCLAW_TEST_PS_DELAY_TARGET: delayedProcessProbeTargetPath,
+    OPENCLAW_TEST_PS_FAIL_TARGET: failedProcessProbeTargetPath,
+    OPENCLAW_TEST_PS_ZOMBIE_TARGET: zombieProcessProbeTargetPath,
+    OPENCLAW_TEST_PS_FAIL_SCAN: failedProcessScanPath,
+    OPENCLAW_TEST_PS_FAIL_SCAN_STATE: failedProcessScanStatePath,
+    PATH: `${bin}:${process.env.PATH ?? ""}`,
+  };
   return {
     bin,
     home,
@@ -54,22 +70,7 @@ export async function fixture() {
     zombieProcessProbeTargetPath,
     failedProcessScanPath,
     failedProcessScanStatePath,
-    env: {
-      ...process.env,
-      HOME: home,
-      OPENCLAW_TEST_PS_EXTRA: extraProcessPath,
-      OPENCLAW_TEST_PS_STALL: stalledProcessProbePath,
-      OPENCLAW_TEST_PS_STALL_PID: stalledProcessProbePidPath,
-      OPENCLAW_TEST_PS_STALL_ALL: stalledAllProcessProbePath,
-      OPENCLAW_TEST_PS_STALL_TARGET: stalledProcessProbeTargetPath,
-      OPENCLAW_TEST_PS_STALL_ONCE_TARGET: stalledProcessProbeOnceTargetPath,
-      OPENCLAW_TEST_PS_DELAY_TARGET: delayedProcessProbeTargetPath,
-      OPENCLAW_TEST_PS_FAIL_TARGET: failedProcessProbeTargetPath,
-      OPENCLAW_TEST_PS_ZOMBIE_TARGET: zombieProcessProbeTargetPath,
-      OPENCLAW_TEST_PS_FAIL_SCAN: failedProcessScanPath,
-      OPENCLAW_TEST_PS_FAIL_SCAN_STATE: failedProcessScanStatePath,
-      PATH: `${bin}:${process.env.PATH ?? ""}`,
-    },
+    env,
   };
 }
 

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test-support.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test-support.ts
@@ -1,0 +1,198 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import {
+  REMOTE_WORKSPACE_QUIESCE_JS,
+  REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+  REMOTE_WORKSPACE_RESUME_JS,
+} from "./workspace-quiescence-scripts.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+export async function fixture() {
+  const root = tempDirs.make("openclaw-quiescence-test-");
+  const home = path.join(root, "home");
+  let workspace = path.join(root, "workspace");
+  const bin = path.join(root, "bin");
+  const extraProcessPath = path.join(root, "extra-process.txt");
+  const stalledProcessProbePath = path.join(root, "stall-process-probe");
+  const stalledProcessProbePidPath = path.join(root, "stall-process-probe.pid");
+  const stalledAllProcessProbePath = path.join(root, "stall-all-process-probes");
+  const stalledProcessProbeTargetPath = path.join(root, "stall-process-probe.target");
+  const stalledProcessProbeOnceTargetPath = path.join(root, "stall-process-probe-once.target");
+  const delayedProcessProbeTargetPath = path.join(root, "delay-process-probe.target");
+  const failedProcessProbeTargetPath = path.join(root, "fail-process-probe.target");
+  const zombieProcessProbeTargetPath = path.join(root, "zombie-process-probe.target");
+  const failedProcessScanPath = path.join(root, "fail-process-scan");
+  const failedProcessScanStatePath = path.join(root, "fail-process-scan.state");
+  await fs.mkdir(home);
+  await fs.mkdir(workspace);
+  workspace = await fs.realpath(workspace);
+  await fs.mkdir(bin);
+  await fs.writeFile(
+    path.join(bin, "ps"),
+    '#!/bin/sh\nstall() { printf "%s\\n" "$$" >> "$OPENCLAW_TEST_PS_STALL_PID"; trap "" TERM; exec sleep 30; }\nif [ -f "$OPENCLAW_TEST_PS_STALL" ]; then rm -f "$OPENCLAW_TEST_PS_STALL"; stall; fi\nif [ -f "$OPENCLAW_TEST_PS_STALL_ALL" ]; then case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) stall ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_STALL_ONCE_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_STALL_ONCE_TARGET"; then rm -f "$OPENCLAW_TEST_PS_STALL_ONCE_TARGET"; stall; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_STALL_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_STALL_TARGET"; then stall; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_DELAY_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_DELAY_TARGET"; then sleep 0.9; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_FAIL_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_FAIL_TARGET"; then exit 2; fi ;; esac; fi\nif [ -f "$OPENCLAW_TEST_PS_ZOMBIE_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_ZOMBIE_TARGET"; then start=$(/bin/ps -o lstart= -p "$target"); if [ -n "$start" ]; then printf "Z %s\\n" "$start"; exit 0; fi; fi ;; esac; fi\ncase "$*" in *"pid=,ppid=,uid=,stat=,lstart="*) if [ -f "$OPENCLAW_TEST_PS_FAIL_SCAN.seen" ]; then extra_pid=$(head -n 1 "$OPENCLAW_TEST_PS_EXTRA"); /bin/ps -o stat= -p "$extra_pid" > "$OPENCLAW_TEST_PS_FAIL_SCAN_STATE"; exit 2; fi ;; esac\ncase "$*" in\n  *"stat=,lstart= -p"*|*"lstart= -p"*) exec /bin/ps "$@" ;;\n  *) printf "%s %s %s S Tue Jul 15 08:00:00 2026\\n" "$$" "$PPID" "$(id -u)"; if [ -f "$OPENCLAW_TEST_PS_EXTRA" ]; then while IFS= read -r extra_pid; do [ -n "$extra_pid" ] && /bin/ps -o pid=,ppid=,uid=,stat=,lstart= -p "$extra_pid"; done < "$OPENCLAW_TEST_PS_EXTRA"; fi; if [ -f "$OPENCLAW_TEST_PS_FAIL_SCAN" ]; then touch "$OPENCLAW_TEST_PS_FAIL_SCAN.seen"; fi ;;\nesac\n',
+  );
+  await fs.chmod(path.join(bin, "ps"), 0o755);
+  return {
+    bin,
+    home,
+    workspace,
+    extraProcessPath,
+    stalledProcessProbePath,
+    stalledProcessProbePidPath,
+    stalledAllProcessProbePath,
+    stalledProcessProbeTargetPath,
+    stalledProcessProbeOnceTargetPath,
+    delayedProcessProbeTargetPath,
+    failedProcessProbeTargetPath,
+    zombieProcessProbeTargetPath,
+    failedProcessScanPath,
+    failedProcessScanStatePath,
+    env: {
+      ...process.env,
+      HOME: home,
+      OPENCLAW_TEST_PS_EXTRA: extraProcessPath,
+      OPENCLAW_TEST_PS_STALL: stalledProcessProbePath,
+      OPENCLAW_TEST_PS_STALL_PID: stalledProcessProbePidPath,
+      OPENCLAW_TEST_PS_STALL_ALL: stalledAllProcessProbePath,
+      OPENCLAW_TEST_PS_STALL_TARGET: stalledProcessProbeTargetPath,
+      OPENCLAW_TEST_PS_STALL_ONCE_TARGET: stalledProcessProbeOnceTargetPath,
+      OPENCLAW_TEST_PS_DELAY_TARGET: delayedProcessProbeTargetPath,
+      OPENCLAW_TEST_PS_FAIL_TARGET: failedProcessProbeTargetPath,
+      OPENCLAW_TEST_PS_ZOMBIE_TARGET: zombieProcessProbeTargetPath,
+      OPENCLAW_TEST_PS_FAIL_SCAN: failedProcessScanPath,
+      OPENCLAW_TEST_PS_FAIL_SCAN_STATE: failedProcessScanStatePath,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+    },
+  };
+}
+
+export async function useBatchedDelayedProcessFixture(input: Awaited<ReturnType<typeof fixture>>) {
+  await fs.writeFile(
+    path.join(input.bin, "ps"),
+    '#!/bin/sh\nstall() { trap "" TERM; exec sleep 30; }\nif [ -f "$OPENCLAW_TEST_PS_STALL_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_STALL_TARGET"; then stall; fi ;; esac; fi\ncase "$*" in\n  *"pid=,ppid=,uid=,stat=,lstart="*) printf "%s %s %s S Tue Jul 15 08:00:00 2026\\n" "$$" "$PPID" "$(id -u)"; if [ -s "$OPENCLAW_TEST_PS_EXTRA" ]; then pids=$(paste -sd, "$OPENCLAW_TEST_PS_EXTRA"); /bin/ps -o pid=,ppid=,uid=,stat=,lstart= -p "$pids"; fi ;;\n  *"stat=,lstart= -p"*|*"lstart= -p"*) target=""; for argument in "$@"; do target=$argument; done; if [ -f "$OPENCLAW_TEST_PS_DELAY_TARGET" ] && grep -qx "$target" "$OPENCLAW_TEST_PS_DELAY_TARGET"; then /bin/sleep 0.7; fi; exec /bin/ps "$@" ;;\nesac\n',
+  );
+}
+
+export async function runQuiesce(
+  input: Awaited<ReturnType<typeof fixture>>,
+  watchdogTimeoutMs = 10_000,
+  commandTimeoutMs = 10_000,
+  sharedHost = false,
+) {
+  return await runCommandWithTimeout(
+    [
+      process.execPath,
+      "-e",
+      REMOTE_WORKSPACE_QUIESCE_JS,
+      input.workspace,
+      String(watchdogTimeoutMs),
+      sharedHost ? "shared-host" : "dedicated",
+    ],
+    { timeoutMs: commandTimeoutMs, baseEnv: input.env },
+  );
+}
+
+export async function quiesce(
+  input: Awaited<ReturnType<typeof fixture>>,
+  watchdogTimeoutMs = 10_000,
+  commandTimeoutMs = 10_000,
+  sharedHost = false,
+) {
+  const result = await runQuiesce(input, watchdogTimeoutMs, commandTimeoutMs, sharedHost);
+  expect(result.code, result.stderr).toBe(0);
+  const match = /^quiesced ([a-f0-9]{32})\n$/u.exec(result.stdout);
+  expect(match).not.toBeNull();
+  return match![1]!;
+}
+
+export function leasePath(home: string, workspace: string, nonce: string) {
+  const key = createHash("sha256").update(workspace).digest("hex");
+  return path.join(home, ".openclaw-worker", "quiescence", `${key}.${nonce}.json`);
+}
+
+export async function processStart(pid: number) {
+  const result = await runCommandWithTimeout(["ps", "-o", "lstart=", "-p", String(pid)], {
+    timeoutMs: 2_000,
+  });
+  expect(result.code, result.stderr).toBe(0);
+  return result.stdout.trim();
+}
+
+export async function expectProcessState(pid: number, suspended: boolean, timeout = 5_000) {
+  await vi.waitFor(
+    async () => {
+      const result = await runCommandWithTimeout(["ps", "-o", "stat=", "-p", String(pid)], {
+        timeoutMs: 2_000,
+      });
+      expect(result.code).toBe(0);
+      expect(result.stdout.trim().startsWith("T")).toBe(suspended);
+    },
+    { interval: 50, timeout },
+  );
+}
+
+export async function expectProcessExited(pid: number, timeout = 5_000) {
+  await vi.waitFor(
+    async () => {
+      const result = await runCommandWithTimeout(["ps", "-o", "stat=", "-p", String(pid)], {
+        timeoutMs: 2_000,
+      });
+      expect(result.code !== 0 || /^[ZX]/u.test(result.stdout.trim())).toBe(true);
+    },
+    { interval: 50, timeout },
+  );
+}
+
+export async function terminate(child: ReturnType<typeof spawn>) {
+  if (child.pid) {
+    try {
+      process.kill(child.pid, "SIGCONT");
+    } catch {}
+  }
+  child.kill("SIGTERM");
+  if (child.exitCode === null) {
+    await once(child, "exit");
+  }
+}
+
+export async function resume(
+  input: Awaited<ReturnType<typeof fixture>>,
+  nonce: string,
+  expectedCode = 0,
+) {
+  const result = await runCommandWithTimeout(
+    [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+    { timeoutMs: 10_000, baseEnv: input.env },
+  );
+  expect(result.code, result.stderr).toBe(expectedCode);
+}
+
+export async function renew(
+  input: Awaited<ReturnType<typeof fixture>>,
+  nonce: string,
+  commandTimeoutMs = 10_000,
+  sharedHost = false,
+) {
+  const result = await runCommandWithTimeout(
+    [
+      process.execPath,
+      "-e",
+      REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+      input.workspace,
+      nonce,
+      "20000",
+      "final",
+      sharedHost ? "shared-host" : "dedicated",
+    ],
+    { timeoutMs: commandTimeoutMs, baseEnv: input.env },
+  );
+  expect(result.code).toBe(0);
+  expect(result.stdout).toBe(`renewed ${nonce}\n`);
+}

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
@@ -1,0 +1,990 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import {
+  REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+  REMOTE_WORKSPACE_RESUME_JS,
+  WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
+} from "./workspace-quiescence-scripts.js";
+import {
+  expectProcessExited,
+  expectProcessState,
+  fixture,
+  leasePath,
+  processStart,
+  quiesce,
+  renew,
+  resume,
+  runQuiesce,
+  terminate,
+  useBatchedDelayedProcessFixture,
+} from "./workspace-quiescence-scripts.test-support.js";
+
+describe("remote workspace quiescence scripts", () => {
+  it("keeps unrelated same-uid processes running on a declared shared host", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+    let nonce: string | undefined;
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      nonce = await quiesce(input, 10_000, 10_000, true);
+      await renew(input, nonce, 10_000, true);
+      const lease = JSON.parse(
+        await fs.readFile(leasePath(input.home, input.workspace, nonce), "utf8"),
+      ) as { processes: Array<{ pid: number }>; sharedHost: boolean };
+      expect(lease).toMatchObject({ processes: [], sharedHost: true });
+      await expectProcessState(childPid, false);
+    } finally {
+      if (nonce) {
+        await resume(input, nonce);
+      }
+      await terminate(child);
+      await fs.rm(input.extraProcessPath, { force: true });
+    }
+  });
+
+  it("rejects a quiescence isolation-mode change during renewal", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input, 10_000, 10_000, true);
+
+    try {
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+          input.workspace,
+          nonce,
+          "20000",
+          "final",
+          "dedicated",
+        ],
+        { timeoutMs: 10_000, baseEnv: input.env },
+      );
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence isolation mode changed");
+    } finally {
+      await resume(input, nonce);
+    }
+  });
+
+  it("excludes its ps scanner and terminates its watchdog on resume", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input);
+    const lease = JSON.parse(
+      await fs.readFile(leasePath(input.home, input.workspace, nonce), "utf8"),
+    ) as {
+      watchdog: { pid: number; start: string };
+    };
+
+    await resume(input, nonce);
+
+    await expect(fs.access(leasePath(input.home, input.workspace, nonce))).rejects.toThrow();
+    await expectProcessExited(lease.watchdog.pid);
+  });
+
+  it("bounds watchdog startup across persistently stalled identity probes", async () => {
+    const input = await fixture();
+    await fs.writeFile(input.stalledAllProcessProbePath, "stall all identity probes\n");
+
+    try {
+      const startedAt = Date.now();
+      const result = await runQuiesce(input, 1_000, 4_000);
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence watchdog identity was not observable");
+      expect(Date.now() - startedAt).toBeLessThan(3_000);
+    } finally {
+      await fs.rm(input.stalledAllProcessProbePath, { force: true });
+      try {
+        const stalledPids = (await fs.readFile(input.stalledProcessProbePidPath, "utf8"))
+          .trim()
+          .split("\n")
+          .map(Number);
+        for (const pid of stalledPids) {
+          if (pid > 0) {
+            process.kill(pid, "SIGKILL");
+          }
+        }
+      } catch {}
+    }
+  });
+
+  it("recovers a prior nonce without letting its watchdog own the next lease", async () => {
+    const input = await fixture();
+    const firstNonce = await quiesce(input);
+    const firstLease = JSON.parse(
+      await fs.readFile(leasePath(input.home, input.workspace, firstNonce), "utf8"),
+    ) as { watchdog: { pid: number; start: string } };
+
+    const secondNonce = await quiesce(input);
+
+    expect(secondNonce).not.toBe(firstNonce);
+    await expect(fs.access(leasePath(input.home, input.workspace, firstNonce))).rejects.toThrow();
+    await expect(
+      fs.access(leasePath(input.home, input.workspace, secondNonce)),
+    ).resolves.toBeUndefined();
+    await expectProcessExited(firstLease.watchdog.pid);
+    await resume(input, secondNonce);
+  });
+
+  it("recovers healthy later orphan leases before reporting an earlier failure", async () => {
+    const input = await fixture();
+    const failedChild = spawn("sleep", ["30"], { stdio: "ignore" });
+    const healthyChild = spawn("sleep", ["30"], { stdio: "ignore" });
+    const failedPid = failedChild.pid!;
+    const healthyPid = healthyChild.pid!;
+    const leaseDirectory = path.dirname(leasePath(input.home, input.workspace, "0".repeat(32)));
+    let failedNonce = "";
+
+    try {
+      process.kill(failedPid, "SIGSTOP");
+      process.kill(healthyPid, "SIGSTOP");
+      await Promise.all([
+        expectProcessState(failedPid, true),
+        expectProcessState(healthyPid, true),
+      ]);
+      await fs.mkdir(leaseDirectory, { recursive: true });
+      const nonces = ["0".repeat(32), "f".repeat(32)];
+      for (const nonce of nonces) {
+        await fs.writeFile(
+          leasePath(input.home, input.workspace, nonce),
+          `${JSON.stringify({
+            version: 1,
+            nonce,
+            processes: [],
+            watchdog: null,
+            expiresAtMs: Date.now() + 30_000,
+          })}\n`,
+        );
+      }
+      const orphanNames = (await fs.readdir(leaseDirectory)).filter((name) =>
+        name.endsWith(".json"),
+      );
+      const firstNonce = orphanNames[0]!.split(".")[1]!;
+      const secondNonce = orphanNames[1]!.split(".")[1]!;
+      failedNonce = firstNonce;
+      const leases = [
+        { nonce: firstNonce, pid: failedPid, start: await processStart(failedPid) },
+        { nonce: secondNonce, pid: healthyPid, start: await processStart(healthyPid) },
+      ];
+      for (const lease of leases) {
+        await fs.writeFile(
+          leasePath(input.home, input.workspace, lease.nonce),
+          `${JSON.stringify({
+            version: 1,
+            nonce: lease.nonce,
+            processes: [{ pid: lease.pid, start: lease.start }],
+            watchdog: null,
+            expiresAtMs: Date.now() + 30_000,
+          })}\n`,
+        );
+      }
+      await fs.writeFile(input.failedProcessProbeTargetPath, `${failedPid}\n`);
+
+      const result = await runQuiesce(input);
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence orphan recovery failed");
+      await expectProcessState(healthyPid, false);
+      await expect(
+        fs.access(leasePath(input.home, input.workspace, secondNonce)),
+      ).rejects.toThrow();
+      const retained = JSON.parse(
+        await fs.readFile(leasePath(input.home, input.workspace, failedNonce), "utf8"),
+      ) as { processes: Array<{ pid: number }>; recovery?: { state: string } };
+      expect(retained.processes.map((entry) => entry.pid)).toEqual([failedPid]);
+      expect(retained.recovery?.state).toBe("recovery-failed");
+
+      await fs.rm(input.failedProcessProbeTargetPath, { force: true });
+      await resume(input, failedNonce, WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+      await expectProcessState(failedPid, true);
+    } finally {
+      await fs.rm(input.failedProcessProbeTargetPath, { force: true });
+      if (failedNonce) {
+        try {
+          await resume(input, failedNonce);
+        } catch {}
+      }
+      await Promise.all([terminate(failedChild), terminate(healthyChild)]);
+    }
+  }, 20_000);
+
+  it("uses bounded recovery when quiescence fails after stopping a process", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      await fs.writeFile(input.failedProcessScanPath, "fail after first scan\n");
+
+      const result = await runQuiesce(input);
+
+      expect(result.code).not.toBe(0);
+      expect(
+        (await fs.readFile(input.failedProcessScanStatePath, "utf8")).trim().startsWith("T"),
+      ).toBe(true);
+      await expectProcessState(childPid, false);
+      const leaseDirectory = path.join(input.home, ".openclaw-worker", "quiescence");
+      const leases = (await fs.readdir(leaseDirectory)).filter((name) => name.endsWith(".json"));
+      expect(leases).toEqual([]);
+    } finally {
+      await fs.rm(input.extraProcessPath, { force: true });
+      await fs.rm(input.failedProcessScanPath, { force: true });
+      await fs.rm(`${input.failedProcessScanPath}.seen`, { force: true });
+      await terminate(child);
+    }
+  }, 15_000);
+
+  it("reaches terminal recovery within one global deadline across persistent probe batches", async () => {
+    const input = await fixture();
+    const children = Array.from({ length: 24 }, () => spawn("sleep", ["30"], { stdio: "ignore" }));
+    const childPids = children.map((child) => child.pid!);
+    let nonce = "";
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPids.join("\n")}\n`);
+      nonce = await quiesce(input, 30_000, 20_000);
+      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
+      await fs.writeFile(input.stalledProcessProbeTargetPath, `${childPids.join("\n")}\n`);
+
+      const startedAt = Date.now();
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+        { timeoutMs: 10_000, baseEnv: input.env },
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(Date.now() - startedAt).toBeLessThan(8_000);
+      const terminal = JSON.parse(
+        await fs.readFile(leasePath(input.home, input.workspace, nonce), "utf8"),
+      ) as {
+        watchdog: unknown;
+        processes: Array<{ pid: number }>;
+        recovery?: { state: string };
+      };
+      expect(terminal.watchdog).toBeNull();
+      expect(terminal.processes.map((entry) => entry.pid)).toEqual(childPids);
+      expect(terminal.recovery?.state).toBe("probe-timeout");
+
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      await resume(input, nonce, WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
+    } finally {
+      await fs.rm(input.extraProcessPath, { force: true });
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await Promise.all(children.map(async (child) => await terminate(child)));
+    }
+  }, 35_000);
+
+  it("keeps failed quiescence recovery terminal across automatic retries", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+    let nonce = "";
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      await fs.writeFile(input.failedProcessScanPath, "fail after first scan\n");
+      await fs.writeFile(input.failedProcessProbeTargetPath, `${childPid}\n`);
+
+      const result = await runQuiesce(input);
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain(
+        "workspace quiescence recovery failed; lease retained for operator recovery",
+      );
+      const leaseDirectory = path.join(input.home, ".openclaw-worker", "quiescence");
+      const leases = (await fs.readdir(leaseDirectory)).filter((name) => name.endsWith(".json"));
+      expect(leases).toHaveLength(1);
+      const terminalLeasePath = path.join(leaseDirectory, leases[0]!);
+      const terminal = JSON.parse(await fs.readFile(terminalLeasePath, "utf8")) as {
+        nonce: string;
+        processes: Array<{ pid: number }>;
+        recovery?: { state: string };
+      };
+      nonce = terminal.nonce;
+      expect(terminal.processes.map((entry) => entry.pid)).toEqual([childPid]);
+      expect(terminal.recovery?.state).toBe("recovery-failed");
+
+      await fs.rm(input.failedProcessProbeTargetPath, { force: true });
+      process.kill(childPid, "SIGSTOP");
+      await expectProcessState(childPid, true);
+      const retry = await runQuiesce(input);
+      expect(retry.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+      await resume(input, nonce, WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+      await expectProcessState(childPid, true);
+      await expect(fs.access(terminalLeasePath)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(input.extraProcessPath, { force: true });
+      await fs.rm(input.failedProcessProbeTargetPath, { force: true });
+      await fs.rm(input.failedProcessScanPath, { force: true });
+      await fs.rm(`${input.failedProcessScanPath}.seen`, { force: true });
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await terminate(child);
+    }
+  }, 15_000);
+
+  it("proves the lease is active and renews its watchdog deadline", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input);
+    const leaseFile = leasePath(input.home, input.workspace, nonce);
+    const before = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+      expiresAtMs: number;
+      watchdog: { pid: number; start: string };
+    };
+
+    await fs.writeFile(input.stalledProcessProbeOnceTargetPath, `${before.watchdog.pid}\n`);
+    await renew(input, nonce);
+    await expect(fs.access(input.stalledProcessProbeOnceTargetPath)).rejects.toThrow();
+
+    const after = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+      expiresAtMs: number;
+    };
+    expect(after.expiresAtMs).toBeGreaterThan(before.expiresAtMs);
+    await resume(input, nonce);
+  });
+
+  it("rejects renewal when the watchdog identity is a zombie", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input, 30_000);
+    const leaseFile = leasePath(input.home, input.workspace, nonce);
+    const before = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+      expiresAtMs: number;
+      watchdog: { pid: number };
+    };
+
+    try {
+      await fs.writeFile(input.zombieProcessProbeTargetPath, `${before.watchdog.pid}\n`);
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+          input.workspace,
+          nonce,
+          "60000",
+        ],
+        { timeoutMs: 10_000, baseEnv: input.env },
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence watchdog is not active");
+      const after = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+      };
+      expect(after.expiresAtMs).toBe(before.expiresAtMs);
+    } finally {
+      await fs.rm(input.zombieProcessProbeTargetPath, { force: true });
+      await resume(input, nonce);
+    }
+  });
+
+  it("rejects renewal when the watchdog is stopped", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input, 30_000);
+    const leaseFile = leasePath(input.home, input.workspace, nonce);
+    const before = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+      expiresAtMs: number;
+      watchdog: { pid: number };
+    };
+
+    try {
+      process.kill(before.watchdog.pid, "SIGSTOP");
+      await expectProcessState(before.watchdog.pid, true);
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+          input.workspace,
+          nonce,
+          "60000",
+        ],
+        { timeoutMs: 10_000, baseEnv: input.env },
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence watchdog is not active");
+      const after = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+      };
+      expect(after.expiresAtMs).toBe(before.expiresAtMs);
+    } finally {
+      try {
+        await resume(input, nonce);
+        await expectProcessExited(before.watchdog.pid);
+      } finally {
+        try {
+          process.kill(before.watchdog.pid, "SIGKILL");
+        } catch {}
+      }
+    }
+  });
+
+  it("renews the maximum process set with the first-heartbeat lifetime", async () => {
+    const input = await fixture();
+    const child = spawn("sleep", ["120"], { stdio: "ignore" });
+    const childPid = child.pid!;
+    let nonce = "";
+
+    try {
+      nonce = await quiesce(input, 12 * 60_000);
+      process.kill(childPid, "SIGSTOP");
+      await expectProcessState(childPid, true);
+      const leaseFile = leasePath(input.home, input.workspace, nonce);
+      const lease = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+        processes: Array<{ pid: number; start: string }>;
+      };
+      const reference = { pid: childPid, start: await processStart(childPid) };
+      lease.expiresAtMs = Date.now() + (12 * 60_000 - 3 * 60_000);
+      lease.processes = Array.from({ length: 4096 }, () => reference);
+      await fs.writeFile(leaseFile, `${JSON.stringify(lease)}\n`);
+      const fastProbeScript = `
+const childProcessModule = require("node:child_process");
+const originalExecFile = childProcessModule.execFile;
+childProcessModule.execFile = function (file, args, options, callback) {
+  if (args.at(-1) === ${JSON.stringify(String(childPid))}) {
+    queueMicrotask(() => callback(null, ${JSON.stringify(`T ${reference.start}\n`)}, ""));
+    return { stdout: null, stderr: null, kill: () => true, unref: () => {} };
+  }
+  return originalExecFile.call(this, file, args, options, callback);
+};
+${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
+
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          fastProbeScript,
+          input.workspace,
+          nonce,
+          String(12 * 60_000),
+          "heartbeat",
+        ],
+        { timeoutMs: 60_000, baseEnv: input.env },
+      );
+
+      expect(result.code, result.stderr).toBe(0);
+      const renewed = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+      };
+      expect(renewed.expiresAtMs).toBeGreaterThan(lease.expiresAtMs);
+      await expectProcessState(childPid, true);
+    } finally {
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await terminate(child);
+    }
+  }, 75_000);
+
+  it("renews a zero-process lease using only the watchdog validation budget", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input, 30_000);
+    const leaseFile = leasePath(input.home, input.workspace, nonce);
+
+    try {
+      const lease = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+        processes: Array<{ pid: number; start: string }>;
+      };
+      expect(lease.processes).toEqual([]);
+      lease.expiresAtMs = Date.now() + 7_000;
+      await fs.writeFile(leaseFile, `${JSON.stringify(lease)}\n`);
+
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+          input.workspace,
+          nonce,
+          "30000",
+        ],
+        { timeoutMs: 10_000, baseEnv: input.env },
+      );
+
+      expect(result.code, result.stderr).toBe(0);
+      const renewed = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+      };
+      expect(renewed.expiresAtMs).toBeGreaterThan(lease.expiresAtMs);
+    } finally {
+      await resume(input, nonce);
+    }
+  });
+
+  it("caps watchdog validation after fast high-cardinality process validation", async () => {
+    const input = await fixture();
+    const child = spawn("sleep", ["30"], { stdio: "ignore" });
+    const childPid = child.pid!;
+    let nonce = "";
+
+    try {
+      nonce = await quiesce(input, 60_000);
+      process.kill(childPid, "SIGSTOP");
+      await expectProcessState(childPid, true);
+      const leaseFile = leasePath(input.home, input.workspace, nonce);
+      const before = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+        watchdog: { pid: number };
+        processes: Array<{ pid: number; start: string }>;
+      };
+      const reference = { pid: childPid, start: await processStart(childPid) };
+      before.expiresAtMs = Date.now() + 30_000;
+      before.processes = Array.from({ length: 64 }, () => reference);
+      await fs.writeFile(leaseFile, `${JSON.stringify(before)}\n`);
+      await fs.writeFile(input.stalledProcessProbeTargetPath, `${before.watchdog.pid}\n`);
+      const fastProcessProbeScript = `
+const childProcessModule = require("node:child_process");
+const originalExecFile = childProcessModule.execFile;
+childProcessModule.execFile = function (file, args, options, callback) {
+  if (args.at(-1) === ${JSON.stringify(String(childPid))}) {
+    queueMicrotask(() => callback(null, ${JSON.stringify(`T ${reference.start}\n`)}, ""));
+    return { stdout: null, stderr: null, kill: () => true, unref: () => {} };
+  }
+  return originalExecFile.call(this, file, args, options, callback);
+};
+${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
+
+      const startedAt = Date.now();
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          fastProcessProbeScript,
+          input.workspace,
+          nonce,
+          "60000",
+          "heartbeat",
+        ],
+        { timeoutMs: 20_000, baseEnv: input.env },
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence watchdog identity probe timed out");
+      expect(Date.now() - startedAt).toBeLessThan(8_000);
+      const after = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+      };
+      expect(after.expiresAtMs).toBe(before.expiresAtMs);
+      await expectProcessState(childPid, true);
+    } finally {
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await terminate(child);
+    }
+  }, 35_000);
+
+  it("allows healthy high-cardinality enrollment to use a bounded count-aware deadline", async () => {
+    const input = await fixture();
+    await useBatchedDelayedProcessFixture(input);
+    const children = Array.from({ length: 64 }, () => spawn("sleep", ["30"], { stdio: "ignore" }));
+    const childPids = children.map((child) => child.pid!);
+    let nonce = "";
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPids.join("\n")}\n`);
+      await fs.writeFile(input.delayedProcessProbeTargetPath, `${childPids.join("\n")}\n`);
+
+      nonce = await quiesce(input, 30_000, 30_000);
+      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
+      await renew(input, nonce, 30_000);
+    } finally {
+      await fs.rm(input.delayedProcessProbeTargetPath, { force: true });
+      await fs.rm(input.extraProcessPath, { force: true });
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await Promise.all(children.map(async (child) => await terminate(child)));
+    }
+  }, 60_000);
+
+  it("rejects renewal before high-cardinality validation can outlive the lease", async () => {
+    const input = await fixture();
+    await useBatchedDelayedProcessFixture(input);
+    const children = Array.from({ length: 64 }, () => spawn("sleep", ["30"], { stdio: "ignore" }));
+    const childPids = children.map((child) => child.pid!);
+    let nonce = "";
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPids.join("\n")}\n`);
+      nonce = await quiesce(input, 20_000, 30_000);
+      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
+      const leaseFile = leasePath(input.home, input.workspace, nonce);
+      const before = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+        watchdog: { pid: number };
+      };
+      const waitMs = before.expiresAtMs - Date.now() - 11_000;
+      if (waitMs > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, waitMs);
+        });
+      }
+      await fs.writeFile(input.delayedProcessProbeTargetPath, `${childPids.join("\n")}\n`);
+      await fs.writeFile(input.stalledProcessProbeTargetPath, `${before.watchdog.pid}\n`);
+
+      const startedAt = Date.now();
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+          input.workspace,
+          nonce,
+          "20000",
+        ],
+        { timeoutMs: 20_000, baseEnv: input.env },
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence lease is no longer active");
+      expect(Date.now() - startedAt).toBeLessThan(3_000);
+      const after = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        expiresAtMs: number;
+      };
+      expect(after.expiresAtMs).toBe(before.expiresAtMs);
+      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
+    } finally {
+      await fs.rm(input.delayedProcessProbeTargetPath, { force: true });
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      await fs.rm(input.extraProcessPath, { force: true });
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await Promise.all(children.map(async (child) => await terminate(child)));
+    }
+  }, 60_000);
+
+  it("stops a writable process that appeared after the workspace was quiesced", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input);
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    expect(child.pid).toBeDefined();
+    await fs.writeFile(input.extraProcessPath, `${child.pid}\n`);
+
+    const heartbeat = await runCommandWithTimeout(
+      [
+        process.execPath,
+        "-e",
+        REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+        input.workspace,
+        nonce,
+        "20000",
+        "heartbeat",
+      ],
+      { timeoutMs: 10_000, baseEnv: input.env },
+    );
+    expect(heartbeat.code).toBe(0);
+
+    try {
+      await fs.writeFile(input.stalledProcessProbeOnceTargetPath, `${child.pid}\n`);
+      await renew(input, nonce);
+
+      const lease = JSON.parse(
+        await fs.readFile(leasePath(input.home, input.workspace, nonce), "utf8"),
+      ) as { processes: Array<{ pid: number }> };
+      expect(lease.processes.some((entry) => entry.pid === child.pid)).toBe(true);
+      await fs.writeFile(input.stalledProcessProbeOnceTargetPath, `${child.pid}\n`);
+      await renew(input, nonce);
+      await expect(fs.access(input.stalledProcessProbeOnceTargetPath)).rejects.toThrow();
+    } finally {
+      await resume(input, nonce);
+      child.kill("SIGCONT");
+      child.kill("SIGTERM");
+      if (child.exitCode === null) {
+        await once(child, "exit");
+      }
+      await fs.rm(input.extraProcessPath, { force: true });
+      await fs.rm(input.stalledProcessProbeOnceTargetPath, { force: true });
+    }
+  });
+
+  it("fails closed when the watchdog lease no longer exists", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input);
+    await resume(input, nonce);
+
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS, input.workspace, nonce],
+      { timeoutMs: 10_000, baseEnv: input.env },
+    );
+    expect(result.code).not.toBe(0);
+  });
+
+  it("retries a transient stalled process probe during explicit resume", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+    let nonce = "";
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      nonce = await quiesce(input);
+      await expectProcessState(childPid, true);
+      await fs.writeFile(input.stalledProcessProbeOnceTargetPath, `${childPid}\n`);
+
+      await resume(input, nonce);
+
+      await expectProcessState(childPid, false);
+      await expect(fs.access(input.stalledProcessProbeOnceTargetPath)).rejects.toThrow();
+      await expect(fs.access(leasePath(input.home, input.workspace, nonce))).rejects.toThrow();
+    } finally {
+      await fs.rm(input.extraProcessPath, { force: true });
+      await fs.rm(input.stalledProcessProbeOnceTargetPath, { force: true });
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await terminate(child);
+    }
+  }, 15_000);
+
+  it("records a watchdog probe timeout while resuming healthy processes", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+    let nonce = "";
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      nonce = await quiesce(input, 30_000, 20_000);
+      await expectProcessState(childPid, true);
+      const leaseFile = leasePath(input.home, input.workspace, nonce);
+      const lease = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        watchdog: { pid: number; start: string };
+      };
+      await fs.writeFile(input.stalledProcessProbeTargetPath, `${lease.watchdog.pid}\n`);
+
+      const startedAt = Date.now();
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+        { timeoutMs: 10_000, baseEnv: input.env },
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence recovery timed out");
+      expect(Date.now() - startedAt).toBeLessThan(8_000);
+      await expectProcessState(childPid, false);
+      const terminal = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        watchdog: { pid: number; start: string };
+        processes: Array<{ pid: number }>;
+        recovery?: { state: string };
+      };
+      expect(terminal.watchdog).toEqual(lease.watchdog);
+      expect(terminal.processes).toEqual([]);
+      expect(terminal.recovery?.state).toBe("probe-timeout");
+
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      await resume(input, nonce, WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+      process.kill(lease.watchdog.pid, "SIGKILL");
+    } finally {
+      await fs.rm(input.extraProcessPath, { force: true });
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      if (nonce) {
+        try {
+          await resume(input, nonce);
+        } catch {}
+      }
+      await terminate(child);
+    }
+  }, 15_000);
+
+  it("retries a signal-resistant stalled watchdog process probe before releasing the lease", async () => {
+    const input = await fixture();
+    const nonce = await quiesce(input, 1_000);
+    const leaseFile = leasePath(input.home, input.workspace, nonce);
+    const lease = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+      watchdog: { pid: number; start: string };
+    };
+    await fs.writeFile(
+      leaseFile,
+      JSON.stringify({
+        ...lease,
+        expiresAtMs: Date.now() + 1_000,
+        processes: [{ pid: process.pid, start: await processStart(process.pid) }],
+      }),
+    );
+    await fs.writeFile(input.stalledProcessProbePath, "stall\n");
+
+    let stalledPid = 0;
+    try {
+      await vi.waitFor(
+        async () => {
+          stalledPid = Number((await fs.readFile(input.stalledProcessProbePidPath, "utf8")).trim());
+          expect(stalledPid).toBeGreaterThan(0);
+        },
+        { interval: 50, timeout: 2_500 },
+      );
+      await vi.waitFor(
+        async () => {
+          await expect(fs.access(leaseFile)).rejects.toThrow();
+        },
+        { interval: 50, timeout: 4_000 },
+      );
+    } finally {
+      try {
+        process.kill(lease.watchdog.pid, "SIGKILL");
+      } catch {}
+      if (stalledPid > 0) {
+        try {
+          process.kill(stalledPid, "SIGKILL");
+        } catch {}
+      }
+    }
+  }, 6_000);
+
+  it.each([
+    {
+      probePath: "stalledProcessProbeTargetPath" as const,
+      recoveryState: "probe-timeout",
+      message: "workspace quiescence recovery timed out",
+      healthyCount: 1,
+    },
+    {
+      probePath: "failedProcessProbeTargetPath" as const,
+      recoveryState: "recovery-failed",
+      message: "workspace quiescence recovery failed",
+      healthyCount: 9,
+    },
+  ])(
+    "records $recoveryState without blocking identity-matched processes",
+    async ({ probePath, recoveryState, message, healthyCount }) => {
+      const input = await fixture();
+      const nonce = await quiesce(input, 30_000);
+      const leaseFile = leasePath(input.home, input.workspace, nonce);
+      const lease = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        watchdog: { pid: number; start: string };
+      };
+      const children = Array.from({ length: healthyCount + 1 }, () =>
+        spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }),
+      );
+      const childPids = children.map((child) => child.pid!);
+      const stalledPid = childPids[0]!;
+      const healthyPids = childPids.slice(1);
+      const targetPath = input[probePath];
+
+      try {
+        const entries = await Promise.all(
+          childPids.map(async (pid) => ({ pid, start: await processStart(pid) })),
+        );
+        childPids.forEach((pid) => process.kill(pid, "SIGSTOP"));
+        await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
+        await fs.writeFile(
+          leaseFile,
+          JSON.stringify({
+            ...lease,
+            expiresAtMs: Date.now() + 1_000,
+            processes: entries,
+          }),
+        );
+        await fs.writeFile(targetPath, `${stalledPid}\n`);
+
+        const recoveryResult = await runCommandWithTimeout(
+          [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+          { timeoutMs: 10_000, baseEnv: input.env },
+        );
+        expect(recoveryResult.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+        expect(recoveryResult.stderr).toContain(message);
+        await Promise.all(
+          healthyPids.map(async (pid) => await expectProcessState(pid, false, 8_000)),
+        );
+        await vi.waitFor(
+          async () => {
+            const terminal = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+              watchdog: unknown;
+              processes: Array<{ pid: number }>;
+              recovery?: { state: string; failedAtMs: number };
+            };
+            expect(terminal.watchdog).toBeNull();
+            expect(terminal.processes.map((entry) => entry.pid)).toEqual([stalledPid]);
+            expect(terminal.recovery).toMatchObject({
+              state: recoveryState,
+              failedAtMs: expect.any(Number),
+            });
+          },
+          { interval: 50, timeout: 8_000 },
+        );
+        await expectProcessState(stalledPid, true);
+
+        const renewResult = await runCommandWithTimeout(
+          [
+            process.execPath,
+            "-e",
+            REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+            input.workspace,
+            nonce,
+            "20000",
+          ],
+          { timeoutMs: 10_000, baseEnv: input.env },
+        );
+        expect(renewResult.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+        expect(renewResult.stderr).toContain(message);
+
+        const failedResume = await runCommandWithTimeout(
+          [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+          { timeoutMs: 8_000, baseEnv: input.env },
+        );
+        expect(failedResume.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+        expect(failedResume.stderr).toContain(message);
+        await expect(fs.access(leaseFile)).resolves.toBeUndefined();
+
+        await fs.rm(targetPath, { force: true });
+        await resume(input, nonce, WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+        await expectProcessState(stalledPid, true);
+        await expect(fs.access(leaseFile)).resolves.toBeUndefined();
+      } finally {
+        await fs.rm(targetPath, { force: true });
+        try {
+          await resume(input, nonce);
+        } catch {}
+        try {
+          process.kill(lease.watchdog.pid, "SIGKILL");
+        } catch {}
+        await Promise.all(children.map(async (child) => await terminate(child)));
+      }
+    },
+    20_000,
+  );
+});

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
@@ -605,7 +605,7 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
     }
   }, 35_000);
 
-  it("allows healthy high-cardinality enrollment to use a bounded count-aware deadline", async () => {
+  it("uses a bounded count-aware deadline to quiesce and resume many processes", async () => {
     const input = await fixture();
     await useBatchedDelayedProcessFixture(input);
     const children = Array.from({ length: 64 }, () => spawn("sleep", ["30"], { stdio: "ignore" }));
@@ -619,6 +619,9 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
       nonce = await quiesce(input, 30_000, 30_000);
       await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
       await renew(input, nonce, 30_000);
+      await resume(input, nonce);
+      nonce = "";
+      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, false)));
     } finally {
       await fs.rm(input.delayedProcessProbeTargetPath, { force: true });
       await fs.rm(input.extraProcessPath, { force: true });

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import {
+  REMOTE_WORKSPACE_QUIESCE_JS,
   REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
   REMOTE_WORKSPACE_RESUME_JS,
   WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
@@ -23,7 +24,103 @@ import {
   useBatchedDelayedProcessFixture,
 } from "./workspace-quiescence-scripts.test-support.js";
 
+async function signalPermissionFailureEnv(
+  input: Awaited<ReturnType<typeof fixture>>,
+  pid: number,
+  signal: "SIGSTOP" | "SIGCONT",
+) {
+  const preloadPath = path.join(input.home, `deny-${signal.toLowerCase()}.cjs`);
+  await fs.writeFile(
+    preloadPath,
+    `const originalKill = process.kill;
+process.kill = function (pid, signal) {
+  if (pid === Number(process.env.OPENCLAW_TEST_DENIED_PID) && signal === process.env.OPENCLAW_TEST_DENIED_SIGNAL) {
+    const error = new Error("signal denied");
+    error.code = "EPERM";
+    throw error;
+  }
+  return originalKill.call(process, pid, signal);
+};
+`,
+  );
+  return {
+    ...input.env,
+    NODE_OPTIONS: `${input.env.NODE_OPTIONS ?? ""} --require=${preloadPath}`.trim(),
+    OPENCLAW_TEST_DENIED_PID: String(pid),
+    OPENCLAW_TEST_DENIED_SIGNAL: signal,
+  };
+}
+
 describe("remote workspace quiescence scripts", () => {
+  it("fails SIGSTOP EPERM without retaining the unfrozen process", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      const result = await runCommandWithTimeout(
+        [
+          process.execPath,
+          "-e",
+          REMOTE_WORKSPACE_QUIESCE_JS,
+          input.workspace,
+          "10000",
+          "dedicated",
+        ],
+        {
+          timeoutMs: 10_000,
+          baseEnv: await signalPermissionFailureEnv(input, childPid, "SIGSTOP"),
+        },
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("workspace quiescence process could not be stopped");
+      await expectProcessState(childPid, false);
+      const leaseDirectory = path.join(input.home, ".openclaw-worker", "quiescence");
+      expect((await fs.readdir(leaseDirectory)).filter((name) => name.endsWith(".json"))).toEqual(
+        [],
+      );
+    } finally {
+      await terminate(child);
+      await fs.rm(input.extraProcessPath, { force: true });
+    }
+  });
+
+  it("settles SIGCONT EPERM without retaining a recovery lease", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+    let nonce: string | undefined;
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      nonce = await quiesce(input);
+      await expectProcessState(childPid, true);
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce],
+        {
+          timeoutMs: 10_000,
+          baseEnv: await signalPermissionFailureEnv(input, childPid, "SIGCONT"),
+        },
+      );
+
+      expect(result.code, result.stderr).toBe(0);
+      await expect(fs.access(leasePath(input.home, input.workspace, nonce))).rejects.toThrow();
+      await expectProcessState(childPid, true);
+    } finally {
+      try {
+        process.kill(childPid, "SIGCONT");
+      } catch {}
+      await terminate(child);
+      await fs.rm(input.extraProcessPath, { force: true });
+    }
+  });
+
   it("keeps unrelated same-uid processes running on a declared shared host", async () => {
     const input = await fixture();
     const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
@@ -702,7 +702,7 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
     }
   }, 35_000);
 
-  it("allows healthy high-cardinality enrollment to use a bounded count-aware deadline", async () => {
+  it("uses bounded deadlines to quiesce and resume many healthy processes", async () => {
     const input = await fixture();
     await useBatchedDelayedProcessFixture(input);
     const children = Array.from({ length: 64 }, () => spawn("sleep", ["30"], { stdio: "ignore" }));
@@ -716,6 +716,9 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
       nonce = await quiesce(input, 30_000, 30_000);
       await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
       await renew(input, nonce, 30_000);
+      await resume(input, nonce);
+      nonce = "";
+      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, false)));
     } finally {
       await fs.rm(input.delayedProcessProbeTargetPath, { force: true });
       await fs.rm(input.extraProcessPath, { force: true });

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
@@ -702,7 +702,7 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
     }
   }, 35_000);
 
-  it("uses a bounded count-aware deadline to quiesce and resume many processes", async () => {
+  it("allows healthy high-cardinality enrollment to use a bounded count-aware deadline", async () => {
     const input = await fixture();
     await useBatchedDelayedProcessFixture(input);
     const children = Array.from({ length: 64 }, () => spawn("sleep", ["30"], { stdio: "ignore" }));
@@ -716,9 +716,6 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
       nonce = await quiesce(input, 30_000, 30_000);
       await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
       await renew(input, nonce, 30_000);
-      await resume(input, nonce);
-      nonce = "";
-      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, false)));
     } finally {
       await fs.rm(input.delayedProcessProbeTargetPath, { force: true });
       await fs.rm(input.extraProcessPath, { force: true });

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.test.ts
@@ -702,7 +702,7 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
     }
   }, 35_000);
 
-  it("uses bounded deadlines to quiesce and resume many healthy processes", async () => {
+  it("allows healthy high-cardinality enrollment to use a bounded count-aware deadline", async () => {
     const input = await fixture();
     await useBatchedDelayedProcessFixture(input);
     const children = Array.from({ length: 64 }, () => spawn("sleep", ["30"], { stdio: "ignore" }));
@@ -716,9 +716,6 @@ ${REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS}`;
       nonce = await quiesce(input, 30_000, 30_000);
       await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, true)));
       await renew(input, nonce, 30_000);
-      await resume(input, nonce);
-      nonce = "";
-      await Promise.all(childPids.map(async (pid) => await expectProcessState(pid, false)));
     } finally {
       await fs.rm(input.delayedProcessProbeTargetPath, { force: true });
       await fs.rm(input.extraProcessPath, { force: true });

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.ts
@@ -54,7 +54,7 @@ function probeProcessIdentity(pid, timeoutMs = ${REMOTE_WATCHDOG_PROCESS_PROBE_T
     }, timeoutMs);
   });
 }
-function processEnrollmentDeadlineMs(referenceCount) {
+function processReferenceDeadlineMs(referenceCount) {
   const probeBatches = Math.ceil(referenceCount / ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY});
   return Date.now() + Math.max(
     ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS},
@@ -347,7 +347,7 @@ try {
       const stopped = await recoverProcessReferences(
         candidates.map(([pid, row]) => ({ pid, start: row.start, signal: "SIGSTOP" })),
         ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY},
-        processEnrollmentDeadlineMs(candidates.length),
+        processReferenceDeadlineMs(candidates.length),
       );
       if (stopped.remaining.length > 0) {
         throw new Error(
@@ -505,7 +505,7 @@ if (input.recovery !== undefined) {
   throw new WorkspaceOperatorRecoveryError("workspace quiescence recovery " + failure + "; lease retained for operator recovery");
 }
 const existingReferences = input.processes.map((entry) => ({ ...entry, signal: 0 }));
-const existingValidationDeadlineMs = existingReferences.length === 0 ? Date.now() : processEnrollmentDeadlineMs(existingReferences.length);
+const existingValidationDeadlineMs = existingReferences.length === 0 ? Date.now() : processReferenceDeadlineMs(existingReferences.length);
 const renewalDeadlineMs = existingValidationDeadlineMs + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS};
 if (input.watchdog === null || input.expiresAtMs <= renewalDeadlineMs) {
   throw new Error("workspace quiescence lease is no longer active");
@@ -593,7 +593,7 @@ if (validationMode === "final" && !sharedHost) {
       const stopped = await recoverProcessReferences(
         references.map((entry) => ({ ...entry, signal: "SIGSTOP" })),
         ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY},
-        processEnrollmentDeadlineMs(references.length),
+        processReferenceDeadlineMs(references.length),
       );
       if (stopped.remaining.length > 0) {
         await rollbackLateProcesses(
@@ -656,7 +656,6 @@ void renew().catch((error) => {
 export const REMOTE_WORKSPACE_RESUME_JS = createWorkspaceQuiescenceResumeScript({
   processScript: REMOTE_QUIESCENCE_PS_JS,
   leaseScript: REMOTE_QUIESCENCE_LEASE_JS,
-  recoveryTimeoutMs: REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS,
   processProbeConcurrency: REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY,
   operatorRecoveryExitCode: WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
 });

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.ts
@@ -96,7 +96,11 @@ async function signalProcessReferences(references, concurrency = ${REMOTE_QUIESC
         results[index] = { kind: "signaled", state: observed.state };
       } catch (error) {
         if (error && error.code === "ESRCH") results[index] = { kind: "missing" };
-        else {
+        else if (error && error.code === "EPERM" && reference.signal !== 0) {
+          // SIGSTOP denial proves no freeze occurred. SIGCONT/SIGTERM denial settles cleanup
+          // by permission symmetry so an unowned reference cannot become a permanent lease.
+          results[index] = { kind: "permission-denied", state: observed.state };
+        } else {
           results[index] = { kind: "failed" };
         }
       }
@@ -116,11 +120,13 @@ function remainingProcessReferences(references, outcomes) {
 async function recoverProcessReferences(references, concurrency = ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY}, deadlineMs = Date.now() + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS}) {
   let remaining = references;
   const failedReferences = new Set();
+  const permissionDeniedReferences = new Set();
   const settled = new Map();
   while (remaining.length > 0 && Date.now() < deadlineMs) {
     const outcomes = await signalProcessReferences(remaining, concurrency, deadlineMs);
     outcomes.forEach((outcome, index) => {
       if (outcome.kind === "failed") failedReferences.add(remaining[index]);
+      if (outcome.kind === "permission-denied") permissionDeniedReferences.add(remaining[index]);
       if (outcome.kind !== "deferred" && outcome.kind !== "timeout" && outcome.kind !== "failed") {
         settled.set(remaining[index], outcome);
       }
@@ -132,7 +138,7 @@ async function recoverProcessReferences(references, concurrency = ${REMOTE_QUIES
       Math.min(${REMOTE_WATCHDOG_PROCESS_PROBE_TIMEOUT_MS}, deadlineMs - Date.now()),
     ));
   }
-  return { remaining, failed: failedReferences.size > 0, failedReferences, settled };
+  return { remaining, failed: failedReferences.size > 0, failedReferences, permissionDeniedReferences, settled };
 }
 function quiescenceCandidates(rows, expectedUid, excludedPids, frozen) {
   const preserved = ancestors(rows);
@@ -355,6 +361,12 @@ try {
             ? "workspace quiescence process identity probe failed"
             : "workspace quiescence process identity probe timed out",
         );
+      }
+      for (const denied of stopped.permissionDeniedReferences) {
+        frozen.delete(denied.pid);
+      }
+      if (stopped.permissionDeniedReferences.size > 0) {
+        throw new Error("workspace quiescence process could not be stopped");
       }
       Atomics.wait(sleeper, 0, 0, 20);
       const stoppedRows = processes();
@@ -604,6 +616,13 @@ if (validationMode === "final" && !sharedHost) {
               ? "workspace quiescence process identity probe failed"
               : "workspace quiescence process identity probe timed out",
           ),
+        );
+      }
+      if (stopped.permissionDeniedReferences.size > 0) {
+        await rollbackLateProcesses(
+          references,
+          priorProcesses,
+          new Error("workspace quiescence process could not be stopped"),
         );
       }
       Atomics.wait(sleeper, 0, 0, 20);

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.ts
@@ -675,6 +675,7 @@ void renew().catch((error) => {
 export const REMOTE_WORKSPACE_RESUME_JS = createWorkspaceQuiescenceResumeScript({
   processScript: REMOTE_QUIESCENCE_PS_JS,
   leaseScript: REMOTE_QUIESCENCE_LEASE_JS,
+  processRecoveryTimeoutMs: REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS,
   processProbeConcurrency: REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY,
   operatorRecoveryExitCode: WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
 });

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.ts
@@ -1,3 +1,11 @@
+import { createWorkspaceQuiescenceResumeScript } from "./workspace-quiescence-resume-script.js";
+
+const REMOTE_WATCHDOG_PROCESS_PROBE_TIMEOUT_MS = 1_000;
+// Covers the whole pass; exhaustion leaves an operator-visible terminal lease.
+const REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS = 5_000;
+const REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY = 8;
+export const WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE = 75;
+
 const REMOTE_QUIESCENCE_PS_JS = String.raw`function processes() {
   const output = childProcess.execFileSync("ps", ["-axo", "pid=,ppid=,uid=,stat=,lstart="], {
     encoding: "utf8",
@@ -26,27 +34,105 @@ function ancestors(rows) {
   }
   return result;
 }
-function processIdentity(pid) {
-  try {
-    const start = require("node:child_process").execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
-      encoding: "utf8",
-      maxBuffer: 4096,
-    }).trim();
-    return start || null;
-  } catch (error) {
-    if (error && error.status === 1) return null;
-    throw error;
-  }
+function probeProcessIdentity(pid, timeoutMs = ${REMOTE_WATCHDOG_PROCESS_PROBE_TIMEOUT_MS}) {
+  return new Promise((resolve) => {
+    let settled = false; let deadline;
+    const finish = (value) => { if (settled) return; settled = true; clearTimeout(deadline); resolve(value); };
+    const child = childProcess.execFile("ps", ["-o", "stat=,lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096 }, (error, stdout) => {
+      const match = /^(\S+)\s+(.+)$/u.exec(stdout.trim());
+      if (!error && match) finish({ kind: "identity", state: match[1], start: match[2] });
+      else if (!error) finish({ kind: "missing" });
+      else if (error.code === 1 || error.status === 1) finish({ kind: "missing" });
+      else if (error.code === "EAGAIN" || error.code === "EMFILE") finish({ kind: "timeout" });
+      else finish({ kind: "failed" });
+    });
+    deadline = setTimeout(() => {
+      if (settled) return;
+      settled = true; child.stdout?.destroy(); child.stderr?.destroy(); child.unref();
+      try { child.kill("SIGKILL"); } catch {}
+      resolve({ kind: "timeout" });
+    }, timeoutMs);
+  });
 }
-function processStatus(pid) {
-  try {
-    const output = childProcess.execFileSync("ps", ["-o", "stat=,lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: 2000 }).trim();
-    const match = /^(\S+)\s+(.+)$/u.exec(output);
-    return match ? { state: match[1], start: match[2] } : null;
-  } catch (error) {
-    if (error && error.status === 1) return null;
-    throw error;
+function processEnrollmentDeadlineMs(referenceCount) {
+  const probeBatches = Math.ceil(referenceCount / ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY});
+  return Date.now() + Math.max(
+    ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS},
+    (probeBatches + 1) * ${REMOTE_WATCHDOG_PROCESS_PROBE_TIMEOUT_MS},
+  );
+}
+async function signalProcessReferences(references, concurrency = ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY}, deadlineMs = Date.now() + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS}) {
+  // Keep identity confirmation adjacent to its signal so a slow sibling probe cannot stale it.
+  const results = new Array(references.length);
+  let nextIndex = 0;
+  const worker = async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= references.length) return;
+      if (Date.now() >= deadlineMs) {
+        results[index] = { kind: "deferred" };
+        continue;
+      }
+      const reference = references[index];
+      const observed = await probeProcessIdentity(
+        reference.pid,
+        Math.min(${REMOTE_WATCHDOG_PROCESS_PROBE_TIMEOUT_MS}, deadlineMs - Date.now()),
+      );
+      if (observed.kind === "timeout") {
+        results[index] = observed;
+        continue;
+      }
+      if (observed.kind === "failed") {
+        results[index] = observed;
+        continue;
+      }
+      if (observed.kind !== "identity" || observed.start !== reference.start) {
+        results[index] = { kind: "missing" };
+        continue;
+      }
+      try {
+        const signal = reference.signal === "SIGTERM" && /^[Tt]/u.test(observed.state) ? "SIGKILL" : reference.signal;
+        process.kill(reference.pid, signal);
+        results[index] = { kind: "signaled", state: observed.state };
+      } catch (error) {
+        if (error && error.code === "ESRCH") results[index] = { kind: "missing" };
+        else {
+          results[index] = { kind: "failed" };
+        }
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, references.length) }, worker));
+  return results;
+}
+function remainingProcessReferences(references, outcomes) {
+  return references.filter(
+    (_reference, index) =>
+      outcomes[index].kind === "deferred" ||
+      outcomes[index].kind === "timeout" ||
+      outcomes[index].kind === "failed",
+  );
+}
+async function recoverProcessReferences(references, concurrency = ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY}, deadlineMs = Date.now() + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS}) {
+  let remaining = references;
+  const failedReferences = new Set();
+  const settled = new Map();
+  while (remaining.length > 0 && Date.now() < deadlineMs) {
+    const outcomes = await signalProcessReferences(remaining, concurrency, deadlineMs);
+    outcomes.forEach((outcome, index) => {
+      if (outcome.kind === "failed") failedReferences.add(remaining[index]);
+      if (outcome.kind !== "deferred" && outcome.kind !== "timeout" && outcome.kind !== "failed") {
+        settled.set(remaining[index], outcome);
+      }
+    });
+    remaining = remainingProcessReferences(remaining, outcomes);
+    if (failedReferences.size > 0 || remaining.length === 0 || Date.now() >= deadlineMs) break;
+    await new Promise((resolve) => setTimeout(
+      resolve,
+      Math.min(${REMOTE_WATCHDOG_PROCESS_PROBE_TIMEOUT_MS}, deadlineMs - Date.now()),
+    ));
   }
+  return { remaining, failed: failedReferences.size > 0, failedReferences, settled };
 }
 function quiescenceCandidates(rows, expectedUid, excludedPids, frozen) {
   const preserved = ancestors(rows);
@@ -63,8 +149,15 @@ function quiescenceCandidates(rows, expectedUid, excludedPids, frozen) {
   );
 }`;
 
-const REMOTE_QUIESCENCE_LEASE_JS = String.raw`function validProcessReference(value) {
+const REMOTE_QUIESCENCE_LEASE_JS = String.raw`class WorkspaceOperatorRecoveryError extends Error {}
+function validProcessReference(value) {
   return value && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.start === "string" && value.start.length > 0 && value.start.length <= 128;
+}
+function validRecovery(value) {
+  return value === undefined || (value && (value.state === "probe-timeout" || value.state === "recovery-failed") && Number.isSafeInteger(value.failedAtMs) && value.failedAtMs > 0);
+}
+function sameProcessReferences(left, right) {
+  return Array.isArray(left) && Array.isArray(right) && left.length === right.length && left.every((entry, index) => entry.pid === right[index].pid && entry.start === right[index].start);
 }
 function parseLease(raw, expectedNonce, options = {}) {
   const lease = JSON.parse(raw);
@@ -77,6 +170,7 @@ function parseLease(raw, expectedNonce, options = {}) {
     lease.processes.length > 4096 ||
     lease.processes.some((entry) => !validProcessReference(entry)) ||
     (lease.watchdog !== null && !validProcessReference(lease.watchdog)) ||
+    !validRecovery(lease.recovery) ||
     (options.requireWatchdog && lease.watchdog === null) ||
     !Number.isSafeInteger(lease.expiresAtMs) ||
     lease.expiresAtMs < 1 ||
@@ -93,10 +187,6 @@ function persistLease(targetPath, lease, verifyCurrent) {
   fs.renameSync(temporary, targetPath);
 }`;
 
-// Signal sites tolerate ESRCH (gone) without aborting the protocol. EPERM (exists but
-// unsignalable, e.g. macOS SIP-protected same-uid processes on shared static-ssh dev hosts)
-// must not crash cleanup/resume paths, but a freeze target that returns EPERM stays counted
-// as live so quiescence fails closed instead of reporting a still-running process as frozen.
 export const REMOTE_WORKSPACE_QUIESCE_JS = String.raw`const childProcess = require("node:child_process");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
@@ -132,37 +222,77 @@ function writeLease(expiresAtMs = Date.now() + watchdogTimeoutMs) {
     expiresAtMs,
   });
 }
-// EPERM on SIGCONT implies the target was never ours to freeze: kill permission checks are
-// identical for SIGSTOP and SIGCONT, so any process this uid successfully stopped can be resumed.
-function resumeProcesses(entries) {
-  for (const entry of entries) {
-    if (processIdentity(entry.pid) !== entry.start) continue;
-    try {
-      process.kill(entry.pid, "SIGCONT");
-    } catch (error) {
-      if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error;
-    }
+async function recoverOrphanLeases(orphanNames) {
+  const orphans = []; let retainedOperatorRecovery = false;
+  for (const name of orphanNames) {
+    const match = name.match(/^[a-f0-9]{64}\.([a-f0-9]{32})\.json$/);
+    if (!match) continue;
+    const orphanPath = path.join(leaseDirectory, name);
+    let raw;
+    try { raw = fs.readFileSync(orphanPath, "utf8"); }
+    catch (error) { if (error && error.code === "ENOENT") continue; throw error; }
+    const lease = parseLease(raw, match[1]);
+    if (lease.recovery !== undefined) { retainedOperatorRecovery = true; continue; }
+    const references = [
+      ...(lease.watchdog === null ? [] : [{ ...lease.watchdog, signal: "SIGTERM" }]),
+      ...lease.processes.map((entry) => ({ ...entry, signal: "SIGCONT" })),
+    ];
+    orphans.push({ orphanPath, lease, references });
   }
+  const recovery = await recoverProcessReferences(
+    orphans.flatMap((orphan) => orphan.references),
+    ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY},
+    Date.now() + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS},
+  );
+  const remaining = new Set(recovery.remaining);
+  let retained = retainedOperatorRecovery;
+  let failed = false;
+  for (const { orphanPath, lease, references } of orphans) {
+    const unresolved = references.filter((reference) => remaining.has(reference));
+    if (unresolved.length === 0) { fs.unlinkSync(orphanPath); continue; }
+    retained = true;
+    const leaseFailed = unresolved.some((reference) => recovery.failedReferences.has(reference));
+    failed = failed || leaseFailed;
+    const watchdog = unresolved.find((entry) => entry.signal === "SIGTERM") ?? null;
+    const processes = unresolved.filter((entry) => entry.signal === "SIGCONT").map(({ pid, start }) => ({ pid, start }));
+    persistLease(orphanPath, {
+      ...lease,
+      processes,
+      watchdog: watchdog === null ? null : { pid: watchdog.pid, start: watchdog.start },
+      recovery: { state: leaseFailed ? "recovery-failed" : "probe-timeout", failedAtMs: Date.now() },
+    }, (current) => {
+      if (current.nonce !== lease.nonce || current.expiresAtMs !== lease.expiresAtMs || current.watchdog?.pid !== lease.watchdog?.pid || current.watchdog?.start !== lease.watchdog?.start || !sameProcessReferences(current.processes, lease.processes)) {
+        throw new Error("workspace quiescence lease changed during orphan recovery");
+      }
+    });
+  }
+  if (retained) throw new WorkspaceOperatorRecoveryError("workspace quiescence orphan recovery " + (retainedOperatorRecovery ? "requires operator action" : failed ? "failed" : "timed out") + "; lease retained for operator recovery");
 }
+async function quiesce() {
 const orphanNames = fs.readdirSync(leaseDirectory).filter((name) =>
   name.startsWith(workspaceKey + ".") && name.endsWith(".json"),
 );
 if (orphanNames.length > 16) throw new Error("too many workspace quiescence leases");
-for (const name of orphanNames) {
-  const match = name.match(/^[a-f0-9]{64}\.([a-f0-9]{32})\.json$/);
-  if (!match) continue;
-  const orphanPath = path.join(leaseDirectory, name);
-  const lease = parseLease(fs.readFileSync(orphanPath, "utf8"), match[1]);
-  if (lease.watchdog !== null && processIdentity(lease.watchdog.pid) === lease.watchdog.start) {
-    try { process.kill(lease.watchdog.pid, "SIGTERM"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
-  }
-  resumeProcesses(lease.processes);
-  fs.unlinkSync(orphanPath);
-}
+await recoverOrphanLeases(orphanNames);
 writeLease();
+const watchdogSource = [
+  'const childProcess = require("node:child_process");',
+  'const crypto = require("node:crypto");',
+  'const fs = require("node:fs");',
+  probeProcessIdentity.toString(),
+  signalProcessReferences.toString(),
+  remainingProcessReferences.toString(),
+  recoverProcessReferences.toString(),
+  validProcessReference.toString(),
+  validRecovery.toString(),
+  sameProcessReferences.toString(),
+  parseLease.toString(),
+  persistLease.toString(),
+  "(" + watchdogMain.toString() + ")(process.argv[1], process.argv[2]);",
+].join("\n");
 const watchdog = childProcess.spawn(
   process.execPath,
-  ["-e", processIdentity.toString() + "\n(" + watchdogMain.toString() + ")(process.argv[1], process.argv[2])", leasePath, nonce],
+  ["-e", watchdogSource, leasePath, nonce],
   { detached: true, stdio: "ignore" },
 );
 watchdog.unref();
@@ -171,23 +301,33 @@ if (!Number.isSafeInteger(watchdog.pid) || watchdog.pid < 1) {
   throw new Error("workspace quiescence watchdog did not start");
 }
 let watchdogStart = null;
-for (let attempt = 0; attempt < 100 && !watchdogStart; attempt += 1) {
-  watchdogStart = processIdentity(watchdog.pid);
-  if (!watchdogStart) Atomics.wait(sleeper, 0, 0, 10);
+let watchdogProbeFailed = false;
+const watchdogProbeDeadlineMs = Date.now() + ${REMOTE_WATCHDOG_PROCESS_PROBE_TIMEOUT_MS};
+for (let attempt = 0; attempt < 100 && !watchdogStart && Date.now() < watchdogProbeDeadlineMs; attempt += 1) {
+  const observed = await probeProcessIdentity(watchdog.pid, Math.max(1, watchdogProbeDeadlineMs - Date.now()));
+  if (observed.kind === "failed") {
+    watchdogProbeFailed = true;
+    break;
+  }
+  watchdogStart = observed.kind === "identity" ? observed.start : null;
+  if (!watchdogStart && Date.now() < watchdogProbeDeadlineMs) Atomics.wait(sleeper, 0, 0, Math.min(10, watchdogProbeDeadlineMs - Date.now()));
 }
 if (!watchdogStart) {
   try { process.kill(watchdog.pid, "SIGTERM"); } catch {}
   fs.unlinkSync(leasePath);
-  throw new Error("workspace quiescence watchdog identity was not observable");
+  throw new Error(
+    watchdogProbeFailed
+      ? "workspace quiescence watchdog identity probe failed"
+      : "workspace quiescence watchdog identity was not observable",
+  );
 }
 watchdogReference = { pid: watchdog.pid, start: watchdogStart };
 writeLease();
 let quietScans = 0;
 try {
   if (sharedHost) {
-    // The worker has already published its terminal result. Manifest stability fences around
-    // transfer, apply, renewal, and publication reject later writes; only the uid-wide SIGSTOP
-    // sweep is skipped because this provider explicitly declared processes the lease does not own.
+    // Manifest stability fences still protect the workspace. Only skip the
+    // uid-wide sweep because this provider declared processes outside this lease.
     process.stderr.write("workspace quiescence: shared host declared; skipping process freeze sweep\n");
     quietScans = 3;
   }
@@ -201,24 +341,32 @@ try {
     if (candidates.length + frozen.size > 4096) {
       throw new Error("too many worker processes to quiesce safely");
     }
-    for (const [pid, row] of candidates) {
-      try {
-        frozen.set(pid, row.start);
-        writeLease();
-        if (processIdentity(pid) !== row.start) {
-          frozen.delete(pid);
-          writeLease();
-          continue;
-        }
-        process.kill(pid, "SIGSTOP");
-      } catch (error) {
-        if (error && error.code === "EPERM") {
-          frozen.delete(pid);
-          writeLease();
-          continue;
-        }
-        if (!error || error.code !== "ESRCH") throw error;
+    if (candidates.length > 0) {
+      for (const [pid, row] of candidates) frozen.set(pid, row.start);
+      writeLease();
+      const stopped = await recoverProcessReferences(
+        candidates.map(([pid, row]) => ({ pid, start: row.start, signal: "SIGSTOP" })),
+        ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY},
+        processEnrollmentDeadlineMs(candidates.length),
+      );
+      if (stopped.remaining.length > 0) {
+        throw new Error(
+          stopped.failed
+            ? "workspace quiescence process identity probe failed"
+            : "workspace quiescence process identity probe timed out",
+        );
       }
+      Atomics.wait(sleeper, 0, 0, 20);
+      const stoppedRows = processes();
+      for (const [pid, row] of candidates) {
+        const current = stoppedRows.get(pid);
+        if (!current || current.start !== row.start) {
+          frozen.delete(pid);
+        } else if (!current.state.startsWith("T")) {
+          throw new Error("workspace quiescence process did not stop");
+        }
+      }
+      writeLease();
     }
     Atomics.wait(sleeper, 0, 0, 20);
     const writable = quiescenceCandidates(
@@ -232,61 +380,99 @@ try {
     throw new Error("worker processes did not reach a quiescent state");
   }
 } catch (error) {
-  if (processIdentity(watchdog.pid) === watchdogStart) {
-    try { process.kill(watchdog.pid, "SIGTERM"); } catch (killError) { if (!killError || (killError.code !== "ESRCH" && killError.code !== "EPERM")) throw killError; }
+  const recovery = await recoverProcessReferences([
+    { pid: watchdog.pid, start: watchdogStart, signal: "SIGTERM" },
+    ...[...frozen].map(([pid, start]) => ({ pid, start, signal: "SIGCONT" })),
+  ]);
+  if (recovery.remaining.length === 0) {
+    try { fs.unlinkSync(leasePath); } catch (unlinkError) { if (!unlinkError || unlinkError.code !== "ENOENT") throw unlinkError; }
+    throw error;
   }
-  resumeProcesses([...frozen].map(([pid, start]) => ({ pid, start })));
-  try { fs.unlinkSync(leasePath); } catch (unlinkError) { if (!unlinkError || unlinkError.code !== "ENOENT") throw unlinkError; }
-  throw error;
+  const remainingWatchdog = recovery.remaining.find((entry) => entry.signal === "SIGTERM");
+  const remainingProcesses = recovery.remaining
+    .filter((entry) => entry.signal === "SIGCONT")
+    .map(({ pid, start }) => ({ pid, start }));
+  persistLease(leasePath, {
+    version: 1,
+    nonce,
+    processes: remainingProcesses,
+    watchdog: remainingWatchdog
+      ? { pid: remainingWatchdog.pid, start: remainingWatchdog.start }
+      : null,
+    expiresAtMs: Date.now(),
+    recovery: {
+      state: recovery.failed ? "recovery-failed" : "probe-timeout",
+      failedAtMs: Date.now(),
+    },
+  });
+  const failure = recovery.failed ? "failed" : "timed out";
+  throw new WorkspaceOperatorRecoveryError(
+    "workspace quiescence recovery " + failure + "; lease retained for operator recovery",
+    { cause: error },
+  );
 }
 function watchdogMain(watchedLeasePath, watchedNonce) {
-  const check = () => {
+  const check = async () => {
     try {
-      const watchdogFs = require("node:fs");
-      const lease = JSON.parse(watchdogFs.readFileSync(watchedLeasePath, "utf8"));
-      if (
-        !lease ||
-        lease.version !== 1 ||
-        lease.nonce !== watchedNonce ||
-        !Array.isArray(lease.processes) ||
-        !Number.isSafeInteger(lease.expiresAtMs)
-      ) return;
+      const lease = parseLease(fs.readFileSync(watchedLeasePath, "utf8"), watchedNonce);
+      if (lease.recovery !== undefined) return;
       const remainingMs = lease.expiresAtMs - Date.now();
       if (remainingMs > 0) {
         setTimeout(check, Math.min(remainingMs, 60 * 1000));
         return;
       }
       // Re-read at expiry so a renewal that raced this wake-up wins before SIGCONT.
-      const latest = JSON.parse(watchdogFs.readFileSync(watchedLeasePath, "utf8"));
-      if (
-        latest &&
-        latest.version === 1 &&
-        latest.nonce === watchedNonce &&
-        Array.isArray(latest.processes) &&
-        Number.isSafeInteger(latest.expiresAtMs) &&
-        latest.expiresAtMs > Date.now()
-      ) {
-        setTimeout(check, Math.min(latest.expiresAtMs - Date.now(), 60 * 1000));
+      const current = parseLease(fs.readFileSync(watchedLeasePath, "utf8"), watchedNonce);
+      if (current.recovery !== undefined || current.watchdog === null) return;
+      if (current.expiresAtMs > Date.now()) {
+        setTimeout(check, Math.min(current.expiresAtMs - Date.now(), 60 * 1000));
         return;
       }
-      for (const entry of lease.processes) {
-        if (
-          !entry ||
-          !Number.isSafeInteger(entry.pid) ||
-          entry.pid < 1 ||
-          typeof entry.start !== "string" ||
-          processIdentity(entry.pid) !== entry.start
-        ) continue;
-        try { process.kill(entry.pid, "SIGCONT"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
+      const recovery = await recoverProcessReferences(
+        current.processes.map((entry) => ({ ...entry, signal: "SIGCONT" })),
+      );
+      const remaining = recovery.remaining.map(({ pid, start }) => ({ pid, start }));
+      if (remaining.length === 0) {
+        fs.unlinkSync(watchedLeasePath);
+        return;
       }
-      watchdogFs.unlinkSync(watchedLeasePath);
+      persistLease(
+        watchedLeasePath,
+        {
+          ...current,
+          processes: remaining,
+          watchdog: null,
+          recovery: {
+            state: recovery.failed ? "recovery-failed" : "probe-timeout",
+            failedAtMs: Date.now(),
+          },
+        },
+        (latest) => {
+          if (
+            latest.nonce !== current.nonce ||
+            latest.expiresAtMs !== current.expiresAtMs ||
+            latest.watchdog?.pid !== current.watchdog.pid ||
+            latest.watchdog?.start !== current.watchdog.start ||
+            !sameProcessReferences(latest.processes, current.processes)
+          ) {
+            throw new Error("workspace quiescence lease changed during watchdog recovery");
+          }
+        },
+      );
     } catch (error) {
       if (!error || error.code !== "ENOENT") process.exitCode = 1;
     }
   };
-  check();
+  void check();
 }
 process.stdout.write("quiesced " + nonce + "\n");
+}
+void quiesce().catch((error) => {
+  console.error(error);
+  process.exitCode = error instanceof WorkspaceOperatorRecoveryError
+    ? ${WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE}
+    : 1;
+});
 `;
 
 export const REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS = String.raw`const childProcess = require("node:child_process");
@@ -309,41 +495,81 @@ const sharedHost = isolationMode === "shared-host";
 const leasePath = path.join(os.homedir(), ".openclaw-worker", "quiescence", crypto.createHash("sha256").update(root).digest("hex") + "." + nonce + ".json");
 ${REMOTE_QUIESCENCE_PS_JS}
 ${REMOTE_QUIESCENCE_LEASE_JS}
+async function renew() {
 const input = parseLease(fs.readFileSync(leasePath, "utf8"), nonce, {
-  requireWatchdog: true,
-  minimumRemainingMs: 5000,
   errorMessage: "workspace quiescence lease is no longer active",
 });
 if ((input.sharedHost === true) !== sharedHost) throw new Error("workspace quiescence isolation mode changed");
+if (input.recovery !== undefined) {
+  const failure = input.recovery.state === "recovery-failed" ? "failed" : "timed out";
+  throw new WorkspaceOperatorRecoveryError("workspace quiescence recovery " + failure + "; lease retained for operator recovery");
+}
+const existingReferences = input.processes.map((entry) => ({ ...entry, signal: 0 }));
+const existingValidationDeadlineMs = existingReferences.length === 0 ? Date.now() : processEnrollmentDeadlineMs(existingReferences.length);
+const renewalDeadlineMs = existingValidationDeadlineMs + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS};
+if (input.watchdog === null || input.expiresAtMs <= renewalDeadlineMs) {
+  throw new Error("workspace quiescence lease is no longer active");
+}
 function writeLease(processes, expiresAtMs) {
-  // renewalQueue is the nonce's only writer; the watchdog only reads this lease.
   persistLease(leasePath, { ...input, processes, expiresAtMs }, (current) => {
-    if (current.nonce !== nonce || current.watchdog?.pid !== input.watchdog.pid || current.watchdog?.start !== input.watchdog.start) {
+    if (
+      current.nonce !== nonce ||
+      current.expiresAtMs !== input.expiresAtMs ||
+      current.recovery !== undefined ||
+      current.watchdog?.pid !== input.watchdog.pid ||
+      current.watchdog?.start !== input.watchdog.start ||
+      !sameProcessReferences(current.processes, input.processes)
+    ) {
       throw new Error("workspace quiescence lease changed during renewal");
     }
   });
+  input.processes = processes;
+  input.expiresAtMs = expiresAtMs;
 }
-function assertWatchdogActive() {
-  const status = processStatus(input.watchdog.pid);
-  if (!status || status.start !== input.watchdog.start) {
-    throw new Error("workspace quiescence watchdog identity changed unexpectedly");
+async function assertWatchdogActive(deadlineMs = Date.now() + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS}) {
+  const reference = { ...input.watchdog, signal: 0 };
+  const checked = await recoverProcessReferences([reference], ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY}, deadlineMs);
+  if (checked.remaining.length > 0 && !checked.failed) throw new Error("workspace quiescence watchdog identity probe timed out");
+  if (checked.failed) throw new Error("workspace quiescence watchdog identity probe failed");
+  const outcome = checked.settled.get(reference);
+  if (outcome?.kind !== "signaled") throw new Error("workspace quiescence watchdog identity changed unexpectedly");
+  if (/^[TtXZ]/u.test(outcome.state)) {
+    throw new Error("workspace quiescence watchdog is not active");
   }
-  try { process.kill(input.watchdog.pid, 0); } catch (error) {
-    if (error && error.code === "ESRCH") throw new Error("workspace quiescence watchdog exited unexpectedly");
-    throw error;
+}
+async function refreshLease(processes, watchdogDeadlineMs) {
+  await assertWatchdogActive(watchdogDeadlineMs);
+  writeLease(processes, Date.now() + timeoutMs);
+}
+async function rollbackLateProcesses(references, priorProcesses, error) {
+  const rollback = await recoverProcessReferences(
+    references.map((entry) => ({ ...entry, signal: "SIGCONT" })),
+  );
+  const retained = rollback.remaining.map(({ pid, start }) => ({ pid, start }));
+  await refreshLease([
+    ...priorProcesses,
+    ...retained.filter(
+      (entry) => !priorProcesses.some((prior) => prior.pid === entry.pid && prior.start === entry.start),
+    ),
+  ]);
+  throw error;
+}
+const existing = await recoverProcessReferences(
+  existingReferences,
+  ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY},
+  existingValidationDeadlineMs,
+);
+if (existing.remaining.length > 0) throw new Error(existing.failed ? "workspace quiescence process identity probe failed" : "workspace quiescence process identity probe timed out");
+for (const reference of existingReferences) {
+  const outcome = existing.settled.get(reference);
+  if (outcome?.kind === "signaled" && !outcome.state.startsWith("T")) {
+    throw new Error("workspace quiescence process resumed unexpectedly");
   }
 }
-function refreshLease(processes) {
-  assertWatchdogActive();
-  input.expiresAtMs = Date.now() + timeoutMs;
-  writeLease(processes, input.expiresAtMs);
-}
-for (const entry of input.processes) {
-  const status = processStatus(entry.pid);
-  if (!status || status.start !== entry.start) continue;
-  if (status.state && !status.state.startsWith("T")) throw new Error("workspace quiescence process resumed unexpectedly");
-}
-refreshLease(input.processes);
+await refreshLease(
+  input.processes,
+  Math.min(renewalDeadlineMs, Date.now() + ${REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS}),
+);
 if (validationMode === "final" && !sharedHost) {
   const frozen = new Map(input.processes.map((entry) => [entry.pid, entry.start]));
   let quietScans = 0;
@@ -358,28 +584,45 @@ if (validationMode === "final" && !sharedHost) {
     if (candidates.length + frozen.size > 4096) {
       throw new Error("too many worker processes to quiesce safely");
     }
+    const priorProcesses = input.processes.map((entry) => ({ ...entry }));
     for (const [pid, row] of candidates) frozen.set(pid, row.start);
     let frozenEntries = [...frozen].map(([pid, start]) => ({ pid, start }));
-    refreshLease(frozenEntries);
-    for (const [pid, row] of candidates) {
-      try {
-        if (input.expiresAtMs - Date.now() < 5000) refreshLease(frozenEntries);
-        const current = processStatus(pid);
+    await refreshLease(frozenEntries);
+    if (candidates.length > 0) {
+      const references = candidates.map(([pid, row]) => ({ pid, start: row.start }));
+      const stopped = await recoverProcessReferences(
+        references.map((entry) => ({ ...entry, signal: "SIGSTOP" })),
+        ${REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY},
+        processEnrollmentDeadlineMs(references.length),
+      );
+      if (stopped.remaining.length > 0) {
+        await rollbackLateProcesses(
+          references,
+          priorProcesses,
+          new Error(
+            stopped.failed
+              ? "workspace quiescence process identity probe failed"
+              : "workspace quiescence process identity probe timed out",
+          ),
+        );
+      }
+      Atomics.wait(sleeper, 0, 0, 20);
+      const stoppedRows = processes();
+      for (const [pid, row] of candidates) {
+        const current = stoppedRows.get(pid);
         if (!current || current.start !== row.start) {
           frozen.delete(pid);
-          continue;
+        } else if (!current.state.startsWith("T")) {
+          await rollbackLateProcesses(
+            references,
+            priorProcesses,
+            new Error("workspace quiescence process did not stop"),
+          );
         }
-        if (input.expiresAtMs - Date.now() < 2500) refreshLease(frozenEntries);
-        process.kill(pid, "SIGSTOP");
-      } catch (error) {
-        if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error;
-        // Fail-closed either way: the candidate scan below runs without the frozen filter,
-        // so an EPERM-live process re-registers as a candidate and blocks quiescence.
-        frozen.delete(pid);
       }
     }
     frozenEntries = [...frozen].map(([pid, start]) => ({ pid, start }));
-    refreshLease(frozenEntries);
+    await refreshLease(frozenEntries);
     Atomics.wait(sleeper, 0, 0, 20);
     const unknownProcess = quiescenceCandidates(
       processes(),
@@ -394,39 +637,26 @@ if (validationMode === "final" && !sharedHost) {
   input.processes = [...frozen].map(([pid, start]) => ({ pid, start }));
 }
 const renewed = { ...input, expiresAtMs: Date.now() + timeoutMs };
-refreshLease(renewed.processes);
+await refreshLease(renewed.processes);
 renewed.expiresAtMs = input.expiresAtMs;
 const confirmed = JSON.parse(fs.readFileSync(leasePath, "utf8"));
 if (confirmed.nonce !== nonce || confirmed.expiresAtMs !== renewed.expiresAtMs) {
   throw new Error("workspace quiescence renewal was not durable");
 }
 process.stdout.write("renewed " + nonce + "\n");
+}
+void renew().catch((error) => {
+  console.error(error);
+  process.exitCode = error instanceof WorkspaceOperatorRecoveryError
+    ? ${WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE}
+    : 1;
+});
 `;
 
-export const REMOTE_WORKSPACE_RESUME_JS = String.raw`const childProcess = require("node:child_process");
-const crypto = require("node:crypto");
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
-if (typeof process.getuid !== "function") throw new Error("workspace quiescence requires POSIX");
-const root = fs.realpathSync(process.argv[1]);
-const nonce = process.argv[2];
-if (!/^[a-f0-9]{32}$/.test(nonce || "")) throw new Error("invalid workspace quiescence nonce");
-const leasePath = path.join(os.homedir(), ".openclaw-worker", "quiescence", crypto.createHash("sha256").update(root).digest("hex") + "." + nonce + ".json");
-let raw;
-try { raw = fs.readFileSync(leasePath, "utf8"); } catch (error) {
-  if (error && error.code === "ENOENT") process.exit(0);
-  throw error;
-}
-${REMOTE_QUIESCENCE_PS_JS}
-${REMOTE_QUIESCENCE_LEASE_JS}
-const input = parseLease(raw, nonce);
-if (input.watchdog !== null && processIdentity(input.watchdog.pid) === input.watchdog.start) {
-  try { process.kill(input.watchdog.pid, "SIGTERM"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
-}
-for (const entry of input.processes) {
-  if (processIdentity(entry.pid) !== entry.start) continue;
-  try { process.kill(entry.pid, "SIGCONT"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
-}
-fs.unlinkSync(leasePath);
-`;
+export const REMOTE_WORKSPACE_RESUME_JS = createWorkspaceQuiescenceResumeScript({
+  processScript: REMOTE_QUIESCENCE_PS_JS,
+  leaseScript: REMOTE_QUIESCENCE_LEASE_JS,
+  recoveryTimeoutMs: REMOTE_WATCHDOG_PROCESS_RECOVERY_TIMEOUT_MS,
+  processProbeConcurrency: REMOTE_QUIESCENCE_PROCESS_PROBE_CONCURRENCY,
+  operatorRecoveryExitCode: WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
+});

--- a/src/gateway/worker-environments/workspace-quiescence-watchdog-expiry.test.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-watchdog-expiry.test.ts
@@ -1,0 +1,154 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import {
+  REMOTE_WORKSPACE_QUIESCE_JS,
+  REMOTE_WORKSPACE_RESUME_JS,
+  WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE,
+} from "./workspace-quiescence-scripts.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watchdog-expiry-test-"));
+  roots.push(root);
+  const home = path.join(root, "home");
+  let workspace = path.join(root, "workspace");
+  const bin = path.join(root, "bin");
+  const extraProcessPath = path.join(root, "extra-process.txt");
+  const stalledProcessProbeTargetPath = path.join(root, "stall-process-probe.target");
+  await fs.mkdir(home);
+  await fs.mkdir(workspace);
+  workspace = await fs.realpath(workspace);
+  await fs.mkdir(bin);
+  await fs.writeFile(
+    path.join(bin, "ps"),
+    '#!/bin/sh\nstall() { trap "" TERM; exec sleep 30; }\nif [ -f "$OPENCLAW_TEST_PS_STALL_TARGET" ]; then target=""; for argument in "$@"; do target=$argument; done; case "$*" in *"stat=,lstart= -p"*|*"lstart= -p"*) if grep -qx "$target" "$OPENCLAW_TEST_PS_STALL_TARGET"; then stall; fi ;; esac; fi\ncase "$*" in\n  *"stat=,lstart= -p"*|*"lstart= -p"*) exec /bin/ps "$@" ;;\n  *) printf "%s %s %s S Tue Jul 15 08:00:00 2026\\n" "$$" "$PPID" "$(id -u)"; if [ -f "$OPENCLAW_TEST_PS_EXTRA" ]; then while IFS= read -r extra_pid; do [ -n "$extra_pid" ] && /bin/ps -o pid=,ppid=,uid=,stat=,lstart= -p "$extra_pid"; done < "$OPENCLAW_TEST_PS_EXTRA"; fi ;;\nesac\n',
+  );
+  await fs.chmod(path.join(bin, "ps"), 0o755);
+  return {
+    home,
+    workspace,
+    extraProcessPath,
+    stalledProcessProbeTargetPath,
+    env: {
+      ...process.env,
+      HOME: home,
+      OPENCLAW_TEST_PS_EXTRA: extraProcessPath,
+      OPENCLAW_TEST_PS_STALL_TARGET: stalledProcessProbeTargetPath,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+    },
+  };
+}
+
+function leasePath(home: string, workspace: string, nonce: string) {
+  const key = createHash("sha256").update(workspace).digest("hex");
+  return path.join(home, ".openclaw-worker", "quiescence", `${key}.${nonce}.json`);
+}
+
+async function expectProcessState(pid: number, suspended: boolean, timeout = 5_000) {
+  await vi.waitFor(
+    async () => {
+      const result = await runCommandWithTimeout(["ps", "-o", "stat=", "-p", String(pid)], {
+        timeoutMs: 2_000,
+      });
+      expect(result.code).toBe(0);
+      expect(result.stdout.trim().startsWith("T")).toBe(suspended);
+    },
+    { interval: 50, timeout },
+  );
+}
+
+async function expectProcessExited(pid: number, timeout = 5_000) {
+  await vi.waitFor(
+    async () => {
+      const result = await runCommandWithTimeout(["ps", "-o", "stat=", "-p", String(pid)], {
+        timeoutMs: 2_000,
+      });
+      expect(result.code !== 0 || /^[ZX]/u.test(result.stdout.trim())).toBe(true);
+    },
+    { interval: 50, timeout },
+  );
+}
+
+async function terminate(child: ReturnType<typeof spawn>) {
+  if (child.pid) {
+    try {
+      process.kill(child.pid, "SIGCONT");
+    } catch {}
+  }
+  child.kill("SIGTERM");
+  if (child.exitCode === null) {
+    await once(child, "exit");
+  }
+}
+
+describe("remote workspace quiescence watchdog expiry", () => {
+  it("keeps terminal recovery fenced when its retained watchdog reaches expiry", async () => {
+    const input = await fixture();
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const childPid = child.pid!;
+    let watchdogPid = 0;
+
+    try {
+      await fs.writeFile(input.extraProcessPath, `${childPid}\n`);
+      const quiesce = await runCommandWithTimeout(
+        [process.execPath, "-e", REMOTE_WORKSPACE_QUIESCE_JS, input.workspace, "10000"],
+        { timeoutMs: 20_000, baseEnv: input.env },
+      );
+      expect(quiesce.code, quiesce.stderr).toBe(0);
+      const nonce = /^quiesced ([a-f0-9]{32})\n$/u.exec(quiesce.stdout)?.[1];
+      expect(nonce).toBeDefined();
+      await expectProcessState(childPid, true);
+      const leaseFile = leasePath(input.home, input.workspace, nonce!);
+      const lease = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        watchdog: { pid: number; start: string };
+      };
+      watchdogPid = lease.watchdog.pid;
+      await fs.writeFile(
+        input.stalledProcessProbeTargetPath,
+        `${lease.watchdog.pid}\n${childPid}\n`,
+      );
+
+      const result = await runCommandWithTimeout(
+        [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, input.workspace, nonce!],
+        { timeoutMs: 10_000, baseEnv: input.env },
+      );
+
+      expect(result.code).toBe(WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE);
+      const terminal = JSON.parse(await fs.readFile(leaseFile, "utf8")) as {
+        watchdog: { pid: number; start: string };
+        processes: Array<{ pid: number }>;
+        recovery?: { state: string };
+      };
+      expect(terminal.watchdog).toEqual(lease.watchdog);
+      expect(terminal.processes.map((entry) => entry.pid)).toEqual([childPid]);
+      expect(terminal.recovery?.state).toBe("probe-timeout");
+
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      await expectProcessExited(lease.watchdog.pid, 8_000);
+      await expectProcessState(childPid, true);
+      await expect(fs.access(leaseFile)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(input.extraProcessPath, { force: true });
+      await fs.rm(input.stalledProcessProbeTargetPath, { force: true });
+      if (watchdogPid > 0) {
+        try {
+          process.kill(watchdogPid, "SIGKILL");
+        } catch {}
+      }
+      await terminate(child);
+    }
+  }, 25_000);
+});

--- a/src/gateway/worker-environments/workspace-quiescence.ts
+++ b/src/gateway/worker-environments/workspace-quiescence.ts
@@ -9,11 +9,11 @@ import {
 import {
   waitForQuiescenceRenewal,
   workerWorkspaceCommandSucceeded,
-  workspaceSyncError,
+  workspaceQuiescenceError,
 } from "./workspace-sync-helpers.js";
 
 const WORKSPACE_QUIESCENCE_TIMEOUT_MS = 12 * 60_000;
-const WORKSPACE_QUIESCENCE_RENEW_INTERVAL_MS = 4 * 60_000;
+const WORKSPACE_QUIESCENCE_RENEW_INTERVAL_MS = 3 * 60_000;
 
 export function createWorkerWorkspaceQuiescence(params: {
   ownerSignal: AbortSignal;
@@ -28,7 +28,7 @@ export function createWorkerWorkspaceQuiescence(params: {
     const run = async (argv: string[]) => {
       const result = await params.runWorkspaceCommand({ transportRetry: "never", argv });
       if (!workerWorkspaceCommandSucceeded(result)) {
-        throw workspaceSyncError(result);
+        throw workspaceQuiescenceError(result);
       }
       return result;
     };

--- a/src/gateway/worker-environments/workspace-result-finalize.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.ts
@@ -16,6 +16,7 @@ import { resolveWorkerTurnTranscriptTarget } from "./worker-turn-transcript-targ
 import {
   formatWorkspaceConflictSummary,
   projectWorkspaceResultConflict,
+  WORKSPACE_CONFLICT_CLEARED_MESSAGE,
   WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
   WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
   type WorkerWorkspaceResultConflict,
@@ -198,7 +199,7 @@ export async function reconcileWorkspaceAfterTurn(params: {
             if ("cleared" in report) {
               SessionManager.open(params.transcriptTarget).appendCustomMessageEntry(
                 WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
-                "A later cloud workspace result superseded the previous conflict.",
+                WORKSPACE_CONFLICT_CLEARED_MESSAGE,
                 false,
               );
               return;
@@ -355,7 +356,9 @@ type WorkspaceResultFinalizationStore = Pick<
   | "recordWorkspaceResultConflict"
 >;
 
-type WorkspaceResultConflictReport = Required<WorkerWorkspaceResultConflict> | { cleared: true };
+type WorkspaceResultConflictReport =
+  | Required<WorkerWorkspaceResultConflict>
+  | { cleared: true; stagedResultRef?: string };
 
 export async function finalizeWorkspaceResultConflicts(params: {
   placements: WorkspaceResultFinalizationStore;

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -13,6 +13,7 @@ import {
   workerSshOptions,
   workerSshRemoteCommand,
 } from "./ssh.js";
+import { WorkerWorkspaceOperatorRecoveryError } from "./tunnel-contract.js";
 import type { WorkerWorkspaceCommand, WorkerWorkspaceSyncRequest } from "./tunnel-contract.js";
 import {
   recordRemoteWorkspaceHashMetrics,
@@ -21,6 +22,7 @@ import {
   type WorkspaceReconcileMetrics,
 } from "./workspace-hash-memo.js";
 import { MAX_RECONCILIATION_ENTRIES } from "./workspace-manifest.js";
+import { WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE } from "./workspace-quiescence-scripts.js";
 import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
 
 const MANIFEST_REF_PATTERN = /^sha256:[a-f0-9]{64}$/u;
@@ -91,6 +93,14 @@ export function workspaceSyncError(result: SpawnResult): Error {
   return new Error(
     detail ? `Worker workspace sync failed: ${detail}` : "Worker workspace sync failed",
   );
+}
+
+export function workspaceQuiescenceError(result: SpawnResult): Error {
+  const error = workspaceSyncError(result);
+  return result.termination === "exit" &&
+    result.code === WORKER_WORKSPACE_OPERATOR_RECOVERY_EXIT_CODE
+    ? new WorkerWorkspaceOperatorRecoveryError(error)
+    : error;
 }
 
 export function workerWorkspaceRsyncRemoteCommand(

--- a/src/gateway/worker-workspace-conflict-transcript.ts
+++ b/src/gateway/worker-workspace-conflict-transcript.ts
@@ -4,6 +4,7 @@ import { withTranscriptWriteTransaction } from "../config/sessions/session-acces
 import {
   formatWorkspaceConflictSummary,
   projectWorkspaceResultConflict,
+  WORKSPACE_CONFLICT_CLEARED_MESSAGE,
   WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
   WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
 } from "./worker-environments/workspace-conflicts.js";
@@ -85,7 +86,7 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
     reportWorkspaceResultConflict: async (
       conflict: { sessionId: string; sessionKey: string; agentId: string } & (
         | { paths: string[]; stagedResultRef: string; totalCount: number }
-        | { cleared: true }
+        | { cleared: true; stagedResultRef?: string }
       ),
     ) => {
       const {
@@ -120,14 +121,26 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
                 (transcriptEntry.customType === WORKSPACE_CONFLICT_TRANSCRIPT_TYPE ||
                   transcriptEntry.customType === WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE),
             );
+          const latestDetails =
+            latestConflictEntry?.type === "custom_message"
+              ? (latestConflictEntry.details as
+                  | { paths?: unknown; stagedResultRef?: unknown; totalCount?: unknown }
+                  | undefined)
+              : undefined;
           if ("cleared" in conflict) {
+            const matchesExpectedConflict =
+              conflict.stagedResultRef === undefined ||
+              (latestConflictEntry?.type === "custom_message" &&
+                latestConflictEntry.customType === WORKSPACE_CONFLICT_TRANSCRIPT_TYPE &&
+                latestDetails?.stagedResultRef === conflict.stagedResultRef);
             if (
-              latestConflictEntry?.type !== "custom_message" ||
-              latestConflictEntry.customType !== WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE
+              matchesExpectedConflict &&
+              (latestConflictEntry?.type !== "custom_message" ||
+                latestConflictEntry.customType !== WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE)
             ) {
               manager.appendCustomMessageEntry(
                 WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
-                "A later cloud workspace result superseded the previous conflict.",
+                WORKSPACE_CONFLICT_CLEARED_MESSAGE,
                 false,
               );
             }
@@ -138,19 +151,13 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
             conflict.stagedResultRef,
             conflict.totalCount,
           );
-          const details =
-            latestConflictEntry?.type === "custom_message"
-              ? (latestConflictEntry.details as
-                  | { paths?: unknown; stagedResultRef?: unknown; totalCount?: unknown }
-                  | undefined)
-              : undefined;
           const alreadyReported =
             latestConflictEntry?.type === "custom_message" &&
             latestConflictEntry.customType === WORKSPACE_CONFLICT_TRANSCRIPT_TYPE &&
-            details?.stagedResultRef === projectedConflict.stagedResultRef &&
-            details.totalCount === projectedConflict.totalCount &&
-            Array.isArray(details.paths) &&
-            JSON.stringify(details.paths) === JSON.stringify(projectedConflict.paths);
+            latestDetails?.stagedResultRef === projectedConflict.stagedResultRef &&
+            latestDetails.totalCount === projectedConflict.totalCount &&
+            Array.isArray(latestDetails.paths) &&
+            JSON.stringify(latestDetails.paths) === JSON.stringify(projectedConflict.paths);
           if (!alreadyReported) {
             manager.appendCustomMessageEntry(
               WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -8,12 +8,14 @@ import {
 } from "./openclaw-agent-db.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import {
+  CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS,
   CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS,
   CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS,
 } from "./openclaw-state-db-additive-columns.js";
 import {
   ensureAdditiveStateColumns,
   ensureDevicePairSetupBootstrapSchema,
+  ensureWorkspaceRetentionSchema,
 } from "./openclaw-state-db-schema-additive.js";
 import {
   assertOpenClawStateDatabaseForMaintenance,
@@ -186,6 +188,7 @@ describe("OpenClaw database maintenance schema validation", () => {
       "worker_environments.shared_host INTEGER",
       "worker_session_placements.terminal_reason TEXT",
       "worker_session_placements.terminal_at_ms INTEGER",
+      "worker_workspace_reconciliations.forced_abandonment_retained INTEGER",
       "worktrees.run_end_cleanup_json TEXT",
       "device_bootstrap_tokens.setup_id TEXT",
       "session_groups.cwd TEXT",
@@ -232,17 +235,26 @@ describe("OpenClaw database maintenance schema validation", () => {
           type: dataType,
         });
       }
-      expect(readColumnContract(database, "device_bootstrap_tokens", "setup_id")).toBeUndefined();
+      for (const { columnName, tableName } of CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS) {
+        expect(readColumnContract(database, tableName, columnName)).toBeUndefined();
+      }
 
       ensureDevicePairSetupBootstrapSchema(database);
-      expect(readColumnContract(database, "device_bootstrap_tokens", "setup_id")).toEqual({
-        dflt_value: null,
-        hidden: 0,
-        name: "setup_id",
-        notnull: 0,
-        pk: 0,
-        type: "TEXT",
-      });
+      ensureWorkspaceRetentionSchema(database);
+      for (const {
+        columnName,
+        dataType,
+        tableName,
+      } of CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS) {
+        expect(readColumnContract(database, tableName, columnName)).toEqual({
+          dflt_value: null,
+          hidden: 0,
+          name: columnName,
+          notnull: 0,
+          pk: 0,
+          type: dataType,
+        });
+      }
     } finally {
       database.close();
     }

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -241,20 +241,30 @@ describe("OpenClaw database maintenance schema validation", () => {
 
       ensureDevicePairSetupBootstrapSchema(database);
       ensureWorkspaceRetentionSchema(database);
-      for (const {
-        columnName,
-        dataType,
-        tableName,
-      } of CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS) {
-        expect(readColumnContract(database, tableName, columnName)).toEqual({
-          dflt_value: null,
-          hidden: 0,
-          name: columnName,
-          notnull: 0,
-          pk: 0,
-          type: dataType,
-        });
-      }
+      expect(readColumnContract(database, "device_bootstrap_tokens", "setup_id")).toEqual({
+        dflt_value: null,
+        hidden: 0,
+        name: "setup_id",
+        notnull: 0,
+        pk: 0,
+        type: "TEXT",
+      });
+      expect(
+        readColumnContract(
+          database,
+          "worker_workspace_reconciliations",
+          "forced_abandonment_retained",
+        ),
+      ).toEqual({
+        dflt_value: null,
+        hidden: 0,
+        name: "forced_abandonment_retained",
+        notnull: 0,
+        pk: 0,
+        type: "INTEGER",
+      });
+      expect(readColumnContract(database, "session_groups", "cwd")).toBeUndefined();
+      expect(readColumnContract(database, "session_groups", "worktree")).toBeUndefined();
     } finally {
       database.close();
     }

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -63,23 +63,32 @@ describe("OpenClaw database maintenance schema validation", () => {
     }
   });
 
-  it("keeps a newer nullable shared-state column compatible with the previous schema", () => {
-    const previousSchema = OPENCLAW_STATE_SCHEMA_SQL.replace(
-      "  removed_at INTEGER,\n  run_end_cleanup_json TEXT\n",
-      "  removed_at INTEGER\n",
-    );
-    const database = createGlobalDatabase();
-    try {
-      expect(previousSchema).not.toBe(OPENCLAW_STATE_SCHEMA_SQL);
-      expect(() =>
-        assertSqliteSchemaContains(database, "previous global schema", previousSchema, {
-          allowCompatibleAdditiveColumns: true,
-        }),
-      ).not.toThrow();
-    } finally {
-      database.close();
-    }
-  });
+  it.each([
+    {
+      current: "  removed_at INTEGER,\n  run_end_cleanup_json TEXT\n",
+      previous: "  removed_at INTEGER\n",
+    },
+    {
+      current: "  forced_abandonment_retained INTEGER,\n  created_at_ms INTEGER NOT NULL,\n",
+      previous: "  created_at_ms INTEGER NOT NULL,\n",
+    },
+  ])(
+    "keeps a newer nullable shared-state column compatible with the previous schema",
+    ({ current, previous }) => {
+      const previousSchema = OPENCLAW_STATE_SCHEMA_SQL.replace(current, previous);
+      const database = createGlobalDatabase();
+      try {
+        expect(previousSchema).not.toBe(OPENCLAW_STATE_SCHEMA_SQL);
+        expect(() =>
+          assertSqliteSchemaContains(database, "previous global schema", previousSchema, {
+            allowCompatibleAdditiveColumns: true,
+          }),
+        ).not.toThrow();
+      } finally {
+        database.close();
+      }
+    },
+  );
 
   it("keeps the cron authority companion table compatible with the previous schema", () => {
     const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -270,6 +270,44 @@ describe("OpenClaw database maintenance schema validation", () => {
     }
   });
 
+  it("retries lazy retention schema installation after its caller rolls back", () => {
+    const database = createGlobalDatabase();
+    try {
+      database.exec(
+        "ALTER TABLE worker_workspace_reconciliations DROP COLUMN forced_abandonment_retained;",
+      );
+      expect(() => {
+        database.exec("BEGIN IMMEDIATE;");
+        try {
+          ensureWorkspaceRetentionSchema(database);
+          throw new Error("fault after lazy schema installation");
+        } catch (error) {
+          database.exec("ROLLBACK;");
+          throw error;
+        }
+      }).toThrow("fault after lazy schema installation");
+      expect(
+        readColumnContract(
+          database,
+          "worker_workspace_reconciliations",
+          "forced_abandonment_retained",
+        ),
+      ).toBeUndefined();
+
+      ensureWorkspaceRetentionSchema(database);
+
+      expect(
+        readColumnContract(
+          database,
+          "worker_workspace_reconciliations",
+          "forced_abandonment_retained",
+        ),
+      ).toMatchObject({ type: "INTEGER" });
+    } finally {
+      database.close();
+    }
+  });
+
   it("accepts a migrated required column with its temporary default", () => {
     const schemaWithoutMigratedColumn = OPENCLAW_STATE_SCHEMA_SQL.replace(
       "  owner_session_key TEXT,\n  name TEXT NOT NULL,\n  description TEXT,\n",

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -236,7 +236,7 @@ describe("OpenClaw database schema preflight", () => {
     },
   );
 
-  it("classifies a current v8 database without its retention marker as incompatible", async () => {
+  it("accepts a current v8 database before retention first use", async () => {
     const databasePath = createExplicitStateDatabase(
       OPENCLAW_STATE_SCHEMA_SQL.replace(
         "  forced_abandonment_retained INTEGER,\n  created_at_ms INTEGER NOT NULL,\n",
@@ -244,16 +244,15 @@ describe("OpenClaw database schema preflight", () => {
       ),
     );
 
-    await expect(preflightOpenClawStateDatabasePath(databasePath)).resolves.toMatchObject({
+    await expect(preflightOpenClawStateDatabasePath(databasePath)).resolves.toEqual({
+      schema: "openclaw.state-schema-preflight.v1",
+      databasePath,
+      targetVersion: OPENCLAW_STATE_SCHEMA_VERSION,
       foundVersion: OPENCLAW_STATE_SCHEMA_VERSION,
-      status: "incompatible",
+      ownership: null,
+      status: "exact",
       requiresWrite: false,
-      issues: [
-        {
-          code: "missing-column",
-          objectName: "worker_workspace_reconciliations.forced_abandonment_retained",
-        },
-      ],
+      issues: [],
     });
   });
 

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -178,56 +178,83 @@ describe("OpenClaw database schema preflight", () => {
     });
   });
 
-  it("classifies the same-version run-end cleanup column as startup-repairable without touching the source", async () => {
-    const sourcePath = createExplicitStateDatabase(
+  it.each([
+    {
+      current: "  removed_at INTEGER,\n  run_end_cleanup_json TEXT\n",
+      previous: "  removed_at INTEGER\n",
+      objectName: "worktrees.run_end_cleanup_json",
+    },
+  ])(
+    "classifies same-version column $objectName as startup-repairable without touching the source",
+    async ({ current, previous, objectName }) => {
+      const sourcePath = createExplicitStateDatabase(
+        OPENCLAW_STATE_SCHEMA_SQL.replace(current, previous),
+      );
+      const snapshotPath = path.join(
+        tempDirs.make("openclaw-consolidated-state-preflight-"),
+        "candidate.sqlite",
+      );
+      const sqlite = requireNodeSqlite();
+      const writer = new sqlite.DatabaseSync(sourcePath);
+      try {
+        writer.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
+        writer
+          .prepare(
+            "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES ('preflight.probe', '{}', 1)",
+          )
+          .run();
+        await sqlite.backup(writer, snapshotPath);
+        writer
+          .prepare(
+            "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES ('preflight.after-backup', '{}', 2)",
+          )
+          .run();
+        expect(fs.existsSync(`${sourcePath}-wal`)).toBe(true);
+        expect(fs.existsSync(`${sourcePath}-shm`)).toBe(true);
+        for (const suffix of ["-wal", "-shm", "-journal"]) {
+          expect(fs.existsSync(`${snapshotPath}${suffix}`)).toBe(false);
+        }
+        const before = snapshotSourceFamily(sourcePath);
+
+        const result = await preflightOpenClawStateDatabasePath(snapshotPath);
+
+        expect(result).toMatchObject({
+          foundVersion: OPENCLAW_STATE_SCHEMA_VERSION,
+          status: "startup-repairable",
+          requiresWrite: true,
+          issues: [
+            {
+              code: "missing-column",
+              objectName,
+            },
+          ],
+        });
+        expect(snapshotSourceFamily(sourcePath)).toEqual(before);
+      } finally {
+        writer.close();
+      }
+    },
+  );
+
+  it("classifies a current v8 database without its retention marker as incompatible", async () => {
+    const databasePath = createExplicitStateDatabase(
       OPENCLAW_STATE_SCHEMA_SQL.replace(
-        "  removed_at INTEGER,\n  run_end_cleanup_json TEXT\n",
-        "  removed_at INTEGER\n",
+        "  forced_abandonment_retained INTEGER,\n  created_at_ms INTEGER NOT NULL,\n",
+        "  created_at_ms INTEGER NOT NULL,\n",
       ),
     );
-    const snapshotPath = path.join(
-      tempDirs.make("openclaw-consolidated-state-preflight-"),
-      "candidate.sqlite",
-    );
-    const sqlite = requireNodeSqlite();
-    const writer = new sqlite.DatabaseSync(sourcePath);
-    try {
-      writer.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
-      writer
-        .prepare(
-          "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES ('preflight.probe', '{}', 1)",
-        )
-        .run();
-      await sqlite.backup(writer, snapshotPath);
-      writer
-        .prepare(
-          "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES ('preflight.after-backup', '{}', 2)",
-        )
-        .run();
-      expect(fs.existsSync(`${sourcePath}-wal`)).toBe(true);
-      expect(fs.existsSync(`${sourcePath}-shm`)).toBe(true);
-      for (const suffix of ["-wal", "-shm", "-journal"]) {
-        expect(fs.existsSync(`${snapshotPath}${suffix}`)).toBe(false);
-      }
-      const before = snapshotSourceFamily(sourcePath);
 
-      const result = await preflightOpenClawStateDatabasePath(snapshotPath);
-
-      expect(result).toMatchObject({
-        foundVersion: OPENCLAW_STATE_SCHEMA_VERSION,
-        status: "startup-repairable",
-        requiresWrite: true,
-        issues: [
-          {
-            code: "missing-column",
-            objectName: "worktrees.run_end_cleanup_json",
-          },
-        ],
-      });
-      expect(snapshotSourceFamily(sourcePath)).toEqual(before);
-    } finally {
-      writer.close();
-    }
+    await expect(preflightOpenClawStateDatabasePath(databasePath)).resolves.toMatchObject({
+      foundVersion: OPENCLAW_STATE_SCHEMA_VERSION,
+      status: "incompatible",
+      requiresWrite: false,
+      issues: [
+        {
+          code: "missing-column",
+          objectName: "worker_workspace_reconciliations.forced_abandonment_retained",
+        },
+      ],
+    });
   });
 
   it("accepts first-use session group columns without requiring a startup write", async () => {

--- a/src/state/openclaw-state-db-additive-columns.ts
+++ b/src/state/openclaw-state-db-additive-columns.ts
@@ -21,6 +21,11 @@ export const CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS = [
   { columnName: "shared_host", dataType: "INTEGER", tableName: "worker_environments" },
   { columnName: "terminal_reason", dataType: "TEXT", tableName: "worker_session_placements" },
   { columnName: "terminal_at_ms", dataType: "INTEGER", tableName: "worker_session_placements" },
+  {
+    columnName: "forced_abandonment_retained",
+    dataType: "INTEGER",
+    tableName: "worker_workspace_reconciliations",
+  },
   { columnName: "run_end_cleanup_json", dataType: "TEXT", tableName: "worktrees" },
   { columnName: "setup_id", dataType: "TEXT", tableName: "device_bootstrap_tokens" },
   { columnName: "cwd", dataType: "TEXT", tableName: "session_groups" },
@@ -35,12 +40,14 @@ function isFirstUseAdditiveStateColumn({
 }: LazyAdditiveStateColumnDefinition): boolean {
   return (
     (tableName === "device_bootstrap_tokens" && columnName === "setup_id") ||
-    (tableName === "session_groups" && (columnName === "cwd" || columnName === "worktree"))
+    (tableName === "session_groups" && (columnName === "cwd" || columnName === "worktree")) ||
+    (tableName === "worker_workspace_reconciliations" &&
+      columnName === "forced_abandonment_retained")
   );
 }
 
 // Most same-version columns repair during a writable shared-state open. These
-// feature-owned columns stay absent until setup or group defaults first uses them.
+// feature-owned columns stay absent until setup, group defaults, or recovery first uses them.
 export const CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS =
   CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS.filter(
     (definition) => !isFirstUseAdditiveStateColumn(definition),

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -30,6 +30,9 @@ const MCP_OAUTH_PENDING_SCHEMA_END = "\n) STRICT;";
 const DEVICE_PAIRING_JOIN_CODE_SCHEMA_START =
   "CREATE TABLE IF NOT EXISTS device_pairing_join_codes (";
 const DEVICE_PAIRING_JOIN_CODE_SCHEMA_END = "\n) STRICT;";
+const LEGACY_FORCED_WORKER_ABANDONMENT_ERROR =
+  "Cloud worker result abandoned by forced operator teardown";
+const workspaceRetentionSchemaConnections = new WeakSet<DatabaseSync>();
 
 function secretStoreSchemaSql(): string {
   const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(SECRET_STORE_SCHEMA_START);
@@ -130,6 +133,32 @@ export function ensureDevicePairSetupCompletionSchema(database: DatabaseSync): v
 /** Lazily add setup correlation only when setup pairing first writes or consumes a token. */
 export function ensureDevicePairSetupBootstrapSchema(database: DatabaseSync): void {
   ensureColumn(database, "device_bootstrap_tokens", "setup_id TEXT");
+}
+
+/** Lazily add durable forced-abandonment ownership before journal retention first runs. */
+export function ensureWorkspaceRetentionSchema(database: DatabaseSync): void {
+  if (workspaceRetentionSchemaConnections.has(database)) {
+    return;
+  }
+  ensureColumn(database, "worker_workspace_reconciliations", "forced_abandonment_retained INTEGER");
+  database
+    .prepare(
+      `UPDATE worker_workspace_reconciliations
+       SET forced_abandonment_retained = 1
+       WHERE forced_abandonment_retained IS NULL
+         AND EXISTS (
+           SELECT 1
+           FROM worker_session_placements AS placement
+           WHERE placement.session_id = worker_workspace_reconciliations.session_id
+             AND placement.state = 'failed'
+             AND placement.environment_id = worker_workspace_reconciliations.environment_id
+             AND placement.active_owner_epoch = worker_workspace_reconciliations.owner_epoch
+             AND placement.transition_generation > worker_workspace_reconciliations.placement_generation
+             AND instr(placement.recovery_error, ?) = 1
+         )`,
+    )
+    .run(LEGACY_FORCED_WORKER_ABANDONMENT_ERROR);
+  workspaceRetentionSchemaConnections.add(database);
 }
 
 function resolveLegacyManagedImageRoot(recordJson: unknown): string | null {

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -140,6 +140,7 @@ export function ensureWorkspaceRetentionSchema(database: DatabaseSync): void {
   if (workspaceRetentionSchemaConnections.has(database)) {
     return;
   }
+  const cacheable = !database.isTransaction;
   ensureColumn(database, "worker_workspace_reconciliations", "forced_abandonment_retained INTEGER");
   database
     .prepare(
@@ -158,7 +159,9 @@ export function ensureWorkspaceRetentionSchema(database: DatabaseSync): void {
          )`,
     )
     .run(LEGACY_FORCED_WORKER_ABANDONMENT_ERROR);
-  workspaceRetentionSchemaConnections.add(database);
+  if (cacheable) {
+    workspaceRetentionSchemaConnections.add(database);
+  }
 }
 
 function resolveLegacyManagedImageRoot(recordJson: unknown): string | null {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -36,12 +36,45 @@ import {
 } from "./openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
+const LEGACY_FORCED_WORKER_ABANDONMENT_ERROR =
+  "Cloud worker result abandoned by forced operator teardown";
+
 export function dropLegacyStateTables(db: DatabaseSync): void {
   // Unreleased transient history; drop, do not migrate.
   const transientHistoryTable = ["database", "verifications"].join("_");
   db.exec(`DROP TABLE IF EXISTS ${transientHistoryTable};`);
   // Retired node pairing tables never had a shipped writer.
   db.exec("DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;");
+}
+
+/** Add v8's semantic marker and promote the shipped v7 error-prefix owner. */
+export function migrateWorkerWorkspaceRetentionV8(db: DatabaseSync, previousVersion: number): void {
+  if (previousVersion >= 8 || !tableExists(db, "worker_workspace_reconciliations")) {
+    return;
+  }
+  if (!tableHasColumn(db, "worker_workspace_reconciliations", "forced_abandonment_retained")) {
+    db.exec(
+      "ALTER TABLE worker_workspace_reconciliations ADD COLUMN forced_abandonment_retained INTEGER;",
+    );
+  }
+  if (previousVersion !== 7) {
+    return;
+  }
+  db.prepare(
+    `UPDATE worker_workspace_reconciliations
+     SET forced_abandonment_retained = 1
+     WHERE forced_abandonment_retained IS NULL
+       AND EXISTS (
+         SELECT 1
+         FROM worker_session_placements AS placement
+         WHERE placement.session_id = worker_workspace_reconciliations.session_id
+           AND placement.state = 'failed'
+           AND placement.environment_id = worker_workspace_reconciliations.environment_id
+           AND placement.active_owner_epoch = worker_workspace_reconciliations.owner_epoch
+           AND placement.transition_generation > worker_workspace_reconciliations.placement_generation
+           AND instr(placement.recovery_error, ?) = 1
+       )`,
+  ).run(LEGACY_FORCED_WORKER_ABANDONMENT_ERROR);
 }
 
 const RETIRED_COMMITMENTS_SCHEMA_SQL = `

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -36,45 +36,12 @@ import {
 } from "./openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
-const LEGACY_FORCED_WORKER_ABANDONMENT_ERROR =
-  "Cloud worker result abandoned by forced operator teardown";
-
 export function dropLegacyStateTables(db: DatabaseSync): void {
   // Unreleased transient history; drop, do not migrate.
   const transientHistoryTable = ["database", "verifications"].join("_");
   db.exec(`DROP TABLE IF EXISTS ${transientHistoryTable};`);
   // Retired node pairing tables never had a shipped writer.
   db.exec("DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;");
-}
-
-/** Add v8's semantic marker and promote supported pre-v8 error-prefix owners. */
-export function migrateWorkerWorkspaceRetentionV8(db: DatabaseSync, previousVersion: number): void {
-  if (previousVersion >= 8 || !tableExists(db, "worker_workspace_reconciliations")) {
-    return;
-  }
-  if (!tableHasColumn(db, "worker_workspace_reconciliations", "forced_abandonment_retained")) {
-    db.exec(
-      "ALTER TABLE worker_workspace_reconciliations ADD COLUMN forced_abandonment_retained INTEGER;",
-    );
-  }
-  if (previousVersion < 5 || previousVersion > 7) {
-    return;
-  }
-  db.prepare(
-    `UPDATE worker_workspace_reconciliations
-     SET forced_abandonment_retained = 1
-     WHERE forced_abandonment_retained IS NULL
-       AND EXISTS (
-         SELECT 1
-         FROM worker_session_placements AS placement
-         WHERE placement.session_id = worker_workspace_reconciliations.session_id
-           AND placement.state = 'failed'
-           AND placement.environment_id = worker_workspace_reconciliations.environment_id
-           AND placement.active_owner_epoch = worker_workspace_reconciliations.owner_epoch
-           AND placement.transition_generation > worker_workspace_reconciliations.placement_generation
-           AND instr(placement.recovery_error, ?) = 1
-       )`,
-  ).run(LEGACY_FORCED_WORKER_ABANDONMENT_ERROR);
 }
 
 const RETIRED_COMMITMENTS_SCHEMA_SQL = `

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -47,7 +47,7 @@ export function dropLegacyStateTables(db: DatabaseSync): void {
   db.exec("DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;");
 }
 
-/** Add v8's semantic marker and promote the shipped v7 error-prefix owner. */
+/** Add v8's semantic marker and promote supported pre-v8 error-prefix owners. */
 export function migrateWorkerWorkspaceRetentionV8(db: DatabaseSync, previousVersion: number): void {
   if (previousVersion >= 8 || !tableExists(db, "worker_workspace_reconciliations")) {
     return;
@@ -57,7 +57,7 @@ export function migrateWorkerWorkspaceRetentionV8(db: DatabaseSync, previousVers
       "ALTER TABLE worker_workspace_reconciliations ADD COLUMN forced_abandonment_retained INTEGER;",
     );
   }
-  if (previousVersion !== 7) {
+  if (previousVersion < 5 || previousVersion > 7) {
     return;
   }
   db.prepare(

--- a/src/state/openclaw-state-db-version-compatibility.test.ts
+++ b/src/state/openclaw-state-db-version-compatibility.test.ts
@@ -1,0 +1,45 @@
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+
+afterEach(() => {
+  vi.doUnmock("./openclaw-state-db-contract.js");
+  vi.resetModules();
+});
+
+describe("state database version compatibility", () => {
+  it("makes a v7 reader refuse v8 before workspace rollback-journal pruning", async () => {
+    vi.resetModules();
+    vi.doMock("./openclaw-state-db-contract.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./openclaw-state-db-contract.js")>();
+      return { ...actual, OPENCLAW_STATE_SCHEMA_VERSION: 7 };
+    });
+    const { assertSupportedSchemaVersion } = await import("./openclaw-state-db-maintenance.js");
+    const { DatabaseSync } = requireNodeSqlite();
+    const database: DatabaseSync = new DatabaseSync(":memory:");
+    database.exec(`
+      PRAGMA user_version = 8;
+      CREATE TABLE worker_workspace_reconciliations (
+        session_id TEXT PRIMARY KEY,
+        base_pack BLOB NOT NULL
+      ) STRICT;
+      INSERT INTO worker_workspace_reconciliations VALUES ('retained-session', X'00');
+    `);
+    const pruneLegacyJournals = vi.fn(() => {
+      database.exec("DELETE FROM worker_workspace_reconciliations;");
+    });
+
+    try {
+      expect(() => {
+        assertSupportedSchemaVersion(database, "/state/openclaw.sqlite");
+        pruneLegacyJournals();
+      }).toThrow(/newer schema version 8; this build supports 7/iu);
+      expect(pruneLegacyJournals).not.toHaveBeenCalled();
+      expect(
+        database.prepare("SELECT session_id FROM worker_workspace_reconciliations").get(),
+      ).toEqual({ session_id: "retained-session" });
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1653,6 +1653,7 @@ export interface WorkerWorkspaceReconciliations {
   created_at_ms: number;
   current_manifest_ref: string;
   environment_id: string;
+  forced_abandonment_retained: number | null;
   owner_epoch: number;
   placement_generation: number;
   plan_json: string;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -194,7 +194,7 @@ function replaceManagedImageRecordsWithLegacyTable(
 const LEGACY_SESSION_WATCH_SCHEMA_VERSION = 3;
 const LEGACY_AMBIENT_WATCH_PREFIX = "ambient-group-watch:";
 
-function markStateDatabaseVersion(database: DatabaseSync, version: 5 | 6): void {
+function markStateDatabaseVersion(database: DatabaseSync, version: 5 | 6 | 7): void {
   database.exec(`
     PRAGMA user_version = ${version};
     UPDATE schema_meta SET schema_version = ${version} WHERE meta_key = 'primary';
@@ -3083,6 +3083,48 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ).not.toThrow();
   });
 
+  it.each(["runtime open", "doctor repair"] as const)(
+    "rejects a current v8 database missing its retention marker through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+
+      const { DatabaseSync } = requireNodeSqlite();
+      const damaged = new DatabaseSync(databasePath);
+      damaged.exec(
+        "ALTER TABLE worker_workspace_reconciliations DROP COLUMN forced_abandonment_retained;",
+      );
+      damaged.close();
+
+      if (migrationPath === "runtime open") {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(
+          /missing column worker_workspace_reconciliations\.forced_abandonment_retained|column definitions differ for worker_workspace_reconciliations/iu,
+        );
+      } else {
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: [],
+          warnings: [
+            expect.stringContaining(
+              "missing column worker_workspace_reconciliations.forced_abandonment_retained",
+            ),
+          ],
+        });
+      }
+
+      const after = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        const columns = after
+          .prepare("PRAGMA table_info(worker_workspace_reconciliations)")
+          .all() as Array<{ name: string }>;
+        expect(columns.map((column) => column.name)).not.toContain("forced_abandonment_retained");
+        expect(readSqliteNumberPragma(after, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+      } finally {
+        after.close();
+      }
+    },
+  );
+
   it("installs same-version worker session tool tables before runtime schema validation", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
@@ -3203,14 +3245,14 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   });
 
   it.each(
-    ([5, 6] as const).flatMap((version) =>
+    ([5, 6, 7] as const).flatMap((version) =>
       (["runtime open", "doctor repair"] as const).map((migrationPath) => ({
         migrationPath,
         version,
       })),
     ),
   )(
-    "rejects a missing stable v$version table before the v7 migration through $migrationPath",
+    "rejects a missing stable v$version table before the current migration through $migrationPath",
     ({ migrationPath, version }) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
@@ -3277,6 +3319,51 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       { name: "worker_turn_tool_authorities" },
     ]);
   });
+
+  it.each(
+    ["worker_session_tool_operations", "worker_turn_tool_authorities"].flatMap((tableName) =>
+      (["runtime open", "doctor repair"] as const).map((migrationPath) => ({
+        migrationPath,
+        tableName,
+      })),
+    ),
+  )(
+    "rejects v7 with missing stable $tableName through $migrationPath",
+    ({ migrationPath, tableName }) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+
+      const { DatabaseSync } = requireNodeSqlite();
+      const damaged = new DatabaseSync(databasePath);
+      damaged.exec(`DROP TABLE ${tableName};`);
+      markStateDatabaseVersion(damaged, 7);
+      damaged.close();
+
+      if (migrationPath === "runtime open") {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(
+          new RegExp(`missing table ${tableName}`, "iu"),
+        );
+      } else {
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: [],
+          warnings: [expect.stringContaining(`missing table ${tableName}`)],
+        });
+      }
+
+      const after = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        expect(
+          after
+            .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+            .get(tableName),
+        ).toBeUndefined();
+        expect(readSqliteNumberPragma(after, "user_version")).toBe(7);
+      } finally {
+        after.close();
+      }
+    },
+  );
 
   it("rejects an inline unique constraint hidden behind a SQLite autoindex", () => {
     const stateDir = createTempStateDir();
@@ -4444,7 +4531,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
   });
 
-  it("adds staged worker-result refs during the v5 state migration", () => {
+  it("adds worker workspace recovery columns during the v5 state migration", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
     const databasePath = materializeCurrentStateDatabase(stateDir);
@@ -4453,6 +4540,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     const legacyDb = new DatabaseSync(databasePath);
     legacyDb.exec(`
       ALTER TABLE worker_workspace_pending_results DROP COLUMN staged_result_ref;
+      ALTER TABLE worker_workspace_reconciliations DROP COLUMN forced_abandonment_retained;
       PRAGMA user_version = 4;
       UPDATE schema_meta SET schema_version = 4 WHERE meta_key = 'primary';
     `);
@@ -4463,6 +4551,12 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       .prepare("PRAGMA table_info(worker_workspace_pending_results)")
       .all() as Array<{ name?: string }>;
     expect(columns.map((column) => column.name)).toContain("staged_result_ref");
+    const reconciliationColumns = reopened.db
+      .prepare("PRAGMA table_info(worker_workspace_reconciliations)")
+      .all() as Array<{ name?: string }>;
+    expect(reconciliationColumns.map((column) => column.name)).toContain(
+      "forced_abandonment_retained",
+    );
     expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
     expect(
       reopened.db
@@ -4470,6 +4564,148 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         .get(),
     ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
   });
+
+  it.each(["runtime open", "doctor repair"] as const)(
+    "backfills retained forced-abandonment journals only while migrating shipped v7 state through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+
+      const { DatabaseSync } = requireNodeSqlite();
+      const legacyDb = new DatabaseSync(databasePath);
+      legacyDb.exec(`
+      ALTER TABLE worker_workspace_reconciliations DROP COLUMN forced_abandonment_retained;
+      INSERT INTO worker_session_placements (
+        session_id,
+        agent_id,
+        session_key,
+        state,
+        environment_id,
+        transition_generation,
+        active_owner_epoch,
+        recovery_error,
+        created_at_ms,
+        updated_at_ms,
+        state_changed_at_ms
+      ) VALUES (
+        'legacy-forced-session',
+        'main',
+        'agent:main:legacy-forced-session',
+        'failed',
+        'legacy-forced-environment',
+        3,
+        7,
+        'Cloud worker result abandoned by forced operator teardown: rollback failed',
+        100,
+        200,
+        200
+      );
+      INSERT INTO worker_workspace_reconciliations (
+        session_id,
+        environment_id,
+        owner_epoch,
+        placement_generation,
+        base_manifest_ref,
+        current_manifest_ref,
+        plan_json,
+        base_pack,
+        created_at_ms
+      ) VALUES (
+        'legacy-forced-session',
+        'legacy-forced-environment',
+        7,
+        2,
+        'sha256:legacy-base',
+        'sha256:legacy-current',
+        '{}',
+        X'00',
+        150
+      );
+    `);
+      markStateDatabaseVersion(legacyDb, 7);
+      legacyDb.close();
+
+      if (migrationPath === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      }
+      const reopened = openOpenClawStateDatabase(options);
+      expect(
+        reopened.db
+          .prepare(
+            `SELECT forced_abandonment_retained
+           FROM worker_workspace_reconciliations
+           WHERE session_id = 'legacy-forced-session'`,
+          )
+          .get(),
+      ).toEqual({ forced_abandonment_retained: 1 });
+      expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
+      reopened.db.exec(`
+      INSERT INTO worker_session_placements (
+        session_id,
+        agent_id,
+        session_key,
+        state,
+        environment_id,
+        transition_generation,
+        active_owner_epoch,
+        recovery_error,
+        created_at_ms,
+        updated_at_ms,
+        state_changed_at_ms
+      ) VALUES (
+        'current-prefix-session',
+        'main',
+        'agent:main:current-prefix-session',
+        'failed',
+        'current-prefix-environment',
+        3,
+        8,
+        'Cloud worker result abandoned by forced operator teardown: current row',
+        300,
+        400,
+        400
+      );
+      INSERT INTO worker_workspace_reconciliations (
+        session_id,
+        environment_id,
+        owner_epoch,
+        placement_generation,
+        base_manifest_ref,
+        current_manifest_ref,
+        plan_json,
+        base_pack,
+        forced_abandonment_retained,
+        created_at_ms
+      ) VALUES (
+        'current-prefix-session',
+        'current-prefix-environment',
+        8,
+        2,
+        'sha256:current-base',
+        'sha256:current-current',
+        '{}',
+        X'00',
+        NULL,
+        350
+      );
+    `);
+      closeOpenClawStateDatabaseForTest();
+
+      const reopenedAgain = openOpenClawStateDatabase(options);
+      expect(
+        reopenedAgain.db
+          .prepare(
+            `SELECT forced_abandonment_retained
+           FROM worker_workspace_reconciliations
+           WHERE session_id = 'current-prefix-session'`,
+          )
+          .get(),
+      ).toEqual({ forced_abandonment_retained: null });
+    },
+  );
 
   it("adds worker transcript commit tables to existing state databases", () => {
     const stateDir = createTempStateDir();

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -4565,9 +4565,16 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
   });
 
-  it.each(["runtime open", "doctor repair"] as const)(
-    "backfills retained forced-abandonment journals only while migrating shipped v7 state through %s",
-    (migrationPath) => {
+  it.each([
+    { migrationPath: "runtime open", previousVersion: 5 },
+    { migrationPath: "runtime open", previousVersion: 6 },
+    { migrationPath: "runtime open", previousVersion: 7 },
+    { migrationPath: "doctor repair", previousVersion: 5 },
+    { migrationPath: "doctor repair", previousVersion: 6 },
+    { migrationPath: "doctor repair", previousVersion: 7 },
+  ] as const)(
+    "backfills retained forced-abandonment journals while migrating v$previousVersion state through $migrationPath",
+    ({ migrationPath, previousVersion }) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
       const databasePath = materializeCurrentStateDatabase(stateDir);
@@ -4623,7 +4630,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         150
       );
     `);
-      markStateDatabaseVersion(legacyDb, 7);
+      markStateDatabaseVersion(legacyDb, previousVersion);
       legacyDb.close();
 
       if (migrationPath === "doctor repair") {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -3084,7 +3084,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   });
 
   it.each(["runtime open", "doctor repair"] as const)(
-    "rejects a current v8 database missing its retention marker through %s",
+    "leaves a current v8 database without its lazy retention marker untouched through %s",
     (migrationPath) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
@@ -3098,17 +3098,12 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       damaged.close();
 
       if (migrationPath === "runtime open") {
-        expect(() => openOpenClawStateDatabase(options)).toThrow(
-          /missing column worker_workspace_reconciliations\.forced_abandonment_retained|column definitions differ for worker_workspace_reconciliations/iu,
-        );
+        expect(() => openOpenClawStateDatabase(options)).not.toThrow();
+        closeOpenClawStateDatabaseForTest();
       } else {
         expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
           changes: [],
-          warnings: [
-            expect.stringContaining(
-              "missing column worker_workspace_reconciliations.forced_abandonment_retained",
-            ),
-          ],
+          warnings: [],
         });
       }
 
@@ -3319,51 +3314,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       { name: "worker_turn_tool_authorities" },
     ]);
   });
-
-  it.each(
-    ["worker_session_tool_operations", "worker_turn_tool_authorities"].flatMap((tableName) =>
-      (["runtime open", "doctor repair"] as const).map((migrationPath) => ({
-        migrationPath,
-        tableName,
-      })),
-    ),
-  )(
-    "rejects v7 with missing stable $tableName through $migrationPath",
-    ({ migrationPath, tableName }) => {
-      const stateDir = createTempStateDir();
-      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-      const databasePath = materializeCurrentStateDatabase(stateDir);
-
-      const { DatabaseSync } = requireNodeSqlite();
-      const damaged = new DatabaseSync(databasePath);
-      damaged.exec(`DROP TABLE ${tableName};`);
-      markStateDatabaseVersion(damaged, 7);
-      damaged.close();
-
-      if (migrationPath === "runtime open") {
-        expect(() => openOpenClawStateDatabase(options)).toThrow(
-          new RegExp(`missing table ${tableName}`, "iu"),
-        );
-      } else {
-        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
-          changes: [],
-          warnings: [expect.stringContaining(`missing table ${tableName}`)],
-        });
-      }
-
-      const after = new DatabaseSync(databasePath, { readOnly: true });
-      try {
-        expect(
-          after
-            .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
-            .get(tableName),
-        ).toBeUndefined();
-        expect(readSqliteNumberPragma(after, "user_version")).toBe(7);
-      } finally {
-        after.close();
-      }
-    },
-  );
 
   it("rejects an inline unique constraint hidden behind a SQLite autoindex", () => {
     const stateDir = createTempStateDir();
@@ -4531,7 +4481,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
   });
 
-  it("adds worker workspace recovery columns during the v5 state migration", () => {
+  it("adds staged worker-result refs during the v5 state migration", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
     const databasePath = materializeCurrentStateDatabase(stateDir);
@@ -4554,7 +4504,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     const reconciliationColumns = reopened.db
       .prepare("PRAGMA table_info(worker_workspace_reconciliations)")
       .all() as Array<{ name?: string }>;
-    expect(reconciliationColumns.map((column) => column.name)).toContain(
+    expect(reconciliationColumns.map((column) => column.name)).not.toContain(
       "forced_abandonment_retained",
     );
     expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
@@ -4564,155 +4514,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         .get(),
     ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
   });
-
-  it.each([
-    { migrationPath: "runtime open", previousVersion: 5 },
-    { migrationPath: "runtime open", previousVersion: 6 },
-    { migrationPath: "runtime open", previousVersion: 7 },
-    { migrationPath: "doctor repair", previousVersion: 5 },
-    { migrationPath: "doctor repair", previousVersion: 6 },
-    { migrationPath: "doctor repair", previousVersion: 7 },
-  ] as const)(
-    "backfills retained forced-abandonment journals while migrating v$previousVersion state through $migrationPath",
-    ({ migrationPath, previousVersion }) => {
-      const stateDir = createTempStateDir();
-      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-      const databasePath = materializeCurrentStateDatabase(stateDir);
-
-      const { DatabaseSync } = requireNodeSqlite();
-      const legacyDb = new DatabaseSync(databasePath);
-      legacyDb.exec(`
-      ALTER TABLE worker_workspace_reconciliations DROP COLUMN forced_abandonment_retained;
-      INSERT INTO worker_session_placements (
-        session_id,
-        agent_id,
-        session_key,
-        state,
-        environment_id,
-        transition_generation,
-        active_owner_epoch,
-        recovery_error,
-        created_at_ms,
-        updated_at_ms,
-        state_changed_at_ms
-      ) VALUES (
-        'legacy-forced-session',
-        'main',
-        'agent:main:legacy-forced-session',
-        'failed',
-        'legacy-forced-environment',
-        3,
-        7,
-        'Cloud worker result abandoned by forced operator teardown: rollback failed',
-        100,
-        200,
-        200
-      );
-      INSERT INTO worker_workspace_reconciliations (
-        session_id,
-        environment_id,
-        owner_epoch,
-        placement_generation,
-        base_manifest_ref,
-        current_manifest_ref,
-        plan_json,
-        base_pack,
-        created_at_ms
-      ) VALUES (
-        'legacy-forced-session',
-        'legacy-forced-environment',
-        7,
-        2,
-        'sha256:legacy-base',
-        'sha256:legacy-current',
-        '{}',
-        X'00',
-        150
-      );
-    `);
-      markStateDatabaseVersion(legacyDb, previousVersion);
-      legacyDb.close();
-
-      if (migrationPath === "doctor repair") {
-        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
-      }
-      const reopened = openOpenClawStateDatabase(options);
-      expect(
-        reopened.db
-          .prepare(
-            `SELECT forced_abandonment_retained
-           FROM worker_workspace_reconciliations
-           WHERE session_id = 'legacy-forced-session'`,
-          )
-          .get(),
-      ).toEqual({ forced_abandonment_retained: 1 });
-      expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(
-        OPENCLAW_STATE_SCHEMA_VERSION,
-      );
-      reopened.db.exec(`
-      INSERT INTO worker_session_placements (
-        session_id,
-        agent_id,
-        session_key,
-        state,
-        environment_id,
-        transition_generation,
-        active_owner_epoch,
-        recovery_error,
-        created_at_ms,
-        updated_at_ms,
-        state_changed_at_ms
-      ) VALUES (
-        'current-prefix-session',
-        'main',
-        'agent:main:current-prefix-session',
-        'failed',
-        'current-prefix-environment',
-        3,
-        8,
-        'Cloud worker result abandoned by forced operator teardown: current row',
-        300,
-        400,
-        400
-      );
-      INSERT INTO worker_workspace_reconciliations (
-        session_id,
-        environment_id,
-        owner_epoch,
-        placement_generation,
-        base_manifest_ref,
-        current_manifest_ref,
-        plan_json,
-        base_pack,
-        forced_abandonment_retained,
-        created_at_ms
-      ) VALUES (
-        'current-prefix-session',
-        'current-prefix-environment',
-        8,
-        2,
-        'sha256:current-base',
-        'sha256:current-current',
-        '{}',
-        X'00',
-        NULL,
-        350
-      );
-    `);
-      closeOpenClawStateDatabaseForTest();
-
-      const reopenedAgain = openOpenClawStateDatabase(options);
-      expect(
-        reopenedAgain.db
-          .prepare(
-            `SELECT forced_abandonment_retained
-           FROM worker_workspace_reconciliations
-           WHERE session_id = 'current-prefix-session'`,
-          )
-          .get(),
-      ).toEqual({ forced_abandonment_retained: null });
-    },
-  );
 
   it("adds worker transcript commit tables to existing state databases", () => {
     const stateDir = createTempStateDir();

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -65,7 +65,7 @@ import {
   ensureAdditiveStateColumns,
   ensureFirstUseAdditiveStateColumnsForStrictMigration,
 } from "./openclaw-state-db-schema-additive.js";
-import { tableExists } from "./openclaw-state-db-schema-helpers.js";
+import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import {
   type AgentDatabasePathMigrationSummary as AgentPathSummary,
   assertCanonicalStateSchemaShape,
@@ -75,6 +75,7 @@ import {
   migrateAgentDatabaseRelativePaths as migrateAgentPaths,
   migrateRetiredCommitmentsSchema,
   migrateWorkerPlacementExecutionModeSchema,
+  migrateWorkerWorkspaceRetentionV8,
   repairAgentDatabasesCompositePrimaryKey,
   repairLegacyGatewayRestartHandoffsForStrictMigration,
 } from "./openclaw-state-db-schema-repair.js";
@@ -178,6 +179,14 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
         const applied: string[] = [];
         const previousVersion = readSqliteUserVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
+          if (
+            tableExists(db, "worker_workspace_reconciliations") &&
+            !tableHasColumn(db, "worker_workspace_reconciliations", "forced_abandonment_retained")
+          ) {
+            throw new Error(
+              `OpenClaw state database ${pathname} is missing column worker_workspace_reconciliations.forced_abandonment_retained`,
+            );
+          }
           for (const name of repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
             allowMissingColumns: true,
           })) {
@@ -229,6 +238,7 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
         assertCanonicalStateSchemaShape(db, pathname);
         if (tableExists(db, "audit_events")) {
           ensureAdditiveStateColumns(db);
+          migrateWorkerWorkspaceRetentionV8(db, previousVersion);
           executeCanonicalStateSchema(db, {
             includeVersionLazyAdditiveTables: previousVersion !== OPENCLAW_STATE_SCHEMA_VERSION,
           });
@@ -401,6 +411,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
         migrateWorkerPlacementExecutionModeSchema(db, previousVersion);
         const pathMigration: AgentPathSummary = migrateAgentPaths(db, previousVersion, pathname);
         ensureAdditiveStateColumns(db);
+        migrateWorkerWorkspaceRetentionV8(db, previousVersion);
         sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         assertCanonicalStateSchemaShape(db, pathname);
         executeCanonicalStateSchema(db, {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -65,7 +65,7 @@ import {
   ensureAdditiveStateColumns,
   ensureFirstUseAdditiveStateColumnsForStrictMigration,
 } from "./openclaw-state-db-schema-additive.js";
-import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
+import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import {
   type AgentDatabasePathMigrationSummary as AgentPathSummary,
   assertCanonicalStateSchemaShape,
@@ -75,7 +75,6 @@ import {
   migrateAgentDatabaseRelativePaths as migrateAgentPaths,
   migrateRetiredCommitmentsSchema,
   migrateWorkerPlacementExecutionModeSchema,
-  migrateWorkerWorkspaceRetentionV8,
   repairAgentDatabasesCompositePrimaryKey,
   repairLegacyGatewayRestartHandoffsForStrictMigration,
 } from "./openclaw-state-db-schema-repair.js";
@@ -179,14 +178,6 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
         const applied: string[] = [];
         const previousVersion = readSqliteUserVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
-          if (
-            tableExists(db, "worker_workspace_reconciliations") &&
-            !tableHasColumn(db, "worker_workspace_reconciliations", "forced_abandonment_retained")
-          ) {
-            throw new Error(
-              `OpenClaw state database ${pathname} is missing column worker_workspace_reconciliations.forced_abandonment_retained`,
-            );
-          }
           for (const name of repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
             allowMissingColumns: true,
           })) {
@@ -238,7 +229,6 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
         assertCanonicalStateSchemaShape(db, pathname);
         if (tableExists(db, "audit_events")) {
           ensureAdditiveStateColumns(db);
-          migrateWorkerWorkspaceRetentionV8(db, previousVersion);
           executeCanonicalStateSchema(db, {
             includeVersionLazyAdditiveTables: previousVersion !== OPENCLAW_STATE_SCHEMA_VERSION,
           });
@@ -411,7 +401,6 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
         migrateWorkerPlacementExecutionModeSchema(db, previousVersion);
         const pathMigration: AgentPathSummary = migrateAgentPaths(db, previousVersion, pathname);
         ensureAdditiveStateColumns(db);
-        migrateWorkerWorkspaceRetentionV8(db, previousVersion);
         sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         assertCanonicalStateSchemaShape(db, pathname);
         executeCanonicalStateSchema(db, {

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -2256,6 +2256,7 @@ CREATE TABLE IF NOT EXISTS worker_workspace_reconciliations (
   current_manifest_ref TEXT NOT NULL,
   plan_json TEXT NOT NULL,
   base_pack BLOB NOT NULL CHECK (length(base_pack) <= 268435456),
+  forced_abandonment_retained INTEGER,
   created_at_ms INTEGER NOT NULL,
   FOREIGN KEY (session_id) REFERENCES worker_session_placements(session_id) ON DELETE CASCADE
 ) STRICT;

--- a/ui/src/components/cloud-worker-stop.test.ts
+++ b/ui/src/components/cloud-worker-stop.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { GatewaySessionRow } from "../api/types.ts";
+import {
+  resolveCloudWorkerStopAction,
+  resolveCloudWorkerStopConfirmation,
+} from "./cloud-worker-stop.ts";
+
+describe("cloud worker stop action", () => {
+  it("forces abandonment only for the structured retained-result recovery state", () => {
+    const placement = {
+      state: "failed",
+      generation: 8,
+      createdAtMs: 100,
+      updatedAtMs: 300,
+      stateChangedAtMs: 300,
+      environmentId: "environment-1",
+      recoveryError: "workspace recovery requires operator action",
+      terminalRecovery: {
+        action: "force-destroy-environment",
+        dataLoss: "unreconciled-workspace-result",
+      },
+    } as GatewaySessionRow["placement"];
+
+    const action = resolveCloudWorkerStopAction(placement);
+    expect(action).toEqual({
+      method: "environments.destroy",
+      params: { environmentId: "environment-1", force: true },
+      requiredScope: "operator.admin",
+    });
+    expect(resolveCloudWorkerStopConfirmation(action!, "Session 1")).toEqual({
+      message:
+        'Permanently abandon the unreconciled remote workspace changes for "Session 1" and stop its cloud worker? Those changes cannot be recovered.',
+      confirmLabel: "Abandon changes and stop",
+      danger: true,
+    });
+  });
+
+  it("keeps ordinary failed placements on non-forced environment cleanup", () => {
+    const placement = {
+      state: "failed",
+      generation: 8,
+      createdAtMs: 100,
+      updatedAtMs: 300,
+      stateChangedAtMs: 300,
+      environmentId: "environment-1",
+      recoveryError: "provider teardown failed",
+    } as GatewaySessionRow["placement"];
+
+    expect(resolveCloudWorkerStopAction(placement)).toEqual({
+      method: "environments.destroy",
+      params: { environmentId: "environment-1" },
+      requiredScope: "operator.admin",
+    });
+  });
+});

--- a/ui/src/components/cloud-worker-stop.ts
+++ b/ui/src/components/cloud-worker-stop.ts
@@ -3,6 +3,7 @@ import { isCloudWorkerPlacementState } from "../../../packages/gateway-protocol/
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { GatewaySessionRow } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
+import { showToast } from "../lib/toast.ts";
 
 export type CloudWorkerStopAction =
   | { method: "sessions.reclaim"; requiredScope: "operator.admin" }
@@ -66,4 +67,16 @@ export async function requestCloudWorkerStop(
     { timeoutMs: 10 * 60_000 },
   );
   return null;
+}
+
+export function showCloudWorkerStopResult(
+  result: EnvironmentsDestroyResult,
+  session: string,
+): void {
+  showToast({
+    message: t("sessionsView.cloudWorkerStopResult", {
+      session,
+      state: result.worker?.state ?? result.status,
+    }),
+  });
 }

--- a/ui/src/components/cloud-worker-stop.ts
+++ b/ui/src/components/cloud-worker-stop.ts
@@ -2,12 +2,13 @@ import type { EnvironmentsDestroyResult } from "../../../packages/gateway-protoc
 import { isCloudWorkerPlacementState } from "../../../packages/gateway-protocol/src/schema/session-placement-state.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { GatewaySessionRow } from "../api/types.ts";
+import { t } from "../i18n/index.ts";
 
 export type CloudWorkerStopAction =
   | { method: "sessions.reclaim"; requiredScope: "operator.admin" }
   | {
       method: "environments.destroy";
-      params: { environmentId: string };
+      params: { environmentId: string; force?: true };
       requiredScope: "operator.admin";
     };
 
@@ -20,13 +21,35 @@ export function resolveCloudWorkerStopAction(
   if (placement.state === "active") {
     return { method: "sessions.reclaim", requiredScope: "operator.admin" };
   }
-  return "environmentId" in placement && placement.environmentId
-    ? {
-        method: "environments.destroy",
-        params: { environmentId: placement.environmentId },
-        requiredScope: "operator.admin",
-      }
-    : null;
+  if (!("environmentId" in placement) || !placement.environmentId) {
+    return null;
+  }
+  const force =
+    placement.state === "failed" &&
+    placement.terminalRecovery?.action === "force-destroy-environment" &&
+    placement.terminalRecovery.dataLoss === "unreconciled-workspace-result";
+  return {
+    method: "environments.destroy",
+    params: { environmentId: placement.environmentId, ...(force ? { force: true as const } : {}) },
+    requiredScope: "operator.admin",
+  };
+}
+
+export function resolveCloudWorkerStopConfirmation(
+  action: CloudWorkerStopAction,
+  session: string,
+): { message: string; confirmLabel: string; danger: true } {
+  const abandonsWorkspaceResult =
+    action.method === "environments.destroy" && action.params.force === true;
+  return {
+    message: abandonsWorkspaceResult
+      ? t("sessionsView.abandonCloudWorkerResultConfirm", { session })
+      : t("sessionsView.stopCloudWorkerConfirm", { session }),
+    confirmLabel: abandonsWorkspaceResult
+      ? t("sessionsView.abandonCloudWorkerResultConfirmAction")
+      : t("sessionsView.stopCloudWorkerConfirmAction"),
+    danger: true,
+  };
 }
 
 export async function requestCloudWorkerStop(

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -15,7 +15,7 @@ import type {
   SidebarSessionMutationScope,
   SidebarSessionPatch,
 } from "./app-sidebar-session-types.ts";
-import { requestCloudWorkerStop } from "./cloud-worker-stop.ts";
+import { requestCloudWorkerStop, resolveCloudWorkerStopConfirmation } from "./cloud-worker-stop.ts";
 import { showConfirmDialog, type ConfirmDialogSkipPreference } from "./confirm-dialog.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 import {
@@ -510,9 +510,7 @@ export async function stopCloudWorker(
     return;
   }
   const confirmed = await showConfirmDialog({
-    message: t("sessionsView.stopCloudWorkerConfirm", { session: session.label }),
-    confirmLabel: t("sessionsView.stopCloudWorkerConfirmAction"),
-    danger: true,
+    ...resolveCloudWorkerStopConfirmation(stopAction, session.label),
     signal: scope.signal,
   });
   // Checked ahead of `confirmed`: a retired scope aborts the dialog to `false`

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -15,7 +15,11 @@ import type {
   SidebarSessionMutationScope,
   SidebarSessionPatch,
 } from "./app-sidebar-session-types.ts";
-import { requestCloudWorkerStop, resolveCloudWorkerStopConfirmation } from "./cloud-worker-stop.ts";
+import {
+  requestCloudWorkerStop,
+  resolveCloudWorkerStopConfirmation,
+  showCloudWorkerStopResult,
+} from "./cloud-worker-stop.ts";
 import { showConfirmDialog, type ConfirmDialogSkipPreference } from "./confirm-dialog.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 import {
@@ -533,12 +537,7 @@ export async function stopCloudWorker(
       agentId,
     });
     if (result && host.sessionData.isSessionMutationScopeCurrent(scope)) {
-      showToast({
-        message: t("sessionsView.cloudWorkerStopResult", {
-          session: session.label,
-          state: result.worker?.state ?? result.status,
-        }),
-      });
+      showCloudWorkerStopResult(result, session.label);
     }
     if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
       return;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1021,6 +1021,9 @@ export const en: TranslationMap = {
     stopCloudWorkerConfirmAction: "Stop worker",
     stopCloudWorkerStale:
       'Gateway connection replaced before the cloud worker for "{session}" was stopped. Try again.',
+    abandonCloudWorkerResultConfirm:
+      'Permanently abandon the unreconciled remote workspace changes for "{session}" and stop its cloud worker? Those changes cannot be recovered.',
+    abandonCloudWorkerResultConfirmAction: "Abandon changes and stop",
     cloudWorkerStopResult: 'Cloud worker for "{session}" is {state}.',
     deleteSessionMenu: "Delete…",
     deleteSessionCount: "Delete {count}…",

--- a/ui/src/pages/chat/chat-pane-placement.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement.test.ts
@@ -1,10 +1,12 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EnvironmentsDestroyResult } from "../../../../packages/gateway-protocol/src/schema/environments.ts";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
+import "../../lib/toast.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
   answerConfirmDialog,
@@ -120,12 +122,27 @@ describe("chat pane placement", () => {
   });
 
   it("force-destroys a terminal recovery after confirming permanent data loss", async () => {
-    const request = vi.fn(async () => ({ ok: true }));
+    const destroyResult = {
+      id: "environment-1",
+      type: "worker",
+      status: "unavailable",
+      worker: {
+        providerId: "static-ssh",
+        state: "destroyed",
+        ageMs: 250,
+        attachedSessionIds: [],
+        tunnelStatus: "stopped",
+      },
+    } satisfies EnvironmentsDestroyResult;
+    const request = vi.fn(async () => destroyResult);
     const refreshReplacement = vi.fn(async () => undefined);
     const { pane } = createTestChatPane({
       client: { request } as unknown as GatewayBrowserClient,
       sessions: { refreshReplacement } as unknown as SessionCapability,
     });
+    const toast = document.createElement("openclaw-toast-host");
+    document.body.append(toast);
+    await toast.updateComplete;
     pane.context.gateway.snapshot.hello = {
       features: { methods: ["environments.destroy"] },
       auth: { role: "operator", scopes: ["operator.admin"] },
@@ -134,6 +151,7 @@ describe("chat pane placement", () => {
       key: "agent:main:terminal-recovery",
       kind: "direct",
       updatedAt: 0,
+      label: "Recovery task",
       hasActiveRun: true,
       placement: {
         state: "failed",
@@ -169,6 +187,9 @@ describe("chat pane placement", () => {
       force: true,
     });
     expect(refreshReplacement).toHaveBeenCalledWith("main");
+    expect(toast.querySelector(".app-toast__message")?.textContent).toBe(
+      'Cloud worker for "Recovery task" is destroyed.',
+    );
   });
 
   it("does not reclaim when the operator cancels", async () => {

--- a/ui/src/pages/chat/chat-pane-placement.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement.test.ts
@@ -119,6 +119,58 @@ describe("chat pane placement", () => {
     expect(refreshReplacement).toHaveBeenCalledWith("main");
   });
 
+  it("force-destroys a terminal recovery after confirming permanent data loss", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    const refreshReplacement = vi.fn(async () => undefined);
+    const { pane } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: { refreshReplacement } as unknown as SessionCapability,
+    });
+    pane.context.gateway.snapshot.hello = {
+      features: { methods: ["environments.destroy"] },
+      auth: { role: "operator", scopes: ["operator.admin"] },
+    } as never;
+    const session = {
+      key: "agent:main:terminal-recovery",
+      kind: "direct",
+      updatedAt: 0,
+      hasActiveRun: true,
+      placement: {
+        state: "failed",
+        generation: 8,
+        createdAtMs: 100,
+        updatedAtMs: 300,
+        stateChangedAtMs: 300,
+        environmentId: "environment-1",
+        recoveryError: "workspace recovery requires operator action",
+        terminalRecovery: {
+          action: "force-destroy-environment",
+          dataLoss: "unreconciled-workspace-result",
+        },
+      } as GatewaySessionRow["placement"],
+    } satisfies GatewaySessionRow;
+
+    expect(
+      resolveChatPanePlacement({
+        gatewaySnapshot: pane.context.gateway.snapshot,
+        reclaimingKey: null,
+        row: session,
+      }).reclaimDisabledReason,
+    ).toBeUndefined();
+    const stop = pane.reclaimHeaderPlacement(session);
+    const actions = await waitForConfirmDialogActions();
+    expect(document.body.textContent).toContain("Permanently abandon");
+    expect(actions.textContent).toContain("Abandon changes and stop");
+    answerConfirmDialog(actions, "confirm");
+    await stop;
+
+    expect(request).toHaveBeenCalledWith("environments.destroy", {
+      environmentId: "environment-1",
+      force: true,
+    });
+    expect(refreshReplacement).toHaveBeenCalledWith("main");
+  });
+
   it("does not reclaim when the operator cancels", async () => {
     const request = vi.fn(async () => ({ ok: true }));
     const { pane } = createTestChatPane({

--- a/ui/src/pages/chat/chat-pane-placement.ts
+++ b/ui/src/pages/chat/chat-pane-placement.ts
@@ -6,6 +6,7 @@ import {
   requestCloudWorkerStop,
   resolveCloudWorkerStopConfirmation,
   resolveCloudWorkerStopAction,
+  type CloudWorkerStopAction,
 } from "../../components/cloud-worker-stop.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import { t } from "../../i18n/index.ts";
@@ -34,16 +35,13 @@ export function resolveChatPanePlacement(params: {
   row: GatewaySessionRow | undefined;
 }): { reclaimDisabledReason: string | undefined } {
   const reclaiming = params.reclaimingKey === params.row?.key;
-  const action = resolveCloudWorkerStopAction(params.row?.placement);
-  const access = readSessionMethodAccess(params.gatewaySnapshot, {
-    method: "sessions.reclaim",
-    requiredScope: "operator.admin",
-  });
+  const action: CloudWorkerStopAction | null = resolveCloudWorkerStopAction(params.row?.placement);
+  const access = action ? readSessionMethodAccess(params.gatewaySnapshot, action) : undefined;
   const reclaimDisabledReason = reclaiming
     ? t("common.loading")
-    : params.row?.hasActiveRun === true
+    : action?.method === "sessions.reclaim" && params.row?.hasActiveRun === true
       ? t("sessionsView.activeRun")
-      : action?.method !== "sessions.reclaim"
+      : !action || !access
         ? t("sessionsView.actionUnavailable")
         : access.allowed
           ? undefined
@@ -67,20 +65,17 @@ export async function reclaimChatPanePlacement(params: {
 }): Promise<void> {
   const client = params.client;
   const connectionGeneration = params.connectionGeneration;
-  const action = resolveCloudWorkerStopAction(params.row.placement);
+  const action: CloudWorkerStopAction | null = resolveCloudWorkerStopAction(params.row.placement);
   const reclaiming = params.reclaimingKey === params.row.key;
   if (
     !client ||
     reclaiming ||
-    params.row.hasActiveRun === true ||
-    action?.method !== "sessions.reclaim"
+    !action ||
+    (action.method === "sessions.reclaim" && params.row.hasActiveRun === true)
   ) {
     return;
   }
-  const access = readSessionMethodAccess(params.gatewaySnapshot, {
-    method: "sessions.reclaim",
-    requiredScope: "operator.admin",
-  });
+  const access = readSessionMethodAccess(params.gatewaySnapshot, action);
   if (!access.allowed) {
     params.publishError(access.reason);
     return;

--- a/ui/src/pages/chat/chat-pane-placement.ts
+++ b/ui/src/pages/chat/chat-pane-placement.ts
@@ -6,6 +6,7 @@ import {
   requestCloudWorkerStop,
   resolveCloudWorkerStopConfirmation,
   resolveCloudWorkerStopAction,
+  showCloudWorkerStopResult,
   type CloudWorkerStopAction,
 } from "../../components/cloud-worker-stop.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
@@ -94,11 +95,14 @@ export async function reclaimChatPanePlacement(params: {
   const agentId = parseAgentSessionKey(params.row.key)?.agentId;
   params.onReclaimingChange(params.row.key);
   try {
-    await requestCloudWorkerStop(client, action, {
+    const result = await requestCloudWorkerStop(client, action, {
       key: params.row.key,
       ...(agentId ? { agentId } : {}),
     });
     if (params.isCurrent(client, connectionGeneration)) {
+      if (result) {
+        showCloudWorkerStopResult(result, params.row.label || params.row.key);
+      }
       await params.refreshReplacement(agentId);
     }
   } catch (error) {

--- a/ui/src/pages/chat/chat-pane-placement.ts
+++ b/ui/src/pages/chat/chat-pane-placement.ts
@@ -4,6 +4,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import {
   requestCloudWorkerStop,
+  resolveCloudWorkerStopConfirmation,
   resolveCloudWorkerStopAction,
 } from "../../components/cloud-worker-stop.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
@@ -86,11 +87,7 @@ export async function reclaimChatPanePlacement(params: {
   }
   const { showConfirmDialog } = await import("../../components/confirm-dialog.js");
   const confirmed = await showConfirmDialog({
-    message: t("sessionsView.stopCloudWorkerConfirm", {
-      session: params.row.label || params.row.key,
-    }),
-    confirmLabel: t("sessionsView.stopCloudWorkerConfirmAction"),
-    danger: true,
+    ...resolveCloudWorkerStopConfirmation(action, params.row.label || params.row.key),
   });
   if (!confirmed) {
     return;

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -17,6 +17,7 @@ import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
 import {
   requestCloudWorkerStop,
+  resolveCloudWorkerStopConfirmation,
   resolveCloudWorkerStopAction,
 } from "../../components/cloud-worker-stop.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
@@ -946,9 +947,7 @@ class SessionsPage extends OpenClawLightDomElement {
     if (
       !scope ||
       !(await showConfirmDialog({
-        message: t("sessionsView.stopCloudWorkerConfirm", { session: label }),
-        confirmLabel: t("sessionsView.stopCloudWorkerConfirmAction"),
-        danger: true,
+        ...resolveCloudWorkerStopConfirmation(stopAction, label),
       })) ||
       !this.isRequestScopeCurrent(scope) ||
       !this.requireMutationAccess(scope, stopAction)

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -19,6 +19,7 @@ import {
   requestCloudWorkerStop,
   resolveCloudWorkerStopConfirmation,
   resolveCloudWorkerStopAction,
+  showCloudWorkerStopResult,
 } from "../../components/cloud-worker-stop.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { sessionMenuReasons } from "../../components/session-menu-access.ts";
@@ -962,12 +963,7 @@ class SessionsPage extends OpenClawLightDomElement {
         ...(agentId ? { agentId } : {}),
       });
       if (result && this.isRequestScopeCurrent(scope)) {
-        showToast({
-          message: t("sessionsView.cloudWorkerStopResult", {
-            session: label,
-            state: result.worker?.state ?? result.status,
-          }),
-        });
+        showCloudWorkerStopResult(result, label);
       }
       if (this.isRequestScopeCurrent(scope)) {
         await this.loadSessions();


### PR DESCRIPTION
## What Problem This Solves

Cloud worker workspaces could remain quiesced indefinitely when a process-identity probe stalled or failed. The generated workspace owner used synchronous `ps` probes in recovery paths, and repeated probe batches could extend the effective wait. Explicit resume also recovered the watchdog before workspace processes, so a stalled watchdog probe or one failed reference could prevent otherwise healthy processes from receiving `SIGCONT`.

The same owner path also reused a strict recovery ceiling for healthy high-cardinality enrollment, admitted renewals without reserving the watchdog validation window, renewed leases whose watchdog was stopped, zombie, or dead, and scheduled the first heartbeat too late for the maximum supported 4,096-reference renewal budget. When a retained terminal lease surfaced during pending-result recovery, the manager treated it like a generic retryable failure, leaving the pending result and worker claim fenced without a durable operator diagnostic. A later automatic finalizer could then run resume again, signal the recovered process, and unlink the terminal lease even though durable placement state still assigned recovery to the operator.

## Why This Change Was Made

The generated worker-workspace quiescence/resume script is the canonical owner of process identity, signals, deadlines, and lease persistence. This change moves its probes to bounded asynchronous execution, applies one five-second wall-clock ceiling to each recovery pass, and treats probe or signal failures as per-reference outcomes so later healthy references can still progress. Unconfirmed references remain identity-protected in a terminal lease for operator recovery instead of being discarded. Watchdog startup uses one absolute one-second probe deadline.

Healthy enrollment and renewal use a separate count-aware process-validation budget. Renewal reserves that budget plus the watchdog's five-second validation window, while actual watchdog validation remains independently capped. A zero-process lease reserves only watchdog time. The heartbeat now runs every three minutes, leaving enough lifetime for the first maximum-size renewal. Renewal rejects stopped, zombie, and dead watchdog identities; recovery uses `SIGKILL` only for an identity-matched watchdog already observed as stopped, while active watchdogs continue to receive `SIGTERM`.

Pending-result recovery now distinguishes a typed terminal operator-recovery outcome from generic resume errors through a dedicated quiescence-protocol exit code, not diagnostic text. The terminal path atomically records `recoveryError`, transitions the placement to failed, releases the worker claim, and preserves the pending workspace result. The matching failed placement and pending row remain the durable operator-recovery owner across later sweeps and Gateway restarts, blocking automatic teardown until explicit forced abandonment. Automatic quiesce retries and automatic resume finalizers recognize the lease's recovery metadata and return the same typed terminal outcome before any process probe, signal, or unlink. Generic and transient resume failures remain fenced and retryable on the next sweep.

Terminal classification follows structured error causes, so workspace-renewal and final-fence wrappers cannot hide the protocol outcome. A shared durable-owner predicate keeps the failed placement and pending result consistent across reconciliation paths. Explicit reclaim applies that same durable failure transition when its final fence contains the terminal cause, after checking the exact placement generation, environment owner, reclaim claim, and pending-result identity; generic reclaim failures retain their existing retry behavior. Explicit forced abandonment updates the operator diagnostic and deletes the identity-matched pending result in one SQLite transaction; an identity mismatch rolls the entire transaction back. After that durable fence closes, it finishes and removes the reconciliation journal and deletes the staged, prepared, and cleanup Git refs owned by the result.

Before placement failure or cleanup can make that journal appear stale, reconciliation records structured forced-abandon ownership in the journal itself. Startup pruning requires that marker plus the exact environment, epoch, and generation identity instead of inferring ownership from mutable diagnostic text. Current-version state databases receive the additive journal column before canonical schema validation, while unrelated schema drift remains rejected.

The final CI repair preserves those semantics while aligning the implementation with repository checks. Terminal-result failure recording is narrowed to active or draining placements, turn-claim release is injected from the placement-store composition boundary to remove a runtime import cycle, and implementation-only result types and diagnostics remain internal while tests share their expected diagnostic through fixtures.

The post-amendment repair makes Gateway startup consult the same exact DB-backed durable-owner predicate before retrying a retained failed journal. Startup skips only a failed journal whose environment, epoch, and generation match a pending terminal workspace result. A `forced_abandonment_retained` journal without that pending result remains distinguishable and retryable instead of being broadly suppressed.

The final review repairs also make every forced-destroy UI surface show the same result outcome, and retire a workspace-conflict projection only after staged refs are successfully removed. Git-ref deletion, compare-by-ref transcript clearing, and compare-by-ref in-memory retirement are independently fault-contained, so a transcript failure cannot strand refs or preserve a stale conflict projection.

This PR remains scoped to the maintainer-requested Piece 1. Large-set fairness rotation across retained references or orphan leases, lease-mutation locking, and ownership/reclaim policy remain deferred to Piece 2.

## User Impact

Stalled or failed identity probes no longer create an unbounded workspace recovery wait. Healthy processes can resume when a sibling probe or watchdog probe fails, unresolved identities remain available for safe operator recovery, and terminal pending-result failures become visible without losing the pending result. Once recovery becomes terminal, automatic cleanup and Gateway startup cannot resume its stopped processes, repeatedly defer the same recovery, or delete its lease behind the operator's durable state, and explicit reclaim cannot leave the current Gateway's worker claim permanently fenced. Healthy high-cardinality workspaces can renew when sufficient lease lifetime remains, unsafe near-expiry renewals fail before validation can outlive the lease, and inactive watchdogs cannot extend ownership.

After an operator confirms destructive teardown, Chat, Sessions, and the sidebar now show the same explicit result. Successfully removed staged refs also clear the matching transcript and in-memory conflict state; cleanup failures keep the conflict projection available instead of presenting broken recovery commands.

There is no external API change. Persisted workspace leases gain optional recovery metadata, terminal pending-result recovery records the existing placement `recoveryError` state while preserving the pending result, and the internal reconciliation journal gains a forced-abandon ownership marker with a same-version additive migration.

## Evidence

The final candidate `49110fb92072a117e4029efe2340b9d05c024cf3` was exercised on Node 24.16.0 through a standalone lifecycle harness using the production-generated watchdog script against real OS processes, the real SQLite placement store, `createGatewayWorkerPlacementRuntime().startRuntime()`, production environment-service reconciliation, and explicit force-abandon cleanup.

```text
[runtime] trigger=terminal-owner-lifecycle head=49110fb92072a117e4029efe2340b9d05c024cf3 runtime=v24.16.0
[runtime] transition=watchdog-expiry recovery=probe-timeout watchdog=exited process=stopped lease=retained
[runtime] transition=gateway-restart placement=failed pending=retained journal=retained startup-deferred-errors=0
[runtime] transition=environment-reconcile terminal-owner=retained provider-destroy=not-called state=attached
[runtime] transition=forced-abandon placement=failed pending=cleared journal=cleared refs=cleared
[runtime] outcome=terminal-recovery-remains-operator-owned-until-explicit-forced-abandon
```

Additional final-head validation was intentionally focused to avoid a workstation-wide test fanout:

- Node 24.16.0, one Vitest test and one worker: `retires the conflict projection after deleting every staged result ref` passed in `placement-force-abandon.test.ts`.
- Node 24.16.0, one Vitest test and one worker: `releases a pending worker claim when its workspace is already gone` passed in `placement-force-abandon.test.ts`.
- Targeted Oxfmt completed on the three final Gateway repair files; targeted Oxlint with `--threads=1` and `git diff --check` passed.
- The exact-ancestor incremental ClawSweeper review for `dfacdb4..49110fb` returned `nothing_found`, `confidence: high`, and `check_conclusion: success`; it confirmed that all prior review findings were resolved.
- Direct sibling Codex inspection at `b6f1cfa3f36a34e0f05b6fafdb45c8986d4b521e` confirmed that `thread/resume` rejoins an existing thread and `turn/interrupt` acts only on the exact active turn. Neither API owns OpenClaw workspace leases, staged refs, placement journals, or durable forced-abandon recovery.

Final base-to-head raw diff accounting (`6575733bc03537bf7535a33fa87f49da3fb52637..49110fb92072a117e4029efe2340b9d05c024cf3`) classifies `.test.*`, `/Tests/`, and explicit test fixture/harness/support files as tests: non-test source/generated files are `+2521/-512` (net `+2009`), while tests and test support are `+4540/-497` (net `+4043`). The final repair commit itself reduces production by 12 lines (`+17/-29`) with test lines net-neutral (`+9/-9`). The positive production growth supplies one canonical durable-ownership capability across process recovery, placement state, pending results, startup journals, environment reconciliation, explicit reclaim, forced-abandon cleanup, additive schema handling, and all operator stop surfaces; it does not add a parallel recovery owner.

Earlier broad CI, dead-code, and max-lines statements in this body were tied to older heads and are intentionally not presented as final-head proof. Hosted CI for the final submitted head is tracked separately from this focused local evidence.

## Maintainer Note

Allow edits from maintainers remains enabled for this PR.
