### PR TITLE
refactor(talk): add realtime voice session harness and adopt in google-meet and voice-call

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-4de3095c7c71d6ed2f1744a73373e9b868934a81a1921d7245fae7e64725fb73  plugin-sdk-api-baseline.json
-0cf729db6b115dc8b1cb98a595efeaa5febe4b90d424f5774400176b71561423  plugin-sdk-api-baseline.jsonl
+fc0f82fe0c44af5bde731e7792f5cb4d93e643f7087b60db5f0c92b7309f1350  plugin-sdk-api-baseline.json
+c78cdefd79531c5e3aff099bcebbd228eb8809b9e3e60091fa781b3cbed07114  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -504,7 +504,7 @@ SDK.
   | `plugin-sdk/speech-core` | Shared speech core | Speech provider types, registry, directives, normalization |
   | `plugin-sdk/speech-settings` | Speech settings | Lightweight TTS config resolution and normalization primitives without provider registries or synthesis runtime |
   | `plugin-sdk/realtime-transcription` | Realtime transcription helpers | Provider types, registry helpers, and shared WebSocket session helper |
-  | `plugin-sdk/realtime-voice` | Realtime voice helpers | Provider types, registry/resolution helpers, bridge session helpers, audio-energy/speech-onset gates, shared agent talk-back queues, active-run voice control, transcript/event health, echo suppression, consult question matching, forced-consult coordination, turn-context tracking, output activity tracking, and fast context consult helpers |
+  | `plugin-sdk/realtime-voice` | Realtime voice helpers | Provider types, registry/resolution helpers, bridge session helpers, the transport-independent session harness, audio-energy/speech-onset gates, shared agent talk-back queues, active-run voice control, transcript/event health, echo suppression, consult question matching, forced-consult coordination, turn-context tracking, output activity tracking, and fast context consult helpers |
   | `plugin-sdk/image-generation` | Image-generation helpers | Image generation provider types plus image asset/data URL helpers and the OpenAI-compatible image provider builder |
   | `plugin-sdk/image-generation-core` | Shared image-generation core | Image-generation types, failover, auth, and registry helpers |
   | `plugin-sdk/music-generation` | Music-generation helpers | Music-generation provider/request/result types |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -360,7 +360,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/speech-settings` | Lightweight TTS config resolution and normalization primitives without provider registries or synthesis runtime |
     | `plugin-sdk/realtime-transcription` | Realtime transcription provider types, registry helpers, and shared WebSocket session helper |
     | `plugin-sdk/realtime-bootstrap-context` | Realtime profile bootstrap helper for bounded `IDENTITY.md`, `USER.md`, and `SOUL.md` context injection |
-    | `plugin-sdk/realtime-voice` | Realtime voice provider types, registry helpers, shared audio-energy/speech-onset gates, and realtime voice behavior helpers, including output activity tracking |
+    | `plugin-sdk/realtime-voice` | Realtime voice provider types, registry helpers, shared audio-energy/speech-onset gates, and realtime voice behavior helpers, including the transport-independent session harness and output activity tracking |
     | `plugin-sdk/image-generation` | Image generation provider types plus image asset/data URL helpers and the OpenAI-compatible image provider builder |
     | `plugin-sdk/image-generation-core` | Shared image-generation types, failover, auth, and registry helpers |
     | `plugin-sdk/music-generation` | Music generation provider/request/result types |

--- a/extensions/google-meet/src/realtime.ts
+++ b/extensions/google-meet/src/realtime.ts
@@ -241,7 +241,6 @@ export async function startMeetAgentRealtimeEngine(params: {
     fullConfig: params.fullConfig,
     providers: params.providers,
   });
-  let harness: RealtimeVoiceSessionHarness;
   params.logger.info(
     formatGoogleMeetAgentAudioModelLog({
       provider: resolved.provider,
@@ -325,7 +324,9 @@ export async function startMeetAgentRealtimeEngine(params: {
       });
   };
 
-  harness = createRealtimeVoiceSessionHarness({
+  // The closures above only run after harness creation; they capture this later `const`.
+  // Annotated because the consult closure references harness inside its own initializer.
+  const harness: RealtimeVoiceSessionHarness = createRealtimeVoiceSessionHarness({
     talk: {
       sessionId: `google-meet:${params.meetingSessionId}:agent`,
       mode: "stt-tts",
@@ -485,8 +486,9 @@ export async function startMeetRealtimeEngine(params: {
   providers?: RealtimeVoiceProviderPlugin[];
 }): Promise<MeetRealtimeAudioEngineHandle> {
   let stopped = false;
-  let bridge: RealtimeVoiceBridgeSession | undefined;
-  let harness: RealtimeVoiceSessionHarness;
+  // Not const: the synchronous onFatal replay can run stop() (and its bridge?.close())
+  // before createBridge() below executes; a later `const` would throw at that read.
+  let bridge: RealtimeVoiceBridgeSession | undefined = undefined;
   let realtimeReady = false;
   let lastClearAt: string | undefined;
   let clearCount = 0;
@@ -571,7 +573,9 @@ export async function startMeetRealtimeEngine(params: {
     : { meetingSessionId: params.meetingSessionId };
   const reasonTalkPayload = (reason: string) =>
     params.talkContext ? { bridgeId: params.talkContext.bridgeId, reason } : { reason };
-  harness = createRealtimeVoiceSessionHarness({
+  // The closures above only run after harness creation; they capture this later `const`.
+  // Annotated because the consult closure references harness inside its own initializer.
+  const harness: RealtimeVoiceSessionHarness = createRealtimeVoiceSessionHarness({
     talk: {
       sessionId: params.talkSessionId ?? `google-meet:${params.meetingSessionId}:command-realtime`,
       mode: "realtime",

--- a/extensions/google-meet/src/realtime.ts
+++ b/extensions/google-meet/src/realtime.ts
@@ -10,28 +10,12 @@ import {
   type RealtimeTranscriptionSession,
 } from "openclaw/plugin-sdk/realtime-transcription";
 import {
-  createRealtimeVoiceAgentTalkbackQueue,
-  createRealtimeVoiceBridgeSession,
-  createRealtimeVoiceOutputActivityTracker,
-  createTalkSessionController,
-  extendRealtimeVoiceOutputEchoSuppression,
-  getRealtimeVoiceBridgeEventHealth,
-  getRealtimeVoiceTranscriptHealth,
-  isLikelyRealtimeVoiceAssistantEchoTranscript,
-  recordRealtimeVoiceBridgeEvent,
-  recordTalkObservabilityEvent,
-  recordRealtimeVoiceTranscript,
+  createRealtimeVoiceSessionHarness,
   resolveConfiguredRealtimeVoiceProvider,
-  type RealtimeVoiceAgentTalkbackQueue,
-  type RealtimeVoiceBridgeEventLogEntry,
   type RealtimeVoiceBridgeSession,
-  type RealtimeVoiceOutputActivityTracker,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceProviderPlugin,
-  type RealtimeVoiceTranscriptEntry,
-  type TalkEvent,
-  type TalkEventInput,
-  type TalkSessionController,
+  type RealtimeVoiceSessionHarness,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -65,77 +49,15 @@ type ResolvedRealtimeTranscriptionProvider = {
   providerConfig: RealtimeTranscriptionProviderConfig;
 };
 
-type GoogleMeetRealtimeTranscriptEntry = RealtimeVoiceTranscriptEntry;
-const recordGoogleMeetRealtimeTranscript = recordRealtimeVoiceTranscript;
-
-function getGoogleMeetRealtimeTranscriptHealth(
-  transcript: GoogleMeetRealtimeTranscriptEntry[],
-): Pick<GoogleMeetChromeHealth, keyof ReturnType<typeof getRealtimeVoiceTranscriptHealth>> {
-  return getRealtimeVoiceTranscriptHealth(transcript);
-}
-
-type GoogleMeetRealtimeEventEntry = RealtimeVoiceBridgeEventLogEntry;
-
 const GOOGLE_MEET_AGENT_TRANSCRIPT_DEBOUNCE_MS = 900;
 // Playback duration plus a tail blocks live loopback; transcript lookback catches delayed echo.
 const GOOGLE_MEET_OUTPUT_ECHO_SUPPRESSION_TAIL_MS = 3_000;
 const GOOGLE_MEET_TRANSCRIPT_ECHO_LOOKBACK_MS = 45_000;
 
-function recordGoogleMeetRealtimeEvent(
-  events: GoogleMeetRealtimeEventEntry[],
-  event: Parameters<typeof recordRealtimeVoiceBridgeEvent>[1],
-): void {
-  recordRealtimeVoiceBridgeEvent(events, event);
-}
-
-function getGoogleMeetRealtimeEventHealth(
-  events: GoogleMeetRealtimeEventEntry[],
-): Pick<GoogleMeetChromeHealth, keyof ReturnType<typeof getRealtimeVoiceBridgeEventHealth>> {
-  return getRealtimeVoiceBridgeEventHealth(events);
-}
-
-function isGoogleMeetLikelyAssistantEchoTranscript(params: {
-  transcript: GoogleMeetRealtimeTranscriptEntry[];
-  text: string;
-  nowMs?: number;
-}): boolean {
-  return isLikelyRealtimeVoiceAssistantEchoTranscript({
-    ...params,
-    lookbackMs: GOOGLE_MEET_TRANSCRIPT_ECHO_LOOKBACK_MS,
-  });
-}
-
-function extendGoogleMeetOutputEchoSuppression(params: {
-  audio: Buffer;
-  audioFormat: GoogleMeetConfig["chrome"]["audioFormat"];
-  nowMs: number;
-  lastOutputPlayableUntilMs: number;
-  suppressInputUntilMs: number;
-}): { lastOutputPlayableUntilMs: number; suppressInputUntilMs: number; durationMs: number } {
-  const bytesPerMs = params.audioFormat === "g711-ulaw-8khz" ? 8 : 48;
-  return extendRealtimeVoiceOutputEchoSuppression({
-    ...params,
-    bytesPerMs,
-    tailMs: GOOGLE_MEET_OUTPUT_ECHO_SUPPRESSION_TAIL_MS,
-  });
-}
-
-function recordGoogleMeetOutputActivity(params: {
-  tracker: RealtimeVoiceOutputActivityTracker;
-  audio: Buffer;
-  audioFormat: GoogleMeetConfig["chrome"]["audioFormat"];
-  nowMs: number;
-  lastOutputPlayableUntilMs: number;
-  suppressInputUntilMs: number;
-}): { lastOutputPlayableUntilMs: number; suppressInputUntilMs: number; durationMs: number } {
-  const suppression = extendGoogleMeetOutputEchoSuppression(params);
-  params.tracker.markPlaybackStarted();
-  params.tracker.markAudio({
-    audioMs: suppression.durationMs,
-    sourceAudioBytes: params.audio.byteLength,
-    sinkAudioBytes: params.audio.byteLength,
-  });
-  return suppression;
+function googleMeetOutputBytesPerMs(
+  audioFormat: GoogleMeetConfig["chrome"]["audioFormat"],
+): number {
+  return audioFormat === "g711-ulaw-8khz" ? 8 : 48;
 }
 
 function resolveGoogleMeetRealtimeProvider(params: {
@@ -298,27 +220,6 @@ function normalizeGoogleMeetTtsPromptText(text: string | undefined): string | un
   return trimmed;
 }
 
-function pushGoogleMeetTalkEvent(events: TalkEvent[], event: TalkEvent, maxEntries = 40): void {
-  events.push(event);
-  if (events.length > maxEntries) {
-    events.splice(0, events.length - maxEntries);
-  }
-}
-
-function summarizeGoogleMeetTalkEvents(
-  events: TalkEvent[],
-): NonNullable<GoogleMeetChromeHealth["recentTalkEvents"]> {
-  return events.slice(-20).map((event) => ({
-    id: event.id,
-    type: event.type,
-    sessionId: event.sessionId,
-    turnId: event.turnId,
-    seq: event.seq,
-    timestamp: event.timestamp,
-    final: event.final,
-  }));
-}
-
 export async function startMeetAgentRealtimeEngine(params: {
   config: GoogleMeetConfig;
   fullConfig: OpenClawConfig;
@@ -333,53 +234,14 @@ export async function startMeetAgentRealtimeEngine(params: {
   let stopped = false;
   let sttSession: RealtimeTranscriptionSession | null = null;
   let realtimeReady = false;
-  let lastInputAt: string | undefined;
-  let lastOutputAt: string | undefined;
-  let lastInputBytes = 0;
-  const outputActivity = createRealtimeVoiceOutputActivityTracker();
-  let suppressedInputBytes = 0;
-  let lastSuppressedInputAt: string | undefined;
-  let suppressInputUntil = 0;
-  let lastOutputPlayableUntilMs = 0;
   let ttsQueue = Promise.resolve();
-  const transcript: GoogleMeetRealtimeTranscriptEntry[] = [];
   const agentLogScope = params.logPrefix ? `${params.logPrefix} agent` : "agent";
   const resolved = resolveGoogleMeetRealtimeTranscriptionProvider({
     config: params.config,
     fullConfig: params.fullConfig,
     providers: params.providers,
   });
-  const talk = createTalkSessionController(
-    {
-      sessionId: `google-meet:${params.meetingSessionId}:agent`,
-      mode: "stt-tts",
-      transport: "gateway-relay",
-      brain: "agent-consult",
-      provider: resolved.provider.id,
-      turnIdPrefix: `google-meet:${params.meetingSessionId}:turn`,
-    },
-    { onEvent: recordTalkObservabilityEvent },
-  );
-  const recentTalkEvents: TalkEvent[] = [];
-  const emitTalkEvent = (inputResult: TalkEventInput) =>
-    pushGoogleMeetTalkEvent(recentTalkEvents, talk.emit(inputResult));
-  const ensureTalkTurn = () => {
-    const turn = talk.ensureTurn({
-      payload: { meetingSessionId: params.meetingSessionId },
-    });
-    if (turn.event) {
-      pushGoogleMeetTalkEvent(recentTalkEvents, turn.event);
-    }
-    return turn.turnId;
-  };
-  const endTalkTurn = () => {
-    const ended = talk.endTurn({
-      payload: { meetingSessionId: params.meetingSessionId },
-    });
-    if (ended.ok) {
-      pushGoogleMeetTalkEvent(recentTalkEvents, ended.event);
-    }
-  };
+  let harness: RealtimeVoiceSessionHarness;
   params.logger.info(
     formatGoogleMeetAgentAudioModelLog({
       provider: resolved.provider,
@@ -393,7 +255,7 @@ export async function startMeetAgentRealtimeEngine(params: {
       return;
     }
     stopped = true;
-    agentTalkback?.close();
+    harness.close();
     try {
       sttSession?.close();
     } catch (error) {
@@ -401,7 +263,7 @@ export async function startMeetAgentRealtimeEngine(params: {
         `[google-meet] ${agentLogScope} transcription bridge close ignored: ${formatErrorMessage(error)}`,
       );
     }
-    emitTalkEvent({
+    harness.emit({
       type: "session.closed",
       final: true,
       payload: { meetingSessionId: params.meetingSessionId },
@@ -411,22 +273,8 @@ export async function startMeetAgentRealtimeEngine(params: {
   };
 
   const writeOutputAudio = async (audio: Buffer) => {
-    const suppression = recordGoogleMeetOutputActivity({
-      tracker: outputActivity,
-      audio,
-      audioFormat: params.config.chrome.audioFormat,
-      nowMs: Date.now(),
-      lastOutputPlayableUntilMs,
-      suppressInputUntilMs: suppressInputUntil,
-    });
-    suppressInputUntil = suppression.suppressInputUntilMs;
-    lastOutputPlayableUntilMs = suppression.lastOutputPlayableUntilMs;
-    lastOutputAt = new Date().toISOString();
-    emitTalkEvent({
-      type: "output.audio.delta",
-      turnId: ensureTalkTurn(),
-      payload: { meetingSessionId: params.meetingSessionId, bytes: audio.byteLength },
-    });
+    harness.outputActivity.markPlaybackStarted();
+    harness.recordOutputAudio(audio);
     await params.transport.writeOutput(audio);
   };
 
@@ -440,12 +288,12 @@ export async function startMeetAgentRealtimeEngine(params: {
         if (stopped) {
           return;
         }
-        recordGoogleMeetRealtimeTranscript(transcript, "assistant", normalized);
+        harness.recordTranscript("assistant", normalized);
         params.logger.info(
           formatGoogleMeetTranscriptSummaryLog(`${agentLogScope} assistant`, normalized),
         );
-        const turnId = ensureTalkTurn();
-        emitTalkEvent({
+        const turnId = harness.ensureTurn();
+        harness.emit({
           type: "output.text.done",
           turnId,
           final: true,
@@ -459,11 +307,6 @@ export async function startMeetAgentRealtimeEngine(params: {
           throw new Error(result.error ?? "TTS conversion failed");
         }
         params.logger.info(formatGoogleMeetAgentTtsResultLog(agentLogScope, result));
-        emitTalkEvent({
-          type: "output.audio.started",
-          turnId,
-          payload: { meetingSessionId: params.meetingSessionId },
-        });
         await writeOutputAudio(
           convertGoogleMeetTtsAudioForBridge(
             result.audioBuffer,
@@ -472,13 +315,8 @@ export async function startMeetAgentRealtimeEngine(params: {
             result.outputFormat,
           ),
         );
-        emitTalkEvent({
-          type: "output.audio.done",
-          turnId,
-          final: true,
-          payload: { meetingSessionId: params.meetingSessionId },
-        });
-        endTalkTurn();
+        harness.finishOutputAudio("completed");
+        harness.endTurn();
       })
       .catch((error: unknown) => {
         params.logger.warn(
@@ -487,10 +325,36 @@ export async function startMeetAgentRealtimeEngine(params: {
       });
   };
 
-  const agentTalkback: RealtimeVoiceAgentTalkbackQueue | undefined =
-    createRealtimeVoiceAgentTalkbackQueue({
+  harness = createRealtimeVoiceSessionHarness({
+    talk: {
+      sessionId: `google-meet:${params.meetingSessionId}:agent`,
+      mode: "stt-tts",
+      transport: "gateway-relay",
+      brain: "agent-consult",
+      provider: resolved.provider.id,
+      turnIdPrefix: `google-meet:${params.meetingSessionId}:turn`,
+    },
+    talkPayloads: {
+      turnStarted: () => ({ meetingSessionId: params.meetingSessionId }),
+      turnEnded: () => ({ meetingSessionId: params.meetingSessionId }),
+      inputAudioDelta: (audio) => ({
+        meetingSessionId: params.meetingSessionId,
+        bytes: audio.byteLength,
+      }),
+      outputAudioStarted: () => ({ meetingSessionId: params.meetingSessionId }),
+      outputAudioDelta: (audio) => ({
+        meetingSessionId: params.meetingSessionId,
+        bytes: audio.byteLength,
+      }),
+      outputAudioDone: () => ({ meetingSessionId: params.meetingSessionId }),
+    },
+    echoSuppression: {
+      bytesPerMs: googleMeetOutputBytesPerMs(params.config.chrome.audioFormat),
+      tailMs: GOOGLE_MEET_OUTPUT_ECHO_SUPPRESSION_TAIL_MS,
+      transcriptLookbackMs: GOOGLE_MEET_TRANSCRIPT_ECHO_LOOKBACK_MS,
+    },
+    talkback: {
       debounceMs: GOOGLE_MEET_AGENT_TRANSCRIPT_DEBOUNCE_MS,
-      isStopped: () => stopped,
       logger: params.logger,
       logPrefix: `[google-meet] ${agentLogScope}`,
       responseStyle: "Brief, natural spoken answer for a live meeting.",
@@ -504,10 +368,11 @@ export async function startMeetAgentRealtimeEngine(params: {
           meetingSessionId: params.meetingSessionId,
           requesterSessionKey: params.requesterSessionKey,
           args: { question, responseStyle },
-          transcript,
+          transcript: harness.transcript,
         }),
       deliver: enqueueSpeakText,
-    });
+    },
+  });
 
   params.transport.onFatal(() => {
     void stop();
@@ -526,22 +391,22 @@ export async function startMeetAgentRealtimeEngine(params: {
       if (!trimmed || stopped) {
         return;
       }
-      const turnId = ensureTalkTurn();
-      emitTalkEvent({
+      const turnId = harness.ensureTurn();
+      harness.emit({
         type: "input.audio.committed",
         turnId,
         final: true,
         payload: { meetingSessionId: params.meetingSessionId },
       });
-      emitTalkEvent({
+      harness.emit({
         type: "transcript.done",
         turnId,
         final: true,
         payload: { meetingSessionId: params.meetingSessionId, text: trimmed, role: "user" },
       });
-      recordGoogleMeetRealtimeTranscript(transcript, "user", trimmed);
+      harness.recordTranscript("user", trimmed);
       params.logger.info(formatGoogleMeetTranscriptSummaryLog(`${agentLogScope} user`, trimmed));
-      if (isGoogleMeetLikelyAssistantEchoTranscript({ transcript, text: trimmed })) {
+      if (harness.isLikelyAssistantEchoTranscript(trimmed)) {
         params.logger.info(
           formatGoogleMeetTranscriptSummaryLog(
             `${agentLogScope} ignored assistant echo transcript`,
@@ -550,13 +415,13 @@ export async function startMeetAgentRealtimeEngine(params: {
         );
         return;
       }
-      agentTalkback?.enqueue(trimmed);
+      harness.talkback?.enqueue(trimmed);
     },
     onError: (error) => {
       params.logger.warn(
         `[google-meet] ${agentLogScope} transcription bridge failed: ${formatErrorMessage(error)}`,
       );
-      emitTalkEvent({
+      harness.emit({
         type: "session.error",
         final: true,
         payload: { meetingSessionId: params.meetingSessionId, error: formatErrorMessage(error) },
@@ -565,7 +430,7 @@ export async function startMeetAgentRealtimeEngine(params: {
     },
   });
 
-  emitTalkEvent({
+  harness.emit({
     type: "session.started",
     payload: { meetingSessionId: params.meetingSessionId, provider: resolved.provider.id },
   });
@@ -575,18 +440,9 @@ export async function startMeetAgentRealtimeEngine(params: {
     if (stopped || !realtimeReady || audio.byteLength === 0) {
       return;
     }
-    if (Date.now() < suppressInputUntil) {
-      lastSuppressedInputAt = new Date().toISOString();
-      suppressedInputBytes += audio.byteLength;
+    if (!harness.recordInputAudio(audio)) {
       return;
     }
-    lastInputAt = new Date().toISOString();
-    lastInputBytes += audio.byteLength;
-    emitTalkEvent({
-      type: "input.audio.delta",
-      turnId: ensureTalkTurn(),
-      payload: { meetingSessionId: params.meetingSessionId, bytes: audio.byteLength },
-    });
     sttSession?.sendAudio(convertGoogleMeetBridgeAudioForStt(audio, params.config));
   });
 
@@ -595,7 +451,7 @@ export async function startMeetAgentRealtimeEngine(params: {
     throw new Error("Google Meet audio transport stopped during transcription provider setup");
   }
   realtimeReady = true;
-  emitTalkEvent({
+  harness.emit({
     type: "session.ready",
     payload: { meetingSessionId: params.meetingSessionId },
   });
@@ -604,19 +460,11 @@ export async function startMeetAgentRealtimeEngine(params: {
     providerId: resolved.provider.id,
     speak: enqueueSpeakText,
     getHealth: () => ({
-      providerConnected: sttSession?.isConnected() ?? false,
-      realtimeReady,
-      audioInputActive: lastInputBytes > 0,
-      audioOutputActive: outputActivity.isActive(),
-      lastInputAt,
-      lastOutputAt,
-      lastSuppressedInputAt,
-      lastInputBytes,
-      lastOutputBytes: outputActivity.snapshot().sinkAudioBytes,
-      suppressedInputBytes,
+      ...harness.getHealth({
+        providerConnected: sttSession?.isConnected() ?? false,
+        realtimeReady,
+      }),
       ...params.transport.getHealth?.(),
-      ...getGoogleMeetRealtimeTranscriptHealth(transcript),
-      recentTalkEvents: summarizeGoogleMeetTalkEvents(recentTalkEvents),
       bridgeClosed: stopped,
     }),
     stop,
@@ -637,39 +485,19 @@ export async function startMeetRealtimeEngine(params: {
   providers?: RealtimeVoiceProviderPlugin[];
 }): Promise<MeetRealtimeAudioEngineHandle> {
   let stopped = false;
-  let bridge: RealtimeVoiceBridgeSession | null = null;
+  let bridge: RealtimeVoiceBridgeSession | undefined;
+  let harness: RealtimeVoiceSessionHarness;
   let realtimeReady = false;
-  let lastInputAt: string | undefined;
-  let lastOutputAt: string | undefined;
-  let lastInputBytes = 0;
-  const outputActivity = createRealtimeVoiceOutputActivityTracker();
   let lastClearAt: string | undefined;
   let clearCount = 0;
-  let suppressedInputBytes = 0;
-  let lastSuppressedInputAt: string | undefined;
-  let suppressInputUntil = 0;
-  let lastOutputPlayableUntilMs = 0;
   const realtimeLogScope = params.logPrefix ? `${params.logPrefix} realtime` : "realtime";
-
-  const suppressInputForOutput = (audio: Buffer) => {
-    const suppression = recordGoogleMeetOutputActivity({
-      tracker: outputActivity,
-      audio,
-      audioFormat: params.config.chrome.audioFormat,
-      nowMs: Date.now(),
-      lastOutputPlayableUntilMs,
-      suppressInputUntilMs: suppressInputUntil,
-    });
-    suppressInputUntil = suppression.suppressInputUntilMs;
-    lastOutputPlayableUntilMs = suppression.lastOutputPlayableUntilMs;
-  };
 
   const stop = async () => {
     if (stopped) {
       return;
     }
     stopped = true;
-    agentTalkback?.close();
+    harness.close();
     try {
       bridge?.close();
     } catch (error) {
@@ -686,8 +514,6 @@ export async function startMeetRealtimeEngine(params: {
     }
     clearCount += 1;
     lastClearAt = new Date().toISOString();
-    suppressInputUntil = 0;
-    lastOutputPlayableUntilMs = 0;
     void params.transport.clearOutput().catch((error: unknown) => {
       params.logger.warn(
         `[google-meet] ${params.logPrefix ? `${params.logPrefix} audio clear` : "audio output clear"} failed: ${formatErrorMessage(error)}`,
@@ -708,22 +534,16 @@ export async function startMeetRealtimeEngine(params: {
       return;
     }
     params.transport.startBargeInMonitor(() => {
-      if (stopped || !outputActivity.isInterruptible()) {
+      if (stopped || !harness.outputActivity.isInterruptible()) {
         return false;
       }
       const now = Date.now();
-      const playbackActive = now <= Math.max(lastOutputPlayableUntilMs, suppressInputUntil);
-      const lastOutputAudioAt = outputActivity.snapshot().lastAudioAt;
+      const playbackActive = harness.isOutputPlaybackWindowActive();
+      const lastOutputAudioAt = harness.outputActivity.snapshot().lastAudioAt;
       if (!playbackActive && (lastOutputAudioAt === undefined || now - lastOutputAudioAt > 1_000)) {
         return false;
       }
-      suppressInputUntil = 0;
-      const beforeClearCount = clearCount;
-      bridge?.handleBargeIn({ audioPlaybackActive: true });
-      // Provider clear callbacks normally flush; this fallback keeps barge-in and playback coupled.
-      if (beforeClearCount === clearCount) {
-        clearOutputPlayback();
-      }
+      harness.handleBargeIn({ audioPlaybackActive: true }, clearOutputPlayback);
       return true;
     });
   };
@@ -743,19 +563,6 @@ export async function startMeetRealtimeEngine(params: {
       audioFormat: params.config.chrome.audioFormat,
     }),
   );
-  const transcript: GoogleMeetRealtimeTranscriptEntry[] = [];
-  const realtimeEvents: GoogleMeetRealtimeEventEntry[] = [];
-  const talk: TalkSessionController = createTalkSessionController(
-    {
-      sessionId: params.talkSessionId ?? `google-meet:${params.meetingSessionId}:command-realtime`,
-      mode: "realtime",
-      transport: "gateway-relay",
-      brain: strategy === "bidi" ? "direct-tools" : "agent-consult",
-      provider: resolved.provider.id,
-    },
-    { onEvent: recordTalkObservabilityEvent },
-  );
-  const recentTalkEvents: TalkEvent[] = [];
   const meetingTalkPayload = params.talkContext
     ? { bridgeId: params.talkContext.bridgeId, meetingSessionId: params.meetingSessionId }
     : { meetingSessionId: params.meetingSessionId };
@@ -764,48 +571,29 @@ export async function startMeetRealtimeEngine(params: {
     : { meetingSessionId: params.meetingSessionId };
   const reasonTalkPayload = (reason: string) =>
     params.talkContext ? { bridgeId: params.talkContext.bridgeId, reason } : { reason };
-  const rememberTalkEvent = (event: TalkEvent | undefined): void => {
-    if (event) {
-      pushGoogleMeetTalkEvent(recentTalkEvents, event);
-    }
-  };
-  const emitTalkEvent = (inputValue: TalkEventInput): void => {
-    rememberTalkEvent(talk.emit(inputValue));
-  };
-  const ensureTalkTurn = (): string => {
-    const turn = talk.ensureTurn({
-      payload: meetingTalkPayload,
-    });
-    if (turn.event) {
-      rememberTalkEvent(turn.event);
-    }
-    return turn.turnId;
-  };
-  const finishOutputAudio = (reason: string): void => {
-    rememberTalkEvent(
-      talk.finishOutputAudio({
-        payload: reasonTalkPayload(reason),
-      }),
-    );
-  };
-  const endTalkTurn = (reason = "completed"): void => {
-    const ended = talk.endTurn({
-      payload: reasonTalkPayload(reason),
-    });
-    if (ended.ok) {
-      rememberTalkEvent(ended.event);
-    }
-  };
-  emitTalkEvent({
-    type: "session.started",
-    payload: params.talkContext
-      ? { ...meetingTalkPayload, nodeId: params.talkContext.nodeId }
-      : meetingTalkPayload,
-  });
-  const agentTalkback: RealtimeVoiceAgentTalkbackQueue | undefined =
-    createRealtimeVoiceAgentTalkbackQueue({
+  harness = createRealtimeVoiceSessionHarness({
+    talk: {
+      sessionId: params.talkSessionId ?? `google-meet:${params.meetingSessionId}:command-realtime`,
+      mode: "realtime",
+      transport: "gateway-relay",
+      brain: strategy === "bidi" ? "direct-tools" : "agent-consult",
+      provider: resolved.provider.id,
+    },
+    talkPayloads: {
+      turnStarted: () => meetingTalkPayload,
+      turnEnded: reasonTalkPayload,
+      inputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+      outputAudioStarted: () => outputTalkPayload,
+      outputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+      outputAudioDone: reasonTalkPayload,
+    },
+    echoSuppression: {
+      bytesPerMs: googleMeetOutputBytesPerMs(params.config.chrome.audioFormat),
+      tailMs: GOOGLE_MEET_OUTPUT_ECHO_SUPPRESSION_TAIL_MS,
+      transcriptLookbackMs: GOOGLE_MEET_TRANSCRIPT_ECHO_LOOKBACK_MS,
+    },
+    talkback: {
       debounceMs: GOOGLE_MEET_AGENT_TRANSCRIPT_DEBOUNCE_MS,
-      isStopped: () => stopped,
       logger: params.logger,
       logPrefix: `[google-meet] ${realtimeLogScope} agent`,
       responseStyle: "Brief, natural spoken answer for a live meeting.",
@@ -819,12 +607,19 @@ export async function startMeetRealtimeEngine(params: {
           meetingSessionId: params.meetingSessionId,
           requesterSessionKey: params.requesterSessionKey,
           args: { question, responseStyle },
-          transcript,
+          transcript: harness.transcript,
         }),
       deliver: (text) => {
         bridge?.sendUserMessage(buildGoogleMeetSpeakExactUserMessage(text));
       },
-    });
+    },
+  });
+  harness.emit({
+    type: "session.started",
+    payload: params.talkContext
+      ? { ...meetingTalkPayload, nodeId: params.talkContext.nodeId }
+      : meetingTalkPayload,
+  });
   params.transport.onFatal(() => {
     void stop();
   });
@@ -833,7 +628,7 @@ export async function startMeetRealtimeEngine(params: {
   if (stopped) {
     throw new Error("Google Meet audio transport failed before realtime provider setup");
   }
-  bridge = createRealtimeVoiceBridgeSession({
+  bridge = harness.createBridge({
     provider: resolved.provider,
     cfg: params.fullConfig,
     providerConfig: resolved.providerConfig,
@@ -848,29 +643,17 @@ export async function startMeetRealtimeEngine(params: {
     audioSink: {
       isOpen: () => !stopped,
       sendAudio: (audio) => {
-        const turnId = ensureTalkTurn();
-        rememberTalkEvent(
-          talk.startOutputAudio({
-            turnId,
-            payload: outputTalkPayload,
-          }).event,
-        );
-        emitTalkEvent({
-          type: "output.audio.delta",
-          turnId,
-          payload: { byteLength: audio.byteLength },
-        });
-        lastOutputAt = new Date().toISOString();
-        suppressInputForOutput(audio);
+        harness.outputActivity.markPlaybackStarted();
+        harness.recordOutputAudio(audio);
         writeOutputAudio(audio);
       },
       clearAudio: () => {
-        clearOutputPlayback();
-        finishOutputAudio("clear");
+        harness.flushOutput(clearOutputPlayback);
+        harness.finishOutputAudio("clear");
       },
     },
     onTranscript: (role, text, isFinal) => {
-      const turnId = ensureTalkTurn();
+      const turnId = harness.ensureTurn();
       const eventType =
         role === "assistant"
           ? isFinal
@@ -880,14 +663,14 @@ export async function startMeetRealtimeEngine(params: {
             ? "transcript.done"
             : "transcript.delta";
       const payload = role === "assistant" ? { text } : { role, text };
-      emitTalkEvent({
+      harness.emit({
         type: eventType,
         turnId,
         payload,
         final: isFinal,
       });
       if (role === "user" && isFinal) {
-        emitTalkEvent({
+        harness.emit({
           type: "input.audio.committed",
           turnId,
           payload: outputTalkPayload,
@@ -895,12 +678,11 @@ export async function startMeetRealtimeEngine(params: {
         });
       }
       if (isFinal) {
-        recordGoogleMeetRealtimeTranscript(transcript, role, text);
         params.logger.info(
           formatGoogleMeetTranscriptSummaryLog(`${realtimeLogScope} ${role}`, text),
         );
         if (role === "user" && strategy === "agent") {
-          if (isGoogleMeetLikelyAssistantEchoTranscript({ transcript, text })) {
+          if (harness.isLikelyAssistantEchoTranscript(text)) {
             params.logger.info(
               formatGoogleMeetTranscriptSummaryLog(
                 `${realtimeLogScope} ignored assistant echo transcript`,
@@ -909,30 +691,29 @@ export async function startMeetRealtimeEngine(params: {
             );
             return;
           }
-          agentTalkback?.enqueue(text);
+          harness.talkback?.enqueue(text);
         }
       }
     },
     onEvent: (event) => {
-      recordGoogleMeetRealtimeEvent(realtimeEvents, event);
       if (event.type === "input_audio_buffer.speech_started") {
-        ensureTalkTurn();
+        harness.ensureTurn();
       } else if (event.type === "input_audio_buffer.speech_stopped") {
-        const turnId = talk.activeTurnId;
+        const turnId = harness.talk.activeTurnId;
         if (!turnId) {
           return;
         }
-        emitTalkEvent({
+        harness.emit({
           type: "input.audio.committed",
           turnId,
           payload: { ...outputTalkPayload, source: event.type },
           final: true,
         });
       } else if (event.type === "response.done") {
-        finishOutputAudio("response.done");
-        endTalkTurn("response.done");
+        harness.finishOutputAudio("response.done");
+        harness.endTurn("response.done");
       } else if (event.type === "error") {
-        emitTalkEvent({
+        harness.emit({
           type: "session.error",
           payload: { message: event.detail ?? "Realtime provider error" },
           final: true,
@@ -953,14 +734,14 @@ export async function startMeetRealtimeEngine(params: {
       }
     },
     onToolCall: (event, session) => {
-      emitTalkEvent({
+      harness.emit({
         type: "tool.call",
-        turnId: ensureTalkTurn(),
+        turnId: harness.ensureTurn(),
         itemId: event.itemId,
         callId: event.callId,
         payload: { name: event.name, args: event.args },
       });
-      const turnId = ensureTalkTurn();
+      const turnId = harness.ensureTurn();
       return handleGoogleMeetRealtimeConsultToolCall({
         strategy,
         session,
@@ -971,13 +752,13 @@ export async function startMeetRealtimeEngine(params: {
         logger: params.logger,
         meetingSessionId: params.meetingSessionId,
         requesterSessionKey: params.requesterSessionKey,
-        transcript,
+        transcript: harness.transcript,
         onTalkEvent: (inputLocal) =>
-          emitTalkEvent({ ...inputLocal, turnId: inputLocal.turnId ?? turnId }),
+          harness.emit({ ...inputLocal, turnId: inputLocal.turnId ?? turnId }),
       });
     },
     onError: (error) => {
-      emitTalkEvent({
+      harness.emit({
         type: "session.error",
         payload: { message: formatErrorMessage(error) },
         final: true,
@@ -989,8 +770,8 @@ export async function startMeetRealtimeEngine(params: {
     },
     onClose: (reason) => {
       realtimeReady = false;
-      finishOutputAudio(reason);
-      emitTalkEvent({
+      harness.finishOutputAudio(reason);
+      harness.emit({
         type: "session.closed",
         payload: { reason },
         final: true,
@@ -1001,7 +782,7 @@ export async function startMeetRealtimeEngine(params: {
     },
     onReady: () => {
       realtimeReady = true;
-      emitTalkEvent({
+      harness.emit({
         type: "session.ready",
         payload: outputTalkPayload,
       });
@@ -1016,18 +797,9 @@ export async function startMeetRealtimeEngine(params: {
     if (stopped || audio.byteLength === 0) {
       return;
     }
-    if (Date.now() < suppressInputUntil) {
-      lastSuppressedInputAt = new Date().toISOString();
-      suppressedInputBytes += audio.byteLength;
+    if (!harness.recordInputAudio(audio)) {
       return;
     }
-    lastInputAt = new Date().toISOString();
-    lastInputBytes += audio.byteLength;
-    emitTalkEvent({
-      type: "input.audio.delta",
-      turnId: ensureTalkTurn(),
-      payload: { byteLength: audio.byteLength },
-    });
     bridge?.sendAudio(audio);
   });
 
@@ -1042,20 +814,11 @@ export async function startMeetRealtimeEngine(params: {
       bridge?.triggerGreeting(instructions);
     },
     getHealth: () => ({
-      providerConnected: bridge?.bridge.isConnected() ?? false,
-      realtimeReady,
-      audioInputActive: lastInputBytes > 0,
-      audioOutputActive: outputActivity.isActive(),
-      lastInputAt,
-      lastOutputAt,
-      lastSuppressedInputAt,
-      lastInputBytes,
-      lastOutputBytes: outputActivity.snapshot().sinkAudioBytes,
-      suppressedInputBytes,
+      ...harness.getHealth({
+        providerConnected: bridge?.bridge.isConnected() ?? false,
+        realtimeReady,
+      }),
       ...params.transport.getHealth?.(),
-      ...getGoogleMeetRealtimeTranscriptHealth(transcript),
-      ...getGoogleMeetRealtimeEventHealth(realtimeEvents),
-      recentTalkEvents: summarizeGoogleMeetTalkEvents(recentTalkEvents),
       lastClearAt,
       clearCount,
       bridgeClosed: stopped,

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -3,8 +3,8 @@ import http from "node:http";
 import { expectDefined } from "@openclaw/normalization-core";
 import type {
   RealtimeVoiceBridge,
-  RealtimeVoiceForcedConsultCoordinator,
   RealtimeVoiceProviderPlugin,
+  RealtimeVoiceSessionHarness,
   RealtimeVoiceToolCallEvent,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -16,7 +16,26 @@ import type { CallRecord, NormalizedEvent } from "../types.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
 import { RealtimeCallHandler } from "./realtime-handler.js";
 
+const realtimeVoiceHarnessTestHooks = vi.hoisted(() => ({
+  onCreate: undefined as ((harness: RealtimeVoiceSessionHarness) => void) | undefined,
+}));
+
+vi.mock("openclaw/plugin-sdk/realtime-voice", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/realtime-voice")>();
+  return {
+    ...actual,
+    createRealtimeVoiceSessionHarness: (
+      params: Parameters<typeof actual.createRealtimeVoiceSessionHarness>[0],
+    ) => {
+      const harness = actual.createRealtimeVoiceSessionHarness(params);
+      realtimeVoiceHarnessTestHooks.onCreate?.(harness);
+      return harness;
+    },
+  };
+});
+
 afterEach(() => {
+  realtimeVoiceHarnessTestHooks.onCreate = undefined;
   vi.useRealTimers();
 });
 
@@ -1253,6 +1272,10 @@ describe("RealtimeCallHandler path routing", () => {
           }) => void;
         }
       | undefined;
+    let sessionHarness: RealtimeVoiceSessionHarness | undefined;
+    realtimeVoiceHarnessTestHooks.onCreate = (harness) => {
+      sessionHarness = harness;
+    };
     const submitToolResult = vi.fn();
     const createBridge = vi.fn(
       (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
@@ -1279,17 +1302,6 @@ describe("RealtimeCallHandler path routing", () => {
     });
     const consult = vi.fn(async () => ({ text: "should not run" }));
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const coordinator = (
-      handler as unknown as {
-        forcedConsultCoordinator(callId: string): RealtimeVoiceForcedConsultCoordinator;
-      }
-    ).forcedConsultCoordinator(call.callId);
-    const cancelled = coordinator.prepare("cancelled question");
-    if (!cancelled) {
-      throw new Error("expected forced consult handle");
-    }
-    coordinator.markStarted(cancelled);
-    coordinator.markCancelled(cancelled);
     const server = await startRealtimeServer(handler);
 
     try {
@@ -1303,7 +1315,19 @@ describe("RealtimeCallHandler path routing", () => {
         );
         await waitForRealtimeTest(() => {
           expect(createBridge).toHaveBeenCalled();
+          expect(sessionHarness).toBeDefined();
         });
+
+        const coordinator = expectDefined(
+          sessionHarness,
+          "voice-call realtime session harness",
+        ).forcedConsults;
+        const cancelled = coordinator.prepare("cancelled question");
+        if (!cancelled) {
+          throw new Error("expected forced consult handle");
+        }
+        coordinator.markStarted(cancelled);
+        coordinator.markCancelled(cancelled);
 
         callbacks?.onToolCall?.({
           itemId: "item-cancelled",

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -11,22 +11,17 @@ import {
 import {
   buildRealtimeVoiceAgentConsultWorkingResponse,
   calculateMulawRms,
-  createRealtimeVoiceForcedConsultCoordinator,
+  createRealtimeVoiceSessionHarness,
   createSpeechThresholdGate,
-  createTalkSessionController,
-  createRealtimeVoiceBridgeSession,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   readRealtimeVoiceConsultQuestion,
   readSpeakableRealtimeVoiceToolResult,
-  recordTalkObservabilityEvent,
-  type RealtimeVoiceForcedConsultCoordinator,
   type RealtimeVoiceForcedConsultHandle,
   type RealtimeVoiceBridgeSession,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceProviderPlugin,
+  type RealtimeVoiceSessionHarness,
   type TalkEvent,
-  type TalkEventInput,
-  type TalkSessionController,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -331,10 +326,6 @@ export class RealtimeCallHandler {
     string,
     ReturnType<typeof setTimeout>
   >();
-  private readonly forcedConsultCoordinatorsByCallId = new Map<
-    string,
-    RealtimeVoiceForcedConsultCoordinator
-  >();
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
   private publicOrigin: string | null = null;
@@ -580,47 +571,24 @@ export class RealtimeCallHandler {
 
     const { callId, instructions, initialGreetingInstructions } = registration;
     const callRecord = this.manager.getCallByProviderCallId(callSid);
-    const talk: TalkSessionController = createTalkSessionController(
-      {
+    const harness = createRealtimeVoiceSessionHarness({
+      talk: {
         sessionId: `voice-call:${callId}:realtime`,
         mode: "realtime",
         transport: "gateway-relay",
         brain: "agent-consult",
         provider: this.realtimeProvider.id,
       },
-      { onEvent: recordTalkObservabilityEvent },
-    );
-    const rememberTalkEvent = (event: TalkEvent | undefined): TalkEvent | undefined => {
-      if (event) {
-        appendRecentTalkEventMetadata(callRecord, event);
-      }
-      return event;
-    };
-    const emitTalkEvent = (input: TalkEventInput): TalkEvent => {
-      return rememberTalkEvent(talk.emit(input)) as TalkEvent;
-    };
-    const ensureTalkTurn = (): string => {
-      const turn = talk.ensureTurn({
-        payload: { callId, providerCallId: callSid },
-      });
-      rememberTalkEvent(turn.event);
-      return turn.turnId;
-    };
-    const endTalkTurn = (reason = "completed"): void => {
-      const ended = talk.endTurn({
-        payload: { callId, providerCallId: callSid, reason },
-      });
-      if (ended.ok) {
-        rememberTalkEvent(ended.event);
-      }
-    };
-    const finishOutputAudio = (reason: string): void => {
-      rememberTalkEvent(
-        talk.finishOutputAudio({
-          payload: { callId, providerCallId: callSid, reason },
-        }),
-      );
-    };
+      talkPayloads: {
+        turnStarted: () => ({ callId, providerCallId: callSid }),
+        turnEnded: (reason) => ({ callId, providerCallId: callSid, reason }),
+        inputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+        outputAudioStarted: () => ({ callId, providerCallId: callSid }),
+        outputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+        outputAudioDone: (reason) => ({ callId, providerCallId: callSid, reason }),
+      },
+      onTalkEvent: (event) => appendRecentTalkEventMetadata(callRecord, event),
+    });
     const providerHandlesInputAudioBargeIn =
       this.realtimeProvider.capabilities?.handlesInputAudioBargeIn === true;
     const cancelOutputAudioForBargeIn = (
@@ -628,7 +596,7 @@ export class RealtimeCallHandler {
       interruptProvider?: (audioPlaybackActive: boolean) => void,
       clearedAudioBytes = 0,
     ): void => {
-      const outputAudioActive = talk.outputAudioActive;
+      const outputAudioActive = harness.talk.outputAudioActive;
       const pendingTelephonyAudio = audioPacer.hasPendingAudio();
       if (
         source === "provider" &&
@@ -640,7 +608,7 @@ export class RealtimeCallHandler {
       }
       // Capture playback before provider interruption. Local fallback must clear
       // telephony even after pacing drains because the remote stream buffers audio.
-      const interruptedTurnId = talk.activeTurnId;
+      const interruptedTurnId = harness.talk.activeTurnId;
       interruptProvider?.(outputAudioActive || pendingTelephonyAudio);
       const shouldClearTelephony = source === "local" || pendingTelephonyAudio;
       const clearedBytes = clearedAudioBytes + (shouldClearTelephony ? audioPacer.clearAudio() : 0);
@@ -651,16 +619,13 @@ export class RealtimeCallHandler {
         return;
       }
       const reason = `${source}-barge-in`;
-      finishOutputAudio(reason);
-      const cancelled = talk.cancelTurn({
+      harness.finishOutputAudio(reason);
+      harness.talk.cancelTurn({
         turnId: interruptedTurnId,
         payload: { callId, providerCallId: callSid, reason },
       });
-      if (cancelled.ok) {
-        rememberTalkEvent(cancelled.event);
-      }
     };
-    emitTalkEvent({
+    harness.emit({
       type: "session.started",
       payload: { callId, providerCallId: callSid, streamSid },
     });
@@ -722,7 +687,7 @@ export class RealtimeCallHandler {
       typeof this.providerConfig.interruptResponseOnInputAudio === "boolean"
         ? this.providerConfig.interruptResponseOnInputAudio
         : undefined;
-    const session = createRealtimeVoiceBridgeSession({
+    const session = harness.createBridge({
       provider: this.realtimeProvider,
       cfg: this.coreConfig,
       providerConfig: this.providerConfig,
@@ -734,37 +699,28 @@ export class RealtimeCallHandler {
       audioSink: {
         isOpen: () => ws.readyState === WebSocket.OPEN,
         sendAudio: (muLaw) => {
-          const turnId = ensureTalkTurn();
-          rememberTalkEvent(
-            talk.startOutputAudio({
-              turnId,
-              payload: { callId, providerCallId: callSid },
-            }).event,
-          );
-          emitTalkEvent({
-            type: "output.audio.delta",
-            turnId,
-            payload: { byteLength: muLaw.length },
-          });
+          harness.recordOutputAudio(muLaw);
           audioPacer.sendAudio(muLaw);
         },
         clearAudio: (reason) => {
-          const clearedBytes = audioPacer.clearAudio();
-          if (reason === "barge-in") {
-            cancelOutputAudioForBargeIn("provider", undefined, clearedBytes);
-            return;
-          }
-          console.log(
-            `[voice-call] realtime outbound audio clear requested callId=${callId} providerCallId=${callSid} queuedBytes=${clearedBytes}`,
-          );
-          finishOutputAudio("clear");
+          harness.flushOutput(() => {
+            const clearedBytes = audioPacer.clearAudio();
+            if (reason === "barge-in") {
+              cancelOutputAudioForBargeIn("provider", undefined, clearedBytes);
+              return;
+            }
+            console.log(
+              `[voice-call] realtime outbound audio clear requested callId=${callId} providerCallId=${callSid} queuedBytes=${clearedBytes}`,
+            );
+            harness.finishOutputAudio("clear");
+          });
         },
         sendMark: (markName) => {
           audioPacer.sendMark(markName);
         },
       },
       onTranscript: (role, text, isFinal) => {
-        const turnId = ensureTalkTurn();
+        const turnId = harness.ensureTurn();
         const eventType =
           role === "assistant"
             ? isFinal
@@ -774,14 +730,14 @@ export class RealtimeCallHandler {
               ? "transcript.done"
               : "transcript.delta";
         const payload = role === "assistant" ? { text } : { role, text };
-        emitTalkEvent({
+        harness.emit({
           type: eventType,
           turnId,
           payload,
           final: isFinal,
         });
         if (role === "user" && isFinal) {
-          emitTalkEvent({
+          harness.emit({
             type: "input.audio.committed",
             turnId,
             payload: { callId, providerCallId: callSid },
@@ -819,6 +775,7 @@ export class RealtimeCallHandler {
           };
           this.manager.processEvent(event);
           this.scheduleForcedAgentConsult({
+            harness,
             session,
             callId,
             callSid,
@@ -842,8 +799,8 @@ export class RealtimeCallHandler {
         });
       },
       onToolCall: (toolEvent, sessionLocal) => {
-        const turnId = ensureTalkTurn();
-        emitTalkEvent({
+        const turnId = harness.ensureTurn();
+        harness.emit({
           type: "tool.call",
           turnId,
           itemId: toolEvent.itemId,
@@ -860,20 +817,20 @@ export class RealtimeCallHandler {
           toolEvent.name,
           toolEvent.args,
           turnId,
-          emitTalkEvent,
+          harness,
         );
       },
       onEvent: (event) => {
         if (event.type === "input_audio_buffer.speech_started") {
-          ensureTalkTurn();
+          harness.ensureTurn();
           return;
         }
         if (event.type === "input_audio_buffer.speech_stopped") {
-          const turnId = talk.activeTurnId;
+          const turnId = harness.talk.activeTurnId;
           if (!turnId) {
             return;
           }
-          emitTalkEvent({
+          harness.emit({
             type: "input.audio.committed",
             turnId,
             payload: { callId, providerCallId: callSid, source: event.type },
@@ -882,12 +839,12 @@ export class RealtimeCallHandler {
           return;
         }
         if (event.type === "response.done") {
-          finishOutputAudio("response.done");
-          endTalkTurn("response.done");
+          harness.finishOutputAudio("response.done");
+          harness.endTurn("response.done");
           return;
         }
         if (event.type === "error") {
-          emitTalkEvent({
+          harness.emit({
             type: "session.error",
             payload: { message: event.detail ?? "Realtime provider error" },
             final: true,
@@ -895,14 +852,14 @@ export class RealtimeCallHandler {
         }
       },
       onReady: () => {
-        emitTalkEvent({
+        harness.emit({
           type: "session.ready",
           payload: { callId, providerCallId: callSid },
         });
       },
       onError: (error) => {
         console.error("[voice-call] realtime voice error:", error.message);
-        emitTalkEvent({
+        harness.emit({
           type: "session.error",
           payload: { message: error.message },
           final: true,
@@ -914,8 +871,8 @@ export class RealtimeCallHandler {
         this.activeTelephonyClosersByCallId.delete(callId);
         this.activeTelephonyClosersByCallId.delete(callSid);
         this.clearUserTranscriptState(callId);
-        finishOutputAudio(reason);
-        emitTalkEvent({
+        harness.finishOutputAudio(reason);
+        harness.emit({
           type: "session.closed",
           payload: { reason },
           final: true,
@@ -961,11 +918,7 @@ export class RealtimeCallHandler {
           });
         }
       }
-      emitTalkEvent({
-        type: "input.audio.delta",
-        turnId: ensureTalkTurn(),
-        payload: { byteLength: audio.length },
-      });
+      harness.recordInputAudio(audio);
       sendAudioToSession(audio);
     };
     const closeSession = session.close.bind(session);
@@ -985,7 +938,8 @@ export class RealtimeCallHandler {
         this.activeTelephonyClosersByCallId.delete(callId);
         this.activeTelephonyClosersByCallId.delete(callSid);
         this.clearUserTranscriptState(callId);
-        this.clearForcedConsultState(callId);
+        this.forcedConsultsByCallId.delete(callId);
+        harness.close();
         audioPacer.close();
       }
     };
@@ -1101,22 +1055,6 @@ export class RealtimeCallHandler {
     }
   }
 
-  private clearForcedConsultState(callId: string): void {
-    this.forcedConsultCoordinatorsByCallId.get(callId)?.clear();
-    this.forcedConsultCoordinatorsByCallId.delete(callId);
-    this.forcedConsultsByCallId.delete(callId);
-  }
-
-  private forcedConsultCoordinator(callId: string): RealtimeVoiceForcedConsultCoordinator {
-    const existing = this.forcedConsultCoordinatorsByCallId.get(callId);
-    if (existing) {
-      return existing;
-    }
-    const created = createRealtimeVoiceForcedConsultCoordinator();
-    this.forcedConsultCoordinatorsByCallId.set(callId, created);
-    return created;
-  }
-
   private closeTelephonyBridge(
     callIdOrSid: string,
     bridge: ActiveRealtimeVoiceBridge | null,
@@ -1131,6 +1069,7 @@ export class RealtimeCallHandler {
   }
 
   private scheduleForcedAgentConsult(params: {
+    harness: RealtimeVoiceSessionHarness;
     session: ActiveRealtimeVoiceBridge;
     callId: string;
     callSid: string;
@@ -1152,7 +1091,7 @@ export class RealtimeCallHandler {
     if (existingForcedConsult && !existingForcedConsult.completedAt) {
       return;
     }
-    const coordinator = this.forcedConsultCoordinator(params.callId);
+    const coordinator = params.harness.forcedConsults;
     if (coordinator.hasRecentNativeConsult(question, { allowUnknownQuestion: true })) {
       return;
     }
@@ -1175,6 +1114,7 @@ export class RealtimeCallHandler {
   }
 
   private async runForcedAgentConsult(params: {
+    harness: RealtimeVoiceSessionHarness;
     session: ActiveRealtimeVoiceBridge;
     callId: string;
     callSid: string;
@@ -1182,7 +1122,7 @@ export class RealtimeCallHandler {
     clearAudio: () => void;
     handler: ToolHandlerFn;
   }): Promise<void> {
-    const coordinator = this.forcedConsultCoordinator(params.callId);
+    const coordinator = params.harness.forcedConsults;
     coordinator.markStarted(params.handle);
     const startedAt = Date.now();
     logger.debug(
@@ -1333,7 +1273,7 @@ export class RealtimeCallHandler {
     name: string,
     args: unknown,
     turnId: string,
-    emitTalkEvent?: (input: TalkEventInput) => TalkEvent,
+    harness: RealtimeVoiceSessionHarness,
   ): Promise<void> {
     const handler = this.toolHandlers.get(name);
     const startedAt = Date.now();
@@ -1343,7 +1283,7 @@ export class RealtimeCallHandler {
       );
     };
     const emitFinalToolEvent = (result: unknown): void => {
-      emitTalkEvent?.({
+      harness.emit({
         type: hasResultError(result) ? "tool.error" : "tool.result",
         turnId,
         callId: bridgeCallId,
@@ -1367,7 +1307,7 @@ export class RealtimeCallHandler {
           buildRealtimeVoiceAgentConsultWorkingResponse("caller"),
           { willContinue: true },
         );
-        emitTalkEvent?.({
+        harness.emit({
           type: "tool.progress",
           turnId,
           callId: bridgeCallId,
@@ -1376,7 +1316,7 @@ export class RealtimeCallHandler {
       }
     };
     if (name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      const coordinator = this.forcedConsultCoordinator(callId);
+      const coordinator = harness.forcedConsults;
       const forcedMatch = coordinator.recordNativeConsult(args, bridgeCallId);
       if (forcedMatch.kind === "none") {
         const pending = coordinator.consumePending();

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -252,7 +252,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +1: selectPreferredLocalModelId shares app-guided local model ranking across providers.
       // +4: shared audio-energy stats and speech-threshold gate through realtime-voice.
       // +2: supplemental sender decision and outbound text chunk sequencer.
-      8012,
+      // +2: shared realtime voice session harness through realtime-voice.
+      8014,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -279,7 +280,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +1: selectPreferredLocalModelId shares app-guided local model ranking across providers.
       // +3: PCM16/mu-law energy readers and speech-threshold gate factory.
       // +2: supplemental sender decision and outbound text chunk sequencer.
-      4478,
+      // +1: shared realtime voice session harness through realtime-voice.
+      4479,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -172,6 +172,10 @@ export {
   type RealtimeVoiceMarkStrategy,
 } from "../talk/session-runtime.js";
 export {
+  createRealtimeVoiceSessionHarness,
+  type RealtimeVoiceSessionHarness,
+} from "../talk/realtime-session-harness.js";
+export {
   extendRealtimeVoiceOutputEchoSuppression,
   getRealtimeVoiceBridgeEventHealth,
   getRealtimeVoiceTranscriptHealth,

--- a/src/talk/realtime-session-harness.test.ts
+++ b/src/talk/realtime-session-harness.test.ts
@@ -1,0 +1,144 @@
+// Realtime session harness tests cover shared Talk, echo, talkback, and barge-in behavior.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
+import type { RealtimeVoiceBridge } from "./provider-types.js";
+import { createRealtimeVoiceSessionHarness } from "./realtime-session-harness.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function createHarness(
+  overrides: Partial<Parameters<typeof createRealtimeVoiceSessionHarness>[0]> = {},
+) {
+  return createRealtimeVoiceSessionHarness({
+    talk: {
+      sessionId: "test-session",
+      mode: "realtime",
+      transport: "gateway-relay",
+      brain: "agent-consult",
+      provider: "test",
+    },
+    talkPayloads: {
+      turnStarted: () => ({ surface: "test" }),
+      turnEnded: (reason) => ({ reason }),
+      inputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+      outputAudioStarted: () => ({ surface: "test" }),
+      outputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+      outputAudioDone: (reason) => ({ reason }),
+    },
+    ...overrides,
+  });
+}
+
+function makeBridge(overrides: Partial<RealtimeVoiceBridge> = {}): RealtimeVoiceBridge {
+  return {
+    acknowledgeMark: vi.fn(),
+    close: vi.fn(),
+    connect: vi.fn(async () => {}),
+    isConnected: vi.fn(() => true),
+    sendAudio: vi.fn(),
+    setMediaTimestamp: vi.fn(),
+    submitToolResult: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("realtime voice session harness", () => {
+  it("keeps shared Talk events ordered across input, output, and turn completion", () => {
+    const harness = createHarness();
+
+    expect(harness.recordInputAudio(Buffer.from([1, 2]))).toBe(true);
+    harness.recordOutputAudio(Buffer.from([3, 4, 5]));
+    harness.finishOutputAudio("response.done");
+    harness.endTurn("response.done");
+
+    expect(harness.talk.recentEvents.map((event) => event.type)).toEqual([
+      "turn.started",
+      "input.audio.delta",
+      "output.audio.started",
+      "output.audio.delta",
+      "output.audio.done",
+      "turn.ended",
+    ]);
+    expect(harness.talk.recentEvents.map((event) => event.seq)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("suppresses input through queued output playback plus the echo tail", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const harness = createHarness({
+      echoSuppression: {
+        bytesPerMs: 48,
+        tailMs: 3_000,
+        transcriptLookbackMs: 45_000,
+      },
+    });
+
+    harness.recordOutputAudio(Buffer.alloc(48_000));
+    vi.setSystemTime(1_100);
+    harness.recordOutputAudio(Buffer.alloc(48_000));
+    vi.setSystemTime(5_999);
+    expect(harness.recordInputAudio(Buffer.from([1, 2, 3, 4]))).toBe(false);
+    vi.setSystemTime(6_000);
+    expect(harness.recordInputAudio(Buffer.from([5, 6, 7]))).toBe(true);
+
+    expect(harness.getHealth({ providerConnected: true, realtimeReady: true })).toMatchObject({
+      lastInputBytes: 3,
+      lastOutputBytes: 96_000,
+      suppressedInputBytes: 4,
+    });
+  });
+
+  it("delegates debounced talkback fragments through one consult", async () => {
+    vi.useFakeTimers();
+    const consult = vi.fn(async ({ question }: { question: string }) => ({
+      text: `answer:${question}`,
+    }));
+    const deliver = vi.fn();
+    const harness = createHarness({
+      talkback: {
+        debounceMs: 100,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        logPrefix: "[test]",
+        responseStyle: "brief",
+        fallbackText: "fallback",
+        consult,
+        deliver,
+      },
+    });
+
+    harness.talkback?.enqueue("first");
+    harness.talkback?.enqueue("second");
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(consult).toHaveBeenCalledOnce();
+    expect(consult.mock.calls[0]?.[0]).toMatchObject({
+      question: "first\nsecond",
+      responseStyle: "brief",
+    });
+    expect(deliver).toHaveBeenCalledWith("answer:first\nsecond");
+  });
+
+  it("flushes transport output when provider barge-in does not clear it", () => {
+    const handleBargeIn = vi.fn();
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "test",
+      label: "Test",
+      isConfigured: () => true,
+      createBridge: () => makeBridge({ handleBargeIn }),
+    };
+    const harness = createHarness();
+    harness.createBridge({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: vi.fn() },
+    });
+    const flushOutput = vi.fn();
+
+    harness.handleBargeIn({ audioPlaybackActive: true }, flushOutput);
+
+    expect(handleBargeIn).toHaveBeenCalledWith({ audioPlaybackActive: true });
+    expect(flushOutput).toHaveBeenCalledOnce();
+  });
+});

--- a/src/talk/realtime-session-harness.ts
+++ b/src/talk/realtime-session-harness.ts
@@ -1,0 +1,288 @@
+import type { RealtimeVoiceAgentTalkbackQueue } from "./agent-talkback-runtime.js";
+import {
+  createRealtimeVoiceAgentTalkbackQueue,
+  type RealtimeVoiceAgentTalkbackQueueParams,
+} from "./agent-talkback-runtime.js";
+import {
+  createRealtimeVoiceForcedConsultCoordinator,
+  type RealtimeVoiceForcedConsultCoordinator,
+  type RealtimeVoiceForcedConsultCoordinatorOptions,
+} from "./forced-consult-coordinator.js";
+import { recordTalkObservabilityEvent } from "./observability.js";
+import {
+  createRealtimeVoiceOutputActivityTracker,
+  type RealtimeVoiceOutputActivityDelta,
+  type RealtimeVoiceOutputActivityTracker,
+} from "./output-activity-tracker.js";
+import type { RealtimeVoiceBargeInOptions, RealtimeVoiceRole } from "./provider-types.js";
+import {
+  extendRealtimeVoiceOutputEchoSuppression,
+  getRealtimeVoiceBridgeEventHealth,
+  getRealtimeVoiceTranscriptHealth,
+  isLikelyRealtimeVoiceAssistantEchoTranscript,
+  recordRealtimeVoiceBridgeEvent,
+  recordRealtimeVoiceTranscript,
+  type RealtimeVoiceBridgeEventLogEntry,
+  type RealtimeVoiceTranscriptEntry,
+} from "./session-log-runtime.js";
+import {
+  createRealtimeVoiceBridgeSession,
+  type RealtimeVoiceBridgeSession,
+  type RealtimeVoiceBridgeSessionParams,
+} from "./session-runtime.js";
+import type { TalkEvent, TalkEventInput } from "./talk-events.js";
+import {
+  createTalkSessionController,
+  type TalkSessionController,
+  type TalkSessionControllerParams,
+} from "./talk-session-controller.js";
+
+type RealtimeVoiceSessionHarnessTalkPayloads = {
+  turnStarted: () => unknown;
+  turnEnded: (reason: string) => unknown;
+  inputAudioDelta: (audio: Buffer) => unknown;
+  outputAudioStarted: () => unknown;
+  outputAudioDelta: (audio: Buffer) => unknown;
+  outputAudioDone: (reason: string) => unknown;
+};
+
+type RealtimeVoiceSessionHarnessEchoSuppression = {
+  bytesPerMs: number;
+  tailMs: number;
+  transcriptLookbackMs: number;
+};
+
+type RealtimeVoiceSessionHarnessHealth = ReturnType<typeof getRealtimeVoiceTranscriptHealth> &
+  Partial<ReturnType<typeof getRealtimeVoiceBridgeEventHealth>> & {
+    providerConnected: boolean;
+    realtimeReady: boolean;
+    audioInputActive: boolean;
+    audioOutputActive: boolean;
+    lastInputAt?: string;
+    lastOutputAt?: string;
+    lastSuppressedInputAt?: string;
+    lastInputBytes: number;
+    lastOutputBytes: number;
+    suppressedInputBytes: number;
+    recentTalkEvents: Array<{
+      id: string;
+      type: TalkEvent["type"];
+      sessionId: string;
+      turnId?: string;
+      seq: number;
+      timestamp: string;
+      final?: boolean;
+    }>;
+  };
+
+export type RealtimeVoiceSessionHarness<TForcedConsultContext = unknown> = {
+  readonly forcedConsults: RealtimeVoiceForcedConsultCoordinator<TForcedConsultContext>;
+  readonly outputActivity: RealtimeVoiceOutputActivityTracker;
+  readonly talk: TalkSessionController;
+  readonly talkback: RealtimeVoiceAgentTalkbackQueue | undefined;
+  readonly transcript: RealtimeVoiceTranscriptEntry[];
+  close(): void;
+  createBridge(params: RealtimeVoiceBridgeSessionParams): RealtimeVoiceBridgeSession;
+  emit<TPayload>(input: TalkEventInput<TPayload>): TalkEvent<TPayload>;
+  ensureTurn(): string;
+  endTurn(reason?: string): void;
+  finishOutputAudio(reason: string): void;
+  flushOutput(flush: () => void): void;
+  getHealth(params: {
+    providerConnected: boolean;
+    realtimeReady: boolean;
+  }): RealtimeVoiceSessionHarnessHealth;
+  handleBargeIn(options: RealtimeVoiceBargeInOptions, flushOutput: () => void): void;
+  isLikelyAssistantEchoTranscript(text: string): boolean;
+  isOutputPlaybackWindowActive(): boolean;
+  recordInputAudio(audio: Buffer): boolean;
+  recordOutputAudio(audio: Buffer, activity?: RealtimeVoiceOutputActivityDelta): void;
+  recordTranscript(role: RealtimeVoiceRole, text: string): RealtimeVoiceTranscriptEntry;
+};
+
+export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknown>(params: {
+  talk: TalkSessionControllerParams;
+  talkPayloads: RealtimeVoiceSessionHarnessTalkPayloads;
+  onTalkEvent?: (event: TalkEvent) => void;
+  talkback?: Omit<RealtimeVoiceAgentTalkbackQueueParams, "isStopped">;
+  forcedConsults?: RealtimeVoiceForcedConsultCoordinatorOptions;
+  echoSuppression?: RealtimeVoiceSessionHarnessEchoSuppression;
+}): RealtimeVoiceSessionHarness<TForcedConsultContext> {
+  let closed = false;
+  let bridge: RealtimeVoiceBridgeSession | undefined;
+  let lastInputAt: string | undefined;
+  let lastOutputAt: string | undefined;
+  let lastSuppressedInputAt: string | undefined;
+  let lastInputBytes = 0;
+  let suppressedInputBytes = 0;
+  let suppressInputUntilMs = 0;
+  let lastOutputPlayableUntilMs = 0;
+  let outputFlushGeneration = 0;
+  const transcript: RealtimeVoiceTranscriptEntry[] = [];
+  const bridgeEvents: RealtimeVoiceBridgeEventLogEntry[] = [];
+  const outputActivity = createRealtimeVoiceOutputActivityTracker();
+  const forcedConsults = createRealtimeVoiceForcedConsultCoordinator<TForcedConsultContext>(
+    params.forcedConsults,
+  );
+  const talk = createTalkSessionController(
+    { ...params.talk, maxRecentEvents: 40 },
+    {
+      onEvent: (event) => {
+        recordTalkObservabilityEvent(event);
+        params.onTalkEvent?.(event);
+      },
+    },
+  );
+  const talkback = params.talkback
+    ? createRealtimeVoiceAgentTalkbackQueue({
+        ...params.talkback,
+        isStopped: () => closed,
+      })
+    : undefined;
+
+  const ensureTurn = () => talk.ensureTurn({ payload: params.talkPayloads.turnStarted() }).turnId;
+
+  const flushOutput = (flush: () => void): void => {
+    outputFlushGeneration += 1;
+    suppressInputUntilMs = 0;
+    lastOutputPlayableUntilMs = 0;
+    flush();
+  };
+
+  const harness: RealtimeVoiceSessionHarness<TForcedConsultContext> = {
+    forcedConsults,
+    outputActivity,
+    talk,
+    talkback,
+    transcript,
+    close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      talkback?.close();
+      forcedConsults.clear();
+    },
+    createBridge(bridgeParams) {
+      bridge = createRealtimeVoiceBridgeSession({
+        ...bridgeParams,
+        onTranscript: (role, text, isFinal) => {
+          if (isFinal) {
+            harness.recordTranscript(role, text);
+          }
+          bridgeParams.onTranscript?.(role, text, isFinal);
+        },
+        onEvent: (event) => {
+          recordRealtimeVoiceBridgeEvent(bridgeEvents, event);
+          bridgeParams.onEvent?.(event);
+        },
+      });
+      return bridge;
+    },
+    emit: (input) => talk.emit(input),
+    ensureTurn,
+    endTurn(reason = "completed") {
+      talk.endTurn({ payload: params.talkPayloads.turnEnded(reason) });
+    },
+    finishOutputAudio(reason) {
+      talk.finishOutputAudio({ payload: params.talkPayloads.outputAudioDone(reason) });
+    },
+    flushOutput,
+    getHealth(healthParams) {
+      const output = outputActivity.snapshot();
+      return {
+        providerConnected: healthParams.providerConnected,
+        realtimeReady: healthParams.realtimeReady,
+        audioInputActive: lastInputBytes > 0,
+        audioOutputActive: outputActivity.isActive(),
+        lastInputAt,
+        lastOutputAt,
+        lastSuppressedInputAt,
+        lastInputBytes,
+        lastOutputBytes: output.sinkAudioBytes,
+        suppressedInputBytes,
+        ...getRealtimeVoiceTranscriptHealth(transcript),
+        ...(bridge ? getRealtimeVoiceBridgeEventHealth(bridgeEvents) : {}),
+        recentTalkEvents: talk.recentEvents.slice(-20).map((event) => ({
+          id: event.id,
+          type: event.type,
+          sessionId: event.sessionId,
+          turnId: event.turnId,
+          seq: event.seq,
+          timestamp: event.timestamp,
+          final: event.final,
+        })),
+      };
+    },
+    handleBargeIn(options, fallbackFlush) {
+      suppressInputUntilMs = 0;
+      const flushGeneration = outputFlushGeneration;
+      bridge?.handleBargeIn(options);
+      if (flushGeneration === outputFlushGeneration) {
+        flushOutput(fallbackFlush);
+      }
+    },
+    isLikelyAssistantEchoTranscript(text) {
+      return params.echoSuppression
+        ? isLikelyRealtimeVoiceAssistantEchoTranscript({
+            transcript,
+            text,
+            lookbackMs: params.echoSuppression.transcriptLookbackMs,
+          })
+        : false;
+    },
+    isOutputPlaybackWindowActive() {
+      return Date.now() <= Math.max(lastOutputPlayableUntilMs, suppressInputUntilMs);
+    },
+    recordInputAudio(audio) {
+      if (Date.now() < suppressInputUntilMs) {
+        lastSuppressedInputAt = new Date().toISOString();
+        suppressedInputBytes += audio.byteLength;
+        return false;
+      }
+      lastInputAt = new Date().toISOString();
+      lastInputBytes += audio.byteLength;
+      harness.emit({
+        type: "input.audio.delta",
+        turnId: ensureTurn(),
+        payload: params.talkPayloads.inputAudioDelta(audio),
+      });
+      return true;
+    },
+    recordOutputAudio(audio, activity = {}) {
+      const turnId = ensureTurn();
+      talk.startOutputAudio({
+        turnId,
+        payload: params.talkPayloads.outputAudioStarted(),
+      });
+      harness.emit({
+        type: "output.audio.delta",
+        turnId,
+        payload: params.talkPayloads.outputAudioDelta(audio),
+      });
+      let audioMs = activity.audioMs;
+      if (params.echoSuppression) {
+        const suppression = extendRealtimeVoiceOutputEchoSuppression({
+          audio,
+          bytesPerMs: params.echoSuppression.bytesPerMs,
+          tailMs: params.echoSuppression.tailMs,
+          nowMs: Date.now(),
+          lastOutputPlayableUntilMs,
+          suppressInputUntilMs,
+        });
+        lastOutputPlayableUntilMs = suppression.lastOutputPlayableUntilMs;
+        suppressInputUntilMs = suppression.suppressInputUntilMs;
+        audioMs ??= suppression.durationMs;
+      }
+      outputActivity.markAudio({
+        audioMs,
+        sourceAudioBytes: activity.sourceAudioBytes ?? audio.byteLength,
+        sinkAudioBytes: activity.sinkAudioBytes ?? audio.byteLength,
+      });
+      lastOutputAt = new Date().toISOString();
+    },
+    recordTranscript: (role, text) => recordRealtimeVoiceTranscript(transcript, role, text),
+  };
+
+  return harness;
+}


### PR DESCRIPTION
## What Problem This Solves

Every realtime voice consumer re-plumbed the same session wiring around the shared bridge/talk primitives: talk-session controller creation and event ring capture, output-activity tracking with echo-suppression window bookkeeping, transcript recording with assistant-echo filtering, agent talkback queue construction, forced-consult coordination, and barge-in-to-output-flush coupling. Google Meet carried this twice (agent/STT and bidi engines), voice-call once, Discord once — four hand-maintained copies of the same invariants.

## Why This Change Was Made

Phase 3 of the voice-stack consolidation (follows #109413, #109466). New `src/talk/realtime-session-harness.ts` (`createRealtimeVoiceSessionHarness`, exported via `openclaw/plugin-sdk/realtime-voice`) owns the transport-agnostic session shape: talk lifecycle helpers with injected payload builders, input/output audio recording with echo-suppression windows and suppressed-byte accounting, bounded transcript + bridge-event capture, talkback queue, forced-consult coordinator, health snapshot assembly, and `handleBargeIn` with flush-generation fallback (generalizing Meet's clear-count pattern).

Adopted by Google Meet (both engines) and voice-call's realtime handler; their local wiring is deleted. Consumers keep audio I/O, format conversion, provider resolution, prompts, and pacing.

Discord adoption is deliberately a follow-up: the mapping was verified against `extensions/discord/src/voice/realtime.ts` (bridge creation, talkback, forced-consult state, output tracker, barge-in paths all map onto the harness; speaker attribution, wake-name policy, Opus conversion, preroll, and player lifecycle stay Discord-side) and no harness API gap was found.

## User Impact

None intended. Talk-event shapes and payloads, health fields, echo-suppression timings, log lines, and barge-in behavior are unchanged per consumer.

## Evidence

- `node scripts/run-vitest.mjs src/talk extensions/google-meet extensions/voice-call`: 1009+ tests pass (rerun after rebase onto current main).
- New harness unit tests (talk-event ordering, echo-suppression window, talkback delegation, barge-in flush fallback); the voice-call forced-consult cancellation regression test was adapted to drive the harness-owned coordinator (review-found, restored — late native consult is terminally answered as cancelled without invoking the consult handler).
- `pnpm plugin-sdk:surface:check` green (+2 exports / +1 callable, standard annotations); `node scripts/check-deadcode-exports.mjs` all scans 0; API baseline regenerated; SDK docs updated.
- Autoreview (Codex gpt-5.6-sol, xhigh): one finding (the deleted regression test) fixed; final round clean.
- Non-test LOC net −3; the four wiring copies collapse to one owner.
