### PR TITLE
fix(discord): add handshakeTimeout to base gateway WebSocket options

### DIFF
--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -51,6 +51,7 @@ const DISCORD_GATEWAY_PAYLOAD_LIMIT_BYTES = 4096;
 // bounding ws's 100 MiB default before an inbound payload reaches JSON parsing.
 export const DISCORD_GATEWAY_WS_CLIENT_OPTIONS = Object.freeze({
   maxPayload: 16 * 1024 * 1024,
+  handshakeTimeout: 30_000,
 }) satisfies ws.ClientOptions;
 const INVALID_SESSION_MIN_DELAY_MS = 1_000;
 const INVALID_SESSION_JITTER_MS = 4_000;


### PR DESCRIPTION
## What Problem This Solves

`DISCORD_GATEWAY_WS_CLIENT_OPTIONS` had no `handshakeTimeout`. The production monitor subclass already passes its own timeout via the constructor, but the base class `createWebSocket` default left the handshake unbounded for any future or test use of the base gateway.

## Why This Change Was Made

Add a 30s default matching the monitor subclass `DISCORD_GATEWAY_HANDSHAKE_TIMEOUT_MS` and the same 30s pattern used across other channel WebSocket handshake guards (mattermost #105553, qqbot #106484, clickclack #106485).

## User Impact

Defense-in-depth: no production impact since the monitor already overrides the timeout, but prevents an unbounded handshake if the base class is used directly in tests or future code paths.

## Risk / Compatibility

Zero-risk. The frozen options object gains one new key that the production path already overrides to the same value.

AI-assisted: contributor patch used coding agents.