### PR TITLE
fix(discord): preserve Unicode model picker buckets

### DIFF
--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -370,7 +370,9 @@ function computeAlphaBuckets(sortedItems: string[]): DiscordModelPickerBucket[] 
     ];
   }
 
-  const firstLetter = (value: string): string => value.charAt(0).toLowerCase();
+  // Bucket ids enter URI-encoded Discord custom ids, so the prefix must never
+  // be a lone UTF-16 surrogate when an identifier starts with an astral character.
+  const firstLetter = (value: string): string => (Array.from(value)[0] ?? "").toLowerCase();
   const firstItem = expectDefined(sortedItems.at(0), "non-empty sorted model picker items");
   const allSamePrefix = sortedItems.every((item) => firstLetter(item) === firstLetter(firstItem));
   if (allSamePrefix) {

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -517,6 +517,62 @@ describe("Discord model picker rendering", () => {
     expect(bucketIds[0]).toMatch(/a=bucket;v=providers;u=42/);
   });
 
+  it("keeps astral provider bucket prefixes intact in rendered custom ids", () => {
+    const entries: Record<string, string[]> = { "a-provider": ["model-a"] };
+    for (let i = 1; i <= 30; i += 1) {
+      entries[`🧭-provider-${String(i).padStart(2, "0")}`] = [`model-${i}`];
+    }
+    const data = createModelsProviderData(entries);
+    const page = getDiscordModelPickerProviderPage({ data, page: 1 });
+
+    expect(page.bucket?.id).toBe("a-🧭");
+    const rendered = renderDiscordModelPickerProvidersView({
+      command: "models",
+      userId: "42",
+      data,
+    });
+    const payload = serializePayload(toDiscordModelPickerMessagePayload(rendered)) as {
+      components?: SerializedComponent[];
+    };
+    const providerSelect = requireValue(
+      extractContainerRows(payload.components)
+        .flatMap((row) => row.components ?? [])
+        .find((component) => component.custom_id?.includes(";a=provider;")),
+      "provider view should render a provider select",
+    );
+
+    expect(parseDiscordModelPickerCustomId(providerSelect.custom_id ?? "")?.providerBucket).toBe(
+      "a-🧭",
+    );
+  });
+
+  it("keeps astral model bucket prefixes intact in rendered custom ids", () => {
+    const models = [
+      "a-model",
+      ...Array.from({ length: 30 }, (_, i) => `🧭-model-${String(i + 1).padStart(2, "0")}`),
+    ];
+    const data = createModelsProviderData({ openai: models });
+    const page = requireValue(
+      getDiscordModelPickerModelPage({ data, provider: "openai", page: 1 }),
+      "model page should exist",
+    );
+
+    expect(page.bucket?.id).toBe("🧭");
+    const navStates = renderModelsViewRows({
+      command: "models",
+      userId: "42",
+      data,
+      provider: "openai",
+      page: 1,
+    })
+      .flatMap((row) => row.components ?? [])
+      .filter((component) => component.custom_id?.includes(";a=nav;"))
+      .map((component) => parseDiscordModelPickerCustomId(component.custom_id ?? ""));
+
+    expect(navStates.length).toBeGreaterThan(0);
+    expect(navStates.every((state) => state?.modelBucket === "🧭")).toBe(true);
+  });
+
   it("model select customId omits providerBucket/modelBucket (derived at re-render)", () => {
     // After reviewloop pass 3 we moved providerBucket/modelBucket OUT of
     // per-item customIds — both are pure functions of the durable state


### PR DESCRIPTION
## What Problem This Solves

When the Discord model picker has more than 25 providers or models, it derives alpha-bucket ids from `charAt(0)`. An emoji-leading identifier therefore produces a lone UTF-16 surrogate; when that bucket enters a Discord `custom_id`, `encodeURIComponent` throws `URIError: URI malformed` and the picker cannot render.

## Why This Change Was Made

Reads the first Unicode code point instead of the first UTF-16 code unit. This preserves the existing bucket algorithm, sorting, pagination, empty-input behavior, and custom-id format while ensuring every bucket prefix is URI-encodable.

## User Impact

Discord users can browse large provider/model catalogs containing emoji- or other astral-character-leading ids without the model picker failing to render.

## Evidence

- Added rendered provider-bucket and model-bucket tests that exercise serialization, URI encoding, and custom-id parsing with `🧭` prefixes.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/model-picker.test.ts`: 44 tests passed.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- Direct current-main repro produced a lone `d83e` code unit and `URIError: URI malformed`.
- Fresh pre-commit autoreview: clean, 0.85 correctness confidence.
- Verified config permits non-empty arbitrary Unicode model ids and arbitrary provider keys.
- No exact live open duplicate found. Full changed-gate execution is delegated to PR CI.