### PR TITLE
fix: thinking level silently clamps to off for Ollama-backed models

### DIFF
--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -456,10 +456,9 @@ export function resolveSession(opts: {
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,
   });
 
-  const persistedThinking =
-    fresh && sessionEntry?.thinkingLevel
-      ? normalizeThinkLevel(sessionEntry.thinkingLevel)
-      : undefined;
+  const persistedThinking = sessionEntry?.thinkingLevel
+    ? normalizeThinkLevel(sessionEntry.thinkingLevel)
+    : undefined;
   const persistedVerbose =
     fresh && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)

--- a/src/agents/thinking-runtime.ts
+++ b/src/agents/thinking-runtime.ts
@@ -9,6 +9,8 @@ import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import { resolveAutoAgentHarnessId } from "./harness/support.js";
+import { findModelInCatalog } from "./model-catalog-lookup.js";
+import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 import { resolveSessionRuntimeOverrideForProvider } from "./session-runtime-compat.js";
 
 /** Convert residual auto policy into the built-in fallback when no registry selection is needed. */
@@ -53,6 +55,42 @@ export function resolveEffectiveAgentRuntime(params: {
   return concretizeAgentRuntime(runtime);
 }
 
+/**
+ * Falls back to the configured provider model row for a provider/model pair
+ * when the caller didn't supply an explicit thinking catalog. Without this,
+ * providers whose thinking-profile policy depends on the catalog's
+ * `reasoning` flag (e.g. Ollama) treat every model as non-reasoning and
+ * silently clamp any requested level down to "off".
+ */
+function resolveConfiguredThinkingCatalogEntry(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+  modelId: string,
+): ThinkingCatalogEntry[] | undefined {
+  if (!cfg) {
+    return undefined;
+  }
+  const entry = findModelInCatalog(buildConfiguredModelCatalog({ cfg }), provider, modelId);
+  if (!entry) {
+    return undefined;
+  }
+  return [
+    {
+      provider,
+      id: modelId,
+      api: entry.api,
+      reasoning: entry.reasoning,
+      params: entry.params,
+      compat: entry.compat
+        ? {
+            thinkingFormat: entry.compat.thinkingFormat,
+            supportedReasoningEfforts: entry.compat.supportedReasoningEfforts,
+          }
+        : undefined,
+    },
+  ];
+}
+
 /** Revalidates a turn-local thinking level after fallback selects its actual model/runtime. */
 export function resolveCandidateThinkingLevel(params: {
   cfg?: OpenClawConfig;
@@ -81,11 +119,14 @@ export function resolveCandidateThinkingLevel(params: {
           sessionKey: params.sessionKey,
           sessionEntry: params.sessionEntry,
         });
+  const catalog =
+    params.catalog ??
+    resolveConfiguredThinkingCatalogEntry(params.cfg, params.provider, params.modelId);
   const policy = {
     provider: params.provider,
     model: params.modelId,
     level: params.level,
-    catalog: params.catalog,
+    catalog,
     agentRuntime,
   };
   return isThinkingLevelSupported(policy) ? params.level : resolveSupportedThinkingLevel(policy);


### PR DESCRIPTION
Closes #109527

## What Problem This Solves

Fixes an issue where users running Ollama-backed models (native `ollama-cloud` or self-hosted Ollama) with extended thinking enabled (via session `/think` or agent/global `thinkingDefault`) would silently get no thinking output on the large majority of real, channel-delivered turns (Discord, iMessage, etc.), even though session state, agent config, and the model's own catalog entry all correctly indicated a non-off thinking level. No error, warning, or log output was produced anywhere in the pipeline.

## Why This Change Was Made

`resolveCandidateThinkingLevel()` revalidates a turn's requested thinking level against the model about to be dispatched to, during provider/model fallback-candidate selection. Several call sites in the fallback-candidate loop (`agent-runner-fallback-candidate.ts`, `agent-runner-memory.ts`, `followup-runner.ts`, and the compaction path in `embedded-agent-runner/compact.ts`) never passed a `catalog`, so the underlying thinking-profile check saw `reasoning: undefined` for the model. Ollama's `resolveThinkingProfile` policy hook (the only bundled provider whose thinking-profile resolution depends on that catalog flag — see issue for the full provider audit) treats undefined reasoning as "this model doesn't support thinking" and clamps any requested level down to `"off"`.

Rather than patching each call site individually (fragile — we found a fourth affected site, the compaction path, that our own manual testing never exercised), `resolveCandidateThinkingLevel` now builds its own catalog entry from the configured provider model row when the caller doesn't supply one, reusing the existing `buildConfiguredModelCatalog`/`findModelInCatalog` helpers. This fixes all current call sites at once and is defensive against future ones making the same omission.

Also includes a narrowly-scoped, related fix in `resolveSession()`: `persistedThinking` only carried a session's persisted `/think` level forward when reusing an existing ("fresh") session entry, discarding it on a fresh entry. Left out of scope: two other related issues found during triage (a `/status` display-only bug, and a `<think>`-tag parsing gap for some Ollama models) are documented in the linked issue but not fixed here, since they're separate, lower-priority problems.

## User Impact

Ollama-backed agents with thinking enabled will now reliably receive `think: <level>` on real conversational turns and return actual reasoning content, instead of silently behaving as if thinking were off. No config changes required — this takes effect for any already-correctly-configured session/agent.

## Evidence

**Static validation:**
```
$ pnpm tsgo:core
# clean, 0 errors

$ node scripts/run-vitest.mjs run src/agents/thinking-runtime.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)

$ node scripts/run-vitest.mjs run src/agents/command/session.provider-owned-reset.test.ts src/agents/command/session-store.test.ts src/commands/agent.session.test.ts
 Test Files  2 passed (2)
      Tests  57 passed (57)

$ npx oxlint src/agents/thinking-runtime.ts src/agents/command/session.ts
# clean, exit 0
```

**Live verification against the compiled equivalent of this fix**, running on a real gateway with two Ollama-cloud models (`deepseek-v4-pro:cloud`, native structured thinking; `glm-5.2:cloud`, inline `<think>` tag format) across dozens of real Discord and iMessage turns over ~2 hours:

- Before: `resolvedThinkLevel` traced as `"high"` at the directive-resolution stage, `"off"` by the time it reached the embedded-agent dispatch — reproduced consistently across the affected call sites (confirmed via stack traces landing in `agent-runner-fallback-candidate.ts` / `agent-runner-memory.ts` / `followup-runner.ts` each time).
- After: `requestedThinkLevel`/`thinkLevel` traced as `"high"` end-to-end through the same dispatch path, `think: "high"` sent in the outbound Ollama request, and native `message.thinking` content present in the response and stored session transcript (confirmed via raw `.jsonl` session content showing `{"type": "thinking", "thinking": "..."}` blocks that were previously absent for the same turns/models).
