### PR TITLE
fix(release): remove duplicate checklist declaration

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -72,11 +72,6 @@ export function buildTelegramArtifactInputs(params: {
   runId: string;
   sourceSha: string;
 }): Record<string, string | number>;
-export function isDirectReleaseCandidateExecution(
-  directPath: string | undefined,
-  modulePath: string,
-  resolveRealPath?: (path: string) => string,
-): boolean;
 /**
  * Calls the GitHub REST API with the gh-auth token and a bounded timeout.
  */


### PR DESCRIPTION
Related: #109546

AI-assisted: yes.

## What Problem This Solves

Resolves a problem where concurrent fixes left two identical declarations for the release-candidate checklist direct-execution helper on `main`.

## Why This Change Was Made

Removes the later duplicate while retaining the declaration that landed first. Runtime behavior and the checked module contract remain unchanged.

## User Impact

No user-visible change. Maintainer release-tool types return to one canonical declaration.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts` — 54 tests passed.
- Declaration inventory — exactly one `isDirectReleaseCandidateExecution` export remains.
- `git diff --check` — passed.
- `oxfmt --check scripts/release-candidate-checklist.d.mts` — passed.
- Mandatory autoreview — clean; no accepted/actionable findings.
