### PR TITLE
fix(release): declare direct checklist execution helper

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -72,6 +72,11 @@ export function buildTelegramArtifactInputs(params: {
   runId: string;
   sourceSha: string;
 }): Record<string, string | number>;
+export function isDirectReleaseCandidateExecution(
+  directPath: string | undefined,
+  modulePath: string,
+  resolveRealPath?: (path: string) => string,
+): boolean;
 /**
  * Calls the GitHub REST API with the gh-auth token and a bounded timeout.
  */


### PR DESCRIPTION
Related: #96250

AI-assisted: yes.

## What Problem This Solves

Resolves a problem where the root test typecheck fails on `main` after the release-candidate checklist gained a directly exported execution helper without the matching declaration export.

## Why This Change Was Made

Adds the missing public declaration with the same optional real-path dependency used by the runtime implementation. No runtime behavior changes.

## User Impact

Maintainer release tooling keeps its checked TypeScript contract aligned with the executable module, restoring the root test typecheck gate.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts` — 54 tests passed.
- `node scripts/check-changed.mjs -- scripts/release-candidate-checklist.mjs test/scripts/release-candidate-checklist.test.ts` — reproduced the missing-export failure on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29549975065
- `git diff --check` — passed.
- `oxfmt --check scripts/release-candidate-checklist.d.mts` — passed.
- Mandatory autoreview — clean; no accepted/actionable findings.
