### PR TITLE
fix(reef): repeated relay reconnects no longer leave stale sockets active

### DIFF
--- a/extensions/reef/src/transport.test-helpers.ts
+++ b/extensions/reef/src/transport.test-helpers.ts
@@ -1,0 +1,28 @@
+export class ControlledSocket {
+  closeCalls = 0;
+  private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
+  private closed = false;
+
+  constructor(private readonly closeImmediately = true) {}
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close(): void {
+    this.closeCalls++;
+    if (this.closed || !this.closeImmediately) {
+      return;
+    }
+    this.closed = true;
+    this.emit("close");
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -12,6 +12,7 @@ import {
   createReefWebSocket,
   type WebSocketLike,
 } from "./transport.js";
+import { ControlledSocket } from "./transport.test-helpers.js";
 import type { InboxEntry, ReefKeys, RelayFriend } from "./types.js";
 
 const ts = 1_752_300_000;
@@ -334,35 +335,6 @@ describe("ReefTransportClient response body bounds", () => {
 });
 
 const INBOX_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
-
-class ControlledSocket {
-  closeCalls = 0;
-  private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
-  private closed = false;
-
-  constructor(private readonly closeImmediately = true) {}
-
-  addEventListener(type: string, listener: (event: unknown) => void): void {
-    const listeners = this.listeners.get(type) ?? [];
-    listeners.push(listener);
-    this.listeners.set(type, listeners);
-  }
-
-  close(): void {
-    this.closeCalls++;
-    if (this.closed || !this.closeImmediately) {
-      return;
-    }
-    this.closed = true;
-    this.emit("close");
-  }
-
-  emit(type: string, event: unknown = {}): void {
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
-    }
-  }
-}
 
 function receiptEntry(seq: number): InboxEntry {
   return {

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -337,7 +337,6 @@ const INBOX_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
 
 class ControlledSocket {
   closeCalls = 0;
-  terminateCalls = 0;
   private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
   private closed = false;
 
@@ -352,15 +351,6 @@ class ControlledSocket {
   close(): void {
     this.closeCalls++;
     if (this.closed || !this.closeImmediately) {
-      return;
-    }
-    this.closed = true;
-    this.emit("close");
-  }
-
-  terminate(): void {
-    this.terminateCalls++;
-    if (this.closed) {
       return;
     }
     this.closed = true;
@@ -967,18 +957,17 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount);
   });
 
-  it("force-terminates a stalled failed generation before reconnecting", async () => {
+  it("waits for the socket close event without imposing a Reef force-close deadline", async () => {
     vi.useFakeTimers();
     const stalledSocket = new ControlledSocket(false);
-    const delayedTerminateSocket = {
+    const terminate = vi.fn();
+    const observableSocket = {
       addEventListener: stalledSocket.addEventListener.bind(stalledSocket),
       close: () => stalledSocket.close(),
-      terminate: () => {
-        stalledSocket.terminateCalls++;
-      },
+      terminate,
     } as unknown as WebSocketLike;
     const sockets: WebSocketLike[] = [
-      delayedTerminateSocket,
+      observableSocket,
       new ControlledSocket() as unknown as WebSocketLike,
     ];
     let socketIndex = 0;
@@ -999,15 +988,8 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     const running = inbox.start(abort.signal);
     stalledSocket.emit("message", { data: "{" });
 
-    await vi.advanceTimersByTimeAsync(4_999);
-    expect(socketIndex).toBe(1);
-    expect(stalledSocket.terminateCalls).toBe(0);
-
-    await vi.advanceTimersByTimeAsync(1);
-    expect(stalledSocket.terminateCalls).toBe(1);
-    expect(socketIndex).toBe(1);
-
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(terminate).not.toHaveBeenCalled();
     expect(socketIndex).toBe(1);
 
     stalledSocket.emit("close");

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -936,7 +936,7 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     const sockets = [new ControlledSocket(), new ControlledSocket()];
     const errors: string[] = [];
     let socketIndex = 0;
-    const webSocketFactory = vi.fn(() => sockets[socketIndex++]!);
+    const webSocketFactory = vi.fn(() => sockets[socketIndex++]! as unknown as WebSocketLike);
     const client = new ReefTransportClient(
       "https://relay.example",
       "alice",
@@ -982,7 +982,7 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     const inbox = new ReefInboxConnection(
       client,
       async () => {},
-      () => sockets[socketIndex++]!,
+      () => sockets[socketIndex++]! as unknown as WebSocketLike,
     );
 
     const running = inbox.start(abort.signal);
@@ -996,6 +996,46 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     expect(sockets[0]!.terminateCalls).toBe(1);
     expect(socketIndex).toBe(1);
 
+    await vi.advanceTimersByTimeAsync(250);
+    expect(socketIndex).toBe(2);
+
+    abort.abort();
+    await running;
+  });
+
+  it("waits for a real close when a stalled generation cannot be terminated", async () => {
+    vi.useFakeTimers();
+    const stalledSocket = new ControlledSocket(false);
+    const closeOnlySocket = {
+      addEventListener: stalledSocket.addEventListener.bind(stalledSocket),
+      close: () => stalledSocket.close(),
+    } as unknown as WebSocketLike;
+    const sockets: WebSocketLike[] = [
+      closeOnlySocket,
+      new ControlledSocket() as unknown as WebSocketLike,
+    ];
+    let socketIndex = 0;
+    const abort = new AbortController();
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [], cursor: 0 }),
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => sockets[socketIndex++]!,
+    );
+
+    const running = inbox.start(abort.signal);
+    stalledSocket.emit("message", { data: "{" });
+
+    await vi.advanceTimersByTimeAsync(5_250);
+    expect(socketIndex).toBe(1);
+
+    stalledSocket.emit("close");
     await vi.advanceTimersByTimeAsync(250);
     expect(socketIndex).toBe(2);
 

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -337,8 +337,11 @@ const INBOX_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
 
 class ControlledSocket {
   closeCalls = 0;
+  terminateCalls = 0;
   private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
   private closed = false;
+
+  constructor(private readonly closeImmediately = true) {}
 
   addEventListener(type: string, listener: (event: unknown) => void): void {
     const listeners = this.listeners.get(type) ?? [];
@@ -348,6 +351,15 @@ class ControlledSocket {
 
   close(): void {
     this.closeCalls++;
+    if (this.closed || !this.closeImmediately) {
+      return;
+    }
+    this.closed = true;
+    this.emit("close");
+  }
+
+  terminate(): void {
+    this.terminateCalls++;
     if (this.closed) {
       return;
     }
@@ -922,6 +934,7 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     const abort = new AbortController();
     const initialListenerCount = getEventListeners(abort.signal, "abort").length;
     const sockets = [new ControlledSocket(), new ControlledSocket()];
+    const errors: string[] = [];
     let socketIndex = 0;
     const webSocketFactory = vi.fn(() => sockets[socketIndex++]!);
     const client = new ReefTransportClient(
@@ -931,7 +944,9 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
       async () => Response.json({ entries: [], cursor: 0 }),
       () => ts,
     );
-    const inbox = new ReefInboxConnection(client, async () => {}, webSocketFactory);
+    const inbox = new ReefInboxConnection(client, async () => {}, webSocketFactory, {
+      onError: (error) => errors.push(error.message),
+    });
 
     const running = inbox.start(abort.signal);
     await vi.waitFor(() => expect(webSocketFactory).toHaveBeenCalledTimes(1));
@@ -940,6 +955,8 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     sockets[0]!.emit("message", { data: "{" });
     await vi.waitFor(() => expect(webSocketFactory).toHaveBeenCalledTimes(2));
     expect(sockets[0]!.closeCalls).toBe(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).not.toContain("socket closed unexpectedly");
     expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount + 1);
 
     abort.abort();
@@ -948,6 +965,42 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     expect(sockets[0]!.closeCalls).toBe(1);
     expect(sockets[1]!.closeCalls).toBe(1);
     expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount);
+  });
+
+  it("force-terminates a stalled failed generation before reconnecting", async () => {
+    vi.useFakeTimers();
+    const sockets = [new ControlledSocket(false), new ControlledSocket()];
+    let socketIndex = 0;
+    const abort = new AbortController();
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [], cursor: 0 }),
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => sockets[socketIndex++]!,
+    );
+
+    const running = inbox.start(abort.signal);
+    sockets[0]!.emit("message", { data: "{" });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(socketIndex).toBe(1);
+    expect(sockets[0]!.terminateCalls).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sockets[0]!.terminateCalls).toBe(1);
+    expect(socketIndex).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(socketIndex).toBe(2);
+
+    abort.abort();
+    await running;
   });
 });
 

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -969,7 +969,18 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
 
   it("force-terminates a stalled failed generation before reconnecting", async () => {
     vi.useFakeTimers();
-    const sockets = [new ControlledSocket(false), new ControlledSocket()];
+    const stalledSocket = new ControlledSocket(false);
+    const delayedTerminateSocket = {
+      addEventListener: stalledSocket.addEventListener.bind(stalledSocket),
+      close: () => stalledSocket.close(),
+      terminate: () => {
+        stalledSocket.terminateCalls++;
+      },
+    } as unknown as WebSocketLike;
+    const sockets: WebSocketLike[] = [
+      delayedTerminateSocket,
+      new ControlledSocket() as unknown as WebSocketLike,
+    ];
     let socketIndex = 0;
     const abort = new AbortController();
     const client = new ReefTransportClient(
@@ -982,20 +993,24 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     const inbox = new ReefInboxConnection(
       client,
       async () => {},
-      () => sockets[socketIndex++]! as unknown as WebSocketLike,
+      () => sockets[socketIndex++]!,
     );
 
     const running = inbox.start(abort.signal);
-    sockets[0]!.emit("message", { data: "{" });
+    stalledSocket.emit("message", { data: "{" });
 
     await vi.advanceTimersByTimeAsync(4_999);
     expect(socketIndex).toBe(1);
-    expect(sockets[0]!.terminateCalls).toBe(0);
+    expect(stalledSocket.terminateCalls).toBe(0);
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(sockets[0]!.terminateCalls).toBe(1);
+    expect(stalledSocket.terminateCalls).toBe(1);
     expect(socketIndex).toBe(1);
 
+    await vi.advanceTimersByTimeAsync(250);
+    expect(socketIndex).toBe(1);
+
+    stalledSocket.emit("close");
     await vi.advanceTimersByTimeAsync(250);
     expect(socketIndex).toBe(2);
 

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -937,14 +937,15 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     await vi.waitFor(() => expect(webSocketFactory).toHaveBeenCalledTimes(1));
     expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount + 1);
 
-    sockets[0]!.emit("close");
+    sockets[0]!.emit("message", { data: "{" });
     await vi.waitFor(() => expect(webSocketFactory).toHaveBeenCalledTimes(2));
+    expect(sockets[0]!.closeCalls).toBe(1);
     expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount + 1);
 
     abort.abort();
     await running;
 
-    expect(sockets[0]!.closeCalls).toBe(0);
+    expect(sockets[0]!.closeCalls).toBe(1);
     expect(sockets[1]!.closeCalls).toBe(1);
     expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount);
   });

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -1,5 +1,5 @@
 import { createPublicKey, verify as verifySignature } from "node:crypto";
-import { once } from "node:events";
+import { getEventListeners, once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -336,6 +336,7 @@ describe("ReefTransportClient response body bounds", () => {
 const INBOX_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
 
 class ControlledSocket {
+  closeCalls = 0;
   private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
   private closed = false;
 
@@ -346,6 +347,7 @@ class ControlledSocket {
   }
 
   close(): void {
+    this.closeCalls++;
     if (this.closed) {
       return;
     }
@@ -912,6 +914,39 @@ describe("createReefWebSocket handshake deadline", () => {
         server.close(() => resolve());
       });
     }
+  });
+});
+
+describe("ReefInboxConnection reconnect lifecycle", () => {
+  it("keeps only the active generation subscribed to channel abort", async () => {
+    const abort = new AbortController();
+    const initialListenerCount = getEventListeners(abort.signal, "abort").length;
+    const sockets = [new ControlledSocket(), new ControlledSocket()];
+    let socketIndex = 0;
+    const webSocketFactory = vi.fn(() => sockets[socketIndex++]!);
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [], cursor: 0 }),
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(client, async () => {}, webSocketFactory);
+
+    const running = inbox.start(abort.signal);
+    await vi.waitFor(() => expect(webSocketFactory).toHaveBeenCalledTimes(1));
+    expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount + 1);
+
+    sockets[0]!.emit("close");
+    await vi.waitFor(() => expect(webSocketFactory).toHaveBeenCalledTimes(2));
+    expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount + 1);
+
+    abort.abort();
+    await running;
+
+    expect(sockets[0]!.closeCalls).toBe(0);
+    expect(sockets[1]!.closeCalls).toBe(1);
+    expect(getEventListeners(abort.signal, "abort")).toHaveLength(initialListenerCount);
   });
 });
 

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -1017,46 +1017,6 @@ describe("ReefInboxConnection reconnect lifecycle", () => {
     abort.abort();
     await running;
   });
-
-  it("waits for a real close when a stalled generation cannot be terminated", async () => {
-    vi.useFakeTimers();
-    const stalledSocket = new ControlledSocket(false);
-    const closeOnlySocket = {
-      addEventListener: stalledSocket.addEventListener.bind(stalledSocket),
-      close: () => stalledSocket.close(),
-    } as unknown as WebSocketLike;
-    const sockets: WebSocketLike[] = [
-      closeOnlySocket,
-      new ControlledSocket() as unknown as WebSocketLike,
-    ];
-    let socketIndex = 0;
-    const abort = new AbortController();
-    const client = new ReefTransportClient(
-      "https://relay.example",
-      "alice",
-      keys,
-      async () => Response.json({ entries: [], cursor: 0 }),
-      () => ts,
-    );
-    const inbox = new ReefInboxConnection(
-      client,
-      async () => {},
-      () => sockets[socketIndex++]!,
-    );
-
-    const running = inbox.start(abort.signal);
-    stalledSocket.emit("message", { data: "{" });
-
-    await vi.advanceTimersByTimeAsync(5_250);
-    expect(socketIndex).toBe(1);
-
-    stalledSocket.emit("close");
-    await vi.advanceTimersByTimeAsync(250);
-    expect(socketIndex).toBe(2);
-
-    abort.abort();
-    await running;
-  });
 });
 
 describe("ReefInboxConnection response frame bounds", () => {

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -25,9 +25,6 @@ const REEF_WS_HANDSHAKE_MS = 30_000;
 // Cover headers and body consumption. A relay that accepts the request but
 // stops producing bytes must not pin inbox recovery forever.
 const REEF_RELAY_REQUEST_TIMEOUT_MS = 15_000;
-// A failed generation must finish closing before its replacement starts. Bound
-// the close handshake so an unresponsive peer cannot stall reconnect forever.
-const REEF_WS_CLOSE_MS = 5_000;
 
 export class ReefRelayError extends Error {
   constructor(
@@ -247,9 +244,6 @@ export interface WebSocketLike {
     listener: (event: { error?: unknown; message?: string }) => void,
   ): void;
   close(): void;
-  // Reconnect must be able to force a stalled generation toward its real close
-  // event without allowing the replacement to overlap it.
-  terminate(): void;
 }
 
 interface ReefInboxConnectionOptions {
@@ -415,7 +409,6 @@ export class ReefInboxConnection {
       let closeComplete = false;
       let processingComplete = true;
       let terminalError: Error | undefined;
-      let closeTimer: ReturnType<typeof setTimeout> | undefined;
       let opened = false;
       let catchUpPending = false;
       let pumpScheduled = false;
@@ -423,9 +416,6 @@ export class ReefInboxConnection {
       const finish = (error?: Error) => {
         if (finished) {
           return;
-        }
-        if (closeTimer) {
-          clearTimeout(closeTimer);
         }
         finished = true;
         signal?.removeEventListener("abort", abortListener);
@@ -471,17 +461,10 @@ export class ReefInboxConnection {
             },
           );
         }
-        // Do not let a stale generation observe a later channel abort while
-        // its asynchronous WebSocket close handshake is still in flight.
-        closeTimer = setTimeout(() => {
-          try {
-            socket.terminate();
-          } catch {
-            // A failed force-close is not proof that the old generation ended.
-            // Keep waiting for its real close event instead of overlapping peers.
-            return;
-          }
-        }, REEF_WS_CLOSE_MS);
+        // The production ws client already bounds its close handshake with its
+        // native 30-second closeTimeout and emits close after destroying a
+        // non-responsive socket. Keep reconnect ordering tied to that real close
+        // event instead of imposing a second Reef-specific force-close deadline.
         socket.close();
       };
       const abortListener = () => closeAndFinish(undefined, true);

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -462,9 +462,9 @@ export class ReefInboxConnection {
           );
         }
         // The production ws client already bounds its close handshake with its
-        // native 30-second closeTimeout and emits close after destroying a
-        // non-responsive socket. Keep reconnect ordering tied to that real close
-        // event instead of imposing a second Reef-specific force-close deadline.
+        // native closeTimeout and emits close after destroying a non-responsive
+        // socket. Keep reconnect ordering tied to that real close event instead
+        // of imposing a second Reef-specific force-close deadline.
         socket.close();
       };
       const abortListener = () => closeAndFinish(undefined, true);

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -482,8 +482,6 @@ export class ReefInboxConnection {
             // Keep waiting for its real close event instead of overlapping peers.
             return;
           }
-          closeComplete = true;
-          finishAfterClose();
         }, REEF_WS_CLOSE_MS);
         socket.close();
       };

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -247,7 +247,9 @@ export interface WebSocketLike {
     listener: (event: { error?: unknown; message?: string }) => void,
   ): void;
   close(): void;
-  terminate?(): void;
+  // Reconnect must be able to force a stalled generation toward its real close
+  // event without allowing the replacement to overlap it.
+  terminate(): void;
 }
 
 interface ReefInboxConnectionOptions {
@@ -472,9 +474,6 @@ export class ReefInboxConnection {
         // Do not let a stale generation observe a later channel abort while
         // its asynchronous WebSocket close handshake is still in flight.
         closeTimer = setTimeout(() => {
-          if (!socket.terminate) {
-            return;
-          }
           try {
             socket.terminate();
           } catch {

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -25,6 +25,9 @@ const REEF_WS_HANDSHAKE_MS = 30_000;
 // Cover headers and body consumption. A relay that accepts the request but
 // stops producing bytes must not pin inbox recovery forever.
 const REEF_RELAY_REQUEST_TIMEOUT_MS = 15_000;
+// A failed generation must finish closing before its replacement starts. Bound
+// the close handshake so an unresponsive peer cannot stall reconnect forever.
+const REEF_WS_CLOSE_MS = 5_000;
 
 export class ReefRelayError extends Error {
   constructor(
@@ -244,6 +247,7 @@ export interface WebSocketLike {
     listener: (event: { error?: unknown; message?: string }) => void,
   ): void;
   close(): void;
+  terminate?(): void;
 }
 
 interface ReefInboxConnectionOptions {
@@ -405,28 +409,21 @@ export class ReefInboxConnection {
       // overwrite the lifecycle state of its replacement (or of a stopped channel).
       let finished = false;
       let disconnected = false;
-      let aborting = false;
+      let closing = false;
+      let closeComplete = false;
+      let processingComplete = true;
+      let terminalError: Error | undefined;
+      let closeTimer: ReturnType<typeof setTimeout> | undefined;
       let opened = false;
       let catchUpPending = false;
       let pumpScheduled = false;
       const bufferedEntries: InboxEntry[] = [];
-      const abortListener = () => {
-        if (finished) {
-          return;
-        }
-        aborting = true;
-        markDisconnected();
-        socket.close();
-        // Older socket work can still own the shared serial tail. Waiting here
-        // prevents a replacement channel from dispatching the same cursor range.
-        void this.processing.then(
-          () => finish(),
-          () => finish(),
-        );
-      };
       const finish = (error?: Error) => {
         if (finished) {
           return;
+        }
+        if (closeTimer) {
+          clearTimeout(closeTimer);
         }
         finished = true;
         signal?.removeEventListener("abort", abortListener);
@@ -445,21 +442,43 @@ export class ReefInboxConnection {
         workAbort.abort();
         this.options.onState?.("disconnected");
       };
-      const disconnect = (error?: Error) => {
-        if (finished) {
+      const finishAfterClose = () => {
+        if (!closeComplete || !processingComplete) {
           return;
         }
-        markDisconnected();
-        // An abort waits for the class-wide serial tail. A close event emitted
-        // synchronously by socket.close() must not finish this invocation early.
-        if (aborting) {
-          return;
-        }
-        finish(error);
-        if (error) {
-          socket.close();
-        }
+        finish(terminalError);
       };
+      const closeAndFinish = (error?: Error, waitForProcessing = false) => {
+        if (finished || closing) {
+          return;
+        }
+        closing = true;
+        terminalError ??= error;
+        markDisconnected();
+        signal?.removeEventListener("abort", abortListener);
+        processingComplete = !waitForProcessing;
+        if (waitForProcessing) {
+          void this.processing.then(
+            () => {
+              processingComplete = true;
+              finishAfterClose();
+            },
+            () => {
+              processingComplete = true;
+              finishAfterClose();
+            },
+          );
+        }
+        // Do not let a stale generation observe a later channel abort while
+        // its asynchronous WebSocket close handshake is still in flight.
+        closeTimer = setTimeout(() => {
+          socket.terminate?.();
+          closeComplete = true;
+          finishAfterClose();
+        }, REEF_WS_CLOSE_MS);
+        socket.close();
+      };
+      const abortListener = () => closeAndFinish(undefined, true);
       const pump = () => {
         if (
           disconnected ||
@@ -498,7 +517,7 @@ export class ReefInboxConnection {
           (error: unknown) => {
             pumpScheduled = false;
             if (!disconnected) {
-              disconnect(asError(error));
+              closeAndFinish(asError(error));
             }
           },
         );
@@ -520,7 +539,7 @@ export class ReefInboxConnection {
             return;
           }
           if (bufferedEntries.length >= REEF_INBOX_LIVE_BUFFER_MAX_ENTRIES) {
-            disconnect(
+            closeAndFinish(
               new Error("Reef inbox live buffer overflow; reconnecting for REST recovery"),
             );
             return;
@@ -528,19 +547,25 @@ export class ReefInboxConnection {
           bufferedEntries.push(frame.entry);
           pump();
         } catch (error) {
-          disconnect(asError(error));
+          closeAndFinish(asError(error));
         }
       });
       // Socket state is independent of a slow REST pull or entry handler. Mark
       // it disconnected now; the shared serial tail preserves ordered recovery.
       socket.addEventListener("close", (event) => {
-        if (aborting || finished) {
+        if (finished) {
           return;
         }
-        disconnect(reefInboxCloseError(event));
+        markDisconnected();
+        if (closing) {
+          closeComplete = true;
+          finishAfterClose();
+          return;
+        }
+        finish(reefInboxCloseError(event));
       });
       socket.addEventListener("error", (event) =>
-        disconnect(new Error(event.message?.trim() || "reef inbox socket error")),
+        closeAndFinish(new Error(event.message?.trim() || "reef inbox socket error")),
       );
       if (signal?.aborted) {
         abortListener();

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -472,7 +472,16 @@ export class ReefInboxConnection {
         // Do not let a stale generation observe a later channel abort while
         // its asynchronous WebSocket close handshake is still in flight.
         closeTimer = setTimeout(() => {
-          socket.terminate?.();
+          if (!socket.terminate) {
+            return;
+          }
+          try {
+            socket.terminate();
+          } catch {
+            // A failed force-close is not proof that the old generation ended.
+            // Keep waiting for its real close event instead of overlapping peers.
+            return;
+          }
           closeComplete = true;
           finishAfterClose();
         }, REEF_WS_CLOSE_MS);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a local Reef frame-processing failure could allow a replacement WebSocket generation to start while the abandoned socket was still closing. Repeated failures could therefore overlap stale and replacement sockets and leave stale socket activity during channel shutdown.

## Why This Change Was Made

Each Reef inbox WebSocket generation now owns one terminal transition. A locally failed generation preserves its original error and waits for confirmed close before allowing reconnect. Production sockets created by `createReefWebSocket` use `ws`, whose native 30-second `closeTimeout` destroys an unresponsive underlying socket and emits the real `close` event. Reef does not add a second force-close deadline or require injected factories to expose `terminate()`. The implementation is rebased onto the current durable-cursor and serialized-recovery lifecycle from `main`, which already removes each generation's abort listener on terminal transition; the regression coverage preserves that existing invariant.

## User Impact

Long-running Reef channels can reconnect repeatedly without overlapping failed and replacement sockets. Channel abort closes the active generation and waits for both its socket and in-flight serialized work to finish. If a peer ignores the closing handshake, reconnect can wait for `ws`'s native close deadline (about 30 seconds) before the replacement starts.

## Evidence

- Rebased onto pinned `main` (`a7e47653fc8`) and resolved the Reef transport conflict while preserving the current Relay request deadline and durable recovery lifecycle.
- Confirmed the production dependency is `ws` 8.21.0. Its default `closeTimeout` is 30,000 ms and its close timer destroys the underlying raw socket when the peer does not complete the closing handshake.
- `node scripts/run-vitest.mjs run extensions/reef/src/transport.test.ts`
  - 1 test file passed
  - 27 tests passed
  - Covers durable recovery plus active-generation listener ownership, malformed-frame error preservation, close-before-reconnect ordering, and the absence of a Reef-specific force-close deadline.
- `./node_modules/.bin/oxfmt --check extensions/reef/src/transport.ts extensions/reef/src/transport.test.ts extensions/reef/src/transport.test-helpers.ts`
  - All matched files use the correct format.
- `node scripts/run-oxlint.mjs --openclaw-focused-config --config .oxlintrc.json extensions/reef/src/transport.ts extensions/reef/src/transport.test.ts extensions/reef/src/transport.test-helpers.ts`
  - Passed with no diagnostics.
- `node scripts/check-max-lines-ratchet.mjs --base 5057fd9e597eff5b6eec3669059a751727874ea8`
  - Passed with 1,162 grandfathered suppressions and no new max-lines regression.
  - The shared controlled-socket fixture is split into `transport.test-helpers.ts`, keeping the hosted `check-lint` max-lines count for `transport.test.ts` below its 1,000-line limit.
- Fresh near-real network proof used the production `createReefWebSocket` client against a raw local protocol-compatible WebSocket peer. The first peer deliberately ignored the client's close frame. Redacted event order:

```text
handshake-complete:1
state:connected
sent:malformed-frame
state:disconnected
close-requested:1
ignored-client-close-frame:1
raw-peer-closed:1
client-close-event:1
error:original-malformed-frame
handshake-complete:2
state:connected
abort:channel
state:disconnected
client-close-frame:2
raw-peer-closed:2
```

  Assertions passed: `ws` emitted close 30.003 seconds after the ignored closing handshake; the replacement connected only after that real close event; the original malformed-frame failure was preserved; final abort closed the replacement; zero relay peers remained.

### Proof boundary

The live proof uses real `ws` network sockets and the production Reef transport owner, with a local protocol-compatible relay rather than a hosted Reef service. A full gateway startup is not the canonical owner of this ordering: malformed-frame handling, socket close completion, reconnect, and abort cleanup all occur inside `ReefInboxConnection`.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>
