### PR TITLE
fix(sqlite): add 10s SIGKILL timeout to mount lookup during WAL safety check

### DIFF
--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -18,6 +18,7 @@ const LINUX_NFS_SUPER_MAGIC = 0x6969;
 const LINUX_SMB_SUPER_MAGIC = 0x517b;
 const LINUX_CIFS_SUPER_MAGIC = 0xff534d42;
 const LINUX_SMB2_SUPER_MAGIC = 0xfe534d42;
+const MOUNT_LOOKUP_TIMEOUT_MS = 10_000;
 const PROC_MOUNTINFO_PATH = "/proc/self/mountinfo";
 const NETWORK_FILESYSTEM_TYPES = new Set(["cifs", "smbfs", "smb2", "smb3"]);
 const JOURNAL_MODE_RETRY_INTERVAL_MS = 10;
@@ -172,7 +173,14 @@ function readMountEntries(): MountEntry[] {
     // Linux superblock magic, so keep this fallback for named filesystem types.
   }
   try {
-    return parseMountCommandEntries(String(childProcess.execFileSync("mount", [])));
+    return parseMountCommandEntries(
+      String(
+        childProcess.execFileSync("mount", [], {
+          timeout: MOUNT_LOOKUP_TIMEOUT_MS,
+          killSignal: "SIGKILL",
+        }),
+      ),
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

`readMountEntries()` in `sqlite-wal.ts` invokes `childProcess.execFileSync("mount", [])` without a timeout. On systems with unresponsive NFS/SMB mounts, the `mount` command can hang indefinitely, blocking the SQLite WAL safety check during startup.

## Why This Change Was Made

The existing try-catch guards against execution failures, but cannot guard against a hung process. Adding `timeout` + `killSignal: "SIGKILL"` ensures the lookup is bounded (10s) and the process is forcibly terminated on timeout, matching the repository pattern used in `src/cli/ports.ts`, `src/tui/tui.ts`, and `src/daemon/program-args.ts`.

## Evidence

35/37 sqlite-wal tests pass (2 pre-existing failures due to SQLite version in test environment):

```
Test Files  1 failed (1)
     Tests  2 failed | 35 passed (37)
```

The change is a pure safety improvement — the existing catch block returns `[]` on failure, and the new options only add a time bound to an otherwise unbounded synchronous call.

## Merge Risk

Low — single-file change, nothing added to the public API surface. The function already has an empty-array fallback in its catch block, so the timeout path degrades gracefully.