### PR TITLE
fix(agents): subagent completion loses captured output after silent reply

### DIFF
--- a/src/agents/agent-steering-queue.test.ts
+++ b/src/agents/agent-steering-queue.test.ts
@@ -189,6 +189,30 @@ describe("agent steering queue", () => {
     });
   });
 
+  it("uses captured fallback output when a resumed completion returns NO_REPLY", () => {
+    const runs = runMap([
+      makeRun({
+        runId: "run-1",
+        delivery: {
+          status: "suspended",
+          payload: payload("run-1", {
+            frozenResultText: "NO_REPLY",
+            fallbackFrozenResultText: "findings captured before the wake",
+          }),
+        },
+      }),
+    ]);
+
+    const leased = leasePendingAgentSteeringItemsFromSubagentRuns({
+      runs,
+      requesterSessionKey,
+      leaseId: "lease-fallback",
+    });
+
+    expect(leased?.prompt).toContain("findings captured before the wake");
+    expect(leased?.prompt).not.toContain("NO_REPLY");
+  });
+
   it("bounds merged prompts and leaves overflow pending", () => {
     const runs = runMap(
       Array.from({ length: 6 }, (_, index) =>

--- a/src/agents/agent-steering-queue.ts
+++ b/src/agents/agent-steering-queue.ts
@@ -6,6 +6,7 @@ import type {
   SubagentCompletionDeliveryState,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
+import { selectDeliverableSessionsReply } from "./tools/sessions-send-tokens.js";
 
 // Steering queue utilities for delivering completed subagent results back into
 // the requester session. Items are leased before injection to avoid duplicate
@@ -43,7 +44,7 @@ function isStaleLease(delivery: SubagentCompletionDeliveryState, now: number): b
 }
 
 function selectResultText(payload: PendingFinalDeliveryPayload): string | undefined {
-  return payload.frozenResultText?.trim() || payload.fallbackFrozenResultText?.trim() || undefined;
+  return selectDeliverableSessionsReply(payload.frozenResultText, payload.fallbackFrozenResultText);
 }
 
 function describeOutcome(payload: PendingFinalDeliveryPayload): string {

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -327,6 +327,44 @@ describe("buildChildCompletionFindings", () => {
     expect(findings).not.toContain("(no output)");
   });
 
+  it("uses captured fallback output when a resumed completion returns NO_REPLY", () => {
+    const findings = buildChildCompletionFindings([
+      {
+        childSessionKey: "agent:main:subagent:child",
+        task: "child task",
+        createdAt: 1,
+        completion: {
+          resultText: "NO_REPLY",
+          fallbackResultText: "findings captured before the wake",
+        },
+        outcome: { status: "ok" },
+      },
+    ]);
+
+    expect(findings).toContain("findings captured before the wake");
+    expect(findings).not.toContain("NO_REPLY");
+  });
+
+  it.each(["ANNOUNCE_SKIP", "REPLY_SKIP", "HEARTBEAT_OK"])(
+    "does not override an intentional %s completion with fallback output",
+    (resultText) => {
+      const findings = buildChildCompletionFindings([
+        {
+          childSessionKey: "agent:main:subagent:silent",
+          task: "silent task",
+          createdAt: 1,
+          completion: {
+            resultText,
+            fallbackResultText: "stale findings",
+          },
+          outcome: { status: "ok" },
+        },
+      ]);
+
+      expect(findings).toBeUndefined();
+    },
+  );
+
   it("numbers findings contiguously after skipped silent completions", () => {
     const findings = buildChildCompletionFindings([
       {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -23,7 +23,7 @@ import {
 import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 import { assistantCallsSessionsYield, isSessionsYieldToolResult } from "./subagent-yield-output.js";
 import { extractAssistantText, sanitizeTextContent } from "./tools/chat-history-text.js";
-import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
+import { isAnnounceSkip, selectDeliverableSessionsReply } from "./tools/sessions-send-tokens.js";
 
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
 
@@ -367,14 +367,25 @@ type ChildCompletionRow = {
 };
 
 function selectChildCompletionResultText(child: ChildCompletionRow): string | undefined {
-  return (
-    child.completion?.resultText ??
-    child.delivery?.payload?.frozenResultText ??
+  const primary = child.completion?.resultText ?? child.delivery?.payload?.frozenResultText;
+  const fallback =
     child.completion?.fallbackResultText ??
     child.delivery?.payload?.fallbackFrozenResultText ??
-    child.frozenResultText ??
-    undefined
-  )?.trim();
+    child.frozenResultText;
+  if (child.outcome?.status === "ok") {
+    return selectDeliverableSessionsReply(primary, fallback);
+  }
+  return (primary ?? fallback)?.trim() || undefined;
+}
+
+function hasCapturedChildCompletionReply(child: ChildCompletionRow): boolean {
+  return [
+    child.completion?.resultText,
+    child.delivery?.payload?.frozenResultText,
+    child.completion?.fallbackResultText,
+    child.delivery?.payload?.fallbackFrozenResultText,
+    child.frozenResultText,
+  ].some((value) => Boolean(value?.trim()));
 }
 
 export function buildChildCompletionFindings(
@@ -393,11 +404,7 @@ export function buildChildCompletionFindings(
   for (const [index, child] of sorted.entries()) {
     const resultText = selectChildCompletionResultText(child);
     const outcome = describeSubagentOutcome(child.outcome);
-    if (
-      child.outcome?.status === "ok" &&
-      resultText &&
-      (isAnnounceSkip(resultText) || isSilentReplyText(resultText, SILENT_REPLY_TOKEN))
-    ) {
+    if (child.outcome?.status === "ok" && !resultText && hasCapturedChildCompletionReply(child)) {
       continue;
     }
     const title =

--- a/src/agents/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.test.ts
@@ -385,6 +385,28 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(String(deliveredCallArg().triggerMessage)).toContain("orphaned findings");
   });
 
+  it("wakes with captured fallback output after a resumed completion returns NO_REPLY", async () => {
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([
+      makeSettledChild({
+        runId: "run-b",
+        delivery: { status: "failed" },
+        completion: {
+          required: true,
+          resultText: "NO_REPLY",
+          fallbackResultText: "findings captured before the wake",
+        },
+        outcome: { status: "ok" },
+      }),
+    ]);
+
+    const woke = await maybeWakeRequesterAfterAllChildrenSettled(wakeParams());
+
+    expect(woke).toBe(true);
+    const message = String(deliveredCallArg().triggerMessage);
+    expect(message).toContain("findings captured before the wake");
+    expect(message).not.toContain("<prompt-data>\nNO_REPLY\n</prompt-data>");
+  });
+
   it("stays out of pure fire-and-forget batches", async () => {
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([
       makeSettledChild({

--- a/src/agents/tools/sessions-send-tokens.ts
+++ b/src/agents/tools/sessions-send-tokens.ts
@@ -31,3 +31,19 @@ export function isReplySkip(text?: string) {
 export function isNonDeliverableSessionsReply(text?: string) {
   return NON_DELIVERABLE_REPLY_TOKENS.some((token) => isSilentReplyText(text, token));
 }
+
+/** Selects a deliverable reply while allowing NO_REPLY to use captured fallback output. */
+export function selectDeliverableSessionsReply(
+  primary?: string | null,
+  fallback?: string | null,
+): string | undefined {
+  const primaryReply = primary?.trim();
+  if (primaryReply && !isNonDeliverableSessionsReply(primaryReply)) {
+    return primaryReply;
+  }
+  if (primaryReply && !isSilentReplyText(primaryReply, SILENT_REPLY_TOKEN)) {
+    return undefined;
+  }
+  const fallbackReply = fallback?.trim();
+  return fallbackReply && !isNonDeliverableSessionsReply(fallbackReply) ? fallbackReply : undefined;
+}


### PR DESCRIPTION
Related: #97922
Related: #67777
Related: #99396

## What Problem This Solves

Fixes an issue where a subagent completion could lose its captured fallback output when a resumed delivery returned `NO_REPLY`. The durable requester wake added by #99396 would still wake the requester, but the completion summary and later steering fallback could omit the actual result.

## Why This Change Was Made

Completion reply selection now has one sentinel-aware owner shared by requester-settle wake output and steering-queue injection. `NO_REPLY` may use captured fallback output; explicit suppression tokens continue to suppress delivery. The older lifecycle changes from #97922 were not carried forward because #99396 now owns durable delete-mode settlement and restart recovery.

Contributor credit is preserved in the commit for @MertBasar0, whose report and implementation identified the fallback-selection gap.

## User Impact

Requesters now receive a subagent's captured result after a silent resumed completion instead of an empty completion or literal `NO_REPLY`. Explicitly skipped announcements remain silent.

## Evidence

- `node scripts/run-vitest.mjs src/agents/agent-steering-queue.test.ts src/agents/subagent-announce-output.test.ts src/agents/subagent-announce.requester-settle-wake.test.ts` — 59 tests passed across 3 files after rebase onto current `origin/main`.
- `node scripts/check-changed.mjs -- src/agents/agent-steering-queue.test.ts src/agents/agent-steering-queue.ts src/agents/subagent-announce-output.test.ts src/agents/subagent-announce-output.ts src/agents/subagent-announce.requester-settle-wake.test.ts src/agents/tools/sessions-send-tokens.ts` — hosted core/coreTests gate passed: https://github.com/openclaw/openclaw/actions/runs/29549269589
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
