### PR TITLE
fix(discord): keep voice participant label truncation UTF-16 safe

### DIFF
--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -58,7 +58,7 @@ describe("normalizeLabel UTF-16 safety", () => {
     } as never;
     const line = formatDiscordVoiceParticipantStateLine(state);
     // format: `- user_id="user1" display_name="<truncated label>"`
-    expect(line).toMatch(/^\- user_id="user1" display_name="/);
+    expect(line).toMatch(/^- user_id="user1" display_name="/);
     // No replacement character (U+FFFD) in output
     expect(line).not.toContain("�");
     // Display name part is at most 100 chars inside the quotes

--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,6 +1,9 @@
 // Discord tests cover voice participant classification.
 import { describe, expect, it } from "vitest";
-import { countDiscordVoiceHumanParticipants } from "./participant-context.js";
+import {
+  countDiscordVoiceHumanParticipants,
+  formatDiscordVoiceParticipantStateLine,
+} from "./participant-context.js";
 
 describe("countDiscordVoiceHumanParticipants", () => {
   it("counts people while excluding the agent and other bots", () => {
@@ -37,5 +40,29 @@ describe("countDiscordVoiceHumanParticipants", () => {
         additionalUserIds: ["known-bot", "cache-race-speaker"],
       }),
     ).toBe(1);
+  });
+});
+
+describe("normalizeLabel UTF-16 safety", () => {
+  it("does not split a surrogate pair at the 100-char truncation boundary", () => {
+    // 99 ASCII chars + emoji (U+1F600 = surrogate pair) + "tail" = 105 chars
+    // .slice(0, 100) would cut at 99 → lone surrogate → U+FFFD on display
+    const state = {
+      userId: "user1",
+      state: {
+        user_id: "user1",
+        member: {
+          user: { id: "user1", global_name: `${"x".repeat(99)}\u{1F600}tail` },
+        },
+      },
+    } as never;
+    const line = formatDiscordVoiceParticipantStateLine(state);
+    // format: `- user_id="user1" display_name="<truncated label>"`
+    expect(line).toMatch(/^\- user_id="user1" display_name="/);
+    // No replacement character (U+FFFD) in output
+    expect(line).not.toContain("�");
+    // Display name part is at most 100 chars inside the quotes
+    const displayName = line.match(/display_name="([^"]*)"/)?.[1] ?? "";
+    expect(displayName.length).toBeLessThanOrEqual(100);
   });
 });

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -1,4 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { type DiscordVoiceIngressContext, resolveDiscordVoiceIngressContext } from "./ingress.js";
@@ -23,7 +24,7 @@ function normalizeLabel(value: unknown): string | undefined {
     return undefined;
   }
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, 100) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, 100) : undefined;
 }
 
 function memberLabel(state: APIVoiceState): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Discord voice participant's display name could show a corrupted Unicode replacement character (U+FFFD) when the name contained an emoji or CJK character at the 100-character truncation boundary.

`normalizeLabel` used `normalized.slice(0, 100)` to cap display names. When the 100th character fell in the middle of a surrogate pair (e.g., 99 ASCII chars + start of a 4-byte emoji), `.slice(0, 100)` produced a lone surrogate, which renders as `�` in voice roster output.

## Why This Change Was Made

`normalizeLabel` now uses `truncateUtf16Safe(normalized, 100)` which drops the orphaned trailing surrogate instead of emitting an invalid code point.

Related prior art: #102225 (ui clampText), #102266 (security truncation), #102378 (acp truncation), #102470 (gateway truncation), #108172 (ClawHub error truncation).

## User Impact

Users with emoji or CJK characters in their Discord display name see intact Unicode in voice roster participant lines instead of `�`.

## Evidence

### Scope

| Item | Value |
| --- | --- |
| Head | `412670e22f2` |
| Files | `extensions/discord/src/voice/participant-context.ts` (+3/−1) · `extensions/discord/src/voice/participant-context.test.ts` (+28/−1) |
| Net | +30 / −2 across 2 files |

### Production change (behavior)

```ts
// Before
return normalized ? normalized.slice(0, 100) : undefined;

// After
return normalized ? truncateUtf16Safe(normalized, 100) : undefined;
```

### Local gates (touched surface)

| Gate | Command | Result |
| --- | --- | --- |
| Unit | `node node_modules/vitest/vitest.mjs run extensions/discord/src/voice/participant-context.test.ts` | **3 passed** / 1 file |

### Proof

The L1 test builds a display name of 99 ASCII chars followed by U+1F600 (smiley emoji, 2-code-unit surrogate pair) at the 100th position boundary:

- Without `truncateUtf16Safe`: `normalized.slice(0, 100)` captures `99x + \uD83D` — a lone surrogate → U+FFFD on display.
- With `truncateUtf16Safe`: the orphaned trailing surrogate is dropped, output is clean and within the 100-char limit.

```ts
const line = formatDiscordVoiceParticipantStateLine({
  userId: "user1",
  state: { member: { user: { global_name: `${"x".repeat(99)}\u{1F600}tail` } } },
});
expect(line).not.toContain("�");
const displayName = line.match(/display_name="([^"]*)"/)?.[1] ?? "";
expect(displayName.length).toBeLessThanOrEqual(100);
```

---

AI-assisted.