### PR TITLE
fix(docker): explain unsupported E2E resource limits

### DIFF
--- a/scripts/lib/docker-e2e-container.sh
+++ b/scripts/lib/docker-e2e-container.sh
@@ -3,6 +3,9 @@
 # Shared helpers for Docker E2E scripts that keep a named container running
 # while polling readiness from the host.
 
+DOCKER_E2E_CONTAINER_LIB_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+source "$DOCKER_E2E_CONTAINER_LIB_DIR/docker-e2e-resource-diagnostics.sh"
+
 docker_e2e_timeout_bin() {
   if command -v timeout >/dev/null 2>&1; then
     printf '%s\n' timeout
@@ -142,11 +145,7 @@ docker_e2e_docker_cmd() {
   if [ "${1:-}" = "run" ]; then
     shift
     docker_e2e_docker_run_resource_args "$@" || return $?
-    if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-      docker_e2e_timeout_cmd "$timeout_value" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
-    else
-      docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
-    fi
+    docker_e2e_docker_run_with_resource_diagnostics "$timeout_value" "$@"
     return
   fi
   docker_e2e_timeout_cmd "$timeout_value" docker "$@"
@@ -157,11 +156,7 @@ docker_e2e_docker_run_cmd() {
   if [ "${1:-}" = "run" ]; then
     shift
     docker_e2e_docker_run_resource_args "$@" || return $?
-    if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-      docker_e2e_timeout_cmd "$timeout_value" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
-    else
-      docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
-    fi
+    docker_e2e_docker_run_with_resource_diagnostics "$timeout_value" "$@"
     return
   fi
   docker_e2e_timeout_cmd "$timeout_value" docker "$@"

--- a/scripts/lib/docker-e2e-container.sh
+++ b/scripts/lib/docker-e2e-container.sh
@@ -3,7 +3,13 @@
 # Shared helpers for Docker E2E scripts that keep a named container running
 # while polling readiness from the host.
 
-DOCKER_E2E_CONTAINER_LIB_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+DOCKER_E2E_CONTAINER_LIB_DIR="${BASH_SOURCE[0]}"
+if [[ "$DOCKER_E2E_CONTAINER_LIB_DIR" == */* ]]; then
+  DOCKER_E2E_CONTAINER_LIB_DIR="${DOCKER_E2E_CONTAINER_LIB_DIR%/*}"
+else
+  DOCKER_E2E_CONTAINER_LIB_DIR=.
+fi
+DOCKER_E2E_CONTAINER_LIB_DIR="$(cd "$DOCKER_E2E_CONTAINER_LIB_DIR" && pwd)"
 source "$DOCKER_E2E_CONTAINER_LIB_DIR/docker-e2e-resource-diagnostics.sh"
 
 docker_e2e_timeout_bin() {

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -7,6 +7,10 @@
 DOCKER_E2E_PACKAGE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="${ROOT_DIR:-$(cd "$DOCKER_E2E_PACKAGE_LIB_DIR/../.." && pwd)}"
 
+if ! declare -F docker_e2e_docker_run_with_resource_diagnostics >/dev/null 2>&1; then
+  source "$DOCKER_E2E_PACKAGE_LIB_DIR/docker-e2e-resource-diagnostics.sh"
+fi
+
 if ! declare -F run_logged >/dev/null 2>&1; then
   source "$DOCKER_E2E_PACKAGE_LIB_DIR/docker-e2e-logs.sh"
 fi
@@ -108,30 +112,10 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
     fi
   }
 fi
-if ! declare -F docker_e2e_docker_run_cmd >/dev/null 2>&1; then
-  docker_e2e_docker_run_cmd() {
-    if [ "${1:-}" = "run" ]; then
-      shift
-      docker_e2e_docker_run_resource_args "$@" || return $?
-      if declare -F docker_e2e_timeout_cmd >/dev/null 2>&1; then
-        if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-          docker_e2e_timeout_cmd "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
-        else
-          docker_e2e_timeout_cmd "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" docker run "$@"
-        fi
-        return
-      fi
-      if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-        set -- run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
-      else
-        set -- run "$@"
-      fi
-    fi
-    if declare -F docker_e2e_timeout_cmd >/dev/null 2>&1; then
-      docker_e2e_timeout_cmd "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" docker "$@"
-      return
-    fi
-    local timeout_value="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}"
+if ! declare -F docker_e2e_timeout_cmd >/dev/null 2>&1; then
+  docker_e2e_timeout_cmd() {
+    local timeout_value="$1"
+    shift
     local timeout_bin=""
     if command -v timeout >/dev/null 2>&1; then
       timeout_bin="timeout"
@@ -140,14 +124,27 @@ if ! declare -F docker_e2e_docker_run_cmd >/dev/null 2>&1; then
     fi
     if [ -n "$timeout_bin" ]; then
       if "$timeout_bin" --kill-after=1s 1s true >/dev/null 2>&1; then
-        "$timeout_bin" --kill-after=30s "$timeout_value" docker "$@"
+        "$timeout_bin" --kill-after=30s "$timeout_value" "$@"
       else
-        "$timeout_bin" "$timeout_value" docker "$@"
+        "$timeout_bin" "$timeout_value" "$@"
       fi
       return
     fi
     echo "timeout command not found; cannot bound Docker run after ${timeout_value}" >&2
     return 127
+  }
+fi
+if ! declare -F docker_e2e_docker_run_cmd >/dev/null 2>&1; then
+  docker_e2e_docker_run_cmd() {
+    if [ "${1:-}" = "run" ]; then
+      shift
+      docker_e2e_docker_run_resource_args "$@" || return $?
+      docker_e2e_docker_run_with_resource_diagnostics \
+        "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" \
+        "$@"
+      return
+    fi
+    docker_e2e_timeout_cmd "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" docker "$@"
   }
 fi
 

--- a/scripts/lib/docker-e2e-resource-diagnostics.sh
+++ b/scripts/lib/docker-e2e-resource-diagnostics.sh
@@ -112,7 +112,15 @@ docker_e2e_docker_run_with_resource_diagnostics() {
   elif [ -x /usr/bin/mkfifo ]; then
     mkfifo_bin=/usr/bin/mkfifo
   fi
-  if [ -z "$mkfifo_bin" ] || ! "$mkfifo_bin" "$stderr_fifo" "$capture_fifo"; then
+  local fifo_status=1
+  if [ -n "$mkfifo_bin" ]; then
+    local previous_umask=""
+    previous_umask="$(umask)"
+    umask 077
+    "$mkfifo_bin" "$stderr_fifo" "$capture_fifo" && fifo_status=0 || fifo_status="$?"
+    umask "$previous_umask"
+  fi
+  if [ "$fifo_status" -ne 0 ]; then
     docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo" "$capture_fifo"
     docker_e2e_timeout_cmd \
       "$timeout_value" \

--- a/scripts/lib/docker-e2e-resource-diagnostics.sh
+++ b/scripts/lib/docker-e2e-resource-diagnostics.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+docker_e2e_resource_limit_error_file() {
+  local status="$1"
+  local stderr_file="$2"
+  local line
+  [ "$status" = "125" ] || return 1
+
+  local text=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    text="${text}${line}
+"
+  done <"$stderr_file"
+
+  case "$text" in
+    *"controller pids is not available"* | *"cgroup controller pids is not available"* | \
+      *"NanoCPUs can not be set"* | *"CPU CFS scheduler"* | \
+      *"cgroup is not mounted"* | *"cgroup not mounted"* | \
+      *"resource limit not supported"* | *"resource limits not supported"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+docker_e2e_resource_limit_stderr_file() {
+  local template="${TMPDIR:-/tmp}/openclaw-docker-resource-limits.XXXXXX"
+  if command -v mktemp >/dev/null 2>&1; then
+    mktemp "$template"
+    return
+  fi
+  if [ -x /usr/bin/mktemp ]; then
+    /usr/bin/mktemp "$template"
+    return
+  fi
+  echo "mktemp command not found; cannot capture Docker resource-limit diagnostics" >&2
+  return 127
+}
+
+docker_e2e_tee_bin() {
+  if command -v tee >/dev/null 2>&1; then
+    command -v tee
+    return
+  fi
+  if [ -x /usr/bin/tee ]; then
+    printf '%s\n' /usr/bin/tee
+    return
+  fi
+  return 1
+}
+
+docker_e2e_remove_diagnostic_file() {
+  if command -v rm >/dev/null 2>&1; then
+    rm -f "$@"
+    return
+  fi
+  /bin/rm -f "$@"
+}
+
+docker_e2e_print_resource_limit_error() {
+  echo "Docker E2E resource limits are incompatible with this Docker runtime. Fix its cgroup support or explicitly opt out with OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1." >&2
+}
+
+docker_e2e_docker_run_with_resource_diagnostics() {
+  local timeout_value="$1"
+  shift
+  if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -eq 0 ]; then
+    docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
+    return
+  fi
+
+  local stderr_file=""
+  if ! stderr_file="$(docker_e2e_resource_limit_stderr_file)"; then
+    docker_e2e_timeout_cmd \
+      "$timeout_value" \
+      docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
+    return
+  fi
+  local tee_bin=""
+  if ! tee_bin="$(docker_e2e_tee_bin)"; then
+    docker_e2e_remove_diagnostic_file "$stderr_file"
+    docker_e2e_timeout_cmd \
+      "$timeout_value" \
+      docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
+    return
+  fi
+  local stderr_fifo="${stderr_file}.pipe"
+  local mkfifo_bin=""
+  if command -v mkfifo >/dev/null 2>&1; then
+    mkfifo_bin="$(command -v mkfifo)"
+  elif [ -x /usr/bin/mkfifo ]; then
+    mkfifo_bin=/usr/bin/mkfifo
+  fi
+  if [ -z "$mkfifo_bin" ] || ! "$mkfifo_bin" "$stderr_fifo"; then
+    docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo"
+    docker_e2e_timeout_cmd \
+      "$timeout_value" \
+      docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
+    return
+  fi
+
+  "$tee_bin" "$stderr_file" <"$stderr_fifo" >&2 &
+  local tee_pid="$!"
+  local run_status=0
+  if docker_e2e_timeout_cmd \
+    "$timeout_value" \
+    docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@" \
+    2>"$stderr_fifo"; then
+    run_status=0
+  else
+    run_status="$?"
+  fi
+  wait "$tee_pid" || true
+
+  if docker_e2e_resource_limit_error_file "$run_status" "$stderr_file"; then
+    docker_e2e_print_resource_limit_error
+  fi
+  docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo"
+  return "$run_status"
+}

--- a/scripts/lib/docker-e2e-resource-diagnostics.sh
+++ b/scripts/lib/docker-e2e-resource-diagnostics.sh
@@ -49,6 +49,18 @@ docker_e2e_tee_bin() {
   return 1
 }
 
+docker_e2e_tail_bin() {
+  if command -v tail >/dev/null 2>&1; then
+    command -v tail
+    return
+  fi
+  if [ -x /usr/bin/tail ]; then
+    printf '%s\n' /usr/bin/tail
+    return
+  fi
+  return 1
+}
+
 docker_e2e_remove_diagnostic_file() {
   if command -v rm >/dev/null 2>&1; then
     rm -f "$@"
@@ -84,22 +96,33 @@ docker_e2e_docker_run_with_resource_diagnostics() {
       docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
     return
   fi
-  local stderr_fifo="${stderr_file}.pipe"
+  local tail_bin=""
+  if ! tail_bin="$(docker_e2e_tail_bin)"; then
+    docker_e2e_remove_diagnostic_file "$stderr_file"
+    docker_e2e_timeout_cmd \
+      "$timeout_value" \
+      docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
+    return
+  fi
+  local stderr_fifo="${stderr_file}.stderr.pipe"
+  local capture_fifo="${stderr_file}.capture.pipe"
   local mkfifo_bin=""
   if command -v mkfifo >/dev/null 2>&1; then
     mkfifo_bin="$(command -v mkfifo)"
   elif [ -x /usr/bin/mkfifo ]; then
     mkfifo_bin=/usr/bin/mkfifo
   fi
-  if [ -z "$mkfifo_bin" ] || ! "$mkfifo_bin" "$stderr_fifo"; then
-    docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo"
+  if [ -z "$mkfifo_bin" ] || ! "$mkfifo_bin" "$stderr_fifo" "$capture_fifo"; then
+    docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo" "$capture_fifo"
     docker_e2e_timeout_cmd \
       "$timeout_value" \
       docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
     return
   fi
 
-  "$tee_bin" "$stderr_file" <"$stderr_fifo" >&2 &
+  "$tail_bin" -c 65536 <"$capture_fifo" >"$stderr_file" &
+  local tail_pid="$!"
+  "$tee_bin" "$capture_fifo" <"$stderr_fifo" >&2 &
   local tee_pid="$!"
   local run_status=0
   if docker_e2e_timeout_cmd \
@@ -111,10 +134,11 @@ docker_e2e_docker_run_with_resource_diagnostics() {
     run_status="$?"
   fi
   wait "$tee_pid" || true
+  wait "$tail_pid" || true
 
   if docker_e2e_resource_limit_error_file "$run_status" "$stderr_file"; then
     docker_e2e_print_resource_limit_error
   fi
-  docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo"
+  docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo" "$capture_fifo"
   return "$run_status"
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -635,7 +635,7 @@ docker_build_run e2e-build -t demo-image .
       chmodSync(join(workDir, "runner.sh"), 0o755);
 
       const waitForFile = async (filePath: string) => {
-        for (let attempt = 0; attempt < 100; attempt += 1) {
+        for (let attempt = 0; attempt < 500; attempt += 1) {
           if (existsSync(filePath)) {
             return;
           }
@@ -648,7 +648,7 @@ docker_build_run e2e-build -t demo-image .
           child.once("exit", (code, signal) => resolve({ code, signal }));
         });
       const waitForDead = async (pid: number) => {
-        for (let attempt = 0; attempt < 100; attempt += 1) {
+        for (let attempt = 0; attempt < 500; attempt += 1) {
           try {
             process.kill(pid, 0);
           } catch {
@@ -1336,6 +1336,11 @@ docker() {
   return 125
 }
 
+tail() {
+  printf "%s\\n" "$*" >"$TMPDIR/tail-seen"
+  /usr/bin/tail "$@"
+}
+
 source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
 docker_e2e_timeout_cmd() {
   shift
@@ -1343,16 +1348,19 @@ docker_e2e_timeout_cmd() {
 }
 
 set +e
-docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
+printf "before Docker\\n" >"$TMPDIR/stderr"
+docker_e2e_docker_cmd run demo 2>>"$TMPDIR/stderr"
 status="$?"
 set -e
 
 stderr="$(<"$TMPDIR/stderr")"
 [[ "$status" = "125" ]]
+[[ "$stderr" = before\\ Docker* ]]
 [[ "$stderr" = *"NanoCPUs can not be set"* ]]
 [[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
 [[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
 [[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+[[ "$(<"$TMPDIR/tail-seen")" = "-c 65536" ]]
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1336,6 +1336,11 @@ docker() {
   return 125
 }
 
+mkfifo() {
+  umask >"$TMPDIR/mkfifo-umask"
+  /usr/bin/mkfifo "$@"
+}
+
 tail() {
   printf "%s\\n" "$*" >"$TMPDIR/tail-seen"
   /usr/bin/tail "$@"
@@ -1361,6 +1366,7 @@ stderr="$(<"$TMPDIR/stderr")"
 [[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
 [[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
 [[ "$(<"$TMPDIR/tail-seen")" = "-c 65536" ]]
+[[ "$(<"$TMPDIR/mkfifo-umask")" = "0077" ]]
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1317,7 +1317,7 @@ OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1 docker_e2e_docker_cmd run demo
   });
 
   it("explains how to opt out when Docker rejects default resource limits", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-diagnostic-"));
+    const workDir = tempDirs.make("openclaw-docker-resource-diagnostic-");
 
     try {
       const rootDir = process.cwd();
@@ -1362,7 +1362,7 @@ stderr="$(<"$TMPDIR/stderr")"
   });
 
   it("does not suggest resource opt-out for other Docker failures", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-unrelated-"));
+    const workDir = tempDirs.make("openclaw-docker-resource-unrelated-");
 
     try {
       const rootDir = process.cwd();
@@ -1406,7 +1406,7 @@ stderr="$(<"$TMPDIR/stderr")"
   });
 
   it("runs Docker when resource diagnostic capture is unavailable", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-no-temp-"));
+    const workDir = tempDirs.make("openclaw-docker-resource-no-temp-");
 
     try {
       const rootDir = process.cwd();
@@ -1791,7 +1791,7 @@ docker_e2e_docker_run_cmd run demo
   });
 
   it("diagnoses rejected resource limits in the package-backed fallback", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-package-diagnostic-"));
+    const workDir = tempDirs.make("openclaw-docker-package-diagnostic-");
 
     try {
       const rootDir = process.cwd();

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1316,6 +1316,136 @@ OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1 docker_e2e_docker_cmd run demo
     }
   });
 
+  it("explains how to opt out when Docker rejects default resource limits", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-diagnostic-"));
+
+    try {
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "docker: Error response from daemon: NanoCPUs can not be set, as the cgroup is not mounted" >&2
+  return 125
+}
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+docker_e2e_timeout_cmd() {
+  shift
+  "$@"
+}
+
+set +e
+docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$status" = "125" ]]
+[[ "$stderr" = *"NanoCPUs can not be set"* ]]
+[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
+[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not suggest resource opt-out for other Docker failures", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-unrelated-"));
+
+    try {
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "docker: Error response from daemon: No such image: cgroup-helper" >&2
+  return 125
+}
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+docker_e2e_timeout_cmd() {
+  shift
+  "$@"
+}
+
+set +e
+docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$status" = "125" ]]
+[[ "$stderr" = *"No such image: cgroup-helper"* ]]
+[[ "$stderr" != *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS"* ]]
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs Docker when resource diagnostic capture is unavailable", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-no-temp-"));
+
+    try {
+      const rootDir = process.cwd();
+      const missingTmpDir = join(workDir, "missing");
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(missingTmpDir)}
+export ROOT_DIR TMPDIR
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+docker() {
+  printf "%s\\n" "$*" >>${shellQuote(join(workDir, "docker-seen"))}
+  return 7
+}
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+docker_e2e_timeout_cmd() {
+  shift
+  "$@"
+}
+
+set +e
+docker_e2e_docker_cmd run demo 2>/dev/null
+status="$?"
+set -e
+
+[[ "$status" = "7" ]]
+[[ "$(grep -c '^run ' ${shellQuote(join(workDir, "docker-seen"))})" = "1" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects invalid Docker run pids limits before invoking docker", () => {
     const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-pids-"));
 
@@ -1652,6 +1782,59 @@ docker_e2e_docker_run_cmd run demo
 
 [[ "$(<"$TMPDIR/timeout-seen")" = "gtimeout:--kill-after=30s 15s|docker run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
 [[ "$(<"$TMPDIR/docker-seen")" = "run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("diagnoses rejected resource limits in the package-backed fallback", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-package-diagnostic-"));
+
+    try {
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+timeout() {
+  if [[ "$1" = "--kill-after=1s" ]]; then
+    return 0
+  fi
+  shift 2
+  "$@"
+}
+
+docker_e2e_docker_cmd() {
+  return 0
+}
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "OCI runtime create failed: crun: controller pids is not available" >&2
+  return 125
+}
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+set +e
+docker_e2e_docker_run_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$status" = "125" ]]
+[[ "$stderr" = *"controller pids is not available"* ]]
+[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
+[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });


### PR DESCRIPTION
Related: #98601

AI-assisted maintainer change approved by Peter.

## What Problem This Solves

Fixes an issue where operators running Docker E2E on a runtime without the required cgroup resource controllers would receive a low-level Docker failure without an actionable explanation.

## Why This Change Was Made

Keep resource limits fail-closed and make recognized Docker runtime incompatibilities actionable. The original error and exit status remain intact, Docker runs only once, live stderr remains streamed, and only a 64 KiB tail is retained for classification. The diagnostic points to the existing explicit `OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1` opt-out instead of silently retrying with weaker constraints.

## User Impact

Operators can distinguish an incompatible Docker runtime from other Docker failures and deliberately choose whether to repair cgroup support or opt out of E2E resource limits.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` — 173 passed.
- `bash -n scripts/lib/docker-e2e-resource-diagnostics.sh scripts/lib/docker-e2e-container.sh scripts/lib/docker-e2e-package.sh` — passed.
- `node scripts/check-docker-e2e-boundaries.mjs` — passed.
- `git diff --check` — passed.
- Docker build signal-interruption regression — 5/5 repeated focused runs passed after raising its brittle one-second wait budget to five seconds.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean after fixing all accepted findings, including best-effort capture setup, Bash 3.2 synchronization, package fallback coverage, bounded capture, basename sourcing, and redirected-stderr preservation.
- Blacksmith changed gate passed all pre-typecheck lanes; its stale delegated checkout reproduced an unrelated release-checklist export failure already fixed on current `main`. Exact-head PR CI is the landing gate.
