### PR TITLE
fix(usage-bar): bound template override warning dedupe cache

### DIFF
--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -12,6 +12,7 @@ const fileCache = new Map<string, CacheEntry>();
 /** Maximum number of template file paths to cache concurrently. */
 const MAX_CACHED_TEMPLATE_FILES = 64;
 const warnedTemplateOverrides = new Set<string>();
+const MAX_WARNED_TEMPLATE_OVERRIDES = 256;
 const usageTemplateLog = createSubsystemLogger("usage-template");
 
 function expandPath(p: string): string {
@@ -87,7 +88,10 @@ function getErrorCode(error: unknown): string | undefined {
 
 function warnInvalidUsageTemplate(source: "inline" | "file", reason: string, path?: string): void {
   const key = `${source}:${reason}:${path ?? ""}`;
-  if (warnedTemplateOverrides.has(key)) {
+  if (
+    warnedTemplateOverrides.has(key) ||
+    warnedTemplateOverrides.size >= MAX_WARNED_TEMPLATE_OVERRIDES
+  ) {
     return;
   }
   warnedTemplateOverrides.add(key);


### PR DESCRIPTION
## What Problem This Solves

The warnedTemplateOverrides Set had no capacity limit while the sibling fileCache in the same module already enforced MAX_CACHED_TEMPLATE_FILES (64). Each distinct template key was retained permanently.

- Cap at MAX_WARNED_TEMPLATE_OVERRIDES (256).

AI-assisted: contributor patch used coding agents.