### PR TITLE
fix(scripts): drop duplicate isDirectReleaseCandidateExecution declaration

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -95,11 +95,6 @@ export function validateWindowsSourceRelease(
     digest: unknown;
   }[];
 }>;
-export function isDirectReleaseCandidateExecution(
-  directPath: string | undefined,
-  modulePath: string,
-  resolveRealPath?: (path: string) => string,
-): boolean;
 export function validateCandidateCheckout({
   targetSha,
   targetHeadSha,


### PR DESCRIPTION
## What Problem This Solves

Every PR's `check-lint` lane on `main` currently fails with `adjacent-overload-signatures` in `scripts/release-candidate-checklist.d.mts`: two overlapping direct-to-main fixes (33a354c655e and #109546 / eb17bfdc955) each added an identical `isDirectReleaseCandidateExecution` declaration (lines 75 and 98), and oxlint rejects the non-adjacent duplicate.

## Why This Change Was Made

Removes the second, undocumented duplicate declaration; the first declaration (identical signature) remains. Declarations-only change; the `.mjs` implementation is untouched.

## User Impact

Unblocks CI (`check-lint` / `ci-gate`) for all open PRs; no runtime behavior change.

## Evidence

- `node scripts/run-oxlint.mjs scripts/release-candidate-checklist.d.mts`: zero findings (was 1 error).
- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts`: pass.
- `git diff --check`: clean.
