### PR TITLE
fix(infra): bound tailscale binary discovery probes

### DIFF
--- a/src/infra/tailscale-find-binary.test.ts
+++ b/src/infra/tailscale-find-binary.test.ts
@@ -1,0 +1,30 @@
+// Covers findTailscaleBinary bounded subprocess calls.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runExecMock } = vi.hoisted(() => ({
+  runExecMock: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", () => ({ runExec: runExecMock }));
+
+import { findTailscaleBinary } from "./tailscale.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("findTailscaleBinary probes", () => {
+  it("bounds which and locate discovery calls with 5s timeout", async () => {
+    runExecMock.mockRejectedValue(new Error("not found"));
+
+    await findTailscaleBinary();
+
+    const whichCall = runExecMock.mock.calls.find((c) => c[0] === "which");
+    expect(whichCall).toBeDefined();
+    expect(whichCall![2]).toMatchObject({ timeoutMs: 5000 });
+
+    const locateCall = runExecMock.mock.calls.find((c) => c[0] === "locate");
+    expect(locateCall).toBeDefined();
+    expect(locateCall![2]).toMatchObject({ timeoutMs: 5000 });
+  });
+});

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,4 +1,4 @@
-// Covers Tailscale whois, Serve, and Funnel helpers.
+// Covers Tailscale whois, Serve, Funnel helpers, and binary discovery.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import * as tailscale from "./tailscale.js";

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -48,7 +48,7 @@ export async function findTailscaleBinary(): Promise<string | null> {
 
   // Strategy 1: which command
   try {
-    const { stdout } = await runExec("which", ["tailscale"]);
+    const { stdout } = await runExec("which", ["tailscale"], { timeoutMs: 5000 });
     const fromPath = stdout.trim();
     if (fromPath && (await checkBinary(fromPath))) {
       return fromPath;
@@ -88,7 +88,7 @@ export async function findTailscaleBinary(): Promise<string | null> {
 
   // Strategy 4: locate command
   try {
-    const { stdout } = await runExec("locate", ["Tailscale.app"]);
+    const { stdout } = await runExec("locate", ["Tailscale.app"], { timeoutMs: 5000 });
     const candidates = stdout
       .trim()
       .split("\n")


### PR DESCRIPTION
## What Problem This Solves

`findTailscaleBinary` can run `which tailscale` or `locate Tailscale.app` during tailnet setup. Neither subprocess had a deadline, so a stalled PATH lookup or locate database scan could block tailnet setup indefinitely.

## Why This Change Was Made

Bound both probes to 5 seconds using the existing runExec timeout option. The try-catch in `findTailscaleBinary` already converts subprocess failures to a `null` fallback, making the timeout path automatically fail-soft.

## User Impact

A stalled `which` or `locate` call can no longer block tailnet binary discovery. After 5 seconds the function continues to the next discovery strategy, or returns null.

## Evidence

- Node 24: `node scripts/run-vitest.mjs src/infra/tailscale-find-binary.test.ts` (1/1 passed)
- `node scripts/run-vitest.mjs src/infra/tailscale.test.ts` (27/27 passed, existing tests unaffected)
- `git diff --check origin/main...HEAD`
