### PR TITLE
fix(google-vertex): ignore blank project env

### DIFF
--- a/packages/ai/src/providers/google-client-auth.test.ts
+++ b/packages/ai/src/providers/google-client-auth.test.ts
@@ -66,6 +66,7 @@ describe("Google SDK construction auth", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     configureAiTransportHost({});
   });
 
@@ -172,4 +173,37 @@ describe("Google SDK construction auth", () => {
       );
     },
   );
+
+  it("ignores blank Vertex project and location env fallbacks", async () => {
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "   ");
+    vi.stubEnv("GCLOUD_PROJECT", "   ");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "   ");
+
+    const missingProject = await streamGoogleVertex(vertexModel(), context).result();
+
+    expect(missingProject.stopReason).toBe("error");
+    expect(JSON.stringify(missingProject)).toContain("Vertex AI requires a project ID");
+    expect(googleMockState.configs).toHaveLength(0);
+
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", " vertex-project ");
+    vi.stubEnv("GCLOUD_PROJECT", "");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "   ");
+
+    const missingLocation = await streamGoogleVertex(vertexModel(), context).result();
+
+    expect(missingLocation.stopReason).toBe("error");
+    expect(JSON.stringify(missingLocation)).toContain("Vertex AI requires a location");
+    expect(googleMockState.configs).toHaveLength(0);
+
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", " us-central1 ");
+
+    const configured = await streamGoogleVertex(vertexModel(), context).result();
+
+    expect(configured.stopReason).toBe("error");
+    expect(googleMockState.configs[0]).toMatchObject({
+      vertexai: true,
+      project: "vertex-project",
+      location: "us-central1",
+    });
+  });
 });

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -5,6 +5,7 @@ import {
   type HttpOptions,
   ResourceScope,
 } from "@google/genai";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import type { Context, Model, SimpleStreamOptions, StreamFunction } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
@@ -155,7 +156,9 @@ function isPlaceholderApiKey(apiKey: string): boolean {
 
 function resolveProject(options?: GoogleVertexOptions): string {
   const project =
-    options?.project || process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
+    normalizeOptionalString(options?.project) ||
+    normalizeOptionalString(process.env.GOOGLE_CLOUD_PROJECT) ||
+    normalizeOptionalString(process.env.GCLOUD_PROJECT);
   if (!project) {
     throw new Error(
       "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT or pass project in options.",
@@ -165,7 +168,9 @@ function resolveProject(options?: GoogleVertexOptions): string {
 }
 
 function resolveLocation(options?: GoogleVertexOptions): string {
-  const location = options?.location || process.env.GOOGLE_CLOUD_LOCATION;
+  const location =
+    normalizeOptionalString(options?.location) ||
+    normalizeOptionalString(process.env.GOOGLE_CLOUD_LOCATION);
   if (!location) {
     throw new Error(
       "Vertex AI requires a location. Set GOOGLE_CLOUD_LOCATION or pass location in options.",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Vertex could treat whitespace-only project or location environment variables as configured ADC values.

## Why This Change Was Made

The built-in Vertex provider now uses the existing string normalizer for `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` before constructing the Google SDK client. This matches the Google transport and ADC detection paths that already ignore blank env values.

## User Impact

Users get the intended missing project/location error when Vertex env vars are blank, while nonblank values with surrounding whitespace still work after trimming.

## Evidence

- `./node_modules/.bin/tsx proof-live.ts`: imported the real `streamGoogleVertex()` production entrypoint; blank project/location env values returned the missing project error before SDK/ADC network lookup.
- `node scripts/run-vitest.mjs packages/ai/src/providers/google-client-auth.test.ts`: 3 tests passed.

```text
$ ./node_modules/.bin/tsx proof-live.ts
blank-env {
  stopReason: 'error',
  errorMessage: 'Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT or pass project in options.'
}
```

<details>
<summary>proof-live.ts</summary>

```ts
import type { Context, Model } from "./packages/ai/src/types.js";
import { streamGoogleVertex } from "./packages/ai/src/providers/google-vertex.js";

const context = {
  messages: [{ role: "user", content: "hello", timestamp: 0 }],
} satisfies Context;

const model = {
  id: "gemini-3-flash-preview",
  name: "Gemini 3 Flash Preview",
  api: "google-vertex",
  provider: "google-vertex",
  baseUrl: "https://us-central1-aiplatform.googleapis.com/v1",
  reasoning: true,
  input: ["text"],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 1_000_000,
  maxTokens: 8192,
} satisfies Model<"google-vertex">;

const previousEnv = { ...process.env };

try {
  process.env.GOOGLE_CLOUD_PROJECT = "   ";
  process.env.GCLOUD_PROJECT = "   ";
  process.env.GOOGLE_CLOUD_LOCATION = "   ";
  delete process.env.GOOGLE_CLOUD_API_KEY;

  const blank = await streamGoogleVertex(model, context).result();
  console.log("blank-env", {
    stopReason: blank.stopReason,
    errorMessage: blank.errorMessage,
  });
} finally {
  process.env = previousEnv;
}
```

</details>

AI-assisted: built with Codex
