### PR TITLE
fix(whatsapp): honor mention patterns with third-party mentions

### DIFF
--- a/extensions/whatsapp/src/auto-reply/mentions.ts
+++ b/extensions/whatsapp/src/auto-reply/mentions.ts
@@ -68,19 +68,23 @@ function isBotMentionedFromTargets(
     : isSelfChatMode(targets.self.e164, mentionCfg.allowFrom) && !isGroupConversation;
 
   const hasMentions = targets.normalizedMentions.length > 0;
+  const bodyClean = clean(msg.payload.body);
+  const matchesConfiguredMention = mentionCfg.mentionRegexes.some((re) => re.test(bodyClean));
   if (hasMentions && !isSelfChat) {
     for (const mention of targets.normalizedMentions) {
       if (identitiesOverlap(targets.self, mention)) {
         return true;
       }
     }
-    // If the message explicitly mentions someone else, do not fall back to regex matches.
+    if (matchesConfiguredMention) {
+      return true;
+    }
+    // If the message explicitly mentions someone else, do not fall back to numeric self matches.
     return false;
   } else if (hasMentions && isSelfChat) {
     // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in self-chat triggers the bot.
   }
-  const bodyClean = clean(msg.payload.body);
-  if (mentionCfg.mentionRegexes.some((re) => re.test(bodyClean))) {
+  if (matchesConfiguredMention) {
     return true;
   }
 

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -565,7 +565,7 @@ describe("applyGroupGating", () => {
     expect(result.shouldProcess).toBe(true);
   });
 
-  it("does not treat group mention gating as self-chat under implicit self fallback", async () => {
+  it("uses configured mention patterns when native mentions target another group member", async () => {
     const cfg = makeConfig({
       channels: {
         whatsapp: {
@@ -580,6 +580,55 @@ describe("applyGroupGating", () => {
       msg: createGroupMessage({
         id: "g-other-mention",
         body: "@openclaw please check this",
+        mentionedJids: ["15550000000@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(true);
+    expect(groupHistories.get("whatsapp:default:group:123@g.us")).toBeUndefined();
+  });
+
+  it("rejects third-party native mentions when configured mention patterns do not match", async () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          groups: { "*": { requireMention: true } },
+        },
+      },
+      messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+    });
+
+    const { result, groupHistories } = await runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "g-other-mention-no-pattern",
+        body: "@someone please check this",
+        mentionedJids: ["15550000000@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(false);
+    expect(groupHistories.get("whatsapp:default:group:123@g.us")?.length).toBe(1);
+  });
+
+  it("does not use numeric self fallback when native mentions target another group member", async () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+
+    const { result, groupHistories } = await runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "g-other-mention-self-number",
+        body: "please check +1 555 123 4567",
         mentionedJids: ["15550000000@s.whatsapp.net"],
         selfE164: "+15551234567",
         selfJid: "15551234567@s.whatsapp.net",

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -136,14 +136,34 @@ describe("isBotMentionedFromTargets", () => {
     expect(debugMention(msg, cfg).wasMentioned).toBe(expected);
   }
 
-  it("ignores regex matches when other mentions are present", () => {
+  it("falls through to regex matches when native mentions target another participant", () => {
     const msg = makeMsg({
       body: "@OpenClaw please help",
       mentionedJids: ["19998887777@s.whatsapp.net"],
       selfE164: "+15551234567",
       selfJid: "15551234567@s.whatsapp.net",
     });
+    expectMentioned(msg, mentionCfg, true);
+  });
+
+  it("rejects third-party native mentions when regexes do not match", () => {
+    const msg = makeMsg({
+      body: "please help",
+      mentionedJids: ["19998887777@s.whatsapp.net"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
     expectMentioned(msg, mentionCfg, false);
+  });
+
+  it("does not use numeric self fallback when native mentions target another participant", () => {
+    const msg = makeMsg({
+      body: "please check +1 555 123 4567",
+      mentionedJids: ["19998887777@s.whatsapp.net"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
+    expectMentioned(msg, { mentionRegexes: [] }, false);
   });
 
   it("matches explicit self mentions", () => {


### PR DESCRIPTION
Closes #109488

## What Problem This Solves

Fixes an issue where WhatsApp group users who address the bot with a configured mention pattern would be silently ignored when the same message also natively @-mentions another group member.

## Why This Change Was Made

The WhatsApp mention gate now checks operator-configured mention regexes after native mention metadata fails to match the bot. It still rejects third-party native mentions when no configured pattern matches, and it still suppresses the numeric self-number fallback in that third-party-native-mention branch.

## User Impact

Operators can keep `requireMention: true` with configured `mentionPatterns` and users can ask the bot about another mentioned participant without the message disappearing before dispatch.

## Evidence

- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts -- -t isBotMentionedFromTargets` passed: 9 passed, 22 skipped.
- `git diff --check` passed.
- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts` was attempted before and after the fix, but this local host runs Node v24.13.0, which OpenClaw rejects because it embeds unsafe SQLite 3.50.4. The failures occur before the changed assertions at `requireNodeSqlite` with the message requiring Node 22.22.3+, 24.15.0+, or 25.9.0+.
- Remote Testbox proof was attempted through Crabbox, but this environment has no usable `crabbox` or `blacksmith` binary; `node scripts/crabbox-wrapper.mjs run --help` failed Crabbox binary sanity checks.
- Autoreview was attempted with `python .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` and `python .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`; both were blocked by installed Git 2.21.0 not supporting the helper's `--end-of-options` Git invocation.
