### PR TITLE
fix(sessions): bound git symbolic-ref async probe

### DIFF
--- a/src/agents/sessions/footer-data-provider.ts
+++ b/src/agents/sessions/footer-data-provider.ts
@@ -87,7 +87,7 @@ async function resolveBranchWithGitAsync(repoDir: string): Promise<string | null
     const { stdout } = await runExec(
       "git",
       ["--no-optional-locks", "symbolic-ref", "--quiet", "--short", "HEAD"],
-      { cwd: repoDir, logOutput: false },
+      { cwd: repoDir, logOutput: false, timeoutMs: 5_000 },
     );
     return stdout.trim() || null;
   } catch {


### PR DESCRIPTION
## What Problem This Solves

`resolveBranchWithGitAsync` runs `git symbolic-ref` without a deadline during session footer data provider refresh. A stalled git command could block the footer data provider indefinitely.

## Why This Change Was Made

Add a 5-second timeout to the existing runExec options. The try-catch in `resolveBranchWithGitAsync` already converts subprocess failures to a `null` return, making the timeout path automatically fail-soft.

## User Impact

A stalled git symbolic-ref call can no longer block session footer data provider refresh. After 5 seconds the function returns null through the existing failure path.

## Evidence

- `git diff --check origin/main...HEAD`
