### PR TITLE
fix: keep the global loop breaker reachable after tool blocks

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -493,6 +493,53 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("counts critical loop vetoes toward the global no-progress breaker", () => {
+      const state = createState();
+      const fixture = createReadNoProgressFixture();
+
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        result: fixture.result,
+        count: CRITICAL_THRESHOLD,
+      });
+      for (let i = CRITICAL_THRESHOLD; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+        expect(
+          detectToolCallLoop(state, fixture.toolName, fixture.params, enabledLoopDetectionConfig),
+        ).toMatchObject({
+          stuck: true,
+          level: "critical",
+          detector: "generic_repeat",
+          count: i,
+        });
+        const recorded = recordToolCallOutcome(state, {
+          toolName: fixture.toolName,
+          toolParams: fixture.params,
+          toolCallId: `loop-veto-${i}`,
+          result: {
+            content: [{ type: "text", text: "blocked" }],
+            details: { status: "blocked", deniedReason: "tool-loop" },
+          },
+          config: enabledLoopDetectionConfig,
+        });
+        expect(recorded).toMatchObject({
+          toolCallId: `loop-veto-${i}`,
+          outcomeKind: "tool-loop-veto",
+          resultHash: undefined,
+        });
+      }
+
+      expect(
+        detectToolCallLoop(state, fixture.toolName, fixture.params, enabledLoopDetectionConfig),
+      ).toMatchObject({
+        stuck: true,
+        level: "critical",
+        detector: "global_circuit_breaker",
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
+    });
+
     it("warns on repeated stable argument churn without vetoing the next call", () => {
       const state = createState();
       const paths = ["/tmp/a.md", "/tmp/b.md", "/tmp/a.md", "/tmp/a.md", "/tmp/b.md"];


### PR DESCRIPTION
Closes #109435

## What Problem This Solves

Fixes an issue where repeated critical tool-loop vetoes could regress without coverage for the session-global breaker transition. The protected behavior is that loop-detector vetoes remain countable no-progress outcomes until the global circuit breaker is reached.

## Why This Change Was Made

Current `main` contains the production loop-veto recording behavior: the detector records its own veto as `outcomeKind: "tool-loop-veto"`, which is countable as no progress. This PR keeps a focused regression around that production path so the critical-veto-to-global-breaker transition cannot silently regress.

Disclosure: AI was used to understand the codebase and review the fix.

## User Impact

This PR is test-only against current `main`; it does not change runtime behavior beyond the production behavior already on the base branch. It protects the availability invariant that a stuck tool loop must keep advancing to the final breaker instead of staying below the global threshold.

## Evidence

Latest pushed head: `6394525ecb2d9cccdec9e0862d82a460212b475d`.

Production-function transcript after the fix:

```text
$ node --import tsx -e '<script invoking detectToolCallLoop, recordToolCall, and recordToolCallOutcome>'
[agents/loop-detection] Critical generic loop detected: read repeated 20 times
[agents/loop-detection] Critical generic loop detected: read repeated 20 times
[agents/loop-detection] Critical generic loop detected: read repeated 21 times
[agents/loop-detection] Critical generic loop detected: read repeated 22 times
[agents/loop-detection] Critical generic loop detected: read repeated 23 times
[agents/loop-detection] Critical generic loop detected: read repeated 24 times
[agents/loop-detection] Critical generic loop detected: read repeated 25 times
[agents/loop-detection] Critical generic loop detected: read repeated 26 times
[agents/loop-detection] Critical generic loop detected: read repeated 27 times
[agents/loop-detection] Critical generic loop detected: read repeated 28 times
[agents/loop-detection] Critical generic loop detected: read repeated 29 times
[agents/loop-detection] Global circuit breaker triggered: read repeated 30 times with no progress
{
  "firstBlock": {
    "stuck": true,
    "level": "critical",
    "detector": "generic_repeat",
    "count": 20
  },
  "vetoSamples": [
    {
      "toolCallId": "loop-veto-20",
      "outcomeKind": "tool-loop-veto",
      "resultHash": null
    },
    {
      "toolCallId": "loop-veto-29",
      "outcomeKind": "tool-loop-veto",
      "resultHash": null
    }
  ],
  "finalBlock": {
    "stuck": true,
    "level": "critical",
    "detector": "global_circuit_breaker",
    "count": 30
  }
}
```

Focused local validation after rebasing onto current `main`:

```text
$ node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts --maxWorkers=1
[test] starting test/vitest/vitest.agents-core.config.ts
Test Files  1 passed (1)
Tests  70 passed (70)
[test] passed 1 Vitest shard

$ git diff --check origin/main...HEAD
exit 0
```

Observed behavior covered by the regression:

```text
- After CRITICAL_THRESHOLD identical no-progress outcomes, detectToolCallLoop returns a critical generic_repeat veto.
- Subsequent detector vetoes are recorded as outcomeKind: "tool-loop-veto" with no resultHash.
- The no-progress count continues to GLOBAL_CIRCUIT_BREAKER_THRESHOLD.
- At the global threshold, detectToolCallLoop returns detector: "global_circuit_breaker".
```

Current proof limitation:

```text
This branch exercises the production loop-detection and session-state accounting path through the focused regression and a direct production-function transcript. It does not include a full live provider-backed agent turn transcript because the PR diff is intentionally limited to the regression guard for behavior already present on current main.
```
