### PR TITLE
fix(agents): global loop circuit breaker never trips past critical block [AI-assisted]

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1274,5 +1274,123 @@ describe("tool-loop-detection", () => {
       expect(loopResult.stuck && loopResult.level).not.toBe("critical");
     });
   });
+
+  describe("global circuit breaker reachability (#109435)", () => {
+    function recordLoopVeto(
+      state: SessionState,
+      toolName: string,
+      params: unknown,
+      index: number,
+    ): void {
+      const toolCallId = `veto-${index}`;
+      recordToolCall(state, toolName, params, toolCallId, enabledLoopDetectionConfig);
+      recordToolCallOutcome(state, {
+        toolName,
+        toolParams: params,
+        toolCallId,
+        result: {
+          content: [{ type: "text", text: "blocked" }],
+          details: { status: "blocked", deniedReason: "tool-loop" },
+        },
+        config: enabledLoopDetectionConfig,
+      });
+    }
+
+    it("stays frozen at the critical block before any post-critical veto (dead breaker)", () => {
+      // Build a no-progress loop to the critical threshold. The next identical call is vetoed
+      // by the critical block; with the bug, those vetoes are recorded hash-less and the
+      // no-progress streak freezes below the global breaker threshold.
+      const fixture = createReadNoProgressFixture();
+      const state = createState();
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        result: fixture.result,
+        count: CRITICAL_THRESHOLD,
+      });
+
+      // One loop veto past critical keeps the streak below the global breaker (30), so the
+      // critical block is what fires here, not the global circuit breaker.
+      recordLoopVeto(state, fixture.toolName, fixture.params, 0);
+      const loopResult = detectToolCallLoop(
+        state,
+        fixture.toolName,
+        fixture.params,
+        enabledLoopDetectionConfig,
+      );
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).not.toBe("global_circuit_breaker");
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("escalates continued post-critical loop vetoes to the global circuit breaker", () => {
+      const fixture = createReadNoProgressFixture();
+      const state = createState();
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        result: fixture.result,
+        count: CRITICAL_THRESHOLD,
+      });
+
+      // The agent keeps retrying the identical call after the critical block trips; each retry
+      // is vetoed and recorded. The global breaker is GLOBAL_CIRCUIT_BREAKER_THRESHOLD (30),
+      // so it must fire once the streak (20 real no-progress outcomes + vetoes) reaches it.
+      const vetoesToBreaker = GLOBAL_CIRCUIT_BREAKER_THRESHOLD - CRITICAL_THRESHOLD;
+      for (let i = 0; i < vetoesToBreaker; i += 1) {
+        recordLoopVeto(state, fixture.toolName, fixture.params, i);
+      }
+
+      const loopResult = detectToolCallLoop(
+        state,
+        fixture.toolName,
+        fixture.params,
+        enabledLoopDetectionConfig,
+      );
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.message).toContain("global circuit breaker");
+      }
+    });
+
+    it("records non-loop blocked denials with their own hash, not the loop-veto sentinel", () => {
+      // Policy/approval denials (deniedReason != "tool-loop") must keep a real result hash and
+      // never receive the loop-veto sentinel, so only the loop detector's own veto extends the
+      // streak unconditionally (the distinction ClawSweeper flagged for #109435).
+      const state = createState();
+      const fixture = createReadNoProgressFixture();
+      const toolCallId = "plugin-veto";
+      recordToolCall(
+        state,
+        fixture.toolName,
+        fixture.params,
+        toolCallId,
+        enabledLoopDetectionConfig,
+      );
+      recordToolCallOutcome(state, {
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        toolCallId,
+        result: {
+          content: [{ type: "text", text: "blocked" }],
+          details: { status: "blocked", deniedReason: "plugin-before-tool-call" },
+        },
+        config: enabledLoopDetectionConfig,
+      });
+
+      const entry = state.toolCallHistory?.find((call) => call.toolCallId === toolCallId);
+      expect(entry?.resultHash).toBeTypeOf("string");
+      // The sentinel is the recognizable constant "tool-loop-veto"; a real outcome is a sha256
+      // hex digest, so a non-loop denial must never collide with the sentinel.
+      expect(entry?.resultHash).not.toBe("tool-loop-veto");
+      expect(entry?.resultHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -321,6 +321,14 @@ function isLoopVetoResult(details: Record<string, unknown>): boolean {
   return details.status === "blocked" && details.deniedReason === "tool-loop";
 }
 
+// A tool-loop veto is an explicit no-progress outcome. Recording it with a distinct
+// sentinel (rather than no hash) lets the no-progress streak keep advancing once critical
+// blocking begins, so the global circuit breaker stays reachable instead of freezing below
+// its threshold (#109435). The sentinel is a recognizable constant, never a sha256 digest,
+// so it cannot collide with a real outcome hash, and only isLoopVetoResult ever yields it,
+// keeping it distinct from policy/approval/abort denials that keep their own hash.
+const LOOP_VETO_RESULT_HASH = "tool-loop-veto";
+
 function hashToolOutcome(
   toolName: string,
   params: unknown,
@@ -340,10 +348,12 @@ function hashToolOutcome(
 
   const details = isPlainObject(result.details) ? result.details : {};
   const text = extractTextContent(result);
-  // The loop detector's own veto is not real progress; giving it no result hash keeps a
-  // critical loop block sticky instead of letting the block reset the streak (#89090).
+  // The loop detector's own veto is not real progress, but it IS an explicit no-progress
+  // outcome. Recording it with the loop-veto sentinel (rather than no hash) keeps a critical
+  // block sticky instead of letting it reset the streak (#89090) while still letting the
+  // streak advance so the global circuit breaker can fire (#109435).
   if (isLoopVetoResult(details)) {
-    return { resultHash: undefined };
+    return { resultHash: LOOP_VETO_RESULT_HASH };
   }
   if (toolName === "exec") {
     const execHash = hashExecToolOutcome(details, text);
@@ -432,12 +442,21 @@ function getNoProgressStreak(
     if (!record || record.toolName !== toolName || record.argsHash !== argsHash) {
       continue;
     }
+    if (record.resultHash === LOOP_VETO_RESULT_HASH) {
+      // A tool-loop veto is an explicit no-progress outcome. Count it and keep scanning so
+      // the streak advances past criticalThreshold once blocking begins — otherwise the
+      // global circuit breaker is unreachable dead code (#109435). The veto carries no
+      // concrete result identity, so the streak keeps being anchored by the surrounding
+      // real no-progress outcomes rather than resetting on the sentinel.
+      streak += 1;
+      continue;
+    }
     if (typeof record.resultHash !== "string" || !record.resultHash) {
       continue;
     }
     if (!latestResultHash) {
       latestResultHash = record.resultHash;
-      streak = 1;
+      streak += 1;
       continue;
     }
     if (record.resultHash !== latestResultHash) {


### PR DESCRIPTION
Closes #109435

> [AI-assisted] This PR was generated using Claude Code. I understand what the code does and reviewed it against the surrounding loop-detection logic, callers, and the existing #89090 veto tests.

## What Problem This Solves

Fixes an issue where a stuck agent can keep re-issuing an identical tool call — already vetoed by the critical no-progress block — for the entire turn timeout. The reporter observed a `kimi-k3` session re-issuing the same `exec` call roughly every 7 seconds for ~40 minutes until the 900s turn limit, because the session-global circuit breaker that is meant to be the final escalation can mathematically never fire. It is effectively dead code once critical blocking begins.

## Why This Change Was Made

When the loop detector blocks a call it synthesizes a veto result (`details.status === "blocked"`, `details.deniedReason === "tool-loop"`). `hashToolOutcome` returned `resultHash: undefined` for that veto, and `getNoProgressStreak()` skips hash-less records — so once the critical block trips, every subsequent identical call is recorded hash-less and the no-progress streak **freezes at `criticalThreshold`**. `globalCircuitBreakerThreshold` is clamped to `>= criticalThreshold + 1`, so the frozen streak can never reach it.

The fix represents the tool-loop veto as an explicit no-progress outcome instead of a non-record:

- The veto is recorded with a dedicated sentinel result hash `"tool-loop-veto"` (a recognizable constant that can never collide with a 64-char sha256 outcome digest), so it is no longer dropped by `recordToolCallOutcome`.
- `getNoProgressStreak()` counts sentinel records, so the streak keeps advancing past `criticalThreshold` and reaches the global breaker.

This preserves the existing #89090 invariant (the veto does **not** reset the streak, so the critical block stays sticky) while making the breaker reachable. Only the loop detector's own veto is special-cased via `isLoopVetoResult`; policy/approval/abort denials keep their own result hash and are not miscounted.

## User Impact

Operators whose agents get stuck on a repeated tool call now get the documented final escalation: after the critical block, continued vetoed retries trip the global circuit breaker instead of grinding on until the turn timeout. No configuration or default changes; the critical-block and run-termination behavior are unchanged.

## Evidence

New `describe("global circuit breaker reachability (#109435)")` in `src/agents/tool-loop-detection.test.ts`:
- after a single post-critical veto the critical block still fires and the breaker is not yet reached,
- after continued vetoes the detector escalates to `global_circuit_breaker`,
- a non-loop (plugin) denial is recorded with its own sha256 hash, not the sentinel.

Real behavior proof running the production `detectToolCallLoop` / `recordToolCall` / `recordToolCallOutcome` path on a real `SessionState` (20 identical no-progress outcomes, then the agent retrying while the critical block vetoes each call).

BEFORE (current main) — streak freezes at 20, breaker never trips:
```text
thresholds: critical=20 globalCircuitBreaker=30
after 20 identical no-progress     -> critical/generic_repeat
  after veto #1 .. #9              -> critical/generic_repeat   (streak frozen at 20)
  after veto #10                   -> critical/generic_repeat
global circuit breaker fired after continued vetoes: false
```

AFTER (this patch) — streak advances 21..30, breaker trips on veto #10:
```text
thresholds: critical=20 globalCircuitBreaker=30
after 20 identical no-progress     -> critical/generic_repeat
  after veto #9                    -> critical/generic_repeat   (streak 29)
  after veto #10                   -> critical/global_circuit_breaker  (streak 30)
global circuit breaker fired after continued vetoes: true
```

The new regression assertion fails on unpatched main (`expected detector "global_circuit_breaker", received "generic_repeat"`) and passes on this branch: 59/59 in `src/agents/tool-loop-detection.test.ts`. The pre-existing #89090 sticky-block and plugin-veto tests continue to pass unchanged.

## Real behavior proof

- Behavior or issue addressed: Session-global loop circuit breaker is unreachable once critical blocking begins (#109435), so a stuck agent re-runs a vetoed tool call until the turn timeout.
- Real environment tested: Windows, Node 22.22, exercising the production loop-detection module via tsx against a real SessionState.
- Exact steps or command run after the patch: `node --import tsx scripts/proof/global-breaker-109435.mjs`, which imports the production helpers from `src/agents/tool-loop-detection.ts` and prints the detector verdict as an identical call is repeated past the critical block and then vetoed.
- Evidence after fix: After veto #10 the verdict becomes `critical/global_circuit_breaker` (streak 30); on unpatched main it stays `critical/generic_repeat` forever (streak frozen at 20). Full before/after transcripts are in the Evidence section above.
- Observed result after fix: Global circuit breaker fires; the critical block is still active at threshold 20.
- What was not tested: A full live agent run to the breaker — the deterministic tsx and regression coverage exercise the exact streak-accounting path the issue describes. Swift lanes are not exercised on Windows. `codex review` was not run locally.
