### PR TITLE
fix(config): reject gateway.port outside the 1-65535 TCP range

### DIFF
--- a/src/config/zod-schema.gateway-port.test.ts
+++ b/src/config/zod-schema.gateway-port.test.ts
@@ -1,0 +1,31 @@
+// Schema-level tests for gateway.port TCP range validation.
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("gateway.port schema", () => {
+  it("rejects a port above the TCP range", () => {
+    const res = validateConfigObject({ gateway: { port: 65_536 } });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toMatch(/port/);
+    }
+  });
+
+  it("rejects port 0", () => {
+    const res = validateConfigObject({ gateway: { port: 0 } });
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts the maximum valid port", () => {
+    const res = validateConfigObject({ gateway: { port: 65_535 } });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.gateway?.port).toBe(65_535);
+    }
+  });
+
+  it("accepts a typical port", () => {
+    const res = validateConfigObject({ gateway: { port: 18_789 } });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1125,7 +1125,7 @@ export const OpenClawSchema = z
     talk: TalkSchema.optional(),
     gateway: z
       .strictObject({
-        port: z.number().int().positive().optional(),
+        port: z.number().int().min(1).max(65_535).optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
         bind: z
           .union([


### PR DESCRIPTION
Closes #109293

_AI-assisted (Claude Code). I understand the change and validated it locally; see Evidence._

## What Problem This Solves

Fixes an issue where an operator who sets `gateway.port` to a value outside the valid TCP port range (e.g. `65536`) has that value silently accepted by config validation and then silently ignored at runtime by `resolveGatewayPort`. The gateway never binds the intended port, and no early, actionable error points at the bad value.

## Why This Change Was Made

`gateway.port` was schema-validated only as `z.number().int().positive()` with no upper bound, while the sibling `gateway.remote.remotePort` is already bounded to `1..65535`. This change applies the same bound to `gateway.port`, so out-of-range ports are rejected at config-validation time with a clear `gateway.port` path — consistent with the existing runtime port parser and the other port fields in the schema. No other config surface, exported type, or default changes.

## User Impact

Operators now get an immediate, clear config-validation error when `gateway.port` is out of range (e.g. `65536`), instead of the value being accepted and then quietly dropped at startup. Valid ports (`1..65535`, including the default `18789`) are unaffected.

## Evidence

Added a focused schema regression test (`src/config/zod-schema.gateway-port.test.ts`) covering out-of-range rejection and valid-port acceptance. Local run:

```
 RUN  v4.1.10 D:/AI_Projects/openclaw
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Test cases: rejects `65536` (with a `gateway.port` issue path) and `0`; accepts `65535` and the default `18789`.

Also verified locally on the changed files: `oxfmt --check` clean, `oxlint` clean, `git diff --check` clean.
