### PR TITLE
fix(pr-gates): accept a green ci-gate check without waiting for the full CI run

### DIFF
--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -19,10 +19,18 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
 ];
 const WORKFLOW_RUNS_PAGE_SIZE = 100;
 const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
+const CHECK_RUNS_PAGE_SIZE = 100;
 const COMPARE_COMMITS_PAGE_SIZE = 100;
 export const HOSTED_GATE_MAX_AGE_HOURS = 24;
 const HOSTED_GATE_MAX_AGE_MS = HOSTED_GATE_MAX_AGE_HOURS * 60 * 60 * 1_000;
 const HOSTED_GATE_CLOCK_SKEW_MS = 5 * 60 * 1_000;
+// This job needs every merge-blocking CI job, so its successful check is the
+// repository's button-green signal. That check survives workflow-run reruns.
+const CI_GATE_CHECK_NAME = "openclaw/ci-gate";
+
+class CiGateCheckRunsFetchError extends Error {}
+class BlockingCiGateCheckError extends Error {}
+class CiGateCheckStateError extends Error {}
 
 function readOptionValue(argv, index, optionName) {
   const value = argv[index + 1];
@@ -130,25 +138,22 @@ function latestRun(runs) {
   )[0];
 }
 
-function runUpdatedAtMs(run) {
-  const value = Date.parse(String(run?.updated_at ?? ""));
-  return Number.isFinite(value) ? value : null;
+function isRecentTimestamp(value, nowMs) {
+  const timestampMs = Date.parse(String(value ?? ""));
+  return (
+    Number.isFinite(timestampMs) &&
+    timestampMs >= nowMs - HOSTED_GATE_MAX_AGE_MS &&
+    timestampMs <= nowMs + HOSTED_GATE_CLOCK_SKEW_MS
+  );
 }
 
 function isRecentRun(run, nowMs) {
-  const updatedAtMs = runUpdatedAtMs(run);
-  return (
-    updatedAtMs !== null &&
-    updatedAtMs >= nowMs - HOSTED_GATE_MAX_AGE_MS &&
-    updatedAtMs <= nowMs + HOSTED_GATE_CLOCK_SKEW_MS
-  );
+  return isRecentTimestamp(run?.updated_at, nowMs);
 }
 
 function isSuccessfulRecentRun(run, nowMs) {
   return run?.status === "completed" && run.conclusion === "success" && isRecentRun(run, nowMs);
 }
-
-const CI_GATE_CHECK_NAME = "openclaw/ci-gate";
 
 /**
  * True when this run's own openclaw/ci-gate job already succeeded on the
@@ -193,6 +198,14 @@ function isGateProvenInProgressRun(run, ciGateJobs, nowMs) {
     (run?.status === "in_progress" || run?.status === "queued") &&
     isRecentRun(run, nowMs) &&
     hasSuccessfulCiGateJob(run, ciGateJobs, nowMs)
+  );
+}
+
+function isSuccessfulRecentCheckRun(checkRun, nowMs) {
+  return (
+    checkRun?.status === "completed" &&
+    checkRun.conclusion === "success" &&
+    isRecentTimestamp(checkRun.completed_at, nowMs)
   );
 }
 
@@ -258,6 +271,112 @@ function successfulRunOrThrow(
   }
   throw new Error(
     `Missing successful recent ${workflowName} workflow for ${sha}. Observed: ${formatObservedRuns(matchingRuns)}`,
+  );
+}
+
+function checkRunSortTimestamp(checkRun) {
+  return checkRun?.completed_at ?? checkRun?.started_at ?? checkRun?.updated_at ?? "";
+}
+
+// Merge-gate evidence must come from the authoritative CI run: any app can
+// publish a check with a spoofed display name, so bind by the run's own
+// check suite and the GitHub Actions app before trusting it.
+function latestAuthoritativeCheckRun(checkRuns, name, checkSuiteId) {
+  return checkRuns
+    .filter(
+      (checkRun) =>
+        checkRun?.name === name &&
+        checkRun?.app?.slug === "github-actions" &&
+        Number.isFinite(checkSuiteId) &&
+        checkRun?.check_suite?.id === checkSuiteId,
+    )
+    .toSorted((left, right) =>
+      String(checkRunSortTimestamp(right)).localeCompare(String(checkRunSortTimestamp(left))),
+    )[0];
+}
+
+function formatCiGateCheckState(checkRun) {
+  if (!checkRun) {
+    return `${CI_GATE_CHECK_NAME}=missing`;
+  }
+  return `${CI_GATE_CHECK_NAME}=${checkRun.status ?? "unknown"}/${checkRun.conclusion ?? "unknown"}, completed_at=${checkRun.completed_at ?? "unknown"}`;
+}
+
+function successfulCiEvidenceOrThrow(
+  runs,
+  sha,
+  { allowManual = true, nowMs = Date.now(), ciGateJobs = [], fetchCheckRuns } = {},
+) {
+  const matchingRuns = matchingAuthoritativeRuns(runs, "CI", sha, allowManual);
+  let run = preferredCiRun(matchingRuns, nowMs);
+  if (isSuccessfulRecentRun(run, nowMs)) {
+    return { run, ciEvidence: "workflow-run" };
+  }
+
+  let gateProvenRun;
+  try {
+    gateProvenRun = successfulRunOrThrow(runs, "CI", sha, {
+      allowManual,
+      nowMs,
+      ciGateJobs,
+    });
+  } catch {
+    // The check-run path below owns its fail-closed error taxonomy when present.
+  }
+  if (gateProvenRun) {
+    run = gateProvenRun;
+  }
+
+  let ciGateState = "";
+  if (isRecentRun(run, nowMs) && typeof fetchCheckRuns === "function") {
+    let checkRuns;
+    try {
+      checkRuns = fetchCheckRuns(sha);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new CiGateCheckRunsFetchError(`Failed to fetch check runs for ${sha}: ${detail}`, {
+        cause: error,
+      });
+    }
+    if (!Array.isArray(checkRuns)) {
+      throw new CiGateCheckRunsFetchError(
+        `Failed to fetch check runs for ${sha}: expected an array.`,
+      );
+    }
+
+    const ciGateCheck = latestAuthoritativeCheckRun(
+      checkRuns,
+      CI_GATE_CHECK_NAME,
+      run?.check_suite_id,
+    );
+    ciGateState = formatCiGateCheckState(ciGateCheck);
+    // Only the gate check itself decides: commit-level check-runs include
+    // advisory scans and other workflows whose reds do not flip the merge
+    // button, and blocking on them would recreate the straggler problem.
+    // Any terminal non-success (failure, timed_out, cancelled, stale, ...)
+    // blocks hard so the previous-head evidence fallback cannot mask it.
+    if (ciGateCheck?.status === "completed" && ciGateCheck.conclusion !== "success") {
+      throw new BlockingCiGateCheckError(
+        `Missing successful recent CI workflow for ${sha}. Observed: ${formatObservedRuns(matchingRuns)}. CI gate check: ${ciGateState}.`,
+      );
+    }
+    if (isSuccessfulRecentCheckRun(ciGateCheck, nowMs)) {
+      return {
+        run,
+        ciEvidence: "ci-gate-check",
+        ciGateCheckCompletedAt: ciGateCheck.completed_at,
+      };
+    }
+  }
+
+  if (gateProvenRun && typeof fetchCheckRuns !== "function") {
+    return { run: gateProvenRun, ciEvidence: "ci-gate-job" };
+  }
+
+  const checkStateSuffix = ciGateState ? ` CI gate check: ${ciGateState}.` : "";
+  const ErrorType = ciGateState ? CiGateCheckStateError : Error;
+  throw new ErrorType(
+    `Missing successful recent CI workflow for ${sha}. Observed: ${formatObservedRuns(matchingRuns)}.${checkStateSuffix}`,
   );
 }
 
@@ -346,6 +465,7 @@ export function collectHostedGateEvidence({
   pullRequestHeadRepository = "",
   workflowRuns,
   ciGateJobs = [],
+  fetchCheckRuns,
   changelogOnly = false,
   nowMs = Date.now(),
 }) {
@@ -357,15 +477,19 @@ export function collectHostedGateEvidence({
   const collectForSha = (evidenceSha, { allowManual, requiredScheduledWorkflows = new Set() }) => {
     const workflows = [];
     const fallbackCoveredWorkflows = [];
+    let ciEvidence;
+    let ciGateCheckCompletedAt;
     if (!changelogOnly) {
-      workflows.push(
-        successfulRunOrThrow(workflowRuns, "CI", evidenceSha, {
-          allowManual,
-          nowMs,
-          // Gate proof only vouches for the exact head under verification.
-          ciGateJobs: evidenceSha === sha ? ciGateJobs : [],
-        }),
-      );
+      const ci = successfulCiEvidenceOrThrow(workflowRuns, evidenceSha, {
+        allowManual,
+        nowMs,
+        // Gate-job proof only vouches for the exact head under verification.
+        ciGateJobs: evidenceSha === sha ? ciGateJobs : [],
+        fetchCheckRuns,
+      });
+      workflows.push(ci.run);
+      ciEvidence = ci.ciEvidence;
+      ciGateCheckCompletedAt = ci.ciGateCheckCompletedAt;
     }
     for (const workflowName of SCHEDULED_HOSTED_WORKFLOWS) {
       const matchingRuns = matchingAuthoritativeRuns(
@@ -396,7 +520,7 @@ export function collectHostedGateEvidence({
         }),
       );
     }
-    return { workflows, fallbackCoveredWorkflows };
+    return { workflows, fallbackCoveredWorkflows, ciEvidence, ciGateCheckCompletedAt };
   };
 
   let evidenceSha = sha;
@@ -404,6 +528,12 @@ export function collectHostedGateEvidence({
   try {
     selected = collectForSha(sha, { allowManual: true });
   } catch (exactError) {
+    if (
+      exactError instanceof CiGateCheckRunsFetchError ||
+      exactError instanceof BlockingCiGateCheckError
+    ) {
+      throw exactError;
+    }
     // Hosted CI proves the PR cohort, not ancestry freshness. A newer head's
     // failure must not discard a complete same-PR green cohort from the last
     // 24 hours; review and focused gates own the newer delta.
@@ -444,10 +574,21 @@ export function collectHostedGateEvidence({
         evidenceSha = fallbackSha;
         break;
       } catch (error) {
+        if (
+          error instanceof CiGateCheckRunsFetchError ||
+          error instanceof BlockingCiGateCheckError
+        ) {
+          throw error;
+        }
         fallbackError ??= error;
       }
     }
     if (!selected) {
+      if (fallbackError && exactError instanceof CiGateCheckStateError) {
+        throw new Error(`${fallbackError.message} Exact-head ${exactError.message}`, {
+          cause: exactError,
+        });
+      }
       throw fallbackError ?? exactError;
     }
   }
@@ -469,6 +610,12 @@ export function collectHostedGateEvidence({
   };
   if (evidenceSha !== sha) {
     evidence.evidenceHeadSha = evidenceSha;
+  }
+  if (selected.ciEvidence) {
+    evidence.ciEvidence = selected.ciEvidence;
+  }
+  if (selected.ciGateCheckCompletedAt) {
+    evidence.ciGateCheckCompletedAt = selected.ciGateCheckCompletedAt;
   }
   if (selected.fallbackCoveredWorkflows.length > 0) {
     evidence.fallbackCoveredWorkflows = selected.fallbackCoveredWorkflows;
@@ -515,6 +662,34 @@ function loadWorkflowRuns(repo, sha, recentSha, headBranch) {
     loadWorkflowRunsForQuery((page) => withPage(query, page)),
   );
   return [...new Map(workflowRuns.map((run) => [run.id, run])).values()];
+}
+
+function loadCheckRuns(repo, sha) {
+  const loadPage = (page) =>
+    JSON.parse(
+      execGhApiRead(
+        `repos/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}&filter=latest&page=${page}`,
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      ),
+    );
+
+  const firstPage = loadPage(1);
+  if (!Array.isArray(firstPage?.check_runs)) {
+    throw new Error("Expected check_runs to be an array.");
+  }
+  const checkRuns = [...firstPage.check_runs];
+  const pageCount = Math.ceil((firstPage.total_count ?? checkRuns.length) / CHECK_RUNS_PAGE_SIZE);
+  for (let page = 2; page <= pageCount; page += 1) {
+    const nextPage = loadPage(page);
+    if (!Array.isArray(nextPage?.check_runs)) {
+      throw new Error(`Expected check_runs page ${page} to be an array.`);
+    }
+    checkRuns.push(...nextPage.check_runs);
+  }
+  return checkRuns;
 }
 
 export function compareCommitPageCount(totalCommits) {
@@ -640,6 +815,7 @@ function main(argv = process.argv.slice(2)) {
     pullRequestHeadRepository: headRepository,
     workflowRuns,
     ciGateJobs: loadCiGateJobs(args.repo, workflowRuns, args.sha),
+    fetchCheckRuns: (evidenceSha) => loadCheckRuns(args.repo, evidenceSha),
     changelogOnly: args.changelogOnly,
   });
   const evidenceHeadSha = evidence.evidenceHeadSha ?? args.sha;

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -41,6 +41,7 @@ function successfulRun(name: string, id: number, updatedAt: string) {
     path: ".github/workflows/ci.yml",
     created_at: "2026-06-17T10:46:24Z",
     updated_at: updatedAt,
+    check_suite_id: 77_000 + id,
     html_url: `https://github.com/openclaw/openclaw/actions/runs/${id}`,
   };
 }
@@ -50,6 +51,26 @@ function releaseGateRun(id: number, updatedAt: string) {
     ...successfulRun(`CI release gate ${sha}`, id, updatedAt),
     event: "workflow_dispatch",
     display_title: `CI release gate ${sha}`,
+  };
+}
+
+function checkRun(
+  name: string,
+  status: string,
+  conclusion: string | null,
+  completedAt: string | null,
+  // Defaults to CI run id 1's suite with the Actions app identity; spoofing
+  // tests override these to prove the gate rejects foreign producers.
+  { checkSuiteId = 77_001, appSlug = "github-actions" } = {},
+) {
+  return {
+    id: 10_000,
+    name,
+    status,
+    conclusion,
+    completed_at: completedAt,
+    check_suite: { id: checkSuiteId },
+    app: { slug: appSlug },
   };
 }
 
@@ -197,6 +218,7 @@ describe("verify-pr-hosted-gates", () => {
 
     expect(evidence).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [
         expect.objectContaining({ name: "CI", id: 1 }),
         expect.objectContaining({ name: "Blacksmith Testbox", id: 3 }),
@@ -230,8 +252,212 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 1 })],
     });
+  });
+
+  it("accepts a recent successful ci-gate check while the CI run is in progress", () => {
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns: [
+        {
+          ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+          status: "in_progress",
+          conclusion: null,
+        },
+      ],
+      fetchCheckRuns: () => [
+        checkRun("openclaw/ci-gate", "completed", "success", "2026-06-17T10:53:00Z"),
+        checkRun("checks-node", "completed", "success", "2026-06-17T10:52:00Z"),
+      ],
+    });
+
+    expect(evidence).toEqual({
+      headSha: sha,
+      ciEvidence: "ci-gate-check",
+      ciGateCheckCompletedAt: "2026-06-17T10:53:00Z",
+      workflows: [expect.objectContaining({ name: "CI", id: 1, status: "in_progress" })],
+    });
+  });
+
+  it("ignores unrelated red checks when the ci-gate check is green", () => {
+    // Advisory scans and other workflows' reds do not flip the merge button;
+    // blocking on them would recreate the straggler problem this path fixes.
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns: [
+        {
+          ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+          status: "in_progress",
+          conclusion: null,
+        },
+      ],
+      fetchCheckRuns: () => [
+        checkRun("openclaw/ci-gate", "completed", "success", "2026-06-17T10:53:00Z"),
+        checkRun("Scan shared kit from iOS", "completed", "failure", "2026-06-17T10:52:00Z"),
+      ],
+    });
+
+    expect(evidence).toEqual({
+      headSha: sha,
+      ciEvidence: "ci-gate-check",
+      ciGateCheckCompletedAt: "2026-06-17T10:53:00Z",
+      workflows: [expect.objectContaining({ name: "CI", id: 1, status: "in_progress" })],
+    });
+  });
+
+  it("ignores a spoofed ci-gate check from a foreign app or suite", () => {
+    // A non-Actions app (or another workflow's suite) publishing a check named
+    // openclaw/ci-gate must never satisfy the merge gate.
+    for (const spoof of [{ appSlug: "evil-app" }, { checkSuiteId: 99_999 }]) {
+      expect(() =>
+        collectHostedGateEvidence({
+          sha,
+          workflowRuns: [
+            {
+              ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+              status: "in_progress",
+              conclusion: null,
+            },
+          ],
+          fetchCheckRuns: () => [
+            checkRun("openclaw/ci-gate", "completed", "success", "2026-06-17T10:53:00Z", spoof),
+          ],
+        }),
+      ).toThrow("openclaw/ci-gate=missing");
+    }
+  });
+
+  it("rejects a failed ci-gate check even when other checks are green", () => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+        fetchCheckRuns: () => [
+          checkRun("openclaw/ci-gate", "completed", "failure", "2026-06-17T10:53:00Z"),
+          checkRun("checks-node", "completed", "success", "2026-06-17T10:52:00Z"),
+        ],
+      }),
+    ).toThrow("openclaw/ci-gate=completed/failure");
+  });
+
+  it("blocks a cancelled current-head gate instead of reusing older evidence", () => {
+    // A terminal non-success on the current head must fail closed even when a
+    // previous SHA has green evidence available through the recentSha path.
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        recentSha: previousSha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+            head_sha: previousSha,
+          },
+          {
+            ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+        fetchCheckRuns: () => [
+          checkRun("openclaw/ci-gate", "completed", "cancelled", "2026-06-17T10:53:00Z", {
+            checkSuiteId: 77_002,
+          }),
+        ],
+      }),
+    ).toThrow("openclaw/ci-gate=completed/cancelled");
+  });
+
+  it("rejects a timed-out ci-gate check", () => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+        fetchCheckRuns: () => [
+          checkRun("openclaw/ci-gate", "completed", "timed_out", "2026-06-17T10:53:00Z"),
+        ],
+      }),
+    ).toThrow("openclaw/ci-gate=completed/timed_out");
+  });
+
+  it("rejects an in-progress ci-gate check with its state in the error", () => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+        fetchCheckRuns: () => [checkRun("openclaw/ci-gate", "in_progress", null, null)],
+      }),
+    ).toThrow("openclaw/ci-gate=in_progress/unknown");
+  });
+
+  it("rejects a successful ci-gate check older than 24 hours", () => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+        fetchCheckRuns: () => [
+          checkRun("openclaw/ci-gate", "completed", "success", "2026-06-16T10:54:59Z"),
+        ],
+      }),
+    ).toThrow("completed_at=2026-06-16T10:54:59Z");
+  });
+
+  it("does not fetch check runs for a completed successful CI workflow", () => {
+    let fetchCalls = 0;
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns: [successfulRun("CI", 1, "2026-06-17T10:54:00Z")],
+      fetchCheckRuns: () => {
+        fetchCalls += 1;
+        return [];
+      },
+    });
+
+    expect(evidence.ciEvidence).toBe("workflow-run");
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("fails closed when the check-runs fetch fails", () => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:54:00Z"),
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+        fetchCheckRuns: () => {
+          throw new Error("GitHub check-runs API unavailable");
+        },
+      }),
+    ).toThrow("GitHub check-runs API unavailable");
   });
 
   it("accepts 13-hour green evidence from the recorded pre-rebase head", () => {
@@ -254,6 +480,7 @@ describe("verify-pr-hosted-gates", () => {
     expect(evidence).toEqual({
       headSha: sha,
       evidenceHeadSha: previousSha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
     });
   });
@@ -277,6 +504,7 @@ describe("verify-pr-hosted-gates", () => {
     expect(evidence).toEqual({
       headSha: sha,
       evidenceHeadSha: previousSha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
     });
   });
@@ -310,6 +538,7 @@ describe("verify-pr-hosted-gates", () => {
     expect(evidence).toEqual({
       headSha: sha,
       evidenceHeadSha: previousSha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
     });
   });
@@ -428,6 +657,7 @@ describe("verify-pr-hosted-gates", () => {
       expect(evidence).toEqual({
         headSha: sha,
         evidenceHeadSha: previousSha,
+        ciEvidence: "workflow-run",
         workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
       });
     },
@@ -528,6 +758,7 @@ describe("verify-pr-hosted-gates", () => {
     expect(evidence).toEqual({
       headSha: sha,
       evidenceHeadSha: previousSha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
     });
   });
@@ -585,6 +816,7 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 2, headSha: sha })],
     });
   });
@@ -604,6 +836,7 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: sha })],
     });
   });
@@ -622,6 +855,7 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: "CI", id: 2 })],
     });
   });
@@ -641,6 +875,7 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: `CI release gate ${sha}`, id: 1 })],
     });
   });
@@ -672,6 +907,7 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [expect.objectContaining({ name: `CI release gate ${sha}`, id: 2 })],
     });
   });
@@ -727,6 +963,7 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toEqual({
       headSha: sha,
+      ciEvidence: "workflow-run",
       workflows: [
         expect.objectContaining({ name: "CI", id: 3 }),
         expect.objectContaining({ name: "Blacksmith Testbox", id: 4 }),


### PR DESCRIPTION
## What Problem This Solves

`scripts/pr prepare-run` requires the `CI` **workflow-run object** to be `completed`. That object stays open while any job in the run executes — including post-gate stragglers — and flips back to `in_progress` when a single flaky job is rerun, even though `openclaw/ci-gate` (the merge button's signal) already succeeded for the head. Result: agent landings block on a green button until the last slow non-gating lane drains (maintainer-reported today; it has repeatedly stretched landing latency into merge-drift territory).

## Why This Change Was Made

The hosted gate verifier gains a second, tightly-scoped CI acceptance path. When the recent CI run for the head is not completed-successful, it consults the head's check runs (`filter=latest`, paginated by `total_count`) and accepts iff the **`openclaw/ci-gate` check** — which `needs` every merge-blocking job, so its success IS the green button — is completed, successful, and within the existing 24-hour freshness window (`completed_at`, same clock-skew rule).

Hardening from three adversarial review rounds, all fixed with regression tests:

- **No spoofing**: the check must come from the selected CI run's own `check_suite_id` AND the `github-actions` app — a foreign app or workflow publishing a check named `openclaw/ci-gate` reads as `missing`.
- **Fail closed**: check-runs fetch errors or malformed pages throw; they never grant passage.
- **Terminal non-success blocks hard**: a `failure`, `timed_out`, `cancelled`, or any other completed non-success gate on the current head throws immediately, so the previous-head (docs-only) evidence fallback can never mask a red gate.
- **Advisory reds don't block**: failed checks from other workflows/apps (periphery scans etc.) neither grant nor block this path — exactly matching the button semantics that motivated the fix.

The completed-run fast path is byte-for-byte unchanged and performs no additional API calls; evidence JSON records which path passed (`ciEvidence: "workflow-run" | "ci-gate-check"` + the gate's `completed_at`).

## User Impact

Maintainer/agent landings via `scripts/pr` proceed as soon as the merge button is green and fresh (≤24h) instead of idling behind non-gating stragglers or run-level rerun churn. No behavior change for red, stale, or still-pending gates; scheduled Testbox gate rules are untouched.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts` — 54/54 pass (new: in-progress-run + green gate acceptance, advisory-red tolerance, spoofed app/suite rejection, failed/timed-out/cancelled gate blocking incl. the previous-head-fallback bypass regression, staleness at the 24h boundary, fast-path fetcher-not-called, fetch-error fail-closed).
- `node scripts/run-oxlint.mjs scripts/verify-pr-hosted-gates.mjs` clean; oxfmt clean; `git diff --check` clean.
- Autoreview (Codex, gpt-5.6-sol, xhigh): four rounds — surfaced the advisory-red over-blocking, the check-name spoofing hole, and the cancelled-conclusion fallback bypass; all fixed with tests; final pass clean (0.87).
- GitHub REST semantics (filter=latest, 100-item pages, workflow-run `check_suite_id`, check-run `check_suite`/`app`) verified against current docs during review.
