### PR TITLE
docs(sandbox): document multiple folders per agent

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3857,7 +3857,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: SSH backend
   - H2: OpenShell backend
   - H2: Workspace access
-  - H2: Custom bind mounts
+  - H2: Multiple folders for one agent
+  - H3: Other bind behavior
   - H2: Images and setup
   - H2: setupCommand (one-time container setup)
   - H2: Tool policy and escape hatches

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -51,6 +51,8 @@ See [Sandboxing](/gateway/sandboxing) for the full matrix (scope, workspace moun
 - Binding `/var/run/docker.sock` effectively hands host control to the sandbox; only do this intentionally.
 - Workspace access (`workspaceAccess`) is independent of bind modes.
 
+For a per-agent configuration with several host folders, access modes, and the external-source safety opt-in, see [Multiple folders for one agent](/gateway/sandboxing#multiple-folders-for-one-agent).
+
 ## Tool policy: which tools exist/are callable
 
 Two layers matter:

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -177,11 +177,73 @@ Inbound media is copied into the active sandbox workspace (`media/inbound/*`).
 **Skills**: the `read` tool is sandbox-rooted. With `workspaceAccess: "none"`, OpenClaw mirrors eligible skills into the sandbox workspace (`.../skills`) so they can be read. With `"rw"`, workspace skills are readable from `/workspace/skills`, and eligible managed, bundled, or plugin skills are materialized into the generated read-only path `/workspace/.openclaw/sandbox-skills/skills`.
 </Note>
 
-## Custom bind mounts
+## Multiple folders for one agent
 
-`agents.defaults.sandbox.docker.binds` mounts additional host directories into the container. Format: `host:container:mode` (e.g., `"/home/user/source:/source:rw"`).
+Use Docker bind mounts when one sandboxed agent needs more than its primary workspace. Each entry maps a host folder to a container path with an explicit access mode:
 
-Global and per-agent binds are merged (not replaced). Under `scope: "shared"`, per-agent binds are ignored.
+```text
+host-directory:container-directory:ro
+host-directory:container-directory:rw
+```
+
+- `ro` makes the mounted folder read-only inside the sandbox.
+- `rw` lets sandboxed tools and processes change the host folder.
+- The container path is the path the agent uses. Host paths are not exposed automatically.
+
+This example gives the `research` agent a writable primary workspace, read-only reference material at `/reference`, and a separate writable output folder at `/drafts`:
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "all",
+        scope: "agent",
+      },
+    },
+    list: [
+      {
+        id: "research",
+        workspace: "/srv/openclaw/research-workspace",
+        sandbox: {
+          workspaceAccess: "rw",
+          docker: {
+            binds: [
+              "/srv/shared/reference:/reference:ro",
+              "/srv/shared/drafts:/drafts:rw",
+            ],
+            // Required because these sources are outside the agent workspace.
+            dangerouslyAllowExternalBindSources: true,
+          },
+        },
+      },
+    ],
+  },
+}
+```
+
+`workspaceAccess` and bind modes are independent:
+
+| Setting                         | Controls                                                                            |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| `workspaceAccess: "none"`      | Uses an isolated sandbox workspace; does not expose the agent workspace.            |
+| `workspaceAccess: "ro"`        | Mounts the agent workspace read-only at `/agent`.                                   |
+| `workspaceAccess: "rw"`        | Mounts the agent workspace read/write at `/workspace`.                              |
+| `docker.binds` entry `:ro`/`:rw` | Controls only that additional host folder at its configured container path.         |
+
+Changing `workspaceAccess` does not change an additional bind from `ro` to `rw`, or vice versa. Global and per-agent `docker.binds` are merged. Keep `scope: "agent"` or `"session"` for per-agent binds; `scope: "shared"` ignores all per-agent Docker overrides and uses only global binds.
+
+Bind mounts are the supported multi-folder boundary because Docker constructs the container's filesystem view with mount isolation, and the `ro`/`rw` mode applies to every process in the sandbox. That boundary covers `exec`, filesystem tools, child processes, and libraries without duplicating path-authorization checks across each OpenClaw code path. A host-side path allowlist cannot provide the same complete boundary when an allowed shell or dependency can access files directly.
+
+The opt-in `dangerouslyAllowExternalBindSources` only permits sources outside the workspace roots. It does not disable OpenClaw's blocked system, credential, Docker socket, symlink-parent, or reserved-target checks. Prefer the smallest folder, use `ro` unless writes are required, and recreate the sandbox after changing mounts:
+
+```bash
+openclaw sandbox recreate --agent research
+```
+
+### Other bind behavior
+
+`agents.defaults.sandbox.docker.binds` configures global mounts. The format is the same `host:container:mode` form (for example, `"/home/user/source:/source:rw"`).
 
 `agents.defaults.sandbox.browser.binds` mounts additional host directories into the **sandbox browser** container only. When set (including `[]`), it replaces `docker.binds` for the browser container; when omitted, the browser container falls back to `docker.binds`.
 

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -208,10 +208,7 @@ This example gives the `research` agent a writable primary workspace, read-only 
         sandbox: {
           workspaceAccess: "rw",
           docker: {
-            binds: [
-              "/srv/shared/reference:/reference:ro",
-              "/srv/shared/drafts:/drafts:rw",
-            ],
+            binds: ["/srv/shared/reference:/reference:ro", "/srv/shared/drafts:/drafts:rw"],
             // Required because these sources are outside the agent workspace.
             dangerouslyAllowExternalBindSources: true,
           },
@@ -224,12 +221,12 @@ This example gives the `research` agent a writable primary workspace, read-only 
 
 `workspaceAccess` and bind modes are independent:
 
-| Setting                         | Controls                                                                            |
-| ------------------------------- | ----------------------------------------------------------------------------------- |
-| `workspaceAccess: "none"`      | Uses an isolated sandbox workspace; does not expose the agent workspace.            |
-| `workspaceAccess: "ro"`        | Mounts the agent workspace read-only at `/agent`.                                   |
-| `workspaceAccess: "rw"`        | Mounts the agent workspace read/write at `/workspace`.                              |
-| `docker.binds` entry `:ro`/`:rw` | Controls only that additional host folder at its configured container path.         |
+| Setting                          | Controls                                                                    |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| `workspaceAccess: "none"`        | Uses an isolated sandbox workspace; does not expose the agent workspace.    |
+| `workspaceAccess: "ro"`          | Mounts the agent workspace read-only at `/agent`.                           |
+| `workspaceAccess: "rw"`          | Mounts the agent workspace read/write at `/workspace`.                      |
+| `docker.binds` entry `:ro`/`:rw` | Controls only that additional host folder at its configured container path. |
 
 Changing `workspaceAccess` does not change an additional bind from `ro` to `rw`, or vice versa. Global and per-agent `docker.binds` are merged. Keep `scope: "agent"` or `"session"` for per-agent binds; `scope: "shared"` ignores all per-agent Docker overrides and uses only global binds.
 


### PR DESCRIPTION
Related: #52951

AI-assisted maintainer change approved by Peter.

## What Problem This Solves

Operators who want one sandboxed agent to work with several host folders do not have a clear guide to the existing supported configuration. The current bind-mount reference does not show the interaction between per-agent binds, `workspaceAccess`, and external-source validation.

## Why This Change Was Made

Document Docker bind mounts as the supported multi-folder boundary for sandboxed agents, with a complete per-agent example, independent read/write controls, scope behavior, and security rationale. Cross-link the sandbox/tool-policy comparison so operators can find the configuration from either guide.

## User Impact

Operators can configure one agent with a primary workspace plus additional read-only or writable folders without introducing a second in-process filesystem authorization system.

## Evidence

- `pnpm docs:list` — passed; both pages remain in the documentation inventory.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- Source contract checked against sandbox config merging, workspace mount construction, bind validation, and adjacent tests.

