### PR TITLE
fix(doctor): preserve Unicode in migration issue reports

### DIFF
--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -460,14 +460,13 @@ export function createSessionSqliteMigrationFailureIssue(
     "OpenClaw doctor generated this sanitized report from a local session SQLite migration recovery.",
     "",
     reportBody,
-  ]
-    .join("\n")
-    .slice(0, 20_000);
+  ].join("\n");
+  const boundedBody = truncateUtf16Safe(body, 20_000);
   return {
-    body,
+    body: boundedBody,
     ...(bodyPath ? { bodyPath } : {}),
     title,
-    url: createPrefilledGithubIssueUrl(title, body),
+    url: createPrefilledGithubIssueUrl(title, boundedBody),
   };
 }
 

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { z } from "zod";
 import { resolveStateDir } from "../config/paths.js";
 import * as replaceFile from "../infra/replace-file.js";
@@ -862,7 +863,7 @@ function manifestSortTime(manifest: SessionSqliteMigrationManifest): number {
 function createPrefilledGithubIssueUrl(title: string, body: string): string {
   const urlBody =
     body.length > 6_000
-      ? `${body.slice(0, 6_000)}\n\n...(truncated for URL; see local failure report for the full sanitized body)`
+      ? `${truncateUtf16Safe(body, 6_000)}\n\n...(truncated for URL; see local failure report for the full sanitized body)`
       : body;
   const params = new URLSearchParams({
     body: urlBody,

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1576,7 +1576,10 @@ describe("runDoctorSessionSqlite", () => {
         targets: Array.from({ length: targetCount }, (_, index) => {
           const targetMessages = index === targetCount - 1 ? messages : ["x".repeat(500)];
           return {
-            agentId: `agent-${index}-${"long-name-".repeat(10)}`,
+            agentId:
+              targetCount === 1
+                ? "agent-with-long-name-".repeat(10)
+                : `agent-${index}-${"long-name-".repeat(10)}`,
             completedMoves: [],
             issues: targetMessages.map((message) => ({ code: "startup_failure", message })),
             plannedMoves: [],

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1566,24 +1566,25 @@ describe("runDoctorSessionSqlite", () => {
   it("keeps truncated GitHub issue bodies on a valid UTF-16 boundary", () => {
     const store = createLegacyStore();
     const manifestPath = path.join(store.tempDir, "failed-migration.json");
-    const writeManifest = (messages: string[]) => {
+    const writeManifest = (messages: string[], targetCount = 1) => {
       const manifest: SessionSqliteMigrationManifest = {
         failedAt: "2030-01-01T00:00:00.000Z",
         manifestVersion: 2,
         openClawVersion: "test",
         runId: "utf16-boundary",
         startedAt: "2030-01-01T00:00:00.000Z",
-        targets: [
-          {
-            agentId: "agent-with-long-name-".repeat(10),
+        targets: Array.from({ length: targetCount }, (_, index) => {
+          const targetMessages = index === targetCount - 1 ? messages : ["x".repeat(500)];
+          return {
+            agentId: `agent-${index}-${"long-name-".repeat(10)}`,
             completedMoves: [],
-            issues: messages.map((message) => ({ code: "startup_failure", message })),
+            issues: targetMessages.map((message) => ({ code: "startup_failure", message })),
             plannedMoves: [],
             sqlitePath: path.join(store.tempDir, "openclaw-agent.sqlite"),
             storePath: store.storePath,
             validationBeforeArchive: "failed",
-          },
-        ],
+          };
+        }),
       };
       fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
     };
@@ -1600,6 +1601,27 @@ describe("runDoctorSessionSqlite", () => {
     const urlBody = new URL(issue?.url ?? "").searchParams.get("body");
     expect(urlBody).not.toContain("�");
     expect(urlBody).toContain("truncated for URL");
+
+    let bodyTargetCount = 0;
+    let bodyMessageOffset = -1;
+    for (let count = 1; count < 50; count += 1) {
+      writeManifest(["BODY_START"], count);
+      const candidateIssue = createSessionSqliteMigrationFailureIssue(manifestPath);
+      const candidateOffset = candidateIssue?.body.indexOf("BODY_START") ?? -1;
+      if (candidateOffset < 0) {
+        break;
+      }
+      bodyTargetCount = count;
+      bodyMessageOffset = candidateOffset;
+    }
+    expect(bodyMessageOffset).toBeGreaterThanOrEqual(0);
+    expect(19_999 - bodyMessageOffset).toBeLessThan(600);
+
+    writeManifest([`${"x".repeat(19_999 - bodyMessageOffset)}🎉tail`], bodyTargetCount);
+    const bodyIssue = createSessionSqliteMigrationFailureIssue(manifestPath);
+    expect(bodyIssue?.body).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
   });
 
   it("recovers only manifests matching an explicit store selector", async () => {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -24,6 +24,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   assertSafeSessionSqliteMigrationMove,
+  createSessionSqliteMigrationFailureIssue,
   restoreSessionSqliteMigrationRun,
   type ActiveSessionSqliteMigrationRun,
 } from "./doctor-session-sqlite-migration-run.js";
@@ -1560,6 +1561,45 @@ describe("runDoctorSessionSqlite", () => {
       expect(recover.supportIssue?.body).not.toContain(process.env.HOME);
     }
     expect(recover.supportIssue?.url).toContain("github.com/openclaw/openclaw/issues/new");
+  });
+
+  it("keeps truncated GitHub issue bodies on a valid UTF-16 boundary", () => {
+    const store = createLegacyStore();
+    const manifestPath = path.join(store.tempDir, "failed-migration.json");
+    const writeManifest = (messages: string[]) => {
+      const manifest: SessionSqliteMigrationManifest = {
+        failedAt: "2030-01-01T00:00:00.000Z",
+        manifestVersion: 2,
+        openClawVersion: "test",
+        runId: "utf16-boundary",
+        startedAt: "2030-01-01T00:00:00.000Z",
+        targets: [
+          {
+            agentId: "agent-with-long-name-".repeat(10),
+            completedMoves: [],
+            issues: messages.map((message) => ({ code: "startup_failure", message })),
+            plannedMoves: [],
+            sqlitePath: path.join(store.tempDir, "openclaw-agent.sqlite"),
+            storePath: store.storePath,
+            validationBeforeArchive: "failed",
+          },
+        ],
+      };
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+    };
+
+    const baseMessages = Array.from({ length: 9 }, () => "x".repeat(500));
+    writeManifest([...baseMessages, "MESSAGE_START"]);
+    const probe = createSessionSqliteMigrationFailureIssue(manifestPath);
+    const messageOffset = probe?.body.indexOf("MESSAGE_START") ?? -1;
+    expect(5_999 - messageOffset).toBeLessThan(500);
+
+    writeManifest([...baseMessages, `${"x".repeat(5_999 - messageOffset)}🎉tail`]);
+    const issue = createSessionSqliteMigrationFailureIssue(manifestPath);
+    expect(issue?.body).toContain("🎉tail");
+    const urlBody = new URL(issue?.url ?? "").searchParams.get("body");
+    expect(urlBody).not.toContain("�");
+    expect(urlBody).toContain("truncated for URL");
   });
 
   it("recovers only manifests matching an explicit store selector", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a long OpenClaw doctor migration recovery report could contain a replacement character in its prefilled GitHub issue URL when the 6,000-character URL limit landed inside an emoji's UTF-16 surrogate pair.

## Why This Change Was Made

The URL builder now uses the existing UTF-16-safe truncation helper before adding its truncation notice. The report contents, URL limit, sanitization, and recovery flow remain unchanged. The main risk is shifting the cutoff back by one code unit at a split pair, covered through the production failure-report and URL generation path.

## User Impact

Operators opening a generated migration-recovery issue retain valid Unicode at the URL boundary instead of seeing `U+FFFD` in the report body.

## Evidence

I ran the same throwaway TypeScript probe against the real exported `createSessionSqliteMigrationFailureIssue` function with a real temporary migration manifest. The source report contained `🎉tail`, with the emoji placed across code-unit positions 5,999–6,000; the probe decoded the production `URLSearchParams` result.

Before the fix, with the production truncation line restored to `body.slice(0, 6_000)`:

```text
{"productionEntry":"createSessionSqliteMigrationFailureIssue","sourceBodyHasEmoji":true,"replacementCharacters":1,"truncated":true}
exit 1
```

After the fix:

```text
{"productionEntry":"createSessionSqliteMigrationFailureIssue","sourceBodyHasEmoji":true,"replacementCharacters":0,"truncated":true}
exit 0
```

Focused regression suite after rebasing onto current `upstream/main`:

```text
node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts
Test Files  1 passed (1)
Tests  65 passed | 2 skipped (67)
```

Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed. Full repository gates are left to fork CI. I did not submit the generated issue to GitHub; the proof exercises the production sanitized report builder, URL truncation, `URLSearchParams` encoding, and decoding locally without external mutation.

AI-assisted: Codex helped implement and review the change; the behavior proof and tests above were run manually.
