### PR TITLE
fix(tui): bound codex CLI binary lookup

### DIFF
--- a/src/tui/tui.resolve-codex-bin.test.ts
+++ b/src/tui/tui.resolve-codex-bin.test.ts
@@ -41,7 +41,7 @@ describe("resolveCodexCliBin", () => {
     expect(execFileSyncMock).toHaveBeenCalledWith(
       path.win32.join("D:\\Windows", "System32", "where.exe"),
       ["codex"],
-      { encoding: "utf8" },
+      { encoding: "utf8", timeout: 5_000 },
     );
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -122,7 +122,10 @@ export function resolveCodexCliBin(): string | null {
     const lookupCmd =
       process.platform === "win32" ? getWindowsSystem32ExePath("where.exe") : "which";
     // `where` on Windows can return multiple lines; take the first match.
-    const raw = execFileSync(lookupCmd, ["codex"], { encoding: "utf8" }).trim();
+    const raw = execFileSync(lookupCmd, ["codex"], {
+      encoding: "utf8",
+      timeout: 5_000,
+    }).trim();
     return raw.split(/\r?\n/)[0] || null;
   } catch {
     return null;


### PR DESCRIPTION
## What Problem This Solves

`resolveCodexCliBin` runs `execFileSync` with `which` or `where.exe` to locate the codex CLI binary without a deadline. A stalled PATH lookup could block TUI initialization indefinitely.

## Why This Change Was Made

Add a 5-second timeout to the execFileSync call. The existing try-catch already converts subprocess failures to a `null` return, making the timeout path automatically fail-soft.

## User Impact

A stalled `which`/`where.exe` call can no longer block TUI codex CLI binary resolution. After 5 seconds the function returns null through the existing failure path.

## Evidence

- `node scripts/run-vitest.mjs src/tui/tui.resolve-codex-bin.test.ts` (existing tests pass with updated options assertion)
- `git diff --check origin/main...HEAD`
