### PR TITLE
fix(ui): reset suppressStageClick flag when exiting browser capture modes

### DIFF
--- a/ui/src/components/browser/browser-panel.test.ts
+++ b/ui/src/components/browser/browser-panel.test.ts
@@ -56,6 +56,22 @@ describe("normalizeBrowserUrlDraft", () => {
     expect((panel as unknown as { open: boolean }).open).toBe(true);
   });
 
+  it("resets suppressStageClick when exiting capture modes", async () => {
+    const panel = document.createElement("openclaw-browser-panel") as unknown as HTMLElement & {
+      available: boolean;
+      suppressStageClick: boolean;
+      exitCaptureModes: () => void;
+    };
+    panel.available = true;
+    document.body.append(panel);
+    await (panel as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+
+    panel.suppressStageClick = true;
+    panel.exitCaptureModes();
+
+    expect(panel.suppressStageClick).toBe(false);
+  });
+
   it("keeps an already closed panel closed for an explicit close request", () => {
     const panel = document.createElement("openclaw-browser-panel") as unknown as HTMLElement & {
       available: boolean;

--- a/ui/src/components/browser/browser-panel.ts
+++ b/ui/src/components/browser/browser-panel.ts
@@ -626,6 +626,7 @@ class OpenClawBrowserPanel extends OpenClawLitElement {
     this.drawingStroke = null;
     this.inspected = null;
     this.inspectPointer = null;
+    this.suppressStageClick = false;
   }
 
   private setMode(mode: BrowserPanelMode): void {


### PR DESCRIPTION
## Summary

- **Problem:** After exiting browser inspect/annotate mode, the next click in interact mode is silently suppressed. Users must click twice to interact after inspecting an element.
- **Root cause:** `exitCaptureModes()` resets `mode`, `strokes`, `drawingStroke`, `inspected`, and `inspectPointer`, but does NOT reset `suppressStageClick`. This flag is set to `true` by `handleOverlayPointerDown` when in inspect mode to suppress the click event that follows the pointerdown. When the mode returns to interact (via `sendAnnotation` triggering `exitCaptureModes`), the flag remains `true`, causing the next `handleStageClick` to bail out.
- **Fix:** Add `this.suppressStageClick = false` to `exitCaptureModes()` alongside the other state resets.
- **Impact:** Every user who uses browser inspect mode is affected; the fix eliminates the phantom click loss.

## Linked context

N/A (no existing issue)

## Real behavior proof

- **Behavior or issue addressed:** Browser panel suppressStageClick flag persists after exiting capture modes, causing next interact-mode click to be silently lost.
- **Real environment tested:** Linux, Node 22, commit `33a354c655e`
- **Exact steps or command run:** `node /tmp/verify-browser-panel-fix.mjs`
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):
```
✅ All assertions passed. suppressStageClick is properly reset by exitCaptureModes.
```
- **Observed result after fix:** The `suppressStageClick` flag is consistently reset to `false` whenever capture modes are exited, preventing the next interact-mode click from being silently discarded.
- **What was not tested:** Full browser integration with actual inspect/annotate pointer events and real click sequencing. Unit test covers the method-level contract.

## Tests and validation

```
$ node scripts/run-vitest.mjs ui/src/components/browser/browser-panel.test.ts

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  10:54:51
   Duration  2.71s
```

## Risk checklist

- [Yes] This change is backward compatible
- [Yes] This change has tests
- [No] This change affects public API
- [No] This change touches config/default surfaces
- [No] This change affects provider/plugin behavior
- [No] This change requires docs update
- [No] This change requires changelog entry