### PR TITLE
fix(doctor): bound legacy launchctl service cleanup

### DIFF
--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -108,7 +108,7 @@ const EXECSTART_REPAIR_CODES = new Set<string>([
   SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
 ]);
 const runLaunchctlQuietly = (args: string[]) =>
-  runExec("launchctl", args, { logOutput: false }).catch(() => undefined);
+  runExec("launchctl", args, { logOutput: false, timeoutMs: 5_000 }).catch(() => undefined);
 const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
 
 function detectGatewayRuntime(programArguments: string[] | undefined): GatewayDaemonRuntime {


### PR DESCRIPTION
## What Problem This Solves

The `runLaunchctlQuietly` helper used during legacy gateway service cleanup runs `launchctl bootout` and `launchctl unload` without a deadline. A stalled launchctl subprocess could block doctor gateway service repair indefinitely.

## Why This Change Was Made

Add a 5-second timeout to the runExec options. The existing `.catch(() => undefined)` handler already converts subprocess failures to a silent undefined, making the timeout path automatically fail-soft.

## User Impact

A stalled launchctl call can no longer block legacy gateway service cleanup during doctor repair. After 5 seconds the function continues through the existing silent-failure path.

## Evidence

- `git diff --check origin/main...HEAD`
- Existing test suite covers the surrounding repair flows via mocks
