### PR TITLE
improve: accelerate Codex startup timeout tests

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -466,6 +466,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("clears the shared app-server when startup abandons an in-flight thread request", async () => {
+    vi.useFakeTimers();
     const { harness, run } = startThreadWithHarness(500);
     const runError = run.then(
       () => undefined,
@@ -473,6 +474,7 @@ describe("startCodexAttemptThread", () => {
     );
     await answerInitialize(harness);
     await waitForThreadStart(harness);
+    await vi.advanceTimersByTimeAsync(500);
 
     const error = await runError;
     await vi.waitFor(() => expect(harness.stdinDestroyed).toBe(true), {
@@ -514,6 +516,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("closes the shared app-server when startup times out during initialize", async () => {
+    vi.useFakeTimers();
     const initializeTimeoutPluginConfig = {
       ...pluginConfig,
       appServer: { command: "codex", requestTimeoutMs: 1_000 },
@@ -528,6 +531,7 @@ describe("startCodexAttemptThread", () => {
 
     const initialize = await waitForRequest(harness, "initialize");
     expect(initialize.id).toBeDefined();
+    await vi.advanceTimersByTimeAsync(1_000);
 
     const error = await runError;
     expect(error).toBeInstanceOf(Error);
@@ -678,6 +682,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("closes a startup client that arrives after startup timeout", async () => {
+    vi.useFakeTimers();
     let observedFactoryOptions:
       | {
           onStartedClient?: (client: CodexAppServerClient) => void;
@@ -690,6 +695,10 @@ describe("startCodexAttemptThread", () => {
     const factoryDone = new Promise<void>((resolve) => {
       resolveFactoryDone = resolve;
     });
+    let releaseFactory: () => void = () => {};
+    const factoryRelease = new Promise<void>((resolve) => {
+      releaseFactory = resolve;
+    });
     const delayedFactoryPluginConfig = {
       ...pluginConfig,
       appServer: { command: "codex", requestTimeoutMs: 2_500 },
@@ -700,9 +709,7 @@ describe("startCodexAttemptThread", () => {
         try {
           factoryCalls += 1;
           observedFactoryOptions = options;
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 250);
-          });
+          await factoryRelease;
           options?.onStartedClient?.(factoryHarness.client);
           return factoryHarness.client;
         } finally {
@@ -711,9 +718,15 @@ describe("startCodexAttemptThread", () => {
       },
     });
     const rejected = expect(run).rejects.toThrow("codex app-server startup timed out");
+    await vi.waitFor(() => expect(factoryCalls).toBe(1), { interval: 1 });
+    await vi.advanceTimersByTimeAsync(100);
 
-    await rejected;
-    await factoryDone;
+    try {
+      await rejected;
+    } finally {
+      releaseFactory();
+      await factoryDone;
+    }
     await vi.waitFor(() => expect(harness.stdinDestroyed).toBe(true), {
       interval: 1,
       timeout: 2_000,
@@ -787,6 +800,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("clears the shared app-server when a startup RPC times out", async () => {
+    vi.useFakeTimers();
     const perRpcTimeoutPluginConfig = {
       ...pluginConfig,
       appServer: { command: "codex", requestTimeoutMs: 1_000 },
@@ -801,6 +815,7 @@ describe("startCodexAttemptThread", () => {
     );
     await answerInitialize(harness);
     await waitForRequest(harness, "plugin/list");
+    await vi.advanceTimersByTimeAsync(1_000);
 
     const error = await runError;
     expect(error).toBeInstanceOf(Error);


### PR DESCRIPTION
## What Problem This Solves

Codex startup timeout coverage spent multiple seconds per run waiting for real wall-clock deadlines after the relevant request or factory state was already observable. The 17-test file had a 7.34 s median test time across three baseline runs.

## Why This Change Was Made

The affected in-process timeout tests now observe the exact request/factory milestone, then advance scoped fake timers through the existing production timeout. The shared-lease case and real stdio subprocess case retain real-clock headroom. The delayed factory uses an explicit release gate with `finally` cleanup instead of a blind 250 ms sleep. Product code and CI configuration are unchanged.

Direct Codex contract inspection at upstream SHA `315195492c80fdade38e917c18f9584efd599304` confirmed the exercised protocol and server ordering: `codex-rs/app-server-protocol/src/protocol/v1.rs:29-74`, `codex-rs/app-server-protocol/src/protocol/common.rs:472-477`, `codex-rs/app-server-protocol/src/protocol/common.rs:693-697`, `codex-rs/app-server/src/message_processor.rs:755-785`, `codex-rs/app-server/src/message_processor.rs:1193-1200`, `codex-rs/app-server/src/request_processors/initialize_processor.rs:44-90`, and `codex-rs/app-server/src/request_processors/plugins.rs:524-554`.

## User Impact

No user-visible behavior change. Developers and CI spend less time in Codex startup timeout coverage while preserving the same timeout values, cleanup assertions, and real subprocess proof.

## Evidence

- Baseline full-file test times: 7.35 s, 7.32 s, 7.34 s; median 7.34 s.
- Patched full-file test times: 4.55 s, 4.59 s, 4.69 s; median 4.59 s, 37.5% faster; 51/51 tests passed.
- Final rebased proof: 17/17 tests passed; 4.62 s test time.
- `pnpm check:changed` passed on Testbox.
- Testbox: `tbx_01kxq23mdjpv6dhkbm0d5t9x8a`; run `29552622798`.
- Fresh branch autoreview: no accepted/actionable findings; correctness 0.94.
- AI-assisted: yes.
