### PR TITLE
fix(whatsapp): multi-account channel startup crashes with readWebAuthState TypeError when running from source

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -86,8 +86,11 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         setupWizard: whatsappSetupWizardProxy,
         setup: whatsappSetupAdapter,
         isConfigured: async (account) => {
-          const channelRuntime = await loadWhatsAppChannelRuntime();
-          return (await channelRuntime.readWebAuthState(account.authDir)) === "linked";
+          // Import auth-store directly (like channel.setup.ts): probing through the
+          // full channel.runtime graph races its own module evaluation during gateway
+          // startup, and the first account probed sees an undefined auth-store binding.
+          const { readWebAuthState } = await import("./auth-store.js");
+          return (await readWebAuthState(account.authDir)) === "linked";
         },
       }),
       agentTools: () => [createWhatsAppLoginTool()],

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/channel-policy";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createChannelPluginBase } from "openclaw/plugin-sdk/core";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   createDelegatedSetupWizardProxy,
   type ChannelSetupWizard,
@@ -41,9 +42,12 @@ import {
 
 const WHATSAPP_CHANNEL = "whatsapp" as const;
 
-export async function loadWhatsAppChannelRuntime() {
-  return await import("./channel.runtime.js");
-}
+// Single-flight: concurrent first imports of the channel runtime through the
+// source-plugin loader (jiti) can observe a partially evaluated module graph;
+// sharing one cached import keeps concurrent multi-account startup off that race.
+export const loadWhatsAppChannelRuntime = createLazyRuntimeModule(
+  () => import("./channel.runtime.js"),
+);
 
 async function loadWhatsAppSetupSurface() {
   return await import("./setup-surface.js");


### PR DESCRIPTION
Related: #77066

## What Problem This Solves

Fixes an issue where users running OpenClaw from a source checkout with two or more WhatsApp accounts would see the whole WhatsApp channel fail at gateway boot with:

```
[channels/whatsapp] [whatsapp] channel startup failed: Cannot read properties of undefined (reading 'readWebAuthState')
```

The failure is deterministic on every boot: one account connects, the other is left `stopped`, and the health monitor loops restart attempts that hit the same crash. This is the same symptom reported in #77066, which was closed as already fixed on `main` — but the crash still reproduces on current `main` because the actual cause is a module-loading race, not the auth-state handling that #67815 stabilized.

Root cause (traced through jiti 2.7.0, which OpenClaw uses to load source plugins):

- Gateway startup probes channel accounts concurrently (`runTasksWithConcurrency`, limit 4, `src/gateway/server-channels.ts:46,473`), and each account task calls `plugin.config.isConfigured` (`src/gateway/server-channels.ts:570`).
- With 2+ WhatsApp accounts, both probes call `loadWhatsAppChannelRuntime()` → `import("./channel.runtime.js")` at the same time. Under jiti, the first import starts evaluating the transpiled module as an **async** wrapper (each static dependency becomes an awaited `jitiImport`), and jiti registers the module in its cache **before** evaluation finishes (`dist/jiti.cjs`: `y[c]=N` in `eval_evalModule`, before the wrapper runs).
- The second concurrent import hits jiti's cache short-circuit — `if (n[a]) return jitiInteropDefault(e, n[a]?.exports)` in `jitiRequire` — which returns the partially initialized exports with **no `loaded` check**. (That path exists to break genuine CJS cycles, but a concurrent sibling import is indistinguishable from a cycle to it.)
- Babel's CommonJS transform hoists function-declaration export assignments above the dependency requires, so the partial namespace already exposes `readWebAuthState` — but the module-level `auth-store` binding inside `channel.runtime.ts` is still `undefined`. Calling it throws exactly the observed TypeError at `channel.runtime.ts:67` (the `Proxy.` stack frame is jiti's `interopDefault` namespace proxy).

There is no true runtime import cycle in the extension: the only cycle madge reports (`inbound/monitor.ts > runtime-api.ts > channel.runtime.ts > auto-reply/monitor.ts`) consists of a type-only edge (`inbound/monitor.ts:35`) and a lazy dynamic edge (`runtime-api.ts:49`), both erased/deferred at runtime. The bug is purely a concurrent-first-import race on the large `channel.runtime.js` graph.

## Why This Change Was Made

Two small changes that each stand on their own:

1. **`channel.ts` — probe auth state directly.** `isConfigured` now imports `./auth-store.js` instead of routing the probe through the full `channel.runtime.js` graph. This mirrors the existing pattern in `channel.setup.ts:13` (added in 604e16c7654e for a related import-cycle problem) and keeps the startup config probe off the heavy Baileys/monitor/login graph entirely. It is deterministically race-free: `channel.ts` statically imports `heartbeat.ts`, which statically imports `auth-store.js`, so `auth-store.js` is always fully evaluated before the plugin object can exist and the dynamic import is a pure loaded-cache hit.
2. **`shared.ts` — single-flight the channel runtime import.** `loadWhatsAppChannelRuntime` is now memoized with `createLazyRuntimeModule` (the exact pattern the extension already uses for the same module in `runtime-api.ts:49`). This closes the same race at every sibling call site that can run concurrently across accounts — `gateway.startAccount`, the status adapter's `resolveAccountSnapshot`/`buildChannelSummary`, the fire-and-forget `logSelfId`, and heartbeat — by making every caller await the one initiating import, which jiti only resolves after the module graph finished evaluating.

Non-goal: fixing jiti's partial-exports cache path itself (it cannot distinguish a cycle from a concurrent sibling import without tracking evaluation chains). `dist`-bundled deployments load the plugin natively and are unaffected; this hardens the supported run-from-source path.

## User Impact

Users running from a source checkout with multiple WhatsApp accounts get a working WhatsApp channel on every gateway boot: all accounts probe, start, and connect. Previously one account deterministically crashed the probe and stayed `stopped` (no inbound messages) until manual in-process recovery, on every single boot. Single-account setups and dist installs are unaffected.

## Evidence

Live before/after on a macOS source checkout with two configured WhatsApp accounts (source-loaded plugin, the failing path):

- **Before:** the first account probed failed on every gateway boot (10/10 occurrences captured in one day) with this stack, captured via temporary dist instrumentation (paths shortened):

  ```
  TypeError: Cannot read properties of undefined (reading 'readWebAuthState')
      at Proxy.readWebAuthState (extensions/whatsapp/src/channel.runtime.ts:67:25)
      at Object.isConfigured (extensions/whatsapp/src/channel.ts:90:38)
      at async withDiagnosticPhase (...)
      at async Object.measure (...)
      at async ... server-channels startup account probe (runTasksWithConcurrency)
  ```

  The failing account was stuck `stopped` in channel status while the other connected.

- **After (with the `isConfigured` fix applied):** both WhatsApp accounts connected and reported healthy immediately at boot, and stayed healthy across a subsequent gateway restart.

Additional validation:

- Root cause verified directly against `jiti@2.7.0` source in `node_modules` (pre-evaluation cache registration in `eval_evalModule`; `loaded`-unchecked cache short-circuit in `jitiRequire`; async ESM wrapper for transpiled modules).
- Verified `auth-store.js` and its dependency subtree do not import back into `channel.runtime.ts`/`channel.ts`/`monitor.ts` (cycle-free), and that `channel.ts`'s static graph already evaluates `auth-store.js` via `heartbeat.ts`.
- `oxfmt --check` clean on both touched files.
- A colocated unit test was not added: the failure is a loader-level evaluation race inside jiti that Vitest (which loads these modules through its own transform pipeline, not the plugin loader) cannot meaningfully reproduce; asserting on the new call shape would test the diff, not the behavior. Tests were not run locally per repo policy (remote/CI validation); relying on PR CI plus the live deterministic before/after above.
