### PR TITLE
fix(qa-lab): prevent WhatsApp setup hangs during archive restore

### DIFF
--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -26,6 +26,16 @@ import {
 import { getWhatsAppQaScenarioDefinition } from "./whatsapp-live.scenarios.js";
 import { unpackWhatsAppAuthArchive } from "./whatsapp-live.setup.js";
 
+const runExecSpy = vi.hoisted(() =>
+  vi.fn<typeof import("openclaw/plugin-sdk/process-runtime").runExec>(),
+);
+
+vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>();
+  runExecSpy.mockImplementation(actual.runExec);
+  return { ...actual, runExec: runExecSpy };
+});
+
 const testing = {
   buildWhatsAppQaConfig,
   callWhatsAppGatewayMessageAction,
@@ -233,6 +243,7 @@ describe("WhatsApp QA live runtime", () => {
   it("unpacks auth archives into a caller-provided temp directory", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-qa-test-"));
     try {
+      runExecSpy.mockClear();
       const archiveBase64 = await createTgz({
         root: tempRoot,
         entries: {
@@ -248,6 +259,15 @@ describe("WhatsApp QA live runtime", () => {
       await expect(fs.readFile(path.join(authDir, "creds.json"), "utf8")).resolves.toBe("{}\n");
       await expect(fs.readFile(path.join(authDir, "session/key.json"), "utf8")).resolves.toBe(
         "{}\n",
+      );
+      const archivePath = path.join(tempRoot, "driver.tgz");
+      const execOptions = { logOutput: false, timeoutMs: 60_000 };
+      expect(runExecSpy).toHaveBeenNthCalledWith(1, "tar", ["-tzf", archivePath], execOptions);
+      expect(runExecSpy).toHaveBeenNthCalledWith(
+        2,
+        "tar",
+        ["-xzf", archivePath, "-C", authDir],
+        execOptions,
       );
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.setup.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.setup.ts
@@ -7,6 +7,7 @@ import type { WhatsAppQaGateway } from "./whatsapp-live.contracts.js";
 
 const WHATSAPP_QA_READY_TIMEOUT_MS = 150_000;
 const WHATSAPP_QA_READY_STABILITY_MS = 20_000;
+const WHATSAPP_QA_AUTH_ARCHIVE_TIMEOUT_MS = 60_000;
 const WHATSAPP_QA_SIGNAL_SESSION_FILE_RE = /^session-[^/\\]+\.json$/u;
 
 type WhatsAppChannelStatus = {
@@ -114,7 +115,10 @@ export async function waitForWhatsAppChannelStable(gateway: WhatsAppQaGateway, a
 }
 
 async function listTarEntries(archivePath: string): Promise<string[]> {
-  const { stdout } = await runExec("tar", ["-tzf", archivePath], { logOutput: false });
+  const { stdout } = await runExec("tar", ["-tzf", archivePath], {
+    logOutput: false,
+    timeoutMs: WHATSAPP_QA_AUTH_ARCHIVE_TIMEOUT_MS,
+  });
   return normalizeStringEntries(stdout.split("\n"));
 }
 
@@ -141,7 +145,10 @@ export async function unpackWhatsAppAuthArchive(params: {
   await fs.writeFile(archivePath, Buffer.from(params.archiveBase64, "base64"), { mode: 0o600 });
   const entries = await listTarEntries(archivePath);
   assertSafeArchiveEntries(entries);
-  await runExec("tar", ["-xzf", archivePath, "-C", authDir], { logOutput: false });
+  await runExec("tar", ["-xzf", archivePath, "-C", authDir], {
+    logOutput: false,
+    timeoutMs: WHATSAPP_QA_AUTH_ARCHIVE_TIMEOUT_MS,
+  });
   await fs.rm(archivePath, { force: true });
   if (params.clearSignalSessions === true) {
     await clearWhatsAppAuthSignalSessions(authDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where WhatsApp QA live setup could hang indefinitely while listing or extracting a restored authentication archive. Because archive restoration happens after the QA lease and heartbeat start but before the driver is ready, a stalled `tar` process could block setup and delay cleanup indefinitely.

## Why This Change Was Made

Both bounded one-shot archive operations now use the existing `runExec` timeout contract with a shared 60-second deadline. This keeps the policy at the archive owner boundary and avoids adding configuration or a second process runner.

The deadline matches existing archive/file-transfer command boundaries in the repository and leaves ample room for the QA credential archive size limit. The surrounding lease, heartbeat, archive validation, extraction destination, and cleanup flow are unchanged.

## User Impact

WhatsApp QA operators now get a bounded setup failure instead of a run that can remain stuck while inspecting or extracting an auth archive. There is no production WhatsApp channel, public API, or configuration change.

## Evidence

- Exact head: `5bab3feadb587918f4951f896f566efccd6e7f01`.
- Full CI is green on the exact head, including `openclaw/ci-gate`.
- Latest-main focused suite: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts --run` passed 50/50.
- Real tgz path: the focused archive test created a valid archive, ran the actual `tar -tzf` and `tar -xzf` commands through a passthrough spy, verified the extracted file, and asserted that both invocations receive `{ logOutput: false, timeoutMs: 60_000 }`; 1/1 passed (`49 skipped`).
- `runExec` forwards `timeoutMs` to Execa and applies the shared 300 ms force-kill grace. Execa 9.6.1 terminates a subprocess after its timeout and escalates to `SIGKILL` when it does not exit ([timeout source](https://github.com/sindresorhus/execa/blob/v9.6.1/lib/terminate/timeout.js#L11-L20), [force-kill source](https://github.com/sindresorhus/execa/blob/v9.6.1/lib/terminate/kill.js#L81-L92)).
- Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh independent Codex adversarial review found no actionable issue and judged the shared `runExec` deadline the best fix at this boundary.

### Real stalled-process and cleanup behavior

Ran the production `createWhatsAppQaTransportAdapter` path from the exact PR head on Linux x64 with Node 24.18.0, outside Vitest. A PATH-isolated `tar` executable deliberately stalled both concurrent auth-archive listing operations. The run used fake non-secret archive payloads, no network, and a data-disk temporary root.

Redacted output:

```text
{"head":"5bab3feadb587918f4951f896f566efccd6e7f01","node":"v24.18.0","platform":"linux/x64","path":"production createWhatsAppQaTransportAdapter"}
{"case":"stalled-auth-archive","elapsedMs":60145,"spawnedTarProcesses":2,"timeoutObserved":true,"error":"Command timed out after 60000 milliseconds: tar -tzf [proof-root]/tmp/openclaw-0/openclaw-whatsapp-qa-adapter-[redacted]/driver-auth.tgz"}
{"case":"setup-cleanup","allTarProcessesReaped":true,"remainingAdapterRoots":0}
```

This exercises the outer setup error path requested in review, not only the archive helper: both stalled subprocesses were gone after timeout, the setup catch/finally path resumed, and the complete adapter auth root was removed.
