### PR TITLE
fix(gateway): clean up stale task and abort entries on terminal chann…

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -732,6 +732,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   restartPending: false,
                   reconnectAttempts: 0,
                 });
+                if (store.tasks.get(id) === trackedPromise) {
+                  store.tasks.delete(id);
+                }
+                if (store.aborts.get(id) === abort) {
+                  store.aborts.delete(id);
+                }
                 log.info?.(`[${id}] auto-restart skipped, terminal disconnect`);
                 return;
               }


### PR DESCRIPTION
## Summary

- **Problem:** When a channel account is stopped with a `terminalDisconnect` flag (authentication failure, session termination), stale entries remain in `store.tasks` and `store.aborts`. These block future channel starts because the task guard checks `store.tasks.has(id)` before allowing a new channel run.
- **Root cause:** The terminal disconnect path cleans up recovery state (`recoveryStopTimedOut`, `recoveryStartRequested`, `restarts`) and resets the runtime, but does not mirror the `store.tasks`/`store.aborts` cleanup that the recovery stop timeout path performs at the same `.then()` level.
- **Fix:** Add the same `store.tasks.delete(id)` and `store.aborts.delete(id)` guard block to the terminal disconnect branch, matching the existing cleanup pattern used by the recovery stop timeout path.
- **Impact:** Channels that encounter a terminal disconnect (e.g., expired or revoked auth tokens, session expiry) can now be restarted without orphaned task/abort entries blocking the start guard.

## Linked context

N/A (no existing issue)

## Real behavior proof

- **Behavior or issue addressed:** Terminal disconnect path leaves stale `store.tasks`/`store.aborts` entries, blocking future channel starts.
- **Real environment tested:** Linux, Node 24, commit `33a354c655e`
- **Exact steps or command run:** `node /tmp/verify-gateway-cleanup-fix.mjs`
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):
```
[SETUP] store.tasks has id: true
[SETUP] store.aborts has id: true

--- Before fix (simulated): terminal disconnect returns without cleanup ---
[BEFORE FIX] store.tasks has id: true (should be cleaned but isn't)

--- After fix: terminal disconnect cleans up ---
[PASS] store.tasks entry cleaned
[PASS] store.aborts entry cleaned

✅ All assertions passed. Terminal disconnect path properly cleans up store.tasks and store.aborts.
```
- **Observed result after fix:** The terminal disconnect path now cleans up `store.tasks` and `store.aborts` entries, matching the behavior of the adjacent recovery stop timeout path.
- **What was not tested:** Full integration test with a real channel run, terminal disconnect trigger, and subsequent restart. The fix mirrors the identical cleanup pattern already used by the sibling recovery stop timeout branch in the same `.then()` chain.

## Tests and validation

```
$ node /tmp/verify-gateway-cleanup-fix.mjs
✅ All assertions passed.
```

The fix adds 6 lines that mirror the existing cleanup pattern used by the recovery stop timeout path (lines 746-751) at the same `.then()` level. The guard conditions (`store.tasks.get(id) === trackedPromise` and `store.aborts.get(id) === abort`) ensure only the owning task's entries are cleaned up, matching the protocol used by all other cleanup sites in the same promise chain.

## Risk checklist

- [Yes] This change is backward compatible — it only adds cleanup that was already present in sibling paths
- [No] This change affects public API
- [No] This change touches config/default surfaces
- [No] This change affects provider/plugin behavior
- [No] This change requires docs update
- [No] This change requires changelog entry