### PR TITLE
fix(scripts): drop duplicate isDirectReleaseCandidateExecution declaration

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -98,11 +98,6 @@ export function validateWindowsSourceRelease(
     digest: unknown;
   }[];
 }>;
-export function isDirectReleaseCandidateExecution(
-  directPath: string | undefined,
-  modulePath: string,
-  resolveRealPath?: (path: string) => string,
-): boolean;
 export function validateCandidateCheckout({
   targetSha,
   targetHeadSha,


### PR DESCRIPTION
## What Problem This Solves

`main` check-lint fails for any PR whose lint scope includes `scripts/`: `scripts/release-candidate-checklist.d.mts` declares `isDirectReleaseCandidateExecution` twice (lines 78 and 101), tripping `typescript(adjacent-overload-signatures)`. #109586 restored the declaration without noticing an identical one already existed.

## Why This Change Was Made

Remove the bare duplicate (kept the doc-commented declaration). Pure declaration-file cleanup; runtime `.mjs` untouched.

## User Impact

Unblocks check-lint on main; no runtime behavior change.

## Evidence

- `node scripts/run-oxlint.mjs scripts/release-candidate-checklist.d.mts` — clean (previously 1 error).
- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts` — 54 passed.
- Observed as a check-lint failure on unrelated PR #109585.
