### PR TITLE
fix(channels): centralize access gates and media fallback

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-e53aad267b77bc3ae033e271e3501ece9e8e4113d243ea9b0740e627bb2acf26  plugin-sdk-api-baseline.json
-e73d9ab6836d36fdfe47452e3f0337d5b15577e395cedb152fcb843928c3cd72  plugin-sdk-api-baseline.jsonl
+4de3095c7c71d6ed2f1744a73373e9b868934a81a1921d7245fae7e64725fb73  plugin-sdk-api-baseline.json
+0cf729db6b115dc8b1cb98a595efeaa5febe4b90d424f5774400176b71561423  plugin-sdk-api-baseline.jsonl

--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -1,5 +1,8 @@
 // Discord plugin module implements allow list behavior.
-import type { AllowlistMatch } from "openclaw/plugin-sdk/allow-from";
+import {
+  type AllowlistMatch,
+  resolveAllowlistMatchByCandidates,
+} from "openclaw/plugin-sdk/allow-from";
 import {
   buildChannelKeyCandidates,
   resolveChannelEntryMatchWithFallback,
@@ -604,13 +607,14 @@ export function resolveGroupDmAllow(params: {
   if (!channels || channels.length === 0) {
     return true;
   }
-  const allowList = new Set(channels.map((entry) => normalizeDiscordSlug(entry)));
-  const candidates = [
-    normalizeDiscordSlug(channelId),
-    channelSlug,
-    channelName ? normalizeDiscordSlug(channelName) : "",
-  ].filter(Boolean);
-  return allowList.has("*") || candidates.some((candidate) => allowList.has(candidate));
+  return resolveAllowlistMatchByCandidates({
+    allowList: channels.map((entry) => normalizeDiscordSlug(entry)),
+    candidates: [
+      { value: normalizeDiscordSlug(channelId), source: "id" },
+      { value: channelSlug, source: "slug" },
+      { value: channelName ? normalizeDiscordSlug(channelName) : undefined, source: "name" },
+    ],
+  }).allowed;
 }
 
 export function shouldEmitDiscordReactionNotification(params: {

--- a/extensions/discord/src/monitor/inbound-context.ts
+++ b/extensions/discord/src/monitor/inbound-context.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements inbound context behavior.
+import { resolveInboundSupplementalSenderAllowed } from "openclaw/plugin-sdk/channel-inbound";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import {
   resolveDiscordMemberAllowed,
@@ -20,18 +21,24 @@ export function createDiscordSupplementalContextAccessChecker(params: {
   allowNameMatching?: boolean;
   isGuild: boolean;
 }) {
+  const userAllowList = params.channelConfig?.users ?? params.guildInfo?.users ?? [];
+  const roleAllowList = params.channelConfig?.roles ?? params.guildInfo?.roles ?? [];
+  const allowFrom = [...userAllowList, ...roleAllowList];
   return (sender: DiscordSupplementalContextSender): boolean => {
-    if (!params.isGuild) {
-      return true;
-    }
-    return resolveDiscordMemberAllowed({
-      userAllowList: params.channelConfig?.users ?? params.guildInfo?.users,
-      roleAllowList: params.channelConfig?.roles ?? params.guildInfo?.roles,
-      memberRoleIds: sender.memberRoleIds ?? [],
-      userId: sender.id ?? "",
-      userName: sender.name,
-      userTag: sender.tag,
-      allowNameMatching: params.allowNameMatching,
+    return resolveInboundSupplementalSenderAllowed({
+      isGroup: params.isGuild,
+      groupPolicy: allowFrom.length === 0 ? "open" : "allowlist",
+      allowFrom,
+      isSenderAllowed: () =>
+        resolveDiscordMemberAllowed({
+          userAllowList,
+          roleAllowList,
+          memberRoleIds: sender.memberRoleIds ?? [],
+          userId: sender.id ?? "",
+          userName: sender.name,
+          userTag: sender.tag,
+          allowNameMatching: params.allowNameMatching,
+        }),
     });
   };
 }

--- a/extensions/discord/src/normalize.ts
+++ b/extensions/discord/src/normalize.ts
@@ -1,4 +1,5 @@
 // Discord helper module supports normalize behavior.
+import { resolveAllowlistMatchByCandidates } from "openclaw/plugin-sdk/allow-from";
 import { parseDiscordTarget } from "./target-parsing.js";
 
 export function normalizeDiscordMessagingTarget(raw: string): string | undefined {
@@ -43,9 +44,13 @@ export function allowFromContainsDiscordUserId(
   if (!normalizedUserId) {
     return false;
   }
-  return (allowFrom ?? []).some(
-    (entry) => normalizeAllowFromDiscordUserId(entry) === normalizedUserId,
-  );
+  const normalizedAllowFrom = (allowFrom ?? [])
+    .map(normalizeAllowFromDiscordUserId)
+    .filter((entry): entry is string => Boolean(entry));
+  return resolveAllowlistMatchByCandidates({
+    allowList: normalizedAllowFrom,
+    candidates: [{ value: normalizedUserId, source: "id" }],
+  }).allowed;
 }
 
 function normalizeAllowFromDiscordUserId(entry: string): string | undefined {

--- a/extensions/feishu/src/read-policy.ts
+++ b/extensions/feishu/src/read-policy.ts
@@ -1,3 +1,7 @@
+import {
+  compileAllowlist,
+  resolveAllowlistMatchByCandidates,
+} from "openclaw/plugin-sdk/allow-from";
 import { ToolAuthorizationError } from "openclaw/plugin-sdk/channel-actions";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
@@ -36,6 +40,10 @@ function normalizeChatId(raw?: string | null): string {
     return "";
   }
   return normalizeFeishuTarget(raw) ?? raw.trim();
+}
+
+function normalizeFeishuAllowlist(entries: Array<string | number> | undefined): string[] {
+  return (entries ?? []).map((entry) => normalizeFeishuAllowEntry(String(entry))).filter(Boolean);
 }
 
 function readContextFields(ctx: FeishuReadContext): {
@@ -115,10 +123,10 @@ export function isFeishuGroupReadAllowed(
   const normalizedChatId = normalizeFeishuAllowEntry(chatId);
   return (
     explicitlyConfigured ||
-    (account.config.groupAllowFrom ?? []).some((entry) => {
-      const normalized = normalizeFeishuAllowEntry(String(entry));
-      return normalized === "*" || normalized === normalizedChatId;
-    })
+    resolveAllowlistMatchByCandidates({
+      allowList: normalizeFeishuAllowlist(account.config.groupAllowFrom),
+      candidates: [{ value: normalizedChatId, source: "id" }],
+    }).allowed
   );
 }
 
@@ -137,9 +145,7 @@ function isDmUniversallyAllowed(account: ResolvedFeishuAccount): boolean {
   // Feishu's canonical schema has no disabled DM mode; channel/account enabled owns shutdown.
   // Account overrides merge field-by-field, so only an allowFrom wildcard proves
   // universal non-current access under every supported ingress policy.
-  return (account.config.allowFrom ?? []).some(
-    (entry) => normalizeFeishuAllowEntry(String(entry)) === "*",
-  );
+  return compileAllowlist(normalizeFeishuAllowlist(account.config.allowFrom)).wildcard;
 }
 
 export function assertFeishuChatReadAllowed(params: {
@@ -261,9 +267,7 @@ export function canEnumerateAllFeishuGroups(
   return (
     policy === "open" ||
     (policy === "allowlist" &&
-      (account.config.groupAllowFrom ?? []).some(
-        (entry) => normalizeFeishuAllowEntry(String(entry)) === "*",
-      ))
+      compileAllowlist(normalizeFeishuAllowlist(account.config.groupAllowFrom)).wildcard)
   );
 }
 

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -10,6 +10,7 @@ import {
   matchesMentionPatterns,
   resolveEnvelopeFormatOptions,
   resolveInboundMentionDecision,
+  resolveInboundSupplementalSenderAllowed,
   toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
@@ -738,18 +739,21 @@ export async function resolveIMessageInboundDecision(params: {
   const replyContextAllowFrom = Array.from(
     new Set([...groupAllowFromForAccess, ...effectiveGroupAllowFrom]),
   );
-  const replySenderAllowed =
-    !isGroup || replyContextAllowFrom.length === 0
-      ? true
-      : replyContext?.sender
+  const replySenderAllowed = resolveInboundSupplementalSenderAllowed({
+    isGroup,
+    groupPolicy: replyContextAllowFrom.length === 0 ? "open" : "allowlist",
+    allowFrom: replyContextAllowFrom,
+    isSenderAllowed: (allowFrom) =>
+      replyContext?.sender
         ? isAllowedIMessageReplyContextSender({
-            allowFrom: replyContextAllowFrom,
+            allowFrom: [...allowFrom],
             sender: replyContext.sender,
             chatId,
             chatGuid,
             chatIdentifier,
           })
-        : false;
+        : false,
+  });
   const visibleReply = filterChannelInboundQuoteContext(
     contextVisibilityMode,
     replyContext

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -466,6 +466,80 @@ describe("matrixOutbound cfg threading", () => {
     ).toBeUndefined();
   });
 
+  it("applies caption and presentation metadata to the first non-empty media URL", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "test-access-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await matrixOutbound.sendPayload!({
+      cfg,
+      to: "room:!room:example",
+      text: "caption",
+      payload: {
+        text: "caption",
+        mediaUrls: ["", "file:///tmp/a.png"],
+        channelData: {
+          matrix: {
+            extraContent: {
+              "com.openclaw.presentation": {
+                version: 1,
+                type: "message.presentation",
+              },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledOnce();
+    const call = mockCall(mocks.sendMessageMatrix, "sendMessageMatrix");
+    expect(call[1]).toBe("caption");
+    const options = mockOptions(mocks.sendMessageMatrix, "sendMessageMatrix");
+    expect(options.mediaUrl).toBe("file:///tmp/a.png");
+    expect(options.extraContent).toEqual({
+      "com.openclaw.presentation": {
+        version: 1,
+        type: "message.presentation",
+      },
+    });
+  });
+
+  it("falls back to a text send when every media URL is empty", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "test-access-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await matrixOutbound.sendPayload!({
+      cfg,
+      to: "room:!room:example",
+      text: "caption",
+      payload: {
+        text: "caption",
+        mediaUrls: [""],
+      },
+      accountId: "default",
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledOnce();
+    const call = mockCall(mocks.sendMessageMatrix, "sendMessageMatrix");
+    expect(call[1]).toBe("caption");
+    expect(mockOptions(mocks.sendMessageMatrix, "sendMessageMatrix").mediaUrl).toBeUndefined();
+    expect(result).toEqual({
+      channel: "matrix",
+      messageId: "evt-1",
+      roomId: "!room:example",
+    });
+  });
+
   it("regression: mediaUrls are never silently dropped by sendPayload", async () => {
     const cfg = {
       channels: {

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -4,7 +4,10 @@ import {
   renderMessagePresentationFallbackText,
   type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
-import { resolvePayloadMediaUrls } from "openclaw/plugin-sdk/reply-payload";
+import {
+  resolvePayloadMediaUrls,
+  sendPayloadMediaSequence,
+} from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
 import type { MatrixExtraContentFields } from "./matrix/send/types.js";
@@ -154,23 +157,24 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     const urls = resolvePayloadMediaUrls(payload);
     const payloadText = resolveMatrixPayloadText(payload);
     if (urls.length > 0) {
-      let lastResult: Awaited<ReturnType<typeof send>> | undefined;
-      for (let i = 0; i < urls.length; i++) {
-        const isFirst = i === 0;
-        lastResult = await send(to, isFirst ? payloadText : "", {
-          cfg,
-          mediaUrl: urls[i],
-          mediaAccess,
-          mediaLocalRoots,
-          mediaReadFile,
-          replyToId: resolveReplyToId(),
-          threadId: resolvedThreadId,
-          accountId: accountId ?? undefined,
-          audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
-          extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
-          onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
-        });
-      }
+      const lastResult = await sendPayloadMediaSequence({
+        text: payloadText,
+        mediaUrls: urls,
+        send: async ({ text, mediaUrl, isFirst }) =>
+          await send(to, text, {
+            cfg,
+            mediaUrl,
+            mediaAccess,
+            mediaLocalRoots,
+            mediaReadFile,
+            replyToId: resolveReplyToId(),
+            threadId: resolvedThreadId,
+            accountId: accountId ?? undefined,
+            audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
+            extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
+            onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
+          }),
+      });
       return {
         channel: "matrix",
         messageId: lastResult!.messageId,

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -175,15 +175,16 @@ export const matrixOutbound: ChannelOutboundAdapter = {
             onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
           }),
       });
-      return {
-        channel: "matrix",
-        messageId: lastResult!.messageId,
-        roomId: lastResult!.roomId,
-      };
+      if (lastResult !== undefined) {
+        return {
+          channel: "matrix",
+          messageId: lastResult.messageId,
+          roomId: lastResult.roomId,
+        };
+      }
     }
     const result = await send(to, payloadText, {
       cfg,
-      mediaUrl: payload.mediaUrl,
       mediaAccess,
       mediaLocalRoots,
       mediaReadFile,

--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -81,9 +81,6 @@ export function isMattermostSenderAllowed(params: {
   allowNameMatching?: boolean;
 }): boolean {
   const allowFrom = normalizeMattermostAllowList(params.allowFrom);
-  if (allowFrom.length === 0) {
-    return false;
-  }
   const match = resolveAllowlistMatchSimple({
     allowFrom,
     senderId: normalizeMattermostAllowEntry(params.senderId),

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -5,6 +5,7 @@ import {
   logInboundDrop,
   resolveInboundMentionDecision,
   resolveInboundSessionEnvelopeContext,
+  resolveInboundSupplementalSenderAllowed,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
   dispatchReplyFromConfigWithSettledDispatcher,
@@ -731,14 +732,18 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           });
         }
         const isThreadSenderAllowed = (msg: GraphThreadMessage) =>
-          groupPolicy === "allowlist"
-            ? resolveMSTeamsAllowlistMatch({
-                allowFrom: effectiveGroupAllowFrom,
+          resolveInboundSupplementalSenderAllowed({
+            isGroup: isChannel,
+            groupPolicy,
+            allowFrom: effectiveGroupAllowFrom,
+            isSenderAllowed: (allowFrom) =>
+              resolveMSTeamsAllowlistMatch({
+                allowFrom,
                 senderId: msg.from?.user?.id ?? "",
                 senderName: msg.from?.user?.displayName,
                 allowNameMatching,
-              }).allowed
-            : true;
+              }).allowed,
+          });
         const parentSummary = summarizeParentMessage(parentMsg);
         const visibleParentMessages = parentMsg
           ? filterSupplementalContextItems({
@@ -826,14 +831,18 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     const commandBody = text.trim();
     const quoteSenderAllowed =
       quoteInfo && quoteInfo.sender
-        ? !isChannel || groupPolicy !== "allowlist"
-          ? true
-          : resolveMSTeamsAllowlistMatch({
-              allowFrom: effectiveGroupAllowFrom,
-              senderId: quoteSenderId ?? "",
-              senderName: quoteSenderName,
-              allowNameMatching,
-            }).allowed
+        ? resolveInboundSupplementalSenderAllowed({
+            isGroup: !isDirectMessage,
+            groupPolicy,
+            allowFrom: effectiveGroupAllowFrom,
+            isSenderAllowed: (allowFrom) =>
+              resolveMSTeamsAllowlistMatch({
+                allowFrom,
+                senderId: quoteSenderId ?? "",
+                senderName: quoteSenderName,
+                allowNameMatching,
+              }).allowed,
+          })
         : true;
     // Prepend thread history to the agent body so the agent has full thread context.
     const bodyForAgent = threadContext

--- a/extensions/msteams/src/policy.ts
+++ b/extensions/msteams/src/policy.ts
@@ -221,7 +221,7 @@ type MSTeamsReplyPolicy = {
 type MSTeamsAllowlistMatch = AllowlistMatch<"wildcard" | "id" | "name">;
 
 export function resolveMSTeamsAllowlistMatch(params: {
-  allowFrom: Array<string | number>;
+  allowFrom: ReadonlyArray<string | number>;
   senderId: string;
   senderName?: string | null;
   allowNameMatching?: boolean;

--- a/extensions/nextcloud-talk/src/policy.ts
+++ b/extensions/nextcloud-talk/src/policy.ts
@@ -1,3 +1,4 @@
+import { resolveAllowlistMatchByCandidates } from "openclaw/plugin-sdk/allow-from";
 import {
   resolveScopeRequireMention,
   resolveScopeToolsPolicy,
@@ -33,16 +34,11 @@ export function resolveNextcloudTalkAllowlistMatch(params: {
   senderId: string;
 }): AllowlistMatch<"wildcard" | "id"> {
   const allowFrom = normalizeNextcloudTalkAllowlist(params.allowFrom);
-  if (allowFrom.length === 0) {
-    return { allowed: false };
-  }
-  if (allowFrom.includes("*")) {
-    return { allowed: true, matchKey: "*", matchSource: "wildcard" };
-  }
   const senderId = normalizeNextcloudTalkAllowEntry(params.senderId);
-  return allowFrom.includes(senderId)
-    ? { allowed: true, matchKey: senderId, matchSource: "id" }
-    : { allowed: false };
+  return resolveAllowlistMatchByCandidates({
+    allowList: allowFrom,
+    candidates: [{ value: senderId, source: "id" }],
+  });
 }
 
 export function resolveNextcloudTalkRoomMatch(params: {

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -145,4 +145,49 @@ describe("outbound deliver sandbox media", () => {
     );
     expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([DEFAULT_MEDIA_SEND_ERROR]);
   });
+
+  it("continues text chunk delivery after a failed chunk", async () => {
+    const actx = makeActx();
+    sendTextMock.mockRejectedValueOnce(new Error("first failed"));
+
+    await sendPlainReply(
+      {},
+      "first second",
+      event,
+      actx,
+      sendWithRetry,
+      vi.fn(() => undefined),
+      [],
+      { mediaSender: makeMediaSender(), chunkText: () => ["first", "second"] },
+    );
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual(["first", "second"]);
+    expect(actx.log.error).toHaveBeenCalledWith("Send failed: first failed");
+  });
+
+  it("continues automatic media delivery after returned and thrown errors", async () => {
+    const mediaSender = makeMediaSender();
+    mediaSender.sendMedia
+      .mockResolvedValueOnce({ channel: "qqbot", error: "rejected" })
+      .mockRejectedValueOnce(new Error("network failed"))
+      .mockResolvedValueOnce({ channel: "qqbot", messageId: "media-3" });
+
+    await sendPlainReply(
+      { mediaUrls: ["first.pdf", "second.pdf", "third.pdf"] },
+      "",
+      event,
+      makeActx(),
+      sendWithRetry,
+      vi.fn(() => undefined),
+      [],
+      { mediaSender, chunkText },
+    );
+
+    expect(mediaSender.sendMedia.mock.calls.map((call) => call[0].mediaUrl)).toEqual([
+      "first.pdf",
+      "second.pdf",
+      "third.pdf",
+    ]);
+    expect(sendTextMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -71,7 +71,9 @@ function makeMediaSender() {
     sendVideoMsg: vi.fn(async () => ({ channel: "qqbot", messageId: "video-1" })),
     sendDocument: vi.fn(async () => ({ channel: "qqbot", messageId: "file-1" })),
     sendMedia: vi.fn(
-      async (): Promise<
+      async (_opts: {
+        mediaUrl: string;
+      }): Promise<
         { channel: "qqbot"; messageId: string } | { channel: "qqbot"; error: string }
       > => ({ channel: "qqbot", messageId: "media-1" }),
     ),

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -6,6 +6,10 @@
  * `DeliverDeps.mediaSender`.
  */
 
+import {
+  sendPayloadMediaSequence,
+  sendPayloadTextChunkSequence,
+} from "openclaw/plugin-sdk/reply-payload";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { GatewayAccount } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
@@ -171,32 +175,34 @@ async function autoMediaBatch(params: {
   onSuccess?: (mediaUrl: string) => string | undefined;
 }): Promise<number> {
   let sentCount = 0;
-  for (const mediaUrl of params.mediaUrls) {
-    try {
-      const result = await params.mediaSender.sendMedia({
-        to: params.qualifiedTarget,
-        text: "",
-        mediaUrl,
-        accountId: params.account.accountId,
-        replyToId: params.replyToId,
-        account: params.account,
-        ...(params.mediaAccess ? { mediaAccess: params.mediaAccess } : {}),
-        ...(params.mediaLocalRoots ? { mediaLocalRoots: params.mediaLocalRoots } : {}),
-        ...(params.mediaReadFile ? { mediaReadFile: params.mediaReadFile } : {}),
-      });
-      if (result.error) {
-        params.log?.error(params.onResultError(mediaUrl, result.error));
-        continue;
+  await sendPayloadMediaSequence({
+    text: "",
+    mediaUrls: params.mediaUrls,
+    send: async ({ mediaUrl }) =>
+      await sendWithResultLogging({
+        run: async () =>
+          await params.mediaSender.sendMedia({
+            to: params.qualifiedTarget,
+            text: "",
+            mediaUrl,
+            accountId: params.account.accountId,
+            replyToId: params.replyToId,
+            account: params.account,
+            ...(params.mediaAccess ? { mediaAccess: params.mediaAccess } : {}),
+            ...(params.mediaLocalRoots ? { mediaLocalRoots: params.mediaLocalRoots } : {}),
+            ...(params.mediaReadFile ? { mediaReadFile: params.mediaReadFile } : {}),
+          }),
+        log: params.log,
+        onSuccess: params.onSuccess ? () => params.onSuccess?.(mediaUrl) : undefined,
+        onError: (error) => params.onResultError(mediaUrl, error),
+        onThrownError: (error) => params.onThrownError(mediaUrl, error),
+      }),
+    onResult: (sent) => {
+      if (sent) {
+        sentCount++;
       }
-      sentCount++;
-      const successMessage = params.onSuccess?.(mediaUrl);
-      if (successMessage) {
-        params.log?.info(successMessage);
-      }
-    } catch (err) {
-      params.log?.error(params.onThrownError(mediaUrl, formatErrorMessage(err)));
-    }
-  }
+    },
+  });
   return sentCount;
 }
 
@@ -292,24 +298,27 @@ async function sendTextChunksWithRetry(params: {
 }): Promise<void> {
   const { account, event, chunks, sendWithRetry, consumeQuoteRef, allowDm, forcePlainText, log } =
     params;
-  for (const chunk of chunks) {
-    try {
-      await sendWithRetry((token) =>
-        sendTextChunkToTarget({
-          account,
-          event,
-          token,
-          text: chunk,
-          consumeQuoteRef,
-          allowDm,
-          forcePlainText,
-        }),
-      );
-      log?.info(params.onSuccess(chunk));
-    } catch (err) {
-      log?.error(params.onError(err));
-    }
-  }
+  await sendPayloadTextChunkSequence({
+    chunks,
+    send: async ({ text }) => {
+      try {
+        await sendWithRetry((token) =>
+          sendTextChunkToTarget({
+            account,
+            event,
+            token,
+            text,
+            consumeQuoteRef,
+            allowDm,
+            forcePlainText,
+          }),
+        );
+        log?.info(params.onSuccess(text));
+      } catch (err) {
+        log?.error(params.onError(err));
+      }
+    },
+  });
 }
 
 // ---- Result logging helpers ----
@@ -319,6 +328,7 @@ async function sendWithResultLogging(params: {
   log?: DeliverAccountContext["log"];
   onSuccess?: () => string | undefined;
   onError: (error: string) => string;
+  onThrownError?: (error: string) => string;
 }): Promise<boolean> {
   try {
     const result = await params.run();
@@ -332,7 +342,8 @@ async function sendWithResultLogging(params: {
     }
     return true;
   } catch (err) {
-    params.log?.error(params.onError(formatErrorMessage(err)));
+    const error = formatErrorMessage(err);
+    params.log?.error((params.onThrownError ?? params.onError)(error));
     return false;
   }
 }

--- a/extensions/signal/src/identity.ts
+++ b/extensions/signal/src/identity.ts
@@ -1,4 +1,5 @@
 // Signal plugin module implements identity behavior.
+import { resolveAllowlistMatchByCandidates } from "openclaw/plugin-sdk/allow-from";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
 import { looksLikeUuid } from "./uuid.js";
@@ -104,29 +105,28 @@ export function normalizeSignalAllowRecipient(entry: string): string | undefined
   return parsed.kind === "phone" ? parsed.e164 : parsed.raw;
 }
 
-export function isSignalSenderAllowed(sender: SignalSender, allowFrom: string[]): boolean {
-  if (allowFrom.length === 0) {
-    return false;
-  }
-  const parsed = allowFrom
-    .map(parseSignalAllowEntry)
-    .filter((entry): entry is SignalAllowEntry => entry !== null);
-  if (parsed.some((entry) => entry.kind === "any")) {
-    return true;
-  }
+export function isSignalSenderAllowed(sender: SignalSender, allowFrom: readonly string[]): boolean {
+  const normalizedAllowFrom = allowFrom.flatMap((entry) => {
+    const parsed = parseSignalAllowEntry(entry);
+    if (!parsed) {
+      return [];
+    }
+    if (parsed.kind === "any") {
+      return ["*"];
+    }
+    return [parsed.kind === "phone" ? `phone:${parsed.e164}` : `uuid:${parsed.raw}`];
+  });
   // A sender carries an alias when signal-cli has both forms cached locally
   // (e.g. after the daemon resolved a number → uuid for an outbound send).
   // Treat both forms as the same identity so an allowlist entry approved as
   // one form keeps matching after the other becomes available.
   const senderE164 = sender.kind === "phone" ? sender.e164 : sender.aliases?.e164;
   const senderUuid = sender.kind === "uuid" ? sender.raw : sender.aliases?.uuid;
-  return parsed.some((entry) => {
-    if (entry.kind === "phone") {
-      return senderE164 !== undefined && entry.e164 === senderE164;
-    }
-    if (entry.kind === "uuid") {
-      return senderUuid !== undefined && entry.raw === senderUuid;
-    }
-    return false;
-  });
+  return resolveAllowlistMatchByCandidates({
+    allowList: normalizedAllowFrom,
+    candidates: [
+      { value: senderE164 ? `phone:${senderE164}` : undefined, source: "phone" },
+      { value: senderUuid ? `uuid:${senderUuid}` : undefined, source: "uuid" },
+    ],
+  }).allowed;
 }

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -1,5 +1,8 @@
 // Signal plugin module implements inbound context behavior.
-import { filterChannelInboundQuoteContext } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  filterChannelInboundQuoteContext,
+  resolveInboundSupplementalSenderAllowed,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import type { ContextVisibilityDecision } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -35,12 +38,13 @@ export function resolveSignalQuoteContext(params: {
     sourceNumber: params.dataMessage?.quote?.author ?? null,
     sourceUuid: params.dataMessage?.quote?.authorUuid ?? null,
   });
-  const quoteSenderAllowed =
-    !params.isGroup || params.effectiveGroupAllow.length === 0
-      ? true
-      : quoteSender
-        ? isSignalSenderAllowed(quoteSender, params.effectiveGroupAllow)
-        : false;
+  const quoteSenderAllowed = resolveInboundSupplementalSenderAllowed({
+    isGroup: params.isGroup,
+    groupPolicy: params.effectiveGroupAllow.length === 0 ? "open" : "allowlist",
+    allowFrom: params.effectiveGroupAllow,
+    isSenderAllowed: (allowFrom) =>
+      quoteSender ? isSignalSenderAllowed(quoteSender, allowFrom) : false,
+  });
   const visibleQuote = filterChannelInboundQuoteContext(contextVisibilityMode, {
     body: quoteText,
     sender: quoteSender ? formatSignalSenderDisplay(quoteSender) : undefined,

--- a/extensions/slack/src/monitor/allow-list.ts
+++ b/extensions/slack/src/monitor/allow-list.ts
@@ -54,7 +54,7 @@ export type SlackAllowListMatch = AllowlistMatch<
 type SlackAllowListSource = Exclude<SlackAllowListMatch["matchSource"], undefined>;
 
 export function resolveSlackAllowListMatch(params: {
-  allowList: string[];
+  allowList: readonly string[];
   id?: string;
   name?: string;
   allowNameMatching?: boolean;

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -1,5 +1,8 @@
 // Slack plugin module implements prepare thread context behavior.
-import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  formatInboundEnvelope,
+  resolveInboundSupplementalSenderAllowed,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import type { ContextVisibilityMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -82,18 +85,25 @@ function isSlackThreadContextSenderAllowed(params: {
   userName?: string;
   botId?: string;
 }): boolean {
-  if (params.allowFromLower.length === 0 || params.botId) {
-    return true;
-  }
-  if (!params.userId) {
-    return false;
-  }
-  return resolveSlackAllowListMatch({
-    allowList: params.allowFromLower,
-    id: params.userId,
-    name: params.userName,
-    allowNameMatching: params.allowNameMatching,
-  }).allowed;
+  return resolveInboundSupplementalSenderAllowed({
+    isGroup: true,
+    groupPolicy: params.allowFromLower.length === 0 ? "open" : "allowlist",
+    allowFrom: params.allowFromLower,
+    isSenderAllowed: (allowFrom) => {
+      if (params.botId) {
+        return true;
+      }
+      if (!params.userId) {
+        return false;
+      }
+      return resolveSlackAllowListMatch({
+        allowList: allowFrom,
+        id: params.userId,
+        name: params.userName,
+        allowNameMatching: params.allowNameMatching,
+      }).allowed;
+    },
+  });
 }
 
 async function resolveSlackThreadUserMap(params: {

--- a/extensions/tlon/src/monitor/utils.ts
+++ b/extensions/tlon/src/monitor/utils.ts
@@ -1,3 +1,4 @@
+import { resolveAllowlistMatchByCandidates } from "openclaw/plugin-sdk/allow-from";
 import {
   implicitMentionKindWhen,
   resolveInboundMentionDecision,
@@ -218,11 +219,11 @@ export function isGroupInviteAllowed(
   inviterShip: string,
   allowlist: string[] | undefined,
 ): boolean {
-  if (!allowlist || allowlist.length === 0) {
-    return false;
-  }
   const normalizedInviter = normalizeShip(inviterShip);
-  return allowlist.map((ship) => normalizeShip(ship)).some((ship) => ship === normalizedInviter);
+  return resolveAllowlistMatchByCandidates({
+    allowList: (allowlist ?? []).map((ship) => normalizeShip(ship)),
+    candidates: [{ value: normalizedInviter, source: "ship" }],
+  }).allowed;
 }
 
 export async function resolveAuthorizedMessageText(params: {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts
@@ -1,5 +1,8 @@
 // Whatsapp plugin module implements inbound context behavior.
-import { filterChannelInboundQuoteContext } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  filterChannelInboundQuoteContext,
+  resolveInboundSupplementalSenderAllowed,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { filterSupplementalContextItems } from "openclaw/plugin-sdk/security-runtime";
 import {
   getComparableIdentityValues,
@@ -23,7 +26,7 @@ export type GroupHistoryEntry = {
 type ContextVisibilityMode = "all" | "allowlist" | "allowlist_quote";
 
 function isWhatsAppSupplementalSenderAllowed(params: {
-  allowFrom: string[];
+  allowFrom: readonly string[];
   authDir?: string;
   sender?: WhatsAppIdentity | null;
 }): boolean {
@@ -56,18 +59,21 @@ export function resolveVisibleWhatsAppGroupHistory(params: {
   groupPolicy: "open" | "allowlist" | "disabled";
   groupAllowFrom: string[];
 }): GroupHistoryEntry[] {
-  if (params.groupPolicy !== "allowlist") {
-    return params.history;
-  }
   return filterSupplementalContextItems({
     items: params.history,
     mode: params.mode,
     kind: "history",
     isSenderAllowed: (entry) =>
-      isWhatsAppSupplementalSenderAllowed({
+      resolveInboundSupplementalSenderAllowed({
+        isGroup: true,
+        groupPolicy: params.groupPolicy,
         allowFrom: params.groupAllowFrom,
-        authDir: params.authDir,
-        sender: entry.senderJid ? { jid: entry.senderJid } : null,
+        isSenderAllowed: (allowFrom) =>
+          isWhatsAppSupplementalSenderAllowed({
+            allowFrom,
+            authDir: params.authDir,
+            sender: entry.senderJid ? { jid: entry.senderJid } : null,
+          }),
       }),
   }).items;
 }
@@ -84,14 +90,17 @@ export function resolveVisibleWhatsAppReplyContext(params: {
     return null;
   }
   const admission = requireWhatsAppInboundAdmission(params.msg);
-  const senderAllowed =
-    admission.conversation.kind !== "group" || params.groupPolicy !== "allowlist"
-      ? true
-      : isWhatsAppSupplementalSenderAllowed({
-          allowFrom: params.groupAllowFrom,
-          authDir: params.authDir,
-          sender: replyTo.sender,
-        });
+  const senderAllowed = resolveInboundSupplementalSenderAllowed({
+    isGroup: admission.conversation.kind === "group",
+    groupPolicy: params.groupPolicy,
+    allowFrom: params.groupAllowFrom,
+    isSenderAllowed: (allowFrom) =>
+      isWhatsAppSupplementalSenderAllowed({
+        allowFrom,
+        authDir: params.authDir,
+        sender: replyTo.sender,
+      }),
+  });
   const visible = filterChannelInboundQuoteContext(params.mode, {
     id: replyTo.id,
     body: replyTo.body,

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -251,7 +251,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +6: shared progress receipt tracker + compositor snapshot across channel barrels.
       // +1: selectPreferredLocalModelId shares app-guided local model ranking across providers.
       // +4: shared audio-energy stats and speech-threshold gate through realtime-voice.
-      8010,
+      // +2: supplemental sender decision and outbound text chunk sequencer.
+      8012,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -277,7 +278,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +1: unified implicit-mention policy resolver.
       // +1: selectPreferredLocalModelId shares app-guided local model ranking across providers.
       // +3: PCM16/mu-law energy readers and speech-threshold gate factory.
-      4476,
+      // +2: supplemental sender decision and outbound text chunk sequencer.
+      4478,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildChannelInboundEventContext,
   finalizeChannelInboundContext,
+  resolveInboundSupplementalSenderAllowed,
   type BuildChannelInboundEventContextParams,
 } from "./context.js";
 
@@ -34,6 +35,71 @@ function createBaseContextParams(
     ...overrides,
   };
 }
+
+describe("resolveInboundSupplementalSenderAllowed", () => {
+  it.each([
+    {
+      name: "allows direct context without consulting the channel matcher",
+      isGroup: false,
+      groupPolicy: "allowlist",
+      allowFrom: ["alice"],
+      matcherResult: false,
+      expected: true,
+      matcherCalls: 0,
+    },
+    {
+      name: "allows open group context without consulting the channel matcher",
+      isGroup: true,
+      groupPolicy: "open",
+      allowFrom: ["alice"],
+      matcherResult: false,
+      expected: true,
+      matcherCalls: 0,
+    },
+    {
+      name: "allows an allowlisted supplemental sender",
+      isGroup: true,
+      groupPolicy: "allowlist",
+      allowFrom: ["alice"],
+      matcherResult: true,
+      expected: true,
+      matcherCalls: 1,
+    },
+    {
+      name: "blocks a non-allowlisted supplemental sender",
+      isGroup: true,
+      groupPolicy: "allowlist",
+      allowFrom: ["alice"],
+      matcherResult: false,
+      expected: false,
+      matcherCalls: 1,
+    },
+    {
+      name: "delegates empty allowlists to the channel matcher",
+      isGroup: true,
+      groupPolicy: "allowlist",
+      allowFrom: [],
+      matcherResult: false,
+      expected: false,
+      matcherCalls: 1,
+    },
+  ])("$name", ({ isGroup, groupPolicy, allowFrom, matcherResult, expected, matcherCalls }) => {
+    const isSenderAllowed = vi.fn(() => matcherResult);
+
+    expect(
+      resolveInboundSupplementalSenderAllowed({
+        isGroup,
+        groupPolicy,
+        allowFrom,
+        isSenderAllowed,
+      }),
+    ).toBe(expected);
+    expect(isSenderAllowed).toHaveBeenCalledTimes(matcherCalls);
+    if (matcherCalls > 0) {
+      expect(isSenderAllowed).toHaveBeenCalledWith(allowFrom);
+    }
+  });
+});
 
 describe("buildChannelInboundEventContext", () => {
   it("maps normalized inbound facts into a finalized message context", async () => {

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -214,6 +214,19 @@ export function filterChannelInboundSupplementalContext(params: {
   };
 }
 
+/** Resolves whether a supplemental-context sender passes the active group policy. */
+export function resolveInboundSupplementalSenderAllowed<TAllowFrom>(params: {
+  isGroup: boolean;
+  groupPolicy: string;
+  allowFrom: readonly TAllowFrom[];
+  isSenderAllowed: (allowFrom: readonly TAllowFrom[]) => boolean;
+}): boolean {
+  if (!params.isGroup || params.groupPolicy !== "allowlist") {
+    return true;
+  }
+  return params.isSenderAllowed(params.allowFrom);
+}
+
 export function filterChannelInboundQuoteContext(
   contextVisibility: ContextVisibilityMode | undefined,
   quote: SupplementalContextFacts["quote"] | undefined,

--- a/src/channels/plugins/chat-target-prefixes.ts
+++ b/src/channels/plugins/chat-target-prefixes.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { parseStrictInteger } from "../../infra/parse-finite-number.js";
+import { resolveAllowlistMatchByCandidates } from "../allowlist-match.js";
 
 /**
  * Prefix mapping for service-qualified target strings.
@@ -65,13 +66,6 @@ export function isAllowedParsedChatSender(params: {
   parseAllowTarget: (entry: string) => ParsedChatAllowTarget;
 }): boolean {
   const allowFrom = normalizeStringEntries(params.allowFrom);
-  if (allowFrom.length === 0) {
-    return false;
-  }
-  if (allowFrom.includes("*")) {
-    return true;
-  }
-
   const senderNormalized = params.normalizeSender(params.sender);
   const allowConversationTargets = params.allowConversationTargets === true;
   // Conversation ids are only considered when the channel opts in; otherwise
@@ -82,30 +76,34 @@ export function isAllowedParsedChatSender(params: {
     ? normalizeOptionalString(params.chatIdentifier)
     : undefined;
 
-  for (const entry of allowFrom) {
-    if (!entry) {
-      continue;
+  const normalizedAllowFrom = allowFrom.map((entry) => {
+    if (entry === "*") {
+      return entry;
     }
     const parsed = params.parseAllowTarget(entry);
-    if (parsed.kind === "chat_id" && chatId !== undefined) {
-      if (parsed.chatId === chatId) {
-        return true;
-      }
-    } else if (parsed.kind === "chat_guid" && chatGuid) {
-      if (parsed.chatGuid === chatGuid) {
-        return true;
-      }
-    } else if (parsed.kind === "chat_identifier" && chatIdentifier) {
-      if (parsed.chatIdentifier === chatIdentifier) {
-        return true;
-      }
-    } else if (parsed.kind === "handle" && senderNormalized) {
-      if (parsed.handle === senderNormalized) {
-        return true;
-      }
+    if (parsed.kind === "chat_id") {
+      return `chat_id:${parsed.chatId}`;
     }
-  }
-  return false;
+    if (parsed.kind === "chat_guid") {
+      return `chat_guid:${parsed.chatGuid}`;
+    }
+    if (parsed.kind === "chat_identifier") {
+      return `chat_identifier:${parsed.chatIdentifier}`;
+    }
+    return `handle:${parsed.handle}`;
+  });
+  return resolveAllowlistMatchByCandidates({
+    allowList: normalizedAllowFrom,
+    candidates: [
+      { value: senderNormalized ? `handle:${senderNormalized}` : undefined, source: "handle" },
+      { value: chatId !== undefined ? `chat_id:${chatId}` : undefined, source: "chat_id" },
+      { value: chatGuid ? `chat_guid:${chatGuid}` : undefined, source: "chat_guid" },
+      {
+        value: chatIdentifier ? `chat_identifier:${chatIdentifier}` : undefined,
+        source: "chat_identifier",
+      },
+    ],
+  }).allowed;
 }
 
 function stripPrefix(value: string, prefix: string): string {

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -4,6 +4,7 @@ import {
   finalizeChannelInboundContext,
   filterChannelInboundQuoteContext,
   filterChannelInboundSupplementalContext,
+  resolveInboundSupplementalSenderAllowed,
   resolveChannelInboundSupplementalContext,
   type BuildChannelInboundEventContextAsyncParams,
   type BuildChannelInboundEventContextParams,
@@ -98,6 +99,7 @@ export {
   finalizeChannelInboundContext,
   filterChannelInboundQuoteContext,
   filterChannelInboundSupplementalContext,
+  resolveInboundSupplementalSenderAllowed,
   // @deprecated Prefer `buildChannelInboundEventContext({ resolveSupplementalMedia: true })`.
   resolveChannelInboundSupplementalContext,
 };

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -18,6 +18,8 @@ import {
   resolveOutboundMediaUrls,
   resolveSendableOutboundReplyParts,
   resolveTextChunksWithFallback,
+  sendPayloadMediaSequence,
+  sendPayloadMediaSequenceOrFallback,
   sendTextMediaPayload,
   sendMediaWithLeadingCaption,
   sendPayloadTextChunkSequence,
@@ -150,7 +152,79 @@ describe("sendPayloadTextChunkSequence", () => {
   });
 });
 
+describe("sendPayloadMediaSequence", () => {
+  it("treats the first non-empty URL as the first media send", async () => {
+    const calls: Array<{ text: string; mediaUrl: string; index: number; isFirst: boolean }> = [];
+
+    const result = await sendPayloadMediaSequence({
+      text: "caption",
+      mediaUrls: ["", "https://example.com/image.png"],
+      send: async (input) => {
+        calls.push(input);
+        return input.mediaUrl;
+      },
+    });
+
+    expect(calls).toEqual([
+      {
+        text: "caption",
+        mediaUrl: "https://example.com/image.png",
+        index: 1,
+        isFirst: true,
+      },
+    ]);
+    expect(result).toBe("https://example.com/image.png");
+  });
+
+  it("returns undefined when every media URL is empty", async () => {
+    const send = vi.fn();
+
+    await expect(
+      sendPayloadMediaSequence({ text: "caption", mediaUrls: [""], send }),
+    ).resolves.toBeUndefined();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("uses the no-media fallback when every media URL is empty", async () => {
+    const send = vi.fn();
+    const sendNoMedia = vi.fn(async () => "text-result");
+
+    await expect(
+      sendPayloadMediaSequenceOrFallback({
+        text: "caption",
+        mediaUrls: ["", ""],
+        send,
+        sendNoMedia,
+        fallbackResult: "fallback-result",
+      }),
+    ).resolves.toBe("text-result");
+    expect(send).not.toHaveBeenCalled();
+    expect(sendNoMedia).toHaveBeenCalledOnce();
+  });
+});
+
 describe("sendTextMediaPayload", () => {
+  it("falls back to text when every media URL is empty", async () => {
+    const sendMedia = vi.fn();
+    const sendText = vi.fn(async ({ text }) => ({ channel: "test", messageId: text }));
+
+    const result = await sendTextMediaPayload({
+      channel: "test",
+      ctx: {
+        cfg: {},
+        to: "target",
+        text: "caption",
+        payload: { text: "caption", mediaUrls: ["", ""] },
+      },
+      adapter: { sendMedia, sendText },
+    });
+
+    expect(sendMedia).not.toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "caption" }));
+    expect(result).toEqual({ channel: "test", messageId: "caption" });
+  });
+
   it("reports each completed text chunk before a later chunk fails", async () => {
     const sendText = vi
       .fn()

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -201,6 +201,23 @@ describe("sendPayloadMediaSequence", () => {
     expect(send).not.toHaveBeenCalled();
     expect(sendNoMedia).toHaveBeenCalledOnce();
   });
+
+  it("does not use the no-media fallback when a media send returns undefined", async () => {
+    const send = vi.fn(async () => undefined);
+    const sendNoMedia = vi.fn(async () => undefined);
+
+    await expect(
+      sendPayloadMediaSequenceOrFallback({
+        text: "caption",
+        mediaUrls: ["https://example.com/image.png"],
+        send,
+        sendNoMedia,
+        fallbackResult: undefined,
+      }),
+    ).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledOnce();
+    expect(sendNoMedia).not.toHaveBeenCalled();
+  });
 });
 
 describe("sendTextMediaPayload", () => {

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -221,6 +221,29 @@ describe("sendPayloadMediaSequence", () => {
 });
 
 describe("sendTextMediaPayload", () => {
+  it("does not duplicate a caption when a media sender returns undefined", async () => {
+    const sendMediaMock = vi.fn(async () => undefined);
+    const sendText = vi.fn();
+    const sendMedia = sendMediaMock as unknown as NonNullable<
+      Parameters<typeof sendTextMediaPayload>[0]["adapter"]["sendMedia"]
+    >;
+
+    await expect(
+      sendTextMediaPayload({
+        channel: "test",
+        ctx: {
+          cfg: {},
+          to: "target",
+          text: "caption",
+          payload: { text: "caption", mediaUrl: "https://example.com/image.png" },
+        },
+        adapter: { sendMedia, sendText },
+      }),
+    ).resolves.toBeUndefined();
+    expect(sendMediaMock).toHaveBeenCalledOnce();
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
   it("falls back to text when every media URL is empty", async () => {
     const sendMedia = vi.fn();
     const sendText = vi.fn(async ({ text }) => ({ channel: "test", messageId: text }));

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -20,6 +20,7 @@ import {
   resolveTextChunksWithFallback,
   sendTextMediaPayload,
   sendMediaWithLeadingCaption,
+  sendPayloadTextChunkSequence,
   sendPayloadWithChunkedTextAndMedia,
 } from "./reply-payload.js";
 
@@ -113,6 +114,39 @@ describe("sendPayloadWithChunkedTextAndMedia", () => {
     expect(isNumericTargetId("  987  ")).toBe(true);
     expect(isNumericTargetId("ab12")).toBe(false);
     expect(isNumericTargetId("")).toBe(false);
+  });
+});
+
+describe("sendPayloadTextChunkSequence", () => {
+  it.each([
+    { name: "empty", chunks: [], expectedCalls: [], expectedResult: undefined },
+    { name: "single", chunks: ["one"], expectedCalls: [["one", 0, true]], expectedResult: "one" },
+    {
+      name: "multiple",
+      chunks: ["one", "two"],
+      expectedCalls: [
+        ["one", 0, true],
+        ["two", 1, false],
+      ],
+      expectedResult: "two",
+    },
+  ])("sends $name chunk sequences", async ({ chunks, expectedCalls, expectedResult }) => {
+    const calls: Array<[string, number, boolean]> = [];
+    const results: string[] = [];
+    const result = await sendPayloadTextChunkSequence({
+      chunks,
+      send: async ({ text, index, isFirst }) => {
+        calls.push([text, index, isFirst]);
+        return text;
+      },
+      onResult: (value) => {
+        results.push(value);
+      },
+    });
+
+    expect(calls).toEqual(expectedCalls);
+    expect(results).toEqual(chunks);
+    expect(result).toBe(expectedResult);
   });
 });
 

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -336,7 +336,7 @@ export async function sendPayloadTextChunkSequence<TResult>(params: {
   return lastResult;
 }
 
-/** Sends a media sequence or returns a fallback when no media send produces a result. */
+/** Sends a media sequence or returns a fallback when no media item is sent. */
 export async function sendPayloadMediaSequenceOrFallback<TResult>(params: {
   /** Caption text attached to the first non-empty media URL only. */
   text: string;
@@ -349,14 +349,24 @@ export async function sendPayloadMediaSequenceOrFallback<TResult>(params: {
     isFirst: boolean;
   }) => Promise<TResult>;
   onResult?: (result: TResult) => Promise<void> | void;
-  /** Result returned when no media result is available. */
+  /** Result returned when no media item is sent. */
   fallbackResult: TResult;
   /** Optional callback used instead of `fallbackResult` when no media item is sent. */
   sendNoMedia?: () => Promise<TResult>;
 }): Promise<TResult> {
-  const result = await sendPayloadMediaSequence(params);
-  if (result !== undefined) {
-    return result;
+  let hasSent = false;
+  let lastResult = params.fallbackResult;
+  await sendPayloadMediaSequence({
+    ...params,
+    send: async (input) => {
+      const result = await params.send(input);
+      hasSent = true;
+      lastResult = result;
+      return result;
+    },
+  });
+  if (hasSent) {
+    return lastResult;
   }
   return params.sendNoMedia ? await params.sendNoMedia() : params.fallbackResult;
 }

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -274,7 +274,10 @@ export async function sendPayloadWithChunkedTextAndMedia<
   return lastResult;
 }
 
-/** Sends a media sequence with caption text on the first item and returns the last send result. */
+/**
+ * Sends non-empty media URLs with caption text on the first actual send.
+ * Returns the last send result, or undefined when every URL is empty.
+ */
 export async function sendPayloadMediaSequence<TResult>(params: {
   /** Caption text attached to the first non-empty media URL only. */
   text: string;
@@ -287,24 +290,27 @@ export async function sendPayloadMediaSequence<TResult>(params: {
     mediaUrl: string;
     /** Original index in `mediaUrls`. */
     index: number;
-    /** Whether this is the first media entry in the original sequence. */
+    /** Whether this is the first non-empty media entry sent. */
     isFirst: boolean;
   }) => Promise<TResult>;
   /** Called after each successful media send and before the next send starts. */
   onResult?: (result: TResult) => Promise<void> | void;
 }): Promise<TResult | undefined> {
   let lastResult: TResult | undefined;
+  let hasSent = false;
   for (let i = 0; i < params.mediaUrls.length; i += 1) {
     const mediaUrl = params.mediaUrls[i];
     if (!mediaUrl) {
       continue;
     }
+    const isFirst = !hasSent;
     lastResult = await params.send({
-      text: i === 0 ? params.text : "",
+      text: isFirst ? params.text : "",
       mediaUrl,
       index: i,
-      isFirst: i === 0,
+      isFirst,
     });
+    hasSent = true;
     await params.onResult?.(lastResult);
   }
   return lastResult;
@@ -345,13 +351,14 @@ export async function sendPayloadMediaSequenceOrFallback<TResult>(params: {
   onResult?: (result: TResult) => Promise<void> | void;
   /** Result returned when no media result is available. */
   fallbackResult: TResult;
-  /** Optional callback used instead of `fallbackResult` when there are no media URLs. */
+  /** Optional callback used instead of `fallbackResult` when no media item is sent. */
   sendNoMedia?: () => Promise<TResult>;
 }): Promise<TResult> {
-  if (params.mediaUrls.length === 0) {
-    return params.sendNoMedia ? await params.sendNoMedia() : params.fallbackResult;
+  const result = await sendPayloadMediaSequence(params);
+  if (result !== undefined) {
+    return result;
   }
-  return (await sendPayloadMediaSequence(params)) ?? params.fallbackResult;
+  return params.sendNoMedia ? await params.sendNoMedia() : params.fallbackResult;
 }
 
 /** Sends media when present, then always runs finalization and returns its result. */
@@ -417,7 +424,12 @@ export async function sendTextMediaPayload(params: {
         return result;
       },
     });
-    return lastResult ?? { channel: params.channel, messageId: "" };
+    if (lastResult !== undefined) {
+      return lastResult;
+    }
+  }
+  if (!text) {
+    return { channel: params.channel, messageId: "" };
   }
   const limit = params.adapter.textChunkLimit;
   const chunks =

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -412,6 +412,7 @@ export async function sendTextMediaPayload(params: {
   const nextReplyToId = createReplyToFanout(params.ctx);
   if (urls.length > 0) {
     const audioAsVoice = params.ctx.payload.audioAsVoice ?? params.ctx.audioAsVoice;
+    let hasSent = false;
     const lastResult = await sendPayloadMediaSequence({
       text,
       mediaUrls: urls,
@@ -431,11 +432,12 @@ export async function sendTextMediaPayload(params: {
         if (!childReported) {
           await params.ctx.onDeliveryResult?.(result);
         }
+        hasSent = true;
         return result;
       },
     });
-    if (lastResult !== undefined) {
-      return lastResult;
+    if (hasSent) {
+      return lastResult!;
     }
   }
   if (!text) {

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -310,6 +310,26 @@ export async function sendPayloadMediaSequence<TResult>(params: {
   return lastResult;
 }
 
+/** Sends text chunks sequentially and returns the last send result. */
+export async function sendPayloadTextChunkSequence<TResult>(params: {
+  /** Ordered text chunks to send. */
+  chunks: readonly string[];
+  send: (input: { text: string; index: number; isFirst: boolean }) => Promise<TResult>;
+  /** Called after each successful chunk send and before the next send starts. */
+  onResult?: (result: TResult) => Promise<void> | void;
+}): Promise<TResult | undefined> {
+  let lastResult: TResult | undefined;
+  for (let index = 0; index < params.chunks.length; index += 1) {
+    lastResult = await params.send({
+      text: params.chunks[index]!,
+      index,
+      isFirst: index === 0,
+    });
+    await params.onResult?.(lastResult);
+  }
+  return lastResult;
+}
+
 /** Sends a media sequence or returns a fallback when no media send produces a result. */
 export async function sendPayloadMediaSequenceOrFallback<TResult>(params: {
   /** Caption text attached to the first non-empty media URL only. */


### PR DESCRIPTION
## What Problem This Solves

Channel plugins duplicated sender allowlist and supplemental-context policy, which let equivalent thread, quote, and history paths drift. Outbound media loops also treated empty media URL entries inconsistently: text fallback could be lost, and first-send metadata could attach to the wrong item.

## Why This Change Was Made

This centralizes candidate matching and supplemental sender gating in typed Plugin SDK helpers, then migrates the affected bundled channel plugins. It also adds shared sequential text/media delivery helpers, skips empty media entries, preserves caption and presentation metadata for the first actual media send, and distinguishes “no media sent” from a successful sender returning `undefined`.

The surface-budget update records the two intentional public SDK exports introduced by the shared helpers. No configuration or migration is added.

## User Impact

Affected channels now apply the same allowlist and supplemental-context rules. Payloads containing blank media entries keep their text fallback, and valid media still delivers sequentially with metadata on the first real attachment. Existing configuration remains valid; no operator action is required.

## Evidence

- Rebases onto current `origin/main` completed with rerere disabled; the Plugin SDK API baseline was regenerated immediately before push and `node scripts/plugin-sdk-surface-report.mjs --check` passed at 8,012 public exports / 4,478 public callable exports.
- Blacksmith Testbox `tbx_01kxpw506ndqcazzc5dv6tdv3t`: `pnpm check:changed` passed all selected core, extension, docs, and tooling lanes; 359 focused tests passed across 14 Vitest shards; `pnpm build` passed, including Plugin SDK declaration checks and Control UI performance gates.
- `node scripts/check-deadcode-exports.mjs` passed with 0 entries.
- `node scripts/check-deadcode-unused-files.mjs` passed with 0 entries.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/plugin-sdk/reply-payload.test.ts extensions/matrix/src/outbound.test.ts extensions/msteams/src/outbound.test.ts` passed 95 tests; the QQBot outbound regression suite separately passed 4 tests.
- Fresh branch autoreview completed with no accepted or actionable findings after fixing both `Promise<void>` media-sender fallback regressions while preserving the existing public SDK return contract.
