### PR TITLE
fix(telegram): honor abortSignal in startup probe retry loop

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1076,6 +1076,7 @@ export const telegramPlugin = createChatChannelPlugin({
                 network: account.config.network,
                 apiRoot: account.config.apiRoot,
                 includeWebhookInfo: false,
+                abortSignal: ctx.abortSignal,
               },
             ),
           );

--- a/extensions/telegram/src/probe.abort-signal.integration.test.ts
+++ b/extensions/telegram/src/probe.abort-signal.integration.test.ts
@@ -1,0 +1,84 @@
+// Real-socket proof that the startup probe retry loop stops when the owning
+// abortSignal fires. Production Telegram transport talks to a local stub that
+// resets the first connection, then aborts before the retry delay elapses.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
+
+describe("probeTelegram startup retry loop honors abortSignal", () => {
+  let server: Server;
+  let apiRoot: string;
+  let requestCount = 0;
+  let connectionCount = 0;
+  const liveSockets = new Set<Socket>();
+
+  beforeAll(async () => {
+    for (const name of [
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "ALL_PROXY",
+      "http_proxy",
+      "https_proxy",
+      "all_proxy",
+      "OPENCLAW_PROXY_URL",
+      "OPENCLAW_DEBUG_PROXY_ENABLED",
+      "OPENCLAW_DEBUG_PROXY_URL",
+    ]) {
+      vi.stubEnv(name, "");
+    }
+
+    server = createServer((_req, res) => {
+      requestCount += 1;
+      // Abruptly terminate the first request so the probe enters its retry
+      // backoff. The abort controller fires while sleepWithAbort is waiting,
+      // which must prevent a second connection attempt.
+      res.socket?.destroy();
+    });
+    server.on("connection", (socket) => {
+      connectionCount += 1;
+      liveSockets.add(socket);
+      socket.once("close", () => {
+        liveSockets.delete(socket);
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    resetTelegramProbeFetcherCacheForTests();
+    vi.unstubAllEnvs();
+    for (const socket of liveSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("stops retrying getMe after abortSignal fires during the backoff", async () => {
+    const abortController = new AbortController();
+    const previousRequestCount = requestCount;
+    const previousConnectionCount = connectionCount;
+
+    // Abort once the first connection has been torn down and the probe is
+    // sleeping before its retry. This must happen before the retry delay
+    // would naturally elapse (timeoutMs/5, capped at 1000ms).
+    server.once("connection", () => {
+      setTimeout(() => abortController.abort(), 50);
+    });
+
+    const result = await probeTelegram("abort-test-token", 10_000, {
+      apiRoot,
+      includeWebhookInfo: false,
+      abortSignal: abortController.signal,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(requestCount).toBe(previousRequestCount + 1);
+    expect(connectionCount).toBe(previousConnectionCount + 1);
+  });
+});

--- a/extensions/telegram/src/probe.abort-signal.integration.test.ts
+++ b/extensions/telegram/src/probe.abort-signal.integration.test.ts
@@ -1,7 +1,6 @@
-// Real-socket proof that the startup probe retry loop stops when the owning
-// abortSignal fires. Production Telegram transport talks to a local stub that
-// resets the first connection, then aborts before the retry delay elapses.
-import { createServer, type Server } from "node:http";
+// Real-socket proof that the startup probe stops when the owning abortSignal
+// fires during either an active request or retry backoff.
+import { createServer, type IncomingMessage, type Server } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
@@ -11,6 +10,7 @@ describe("probeTelegram startup retry loop honors abortSignal", () => {
   let apiRoot: string;
   let requestCount = 0;
   let connectionCount = 0;
+  let stallMode: "all" | "webhook" | null = null;
   const liveSockets = new Set<Socket>();
 
   beforeAll(async () => {
@@ -28,8 +28,19 @@ describe("probeTelegram startup retry loop honors abortSignal", () => {
       vi.stubEnv(name, "");
     }
 
-    server = createServer((_req, res) => {
+    server = createServer((req, res) => {
       requestCount += 1;
+      if (
+        stallMode === "all" ||
+        (stallMode === "webhook" && req.url?.endsWith("/getWebhookInfo"))
+      ) {
+        return;
+      }
+      if (stallMode === "webhook") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, result: { id: 1, is_bot: true } }));
+        return;
+      }
       // Abruptly terminate the first request so the probe enters its retry
       // backoff. The abort controller fires while sleepWithAbort is waiting,
       // which must prevent a second connection attempt.
@@ -83,5 +94,65 @@ describe("probeTelegram startup retry loop honors abortSignal", () => {
     expect(result.ok).toBe(false);
     expect(requestCount).toBe(previousRequestCount + 1);
     expect(connectionCount).toBe(previousConnectionCount + 1);
+  });
+
+  it("aborts a stalled in-flight getMe request", async () => {
+    const abortController = new AbortController();
+    const previousRequestCount = requestCount;
+    const previousConnectionCount = connectionCount;
+    let markRequestStarted: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    server.once("request", () => markRequestStarted?.());
+    stallMode = "all";
+
+    const startedAt = Date.now();
+    const probePromise = probeTelegram("abort-active-request-token", 10_000, {
+      apiRoot,
+      includeWebhookInfo: false,
+      abortSignal: abortController.signal,
+      network: { autoSelectFamily: false, dnsResultOrder: "verbatim" },
+    });
+    await requestStarted;
+    abortController.abort();
+    const result = await probePromise;
+    stallMode = null;
+
+    expect(result.ok).toBe(false);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(requestCount).toBe(previousRequestCount + 1);
+    expect(connectionCount).toBe(previousConnectionCount + 1);
+  });
+
+  it("does not report success when aborting a stalled webhook-info request", async () => {
+    const abortController = new AbortController();
+    const previousRequestCount = requestCount;
+    const webhookRequestStarted = new Promise<void>((resolve) => {
+      const onRequest = (req: IncomingMessage) => {
+        if (!req.url?.endsWith("/getWebhookInfo")) {
+          return;
+        }
+        server.off("request", onRequest);
+        resolve();
+      };
+      server.on("request", onRequest);
+    });
+    stallMode = "webhook";
+
+    const startedAt = Date.now();
+    const probePromise = probeTelegram("abort-webhook-request-token", 10_000, {
+      apiRoot,
+      abortSignal: abortController.signal,
+      network: { autoSelectFamily: false, dnsResultOrder: "verbatim" },
+    });
+    await webhookRequestStarted;
+    abortController.abort();
+    const result = await probePromise;
+    stallMode = null;
+
+    expect(result.ok).toBe(false);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(requestCount).toBe(previousRequestCount + 2);
   });
 });

--- a/extensions/telegram/src/probe.abort-signal.integration.test.ts
+++ b/extensions/telegram/src/probe.abort-signal.integration.test.ts
@@ -75,6 +75,9 @@ describe("probeTelegram startup retry loop honors abortSignal", () => {
       apiRoot,
       includeWebhookInfo: false,
       abortSignal: abortController.signal,
+      // Disable the transport's internal dispatcher fallbacks so request
+      // counts isolate the outer startup-probe retry loop under test.
+      network: { autoSelectFamily: false, dnsResultOrder: "verbatim" },
     });
 
     expect(result.ok).toBe(false);

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -3,6 +3,7 @@ import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeTelegramBotInfo, type TelegramBotInfo } from "./bot-info.js";
 import {
@@ -39,6 +40,7 @@ export type TelegramProbeOptions = {
   accountId?: string;
   apiRoot?: string;
   includeWebhookInfo?: boolean;
+  abortSignal?: AbortSignal;
 };
 
 const probeTransportCache = new Map<string, TelegramTransport>();
@@ -163,7 +165,7 @@ export async function probeTelegram(
     // Retry loop for initial connection (handles network/DNS startup races)
     for (let i = 0; i < 3; i++) {
       const remainingBudgetMs = resolveRemainingBudgetMs();
-      if (remainingBudgetMs <= 0) {
+      if (remainingBudgetMs <= 0 || options?.abortSignal?.aborted) {
         break;
       }
       try {
@@ -176,6 +178,9 @@ export async function probeTelegram(
         break;
       } catch (err) {
         fetchError = err;
+        if (options?.abortSignal?.aborted) {
+          throw err;
+        }
         // On timeout or network error, promote the transport to its IPv4
         // fallback dispatcher so the next retry (and all future probes
         // sharing this cached transport) skip the stalled IPv6 path.
@@ -188,9 +193,7 @@ export async function probeTelegram(
           }
           const delayMs = Math.min(retryDelayMs, remainingAfterAttemptMs);
           if (delayMs > 0) {
-            await new Promise((resolve) => {
-              setTimeout(resolve, delayMs);
-            });
+            await sleepWithAbort(delayMs, options?.abortSignal);
           }
         }
       }

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -143,6 +143,7 @@ export async function probeTelegram(
   const timeoutBudgetMs = Math.max(1, Math.floor(timeoutMs));
   const deadlineMs = started + timeoutBudgetMs;
   const options = resolveProbeOptions(proxyOrOptions);
+  const abortSignal = options?.abortSignal;
   const includeWebhookInfo = options?.includeWebhookInfo !== false;
   const transport = resolveProbeTransport(token, options);
   const fetcher = transport.fetch;
@@ -165,20 +166,20 @@ export async function probeTelegram(
     // Retry loop for initial connection (handles network/DNS startup races)
     for (let i = 0; i < 3; i++) {
       const remainingBudgetMs = resolveRemainingBudgetMs();
-      if (remainingBudgetMs <= 0 || options?.abortSignal?.aborted) {
+      if (remainingBudgetMs <= 0 || abortSignal?.aborted) {
         break;
       }
       try {
         meRes = await fetchWithTimeout(
           `${base}/getMe`,
-          {},
+          { signal: abortSignal },
           Math.max(1, Math.min(timeoutBudgetMs, remainingBudgetMs)),
           fetcher,
         );
         break;
       } catch (err) {
         fetchError = err;
-        if (options?.abortSignal?.aborted) {
+        if (abortSignal?.aborted) {
           throw err;
         }
         // On timeout or network error, promote the transport to its IPv4
@@ -193,7 +194,7 @@ export async function probeTelegram(
           }
           const delayMs = Math.min(retryDelayMs, remainingAfterAttemptMs);
           if (delayMs > 0) {
-            await sleepWithAbort(delayMs, options?.abortSignal);
+            await sleepWithAbort(delayMs, abortSignal);
           }
         }
       }
@@ -252,7 +253,7 @@ export async function probeTelegram(
         if (webhookRemainingBudgetMs > 0) {
           const webhookRes = await fetchWithTimeout(
             `${base}/getWebhookInfo`,
-            {},
+            { signal: abortSignal },
             Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
             fetcher,
           );
@@ -274,7 +275,10 @@ export async function probeTelegram(
             };
           }
         }
-      } catch {
+      } catch (err) {
+        if (abortSignal?.aborted) {
+          throw err;
+        }
         // ignore webhook errors for probe
       }
     }


### PR DESCRIPTION
## What Problem This Solves

`extensions/telegram/src/probe.ts` has a retry loop for the initial `getMe` call that waits on a bare `setTimeout`. When a Telegram account startup is aborted (e.g. gateway shutdown, account removal, or session cancellation), the probe keeps sleeping through its full retry backoff and may issue additional `getMe` requests even though the result will be discarded. This wastes resources and delays shutdown.

## Why This Change Was Made

The `startAccount` caller in `extensions/telegram/src/channel.ts` already owns `ctx.abortSignal` and passes it to the startup probe concurrency limiter, but it never reached `probeTelegram`. This change threads the signal through `TelegramProbeOptions` and replaces the bare `setTimeout` with `sleepWithAbort` from `openclaw/plugin-sdk/runtime-env`, the same helper already used throughout the Telegram plugin (polling, webhook, delivery, ingress spool).

This follows the same pattern as recent merged fixes in sibling plugins:
- #108408 (feishu) propagated `abortSignal` through comment-event handlers and used an abortable delay in the comment reply retry loop.
- #108561 (discord) replaced a bare `setTimeout` in `waitForGatewayReady` with `sleepWithAbort` so gateway shutdown interrupts the READY retry backoff.

## User Impact

Telegram account startup now respects cancellation promptly. If an account is stopped while the startup probe is retrying a network/DNS stall, the retry loop exits as soon as the abort signal fires instead of waiting out the remaining backoff and firing another `getMe` request.

## Evidence

**Before** (`probe.ts` retry delay):
```ts
await new Promise((resolve) => {
  setTimeout(resolve, delayMs);
});
```
The delay could not be interrupted, so a second `getMe` fetch could be issued after abort.

**After**:
```ts
await sleepWithAbort(delayMs, options?.abortSignal);
```
The loop now exits immediately when the owning `AbortSignal` aborts, and the transport is not promoted to a fallback dispatcher for an abort-induced error.

**Regression test**: `extensions/telegram/src/probe.abort-signal.integration.test.ts` starts a local HTTP stub, destroys the first connection to force a retry, fires a real `AbortController` while the probe is in its backoff, and asserts that only one `getMe` request and one TCP connection are observed.

**Validation run**:
```
node scripts/run-vitest.mjs \\
  extensions/telegram/src/probe.test.ts \\
  extensions/telegram/src/probe.abort-signal.integration.test.ts
# Test Files  2 passed (2)
# Tests  14 passed (14)

pnpm tsgo:extensions
# passes
git diff --check
# clean
```
