### PR TITLE
fix(polls): reject polls with fewer than two options

### DIFF
--- a/src/polls.test.ts
+++ b/src/polls.test.ts
@@ -1,6 +1,10 @@
 // Tests poll input contracts and option defaults.
 import { describe, expect, it } from "vitest";
-import { normalizePollDurationHours, normalizePollInput } from "./polls.js";
+import {
+  normalizePollDurationHours,
+  normalizePollInput,
+  resolvePollMaxSelections,
+} from "./polls.js";
 
 describe("polls", () => {
   it("normalizes question/options and validates maxSelections", () => {
@@ -44,5 +48,25 @@ describe("polls", () => {
         durationHours: 1,
       }),
     ).toThrow(/mutually exclusive/);
+  });
+});
+
+describe("resolvePollMaxSelections", () => {
+  it("returns 1 when multiselect is disabled", () => {
+    expect(resolvePollMaxSelections(5, false)).toBe(1);
+  });
+
+  it("returns 1 when multiselect is undefined", () => {
+    expect(resolvePollMaxSelections(5, undefined)).toBe(1);
+  });
+
+  it("returns optionCount when multiselect enabled and options >= 2", () => {
+    expect(resolvePollMaxSelections(2, true)).toBe(2);
+    expect(resolvePollMaxSelections(5, true)).toBe(5);
+  });
+
+  it("caps maxSelections at optionCount when fewer than 2 options", () => {
+    expect(resolvePollMaxSelections(0, true)).toBe(0);
+    expect(resolvePollMaxSelections(1, true)).toBe(1);
   });
 });

--- a/src/polls.test.ts
+++ b/src/polls.test.ts
@@ -65,8 +65,10 @@ describe("resolvePollMaxSelections", () => {
     expect(resolvePollMaxSelections(5, true)).toBe(5);
   });
 
-  it("caps maxSelections at optionCount when fewer than 2 options", () => {
-    expect(resolvePollMaxSelections(0, true)).toBe(0);
-    expect(resolvePollMaxSelections(1, true)).toBe(1);
+  it("rejects fewer than 2 options for either poll mode", () => {
+    expect(() => resolvePollMaxSelections(0, true)).toThrow("Poll requires at least 2 options");
+    expect(() => resolvePollMaxSelections(1, true)).toThrow("Poll requires at least 2 options");
+    expect(() => resolvePollMaxSelections(0, false)).toThrow("Poll requires at least 2 options");
+    expect(() => resolvePollMaxSelections(1, false)).toThrow("Poll requires at least 2 options");
   });
 });

--- a/src/polls.ts
+++ b/src/polls.ts
@@ -31,7 +31,10 @@ export function resolvePollMaxSelections(
   optionCount: number,
   allowMultiselect: boolean | undefined,
 ): number {
-  return allowMultiselect ? Math.min(optionCount, Math.max(2, optionCount)) : 1;
+  if (optionCount < 2) {
+    throw new Error("Poll requires at least 2 options");
+  }
+  return allowMultiselect ? optionCount : 1;
 }
 
 export function normalizePollInput(

--- a/src/polls.ts
+++ b/src/polls.ts
@@ -31,7 +31,7 @@ export function resolvePollMaxSelections(
   optionCount: number,
   allowMultiselect: boolean | undefined,
 ): number {
-  return allowMultiselect ? Math.max(2, optionCount) : 1;
+  return allowMultiselect ? Math.min(optionCount, Math.max(2, optionCount)) : 1;
 }
 
 export function normalizePollInput(


### PR DESCRIPTION
## What Problem This Solves

Plugin poll actions with fewer than two options could receive an impossible `maxSelections` value and continue toward channel delivery. The public SDK helper returned `2` for invalid zero/one-option multiselect input.

## Why This Change Was Made

`resolvePollMaxSelections` now enforces the same minimum-two-options invariant as `normalizePollInput`. Invalid single-select and multiselect inputs fail immediately with `Poll requires at least 2 options`; valid behavior is unchanged.

## User Impact

Plugin authors and bundled Discord/Telegram poll actions receive one consistent actionable error for invalid option counts. Polls with two or more options keep their existing selection limits.

## Compatibility Evidence

`resolvePollMaxSelections` was introduced on 2026-07-16 in `16c14e5bbfc9e3a82203272ec7bb82b586df0a84`. No `v*` release tag contains that commit; the latest shipped tag at investigation time, `v2026.7.1`, predates the helper. The invalid-input return behavior is not a shipped public SDK contract.

Final-head caller review:

- Core outbound normalizes/rejects fewer than two options before calling the helper.
- Discord and Telegram action runtimes pass parsed answer-array lengths; rejecting 0/1 aligns them with `normalizePollInput` instead of delivering an impossible poll.
- The Plugin SDK export has no public documentation promising permissive invalid-input behavior.

## Real behavior proof

- **Behavior or issue addressed:** Reject invalid option counts at the shared public SDK helper while preserving valid single/multiselect results.
- **Real environment tested:** Linux, Node 24.13.1, exact head `2f562556ed54f858999596e573b480cfce84b7e9`.
- **Exact steps or command run:** `node --import tsx --input-type=module -e '<import resolvePollMaxSelections from src/polls.ts and print invalid/valid results>'`
- **Evidence after fix:** Terminal capture of exact-head `node` source-runtime verification:
```text
0/true: error=Poll requires at least 2 options
1/true: error=Poll requires at least 2 options
0/false: error=Poll requires at least 2 options
1/false: error=Poll requires at least 2 options
2/true: result=2
5/true: result=5
5/false: result=1
exact_head=2f562556ed54f858999596e573b480cfce84b7e9
```
- **Observed result after fix:** All invalid option counts throw the established error; valid 2+/single-select results are unchanged.
- **What was not tested:** Third-party plugin packages in production and cross-platform runtime; the helper is pure and the focused suite passed.

## Tests and validation

```text
$ node scripts/run-vitest.mjs src/polls.test.ts
Test Files  1 passed (1)
Tests       10 passed (10)
[test] passed 1 Vitest shard in 11.10s

$ git diff --check
# no output
```

## Risk checklist

| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes for shipped releases; helper is unshipped |
| Performance impact | None |
| Security improvement | No direct security impact |
| Requires config migration | No |
| Affects external API | Yes; unshipped Plugin SDK invalid-input contract |
| Tested on all platforms | No; Linux focused proof |
| Documentation needed | No shipped contract to update |

AI-assisted: yes. Fresh autoreview was attempted; the local Codex CLI exited before producing findings because its isolated CODEX_HOME rejected PATH helper creation. No autoreview-clean claim is made.
