### PR TITLE
fix(cli): reject missing separator after config path brackets

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -420,6 +420,7 @@ function requireResolveSecretRefCall(index: number): [unknown, unknown] {
 }
 
 let registerConfigCli: typeof import("./config-cli.js").registerConfigCli;
+let parseConfigSetPath: typeof import("./config-cli.js").parseConfigSetPath;
 let sharedProgram: Command;
 
 async function runConfigCommand(args: string[]) {
@@ -428,7 +429,7 @@ async function runConfigCommand(args: string[]) {
 
 describe("config cli", () => {
   beforeAll(async () => {
-    ({ registerConfigCli } = await import("./config-cli.js"));
+    ({ parseConfigSetPath, registerConfigCli } = await import("./config-cli.js"));
     const { resolveConfigSecretTargetByPath } = await import("../secrets/target-registry.js");
     resolveConfigSecretTargetByPath(["channels", "googlechat", "serviceAccount"]);
     sharedProgram = new Command();
@@ -3209,49 +3210,46 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 
-    it("rejects a whitespace-only segment after a bracket before a dot", async () => {
-      await expect(runConfigCommand(["config", "get", "agents.list[0] .id"])).rejects.toThrow(
-        "Invalid path (missing separator after bracket): agents.list[0] .id",
+    it.each([
+      "agents.list[0]id",
+      "agents.list[0] id",
+      "agents.list[0]\\id",
+      "agents.list[0] .id",
+      "agents.list[0] [1]",
+    ])("rejects malformed post-bracket path %s", (configPath) => {
+      expect(() => parseConfigSetPath(configPath)).toThrow(
+        `Invalid path (missing separator after bracket): ${configPath}`,
+      );
+    });
+
+    it.each([
+      ["get", ["config", "get", "agents.list[0]id"]],
+      ["set", ["config", "set", "agents.list[0]id", '"renamed"']],
+      ["unset", ["config", "unset", "agents.list[0]id"]],
+      [
+        "batch set",
+        [
+          "config",
+          "set",
+          "--batch-json",
+          JSON.stringify([{ path: "agents.list[0]id", value: "renamed" }]),
+        ],
+      ],
+    ])("rejects malformed bracket paths for config %s", async (_command, args) => {
+      await expect(runConfigCommand(args)).rejects.toThrow(
+        "Invalid path (missing separator after bracket): agents.list[0]id",
       );
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
 
-    it("rejects a whitespace-only segment after a bracket before another bracket", async () => {
-      await expect(runConfigCommand(["config", "get", "agents.list[0] [1]"])).rejects.toThrow(
-        "Invalid path (missing separator after bracket): agents.list[0] [1]",
-      );
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects non-delimited text after a bracket path segment", async () => {
-      await expect(
-        runConfigCommand(["config", "set", "agents.list[0]id", '"renamed"']),
-      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0]id");
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects whitespace-prefixed text after a bracket path segment", async () => {
-      await expect(
-        runConfigCommand(["config", "set", "agents.list[0] id", '"renamed"']),
-      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0] id");
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-    });
-
-    it("rejects escape-prefixed continuations after a bracket path segment", async () => {
-      await expect(
-        runConfigCommand(["config", "set", "agents.list[0]\\id", '"renamed"']),
-      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0]\\id");
-
-      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    it.each([
+      ["agents.list[0].id", ["agents", "list", "0", "id"]],
+      ["agents.list[0][1]", ["agents", "list", "0", "1"]],
+      ["[0]", ["0"]],
+    ])("preserves valid bracket path %s", (configPath, expected) => {
+      expect(parseConfigSetPath(configPath)).toEqual(expected);
     });
 
     it("preserves valid bracket path forms", async () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3211,7 +3211,7 @@ describe("config cli", () => {
 
     it("rejects a whitespace-only segment after a bracket before a dot", async () => {
       await expect(runConfigCommand(["config", "get", "agents.list[0] .id"])).rejects.toThrow(
-        "Invalid path (empty segment): agents.list[0] .id",
+        "Invalid path (missing separator after bracket): agents.list[0] .id",
       );
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
@@ -3220,8 +3220,35 @@ describe("config cli", () => {
 
     it("rejects a whitespace-only segment after a bracket before another bracket", async () => {
       await expect(runConfigCommand(["config", "get", "agents.list[0] [1]"])).rejects.toThrow(
-        "Invalid path (empty segment): agents.list[0] [1]",
+        "Invalid path (missing separator after bracket): agents.list[0] [1]",
       );
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-delimited text after a bracket path segment", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "agents.list[0]id", '"renamed"']),
+      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0]id");
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects whitespace-prefixed text after a bracket path segment", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "agents.list[0] id", '"renamed"']),
+      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0] id");
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects escape-prefixed continuations after a bracket path segment", async () => {
+      await expect(
+        runConfigCommand(["config", "set", "agents.list[0]\\id", '"renamed"']),
+      ).rejects.toThrow("Invalid path (missing separator after bracket): agents.list[0]\\id");
 
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expect(mockWriteConfigFile).not.toHaveBeenCalled();

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -385,9 +385,17 @@ function parsePath(raw: string): PathSegment[] {
   // "foo[0].bar" is accepted while empty key segments (leading/trailing/double dots,
   // whitespace-only segments) are rejected instead of silently collapsed.
   let segmentEmitted = false;
+  // After `]`, only `.`, `[`, or end-of-input are legal. Bare text, whitespace, or
+  // escape continuations would invent a next segment (e.g. `foo[0]id`, `foo[0] id`).
+  let requireSeparatorAfterBracket = false;
   let i = 0;
   while (i < trimmed.length) {
     const ch = trimmed[i];
+    // Reject every post-bracket continuation before escape/text handling so
+    // whitespace and backslash cannot bypass the separator requirement.
+    if (requireSeparatorAfterBracket && ch !== "." && ch !== "[") {
+      throw new Error(`Invalid path (missing separator after bracket): ${raw}`);
+    }
     if (ch === "\\") {
       const next = trimmed[i + 1];
       if (next) {
@@ -397,6 +405,7 @@ function parsePath(raw: string): PathSegment[] {
       continue;
     }
     if (ch === ".") {
+      requireSeparatorAfterBracket = false;
       assertNotWhitespaceSegment(current, raw);
       if (!segmentEmitted && !current.trim()) {
         throw new Error(`Invalid path (empty segment): ${raw}`);
@@ -413,6 +422,8 @@ function parsePath(raw: string): PathSegment[] {
       // A bracket may start the path ("[0]"), follow a key ("foo[0]"), or follow
       // another bracket ("foo[0][1]"), but a bracket right after a "." boundary with
       // no key (e.g. "gateway.[port]") is an empty segment, same as a double dot.
+      // Post-bracket separator requirement is already satisfied by `ch === "["`
+      // above; the flag is re-armed after this bracket closes.
       assertNotWhitespaceSegment(current, raw);
       if (!current.trim() && !segmentEmitted && parts.length > 0) {
         throw new Error(`Invalid path (empty segment): ${raw}`);
@@ -431,6 +442,7 @@ function parsePath(raw: string): PathSegment[] {
       }
       parts.push(parseBracketPathSegment(inside, raw));
       segmentEmitted = true;
+      requireSeparatorAfterBracket = true;
       i = close + 1;
       continue;
     }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -365,9 +365,8 @@ function parseBracketPathSegment(raw: string, fullPath: string): string {
   return trimmed;
 }
 
-// A buffered key with characters that are all whitespace is stray text between a
-// "."/"]" and the next "."/"[" boundary (e.g. "agents.list[0] .id" or "agents.list[0] [1]").
-// Pushing it would silently collapse into a different key, so reject it like an empty segment.
+// A buffered key with characters that are all whitespace is stray text between
+// path boundaries (for example, "gateway. .port"). Reject it like an empty segment.
 function assertNotWhitespaceSegment(current: string, raw: string): void {
   if (current.length > 0 && !current.trim()) {
     throw new Error(`Invalid path (empty segment): ${raw}`);
@@ -382,20 +381,11 @@ function parsePath(raw: string): PathSegment[] {
   const parts: string[] = [];
   let current = "";
   // Tracks whether a bracket segment was emitted since the last "." boundary, so
-  // "foo[0].bar" is accepted while empty key segments (leading/trailing/double dots,
-  // whitespace-only segments) are rejected instead of silently collapsed.
+  // "foo[0].bar" is accepted while empty key segments are rejected.
   let segmentEmitted = false;
-  // After `]`, only `.`, `[`, or end-of-input are legal. Bare text, whitespace, or
-  // escape continuations would invent a next segment (e.g. `foo[0]id`, `foo[0] id`).
-  let requireSeparatorAfterBracket = false;
   let i = 0;
   while (i < trimmed.length) {
     const ch = trimmed[i];
-    // Reject every post-bracket continuation before escape/text handling so
-    // whitespace and backslash cannot bypass the separator requirement.
-    if (requireSeparatorAfterBracket && ch !== "." && ch !== "[") {
-      throw new Error(`Invalid path (missing separator after bracket): ${raw}`);
-    }
     if (ch === "\\") {
       const next = trimmed[i + 1];
       if (next) {
@@ -405,7 +395,6 @@ function parsePath(raw: string): PathSegment[] {
       continue;
     }
     if (ch === ".") {
-      requireSeparatorAfterBracket = false;
       assertNotWhitespaceSegment(current, raw);
       if (!segmentEmitted && !current.trim()) {
         throw new Error(`Invalid path (empty segment): ${raw}`);
@@ -422,8 +411,6 @@ function parsePath(raw: string): PathSegment[] {
       // A bracket may start the path ("[0]"), follow a key ("foo[0]"), or follow
       // another bracket ("foo[0][1]"), but a bracket right after a "." boundary with
       // no key (e.g. "gateway.[port]") is an empty segment, same as a double dot.
-      // Post-bracket separator requirement is already satisfied by `ch === "["`
-      // above; the flag is re-armed after this bracket closes.
       assertNotWhitespaceSegment(current, raw);
       if (!current.trim() && !segmentEmitted && parts.length > 0) {
         throw new Error(`Invalid path (empty segment): ${raw}`);
@@ -441,8 +428,11 @@ function parsePath(raw: string): PathSegment[] {
         throw new Error(`Invalid path (empty "[]"): ${raw}`);
       }
       parts.push(parseBracketPathSegment(inside, raw));
+      const next = trimmed[close + 1];
+      if (next !== undefined && next !== "." && next !== "[") {
+        throw new Error(`Invalid path (missing separator after bracket): ${raw}`);
+      }
       segmentEmitted = true;
-      requireSeparatorAfterBracket = true;
       i = close + 1;
       continue;
     }


### PR DESCRIPTION
Closes #109299

## What Problem This Solves

Malformed config paths such as `agents.list[0]id` were accepted as if they were `agents.list[0].id`. That could make config get, set, unset, and batch-set commands target a different path than the operator wrote.

## Why This Change Was Made

The shared config-path parser now checks the character immediately after each closing bracket. Only `.`, another `[`, or end-of-input is accepted. Bare text, whitespace, and backslash continuations fail before config is read or written.

Valid forms such as `foo[0].bar`, `foo[0][1]`, and `[0]` remain accepted. The compatibility impact is intentional and limited to previously undocumented malformed paths.

## User Impact

Typoed bracket paths fail with a clear error instead of silently targeting another config location.

## Evidence

```text
node scripts/run-vitest.mjs src/cli/config-cli.test.ts

Test Files  1 passed (1)
Tests       141 passed (141)
```

The table-driven regression coverage includes bare text, whitespace, escaped continuations, whitespace before dot/bracket separators, valid dotted/consecutive/root brackets, and the config get, set, unset, and batch-set callers.

```text
node scripts/run-oxlint.mjs src/cli/config-cli.ts src/cli/config-cli.test.ts
./node_modules/.bin/oxfmt --check src/cli/config-cli.ts src/cli/config-cli.test.ts
git diff --check origin/main...HEAD
```

All passed. The hosted changed gate also passed conflict, max-lines, changelog-attribution, export, duplicate, dependency-pin, and touched-format checks. It stopped only on unrelated current-main Plugin SDK baseline drift: https://github.com/openclaw/openclaw/actions/runs/29573555988

## Real behavior proof

- Malformed paths throw `Invalid path (missing separator after bracket)` before config I/O.
- Valid dot, adjacent-bracket, and root-bracket forms return the expected path segments.
- Existing escaped-dot behavior remains covered.

---

This PR was authored with AI assistance (Grok).

Co-authored-by: wuqingxuan <wu.qingxuan@xydigit.com>
