### PR TITLE
fix(openai): prevent device-code login hangs on stalled requests

### DIFF
--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -1,5 +1,5 @@
 // Openai tests cover openai chatgpt device code plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveCodexAccessTokenExpiry } from "./openai-chatgpt-auth-identity.js";
 import { loginOpenAICodexDeviceCode } from "./openai-chatgpt-device-code.js";
 
@@ -48,7 +48,103 @@ function fetchCall(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, index: num
   return call;
 }
 
+function waitForFetchAbort(init?: RequestInit): Promise<Response> {
+  const signal = init?.signal;
+  if (!signal) {
+    return Promise.reject(new Error("expected fetch signal"));
+  }
+  return new Promise((_resolve, reject) => {
+    const rejectWithReason = () =>
+      reject(signal.reason instanceof Error ? signal.reason : new Error("request aborted"));
+    if (signal.aborted) {
+      rejectWithReason();
+      return;
+    }
+    signal.addEventListener("abort", rejectWithReason, { once: true });
+  });
+}
+
+function createBodyThatStallsUntilAbort(init?: RequestInit): Response {
+  const signal = init?.signal;
+  if (!signal) {
+    throw new Error("expected fetch signal");
+  }
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        const fail = () => controller.error(signal.reason);
+        if (signal.aborted) {
+          fail();
+          return;
+        }
+        signal.addEventListener("abort", fail, { once: true });
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
 describe("loginOpenAICodexDeviceCode", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("times out while waiting for device-code response headers", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>((_input, init) => waitForFetchAbort(init));
+
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchCall(fetchMock, 0)[1]?.signal).toBeInstanceOf(AbortSignal);
+    const rejected = expect(login).rejects.toThrow(
+      "OpenAI device code user code request timed out after 30000ms",
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejected;
+  });
+
+  it("keeps the request timeout active while reading the response body", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) =>
+      createBodyThatStallsUntilAbort(init),
+    );
+
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const rejected = expect(login).rejects.toThrow(
+      "OpenAI device code user code request timed out after 30000ms",
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejected;
+  });
+
+  it("still honors caller cancellation during an active device-code request", async () => {
+    const callerController = new AbortController();
+    const fetchMock = vi.fn<typeof fetch>((_input, init) => waitForFetchAbort(init));
+
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+      signal: callerController.signal,
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    callerController.abort(new Error("cancelled by caller"));
+    await expect(login).rejects.toThrow("cancelled by caller");
+  });
+
   it("requests a device code, polls for authorization, and exchanges OAuth tokens", async () => {
     vi.useFakeTimers();
     vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
@@ -108,6 +204,7 @@ describe("loginOpenAICodexDeviceCode", () => {
       const userCodeRequest = fetchCall(fetchMock, 0);
       expect(userCodeRequest[0]).toBe("https://auth.openai.com/api/accounts/deviceauth/usercode");
       expect(userCodeRequest[1]?.method).toBe("POST");
+      expect(userCodeRequest[1]?.signal).toBeInstanceOf(AbortSignal);
       expect(userCodeRequest[1]?.headers).toEqual({
         "Content-Type": "application/json",
         originator: "openclaw",
@@ -118,6 +215,7 @@ describe("loginOpenAICodexDeviceCode", () => {
       const deviceTokenRequest = fetchCall(fetchMock, 1);
       expect(deviceTokenRequest[0]).toBe("https://auth.openai.com/api/accounts/deviceauth/token");
       expect(deviceTokenRequest[1]?.method).toBe("POST");
+      expect(deviceTokenRequest[1]?.signal).toBeInstanceOf(AbortSignal);
       expect(deviceTokenRequest[1]?.headers).toEqual({
         "Content-Type": "application/json",
         originator: "openclaw",
@@ -128,6 +226,7 @@ describe("loginOpenAICodexDeviceCode", () => {
       const oauthTokenRequest = fetchCall(fetchMock, 3);
       expect(oauthTokenRequest[0]).toBe("https://auth.openai.com/oauth/token");
       expect(oauthTokenRequest[1]?.method).toBe("POST");
+      expect(oauthTokenRequest[1]?.signal).toBeInstanceOf(AbortSignal);
       expect(oauthTokenRequest[1]?.headers).toEqual({
         "Content-Type": "application/x-www-form-urlencoded",
         originator: "openclaw",
@@ -151,6 +250,55 @@ describe("loginOpenAICodexDeviceCode", () => {
       vi.useRealTimers();
       vi.unstubAllEnvs();
     }
+  });
+
+  it("retries a timed-out authorization poll within the overall device deadline", async () => {
+    vi.useFakeTimers();
+    const accessToken = createJwt({
+      exp: Math.floor(Date.now() / 1000) + 600,
+    });
+    let pollAttempts = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/api/accounts/deviceauth/usercode")) {
+        return createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        });
+      }
+      if (url.endsWith("/api/accounts/deviceauth/token")) {
+        pollAttempts += 1;
+        if (pollAttempts === 1) {
+          return await waitForFetchAbort(init);
+        }
+        return createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        });
+      }
+      if (url.endsWith("/oauth/token")) {
+        return createJsonResponse({
+          access_token: accessToken,
+          refresh_token: "refresh-token-123",
+          expires_in: 600,
+        });
+      }
+      throw new Error(`unexpected OpenAI device-code URL: ${url}`);
+    });
+
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(pollAttempts).toBe(1);
+
+    const resolved = expect(login).resolves.toMatchObject({ refresh: "refresh-token-123" });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await resolved;
+    expect(pollAttempts).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it("aborts device-code polling without another request", async () => {

--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -3,19 +3,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveCodexAccessTokenExpiry } from "./openai-chatgpt-auth-identity.js";
 import { loginOpenAICodexDeviceCode } from "./openai-chatgpt-device-code.js";
 
-const guardedFetchOptionsSpy = vi.hoisted(() => vi.fn());
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
-  return {
-    ...actual,
-    fetchWithSsrFGuard: async (options: Parameters<typeof actual.fetchWithSsrFGuard>[0]) => {
-      guardedFetchOptionsSpy(options);
-      return await actual.fetchWithSsrFGuard(options);
-    },
-  };
-});
-
 function createJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
@@ -61,14 +48,6 @@ function fetchCall(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, index: num
   return call;
 }
 
-function lastGuardedFetchOptions(): { mode?: string } {
-  const options = guardedFetchOptionsSpy.mock.calls.at(-1)?.[0];
-  if (!options || typeof options !== "object") {
-    throw new Error("expected guarded fetch options");
-  }
-  return options as { mode?: string };
-}
-
 function waitForFetchAbort(init?: RequestInit): Promise<Response> {
   const signal = init?.signal;
   if (!signal) {
@@ -107,7 +86,6 @@ function createBodyThatStallsUntilAbort(init?: RequestInit): Response {
 
 describe("loginOpenAICodexDeviceCode", () => {
   afterEach(() => {
-    guardedFetchOptionsSpy.mockClear();
     vi.restoreAllMocks();
     vi.useRealTimers();
     vi.unstubAllEnvs();
@@ -182,7 +160,6 @@ describe("loginOpenAICodexDeviceCode", () => {
     const requestInit = fetchCall(fetchMock, 0)[1] as
       | (RequestInit & { dispatcher?: { constructor?: { name?: string } } })
       | undefined;
-    expect(lastGuardedFetchOptions().mode).toBe("trusted_env_proxy");
     expect(requestInit?.dispatcher?.constructor?.name).toContain("EnvHttpProxyAgent");
   });
 
@@ -201,7 +178,6 @@ describe("loginOpenAICodexDeviceCode", () => {
     const requestInit = fetchCall(fetchMock, 0)[1] as
       | (RequestInit & { dispatcher?: unknown })
       | undefined;
-    expect(lastGuardedFetchOptions().mode).toBeUndefined();
     expect(requestInit?.dispatcher).toBeUndefined();
   });
 

--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -3,6 +3,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveCodexAccessTokenExpiry } from "./openai-chatgpt-auth-identity.js";
 import { loginOpenAICodexDeviceCode } from "./openai-chatgpt-device-code.js";
 
+const guardedFetchOptionsSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (options: Parameters<typeof actual.fetchWithSsrFGuard>[0]) => {
+      guardedFetchOptionsSpy(options);
+      return await actual.fetchWithSsrFGuard(options);
+    },
+  };
+});
+
 function createJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
@@ -48,6 +61,14 @@ function fetchCall(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, index: num
   return call;
 }
 
+function lastGuardedFetchOptions(): { mode?: string } {
+  const options = guardedFetchOptionsSpy.mock.calls.at(-1)?.[0];
+  if (!options || typeof options !== "object") {
+    throw new Error("expected guarded fetch options");
+  }
+  return options as { mode?: string };
+}
+
 function waitForFetchAbort(init?: RequestInit): Promise<Response> {
   const signal = init?.signal;
   if (!signal) {
@@ -86,6 +107,7 @@ function createBodyThatStallsUntilAbort(init?: RequestInit): Response {
 
 describe("loginOpenAICodexDeviceCode", () => {
   afterEach(() => {
+    guardedFetchOptionsSpy.mockClear();
     vi.restoreAllMocks();
     vi.useRealTimers();
     vi.unstubAllEnvs();
@@ -143,6 +165,44 @@ describe("loginOpenAICodexDeviceCode", () => {
 
     callerController.abort(new Error("cancelled by caller"));
     await expect(login).rejects.toThrow("cancelled by caller");
+  });
+
+  it("routes device-code auth through a configured HTTPS proxy", async () => {
+    vi.stubEnv("https_proxy", "http://127.0.0.1:7897");
+    vi.stubEnv("no_proxy", "");
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 503 }));
+
+    await expect(
+      loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock,
+        onVerification: async () => {},
+      }),
+    ).rejects.toThrow("OpenAI device code request failed: HTTP 503");
+
+    const requestInit = fetchCall(fetchMock, 0)[1] as
+      | (RequestInit & { dispatcher?: { constructor?: { name?: string } } })
+      | undefined;
+    expect(lastGuardedFetchOptions().mode).toBe("trusted_env_proxy");
+    expect(requestInit?.dispatcher?.constructor?.name).toContain("EnvHttpProxyAgent");
+  });
+
+  it("keeps strict guarded fetch when NO_PROXY bypasses OpenAI auth", async () => {
+    vi.stubEnv("https_proxy", "http://127.0.0.1:7897");
+    vi.stubEnv("no_proxy", "auth.openai.com");
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 503 }));
+
+    await expect(
+      loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock,
+        onVerification: async () => {},
+      }),
+    ).rejects.toThrow("OpenAI device code request failed: HTTP 503");
+
+    const requestInit = fetchCall(fetchMock, 0)[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    expect(lastGuardedFetchOptions().mode).toBeUndefined();
+    expect(requestInit?.dispatcher).toBeUndefined();
   });
 
   it("requests a device code, polls for authorization, and exchanges OAuth tokens", async () => {

--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -4,12 +4,14 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveCodexAccessTokenExpiry } from "./openai-chatgpt-auth-identity.js";
 import { trimNonEmptyString } from "./openai-chatgpt-shared.js";
 
 const OPENAI_AUTH_BASE_URL = "https://auth.openai.com";
 const OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_CODEX_DEVICE_CODE_TIMEOUT_MS = 15 * 60_000;
+const OPENAI_CODEX_DEVICE_REQUEST_TIMEOUT_MS = 30_000;
 const OPENAI_CODEX_DEVICE_CODE_DEFAULT_INTERVAL_MS = 5_000;
 const OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS = 1_000;
 const OPENAI_CODEX_DEVICE_CALLBACK_URL = `${OPENAI_AUTH_BASE_URL}/deviceauth/callback`;
@@ -69,6 +71,12 @@ type DeviceCodeAuthorizationCode = {
   codeVerifier: string;
 };
 
+type DeviceCodeHttpResult = {
+  ok: boolean;
+  status: number;
+  bodyText: string;
+};
+
 function parseJsonObject(text: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(text);
@@ -99,6 +107,20 @@ function sanitizeDeviceCodeErrorText(value: string): string {
 function resolveNextDeviceCodePollDelayMs(intervalMs: number, deadlineMs: number): number {
   const remainingMs = Math.max(0, deadlineMs - Date.now());
   return Math.min(Math.max(intervalMs, OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS), remainingMs);
+}
+
+function resolveDeviceCodePollRequestTimeoutMs(deadlineMs: number): number {
+  return Math.min(OPENAI_CODEX_DEVICE_REQUEST_TIMEOUT_MS, Math.max(0, deadlineMs - Date.now()));
+}
+
+function isDeviceCodeOperationTimeoutError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
+}
+
+function rethrowIfDeviceCodeCallerAborted(signal: AbortSignal | undefined, error: unknown): void {
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error ? signal.reason : error;
+  }
 }
 
 function formatDeviceCodeError(params: {
@@ -132,23 +154,78 @@ async function readOpenAICodexDeviceBody(response: Response): Promise<string> {
   );
 }
 
+async function runOpenAICodexDeviceRequest(params: {
+  fetchFn: typeof fetch;
+  url: string;
+  init: Omit<RequestInit, "signal">;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<DeviceCodeHttpResult> {
+  const { response, release } = await fetchWithSsrFGuard({
+    url: params.url,
+    fetchImpl: params.fetchFn,
+    init: params.init,
+    timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
+    requireHttps: true,
+    auditContext: "openai-chatgpt-device-code",
+  });
+  try {
+    return {
+      ok: response.ok,
+      status: response.status,
+      bodyText: await readOpenAICodexDeviceBody(response),
+    };
+  } finally {
+    await release();
+  }
+}
+
+async function fetchOpenAICodexDeviceCode(params: {
+  fetchFn: typeof fetch;
+  url: string;
+  init: Omit<RequestInit, "signal">;
+  timeoutOperation: string;
+  signal?: AbortSignal;
+}): Promise<DeviceCodeHttpResult> {
+  try {
+    return await runOpenAICodexDeviceRequest({
+      ...params,
+      timeoutMs: OPENAI_CODEX_DEVICE_REQUEST_TIMEOUT_MS,
+    });
+  } catch (error) {
+    rethrowIfDeviceCodeCallerAborted(params.signal, error);
+    if (isDeviceCodeOperationTimeoutError(error)) {
+      throw new Error(
+        `OpenAI device code ${params.timeoutOperation} timed out after ${OPENAI_CODEX_DEVICE_REQUEST_TIMEOUT_MS}ms`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
 async function requestOpenAICodexDeviceCode(
   fetchFn: typeof fetch,
   signal?: AbortSignal,
 ): Promise<RequestedDeviceCode> {
   signal?.throwIfAborted();
-  const response = await fetchFn(`${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/usercode`, {
-    method: "POST",
-    headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
-    body: JSON.stringify({
-      client_id: OPENAI_CODEX_CLIENT_ID,
-    }),
+  const result = await fetchOpenAICodexDeviceCode({
+    fetchFn,
+    url: `${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/usercode`,
+    init: {
+      method: "POST",
+      headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
+      body: JSON.stringify({
+        client_id: OPENAI_CODEX_CLIENT_ID,
+      }),
+    },
+    timeoutOperation: "user code request",
     ...(signal ? { signal } : {}),
   });
 
-  const bodyText = await readOpenAICodexDeviceBody(response);
-  if (!response.ok) {
-    if (response.status === 404) {
+  if (!result.ok) {
+    if (result.status === 404) {
       throw new Error(
         "OpenAI Codex device code login is not enabled for this server. Use ChatGPT OAuth instead.",
       );
@@ -156,13 +233,13 @@ async function requestOpenAICodexDeviceCode(
     throw new Error(
       formatDeviceCodeError({
         prefix: "OpenAI device code request failed",
-        status: response.status,
-        bodyText,
+        status: result.status,
+        bodyText: result.bodyText,
       }),
     );
   }
 
-  const body = parseJsonObject(bodyText) as DeviceCodeUserCodePayload | null;
+  const body = parseJsonObject(result.bodyText) as DeviceCodeUserCodePayload | null;
   const deviceAuthId = trimNonEmptyString(body?.device_auth_id);
   const userCode = trimNonEmptyString(body?.user_code) ?? trimNonEmptyString(body?.usercode);
   if (!deviceAuthId || !userCode) {
@@ -190,19 +267,38 @@ async function pollOpenAICodexDeviceCode(params: {
 
   while (Date.now() < deadline) {
     params.signal?.throwIfAborted();
-    const response = await params.fetchFn(`${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/token`, {
-      method: "POST",
-      headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
-      body: JSON.stringify({
-        device_auth_id: params.deviceAuthId,
-        user_code: params.userCode,
-      }),
-      ...(params.signal ? { signal: params.signal } : {}),
-    });
+    const requestTimeoutMs = resolveDeviceCodePollRequestTimeoutMs(deadline);
+    if (requestTimeoutMs <= 0) {
+      break;
+    }
 
-    const bodyText = await readOpenAICodexDeviceBody(response);
-    if (response.ok) {
-      const body = parseJsonObject(bodyText) as DeviceCodeTokenPayload | null;
+    let result: DeviceCodeHttpResult;
+    try {
+      result = await runOpenAICodexDeviceRequest({
+        fetchFn: params.fetchFn,
+        url: `${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/token`,
+        init: {
+          method: "POST",
+          headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
+          body: JSON.stringify({
+            device_auth_id: params.deviceAuthId,
+            user_code: params.userCode,
+          }),
+        },
+        timeoutMs: requestTimeoutMs,
+        ...(params.signal ? { signal: params.signal } : {}),
+      });
+    } catch (error) {
+      rethrowIfDeviceCodeCallerAborted(params.signal, error);
+      // A stalled poll is transient; keep the overall 15-minute authorization deadline.
+      if (isDeviceCodeOperationTimeoutError(error)) {
+        continue;
+      }
+      throw error;
+    }
+
+    if (result.ok) {
+      const body = parseJsonObject(result.bodyText) as DeviceCodeTokenPayload | null;
       const authorizationCode = trimNonEmptyString(body?.authorization_code);
       const codeVerifier = trimNonEmptyString(body?.code_verifier);
       if (!authorizationCode || !codeVerifier) {
@@ -214,7 +310,7 @@ async function pollOpenAICodexDeviceCode(params: {
       };
     }
 
-    if (response.status === 403 || response.status === 404) {
+    if (result.status === 403 || result.status === 404) {
       await waitForDeviceCodePoll(
         resolveNextDeviceCodePollDelayMs(params.intervalMs, deadline),
         params.signal,
@@ -225,8 +321,8 @@ async function pollOpenAICodexDeviceCode(params: {
     throw new Error(
       formatDeviceCodeError({
         prefix: "OpenAI device authorization failed",
-        status: response.status,
-        bodyText,
+        status: result.status,
+        bodyText: result.bodyText,
       }),
     );
   }
@@ -241,31 +337,35 @@ async function exchangeOpenAICodexDeviceCode(params: {
   signal?: AbortSignal;
 }): Promise<OpenAICodexDeviceCodeCredentials> {
   params.signal?.throwIfAborted();
-  const response = await params.fetchFn(`${OPENAI_AUTH_BASE_URL}/oauth/token`, {
-    method: "POST",
-    headers: resolveOpenAICodexDeviceCodeHeaders("application/x-www-form-urlencoded"),
-    body: new URLSearchParams({
-      grant_type: "authorization_code",
-      code: params.authorizationCode,
-      redirect_uri: OPENAI_CODEX_DEVICE_CALLBACK_URL,
-      client_id: OPENAI_CODEX_CLIENT_ID,
-      code_verifier: params.codeVerifier,
-    }),
+  const result = await fetchOpenAICodexDeviceCode({
+    fetchFn: params.fetchFn,
+    url: `${OPENAI_AUTH_BASE_URL}/oauth/token`,
+    init: {
+      method: "POST",
+      headers: resolveOpenAICodexDeviceCodeHeaders("application/x-www-form-urlencoded"),
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: params.authorizationCode,
+        redirect_uri: OPENAI_CODEX_DEVICE_CALLBACK_URL,
+        client_id: OPENAI_CODEX_CLIENT_ID,
+        code_verifier: params.codeVerifier,
+      }),
+    },
+    timeoutOperation: "token exchange",
     ...(params.signal ? { signal: params.signal } : {}),
   });
 
-  const bodyText = await readOpenAICodexDeviceBody(response);
-  if (!response.ok) {
+  if (!result.ok) {
     throw new Error(
       formatDeviceCodeError({
         prefix: "OpenAI device token exchange failed",
-        status: response.status,
-        bodyText,
+        status: result.status,
+        bodyText: result.bodyText,
       }),
     );
   }
 
-  const body = parseJsonObject(bodyText) as OAuthTokenPayload | null;
+  const body = parseJsonObject(result.bodyText) as OAuthTokenPayload | null;
   const access = trimNonEmptyString(body?.access_token);
   const refresh = trimNonEmptyString(body?.refresh_token);
   if (!access || !refresh) {

--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -1,5 +1,9 @@
 // Openai plugin module implements openai chatgpt device code behavior.
 import {
+  shouldUseEnvHttpProxyForUrl,
+  withTrustedEnvProxyGuardedFetchMode,
+} from "openclaw/plugin-sdk/fetch-runtime";
+import {
   positiveSecondsToSafeMilliseconds,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
@@ -161,7 +165,7 @@ async function runOpenAICodexDeviceRequest(params: {
   timeoutMs: number;
   signal?: AbortSignal;
 }): Promise<DeviceCodeHttpResult> {
-  const { response, release } = await fetchWithSsrFGuard({
+  const guardedOptions = {
     url: params.url,
     fetchImpl: params.fetchFn,
     init: params.init,
@@ -169,7 +173,12 @@ async function runOpenAICodexDeviceRequest(params: {
     ...(params.signal ? { signal: params.signal } : {}),
     requireHttps: true,
     auditContext: "openai-chatgpt-device-code",
-  });
+  };
+  const { response, release } = await fetchWithSsrFGuard(
+    shouldUseEnvHttpProxyForUrl(params.url)
+      ? withTrustedEnvProxyGuardedFetchMode(guardedOptions)
+      : guardedOptions,
+  );
   try {
     return {
       ok: response.ok,


### PR DESCRIPTION
Related: #104477

## What Problem This Solves

Fixes an issue where users running OpenAI device-code login could remain stuck indefinitely when an `auth.openai.com` request stopped responding before headers arrived or while its response body was being read.

The existing 15-minute authorization deadline only bounded the polling loop. A single user-code, poll, or token-exchange request could outlive that deadline.

## Why This Change Was Made

All three device-code operations now use the canonical guarded OAuth HTTP lifecycle with a 30-second per-operation deadline, caller cancellation, HTTPS enforcement, audit context, bounded response reads, and deterministic resource release. Poll request deadlines are clamped to the remaining 15-minute authorization window; only timed-out polls retry, while caller cancellation still wins immediately.

When `HTTP_PROXY` or `HTTPS_PROXY` applies to an OpenAI auth URL, the request selects the same trusted environment-proxy guarded mode used by Google OAuth. `NO_PROXY` matches retain strict guarded fetch. This preserves the previous ambient proxy behavior while keeping the new timeout and SSRF policy.

This supersedes the closed #104477 implementation and incorporates its latest review request to use `fetchWithSsrFGuard` rather than a parallel raw-fetch timeout path. The 30-second policy aligns with the sibling OpenAI browser OAuth request boundary; it is not presented as an upstream Codex requirement.

## User Impact

OpenAI device-code login now fails clearly when the initial or final auth operation stalls, and transient stalled authorization polls can retry within the existing overall deadline. Ctrl-C and other caller cancellation behavior remains unchanged. Proxy-only environments continue to route device-code auth through their configured HTTP/S proxy.

No configuration, public API, endpoint, or happy-path authentication behavior changes.

## Evidence

- Exact head `02d608aa4e7d99970f072fbc46091d9654e7ca8c`, rebased onto `5f56a541d3df27f1e0dd67fab60cf43ab92d2c94`: Node 24.18.0 focused suite `node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-device-code.test.ts` passed 15/15.
- Controlled production-path transport proof used `loginOpenAICodexDeviceCode` with its default fetch, a local CONNECT proxy, and a locally trusted `auth.openai.com` test certificate. The proxy observed `CONNECT auth.openai.com:443` and `POST /api/accounts/deviceauth/usercode` in both cases.
- Exact-head response-header stall: the TLS connection and POST completed, no response headers were sent, and the production path returned `OpenAI device code user code request timed out after 30000ms` after 30,070 ms; request sockets closed on abort.
- Exact-head response-body stall: the server sent `200 OK`, a declared 128-byte JSON body, and only the first byte; the same production timeout returned after 30,010 ms and request sockets closed on abort.
- Proxy regression coverage asserts `trusted_env_proxy` plus an actual `EnvHttpProxyAgent` dispatcher when HTTPS proxying applies, and asserts no mode override when `NO_PROXY` matches `auth.openai.com`.
- Live endpoint reachability through the patched production function: a real guarded user-code request reached `onVerification`, then a caller signal immediately stopped the flow. Redacted output: `{"verified":true,"cancelledAfterVerification":true}`. No user code, device id, or credentials were emitted.
- Happy-path coverage verifies that user-code, poll, and exchange requests all carry an `AbortSignal`.
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check` passed. Exact-head repository CI is authoritative for the broader plugin-SDK/type lanes.
- Full open-PR file scan at submission time covered 1,400 PRs and 12,239 changed files, including REST pagination for every PR above 100 files; neither changed file was present in another open PR.
- Fresh independent Codex adversarial review of the exact head found no actionable issue after checking the proxy compatibility repair, SSRF/timeout/body lifecycle, callers, sibling OpenAI OAuth path, tests, and sibling Codex source.
- Direct Codex source inspection confirms the same device-code endpoints and 15-minute overall polling window ([device flow](https://github.com/openai/codex/blob/5c19155cbd93bfa099016e7487259f61669823ff/codex-rs/login/src/device_code_auth.rs#L62-L108)); its HTTP client exposes a per-request timeout API but does not prescribe 30 seconds ([client API](https://github.com/openai/codex/blob/5c19155cbd93bfa099016e7487259f61669823ff/codex-rs/http-client/src/default_client.rs#L129-L131)).
