### PR TITLE
fix(opencode): preserve Unicode in catalog tool input

### DIFF
--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -86,6 +86,7 @@ function captureOpenCodeSessionRegistrations(pluginConfig: unknown = {}) {
 async function installFakeOpenCode(
   assistantText = "hi",
   sessionTitle = "Catalog session",
+  toolInput: unknown = { command: "pwd" },
 ): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opencode-catalog-"));
   temporaryDirectories.push(directory);
@@ -125,7 +126,7 @@ async function installFakeOpenCode(
             id: "prt_tool",
             type: "tool",
             tool: "bash",
-            state: { status: "completed", input: { command: "pwd" }, output: "/workspace" },
+            state: { status: "completed", input: toolInput, output: "/workspace" },
           },
         ],
       },
@@ -296,6 +297,25 @@ describe("OpenCode session catalog", () => {
       const answer = transcript.items.find((item) => item.type === "agentMessage");
       expect(answer?.text?.endsWith("…")).toBe(true);
       expect(Buffer.byteLength(JSON.stringify(transcript), "utf8")).toBeLessThan(20 * 1024 * 1024);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps truncated tool input on a valid UTF-16 boundary",
+    async () => {
+      await installFakeOpenCode("hi", "Catalog session", {
+        value: `${"x".repeat(19_989)}🎉`,
+      });
+      const transcript = await readLocalOpenCodeTranscriptPage({
+        threadId: "ses_test",
+        limit: 20,
+      });
+      const toolCall = transcript.items.find((item) => item.type === "toolCall");
+
+      expect(toolCall?.text).toMatch(/…$/u);
+      expect(toolCall?.text).not.toMatch(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+      );
     },
   );
 

--- a/extensions/opencode/session-catalog.ts
+++ b/extensions/opencode/session-catalog.ts
@@ -6,6 +6,7 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
@@ -352,7 +353,7 @@ export async function listLocalOpenCodeSessionPage(value?: unknown): Promise<Ope
 function jsonText(value: unknown, maxLength = 20_000): string | undefined {
   try {
     const text = JSON.stringify(value);
-    return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+    return text.length > maxLength ? `${truncateUtf16Safe(text, maxLength)}…` : text;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing an OpenCode session catalog could receive malformed Unicode in long tool input when the 20,000-character display limit landed inside an emoji's UTF-16 surrogate pair.

## Why This Change Was Made

The catalog now uses the existing UTF-16-safe truncation helper before appending its ellipsis. This changes only the over-limit boundary; CLI invocation, parsing, limits, and paging remain unchanged. The main risk is altering catalog text length by one code unit at a split pair, covered through the production reader and its real child-process boundary.

## User Impact

Long OpenCode tool input retains valid Unicode at the catalog boundary instead of producing a replacement character when encoded for transport or display.

## Evidence

I ran the same throwaway TypeScript probe against the real exported `readLocalOpenCodeTranscriptPage` function. It spawned a real child process at the OpenCode CLI seam, returned the official export JSON shape, and placed `🎉` across code-unit positions 19,999–20,000 in tool input; only the upstream CLI response was controlled.

Before the fix, with the production truncation line restored to `slice(0, maxLength)`:

```text
{"productionEntry":"readLocalOpenCodeTranscriptPage","realChildProcess":true,"unpaired":true,"utf8RoundTrip":false}
exit 1
```

After the fix:

```text
{"productionEntry":"readLocalOpenCodeTranscriptPage","realChildProcess":true,"unpaired":false,"utf8RoundTrip":true}
exit 0
```

Focused regression suite after rebasing onto current `upstream/main`:

```text
node scripts/run-vitest.mjs extensions/opencode/session-catalog.test.ts
Test Files  1 passed (1)
Tests  12 passed (12)
```

Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed. Full repository gates are left to fork CI. I did not use a persistent live OpenCode session; the proof drives the production child-process invocation, export parser, transcript mapper, and catalog output, while controlling only the CLI payload needed to place the exact boundary.

AI-assisted: Codex helped implement and review the change; the behavior proof and tests above were run manually.
