### PR TITLE
fix(memory-embeddings): use longer backoff for rate-limit (429) errors

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -511,7 +511,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
   }
 
-  private async waitForEmbeddingRetry(delayMs: number, action: string, err?: unknown): Promise<void> {
+  private async waitForEmbeddingRetry(
+    delayMs: number,
+    action: string,
+    err?: unknown,
+  ): Promise<void> {
     // When the error is a rate-limit (429 / resource exhausted), use a longer
     // max delay since the reset window is typically 60s.
     const maxDelayMs =

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -40,6 +40,7 @@ import {
   buildMemoryEmbeddingBatches,
   buildTextEmbeddingInputs,
   filterNonEmptyMemoryChunks,
+  isRateLimitMemoryEmbeddingError,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
   resolveMemoryEmbeddingRetryDelay,
@@ -435,8 +436,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         isRetryable: isRetryableMemoryEmbeddingError,
         isSplittable: isSplittableMemoryEmbeddingTransportError,
-        waitForRetry: async (delayMs) => {
-          await this.waitForEmbeddingRetry(delayMs, "retrying");
+        waitForRetry: async (delayMs, _maxDelayMs, err) => {
+          await this.waitForEmbeddingRetry(delayMs, "retrying", err);
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
@@ -488,8 +489,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         isRetryable: isRetryableMemoryEmbeddingError,
         isSplittable: isSplittableMemoryEmbeddingTransportError,
-        waitForRetry: async (delayMs) => {
-          await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
+        waitForRetry: async (delayMs, _maxDelayMs, err) => {
+          await this.waitForEmbeddingRetry(delayMs, "retrying structured batch", err);
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
@@ -510,11 +511,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
   }
 
-  private async waitForEmbeddingRetry(delayMs: number, action: string): Promise<void> {
-    // When delayMs exceeds the normal cap, the retry loop detected a rate-limit
-    // error and used a longer base delay — use the rate-limit max delay too.
+  private async waitForEmbeddingRetry(delayMs: number, action: string, err?: unknown): Promise<void> {
+    // When the error is a rate-limit (429 / resource exhausted), use a longer
+    // max delay since the reset window is typically 60s.
     const maxDelayMs =
-      delayMs > EMBEDDING_RETRY_MAX_DELAY_MS
+      err && isRateLimitMemoryEmbeddingError(formatErrorMessage(err))
         ? EMBEDDING_RETRY_RATE_LIMIT_MAX_DELAY_MS
         : EMBEDDING_RETRY_MAX_DELAY_MS;
     const waitMs = resolveMemoryEmbeddingRetryDelay(delayMs, Math.random(), maxDelayMs);
@@ -553,8 +554,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         signal,
         isRetryable: isRetryableMemoryEmbeddingError,
-        waitForRetry: async (delayMs) => {
-          await this.waitForEmbeddingRetry(delayMs, "retrying query");
+        waitForRetry: async (delayMs, _maxDelayMs, err) => {
+          await this.waitForEmbeddingRetry(delayMs, "retrying query", err);
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -63,6 +63,9 @@ const EMBEDDING_INDEX_CONCURRENCY = 4;
 const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
 const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
 const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
+/** Longer initial delay for rate-limit (429) errors — reset window is typically 60s. */
+const EMBEDDING_RETRY_RATE_LIMIT_BASE_DELAY_MS = 30_000;
+const EMBEDDING_RETRY_RATE_LIMIT_MAX_DELAY_MS = 120_000;
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
@@ -437,6 +440,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        rateLimitBaseDelayMs: EMBEDDING_RETRY_RATE_LIMIT_BASE_DELAY_MS,
         onSplit: ({ itemCount, splitAt }) => {
           log.warn(
             `memory embeddings transport failed after retries; splitting batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
@@ -489,6 +493,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        rateLimitBaseDelayMs: EMBEDDING_RETRY_RATE_LIMIT_BASE_DELAY_MS,
         onSplit: ({ itemCount, splitAt }) => {
           log.warn(
             `memory embeddings transport failed after retries; splitting structured batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
@@ -506,11 +511,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private async waitForEmbeddingRetry(delayMs: number, action: string): Promise<void> {
-    const waitMs = resolveMemoryEmbeddingRetryDelay(
-      delayMs,
-      Math.random(),
-      EMBEDDING_RETRY_MAX_DELAY_MS,
-    );
+    // When delayMs exceeds the normal cap, the retry loop detected a rate-limit
+    // error and used a longer base delay — use the rate-limit max delay too.
+    const maxDelayMs =
+      delayMs > EMBEDDING_RETRY_MAX_DELAY_MS
+        ? EMBEDDING_RETRY_RATE_LIMIT_MAX_DELAY_MS
+        : EMBEDDING_RETRY_MAX_DELAY_MS;
+    const waitMs = resolveMemoryEmbeddingRetryDelay(delayMs, Math.random(), maxDelayMs);
     log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
     await new Promise((resolve) => {
       setTimeout(resolve, waitMs);
@@ -551,6 +558,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        rateLimitBaseDelayMs: EMBEDDING_RETRY_RATE_LIMIT_BASE_DELAY_MS,
       });
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -278,7 +278,7 @@ describe("memory embedding policy", () => {
     expect(isRateLimitMemoryEmbeddingError("429 rate limit exceeded")).toBe(true);
     expect(isRateLimitMemoryEmbeddingError("resource has been exhausted")).toBe(true);
     expect(isRateLimitMemoryEmbeddingError("too many requests, try again later")).toBe(true);
-    expect(isRateLimitMemoryEmbeddingError("rate_limit: token quota reached")).toBe(true);
+    expect(isRateLimitMemoryEmbeddingError("rate_limit: token quota reached")).toBe(false);
     expect(isRateLimitMemoryEmbeddingError("fetch failed | other side closed")).toBe(false);
     expect(isRateLimitMemoryEmbeddingError("502 Bad Gateway (cloudflare)")).toBe(false);
     expect(isRateLimitMemoryEmbeddingError("too many tokens per day")).toBe(false);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -6,7 +6,6 @@ import {
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
   isRateLimitMemoryEmbeddingError,
-  isStructuredInputTooLargeMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
@@ -272,24 +271,6 @@ describe("memory embedding policy", () => {
     expect(resolveMemoryEmbeddingRetryDelay(500, 0, 8000)).toBe(500);
     expect(resolveMemoryEmbeddingRetryDelay(500, 1, 8000)).toBe(600);
     expect(resolveMemoryEmbeddingRetryDelay(10_000, 1, 8000)).toBe(8000);
-  });
-
-  it("detects structured input too large errors (413 / request too large)", () => {
-    expect(isStructuredInputTooLargeMemoryEmbeddingError("413 Payload Too Large")).toBe(true);
-    expect(
-      isStructuredInputTooLargeMemoryEmbeddingError("request too large: 10MB > 1MB limit"),
-    ).toBe(true);
-    expect(isStructuredInputTooLargeMemoryEmbeddingError("input too large, max 4096 tokens")).toBe(
-      true,
-    );
-    expect(
-      isStructuredInputTooLargeMemoryEmbeddingError("request size exceeds limit for model"),
-    ).toBe(true);
-    expect(
-      isStructuredInputTooLargeMemoryEmbeddingError("too many tokens in embedding input"),
-    ).toBe(true);
-    expect(isStructuredInputTooLargeMemoryEmbeddingError("429 rate limit")).toBe(false);
-    expect(isStructuredInputTooLargeMemoryEmbeddingError("502 Bad Gateway")).toBe(false);
   });
 
   it("detects rate-limit errors (429 / resource exhausted)", () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -281,6 +281,14 @@ describe("memory embedding policy", () => {
     expect(isRateLimitMemoryEmbeddingError("fetch failed | other side closed")).toBe(false);
     expect(isRateLimitMemoryEmbeddingError("502 Bad Gateway (cloudflare)")).toBe(false);
     expect(isRateLimitMemoryEmbeddingError("too many tokens per day")).toBe(false);
+    // Canonical Google-style RESOURCE_EXHAUSTED with rate-limit keyword
+    expect(isRateLimitMemoryEmbeddingError("RESOURCE_EXHAUSTED: rate limit exceeded")).toBe(true);
+    // Pure quota/billing RESOURCE_EXHAUSTED without rate-limit keyword
+    expect(
+      isRateLimitMemoryEmbeddingError(
+        "RESOURCE_EXHAUSTED: You exceeded your current quota, please check your plan and billing details",
+      ),
+    ).toBe(false);
   });
 
   it("uses longer backoff for rate-limit errors when rateLimitBaseDelayMs is set", async () => {
@@ -361,5 +369,53 @@ describe("memory embedding policy", () => {
     expect(run).toHaveBeenCalledTimes(2);
     // 1 retry with rate-limit backoff before exhausting maxAttempts=2
     expect(waits).toEqual([30_000]);
+  });
+
+  it("uses longer backoff for Google-style RESOURCE_EXHAUSTED with rate-limit keyword", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("RESOURCE_EXHAUSTED: rate limit exceeded");
+    });
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 30_000,
+      }),
+    ).rejects.toThrow("RESOURCE_EXHAUSTED");
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([30_000, 60_000]);
+  });
+
+  it("uses short backoff for RESOURCE_EXHAUSTED with quota message (not rate-limit)", async () => {
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          throw new Error(
+            "RESOURCE_EXHAUSTED: You exceeded your current quota, please check your plan and billing details",
+          );
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 30_000,
+      }),
+    ).rejects.toThrow("RESOURCE_EXHAUSTED");
+
+    // The quota message does not match isRetryableMemoryEmbeddingError,
+    // so the error is thrown immediately without any retry wait.
+    expect(waits).toEqual([]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -5,6 +5,8 @@ import {
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
+  isStructuredInputTooLargeMemoryEmbeddingError,
+  isRateLimitMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
@@ -270,5 +272,95 @@ describe("memory embedding policy", () => {
     expect(resolveMemoryEmbeddingRetryDelay(500, 0, 8000)).toBe(500);
     expect(resolveMemoryEmbeddingRetryDelay(500, 1, 8000)).toBe(600);
     expect(resolveMemoryEmbeddingRetryDelay(10_000, 1, 8000)).toBe(8000);
+  });
+
+  it("detects rate-limit errors (429 / resource exhausted)", () => {
+    expect(isRateLimitMemoryEmbeddingError("429 rate limit exceeded")).toBe(true);
+    expect(isRateLimitMemoryEmbeddingError("resource has been exhausted")).toBe(true);
+    expect(isRateLimitMemoryEmbeddingError("too many requests, try again later")).toBe(true);
+    expect(isRateLimitMemoryEmbeddingError("rate_limit: token quota reached")).toBe(true);
+    expect(isRateLimitMemoryEmbeddingError("fetch failed | other side closed")).toBe(false);
+    expect(isRateLimitMemoryEmbeddingError("502 Bad Gateway (cloudflare)")).toBe(false);
+    expect(isRateLimitMemoryEmbeddingError("too many tokens per day")).toBe(false);
+  });
+
+  it("uses longer backoff for rate-limit errors when rateLimitBaseDelayMs is set", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("openai embeddings failed: 429 rate limit");
+    });
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 30_000,
+      }),
+    ).rejects.toThrow("429 rate limit");
+
+    expect(run).toHaveBeenCalledTimes(3);
+    // 30s → 60s; the 3rd attempt (120s) throws before queuing a wait
+    expect(waits).toEqual([30_000, 60_000]);
+  });
+
+  it("still uses short backoff for non-rate-limit retryable errors even when rateLimitBaseDelayMs is set", async () => {
+    let calls = 0;
+    const waits: number[] = [];
+
+    const result = await runMemoryEmbeddingRetryLoop({
+      run: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("TypeError: fetch failed | other side closed");
+        }
+        return "ok";
+      },
+      isRetryable: isRetryableMemoryEmbeddingError,
+      waitForRetry: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      maxAttempts: 3,
+      baseDelayMs: 500,
+      rateLimitBaseDelayMs: 30_000,
+    });
+
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+    // Transient network errors still use the normal 500ms base delay
+    expect(waits).toEqual([500]);
+  });
+
+  it("uses longer backoff for rate-limit errors in batch retry — 429 is not splittable, so it throws", async () => {
+    const waits: number[] = [];
+    const run = vi.fn(async (items: string[]) => {
+      if (items.length > 1) {
+        throw new Error("gemini embeddings failed: 429 resource has been exhausted");
+      }
+      return items.map((item) => [item.charCodeAt(0)]);
+    });
+
+    await expect(
+      runMemoryEmbeddingBatchRetryWithSplit({
+        items: ["a", "b", "c"],
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        isSplittable: isSplittableMemoryEmbeddingTransportError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 2,
+        baseDelayMs: 500,
+        rateLimitBaseDelayMs: 30_000,
+      }),
+    ).rejects.toThrow("429 resource has been exhausted");
+
+    expect(run).toHaveBeenCalledTimes(2);
+    // 1 retry with rate-limit backoff before exhausting maxAttempts=2
+    expect(waits).toEqual([30_000]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -5,8 +5,8 @@ import {
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
-  isStructuredInputTooLargeMemoryEmbeddingError,
   isRateLimitMemoryEmbeddingError,
+  isStructuredInputTooLargeMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
@@ -272,6 +272,24 @@ describe("memory embedding policy", () => {
     expect(resolveMemoryEmbeddingRetryDelay(500, 0, 8000)).toBe(500);
     expect(resolveMemoryEmbeddingRetryDelay(500, 1, 8000)).toBe(600);
     expect(resolveMemoryEmbeddingRetryDelay(10_000, 1, 8000)).toBe(8000);
+  });
+
+  it("detects structured input too large errors (413 / request too large)", () => {
+    expect(isStructuredInputTooLargeMemoryEmbeddingError("413 Payload Too Large")).toBe(true);
+    expect(
+      isStructuredInputTooLargeMemoryEmbeddingError("request too large: 10MB > 1MB limit"),
+    ).toBe(true);
+    expect(isStructuredInputTooLargeMemoryEmbeddingError("input too large, max 4096 tokens")).toBe(
+      true,
+    );
+    expect(
+      isStructuredInputTooLargeMemoryEmbeddingError("request size exceeds limit for model"),
+    ).toBe(true);
+    expect(
+      isStructuredInputTooLargeMemoryEmbeddingError("too many tokens in embedding input"),
+    ).toBe(true);
+    expect(isStructuredInputTooLargeMemoryEmbeddingError("429 rate limit")).toBe(false);
+    expect(isStructuredInputTooLargeMemoryEmbeddingError("502 Bad Gateway")).toBe(false);
   });
 
   it("detects rate-limit errors (429 / resource exhausted)", () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -116,12 +116,10 @@ export function isRateLimitMemoryEmbeddingError(message: string): boolean {
   // text / error type) AND a human-readable keyword, so that pure quota or
   // billing messages (whose reset window is hours, not seconds) fall through
   // to the normal retry path.
-  const hasRateLimitIndicator = /(429|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(
-    message,
-  );
-  const hasRateLimitKeyword = /(rate\s*_?\s*limit|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(
-    message,
-  );
+  const hasRateLimitIndicator =
+    /(429|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(message);
+  const hasRateLimitKeyword =
+    /(rate\s*_?\s*limit|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(message);
   return hasRateLimitIndicator && hasRateLimitKeyword;
 }
 

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -81,9 +81,6 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   return batches;
 }
 
-const RATE_LIMIT_MEMORY_EMBEDDING_ERROR_RE =
-  /(rate[_ ]limit|too many requests|429|resource has been exhausted)/i;
-
 const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
   /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i;
 
@@ -115,7 +112,17 @@ export function isStructuredInputTooLargeMemoryEmbeddingError(message: string): 
 }
 
 export function isRateLimitMemoryEmbeddingError(message: string): boolean {
-  return RATE_LIMIT_MEMORY_EMBEDDING_ERROR_RE.test(message);
+  // Require both a rate-limit type indicator (status code / standard status
+  // text / error type) AND a human-readable keyword, so that pure quota or
+  // billing messages (whose reset window is hours, not seconds) fall through
+  // to the normal retry path.
+  const hasRateLimitIndicator = /(429|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(
+    message,
+  );
+  const hasRateLimitKeyword = /(rate\s*_?\s*limit|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(
+    message,
+  );
+  return hasRateLimitIndicator && hasRateLimitKeyword;
 }
 
 export function resolveMemoryEmbeddingRetryDelay(
@@ -129,16 +136,23 @@ export function resolveMemoryEmbeddingRetryDelay(
 export async function runMemoryEmbeddingRetryLoop<T>(params: {
   run: () => Promise<T>;
   isRetryable: (message: string) => boolean;
-  waitForRetry: (delayMs: number, maxDelayMs?: number) => Promise<void>;
+  waitForRetry: (delayMs: number, maxDelayMs?: number, err?: unknown) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
   /** Longer base delay for rate-limit (429) errors whose reset window is typically 60s. */
   rateLimitBaseDelayMs?: number;
+  /** Max attempts for rate-limit errors; defaults to maxAttempts. */
+  rateLimitMaxAttempts?: number;
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
-  const attempts = Math.max(1, params.maxAttempts);
-  for (const attempt of Array.from({ length: attempts }, (_, index) => index + 1)) {
+  const normalAttempts = Math.max(1, params.maxAttempts);
+  const rateLimitAttempts = Math.max(
+    normalAttempts,
+    params.rateLimitMaxAttempts ?? params.maxAttempts,
+  );
+  const maxLoopAttempts = Math.max(normalAttempts, rateLimitAttempts);
+  for (const attempt of Array.from({ length: maxLoopAttempts }, (_, index) => index + 1)) {
     try {
       return await params.run();
     } catch (err) {
@@ -149,16 +163,20 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
         throw err;
       }
       const message = formatErrorMessage(err);
-      if (!params.isRetryable(message) || attempt >= params.maxAttempts) {
+      if (!params.isRetryable(message)) {
         throw err;
       }
       const isRateLimit =
         params.rateLimitBaseDelayMs != null && isRateLimitMemoryEmbeddingError(message);
+      const effectiveMaxAttempts = isRateLimit ? rateLimitAttempts : normalAttempts;
+      if (attempt >= effectiveMaxAttempts) {
+        throw err;
+      }
       const effectiveBaseDelayMs: number = isRateLimit
         ? params.rateLimitBaseDelayMs!
         : params.baseDelayMs;
       const delayMs = effectiveBaseDelayMs * 2 ** (attempt - 1);
-      await params.waitForRetry(delayMs);
+      await params.waitForRetry(delayMs, undefined, err);
     }
   }
   throw new Error("retry loop exhausted");
@@ -169,10 +187,11 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
   run: (items: TInput[]) => Promise<TOutput[]>;
   isRetryable: (message: string) => boolean;
   isSplittable: (message: string) => boolean;
-  waitForRetry: (delayMs: number, maxDelayMs?: number) => Promise<void>;
+  waitForRetry: (delayMs: number, maxDelayMs?: number, err?: unknown) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
   rateLimitBaseDelayMs?: number;
+  rateLimitMaxAttempts?: number;
   onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
 }): Promise<TOutput[]> {
   try {
@@ -183,6 +202,7 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
       maxAttempts: params.maxAttempts,
       baseDelayMs: params.baseDelayMs,
       rateLimitBaseDelayMs: params.rateLimitBaseDelayMs,
+      rateLimitMaxAttempts: params.rateLimitMaxAttempts,
     });
   } catch (err) {
     const message = formatErrorMessage(err);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -81,6 +81,9 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   return batches;
 }
 
+const RATE_LIMIT_MEMORY_EMBEDDING_ERROR_RE =
+  /(rate[_ ]limit|too many requests|429|resource has been exhausted)/i;
+
 const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
   /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i;
 
@@ -105,6 +108,16 @@ export function isRetryableMemoryEmbeddingError(message: string): boolean {
   );
 }
 
+export function isStructuredInputTooLargeMemoryEmbeddingError(message: string): boolean {
+  return /(413|payload too large|request too large|input too large|too many tokens|input limit|request size)/i.test(
+    message,
+  );
+}
+
+export function isRateLimitMemoryEmbeddingError(message: string): boolean {
+  return RATE_LIMIT_MEMORY_EMBEDDING_ERROR_RE.test(message);
+}
+
 export function resolveMemoryEmbeddingRetryDelay(
   delayMs: number,
   randomValue: number,
@@ -116,15 +129,16 @@ export function resolveMemoryEmbeddingRetryDelay(
 export async function runMemoryEmbeddingRetryLoop<T>(params: {
   run: () => Promise<T>;
   isRetryable: (message: string) => boolean;
-  waitForRetry: (delayMs: number) => Promise<void>;
+  waitForRetry: (delayMs: number, maxDelayMs?: number) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
+  /** Longer base delay for rate-limit (429) errors whose reset window is typically 60s. */
+  rateLimitBaseDelayMs?: number;
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
   const attempts = Math.max(1, params.maxAttempts);
   for (const attempt of Array.from({ length: attempts }, (_, index) => index + 1)) {
-    const delayMs = params.baseDelayMs * 2 ** (attempt - 1);
     try {
       return await params.run();
     } catch (err) {
@@ -138,6 +152,12 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
       if (!params.isRetryable(message) || attempt >= params.maxAttempts) {
         throw err;
       }
+      const isRateLimit =
+        params.rateLimitBaseDelayMs != null && isRateLimitMemoryEmbeddingError(message);
+      const effectiveBaseDelayMs: number = isRateLimit
+        ? params.rateLimitBaseDelayMs!
+        : params.baseDelayMs;
+      const delayMs = effectiveBaseDelayMs * 2 ** (attempt - 1);
       await params.waitForRetry(delayMs);
     }
   }
@@ -149,9 +169,10 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
   run: (items: TInput[]) => Promise<TOutput[]>;
   isRetryable: (message: string) => boolean;
   isSplittable: (message: string) => boolean;
-  waitForRetry: (delayMs: number) => Promise<void>;
+  waitForRetry: (delayMs: number, maxDelayMs?: number) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
+  rateLimitBaseDelayMs?: number;
   onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
 }): Promise<TOutput[]> {
   try {
@@ -161,6 +182,7 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
       waitForRetry: params.waitForRetry,
       maxAttempts: params.maxAttempts,
       baseDelayMs: params.baseDelayMs,
+      rateLimitBaseDelayMs: params.rateLimitBaseDelayMs,
     });
   } catch (err) {
     const message = formatErrorMessage(err);
@@ -173,10 +195,12 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
     const left = await runMemoryEmbeddingBatchRetryWithSplit({
       ...params,
       items: params.items.slice(0, splitAt),
+      rateLimitBaseDelayMs: params.rateLimitBaseDelayMs,
     });
     const right = await runMemoryEmbeddingBatchRetryWithSplit({
       ...params,
       items: params.items.slice(splitAt),
+      rateLimitBaseDelayMs: params.rateLimitBaseDelayMs,
     });
     return [...left, ...right];
   }

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -105,12 +105,6 @@ export function isRetryableMemoryEmbeddingError(message: string): boolean {
   );
 }
 
-export function isStructuredInputTooLargeMemoryEmbeddingError(message: string): boolean {
-  return /(413|payload too large|request too large|input too large|too many tokens|input limit|request size)/i.test(
-    message,
-  );
-}
-
 export function isRateLimitMemoryEmbeddingError(message: string): boolean {
   // Require both a rate-limit type indicator (status code / standard status
   // text / error type) AND a human-readable keyword, so that pure quota or

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -111,7 +111,9 @@ export function isRateLimitMemoryEmbeddingError(message: string): boolean {
   // billing messages (whose reset window is hours, not seconds) fall through
   // to the normal retry path.
   const hasRateLimitIndicator =
-    /(429|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(message);
+    /(429|too\s+many\s+requests|resource\s+has\s+been\s+exhausted|resource_exhausted)/i.test(
+      message,
+    );
   const hasRateLimitKeyword =
     /(rate\s*_?\s*limit|too\s+many\s+requests|resource\s+has\s+been\s+exhausted)/i.test(message);
   return hasRateLimitIndicator && hasRateLimitKeyword;


### PR DESCRIPTION
## What Problem This Solves

When `openclaw memory index` encounters a rate-limit (429 / RESOURCE_EXHAUSTED) error from the embedding provider, the retry loop uses the normal 500ms base delay with an 8000ms cap. Rate-limit windows are typically 60 seconds, so all 3 retries exhaust in under 5 seconds and the entire index operation fails. The reporter's log shows retries completing at `~553ms/526ms/520ms/548ms/1028ms/1194ms` — nowhere near the 60s window required.

## Changes

- **New `isRateLimitMemoryEmbeddingError()` in policy** — two-part classifier requires BOTH a status indicator (429 / too many requests / RESOURCE_EXHAUSTED / resource has been exhausted) AND a rate-limit keyword, so pure quota/billing messages (which won't recover in 60s) fall through to the normal short retry path
- **`rateLimitBaseDelayMs` (30s) param on `runMemoryEmbeddingRetryLoop`** — when a rate-limit error fires, use this base instead of the normal `500ms`; produces wait sequence: 30s → 60s → 120s
- **`rateLimitMaxAttempts` param** — separate attempt budget for rate-limit errors so they don't burn through the normal retry budget
- **Explicit `isRateLimitMemoryEmbeddingError(err)` in `waitForEmbeddingRetry`** — replaced the fragile delayMs heuristic with an explicit predicate check on the actual error
- **Threaded through `runMemoryEmbeddingBatchRetryWithSplit`** — both retry loops and recursive split calls get the same longer backoff for rate-limit errors
- Normal transient errors (connection reset, fetch failed, timed out, 5xx) still use the original 500ms base — no regression

## Evidence

- All 19 tests pass (17 original + 2 new for Google-style RESOURCE_EXHAUSTED)
- Test `uses longer backoff for rate-limit errors` confirms: 429 with default config produces waits = [30000, 60000] before exhausting 3 attempts
- Test `uses longer backoff for Google-style RESOURCE_EXHAUSTED with rate-limit keyword` confirms the canonical provider throttle spelling gets the same long backoff
- Test `still uses short backoff for non-rate-limit retryable errors` confirms: transient `fetch failed` with the same config still uses [500ms] delay — no cross-contamination
- Test for quota RESOURCE_EXHAUSTED confirms: pure billing messages are not retried (not classified as retryable) — no spurious 60s waits for quota exhaustion
- The `waitForEmbeddingRetry` max-delay now uses explicit `isRateLimitMemoryEmbeddingError(err)` instead of the old delayMs heuristic