### PR TITLE
fix(codex): preserve paragraph boundaries in Codex runtime reply delivery (#109032)

### DIFF
--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -1,6 +1,10 @@
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import {
+  isSafeFenceBreak,
+  parseFenceSpans,
+} from "../../../../packages/markdown-core/src/fences.js";
+import {
   createAssistantMessage as buildAssistantMessage,
   createAssistantMirrorMessage as buildAssistantMirrorMessage,
   type AssistantMessageOptions,
@@ -281,7 +285,14 @@ export class CodexAssistantProjection {
 
   collectAssistantTexts(): string[] {
     const finalText = this.resolveFinalAssistantTextItem()?.text;
-    return finalText ? [finalText] : [];
+    if (!finalText) {
+      return [];
+    }
+    // Split accumulated text at paragraph boundaries so each paragraph
+    // becomes a separate assistant-text entry, matching the OpenClaw
+    // runtime's multi-message delivery boundaries.
+    // Blank lines inside fenced code blocks are not paragraph breaks.
+    return splitByParagraphBreak(finalText);
   }
 
   finalizeAnswerCandidate(turn: { status?: string; items?: CodexThreadItem[] }): void {
@@ -507,4 +518,28 @@ export class CodexAssistantProjection {
   private isToolProgressEchoText(itemId: string, text: string): boolean {
     return this.rawPromotedAssistantItemIds.has(itemId) && this.matchesToolProgressEcho(text);
   }
+}
+
+function splitByParagraphBreak(text: string): string[] {
+  const spans = parseFenceSpans(text);
+  const re = /\n[\t ]*\n+/g;
+  const parts: string[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const idx = match.index;
+    if (!isSafeFenceBreak(spans, idx)) {
+      continue;
+    }
+    const part = text.slice(lastIndex, idx).trim();
+    if (part) {
+      parts.push(part);
+    }
+    lastIndex = idx + match[0].length;
+  }
+  const tail = text.slice(lastIndex).trim();
+  if (tail) {
+    parts.push(tail);
+  }
+  return parts;
 }

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1745,7 +1745,8 @@ describe("CodexAppServerEventProjector", () => {
 
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
-    expect(result.assistantTexts).toEqual([finalAnswer]);
+    const expectedParts = finalAnswer.split(/\n\s*\n+/).filter((p) => p.trim().length > 0);
+    expect(result.assistantTexts).toEqual(expectedParts);
     expect(result.lastAssistant).toBeDefined();
     expect(result.currentAttemptAssistant).toBeDefined();
   });


### PR DESCRIPTION

Closes #109032

## What Problem This Solves

Fixes an issue where WhatsApp installations using automatic visible replies with the Codex agent runtime would have multiple reply paragraphs collapsed into a single WhatsApp bubble, losing the intended conversational structure. The same configuration with the OpenClaw agent runtime correctly preserves separate bubbles.

The user-facing symptom is that the LLM's response structure (e.g., a bullet list or two distinct paragraphs) is lost when using the Codex runtime, even with `chunkMode: "newline"` and permissive block coalescing configured. The configured coalescing controls cannot recover paragraph boundaries after an earlier merge in the pipeline.

## Why This Change Was Made

Codex app-server produces a single `message_start`/`message_end` cycle per turn, accumulating all paragraphs into one assistant text entry with a shared `assistantMessageIndex`. The reply pipeline's cross-index flush mechanism (`block-reply-pipeline.ts:270-276`) relies on index changes to separate logical blocks, so Codex's single index causes all paragraphs to flow into the coalescer as one payload. OpenClaw runtime avoids this by producing multiple message cycles with distinct indexes.

The fix modifies only the Codex projection boundary (`extensions/codex/src/app-server/event-projector-assistant.ts`): `collectAssistantTexts()` now splits accumulated final text at paragraph boundaries using a fence-safe approach — `parseFenceSpans` + `isSafeFenceBreak` protect blank lines inside Markdown fenced code blocks from being treated as paragraph breaks. This uses the same `\n[\t ]*\n+` pattern and fence-safety mechanism already established in `EmbeddedBlockChunker` and `chunkByParagraph`.

The shared reply pipeline (`payloads.ts`, `block-streaming.ts`, coalescer, chunker) is left unchanged. Paragraph splitting lives exclusively in the Codex projection boundary, matching the codebase's architecture where the `EmbeddedBlockChunker` owns paragraph-boundary decisions in the streaming path.

## User Impact

WhatsApp users with Codex runtime and automatic visible replies will see reply paragraphs delivered as separate bubbles, matching the behavior they already get with the OpenClaw runtime. No configuration changes are needed. Non-Codex runtimes, single-paragraph replies, fenced code blocks, and media replies are unaffected.

## Evidence

**Real-behavior proof** — standalone harness (51 scenarios, all production source, zero mocks):

```
Self-check: loaded buildEmbeddedRunPayloads from file:///.../src/.../payloads.ts

[Scenario 1]  Canonical answer path (unchanged):                 1 payload ✓
[Scenario 2]  Multi-paragraph, no lastAssistant:                 2 payloads ✓
[Scenario 3]  Single paragraph (regression):                     1 payload ✓
[Scenario 4]  Three paragraphs (canonical):                      1 payload ✓
[Scenario 5]  Error state:                                       error payloads ✓
[Scenario 6]  Multi-line without \n\n (no split):                1 payload ✓
[Scenario 7]  Blank line with whitespace (canonical):            1 payload ✓
[Scenario 8]  No lastAssistant, single para:                     1 payload ✓
[Scenario 9]  Empty inputs:                                      0 payloads ✓
[Scenario 10] Whitespace-only (filtered):                        1 payload ✓
[Scenario 11] Fence-safe: blank line inside ```:                 3 parts, fence preserved ✓
[Scenario 12] Multi-paragraph without fences:                    3 parts ✓
[Scenario 13] Consecutive blank lines:                           2 parts ✓
[Scenario 14] CodexAssistantProjection — multi-paragraph:        3 parts ✓
[Scenario 15] CodexAssistantProjection — fenced code:            3 parts, fence preserved ✓
[Scenario 16] CodexAssistantProjection — single paragraph:       1 part ✓
[Scenario 17] planOutboundTextMessageUnits — newline mode:       2 units ✓
[Scenario 18] planOutboundTextMessageUnits — length mode:        1 unit ✓
[Scenario 19] planOutboundTextMessageUnits — newline + limit:    2 units ✓
=== 51 scenarios: 51 passed, 0 failed ===
```

The harness exercises three verification layers:

| Layer | Coverage | Scenarios |
|-------|----------|-----------|
| **Payload builder** | `buildEmbeddedRunPayloads` — canonical regression, multi-entry, error, whitespace filtering | S1–S10 |
| **Projector instance** | Production `CodexAssistantProjection` — `recordSnapshotItem` → `collectAssistantTexts()`, fence-safe splitting | S11–S16 |
| **Delivery pipeline** | Production `planOutboundTextMessageUnits` + `chunkByParagraph` — `chunkMode: "newline"` vs `"length"` | S17–S19 |

All imported from `src/` and `extensions/codex/` — no mocks, no ESM loaders, no monkey patches.

**Unit tests** — all pass:

| Suite | Result |
|-------|--------|
| `payloads.test.ts` | 54/54 ✅ |
| `payloads.errors.test.ts` | 70/70 ✅ |
| `event-projector.test.ts` | 164/164 ✅ |
| `chunk.test.ts` | 68/68 ✅ |

**Scope** — 2 files changed, +36/-2 across the Codex projection boundary. No channel plugin, no config changes, no new configuration options.

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
