### PR TITLE
fix(scripts): preserve UTF-16 surrogate pairs in prompt probe summarization

### DIFF
--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import { truncateUtf16Safe as n } from "@openclaw/normalization-core/utf16-slice";
 import type { AuthProfileCredential } from "../src/agents/auth-profiles.js";
 import {
   parseBooleanEnv,
@@ -140,7 +141,7 @@ function summarizeText(text: string, max = 120): string {
   if (normalized.length <= max) {
     return normalized;
   }
-  return `${normalized.slice(0, max - 1)}…`;
+  return `${n(normalized, max - 1)}…`;
 }
 
 function summarizeCapture(


### PR DESCRIPTION
## Summary

Replace `String.prototype.slice` with `truncateUtf16Safe` in `summarizeText` to preserve UTF-16 surrogate pairs (emoji, supplementary-plane characters) during prompt-probe summarization.

## What Problem This Solves

**Problem**: `summarizeText` in `scripts/anthropic-prompt-probe.ts` uses `normalized.slice(0, max - 1)` which can split a UTF-16 surrogate pair in half, producing a broken/lone surrogate character in prompt probe output.

**Root Cause**: The raw `String.prototype.slice()` operates on UTF-16 code units, not code points. Characters outside the Basic Multilingual Plane (U+10000 and above, including emoji like 🔥😀🎉) are encoded as two 16-bit code units (a surrogate pair). When the truncation boundary falls in the middle of a surrogate pair, `.slice()` returns a dangling high surrogate — an invalid Unicode string.

**Solution**: Import `truncateUtf16Safe` (from `@openclaw/normalization-core/utf16-slice`) and replace `.slice(0, max - 1)` with `n(normalized, max - 1)`. The safe function checks both edges of the sliced range and adjusts by one code unit when it detects a split surrogate pair, ensuring the result is always valid UTF-16.

## Evidence

**Real environment tested**: Linux 6.17.0-35-generic, Node.js v25.9.0, tsx v4.22.4

**Exact steps or command run after this patch**:
Evidence collected via the actual exported `testing.summarizeText` / `testing.summarizeCapture` functions from `scripts/anthropic-prompt-probe.ts` — NOT a reconstructed helper. See `docs/.local/scan-20260717-3/verify.log` for full output.

```typescript
import { testing } from "./scripts/anthropic-prompt-probe.ts";
const { summarizeText, summarizeCapture } = testing;
```

Test cases exercised:
1. ASCII baseline (no surrogate pairs)
2. Text shorter than max (no truncation needed)
3. **Fire emoji (U+1F525) at truncation boundary** — the actual bug scenario
4. Multiple emoji at various boundary positions (grinning face, party popper, pile of poo, rainbow)
5. `summarizeCapture` — exercises `summarizeText` indirectly through the capture summary path
6. Edge cases: empty string, single char, whitespace-only, exact max length, emoji at start with max=1

**After-fix evidence**:
```
--- Test 3: Emoji (🔥 U+1F525) at truncation boundary ---
  Input length: 130
  Safe result (summarizeText): length=119
  Has orphan surrogate: false
  Old slice() has orphan surrogate: true
  PASS: true

--- Test 4: Multiple emoji at various boundary positions ---
  grinning face 😀 U+1F600: length=120, hasOrphan=false OK
  party popper 🎉 U+1F389: length=120, hasOrphan=false OK
  pile of poo 💩 U+1F4A9: length=120, hasOrphan=false OK
  rainbow 🌈 U+1F308: length=120, hasOrphan=false OK

--- Test 5: summarizeCapture (exercises summarizeText indirectly) ---
  systemBlocks[0].preview length: 119, hasOrphan: false OK
  systemBlocks[1].preview length: 119, hasOrphan: false OK
  userPreview length: 119, hasOrphan: false OK
```

**Observed result after the fix**: The patched `summarizeText` correctly truncates text without producing orphan surrogate characters. Every test case with surrogate pairs at the truncation boundary produces clean output (no `[\uD800-\uDFFF]` matches). The old `.slice()` version consistently produces orphan surrogates when a surrogate pair falls at the boundary.

**What was not tested**: Integration/anthropic API round-trip tests. The change is limited to a pure-text helper function used for display summarization in prompt probe output.

## CI failure investigation

Two CI checks failed in the PR run:
- `checks-node-compact-large-3` — failure in `src/media/store.test.ts` > `'prunes empty directory chains after r…'` with `ENOENT: no such file or directory, stat '/tmp/openclaw-test-home-*/home-0/.openclaw/media/remote-cache'` — a pre-existing flaky test (timing/race condition in temp directory cleanup), **unrelated to this change**.
- `openclaw/ci-gate` — cascaded from the same flaky test failure; the gate aggregates all check results.

Our change only touches `scripts/anthropic-prompt-probe.ts`, which is a standalone script — it cannot cause a media store test to fail with ENOENT.

## Tests and validation

- Evidence script exercises the actual exported functions from `scripts/anthropic-prompt-probe.ts`
- All surrogate pair boundary cases handled correctly: safe function either includes the full pair or excludes it entirely, never returning a lone surrogate
- Existing unit tests in `packages/normalization-core/src/utf16-slice.test.ts` cover the `truncateUtf16Safe` implementation

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation
- [ ] Breaking changes (if any) are documented in Summary