### PR TITLE
fix(scripts): dedupe isDirectReleaseCandidateExecution declaration after racing restores

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -98,11 +98,6 @@ export function validateWindowsSourceRelease(
     digest: unknown;
   }[];
 }>;
-export function isDirectReleaseCandidateExecution(
-  directPath: string | undefined,
-  modulePath: string,
-  resolveRealPath?: (path: string) => string,
-): boolean;
 export function validateCandidateCheckout({
   targetSha,
   targetHeadSha,

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -1180,10 +1180,9 @@ if (isPrlctl) {
     );
   });
 
-  it("seeds agent workspace state before OS smoke agent turns", () => {
+  it("seeds the agent workspace before OS smoke agent turns", () => {
     const workspace = readFileSync(TS_PATHS.agentWorkspace, "utf8");
 
-    expect(workspace).toContain("workspace-state.json");
     expect(workspace).toContain("IDENTITY.md");
     expect(workspace).toContain("BOOTSTRAP.md");
 


### PR DESCRIPTION
## What Problem This Solves

`check-lint` on `main` is failing again with `adjacent-overload-signatures`: `scripts/release-candidate-checklist.d.mts` has two identical `isDirectReleaseCandidateExecution` declarations. The full Node matrix also fails because a Parallels test still requires the retired `workspace-state.json` smoke artifact.

## Why This Change Was Made

Tonight's sequence produced a fix race in both directions: #109546 introduced a duplicate; #109553 and #109560 each removed one copy in parallel (leaving zero, breaking `check-test-types`); then #109586 restored a second copy (breaking `check-lint` again). This PR removes the second copy, leaving exactly one declaration matching the `.mjs` implementation. It also removes only the obsolete workspace-state assertion; identity and bootstrap workspace checks remain.

## User Impact

Unblocks `check-lint`, the shared tooling shard, and `ci-gate` for all open PRs. No runtime behavior change.

## Evidence

- `node scripts/run-oxlint.mjs scripts/release-candidate-checklist.d.mts`: zero findings.
- Script-asserted exactly one remaining declaration.
- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts`: pass.
- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts`: 87 passed.
- `node scripts/run-vitest.mjs test/scripts/parallels-npm-update-smoke.test.ts`: 31 passed.
- Fresh autoreview clean.

AI-assisted: yes. I verified both failures against current main and reviewed the bounded test-contract update.
