### PR TITLE
fix(docker): bound Docker GPG key download with connect timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -292,7 +292,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       # Require exactly one primary key (`pub` in --with-colons; subkeys use `sub`) so we
       # never pin the first fingerprint while apt trusts extra keys from the same file.
       # Update OPENCLAW_DOCKER_GPG_FINGERPRINT when Docker rotates release keys.
-      curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc && \
+      curl -fsSL --connect-timeout 10 --max-time 120 https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc && \
       expected_fingerprint="$(printf '%s' "$OPENCLAW_DOCKER_GPG_FINGERPRINT" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')" && \
       docker_gpg_pub_count="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == "pub" { c++ } END { print c+0 }')" && \
       if [ "$docker_gpg_pub_count" != "1" ]; then \

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -426,7 +426,7 @@ describe("Dockerfile", () => {
   it("counts primary pub keys before Docker apt fingerprint compare and dearmor", async () => {
     const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
     const anchor = dockerfile.indexOf(
-      "curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc",
+      "curl -fsSL --connect-timeout 10 --max-time 120 https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc",
     );
     expect(anchor).toBeGreaterThan(-1);
     const slice = dockerfile.slice(anchor);


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

The main `Dockerfile` downloads the Docker apt signing key from `download.docker.com` with no connect or transfer timeout. A stalled connection during image build could hang indefinitely.

## Why This Change Was Made

Add `--connect-timeout 10` and `--max-time 120` to the curl invocation at line 295. The key is under 4 KB, so 120 s is generous for a healthy transfer while bounding the worst case. This follows the same pattern already applied to sandbox Dockerfiles and CI workflow downloads.

## User Impact

Docker image builds now fail within a bounded time when Docker's key server stalls, rather than occupying the build host until an external timeout.

## Evidence

- `node scripts/run-vitest.mjs src/dockerfile.test.ts --run`: 25/25 passed.
- `git diff --check`: passed.
- The existing "counts primary pub keys" test anchor was updated to include the timeout flags in its assertion.

### Real behavior proof (controlled stalled-fetch)

Healthy path — the Docker signing key downloads in under 1 second:

```
$ curl -fsSL --connect-timeout 10 --max-time 120 -o /tmp/docker.gpg.asc   -w 'HTTP %{http_code}, time_total: %{time_total}s, size_download: %{size_download} bytes\n'   'https://download.docker.com/linux/debian/gpg'
HTTP 200, time_total: 0.690254s, size_download: 3817 bytes
$ file /tmp/docker.gpg.asc
/tmp/docker.gpg.asc: PGP public key block Public-Key (old)
```

Stalled path — connecting to a non-routable address exits within the connect-timeout bound:

```
$ curl -fsSL --connect-timeout 3 --max-time 10 -o /dev/null 'https://10.255.255.1:9999/gpg'
curl: (28) Connection timed out after 3013 milliseconds
Exit code: 28 (CURLE_OPERATION_TIMEDOUT)
Elapsed: 3s (vs >60s without --connect-timeout)
```

Without `--connect-timeout`, the same command would hang until the system TCP retransmit limit, confirming the current main-path vulnerability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)