### PR TITLE
fix(linux-canvas): report degraded socket monitoring

### DIFF
--- a/extensions/linux-canvas/src/socket-path.test.ts
+++ b/extensions/linux-canvas/src/socket-path.test.ts
@@ -1,13 +1,22 @@
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { linuxCanvasSocketExists } from "./socket-path.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { linuxCanvasSocketExists, watchLinuxCanvasSocket } from "./socket-path.js";
+
+const loggerMocks = vi.hoisted(() => ({ warn: vi.fn() }));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  createSubsystemLogger: () => loggerMocks,
+}));
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  loggerMocks.warn.mockReset();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -41,4 +50,31 @@ describe("Linux Canvas socket availability", () => {
       expect(linuxCanvasSocketExists(socketPath)).toBe(false);
     },
   );
+
+  it("reports synchronous and asynchronous watcher failures before falling back to polling", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-linux-canvas-watch-"));
+    tempDirs.push(directory);
+    const socketPath = path.join(directory, "canvas.sock");
+    const watcher = Object.assign(new EventEmitter(), { close: vi.fn() });
+    const watch = vi
+      .spyOn(fs, "watch")
+      .mockImplementationOnce(() => watcher as unknown as fs.FSWatcher)
+      .mockImplementationOnce(() => {
+        throw new Error("EMFILE");
+      });
+
+    const stop = watchLinuxCanvasSocket(socketPath, vi.fn());
+    watcher.emit("error", new Error("ENOSPC"));
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining("continuing with availability polling: Error: ENOSPC"),
+    );
+    stop();
+    expect(watcher.close).toHaveBeenCalledOnce();
+
+    expect(() => watchLinuxCanvasSocket(socketPath, vi.fn())).not.toThrow();
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining("continuing with availability polling: Error: EMFILE"),
+    );
+    expect(watch).toHaveBeenCalledTimes(2);
+  });
 });

--- a/extensions/linux-canvas/src/socket-path.ts
+++ b/extensions/linux-canvas/src/socket-path.ts
@@ -1,5 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+
+const log = createSubsystemLogger("linux-canvas");
+
+function reportSocketWatchError(directory: string, error: unknown): void {
+  log.warn(
+    `linux canvas socket watcher unavailable for ${directory}; continuing with availability polling: ${String(error)}`,
+  );
+}
 
 export function resolveLinuxCanvasSocketPath(
   env: NodeJS.ProcessEnv = process.env,
@@ -35,9 +44,10 @@ export function watchLinuxCanvasSocket(socketPath: string, onChange: () => void)
         onChange();
       }
     });
-    watcher.on("error", () => {});
+    watcher.on("error", (error) => reportSocketWatchError(directory, error));
     return () => watcher.close();
-  } catch {
+  } catch (error) {
+    reportSocketWatchError(directory, error);
     return () => {};
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the Linux Canvas node host received no diagnostic when the desktop socket directory could not be watched. Canvas availability continued through periodic polling, but the loss of immediate filesystem notifications was completely silent.

## Why This Change Was Made

The Linux Canvas plugin now reports both synchronous `fs.watch()` setup failures and asynchronous watcher failures through the public plugin SDK logger, while preserving the existing one-second `/proc/net/unix` polling fallback and cleanup behavior. This is limited to diagnostics for the existing degraded mode; it does not change Canvas availability policy, IPC behavior, configuration, or protocol shapes.

## User Impact

Linux operators can now see when Canvas socket monitoring has degraded to polling and diagnose missing directories, file-descriptor pressure, permission failures, or watcher backend failures without losing the existing fallback behavior.

## Evidence

**Real-machine before / premise / after / negative control**

Environment: Linux x86_64, Node v24.18.0. The same exported production function was run on a real Linux filesystem from a detached latest-main worktree and the fixed worktree. A deliberately absent socket parent directory makes the operating system return a real `ENOENT` from `fs.watch()`; no filesystem API was mocked or replaced.

```bash
node --import tsx --input-type=module -e 'import os from "node:os"; import path from "node:path"; import { watchLinuxCanvasSocket } from "./extensions/linux-canvas/src/socket-path.ts"; const socketPath = path.join(os.tmpdir(), `openclaw-missing-watch-${process.pid}`, "canvas.sock"); console.log(`PROOF socket_parent_exists=false path=${socketPath}`); const stop = watchLinuxCanvasSocket(socketPath, () => console.log("unexpected-change")); stop(); console.log("PROOF returned_cleanup_without_throw=true");'
```

Negative control / before (`upstream/main` at `510cf463300e596204738b7b1a62f56520306696`):

```text
PROOF socket_parent_exists=false path=/tmp/openclaw-missing-watch-521001/canvas.sock
PROOF returned_cleanup_without_throw=true
```

The real `fs.watch()` failure is swallowed without any diagnostic. The cleanup contract still returns and does not throw.

Premise: Node documents that `fs.watch()` may throw when its underlying watcher is unavailable and that an `FSWatcher` is no longer usable after it emits `error`: https://nodejs.org/api/fs.html#fswatchfilename-options-listener. The production caller already starts a one-second `/proc/net/unix` reconciliation timer after `watchLinuxCanvasSocket()` returns, so reporting the degraded state preserves the existing recovery owner instead of adding a second watcher or retry loop.

After (`65e9414eb60516f5995a9c6bd9c085d2a1bf8018`):

```text
PROOF socket_parent_exists=false path=/tmp/openclaw-missing-watch-521012/canvas.sock
[linux-canvas] linux canvas socket watcher unavailable for /tmp/openclaw-missing-watch-521012; continuing with availability polling: Error: ENOENT: no such file or directory, watch '/tmp/openclaw-missing-watch-521012'
PROOF returned_cleanup_without_throw=true
```

The same real failure is now observable and explicitly names the active polling fallback, while the production function keeps its non-throwing cleanup behavior. The regression test separately drives the asynchronous `FSWatcher.error` contract and verifies that it is reported too.

Focused validation:

```text
node scripts/run-vitest.mjs extensions/linux-canvas
Test Files  3 passed (3)
Tests       18 passed (18)

./node_modules/.bin/oxfmt --check extensions/linux-canvas/src/socket-path.ts extensions/linux-canvas/src/socket-path.test.ts
All matched files use the correct format.

./node_modules/.bin/oxlint extensions/linux-canvas/src/socket-path.ts extensions/linux-canvas/src/socket-path.test.ts
exit 0

git diff --check upstream/main...HEAD
exit 0
```

Full build and full typecheck were not run locally; fork GitHub Actions are expected to cover the wider repository gates. The Linux desktop Canvas UI was not exercised because this is a non-visual node-host diagnostic change; the affected production watcher path itself was exercised on a real Linux filesystem.

**AI-assisted:** Yes. I reviewed the complete watcher caller and cleanup path, the polling fallback, sibling watcher error handling, the public plugin SDK logger implementation, adjacent tests, Node's watcher contract, and the real-machine evidence.
