### PR TITLE
improve: control worker shutdown timer in tests

### DIFF
--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -926,10 +926,21 @@ describe("worker runtime", () => {
     const result = runWorkerDescriptor(launch, { signal: controller.signal });
     await vi.waitFor(() => expect(gateway.inferenceRequests).toHaveLength(1));
 
-    controller.abort(new Error("operator stopped worker during outage"));
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const rejected = expect(result).rejects.toThrow("operator stopped worker during outage");
 
-    await expect(result).rejects.toThrow("operator stopped worker during outage");
-    expect(gateway.methods).toContain("worker.inference.cancel");
+      controller.abort(new Error("operator stopped worker during outage"));
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await rejected;
+      expect(gateway.methods).toContain("worker.inference.cancel");
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- run the worker shutdown grace timer under scoped fake timers
- assert the production one-second forced-stop delay is scheduled before advancing it
- preserve the real cancellation outage path while reducing the target from 1.054s to 0.111s (89.5%)

## Validation

- Testbox `tbx_01kxpw2qnfn89xqadyf3n5w46e`: warmed target passed at 111ms
- Testbox: `pnpm test src/worker/worker.runtime.test.ts --reporter=verbose` (26/26 passed; target 112ms)
- Testbox: `pnpm check:changed`
- fresh autoreview: clean, no accepted/actionable findings

## Scope

Test-only change. No runtime or CI behavior changes.
