### PR TITLE
fix(sessions): bound sync git symbolic-ref probe

### DIFF
--- a/src/agents/sessions/footer-data-provider.ts
+++ b/src/agents/sessions/footer-data-provider.ts
@@ -75,6 +75,7 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
       cwd: repoDir,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
     },
   );
   const branch = result.status === 0 ? result.stdout.trim() : "";


### PR DESCRIPTION
## What Problem This Solves

`resolveBranchWithGitSync` runs `spawnSync("git", ["symbolic-ref", ...])` without a timeout. A stalled git command could block the sync branch resolution path used during footer data provider initialization.

## Why This Change Was Made

Add a 5-second timeout to the spawnSync call. The existing result.status check already returns null on failure, making the timeout path automatically fail-soft.

## User Impact

A stalled git symbolic-ref call can no longer block the sync branch resolution path. After 5 seconds the function returns null through the existing failure path.

## Evidence

- `git diff --check origin/main...HEAD`
