### PR TITLE
fix(discord): bound gateway metadata response reads to prevent OOM

### DIFF
--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -2,7 +2,6 @@
 import { createServer, type Server } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  fetchDiscordGatewayInfo,
   fetchDiscordGatewayInfoWithTimeout,
   fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
@@ -116,7 +115,7 @@ describe("Discord gateway metadata", () => {
   });
 });
 
-describe("fetchDiscordGatewayInfo bounded reads", () => {
+describe("fetchDiscordGatewayInfoWithTimeout bounded reads", () => {
   const validPayload = JSON.stringify({
     url: "wss://gateway.discord.gg/",
     shards: 1,
@@ -138,7 +137,7 @@ describe("fetchDiscordGatewayInfo bounded reads", () => {
   }
 
   it("returns parsed gateway info when response body is within the 4 MiB cap", async () => {
-    const info = await fetchDiscordGatewayInfo({
+    const info = await fetchDiscordGatewayInfoWithTimeout({
       token: "test",
       fetchImpl: async () => bodyLessMock(validPayload),
     });
@@ -148,12 +147,16 @@ describe("fetchDiscordGatewayInfo bounded reads", () => {
     expect(info.session_start_limit.total).toBe(1000);
   });
 
-  it("rejects oversized response via loopback HTTP (streaming pre-read bound)", async () => {
-    const oversizedPayloadBytes = DISCORD_GATEWAY_METADATA_MAX_BYTES + 256 * 1024;
+  it("falls back on oversized loopback HTTP responses after streaming rejection", async () => {
+    const oversizedPayloadBytes = 32 * 1024 * 1024;
     let streamedBytes = 0;
+    let responseClosed = false;
     const server = createServer((_request, res) => {
       const chunk = Buffer.alloc(64 * 1024, 0x78);
       res.writeHead(200, { "content-type": "application/json" });
+      res.once("close", () => {
+        responseClosed = true;
+      });
       const writeMore = () => {
         while (streamedBytes < oversizedPayloadBytes) {
           if (res.destroyed) {
@@ -172,44 +175,46 @@ describe("fetchDiscordGatewayInfo bounded reads", () => {
     const port = await listenLoopbackServer(server);
     try {
       const rawResponse = await fetch(`http://127.0.0.1:${port}`);
-      await expect(
-        fetchDiscordGatewayInfo({
-          token: "test",
-          fetchImpl: async () => rawResponse,
-        }),
-      ).rejects.toMatchObject({
-        message: expect.stringMatching(
-          `Failed to get gateway information from Discord: Discord gateway metadata response body too large: \\d+ bytes \\(limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes\\)`,
-        ) as unknown as string,
+      const error = await fetchDiscordGatewayInfoWithTimeout({
+        token: "test",
+        fetchImpl: async () => rawResponse,
+      }).catch((cause: unknown) => cause);
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+      const resolved = resolveGatewayInfoWithFallback({ runtime, error });
+
+      expect(resolved).toMatchObject({
+        usedFallback: true,
+        info: { url: "wss://gateway.discord.gg/" },
       });
+      expect(String(runtime.log.mock.calls[0]?.[0])).toMatch(
+        new RegExp(
+          `Discord gateway metadata response body too large: \\d+ bytes \\(limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes\\)`,
+        ),
+      );
+      await vi.waitFor(() => expect(responseClosed).toBe(true));
+      expect(streamedBytes).toBeGreaterThan(DISCORD_GATEWAY_METADATA_MAX_BYTES);
+      expect(streamedBytes).toBeLessThan(oversizedPayloadBytes);
     } finally {
       await closeServer(server);
     }
   });
 
-  it("rejects oversized body-less response via post-hoc fallback guard", async () => {
+  it("falls back on oversized body-less responses after the post-hoc guard", async () => {
     const body = "x".repeat(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1024);
-    await expect(
-      fetchDiscordGatewayInfo({
-        token: "test",
-        fetchImpl: async () => bodyLessMock(body),
-      }),
-    ).rejects.toMatchObject({
-      message: expect.stringMatching(
-        `Failed to get gateway information from Discord: Discord gateway metadata response body too large: \\d+ bytes \\(limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes\\)`,
-      ) as unknown as string,
-    });
-  });
-
-  it("mutation: removing both guards causes over-cap bodies to be accepted silently", async () => {
-    const body = Buffer.alloc(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1, 0x78).toString();
-    const error = await fetchDiscordGatewayInfo({
+    const error = await fetchDiscordGatewayInfoWithTimeout({
       token: "test",
       fetchImpl: async () => bodyLessMock(body),
-    }).catch((err: unknown) => err);
+    }).catch((cause: unknown) => cause);
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toMatch(/Discord gateway metadata response body too large:/);
+    expect(resolveGatewayInfoWithFallback({ runtime, error })).toMatchObject({
+      usedFallback: true,
+      info: { url: "wss://gateway.discord.gg/" },
+    });
+    expect(String(runtime.log.mock.calls[0]?.[0])).toContain(
+      `Discord gateway metadata response body too large: ${Buffer.byteLength(body)} bytes (limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes)`,
+    );
   });
 });
 

--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -115,9 +115,7 @@ describe("Discord gateway metadata", () => {
   });
 });
 
-describe("fetchDiscordGatewayInfo bounded reads (post-hoc)", () => {
-  const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
-
+describe("fetchDiscordGatewayInfo bounded reads", () => {
   const validPayload = JSON.stringify({
     url: "wss://gateway.discord.gg/",
     shards: 1,
@@ -129,16 +127,19 @@ describe("fetchDiscordGatewayInfo bounded reads (post-hoc)", () => {
     },
   });
 
-  it("returns parsed gateway info when response body is within the 4 MiB cap", async () => {
-    const okResponse = {
+  function bodyLessMock(text: string) {
+    return {
       ok: true as const,
       status: 200,
-      text: async () => validPayload,
+      body: null,
+      text: async () => text,
     };
+  }
 
+  it("returns parsed gateway info when response body is within the 4 MiB cap", async () => {
     const info = await fetchDiscordGatewayInfo({
       token: "test",
-      fetchImpl: async () => okResponse,
+      fetchImpl: async () => bodyLessMock(validPayload),
     });
 
     expect(info.url).toBe("wss://gateway.discord.gg/");
@@ -146,18 +147,49 @@ describe("fetchDiscordGatewayInfo bounded reads (post-hoc)", () => {
     expect(info.session_start_limit.total).toBe(1000);
   });
 
-  it("rejects with a size error when response body exceeds the 4 MiB cap", async () => {
-    const body = "x".repeat(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1024);
-    const okResponse = {
-      ok: true as const,
-      status: 200,
-      text: async () => body,
-    };
+  it("rejects oversized response via loopback HTTP (streaming pre-read bound)", async () => {
+    const oversizedPayloadBytes = DISCORD_GATEWAY_METADATA_MAX_BYTES + 256 * 1024;
+    let streamedBytes = 0;
+    const server = createServer((_request, res) => {
+      const chunk = Buffer.alloc(64 * 1024, 0x78);
+      res.writeHead(200, { "content-type": "application/json" });
+      const writeMore = () => {
+        while (streamedBytes < oversizedPayloadBytes) {
+          if (res.destroyed) return;
+          streamedBytes += chunk.byteLength;
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        res.end();
+      };
+      writeMore();
+    });
+    const port = await listenLoopbackServer(server);
+    try {
+      const rawResponse = await fetch(`http://127.0.0.1:${port}`);
+      await expect(
+        fetchDiscordGatewayInfo({
+          token: "test",
+          fetchImpl: async () => rawResponse,
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringMatching(
+          `Failed to get gateway information from Discord: Discord gateway metadata response body too large: \\d+ bytes \\(limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes\\)`,
+        ) as unknown as string,
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
 
+  it("rejects oversized body-less response via post-hoc fallback guard", async () => {
+    const body = "x".repeat(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1024);
     await expect(
       fetchDiscordGatewayInfo({
         token: "test",
-        fetchImpl: async () => okResponse,
+        fetchImpl: async () => bodyLessMock(body),
       }),
     ).rejects.toMatchObject({
       message: expect.stringMatching(
@@ -166,46 +198,11 @@ describe("fetchDiscordGatewayInfo bounded reads (post-hoc)", () => {
     });
   });
 
-  it("negative-control: unbounded response.text() would buffer the full oversized body", async () => {
-    // This test proves the raw .text() call (without the post-hoc check)
-    // would silently buffer a body larger than the cap. The fix adds the
-    // post-hoc byte-length check so it now throws.
-    const oversizedBody = "x".repeat(DISCORD_GATEWAY_METADATA_MAX_BYTES + 64 * 1024);
-    const okResponse = {
-      ok: true as const,
-      status: 200,
-      text: async () => oversizedBody,
-    };
-
-    // Without the fix, this would resolve successfully (silently buffering >4 MiB).
-    // With the fix, it throws.
-    await expect(
-      fetchDiscordGatewayInfo({
-        token: "test",
-        fetchImpl: async () => okResponse,
-      }),
-    ).rejects.toMatchObject({
-      message: expect.stringContaining(
-        "Discord gateway metadata response body too large:",
-      ) as unknown as string,
-    });
-  });
-
-  it("mutation: removing the post-hoc check causes over-cap bodies to be accepted silently (load-bearing)", async () => {
-    // This test asserts that the fix is load-bearing: if someone removes
-    // the byte-length check from fetchDiscordGatewayInfo and reverts to
-    // bare response.text(), the oversized body test should catch it.
+  it("mutation: removing both guards causes over-cap bodies to be accepted silently", async () => {
     const body = Buffer.alloc(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1, 0x78).toString();
-    const okResponse = {
-      ok: true as const,
-      status: 200,
-      text: async () => body,
-    };
-
-    // The fix rejects; a revert to bare .text() would not reject.
     const error = await fetchDiscordGatewayInfo({
       token: "test",
-      fetchImpl: async () => okResponse,
+      fetchImpl: async () => bodyLessMock(body),
     }).catch((err: unknown) => err);
 
     expect(error).toBeInstanceOf(Error);

--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -2,6 +2,7 @@
 import { createServer, type Server } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  fetchDiscordGatewayInfo,
   fetchDiscordGatewayInfoWithTimeout,
   fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
@@ -155,7 +156,9 @@ describe("fetchDiscordGatewayInfo bounded reads", () => {
       res.writeHead(200, { "content-type": "application/json" });
       const writeMore = () => {
         while (streamedBytes < oversizedPayloadBytes) {
-          if (res.destroyed) return;
+          if (res.destroyed) {
+            return;
+          }
           streamedBytes += chunk.byteLength;
           if (!res.write(chunk)) {
             res.once("drain", writeMore);

--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -115,6 +115,104 @@ describe("Discord gateway metadata", () => {
   });
 });
 
+describe("fetchDiscordGatewayInfo bounded reads (post-hoc)", () => {
+  const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
+
+  const validPayload = JSON.stringify({
+    url: "wss://gateway.discord.gg/",
+    shards: 1,
+    session_start_limit: {
+      total: 1000,
+      remaining: 999,
+      reset_after: 3600000,
+      max_concurrency: 1,
+    },
+  });
+
+  it("returns parsed gateway info when response body is within the 4 MiB cap", async () => {
+    const okResponse = {
+      ok: true as const,
+      status: 200,
+      text: async () => validPayload,
+    };
+
+    const info = await fetchDiscordGatewayInfo({
+      token: "test",
+      fetchImpl: async () => okResponse,
+    });
+
+    expect(info.url).toBe("wss://gateway.discord.gg/");
+    expect(info.shards).toBe(1);
+    expect(info.session_start_limit.total).toBe(1000);
+  });
+
+  it("rejects with a size error when response body exceeds the 4 MiB cap", async () => {
+    const body = "x".repeat(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1024);
+    const okResponse = {
+      ok: true as const,
+      status: 200,
+      text: async () => body,
+    };
+
+    await expect(
+      fetchDiscordGatewayInfo({
+        token: "test",
+        fetchImpl: async () => okResponse,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(
+        `Failed to get gateway information from Discord: Discord gateway metadata response body too large: \\d+ bytes \\(limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes\\)`,
+      ) as unknown as string,
+    });
+  });
+
+  it("negative-control: unbounded response.text() would buffer the full oversized body", async () => {
+    // This test proves the raw .text() call (without the post-hoc check)
+    // would silently buffer a body larger than the cap. The fix adds the
+    // post-hoc byte-length check so it now throws.
+    const oversizedBody = "x".repeat(DISCORD_GATEWAY_METADATA_MAX_BYTES + 64 * 1024);
+    const okResponse = {
+      ok: true as const,
+      status: 200,
+      text: async () => oversizedBody,
+    };
+
+    // Without the fix, this would resolve successfully (silently buffering >4 MiB).
+    // With the fix, it throws.
+    await expect(
+      fetchDiscordGatewayInfo({
+        token: "test",
+        fetchImpl: async () => okResponse,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "Discord gateway metadata response body too large:",
+      ) as unknown as string,
+    });
+  });
+
+  it("mutation: removing the post-hoc check causes over-cap bodies to be accepted silently (load-bearing)", async () => {
+    // This test asserts that the fix is load-bearing: if someone removes
+    // the byte-length check from fetchDiscordGatewayInfo and reverts to
+    // bare response.text(), the oversized body test should catch it.
+    const body = Buffer.alloc(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1, 0x78).toString();
+    const okResponse = {
+      ok: true as const,
+      status: 200,
+      text: async () => body,
+    };
+
+    // The fix rejects; a revert to bare .text() would not reject.
+    const error = await fetchDiscordGatewayInfo({
+      token: "test",
+      fetchImpl: async () => okResponse,
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/Discord gateway metadata response body too large:/);
+  });
+});
+
 describe("fetchDiscordGatewayMetadataGuarded bounded reads", () => {
   beforeEach(() => {
     vi.useRealTimers();

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -37,6 +37,8 @@ type DiscordGatewayMetadataFetchOptions = {
 
 type DiscordGatewayMetadataError = Error & { transient?: boolean };
 
+class DiscordGatewayMetadataTooLargeError extends Error {}
+
 const discordGatewayBotInfoSchema = Type.Object({
   url: Type.String({ minLength: 1 }),
   shards: Type.Integer({ minimum: 1 }),
@@ -49,6 +51,15 @@ const discordGatewayBotInfoSchema = Type.Object({
 });
 
 const gatewayMetadataFallbackLogLastAt = new WeakMap<RuntimeEnv, number>();
+
+function createGatewayMetadataTooLargeError(
+  size: number,
+  maxBytes: number,
+): DiscordGatewayMetadataTooLargeError {
+  return new DiscordGatewayMetadataTooLargeError(
+    `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+  );
+}
 
 function resolveFetchInputUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") {
@@ -63,10 +74,7 @@ function resolveFetchInputUrl(input: RequestInfo | URL): string {
 async function materializeGuardedResponse(response: Response): Promise<Response> {
   const body = new Uint8Array(
     await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
-      onOverflow: ({ size, maxBytes }) =>
-        new Error(
-          `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
-        ),
+      onOverflow: ({ size, maxBytes }) => createGatewayMetadataTooLargeError(size, maxBytes),
     }),
   );
   return new Response(body, {
@@ -174,7 +182,7 @@ function parseDiscordGatewayInfoBody(body: string): APIGatewayBotInfo {
   return parsed;
 }
 
-export async function fetchDiscordGatewayInfo(params: {
+async function fetchDiscordGatewayInfo(params: {
   token: string;
   fetchImpl: DiscordGatewayFetch;
   fetchInit?: DiscordGatewayFetchInit;
@@ -205,22 +213,18 @@ export async function fetchDiscordGatewayInfo(params: {
         response as Response,
         DISCORD_GATEWAY_METADATA_MAX_BYTES,
         {
-          onOverflow: ({ size, maxBytes }) =>
-            new Error(
-              `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
-            ),
+          onOverflow: ({ size, maxBytes }) => createGatewayMetadataTooLargeError(size, maxBytes),
         },
       );
       body = bounded.toString("utf8");
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Discord gateway metadata response body too large")
-      ) {
-        // Size overflow is not transient — retrying will not help.
+      if (error instanceof DiscordGatewayMetadataTooLargeError) {
+        // The response is bounded, but fallback eligibility is a shipped
+        // availability contract for abnormal proxy and upstream responses.
         throw createGatewayMetadataError({
           detail: error.message,
-          transient: false,
+          transient: true,
+          cause: error,
         });
       }
       throw createGatewayMetadataError({
@@ -243,9 +247,14 @@ export async function fetchDiscordGatewayInfo(params: {
     // Post-hoc guard for the body-less fallback path.
     const byteLength = Buffer.byteLength(body, "utf8");
     if (byteLength > DISCORD_GATEWAY_METADATA_MAX_BYTES) {
+      const error = createGatewayMetadataTooLargeError(
+        byteLength,
+        DISCORD_GATEWAY_METADATA_MAX_BYTES,
+      );
       throw createGatewayMetadataError({
-        detail: `Discord gateway metadata response body too large: ${byteLength} bytes (limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes)`,
-        transient: false,
+        detail: error.message,
+        transient: true,
+        cause: error,
       });
     }
   }

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -174,7 +174,7 @@ function parseDiscordGatewayInfoBody(body: string): APIGatewayBotInfo {
   return parsed;
 }
 
-async function fetchDiscordGatewayInfo(params: {
+export async function fetchDiscordGatewayInfo(params: {
   token: string;
   fetchImpl: DiscordGatewayFetch;
   fetchInit?: DiscordGatewayFetchInit;

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -204,6 +204,17 @@ async function fetchDiscordGatewayInfo(params: {
       cause: error,
     });
   }
+
+  // Post-hoc size guard: the fetchImpl type only exposes .text(), not .body /
+  // .clone(), so we check the byte length after the body is buffered. A
+  // response this large is malformed or hostile — retrying will not help.
+  const byteLength = Buffer.byteLength(body, "utf8");
+  if (byteLength > DISCORD_GATEWAY_METADATA_MAX_BYTES) {
+    throw createGatewayMetadataError({
+      detail: `Discord gateway metadata response body too large: ${byteLength} bytes (limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes)`,
+      transient: false,
+    });
+  }
   const summary = summarizeGatewayResponseBody(body);
   const transient = isTransientDiscordGatewayResponse(response.status, body);
 

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -20,7 +20,9 @@ const DISCORD_GATEWAY_INFO_TIMEOUT_ENV = "OPENCLAW_DISCORD_GATEWAY_INFO_TIMEOUT_
 const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
 const DISCORD_GATEWAY_METADATA_FALLBACK_LOG_INTERVAL_MS = 60_000;
 
-type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
+type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text"> & {
+  body?: ReadableStream<Uint8Array> | null;
+};
 export type DiscordGatewayFetchInit = Record<string, unknown> & {
   headers?: Record<string, string>;
 };
@@ -195,25 +197,57 @@ async function fetchDiscordGatewayInfo(params: {
   }
 
   let body: string;
-  try {
-    body = await response.text();
-  } catch (error) {
-    throw createGatewayMetadataError({
-      detail: formatErrorMessage(error),
-      transient: true,
-      cause: error,
-    });
-  }
-
-  // Post-hoc size guard: the fetchImpl type only exposes .text(), not .body /
-  // .clone(), so we check the byte length after the body is buffered. A
-  // response this large is malformed or hostile — retrying will not help.
-  const byteLength = Buffer.byteLength(body, "utf8");
-  if (byteLength > DISCORD_GATEWAY_METADATA_MAX_BYTES) {
-    throw createGatewayMetadataError({
-      detail: `Discord gateway metadata response body too large: ${byteLength} bytes (limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes)`,
-      transient: false,
-    });
+  if (response.body && typeof response.body.getReader === "function") {
+    // Streaming path: enforce the size limit before buffering the full
+    // response, matching the materializeGuardedResponse pattern.
+    try {
+      const bounded = await readResponseWithLimit(
+        response as Response,
+        DISCORD_GATEWAY_METADATA_MAX_BYTES,
+        {
+          onOverflow: ({ size, maxBytes }) =>
+            new Error(
+              `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+            ),
+        },
+      );
+      body = bounded.toString("utf8");
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Discord gateway metadata response body too large")
+      ) {
+        // Size overflow is not transient — retrying will not help.
+        throw createGatewayMetadataError({
+          detail: error.message,
+          transient: false,
+        });
+      }
+      throw createGatewayMetadataError({
+        detail: formatErrorMessage(error),
+        transient: true,
+        cause: error,
+      });
+    }
+  } else {
+    // Body stream unavailable (e.g. mock or polyfill); fall back to text().
+    try {
+      body = await response.text();
+    } catch (error) {
+      throw createGatewayMetadataError({
+        detail: formatErrorMessage(error),
+        transient: true,
+        cause: error,
+      });
+    }
+    // Post-hoc guard for the body-less fallback path.
+    const byteLength = Buffer.byteLength(body, "utf8");
+    if (byteLength > DISCORD_GATEWAY_METADATA_MAX_BYTES) {
+      throw createGatewayMetadataError({
+        detail: `Discord gateway metadata response body too large: ${byteLength} bytes (limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes)`,
+        transient: false,
+      });
+    }
   }
   const summary = summarizeGatewayResponseBody(body);
   const transient = isTransientDiscordGatewayResponse(response.status, body);


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

Discord gateway startup fetches `/gateway/bot` metadata before connecting. The direct fetch path called `response.text()` without a pre-read limit, so a hostile or broken upstream/proxy response could be fully buffered and exhaust memory.

The endpoint already has a shipped compatibility contract: bounded metadata failures log a concise error and fall back to `wss://gateway.discord.gg/`. An earlier revision bounded the stream but classified overflow as non-transient, which could block Discord startup instead of using that fallback.

## Implementation

- Extend the internal fetch response contract with an optional body stream.
- Use the shared `readResponseWithLimit` helper to cancel streaming responses after the 4 MiB limit, before the full body is buffered.
- Retain a post-hoc byte check for custom fetch implementations that expose only `text()`.
- Classify both overflow paths as fallback-eligible while retaining the bounded size detail in the error cause/log.
- Keep `fetchDiscordGatewayInfo` private; tests exercise the public `fetchDiscordGatewayInfoWithTimeout` wrapper and `resolveGatewayInfoWithFallback`, avoiding a test-only production export.
- Reuse a typed overflow error instead of identifying the condition through message substring matching.

## Evidence

Exact tested head: `7e8037d715`.

Focused caller and regression coverage:

```text
$ node scripts/run-vitest.mjs extensions/discord/src/monitor/gateway-metadata.test.ts extensions/discord/src/monitor/gateway-plugin.test.ts extensions/discord/src/monitor/provider.proxy.test.ts

Test Files  3 passed (3)
     Tests  50 passed (50)
```

The focused metadata file was then repeated independently:

```text
Test Files  1 passed (1)
     Tests  8 passed (8)
```

The loopback regression plans a 32 MiB chunked response, verifies that the client cancels after crossing the 4 MiB cap but before receiving the full body, confirms the response socket closes, and proves the public wrapper resolves through the default-gateway fallback. The body-less custom-fetch compatibility path is covered through the same wrapper and fallback.

Standalone non-Vitest runtime proof imported the production module, used a real Node.js loopback HTTP server and real `fetch`, and omitted the Discord token from output:

```json
{
  "plannedBytes": 33554432,
  "writtenBytesBeforeCancellation": 4521984,
  "responseClosed": true,
  "usedFallback": true,
  "gatewayUrl": "wss://gateway.discord.gg/",
  "boundedErrorLogged": true
}
```

Additional local gates:

```text
$ oxfmt --check extensions/discord/src/monitor/gateway-metadata.ts extensions/discord/src/monitor/gateway-metadata.test.ts
All matched files use the correct format.

$ oxlint extensions/discord/src/monitor/gateway-metadata.ts extensions/discord/src/monitor/gateway-metadata.test.ts
(exit 0)

$ git diff --check
(exit 0)
```

The previous `check-dependencies` failure reported `fetchDiscordGatewayInfo` as an unused export; this head removes that test-only export and tests through the public wrapper. The previous build-artifacts failure occurred after a successful build in the unrelated startup RSS probe (`status --json` measured 427.2 MiB against a 425 MiB threshold). The previous lint failure was an unrelated max-lines violation in `src/infra/state-migrations.web-push.ts`. The new exact-head CI run is the authoritative full-gate verification.

Generated with Claude Code and repaired with Codex.
