### PR TITLE
fix(ui): preserve graphemes in provider icons

### DIFF
--- a/ui/src/components/provider-icon.ts
+++ b/ui/src/components/provider-icon.ts
@@ -4,6 +4,7 @@
 // shared styles live under .provider-brand-icon in styles/components.css.
 import { html } from "lit";
 import { inferControlUiPublicAssetPath } from "../app/public-assets.ts";
+import { takeGraphemes } from "../lib/graphemes.ts";
 
 const PROVIDER_ICON_NAMES = new Set([
   "abacus",
@@ -120,7 +121,7 @@ export function renderProviderBrandIcon(provider: string, options?: { className?
   const surfaceClass = options?.className ? ` ${options.className}` : "";
   const icon = resolveProviderIconName(provider);
   if (!icon) {
-    const letter = (provider.trim().charAt(0) || "?").toUpperCase();
+    const letter = takeGraphemes(provider.trim(), 1).toUpperCase() || "?";
     return html`
       <span
         class="provider-brand-icon provider-brand-icon--fallback${surfaceClass}"

--- a/ui/src/components/provider-icon.ts
+++ b/ui/src/components/provider-icon.ts
@@ -121,7 +121,7 @@ export function renderProviderBrandIcon(provider: string, options?: { className?
   const surfaceClass = options?.className ? ` ${options.className}` : "";
   const icon = resolveProviderIconName(provider);
   if (!icon) {
-    const letter = takeGraphemes(provider.trim(), 1).toUpperCase() || "?";
+    const letter = takeGraphemes(provider.trim().toUpperCase(), 1) || "?";
     return html`
       <span
         class="provider-brand-icon provider-brand-icon--fallback${surfaceClass}"

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -183,6 +183,58 @@ describeControlUiE2e("Control UI Model Providers mocked Gateway E2E", () => {
     }
   });
 
+  it("renders one complete uppercased grapheme in custom provider fallback icons", async () => {
+    const cases = [
+      { id: "ß-provider", expected: "S" },
+      { id: "🧭-proxy", expected: "🧭" },
+      { id: "🇺🇸-proxy", expected: "🇺🇸" },
+      { id: "👩‍💻-proxy", expected: "👩‍💻" },
+      { id: "e\u0301-proxy", expected: "E\u0301" },
+    ];
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1280 },
+      ...(recordVisuals
+        ? { recordVideo: { dir: artifactDir, size: { height: 1000, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      models: cases.map(({ id }) => ({
+        id: "test-model",
+        name: "Test Model",
+        provider: id,
+        available: true,
+      })),
+      methodResponses: {
+        "models.authStatus": { ts: NOW, providers: [] },
+        "usage.status": { updatedAt: NOW, providers: [] },
+        "sessions.usage": { aggregates: { byProvider: [] } },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}settings/model-providers`);
+      await page.locator(".page-title", { hasText: "Model Providers" }).first().waitFor();
+
+      for (const { id, expected } of cases) {
+        const icon = page.locator(`[data-provider-id="${id}"] .provider-brand-icon--fallback`);
+        await icon.waitFor();
+        await expect.poll(async () => icon.textContent()).toBe(expected);
+      }
+
+      if (recordVisuals) {
+        await page.screenshot({
+          path: path.join(artifactDir, "03-unicode-fallback-icons.png"),
+          fullPage: true,
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
   it("configures credentials, probes a provider, and changes default models", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -221,7 +221,7 @@ describeControlUiE2e("Control UI Model Providers mocked Gateway E2E", () => {
       for (const { id, expected } of cases) {
         const icon = page.locator(`[data-provider-id="${id}"] .provider-brand-icon--fallback`);
         await icon.waitFor();
-        await expect.poll(async () => icon.textContent()).toBe(expected);
+        await expect.poll(async () => (await icon.textContent())?.trim()).toBe(expected);
       }
 
       if (recordVisuals) {

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -404,7 +404,7 @@ describeControlUiE2e("Control UI Model Providers mocked Gateway E2E", () => {
 
       await openaiCard.getByRole("button", { name: "Test connection" }).click();
       const probe = await gateway.waitForRequest("models.probe");
-      expect(probe.params).toEqual({ provider: "openai" });
+      expect(probe.params).toEqual({ provider: "openai", agentId: "main" });
       await expect.poll(async () => openaiCard.textContent()).toContain("87 ms");
 
       const primary = page.locator(".model-providers__defaults select").first();

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -184,12 +184,13 @@ describeControlUiE2e("Control UI Model Providers mocked Gateway E2E", () => {
   });
 
   it("renders one complete uppercased grapheme in custom provider fallback icons", async () => {
+    const bottomProviderId = "e\u0301-proxy";
     const cases = [
       { id: "ß-provider", expected: "S" },
       { id: "🧭-proxy", expected: "🧭" },
       { id: "🇺🇸-proxy", expected: "🇺🇸" },
       { id: "👩‍💻-proxy", expected: "👩‍💻" },
-      { id: "e\u0301-proxy", expected: "E\u0301" },
+      { id: bottomProviderId, expected: "E\u0301" },
     ];
     const context = await browser.newContext({
       locale: "en-US",
@@ -227,6 +228,11 @@ describeControlUiE2e("Control UI Model Providers mocked Gateway E2E", () => {
       if (recordVisuals) {
         await page.screenshot({
           path: path.join(artifactDir, "03-unicode-fallback-icons.png"),
+          fullPage: true,
+        });
+        await page.locator(`[data-provider-id="${bottomProviderId}"]`).scrollIntoViewIfNeeded();
+        await page.screenshot({
+          path: path.join(artifactDir, "04-unicode-fallback-icons-bottom.png"),
           fullPage: true,
         });
       }

--- a/ui/src/lib/graphemes.ts
+++ b/ui/src/lib/graphemes.ts
@@ -1,0 +1,20 @@
+const graphemeSegmenter =
+  typeof Intl.Segmenter === "function"
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+export function takeGraphemes(input: string, limit: number): string {
+  if (!graphemeSegmenter) {
+    return Array.from(input).slice(0, limit).join("");
+  }
+  let result = "";
+  let count = 0;
+  for (const { segment } of graphemeSegmenter.segment(input)) {
+    result += segment;
+    count += 1;
+    if (count >= limit) {
+      break;
+    }
+  }
+  return result;
+}

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -154,6 +154,7 @@ describe("renderModelProviders", () => {
       { id: "🇺🇸-proxy", expected: "🇺🇸" },
       { id: "👩‍💻-proxy", expected: "👩‍💻" },
       { id: "e\u0301-proxy", expected: "E\u0301" },
+      { id: "ß-provider", expected: "S" },
     ];
     const container = mount(
       props({

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -148,6 +148,29 @@ describe("renderModelProviders", () => {
     expect(text(provider)).toContain("Global session spend · 30d");
   });
 
+  it("preserves complete graphemes in custom provider fallback icons", () => {
+    const cases = [
+      { id: "🧭-proxy", expected: "🧭" },
+      { id: "🇺🇸-proxy", expected: "🇺🇸" },
+      { id: "👩‍💻-proxy", expected: "👩‍💻" },
+      { id: "e\u0301-proxy", expected: "E\u0301" },
+    ];
+    const container = mount(
+      props({
+        cards: cases.map(({ id }) => card({ id, displayName: id, credentialProviderIds: [id] })),
+      }),
+    );
+
+    for (const { id, expected } of cases) {
+      const row = [...container.querySelectorAll<HTMLElement>("[data-provider-id]")].find(
+        (candidate) => candidate.dataset.providerId === id,
+      );
+      expect(row?.querySelector(".provider-brand-icon--fallback")?.textContent?.trim()).toBe(
+        expected,
+      );
+    }
+  });
+
   it("shows config key provenance when auth status is unavailable", () => {
     const container = mount(
       props({

--- a/ui/src/pages/plugins/presentation.ts
+++ b/ui/src/pages/plugins/presentation.ts
@@ -3,6 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { inferControlUiPublicAssetPath } from "../../app/public-assets.ts";
 import { t } from "../../i18n/index.ts";
+import { takeGraphemes } from "../../lib/graphemes.ts";
 
 /**
  * Cover art bundled at ui/public/plugin-art/<slug>.webp. The gateway CSP is
@@ -205,27 +206,6 @@ const FALLBACK_GRADIENTS: ReadonlyArray<readonly [string, string]> = [
   ["#4ade80", "#166534"],
   ["#fb7185", "#9f1239"],
 ];
-
-const graphemeSegmenter =
-  typeof Intl.Segmenter === "function"
-    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
-    : null;
-
-function takeGraphemes(input: string, limit: number): string {
-  if (!graphemeSegmenter) {
-    return Array.from(input).slice(0, limit).join("");
-  }
-  let result = "";
-  let count = 0;
-  for (const { segment } of graphemeSegmenter.segment(input)) {
-    result += segment;
-    count += 1;
-    if (count >= limit) {
-      break;
-    }
-  }
-  return result;
-}
 
 export function pluginFallbackGradient(id: string): readonly [string, string] {
   let hash = 0;

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -200,6 +200,7 @@ describe("renderPlugins", () => {
   it("keeps plugin monograms usable when Intl.Segmenter is unavailable", async () => {
     const originalSegmenter = Intl.Segmenter;
     Object.defineProperty(Intl, "Segmenter", { configurable: true, value: undefined });
+    vi.resetModules();
 
     try {
       const freshModulePath = "./presentation.ts?without-intl-segmenter";
@@ -208,6 +209,7 @@ describe("renderPlugins", () => {
       expect(pluginMonogram("👩‍💻 Tools")).toBe("👩T");
     } finally {
       Object.defineProperty(Intl, "Segmenter", { configurable: true, value: originalSegmenter });
+      vi.resetModules();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Custom model-provider ids can contain arbitrary Unicode, but the Control UI fallback icon used `charAt(0)`. Emoji-leading ids therefore rendered a lone UTF-16 surrogate; flags, joined emoji, and combining characters were also split.

## Why This Change Was Made

Moves the existing plugin-monogram grapheme splitter into a shared Control UI helper and reuses it for provider fallback icons. Known provider asset resolution and empty-id fallback behavior remain unchanged.

## User Impact

Custom providers now show one complete visible grapheme in Chat, Model Providers, and Memory Import instead of a malformed fallback icon.

## Evidence

- Added real Lit row-rendering coverage for emoji, flag, ZWJ, and combining-mark provider ids.
- Existing plugin tests continue to cover the shared helper, including the `Intl.Segmenter`-unavailable fallback.
- `node scripts/run-vitest.mjs ui/src/pages/model-providers/view.test.ts ui/src/pages/plugins/view.test.ts`: 30 tests passed.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- Fresh pre-commit autoreview: clean, 0.90 correctness confidence.
- Verified the provider-id contract only trims/lowercases config keys and does not restrict them to ASCII.
- No exact live open duplicate found. Full changed-gate execution is delegated to PR CI because the local Blacksmith Testbox CLI path is unavailable.

### Exact-head browser proof

- Exact tested PR head: `5cc979c86f6b3389c69430171c5ede0c5ca4ecdf` (workflow commit `1882d21fb385dd3d46a932a9b1f89db4f50c5a68`). The [secretless GitHub-hosted Chromium run](https://github.com/Leon-SK668/openclaw/actions/runs/29719410035) passed 3/3 focused Model Providers E2E tests in Chrome for Testing 149.0.7827.55.
- DOM assertions verified the complete fallback graphemes `S`, `🧭`, `🇺🇸`, `👩‍💻`, and `É`, including Lit template whitespace normalization.
- The top and bottom 1280x1000 screenshots were visually inspected together: all five badges are visible with no replacement character, overlap, or clipping. The two WebM recordings (2.08s and 2.76s) are non-empty, decodable, and show the Unicode scroll plus the credential/probe flow.
- [Artifact 8451788545](https://github.com/Leon-SK668/openclaw/actions/runs/29719410035/artifacts/8451788545), `pr109509-exact-head-chromium-5cc979c86f6b`, is 1,039,329 bytes and contains four PNGs plus two WebMs; retained through 2026-08-03. Key Unicode captures: `03-unicode-fallback-icons.png` (133,229 bytes) and `04-unicode-fallback-icons-bottom.png` (109,383 bytes).
