### PR TITLE
fix(ci): Mantis desktop scenario dispatch works from umbrella workflow

### DIFF
--- a/.github/workflows/mantis-scenario.yml
+++ b/.github/workflows/mantis-scenario.yml
@@ -106,20 +106,16 @@ jobs:
               gh "${args[@]}"
               ;;
             telegram-desktop-proof)
-              baseline_ref="$BASELINE_REF"
-              if [[ -z "$baseline_ref" || "$baseline_ref" == "0bf06e953fdda290799fc9fb9244a8f67fdae593" ]]; then
-                baseline_ref="main"
+              if [[ -z "${PR_NUMBER:-}" ]]; then
+                echo "telegram-desktop-proof requires pr_number." >&2
+                exit 1
               fi
               args=(
                 workflow run mantis-telegram-desktop-proof.yml
                 --repo "$GITHUB_REPOSITORY"
                 --ref main
-                -f "baseline_ref=${baseline_ref}"
-                -f "candidate_ref=${CANDIDATE_REF}"
+                -f "pr_number=${PR_NUMBER}"
               )
-              if [[ -n "${PR_NUMBER:-}" ]]; then
-                args+=(-f "pr_number=${PR_NUMBER}")
-              fi
               gh "${args[@]}"
               ;;
             web-ui-chat-proof)

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -527,6 +527,10 @@ const GITHUB_WORKFLOW_OWNER_TEST_TARGETS = new Map([
   ],
   [".github/workflows/macos-release.yml", ["test/scripts/package-acceptance-workflow.test.ts"]],
   [
+    ".github/workflows/mantis-scenario.yml",
+    ["test/scripts/mantis-telegram-desktop-proof-workflow.test.ts"],
+  ],
+  [
     ".github/workflows/mantis-telegram-desktop-proof.yml",
     [
       "test/scripts/mantis-telegram-desktop-proof-workflow.test.ts",

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -10,6 +10,7 @@ const QA_LAB_RUNTIME_API = "extensions/qa-lab/runtime-api.ts";
 const PACKAGE_JSON = "package.json";
 const WORKFLOW = ".github/workflows/mantis-telegram-desktop-proof.yml";
 const LIVE_WORKFLOW = ".github/workflows/mantis-telegram-live.yml";
+const SCENARIO_WORKFLOW = ".github/workflows/mantis-scenario.yml";
 const PROMPT = ".github/codex/prompts/mantis-telegram-desktop-proof.md";
 const TELEGRAM_PROOF_SKILL = ".agents/skills/telegram-crabbox-e2e-proof/SKILL.md";
 const DOCS = ["docs/help/testing.md", "docs/concepts/qa-e2e-automation.md"];
@@ -77,6 +78,17 @@ function filesUnder(root: string): string[] {
 }
 
 describe("Mantis Telegram Desktop proof workflow", () => {
+  it("dispatches from the scenario workflow using the proof workflow input contract", () => {
+    const run = jobStep(SCENARIO_WORKFLOW, "dispatch", "Dispatch scenario").run ?? "";
+    const branch = run.match(/telegram-desktop-proof\)([\s\S]*?)\n\s*;;/)?.[1];
+
+    expect(branch).toBeDefined();
+    expect(branch).toContain('if [[ -z "${PR_NUMBER:-}" ]]');
+    expect(branch).toContain('-f "pr_number=${PR_NUMBER}"');
+    expect(branch).not.toContain("baseline_ref=");
+    expect(branch).not.toContain("candidate_ref=");
+  });
+
   it("uses repository pnpm setup defaults", () => {
     const workflow = parse(readFileSync(WORKFLOW, "utf8")) as Workflow;
     const liveWorkflow = parse(readFileSync(LIVE_WORKFLOW, "utf8")) as Workflow;


### PR DESCRIPTION
Related: #100237

## What Problem This Solves

Fixes an issue where maintainers selecting `telegram-desktop-proof` from the umbrella Mantis Scenario workflow would get a dispatch failure every time. The scenario route sent inputs that the target workflow does not accept and treated the target's required PR number as optional.

## Why This Change Was Made

The scenario-specific route now requires `pr_number` and forwards only that supported target-workflow input. A focused contract test locks the dispatcher and target workflow together, and the changed-test map now runs it whenever the umbrella workflow changes.

## User Impact

Maintainers can launch Telegram Desktop proof from the Mantis Scenario workflow instead of bypassing the broken umbrella route. Other scenarios and proof behavior are unchanged.

## Evidence

- `git diff --check`: pass.
- `actionlint .github/workflows/mantis-scenario.yml .github/workflows/mantis-telegram-desktop-proof.yml`: pass.
- `./node_modules/.bin/oxfmt --check test/scripts/mantis-telegram-desktop-proof-workflow.test.ts scripts/test-projects.test-support.mjs`: pass.
- `node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts`: pass, 20 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, correctness 0.91.

AI-assisted maintainer follow-up. I reviewed the complete dispatcher and target workflow input contract and understand the change.
