### PR TITLE
fix(scripts): restore isDirectReleaseCandidateExecution declaration

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -73,6 +73,14 @@ export function buildTelegramArtifactInputs(params: {
   sourceSha: string;
 }): Record<string, string | number>;
 /**
+ * Detects whether the checklist module is being executed directly.
+ */
+export function isDirectReleaseCandidateExecution(
+  directPath: string | undefined,
+  modulePath: string,
+  resolveRealPath?: (path: string) => string,
+): boolean;
+/**
  * Calls the GitHub REST API with the gh-auth token and a bounded timeout.
  */
 export function githubApi(path: unknown, options?: Record<string, unknown>): Promise<unknown>;


### PR DESCRIPTION
## What Problem This Solves

`check-test-types` fails repo-wide on `main`: `test/scripts/release-candidate-checklist.test.ts` gets TS2305 because `scripts/release-candidate-checklist.d.mts` no longer declares `isDirectReleaseCandidateExecution` at all.

## Why This Change Was Made

Two parallel fixes each removed one of the two duplicate declarations: #109553 (082ffd442ae) and #109560 (69b2916dd60). Merged together they removed both copies. The second merge was not caught because prepare reused a patch-identical pre-rebase CI run, which masked the semantic conflict. This PR restores exactly one documented declaration matching the `.mjs` implementation signature.

## User Impact

Unblocks `check-test-types` / `ci-gate` for all open PRs; declarations-only change, no runtime behavior.

## Evidence

- `pnpm tsgo:test` (full test-types lane): green with the restored declaration.
- `node scripts/run-oxlint.mjs scripts/release-candidate-checklist.d.mts`: zero findings (exactly one declaration, no adjacent-overload issue).
- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts`: pass.
