### PR TITLE
fix(pr): close the review follow-ups on early gate proof

### DIFF
--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -230,17 +230,27 @@ function successfulRunOrThrow(
     if (isGateProvenInProgressRun(run, ciGateJobs, nowMs)) {
       return run;
     }
-    // A terminal non-success stays blocking unless a pending SCHEDULED rerun
-    // on the same head has already passed its own gate — the gate needs every
-    // selected lane, so that attempt is authoritative proof the failure is
-    // re-resolved. Manual runs can never mask an unresolved failure this way.
+    // A terminal non-success stays blocking unless a NEWER pending SCHEDULED
+    // rerun on the same head has already passed its own gate — the gate needs
+    // every selected lane, so that attempt is authoritative proof the failure
+    // is re-resolved. The newer-than bound stops a stalled older run's gate
+    // from masking a later failure, and manual runs can never mask one.
     if (run?.status === "completed" && run.conclusion !== "success") {
-      const gateProvenRerun = matchingRuns.find(
-        (candidate) =>
-          candidate !== run &&
-          candidate.event === "pull_request" &&
-          isGateProvenInProgressRun(candidate, ciGateJobs, nowMs),
-      );
+      const failedRunCreatedAtMs = Date.parse(String(run?.created_at ?? ""));
+      const gateProvenRerun = matchingRuns.find((candidate) => {
+        if (candidate === run || candidate.event !== "pull_request") {
+          return false;
+        }
+        const candidateCreatedAtMs = Date.parse(String(candidate?.created_at ?? ""));
+        if (
+          !Number.isFinite(candidateCreatedAtMs) ||
+          !Number.isFinite(failedRunCreatedAtMs) ||
+          candidateCreatedAtMs <= failedRunCreatedAtMs
+        ) {
+          return false;
+        }
+        return isGateProvenInProgressRun(candidate, ciGateJobs, nowMs);
+      });
       if (gateProvenRerun) {
         return gateProvenRerun;
       }

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -226,8 +226,25 @@ function successfulRunOrThrow(
   if (isSuccessfulRecentRun(run, nowMs)) {
     return run;
   }
-  if (workflowName === "CI" && isGateProvenInProgressRun(run, ciGateJobs, nowMs)) {
-    return run;
+  if (workflowName === "CI") {
+    if (isGateProvenInProgressRun(run, ciGateJobs, nowMs)) {
+      return run;
+    }
+    // A terminal non-success stays blocking unless a pending SCHEDULED rerun
+    // on the same head has already passed its own gate — the gate needs every
+    // selected lane, so that attempt is authoritative proof the failure is
+    // re-resolved. Manual runs can never mask an unresolved failure this way.
+    if (run?.status === "completed" && run.conclusion !== "success") {
+      const gateProvenRerun = matchingRuns.find(
+        (candidate) =>
+          candidate !== run &&
+          candidate.event === "pull_request" &&
+          isGateProvenInProgressRun(candidate, ciGateJobs, nowMs),
+      );
+      if (gateProvenRerun) {
+        return gateProvenRerun;
+      }
+    }
   }
   throw new Error(
     `Missing successful recent ${workflowName} workflow for ${sha}. Observed: ${formatObservedRuns(matchingRuns)}`,
@@ -541,25 +558,44 @@ function loadCiGateJobs(repo, workflowRuns, sha, nowMs = Date.now()) {
   );
   return candidates.flatMap((run) => {
     const attempt = run.run_attempt ?? 1;
-    const payload = JSON.parse(
-      execGhApiRead(`repos/${repo}/actions/runs/${run.id}/attempts/${attempt}/jobs?per_page=100`, {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      }),
-    );
-    const jobs = Array.isArray(payload?.jobs) ? payload.jobs : [];
+    // The jobs endpoint pages at 100 and full-scope runs already sit near
+    // that; page until the gate job is visible so growth past one page can
+    // never silently disable the early-proof path.
+    const jobs = [];
+    for (let page = 1; page <= 5; page += 1) {
+      const payload = JSON.parse(
+        execGhApiRead(
+          `repos/${repo}/actions/runs/${run.id}/attempts/${attempt}/jobs?per_page=100&page=${page}`,
+          { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+        ),
+      );
+      const pageJobs = Array.isArray(payload?.jobs) ? payload.jobs : [];
+      jobs.push(...pageJobs);
+      const totalCount = Number(payload?.total_count ?? 0);
+      if (
+        pageJobs.length === 0 ||
+        jobs.length >= totalCount ||
+        jobs.some((job) => job?.name === CI_GATE_CHECK_NAME)
+      ) {
+        break;
+      }
+    }
     // Re-read the run after fetching its attempt jobs and drop the evidence if
-    // the attempt advanced or the run completed in between: otherwise a rerun
-    // starting in that window would let the just-fetched prior-attempt gate
-    // vouch for an attempt that has not reached its own gate.
+    // the attempt advanced in between: otherwise a rerun starting in that
+    // window would let the just-fetched prior-attempt gate vouch for an
+    // attempt that has not reached its own gate. Same-attempt completion is
+    // fine — a run that finished successfully still proves this attempt, and
+    // a non-success completion must not be blessed by its own earlier gate.
     const current = JSON.parse(
       execGhApiRead(`repos/${repo}/actions/runs/${run.id}`, {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       }),
     );
+    const sameAttempt = (current?.run_attempt ?? attempt) === attempt;
     const stillPending = current?.status === "in_progress" || current?.status === "queued";
-    if (!stillPending || (current?.run_attempt ?? attempt) !== attempt) {
+    const completedSuccess = current?.status === "completed" && current?.conclusion === "success";
+    if (!sameAttempt || (!stillPending && !completedSuccess)) {
       return [];
     }
     return jobs;

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -129,6 +129,45 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow(/Missing successful recent CI workflow/);
   });
 
+  it("lets a gate-proven pending rerun win over an older terminal failure", () => {
+    const failedRun = {
+      ...successfulRun("CI", 40, "2026-06-17T10:40:00Z"),
+      conclusion: "failure",
+    };
+    const pendingRerun = {
+      ...successfulRun("CI", 42, "2026-06-17T10:52:00Z"),
+      status: "in_progress",
+      conclusion: null,
+      run_attempt: 1,
+    };
+    const gateJob = {
+      name: "openclaw/ci-gate",
+      run_id: 42,
+      run_attempt: 1,
+      status: "completed",
+      conclusion: "success",
+      completed_at: "2026-06-17T10:51:30Z",
+    };
+
+    // The newer pending run is re-resolving the failure; its successful gate
+    // proves the selected lanes, so the stale failure must not block.
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns: [failedRun, pendingRerun],
+      ciGateJobs: [gateJob],
+    });
+    expect(evidence.workflows.map((workflow: { id: unknown }) => workflow.id)).toContain(42);
+
+    // Without gate proof the pending run still blocks (no early acceptance),
+    // and a failure that IS the latest scheduled run still blocks outright.
+    expect(() =>
+      collectHostedGateEvidence({ sha, workflowRuns: [failedRun, pendingRerun], ciGateJobs: [] }),
+    ).toThrow(/Missing successful recent CI workflow/);
+    expect(() =>
+      collectHostedGateEvidence({ sha, workflowRuns: [failedRun], ciGateJobs: [gateJob] }),
+    ).toThrow(/Missing successful recent CI workflow/);
+  });
+
   it("requires the latest scheduled workflow run to pass", () => {
     const evidence = collectHostedGateEvidence({
       sha,

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -139,6 +139,7 @@ describe("verify-pr-hosted-gates", () => {
       status: "in_progress",
       conclusion: null,
       run_attempt: 1,
+      created_at: "2026-06-17T10:50:00Z",
     };
     const gateJob = {
       name: "openclaw/ci-gate",
@@ -165,6 +166,16 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow(/Missing successful recent CI workflow/);
     expect(() =>
       collectHostedGateEvidence({ sha, workflowRuns: [failedRun], ciGateJobs: [gateJob] }),
+    ).toThrow(/Missing successful recent CI workflow/);
+
+    // A stalled OLDER run's gate must not mask a newer terminal failure.
+    const stalledOlderRun = { ...pendingRerun, created_at: "2026-06-17T10:40:00Z" };
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [failedRun, stalledOlderRun],
+        ciGateJobs: [gateJob],
+      }),
     ).toThrow(/Missing successful recent CI workflow/);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Codex review on the landed #109331 left three verified findings. All are fail-safe (each silently disables the early-gate speedup rather than accepting anything wrong), but two of them no-op the feature in exactly the scenarios it exists for:

1. **Stale terminal failure blocks a gate-proven rerun.** With an older completed failure on the same head, `preferredCiRun()` selected the failure before the gate-proven pending run was ever evaluated — the rerun-a-flake-then-land-fast case never fired.
2. **Single-page jobs lookup.** Full-scope PR runs measure ~71 jobs with `openclaw/ci-gate` at index ~69 (verified live); one compact-bin growth past 100 puts the gate on page 2 and `loadCiGateJobs` returns no proof forever.
3. **Same-attempt completion discarded valid evidence.** A run finishing successfully between the workflow-run snapshot and the revalidation re-read rejected the just-fetched gate jobs, failing the verifier until re-run.

## Why This Change Was Made

- A terminal non-success is now superseded **only** by a pending *scheduled* run whose own gate already passed — the gate needs every selected lane, so that attempt is authoritative re-resolution. The existing guard ("does not mask a failed CI run with a queued rerun and release-gate fallback") stays intact: manual/dispatch runs still cannot mask unresolved failures.
- The attempt-jobs lookup pages (bounded at 5 pages) until the gate job is visible or the listing is exhausted.
- Revalidation rejects only when the attempt advanced or the run completed with non-success; same-attempt successful completion keeps its evidence.

## User Impact

None at runtime — landing-flow only. The early-mergeable path now works for reruns-after-failure and survives job-count growth.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts` — green, including the new rerun-preference cases (gate-proven rerun accepted; pending-without-proof still blocks; lone failure still blocks) and the pre-existing manual-masking guard.
- Live measurement: recent full-scope runs at 71 jobs, ci-gate at index 69 of page 1.
