### PR TITLE
fix: OpenAI-compatible provider compat and error-body surfacing

### DIFF
--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -8,6 +8,7 @@ import {
   buildGoogleGenerateContentParams,
   buildGoogleSimpleThinking,
   consumeGoogleGenerateContentStream,
+  runGoogleGenerateContentLifecycle,
 } from "./google-shared.js";
 
 const model: Model<"google-generative-ai"> = {
@@ -259,6 +260,34 @@ describe("consumeGoogleGenerateContentStream", () => {
         arguments: {},
       },
     ]);
+  });
+});
+
+describe("runGoogleGenerateContentLifecycle", () => {
+  it("surfaces HTTP response body text from Google-compatible errors", async () => {
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+    const error = Object.assign(new Error("502 status code (no body)"), {
+      status: 502,
+      body: "gateway maintenance",
+    });
+
+    await runGoogleGenerateContentLifecycle({
+      stream,
+      model,
+      output,
+      createClient: () => ({
+        models: {
+          generateContentStream: async () => {
+            throw error;
+          },
+        },
+      }),
+      buildParams: () => ({ model: model.id, contents: [] }),
+      nextToolCallId: () => "call_1",
+    });
+
+    expect(output.errorMessage).toBe("502: gateway maintenance");
   });
 });
 

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -30,6 +30,7 @@ import type {
   StreamOptions,
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { formatProviderError } from "../utils/provider-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import {
@@ -469,7 +470,7 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
       }
     }
     output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-    output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+    output.errorMessage = formatProviderError(error);
     stream.push({ type: "error", reason: output.stopReason, error: output });
     stream.end();
   }

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AssistantMessage, Context, Model, OpenAICompletionsCompat } from "../types.js";
+
+const mockOpenAI = vi.hoisted(() => ({
+  chunks: [] as unknown[],
+  clientOptions: [] as unknown[],
+  payloads: [] as unknown[],
+  requestOptions: [] as unknown[],
+  nextError: undefined as Error | undefined,
+}));
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    constructor(options: unknown) {
+      mockOpenAI.clientOptions.push(options);
+    }
+
+    chat = {
+      completions: {
+        create: (payload: unknown, requestOptions: unknown) => {
+          mockOpenAI.payloads.push(payload);
+          mockOpenAI.requestOptions.push(requestOptions);
+          return {
+            withResponse: async () => {
+              if (mockOpenAI.nextError !== undefined) {
+                throw mockOpenAI.nextError;
+              }
+              async function* stream() {
+                yield* mockOpenAI.chunks;
+              }
+              return {
+                data: stream(),
+                response: { status: 200, headers: new Headers() },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  return { default: MockOpenAI };
+});
+
+import { streamOpenAICompletions } from "./openai-completions.js";
+
+const baseModel: Model<"openai-completions"> = {
+  id: "test-model",
+  name: "Test model",
+  api: "openai-completions",
+  provider: "custom-openai-compatible",
+  baseUrl: "https://proxy.example/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4_096,
+};
+
+const userMessage = { role: "user", content: "hello", timestamp: 1 } as const;
+const context: Context = { messages: [userMessage] };
+
+function createModel(
+  overrides: Partial<Model<"openai-completions">> & {
+    compat?: OpenAICompletionsCompat;
+  } = {},
+): Model<"openai-completions"> {
+  return { ...baseModel, ...overrides };
+}
+
+function chunk(delta: Record<string, unknown>, finishReason?: string): unknown {
+  return {
+    id: "chatcmpl-test",
+    choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+  };
+}
+
+beforeEach(() => {
+  mockOpenAI.chunks = [chunk({ content: "ok" }), chunk({}, "stop")];
+  mockOpenAI.clientOptions = [];
+  mockOpenAI.payloads = [];
+  mockOpenAI.requestOptions = [];
+  mockOpenAI.nextError = undefined;
+});
+
+describe("OpenAI-compatible completions compatibility", () => {
+  it("buffers encrypted reasoning details until their tool call arrives", async () => {
+    const reasoningDetail = {
+      type: "reasoning.encrypted",
+      id: "call_1",
+      data: "encrypted-signature",
+    };
+    mockOpenAI.chunks = [
+      chunk({ reasoning_details: [reasoningDetail] }),
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_1",
+            type: "function",
+            function: { name: "lookup", arguments: '{"query":"cats"}' },
+          },
+        ],
+      }),
+      chunk({}, "tool_calls"),
+    ];
+    const model = createModel({
+      id: "google/gemini-test",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+    });
+
+    const result = await streamOpenAICompletions(model, context, {
+      apiKey: "test",
+    }).result();
+
+    expect(result.content.find((block) => block.type === "toolCall")).toMatchObject({
+      id: "call_1",
+      thoughtSignature: JSON.stringify(reasoningDetail),
+    });
+
+    let replayPayload: unknown;
+    await streamOpenAICompletions(
+      model,
+      { messages: [result] },
+      {
+        apiKey: "test",
+        onPayload(payload) {
+          replayPayload = payload;
+          throw new Error("payload captured");
+        },
+      },
+    ).result();
+    const replayedAssistant = (
+      replayPayload as { messages?: Array<{ role?: string; reasoning_details?: unknown }> }
+    ).messages?.find((message) => message.role === "assistant");
+    expect(replayedAssistant?.reasoning_details).toEqual([reasoningDetail]);
+  });
+
+  it.each([
+    { modelId: "openai/gpt-5.6-luna", expectedRole: "developer" },
+    { modelId: "anthropic/claude-sonnet-4.6", expectedRole: "developer" },
+    { modelId: "moonshotai/kimi-k2.6", expectedRole: "system" },
+  ])("uses $expectedRole instructions for OpenRouter model $modelId", async (testCase) => {
+    let payload: unknown;
+    const model = createModel({
+      id: testCase.modelId,
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+    });
+
+    await streamOpenAICompletions(
+      model,
+      { ...context, systemPrompt: "Follow instructions." },
+      {
+        apiKey: "test",
+        onPayload(nextPayload) {
+          payload = nextPayload;
+          throw new Error("payload captured");
+        },
+      },
+    ).result();
+
+    expect((payload as { messages?: Array<{ role?: string }> }).messages?.[0]?.role).toBe(
+      testCase.expectedRole,
+    );
+  });
+
+  it("sends configured OpenRouter routing through a compatible proxy", async () => {
+    let payload: unknown;
+    const routing = { only: ["google-vertex"] };
+    const model = createModel({ compat: { openRouterRouting: routing } });
+
+    await streamOpenAICompletions(model, context, {
+      apiKey: "test",
+      onPayload(nextPayload) {
+        payload = nextPayload;
+        throw new Error("payload captured");
+      },
+    }).result();
+
+    expect((payload as { provider?: unknown }).provider).toEqual(routing);
+  });
+
+  it.each([
+    {
+      name: "OpenAI",
+      model: createModel({ compat: { sendSessionAffinityHeaders: true } }),
+      expectedHeaders: {
+        session_id: "session-123",
+        "x-client-request-id": "session-123",
+        "x-session-affinity": "session-123",
+      },
+    },
+    {
+      name: "OpenRouter",
+      model: createModel({
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: { sendSessionAffinityHeaders: true },
+      }),
+      expectedHeaders: { "x-session-id": "session-123" },
+    },
+    {
+      name: "OpenRouter-compatible proxy",
+      model: createModel({
+        compat: {
+          sendSessionAffinityHeaders: true,
+          thinkingFormat: "openrouter",
+        },
+      }),
+      expectedHeaders: { "x-session-id": "session-123" },
+    },
+  ])("sends exact $name session-affinity headers", async ({ model, expectedHeaders }) => {
+    await streamOpenAICompletions(model, context, {
+      apiKey: "test",
+      sessionId: "session-123",
+    }).result();
+
+    const clientOptions = mockOpenAI.clientOptions[0] as {
+      defaultHeaders?: Record<string, string>;
+    };
+    expect(clientOptions.defaultHeaders).toEqual(expectedHeaders);
+  });
+
+  it("retains replayed Z.AI thinking when reasoning is enabled", async () => {
+    let payload: unknown;
+    const model = createModel({
+      id: "glm-test",
+      provider: "zai",
+      baseUrl: "https://api.z.ai/api/paas/v4",
+      reasoning: true,
+    });
+    const assistant: AssistantMessage = {
+      role: "assistant",
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      content: [
+        {
+          type: "thinking",
+          thinking: "prior reasoning",
+          thinkingSignature: "reasoning_content",
+        },
+        { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+      ],
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "toolUse",
+      timestamp: 2,
+    };
+
+    await streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          userMessage,
+          assistant,
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "done" }],
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+      },
+      {
+        apiKey: "test",
+        reasoningEffort: "high",
+        onPayload(nextPayload) {
+          payload = nextPayload;
+          throw new Error("payload captured");
+        },
+      },
+    ).result();
+
+    const request = payload as {
+      thinking?: unknown;
+      messages?: Array<Record<string, unknown>>;
+    };
+    expect(request.thinking).toEqual({ type: "enabled", clear_thinking: false });
+    expect(request.messages?.find((message) => message.role === "assistant")).toMatchObject({
+      reasoning_content: "prior reasoning",
+    });
+  });
+
+  it.each([
+    { configured: undefined, expected: 0 },
+    { configured: 3, expected: 3 },
+  ])("uses maxRetries=$expected when configured value is $configured", async (testCase) => {
+    await streamOpenAICompletions(baseModel, context, {
+      apiKey: "test",
+      maxRetries: testCase.configured,
+    }).result();
+
+    expect(mockOpenAI.requestOptions[0]).toMatchObject({ maxRetries: testCase.expected });
+  });
+
+  it("surfaces HTTP response body text from OpenAI-compatible errors", async () => {
+    mockOpenAI.nextError = Object.assign(new Error("502 status code (no body)"), {
+      status: 502,
+      body: "gateway maintenance",
+    });
+
+    const result = await streamOpenAICompletions(baseModel, context, {
+      apiKey: "test",
+    }).result();
+
+    expect(result.errorMessage).toBe("502: gateway maintenance");
+  });
+});

--- a/packages/ai/src/providers/openai-completions.live.test.ts
+++ b/packages/ai/src/providers/openai-completions.live.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { Context, Model } from "../types.js";
+import { streamOpenAICompletions } from "./openai-completions.js";
+
+// Live coverage for provider compat behavior that unit fakes cannot prove:
+// role selection and thinking parameters are validated by the real backends.
+const LIVE = process.env.OPENCLAW_LIVE_TEST === "1";
+const LIVE_TIMEOUT_MS = 120_000;
+
+function liveModel(overrides: Partial<Model<"openai-completions">>) {
+  return {
+    id: "gpt-5.6-luna",
+    name: "live model",
+    api: "openai-completions",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+    ...overrides,
+  } satisfies Model<"openai-completions">;
+}
+
+const context: Context = {
+  systemPrompt: "You are terse.",
+  messages: [{ role: "user", content: "Reply with exactly: OK", timestamp: 0 }],
+};
+
+async function expectLiveReply(model: Model<"openai-completions">, apiKey: string) {
+  const result = await streamOpenAICompletions(model, context, {
+    apiKey,
+    maxTokens: 512,
+  }).result();
+
+  expect(result.errorMessage).toBeUndefined();
+  expect(result.stopReason).toBe("stop");
+  const text = result.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+  expect(text.length).toBeGreaterThan(0);
+  expect(result.usage.output).toBeGreaterThan(0);
+  return result;
+}
+
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+(LIVE && OPENAI_KEY ? describe : describe.skip)("OpenAI completions live", () => {
+  it(
+    "streams a completion with usage and no hidden retry stalls",
+    async () => {
+      await expectLiveReply(liveModel({}), OPENAI_KEY);
+    },
+    LIVE_TIMEOUT_MS,
+  );
+});
+
+const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY ?? "";
+(LIVE && OPENROUTER_KEY ? describe : describe.skip)("OpenRouter completions live", () => {
+  it(
+    "accepts a system prompt on a model family without developer-role support",
+    async () => {
+      // Non-OpenAI/Anthropic model ids reject the developer role; this proves
+      // the system-role selection end to end against the real gateway.
+      await expectLiveReply(
+        liveModel({
+          id: process.env.OPENCLAW_LIVE_OPENROUTER_MODEL || "moonshotai/kimi-k2",
+          provider: "openrouter",
+          baseUrl: "https://openrouter.ai/api/v1",
+        }),
+        OPENROUTER_KEY,
+      );
+    },
+    LIVE_TIMEOUT_MS,
+  );
+});
+
+const ZAI_KEY = process.env.ZAI_API_KEY ?? "";
+(LIVE && ZAI_KEY ? describe : describe.skip)("Z.AI completions live", () => {
+  it(
+    "streams with thinking enabled and retention opted in",
+    async () => {
+      const result = await streamOpenAICompletions(
+        liveModel({
+          id: "glm-5.1",
+          provider: "zai",
+          baseUrl: "https://api.z.ai/api/paas/v4",
+          reasoning: true,
+        }),
+        context,
+        {
+          apiKey: ZAI_KEY,
+          maxTokens: 1024,
+          reasoningEffort: "low",
+        },
+      ).result();
+
+      expect(result.errorMessage).toBeUndefined();
+      expect(result.stopReason).toBe("stop");
+      expect(result.usage.output).toBeGreaterThan(0);
+    },
+    LIVE_TIMEOUT_MS,
+  );
+});

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -36,6 +36,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { formatProviderError } from "../utils/provider-error.js";
 import { createReasoningTagTextPartitioner } from "../utils/reasoning-tag-text-partitioner.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
@@ -122,7 +123,28 @@ type ResolvedOpenAICompletionsCompat = Omit<
   "cacheControlFormat"
 > & {
   cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+  sessionAffinityFormat: "openai" | "openrouter";
 };
+
+type EncryptedReasoningDetail = {
+  type: "reasoning.encrypted";
+  id: string;
+  data: string;
+};
+
+function isEncryptedReasoningDetail(detail: unknown): detail is EncryptedReasoningDetail {
+  if (typeof detail !== "object" || detail === null) {
+    return false;
+  }
+  const candidate = detail as Record<string, unknown>;
+  return (
+    candidate.type === "reasoning.encrypted" &&
+    typeof candidate.id === "string" &&
+    candidate.id.length > 0 &&
+    typeof candidate.data === "string" &&
+    candidate.data.length > 0
+  );
+}
 
 type ChatCompletionInstructionMessageParam =
   | ChatCompletionDeveloperMessageParam
@@ -177,7 +199,7 @@ export const streamOpenAICompletions: StreamFunction<
       const requestOptions = {
         signal: firstEventAbort.signal,
         ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-        ...(options?.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
+        maxRetries: options?.maxRetries ?? 0,
       };
       const { data: openaiStream, response } = await client.chat.completions
         .create(
@@ -206,6 +228,7 @@ export const streamOpenAICompletions: StreamFunction<
       const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
       const toolCallBlocksByFirstId = new Map<string, StreamingToolCallBlock>();
+      const pendingReasoningDetailsByToolCallId = new Map<string, string>();
       const blocks = output.content as StreamingBlock[];
       // A block can be finished mid-stream (native reasoning sealed at the
       // text-lane transition) and again by the end-of-stream loop; guard so its
@@ -218,8 +241,16 @@ export const streamOpenAICompletions: StreamFunction<
       };
       const getContentIndex = (block: StreamingBlock) => contentIndices.get(block) ?? -1;
       const rememberFirstToolCallById = (id: string, block: StreamingToolCallBlock) => {
-        if (!toolCallBlocksByFirstId.has(id)) {
-          toolCallBlocksByFirstId.set(id, block);
+        if (toolCallBlocksByFirstId.has(id)) {
+          return;
+        }
+        toolCallBlocksByFirstId.set(id, block);
+        // Some gateways emit encrypted reasoning before the referenced call.
+        // Attach it once the first matching block exists so replay stays intact.
+        const pendingDetail = pendingReasoningDetailsByToolCallId.get(id);
+        if (pendingDetail) {
+          block.thoughtSignature = pendingDetail;
+          pendingReasoningDetailsByToolCallId.delete(id);
         }
       };
       const finishBlock = (block: StreamingBlock) => {
@@ -505,12 +536,15 @@ export const streamOpenAICompletions: StreamFunction<
 
           const reasoningDetails = (choiceDelta as { reasoning_details?: unknown })
             .reasoning_details;
-          if (reasoningDetails && Array.isArray(reasoningDetails)) {
+          if (Array.isArray(reasoningDetails)) {
             for (const detail of reasoningDetails) {
-              if (detail.type === "reasoning.encrypted" && detail.id && detail.data) {
+              if (isEncryptedReasoningDetail(detail)) {
+                const serializedDetail = JSON.stringify(detail);
                 const matchingToolCall = toolCallBlocksByFirstId.get(detail.id);
                 if (matchingToolCall) {
-                  matchingToolCall.thoughtSignature = JSON.stringify(detail);
+                  matchingToolCall.thoughtSignature = serializedDetail;
+                } else {
+                  pendingReasoningDetailsByToolCallId.set(detail.id, serializedDetail);
                 }
               }
             }
@@ -561,11 +595,11 @@ export const streamOpenAICompletions: StreamFunction<
         delete (block as { streamIndex?: number }).streamIndex;
       }
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      output.errorMessage = formatProviderError(error);
       // Some providers via OpenRouter give additional information in this field.
       const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata
         ?.raw;
-      if (rawMetadata) {
+      if (rawMetadata && !output.errorMessage.includes(rawMetadata)) {
         output.errorMessage += `\n${rawMetadata}`;
       }
       stream.push({ type: "error", reason: output.stopReason, error: output });
@@ -629,9 +663,13 @@ function createClient(
   }
 
   if (sessionId && compat.sendSessionAffinityHeaders) {
-    headers.session_id = sessionId;
-    headers["x-client-request-id"] = sessionId;
-    headers["x-session-affinity"] = sessionId;
+    if (compat.sessionAffinityFormat === "openrouter") {
+      headers["x-session-id"] = sessionId;
+    } else {
+      headers.session_id = sessionId;
+      headers["x-client-request-id"] = sessionId;
+      headers["x-session-affinity"] = sessionId;
+    }
   }
 
   // Merge options headers last so they can override defaults
@@ -686,7 +724,7 @@ function buildParams(
     tool_stream?: boolean;
     enable_thinking?: boolean;
     chat_template_kwargs?: { enable_thinking: boolean; preserve_thinking: boolean };
-    thinking?: { type: string };
+    thinking?: { type: string; clear_thinking?: boolean };
     provider?: unknown;
     providerOptions?: unknown;
   };
@@ -765,7 +803,9 @@ function buildParams(
   }
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
+    params.thinking = options?.reasoningEffort
+      ? { type: "enabled", clear_thinking: false }
+      : { type: "disabled" };
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
     params.enable_thinking = Boolean(options?.reasoningEffort);
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
@@ -811,7 +851,7 @@ function buildParams(
   }
 
   // OpenRouter provider routing preferences
-  if (model.baseUrl.includes("openrouter.ai") && model.compat?.openRouterRouting) {
+  if (model.compat?.openRouterRouting) {
     params.provider = model.compat.openRouterRouting;
   }
 
@@ -1357,6 +1397,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
   const isCloudflareAiGateway =
     provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
+  const isOpenRouter = provider === "openrouter" || baseUrl.includes("openrouter.ai");
 
   const isNonStandard =
     provider === "cerebras" ||
@@ -1379,12 +1420,18 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
   const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
   const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
   const isXiaomi = provider === "xiaomi" || baseUrl.includes("xiaomimimo.com");
+  const supportsOpenRouterDeveloperRole =
+    isOpenRouter && (model.id.startsWith("anthropic/") || model.id.startsWith("openai/"));
+  const usesOpenRouterSessionAffinity =
+    isOpenRouter ||
+    model.compat?.thinkingFormat === "openrouter" ||
+    model.compat?.openRouterRouting !== undefined;
   const cacheControlFormat =
     provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
   return {
     supportsStore: !isNonStandard,
-    supportsDeveloperRole: !isNonStandard,
+    supportsDeveloperRole: supportsOpenRouterDeveloperRole || (!isNonStandard && !isOpenRouter),
     supportsReasoningEffort:
       !isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway,
     supportsUsageInStreaming: true,
@@ -1401,7 +1448,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
           ? "zai"
           : isTogether
             ? "together"
-            : provider === "openrouter" || baseUrl.includes("openrouter.ai")
+            : isOpenRouter
               ? "openrouter"
               : "openai",
     openRouterRouting: {},
@@ -1410,6 +1457,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway,
     cacheControlFormat,
     sendSessionAffinityHeaders: false,
+    sessionAffinityFormat: usesOpenRouterSessionAffinity ? "openrouter" : "openai",
     supportsPromptCacheKey: false,
     supportsLongCacheRetention: !(isTogether || isCloudflareWorkersAI || isCloudflareAiGateway),
   };
@@ -1448,6 +1496,7 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
     cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
     sendSessionAffinityHeaders:
       model.compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,
+    sessionAffinityFormat: detected.sessionAffinityFormat,
     supportsPromptCacheKey: model.compat.supportsPromptCacheKey ?? detected.supportsPromptCacheKey,
     supportsLongCacheRetention:
       model.compat.supportsLongCacheRetention ?? detected.supportsLongCacheRetention,

--- a/packages/ai/src/providers/transform-messages.test.ts
+++ b/packages/ai/src/providers/transform-messages.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { Message, Model } from "../types.js";
+import { transformMessages } from "./transform-messages.js";
+
+const model: Model<"openai-completions"> = {
+  id: "text-only-model",
+  name: "Text-only model",
+  api: "openai-completions",
+  provider: "openai",
+  baseUrl: "https://example.invalid/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4_096,
+};
+
+describe("transformMessages", () => {
+  it("normalizes null or missing content before provider transforms", () => {
+    const messages = [
+      { role: "user", content: null, timestamp: 1 },
+      {
+        role: "assistant",
+        content: null,
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "lookup",
+        isError: false,
+        timestamp: 3,
+      },
+    ] as unknown as Message[];
+
+    const transformed = transformMessages(messages, model);
+
+    expect(transformed).toHaveLength(3);
+    expect(transformed.map((message) => message.content)).toEqual([[], [], []]);
+  });
+});

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -80,7 +80,10 @@ export function transformMessages<TApi extends Api>(
 ): Message[] {
   // Build a map of original tool call IDs to normalized IDs
   const toolCallIdMap = new Map<string, string>();
-  const imageAwareMessages = downgradeUnsupportedImages(messages, model);
+  const normalizedMessages = messages.map((msg) =>
+    msg.content == null ? { ...msg, content: [] } : msg,
+  );
+  const imageAwareMessages = downgradeUnsupportedImages(normalizedMessages, model);
 
   // First pass: transform messages (unsupported image downgrade, thinking blocks, tool call ID normalization)
   const transformed = imageAwareMessages.map((msg) => {

--- a/packages/ai/src/utils/provider-error.test.ts
+++ b/packages/ai/src/utils/provider-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatProviderError } from "./provider-error.js";
+
+describe("formatProviderError", () => {
+  it.each([
+    {
+      name: "JSON body",
+      error: Object.assign(new Error("403 status code (no body)"), {
+        status: 403,
+        error: { message: "blocked by gateway" },
+      }),
+      expected: '403: {"message":"blocked by gateway"}',
+    },
+    {
+      name: "text body",
+      error: Object.assign(new Error("502 status code (no body)"), {
+        status: 502,
+        body: "proxy unavailable",
+      }),
+      expected: "502: proxy unavailable",
+    },
+    {
+      name: "no body",
+      error: Object.assign(new Error("503 status code (no body)"), { status: 503 }),
+      expected: "503 status code (no body)",
+    },
+  ])("formats an HTTP error with $name", ({ error, expected }) => {
+    expect(formatProviderError(error)).toBe(expected);
+  });
+
+  it("preserves an SDK message that already contains the response body", () => {
+    const body = '{"error":{"message":"permission denied"}}';
+    const error = Object.assign(new Error(body), { status: 403, body });
+
+    expect(formatProviderError(error)).toBe(body);
+  });
+});

--- a/packages/ai/src/utils/provider-error.ts
+++ b/packages/ai/src/utils/provider-error.ts
@@ -1,0 +1,68 @@
+const MAX_ERROR_BODY_LENGTH = 4000;
+
+type HttpErrorShape = Error & {
+  status?: unknown;
+  statusCode?: unknown;
+  body?: unknown;
+  error?: unknown;
+  response?: {
+    status?: unknown;
+    statusCode?: unknown;
+    body?: unknown;
+    data?: unknown;
+  };
+};
+
+function stringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function readStatus(error: HttpErrorShape): number | undefined {
+  for (const value of [
+    error.status,
+    error.statusCode,
+    error.response?.status,
+    error.response?.statusCode,
+  ]) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readBody(error: HttpErrorShape): string | undefined {
+  for (const value of [error.body, error.error, error.response?.body, error.response?.data]) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0) {
+      continue;
+    }
+    const body = (typeof value === "string" ? value : stringify(value)).trim();
+    if (body.length > 0) {
+      return body.length <= MAX_ERROR_BODY_LENGTH
+        ? body
+        : `${body.slice(0, MAX_ERROR_BODY_LENGTH)}... [truncated]`;
+    }
+  }
+  return undefined;
+}
+
+export function formatProviderError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return stringify(error);
+  }
+
+  const httpError = error as HttpErrorShape;
+  const status = readStatus(httpError);
+  const body = readBody(httpError);
+  if (status === undefined || body === undefined || error.message.includes(body)) {
+    return error.message;
+  }
+  return `${status}: ${body}`;
+}

--- a/src/infra/vitest-live-config.test.ts
+++ b/src/infra/vitest-live-config.test.ts
@@ -22,6 +22,7 @@ describe("live vitest config", () => {
     expect(liveConfig.test?.include).toEqual([
       "src/**/*.live.test.ts",
       "test/**/*.live.test.ts",
+      "packages/*/src/**/*.live.test.ts",
       BUNDLED_PLUGIN_LIVE_TEST_GLOB,
     ]);
     expect(normalizeConfigPaths(liveConfig.test?.setupFiles)).toEqual([

--- a/test/vitest/vitest.live.config.ts
+++ b/test/vitest/vitest.live.config.ts
@@ -27,7 +27,12 @@ export default defineConfig({
         [...(baseTest.setupFiles ?? []), "test/setup-openclaw-runtime.ts"].map(resolveRepoRootPath),
       ),
     ],
-    include: ["src/**/*.live.test.ts", "test/**/*.live.test.ts", BUNDLED_PLUGIN_LIVE_TEST_GLOB],
+    include: [
+      "src/**/*.live.test.ts",
+      "test/**/*.live.test.ts",
+      "packages/*/src/**/*.live.test.ts",
+      BUNDLED_PLUGIN_LIVE_TEST_GLOB,
+    ],
     exclude,
   },
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes a cluster of OpenAI-compatible provider issues that degrade reliability and observability for chat completions backends:

- Messages persisted with `content: null` (e.g. from loosely-typed tools or older transcripts) crash provider conversion mid-request instead of being treated as empty.
- Encrypted reasoning details that arrive before their matching tool-call block are silently dropped, breaking reasoning replay on OpenRouter-style gateways.
- OpenRouter reasoning models (e.g. Kimi) reject requests because the system prompt is sent under the `developer` role they don't accept; routing preferences are also ignored on OpenRouter-compatible proxies hosted on other domains, and session-affinity headers use the wrong shape for OpenRouter-style cache routing.
- Z.AI streams lose replayed thinking content from the cache prefix because the request doesn't opt out of thinking-clearing.
- The OpenAI SDK silently retries twice on 429/5xx underneath the app's own retry/failover policy, producing invisible stalls and duplicate retries.
- Proxy/gateway HTTP errors with non-JSON bodies surface as bare "<status> status code (no body)", hiding the real reason.

## Why This Change Was Made

These are all correctness/diagnosability gaps at the provider boundary that users hit with third-party OpenAI-compatible backends. Fixing them at the shared transform/compat layer keeps per-provider quirks declarative and avoids per-call-site patches.

## User Impact

- No more mid-stream crashes on null message content.
- Reasoning replay stays intact when gateways emit encrypted reasoning ahead of tool calls.
- OpenRouter (and compatible proxies): correct system/developer role per model family, routing preferences honored on any host, and `x-session-id` affinity for cache routing.
- Z.AI: thinking context survives replay, improving cache hits.
- Retry behavior is fully owned by the app's retry policy (no hidden SDK double-retries).
- Provider errors now include the HTTP status and response body, so failures are actionable.

## Evidence

- New/extended focused tests: `packages/ai/src/providers/openai-completions.compat.test.ts`, `packages/ai/src/providers/transform-messages.test.ts`, `packages/ai/src/utils/provider-error.test.ts`, `packages/ai/src/providers/google-shared.test.ts` — 5 files, 72 tests passing (`node scripts/run-vitest.mjs ...`).
- `node scripts/check-changed.mjs -- <changed files>`: typecheck + lint green.
- Header/param shapes validated against OpenRouter provider-routing and prompt-caching docs and Z.AI thinking-mode docs.


**Live verification (real API keys):** `node scripts/test-live.mjs -- packages/ai/src/providers/openai-completions.live.test.ts` — OpenAI completions stream (usage + stop) and OpenRouter `moonshotai/kimi-k2` accepting a system prompt (the role-selection fix, previously rejected) both pass live. Z.AI live case is written but currently blocked on account balance for both available keys (`429 code 1113 Insufficient balance` — surfaced readably by this PR's error-body fix); its request shape is unit-asserted. Live suite added in this PR (gated on `OPENCLAW_LIVE_TEST=1` + keys).
