### PR TITLE
fix(cli): bound DNS admin subprocess probes

### DIFF
--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -21,6 +21,7 @@ function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
+    timeout: 30_000,
   });
   if (res.error) {
     throw res.error;
@@ -51,6 +52,7 @@ function writeFileSudoIfNeeded(filePath: string, content: string): void {
     input: content,
     encoding: "utf-8",
     stdio: ["pipe", "ignore", "inherit"],
+    timeout: 5_000,
   });
   if (res.error) {
     throw res.error;


### PR DESCRIPTION
## What Problem This Solves

The DNS CLI's `run()` helper and `writeFileSudoIfNeeded` function use `spawnSync` without deadlines for `brew`, `sudo mkdir`, `sudo tee`, `sudo brew services restart`, and other DNS admin commands. A stalled subprocess could block DNS setup indefinitely.

## Why This Change Was Made

Add a 30-second timeout to the general `run()` helper (covers `brew --prefix`, `brew list`, `brew install`, `sudo mkdir`, `sudo brew services restart`) and a 5-second timeout to the `sudo tee` file write fallback. Both functions already have error handling that converts failures to thrown errors or filesystem retries.

## User Impact

Stalled DNS admin subprocesses can no longer block DNS setup commands. After the respective timeout periods, the commands fail through their existing error paths.

## Evidence

- `git diff --check origin/main...HEAD`
