### PR TITLE
fix(ci): extend frozen target hook timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1883,6 +1883,9 @@ jobs:
           OPENCLAW_NODE_TEST_ENV_JSON: ${{ toJson(matrix.env) }}
           OPENCLAW_NODE_TEST_INCLUDE_PATTERNS_JSON: ${{ toJson(matrix.includePatterns) }}
           OPENCLAW_NODE_TEST_TARGETS_JSON: ${{ toJson(matrix.targets) }}
+          # Frozen targets can carry integration hooks whose cold setup exceeds
+          # the current 120-second default on shared release runners.
+          OPENCLAW_NODE_TEST_VITEST_ARGS_JSON: ${{ needs.preflight.outputs.compatibility_target == 'true' && '["--hookTimeout=300000"]' || '[]' }}
           OPENCLAW_VITEST_SHARD_NAME: ${{ matrix.shard_name }}
           OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "300000"
           OPENCLAW_VITEST_NO_OUTPUT_RETRY: "1"

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -1050,7 +1050,7 @@
     <string name="native_b78426f40a794c5d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未ペアリング"</string>
     <string name="native_b7b190b4be0b2385" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayがこのスマートフォンを認識しました"</string>
     <string name="native_b7b89bf0fd930a9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"設定済みのモデルはありません"</string>
-    <string name="native_b7e3e4aa4257b9a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無効にする"</string>
+    <string name="native_b7e3e4aa4257b9a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無効化"</string>
     <string name="native_b8352b44a588721c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"アプリの言語"</string>
     <string name="native_b8380b8a2317b9fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayをペアリング中"</string>
     <string name="native_b860c709e9ba7e6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存済みの認証情報が無効です"</string>

--- a/scripts/ci-run-node-test-shard.mjs
+++ b/scripts/ci-run-node-test-shard.mjs
@@ -17,6 +17,7 @@ const FS_MODULE_CACHE_PATH_ENV_KEY = "OPENCLAW_VITEST_FS_MODULE_CACHE_PATH";
 const FS_MODULE_CACHE_WRITER_ENV_KEY = "OPENCLAW_VITEST_FS_MODULE_CACHE_WRITER";
 const NODE_COMPILE_CACHE_PATH_ENV_KEY = "NODE_COMPILE_CACHE";
 const NODE_COMPILE_CACHE_WRITER_ENV_KEY = "OPENCLAW_NODE_COMPILE_CACHE_WRITER";
+const VITEST_EXTRA_ARGS_ENV_KEY = "OPENCLAW_NODE_TEST_VITEST_ARGS_JSON";
 const FS_MODULE_CACHE_MAX_BYTES = 2 * 1024 * 1024 * 1024;
 const NODE_COMPILE_CACHE_MAX_BYTES = 1024 * 1024 * 1024;
 const FS_MODULE_CACHE_PRUNE_TARGET_RATIO = 0.75;
@@ -220,6 +221,7 @@ function runChild(args, childEnv, label) {
 
 export async function runShardPlans(plans, options = {}) {
   const baseEnv = options.env ?? process.env;
+  const vitestExtraArgs = parseJsonEnv(baseEnv, VITEST_EXTRA_ARGS_ENV_KEY, []);
   const concurrency = Math.max(1, options.concurrency ?? PLAN_CONCURRENCY);
   const runner = options.runChild ?? runChild;
   const scratchDir = options.scratchDir ?? mkdtempSync(join(tmpdir(), "openclaw-node-shard-"));
@@ -233,12 +235,16 @@ export async function runShardPlans(plans, options = {}) {
       const index = nextIndex;
       nextIndex += 1;
       const entry = plans[index];
-      const args = entry.kind === "target" ? [entry.target] : entry.plan.configs;
-      if (!Array.isArray(args) || args.length === 0) {
+      const targetArgs = entry.kind === "target" ? [entry.target] : entry.plan.configs;
+      if (!Array.isArray(targetArgs) || targetArgs.length === 0) {
         console.error(`Missing node test shard configs for ${entry.name}`);
         exitCode = exitCode || 1;
         return;
       }
+      const args =
+        Array.isArray(vitestExtraArgs) && vitestExtraArgs.length > 0
+          ? [...targetArgs, "--", ...vitestExtraArgs]
+          : targetArgs;
       const childEnv = buildChildEnv(entry, baseEnv, scratchDir, index, {
         serial: concurrency === 1,
         cacheSlot,

--- a/test/scripts/ci-run-node-test-shard.test.ts
+++ b/test/scripts/ci-run-node-test-shard.test.ts
@@ -152,6 +152,30 @@ describe("scripts/ci-run-node-test-shard.mjs", () => {
     expect(new Set(seen.map((run) => run.cache)).size).toBe(3);
   });
 
+  it("forwards trusted Vitest arguments after the target separator", async () => {
+    const scratchDir = makeScratchDir();
+    const seen: string[][] = [];
+    const exitCode = await runShardPlans(
+      resolveShardPlans({
+        OPENCLAW_NODE_TEST_CONFIGS_JSON: JSON.stringify(["test/vitest/vitest.unit.config.ts"]),
+      }),
+      {
+        concurrency: 1,
+        env: {
+          OPENCLAW_NODE_TEST_VITEST_ARGS_JSON: JSON.stringify(["--hookTimeout=300000"]),
+        },
+        runChild: async (args: string[]) => {
+          seen.push(args);
+          return 0;
+        },
+        scratchDir,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(seen).toEqual([["test/vitest/vitest.unit.config.ts", "--", "--hookTimeout=300000"]]);
+  });
+
   it("reuses isolated persistent cache slots across serial work", async () => {
     const scratchDir = makeScratchDir();
     const persistentRoot = path.join(makeScratchDir(), "persistent");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3800,6 +3800,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_RETRY).toBe("1");
     expect(runStep.env.OPENCLAW_NODE_TEST_ENV_JSON).toBe("${{ toJson(matrix.env) }}");
     expect(runStep.env.OPENCLAW_NODE_TEST_TARGETS_JSON).toBe("${{ toJson(matrix.targets) }}");
+    expect(runStep.env.OPENCLAW_NODE_TEST_VITEST_ARGS_JSON).toBe(
+      "${{ needs.preflight.outputs.compatibility_target == 'true' && '[\"--hookTimeout=300000\"]' || '[]' }}",
+    );
     expect(runStep.env.JOB_CONTEXT_JSON).toBe("${{ toJSON(job) }}");
     // Shard execution policy lives in the unit-tested wrapper script. Frozen
     // release targets load that wrapper from the exact trusted workflow SHA.

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2385,7 +2385,7 @@ describe("package artifact reuse", () => {
     });
     expect(dockerAcceptanceJob.with).toMatchObject({
       allow_frozen_target_scenario_omissions:
-        "${{ inputs.allow_frozen_target_scenario_omissions }}",
+        "${{ inputs.allow_frozen_target_scenario_omissions || false }}",
     });
     expect(workflow).toContain(
       "live_repo_e2e_release_checks:\n    name: Run repo/live E2E validation\n    needs: [resolve_target]",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation repeatedly fails frozen release candidates when a cold integration-test `beforeAll` hook crosses the normal 120-second Vitest limit. The same exact candidate and shard pass on retry, but the parent correctly fail-fasts and cannot adopt that later attempt.

Observed on the OpenClaw 2026.6.33 extended-stable candidate:

- Full validation `29543257562`: `checks-node-agentic-agents-embedded` timed out, then passed on child attempt 2.
- Full validation `29550380847`: the same hook timed out again after 84 files and 1,496 tests had passed.

PR CI also exposed two current-main baseline mismatches: the package-acceptance structural test had not followed the Docker caller's explicit false default, and the generated Japanese Android resources retained an older minority translation for `Disable`.

## Why This Change Was Made

Frozen candidates run target-owned tests through the trusted current-main shard runner. This change lets that runner forward trusted Vitest arguments and gives compatibility targets a five-minute hook timeout. Current main, PR, and push CI retain the existing 120-second default.

The adjacent baseline repairs are intentionally mechanical: one test expectation follows the owning workflow, and one generated Android string follows the deterministic localization generator. The candidate SHA and product code remain unchanged.

## User Impact

No runtime or package behavior changes. Frozen release validation gets enough setup headroom on cold shared runners, at the cost of waiting up to three additional minutes only when a frozen-target hook is genuinely stuck. The Android resource refresh changes the Japanese label for `Disable` from `無効にする` to the generator-selected `無効化`.

## Evidence

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Android generated-resource check
- Blacksmith Testbox `tbx_01kxrrw37493bds1fdsqmv5hsk`
- Actions run `29607706788`
- Focused tests: 4 files, 198 tests passed
- Exact-candidate Normal CI run `29551213367`

The tests prove the workflow scopes the override to compatibility targets, the trusted shard runner forwards arguments after the target separator, the package-acceptance wrapper preserves the caller input, and generated Android resources remain aligned.
