### PR TITLE
fix(cli): enable doctor workspace suggestions by default

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -82,6 +82,25 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(0);
   });
 
+  it("enables workspace suggestions by default and allows disabling them", async () => {
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--non-interactive", "--yes"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, defaultOptions] = commandCall(doctorCommand);
+    expect(defaultOptions.workspaceSuggestions).toBe(true);
+
+    vi.clearAllMocks();
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--non-interactive", "--yes", "--no-workspace-suggestions"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, disabledOptions] = commandCall(doctorCommand);
+    expect(disabledOptions.workspaceSuggestions).toBe(false);
+  });
+
   it("exits with code 1 when doctor fails", async () => {
     doctorCommand.mockRejectedValue(new Error("doctor failed"));
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -39,7 +39,7 @@ export function registerMaintenanceCommands(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/doctor", "docs.openclaw.ai/cli/doctor")}\n`,
     )
-    .option("--no-workspace-suggestions", "Disable workspace memory system suggestions", false)
+    .option("--no-workspace-suggestions", "Disable workspace memory system suggestions", true)
     .option("--yes", "Accept defaults without prompting", false)
     .option("--repair", "Apply recommended repairs without prompting", false)
     .option("--fix", "Apply recommended repairs (alias for --repair)", false)


### PR DESCRIPTION
Closes #109503

## What Problem This Solves

Fixes `openclaw doctor` silently disabling workspace memory-system suggestions even when `--no-workspace-suggestions` is not passed.

## Why This Change Was Made

The `--no-workspace-suggestions` option was registered with an explicit default of `false`. For a Commander `--no-*` option, the third argument is the value of the positive property (`workspaceSuggestions`) when the flag is absent, so `false` made the feature default to off. The downstream health flow only skips suggestions when `workspaceSuggestions === false`, so the option as registered permanently disabled the feature.

## User Impact

Running `openclaw doctor` now allows workspace memory-system suggestions to be contributed by default, matching the option's help text. Users who want to suppress them can still pass `--no-workspace-suggestions`.

## Evidence

### Regression test

Focused regression test added in `src/cli/program/register.maintenance.test.ts`:

- Before the fix:

```
FAIL  |cli| src/cli/program/register.maintenance.test.ts > registerMaintenanceCommands doctor action > enables workspace suggestions by default and allows disabling them
AssertionError: expected false to be true // Object.is equality
 ❯ src/cli/program/register.maintenance.test.ts:92:49
```

- After the fix:

```
Test Files  1 passed (1)
Tests  32 passed (32)
```

Command used:

```
node scripts/run-vitest.mjs src/cli/program/register.maintenance.test.ts
```

### Real behavior proof

Real output from the actual `doctor:workspace-suggestions` health contribution, run against a temporary empty workspace:

**Default (`workspaceSuggestions: true`)**

```text
=== doctor workspace-suggestions contribution (default enabled) ===
│
◇  Workspace ──────────────────────────────────────────────────────╮
│                                                                  │
│  - Tip: back up the agent workspace in a private git repo; keep  │
│    ~/.openclaw out of git (credentials, sessions). Details:      │
│    /concepts/agent-workspace#git-backup-recommended              │
│                                                                  │
├──────────────────────────────────────────────────────────────────┘
│
◇  Workspace ────────────────────────────────────────────────────────────────────────────╮
│                                                                                        │
│  Memory system not found in workspace.                                                 │
│  Paste this into your agent:                                                           │
│                                                                                        │
│  Install the memory system by applying:                                                │
│  https://github.com/openclaw/openclaw/commit/9ffea23f31ca1df5183b25668f8f814bee0fb34e  │
│  https://github.com/openclaw/openclaw/commit/7d1fee70e76f2f634f1b41fca927ee663914183a  │
│                                                                                        │
├────────────────────────────────────────────────────────────────────────────────────────┘
```

**With `--no-workspace-suggestions` (`workspaceSuggestions: false`)**

```text
=== doctor workspace-suggestions contribution (--no-workspace-suggestions) ===
(no output above because the contribution short-circuits on workspaceSuggestions === false)
```

The contribution is the same code path invoked by `src/flows/doctor-health-contributions.ts` during a normal `openclaw doctor` run; it is run here in isolation via the module's test-mode API so the workspace-suggestion output is visible without the rest of the interactive doctor flow.