### PR TITLE
fix(release): checklist test types fail on direct execution helper

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -90,6 +90,11 @@ export function validateWindowsSourceRelease(
     digest: unknown;
   }[];
 }>;
+export function isDirectReleaseCandidateExecution(
+  directPath: string | undefined,
+  modulePath: string,
+  resolveRealPath?: (path: string) => string,
+): boolean;
 export function validateCandidateCheckout({
   targetSha,
   targetHeadSha,


### PR DESCRIPTION
Related: #109541

## What Problem This Solves

Fixes an issue where the root test-type CI shard failed because the release-candidate checklist test imported a runtime export that was missing from the script's declaration file.

## Why This Change Was Made

The declaration now exposes the existing `isDirectReleaseCandidateExecution` runtime helper with its real signature. Runtime behavior is unchanged.

## User Impact

Maintainer CI can typecheck release-candidate checklist tests again. No product behavior changes.

## Evidence

- Main failure: https://github.com/openclaw/openclaw/actions/runs/29549837153/job/87790160718
- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts` — 54 tests passed.
- `node scripts/check-changed.mjs -- scripts/release-candidate-checklist.d.mts` — hosted scripts/tooling gate passed: https://github.com/openclaw/openclaw/actions/runs/29550485583
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
