### PR TITLE
improve: use lightweight worker keepalive in tests

### DIFF
--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -591,9 +591,13 @@ class FakeWorkerGateway {
     const toolCallId = "local-exec-call";
     const args = background
       ? {
-          command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
-            "setInterval(() => undefined, 1000)",
-          )}`,
+          // POSIX sleep avoids Node startup; Windows keeps the portable Node fixture.
+          command:
+            process.platform === "win32"
+              ? `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
+                  "setInterval(() => undefined, 1000)",
+                )}`
+              : "exec sleep 60",
           background: true,
         }
       : { command: "printf worker-local > local-proof.txt" };


### PR DESCRIPTION
## Summary

- use a lightweight POSIX `sleep` process for the worker background-process lifecycle fixture
- retain the portable Node keepalive on Windows
- preserve real process tracking and fencing cleanup while cutting the full-file test from 416ms to 211ms (49.3%)

## Validation

- Testbox `tbx_01kxpxhr91tg862btxcy9akt3b`: `pnpm test src/worker/worker.runtime.test.ts --reporter=verbose` (26/26 passed; target 211ms)
- Testbox: `pnpm check:changed`
- fresh autoreview: clean (0.95 confidence)

## Scope

Test-only change. No runtime or CI behavior changes.
