### PR TITLE
fix(qa-lab): preserve emoji in Matrix timeout diagnostics

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-diagnostics.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-diagnostics.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { MatrixQaObservedEvent } from "../substrate/events.js";
+import {
+  buildMatrixQaToolProgressFinalTimeoutMessage,
+  buildMatrixQaToolProgressTimeoutMessage,
+} from "./scenario-runtime-tool-progress-diagnostics.js";
+
+const UNPAIRED_SURROGATE_PATTERN =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
+
+function buildBoundaryEvent(overrides: Partial<MatrixQaObservedEvent> = {}) {
+  return {
+    body: `${"a".repeat(236)}😀tail`,
+    eventId: "$preview",
+    kind: "notice",
+    roomId: "!room:matrix-qa.test",
+    sender: "@sut:matrix-qa.test",
+    type: "m.room.message",
+    ...overrides,
+  } satisfies MatrixQaObservedEvent;
+}
+
+function expectValidUtf16(message: string) {
+  expect(message).toContain(`${"a".repeat(236)}...`);
+  expect(message).not.toMatch(UNPAIRED_SURROGATE_PATTERN);
+  expect(Buffer.from(message, "utf8").toString("utf8")).not.toContain("�");
+}
+
+describe("Matrix tool-progress timeout diagnostics", () => {
+  it("preserves complete Unicode code points in preview candidates", () => {
+    const message = buildMatrixQaToolProgressTimeoutMessage({
+      cause: new Error("preview wait timed out"),
+      events: [buildBoundaryEvent()],
+      expectedPreviewKind: "notice",
+      previewEventId: "$preview",
+      roomId: "!room:matrix-qa.test",
+      startIndex: 0,
+      sutUserId: "@sut:matrix-qa.test",
+    });
+
+    expectValidUtf16(message);
+  });
+
+  it("preserves complete Unicode code points in final candidates", () => {
+    const message = buildMatrixQaToolProgressFinalTimeoutMessage({
+      cause: new Error("final wait timed out"),
+      events: [
+        buildBoundaryEvent({
+          eventId: "$replacement",
+          relatesTo: { eventId: "$preview", relType: "m.replace" },
+        }),
+      ],
+      previewEventId: "$preview",
+      roomId: "!room:matrix-qa.test",
+      startIndex: 0,
+      sutUserId: "@sut:matrix-qa.test",
+      token: "x",
+    });
+
+    expectValidUtf16(message);
+  });
+});

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-diagnostics.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-diagnostics.ts
@@ -1,4 +1,5 @@
 // QA Lab Matrix tool-progress diagnostics preserve actionable failure evidence.
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixQaObservedEvent } from "../substrate/events.js";
 import { isMatrixQaMessageLikeKind } from "./scenario-runtime-shared.js";
 
@@ -56,7 +57,7 @@ function truncateMatrixQaToolProgressBody(body: string | undefined) {
   if (!body) {
     return "<none>";
   }
-  return body.length <= 240 ? body : `${body.slice(0, 237)}...`;
+  return body.length <= 240 ? body : `${truncateUtf16Safe(body, 237)}...`;
 }
 
 function describeMatrixQaToolProgressCandidate(event: MatrixQaObservedEvent) {


### PR DESCRIPTION
## What Problem This Solves

Matrix QA tool-progress timeout diagnostics shorten observed event bodies to a 240-code-unit preview. When an emoji began at the existing raw `slice(0, 237)` boundary, the later JSON diagnostic serialized only its high surrogate as an escaped `\\ud83d`, discarding the complete character and making the timeout evidence misleading.

## Why This Change Was Made

The shared `truncateUtf16Safe` helper now backs off to a complete Unicode code-point boundary while retaining the existing preview budget and suffix. Both preview-wait and final-wait diagnostics use the same formatter.

## User Impact

Matrix QA timeout failures no longer expose a half-character escape when observed messages cross the Unicode truncation boundary, so the retained failure evidence stays well-formed and actionable.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-diagnostics.test.ts` (2 tests passed on Node 24.15.0)
- Added exact-boundary regression coverage for both exported timeout builders.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Pre-commit autoreview: clean, no actionable findings (0.85 confidence).
- Exact-head `build-artifacts`, type checks, lint, and aggregate CI gate passed.
- Verified the focused SDK boundary at exact head: both package export maps, the SDK entrypoint registry, and SDK docs include `text-utility-runtime`; four sibling Matrix QA modules use the same subpath.
- Downloaded the exact-head `dist-runtime-build` artifact and loaded `openclaw/plugin-sdk/text-utility-runtime` through its packaged Node shim. `truncateUtf16Safe` resolved as a function, and the boundary probe produced no half-surrogate escape or UTF-8 replacement.
- [Exact-head real Matrix timeout proof](https://github.com/Leon-SK668/openclaw/actions/runs/29718697982) passed against current PR head `89d0abba888e6ea5acd0cb2b04ec544639f07fdf` on Node 24.15.0 with disposable Tuwunel v1.5.1. The production QA scenario registered real Matrix clients, created and joined a room, sent the trigger plus `m.replace` progress events, then exercised the actual 15-second final-event timeout path.
- The uploaded `matrix-timeout-proof-89d0abba888e6ea5acd0cb2b04ec544639f07fdf` artifact (`sha256:646e6bbb14be1c5c381c011063020399d4c7e095babd6bfe9659cdee291efc2a`) contains the redacted timeout log and route inventory. Assertions confirm a preserved boundary emoji, retreat before a split surrogate pair, no escaped half surrogate, no lone surrogate, no replacement character, and a valid UTF-8 round trip.
