### PR TITLE
fix(tasks): sweep terminal task flows

### DIFF
--- a/src/tasks/task-flow-registry.maintenance.test.ts
+++ b/src/tasks/task-flow-registry.maintenance.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./task-flow-registry.maintenance.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import { finalizeTaskRunByRunId } from "./task-registry.js";
+import { sweepTaskRegistry } from "./task-registry.maintenance.js";
 import type { TaskRecord } from "./task-registry.types.js";
 import {
   createFlowRecord as createFlowRecordOrNull,
@@ -139,6 +140,49 @@ describe("task-flow-registry maintenance", () => {
         reconciled: 0,
         pruned: 1,
       });
+      expect(getTaskFlowById(oldFlow.flowId)).toBeUndefined();
+    });
+  });
+
+  it("retains durable blocked flows until they have ended", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const now = Date.now();
+      const blocked = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Wait for durable follow-up",
+        status: "blocked",
+        createdAt: now - 8 * 24 * 60 * 60_000,
+        updatedAt: now - 8 * 24 * 60 * 60_000,
+      });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+      });
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        pruned: 0,
+      });
+      expect(getTaskFlowById(blocked.flowId)?.status).toBe("blocked");
+    });
+  });
+
+  it("includes task-flow maintenance in the scheduled task sweep", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const now = Date.now();
+      const oldFlow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Old terminal flow",
+        status: "succeeded",
+        createdAt: now - 8 * 24 * 60 * 60_000,
+        updatedAt: now - 8 * 24 * 60 * 60_000,
+        endedAt: now - 8 * 24 * 60 * 60_000,
+      });
+
+      await sweepTaskRegistry();
+
       expect(getTaskFlowById(oldFlow.flowId)).toBeUndefined();
     });
   });

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -33,9 +33,11 @@ export function assertTaskFlowRegistryMaintenanceReady(): void {
 }
 
 function isTerminalFlow(flow: TaskFlowRecord): boolean {
+  // Managed flows use blocked as a durable wait state; only endedAt proves
+  // that a blocked flow is terminal and eligible for retention pruning.
   return (
     flow.status === "succeeded" ||
-    flow.status === "blocked" ||
+    (flow.status === "blocked" && flow.endedAt != null) ||
     flow.status === "failed" ||
     flow.status === "cancelled" ||
     flow.status === "lost"

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -59,6 +59,7 @@ import {
   resolveTaskForLookupToken,
   setTaskCleanupAfterById,
 } from "./runtime-internal.js";
+import { runTaskFlowRegistryMaintenance } from "./task-flow-registry.maintenance.js";
 import {
   configureTaskAuditTaskProvider,
   listTaskAuditFindings,
@@ -1112,7 +1113,9 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
 }
 
 export async function sweepTaskRegistry(): Promise<TaskRegistryMaintenanceSummary> {
-  return runTaskRegistryMaintenance();
+  const summary = await runTaskRegistryMaintenance();
+  await runTaskFlowRegistryMaintenance();
+  return summary;
 }
 
 export function startTaskRegistryMaintenance() {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -59,7 +59,10 @@ import {
   resolveTaskForLookupToken,
   setTaskCleanupAfterById,
 } from "./runtime-internal.js";
-import { runTaskFlowRegistryMaintenance } from "./task-flow-registry.maintenance.js";
+import {
+  assertTaskFlowRegistryMaintenanceReady,
+  runTaskFlowRegistryMaintenance,
+} from "./task-flow-registry.maintenance.js";
 import {
   configureTaskAuditTaskProvider,
   listTaskAuditFindings,
@@ -1113,6 +1116,7 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
 }
 
 export async function sweepTaskRegistry(): Promise<TaskRegistryMaintenanceSummary> {
+  assertTaskFlowRegistryMaintenanceReady();
   const summary = await runTaskRegistryMaintenance();
   await runTaskFlowRegistryMaintenance();
   return summary;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -3582,6 +3582,55 @@ describe("task-registry", () => {
     });
   });
 
+  it("does not mutate tasks when a scheduled sweep cannot restore task-flow state", async () => {
+    await withTaskRegistryTempDir(async () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-scheduled-corrupt-flow-store",
+        task: "Retain while task-flow state is unavailable",
+        status: "succeeded",
+        deliveryStatus: "not_applicable",
+      });
+      const staleTask = {
+        ...task,
+        endedAt: now - 8 * 24 * 60 * 60_000,
+        lastEventAt: now - 8 * 24 * 60 * 60_000,
+        cleanupAfter: now - 1,
+      };
+      const currentTasks = new Map([[task.taskId, staleTask]]);
+      configureTaskRegistryMaintenanceRuntimeForTest({
+        currentTasks,
+        snapshotTasks: [staleTask],
+      });
+      resetTaskFlowRegistryForTests({ persist: false });
+      const loadSnapshot = vi.fn(() => {
+        throw new Error("SQLITE_CORRUPT: scheduled task-flow restore failed");
+      });
+      configureTaskFlowRegistryRuntime({
+        store: {
+          loadSnapshot,
+          saveSnapshot: vi.fn(),
+        },
+      });
+
+      startTaskRegistryMaintenance();
+      try {
+        await vi.advanceTimersByTimeAsync(5_000);
+        await flushAsyncWork();
+
+        expect(loadSnapshot).toHaveBeenCalledTimes(1);
+        expect(currentTasks.get(task.taskId)).toEqual(staleTask);
+      } finally {
+        stopTaskRegistryMaintenance();
+      }
+    });
+  });
+
   it("does not leak unhandled rejections when the scheduled maintenance sweep fails", async () => {
     await withTaskRegistryTempDir(async () => {
       vi.useFakeTimers();


### PR DESCRIPTION
## Summary

- run task-flow registry maintenance from the existing scheduled task-registry sweep
- preserve managed blocked flows that have no endedAt timestamp because blocked is a durable wait state
- add regressions proving old durable blocked flows survive and old terminal flows are pruned by the scheduled sweep

## What Problem This Solves

Task registry maintenance runs after gateway startup and every minute, but task-flow maintenance was only reachable through the explicit CLI command. Terminal managed flows could therefore accumulate indefinitely. Separately, treating every blocked flow as terminal could prune an old but still-durable wait before it had an endedAt timestamp.

## Evidence

- Focused Vitest run: 125 passed, 0 failed across task-flow maintenance and task-registry tests
- oxfmt check passed on all three changed files
- oxlint passed on all three changed files
- git diff check passed
- Regression coverage proves durable blocked flows survive and terminal flows are pruned by the scheduled sweep

The broad core tsgo run was also attempted in the sparse validation checkout. It remains red on unrelated net-policy typing errors and missing sparse test-helper modules; none of the diagnostics point at these three files.