### PR TITLE
fix(gateway): multi-account channel stops no longer fan out unbounded

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1435,6 +1435,82 @@ describe("server-channels auto restart", () => {
     await manager.stopChannel("discord");
   });
 
+  it("limits whole-channel account shutdown fanout to four after aborting every account", async () => {
+    const accountIds = ["one", "two", "three", "four", "five", "six"];
+    const releases = new Map(accountIds.map((id) => [id, createDeferred()]));
+    const aborted = new Set<string>();
+    const abortCountsAtStop: number[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const startAccount = vi.fn(
+      async ({ abortSignal, accountId }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener(
+            "abort",
+            () => {
+              aborted.add(accountId);
+              resolve();
+            },
+            { once: true },
+          );
+        }),
+    );
+    const stopAccount = vi.fn(async ({ accountId }: ChannelGatewayContext<TestAccount>) => {
+      abortCountsAtStop.push(aborted.size);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await releases.get(accountId)?.promise;
+      active -= 1;
+    });
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => accountIds,
+        startAccount,
+        stopAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannel("discord");
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === accountIds.length,
+      "expected every account runtime to start",
+    );
+
+    const stop = manager.stopChannel("discord");
+    await waitForMicrotaskCondition(
+      () => stopAccount.mock.calls.length >= 4,
+      "expected first account shutdown wave",
+    );
+    const firstWaveCallCount = stopAccount.mock.calls.length;
+    const firstWaveActive = active;
+    const abortedBeforeFirstWave = new Set(aborted);
+
+    accountIds.slice(0, 4).forEach((id) => releases.get(id)?.resolve());
+    await waitForMicrotaskCondition(
+      () => stopAccount.mock.calls.length === accountIds.length,
+      "expected second account shutdown wave",
+    );
+    const secondWaveActive = active;
+
+    accountIds.slice(4).forEach((id) => releases.get(id)?.resolve());
+    await stop;
+
+    expect(firstWaveCallCount).toBe(4);
+    expect(firstWaveActive).toBe(4);
+    expect(maxActive).toBe(4);
+    expect(abortedBeforeFirstWave).toEqual(new Set(accountIds));
+    expect(abortCountsAtStop).toEqual(Array.from({ length: accountIds.length }, () => 6));
+    expect(secondWaveActive).toBe(2);
+    expect(stopAccount).toHaveBeenCalledTimes(6);
+    expect(active).toBe(0);
+    for (const account of Object.values(
+      manager.getRuntimeSnapshot().channelAccounts.discord ?? {},
+    )) {
+      expect(account.running).toBe(false);
+    }
+  });
+
   it("limits channel plugin startup fanout to four", async () => {
     const channelIds = Array.from({ length: 6 }, (_, index) => `test-${index}` as ChannelId);
     const releases: Array<() => void> = [];

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1511,6 +1511,115 @@ describe("server-channels auto restart", () => {
     }
   });
 
+  it("shares the stop grace deadline across whole-channel shutdown batches", async () => {
+    const accountIds = ["one", "two", "three", "four", "five", "six"];
+    const releaseTasks = createDeferred();
+    const startAccount = vi.fn(
+      async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => {}, { once: true });
+          void releaseTasks.promise.then(resolve);
+        }),
+    );
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => accountIds,
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannel("discord");
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === accountIds.length,
+      "expected every account runtime to start",
+    );
+
+    let stopped = false;
+    const stop = manager.stopChannel("discord").then(() => {
+      stopped = true;
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushMicrotasks(20);
+    const stoppedAtFirstDeadline = stopped;
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stop;
+    releaseTasks.resolve();
+    await flushMicrotasks(20);
+
+    expect(stoppedAtFirstDeadline).toBe(true);
+  });
+
+  it("does not let queued teardown overwrite a replacement account runtime", async () => {
+    const accountIds = ["one", "two", "three", "four", "five", "six"];
+    const firstWaveReleases = new Map(accountIds.slice(0, 4).map((id) => [id, createDeferred()]));
+    const replacementRelease = createDeferred();
+    const startCounts = new Map<string, number>();
+    let replacementSignal: AbortSignal | undefined;
+    const startAccount = vi.fn(
+      async ({ abortSignal, accountId }: ChannelGatewayContext<TestAccount>) => {
+        const startCount = (startCounts.get(accountId) ?? 0) + 1;
+        startCounts.set(accountId, startCount);
+        if (accountId === "five" && startCount === 2) {
+          replacementSignal = abortSignal;
+          await replacementRelease.promise;
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    );
+    const stopAccount = vi.fn(async ({ accountId }: ChannelGatewayContext<TestAccount>) => {
+      await firstWaveReleases.get(accountId)?.promise;
+    });
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => accountIds,
+        startAccount,
+        stopAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannel("discord");
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === accountIds.length,
+      "expected every account runtime to start",
+    );
+
+    const stop = manager.stopChannel("discord");
+    await waitForMicrotaskCondition(
+      () => stopAccount.mock.calls.length === 4,
+      "expected first account shutdown wave",
+    );
+    await flushMicrotasks(20);
+    await manager.startChannel("discord", "five");
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === accountIds.length + 1,
+      "expected replacement account runtime to start",
+    );
+
+    for (const release of firstWaveReleases.values()) {
+      release.resolve();
+    }
+    await stop;
+
+    const stoppedAccountIds = stopAccount.mock.calls.map(
+      ([ctx]) => (ctx as ChannelGatewayContext<TestAccount>).accountId,
+    );
+    const replacementWasAborted = replacementSignal?.aborted;
+    const replacementRunning =
+      manager.getRuntimeSnapshot().channelAccounts.discord?.five?.running === true;
+    replacementRelease.resolve();
+    await flushMicrotasks();
+
+    expect(stoppedAccountIds).not.toContain("five");
+    expect(replacementWasAborted).toBe(false);
+    expect(replacementRunning).toBe(true);
+  });
+
   it("limits channel plugin startup fanout to four", async () => {
     const channelIds = Array.from({ length: 6 }, (_, index) => `test-${index}` as ChannelId);
     const releases: Array<() => void> = [];

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -899,18 +899,21 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       knownIds.add(accountId);
     }
 
-    await Promise.all(
-      Array.from(knownIds.values()).map(async (id) => {
-        const abort = store.aborts.get(id);
-        const task = store.tasks.get(id);
-        if (!abort && !task && !plugin?.gateway?.stopAccount) {
-          return;
-        }
-        const rKey = restartKey(channelId, id);
-        if (manual) {
-          manuallyStopped.add(rKey);
-        }
-        abort?.abort();
+    const stopTasks: Array<() => Promise<void>> = [];
+    // Abort every account before provider hooks run so one slow stop hook cannot
+    // delay cancellation of the remaining channel runtimes.
+    for (const id of knownIds) {
+      const abort = store.aborts.get(id);
+      const task = store.tasks.get(id);
+      if (!abort && !task && !plugin?.gateway?.stopAccount) {
+        continue;
+      }
+      const rKey = restartKey(channelId, id);
+      if (manual) {
+        manuallyStopped.add(rKey);
+      }
+      abort?.abort();
+      stopTasks.push(async () => {
         const log = ensureChannelLog(channelId);
         const runtime = ensureChannelRuntime(channelId);
         if (plugin?.gateway?.stopAccount) {
@@ -960,8 +963,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           restartPending: false,
           lastStopAt: Date.now(),
         });
-      }),
-    );
+      });
+    }
+
+    const shutdown = await runTasksWithConcurrency({
+      limit: CHANNEL_STARTUP_CONCURRENCY,
+      tasks: stopTasks,
+    });
+    if (shutdown.hasError) {
+      throw shutdown.firstError;
+    }
   };
 
   const startChannels = async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -913,7 +913,19 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         manuallyStopped.add(rKey);
       }
       abort?.abort();
+      const gracefulStop = waitForChannelStopGracefully(task, CHANNEL_STOP_ABORT_TIMEOUT_MS);
+      const lifecycleWasReplaced = () => {
+        const currentAbort = store.aborts.get(id);
+        const currentTask = store.tasks.get(id);
+        return (
+          (currentAbort !== undefined && currentAbort !== abort) ||
+          (currentTask !== undefined && currentTask !== task)
+        );
+      };
       stopTasks.push(async () => {
+        if (lifecycleWasReplaced()) {
+          return;
+        }
         const log = ensureChannelLog(channelId);
         const runtime = ensureChannelRuntime(channelId);
         if (plugin?.gateway?.stopAccount) {
@@ -929,10 +941,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             setStatus: (next) => setRuntime(channelId, id, next),
           });
         }
-        const stoppedCleanly = await waitForChannelStopGracefully(
-          task,
-          CHANNEL_STOP_ABORT_TIMEOUT_MS,
-        );
+        const stoppedCleanly = await gracefulStop;
+        if (lifecycleWasReplaced()) {
+          return;
+        }
         if (!stoppedCleanly) {
           log.warn?.(
             `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
@@ -957,8 +969,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         }
         recoveryStopTimedOut.delete(rKey);
         recoveryStartRequested.delete(rKey);
-        store.aborts.delete(id);
-        store.tasks.delete(id);
+        if (store.aborts.get(id) === abort) {
+          store.aborts.delete(id);
+        }
+        if (store.tasks.get(id) === task) {
+          store.tasks.delete(id);
+        }
         setStoppedRuntime(channelId, id, {
           restartPending: false,
           lastStopAt: Date.now(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping or reloading a channel with many configured accounts could launch every provider teardown hook at once. A six-account reproduction reached six concurrent stop hooks, and a slow hook could run before later account runtimes had even received their abort signal.

## Why This Change Was Made

Whole-channel stops now abort every selected account first, then run provider stop hooks and the existing graceful task wait with the same four-account concurrency bound already used for account startup. Grace deadlines start at abort time so queued accounts keep the same five-second stop window, and queued teardown work is fenced from any newer replacement runtime. Single-account behavior, timeout state, and public configuration are unchanged.

## User Impact

Gateway shutdowns and channel reloads avoid unbounded account teardown bursts while still cancelling all affected runtimes immediately. Large multi-account channel configurations no longer multiply provider cleanup concurrency.

## Evidence

- Regression RED on the previous implementation: the six-account test reported `expected 4, received 6`; stop hooks observed abort counts `[1, 2, 3, 4, 5, 6]` instead of all six accounts already being aborted.
- Immediate abort ordering: the green regression requires all six aborts to be visible before the first stop hook and requires every hook to observe an abort count of six.
- Bounded teardown: the green regression requires a first wave of four active stop hooks, a second wave of two, and a maximum concurrency of four.
- Shared deadline: a six-account stalled-task regression requires the whole stop to finish at the first five-second grace deadline rather than adding another deadline for queued accounts.
- Replacement fencing: a queued-teardown regression starts a replacement for account five and verifies that stale teardown neither calls its stop hook nor marks the replacement runtime stopped.
- `node scripts/run-vitest.mjs src/gateway/server-channels.test.ts` — 51 tests passed on `4c3d851746027a293236e58cbe0080a2a5d73258`. Gateway benchmark before: Vitest 132.05s / wrapper wall 147.19s (48 tests, cold transform). Final: Vitest 31.66s; wrapper wall 381.08s included 5m31s queued behind another worktree's shared heavy-check lock, so the timing delta is not presented as a performance claim.
- `./node_modules/.bin/oxfmt --check src/gateway/server-channels.ts src/gateway/server-channels.test.ts`
- `./node_modules/.bin/oxlint src/gateway/server-channels.ts src/gateway/server-channels.test.ts`
- `git diff --check`
- `codex review --base origin/main` completed once; both findings were addressed with deadline-window and replacement-generation regression coverage.
- GitHub exact-head checks completed: 81 passed and 42 skipped/neutral; no failed or pending checks.

Proof scope: the lifecycle evidence above is deterministic Gateway-manager coverage using the repository's test plugin registry. It is not a live third-party provider or user gateway run. No live six-account provider credentials/setup was available, so the requested real-setup transcript remains an explicitly unverified boundary.

Not run locally: the broad changed-file gate could not delegate because the local Blacksmith CLI is unavailable. The focused Gateway lifecycle suite and touched-file checks above passed on the final diff; GitHub's exact-head checks subsequently completed without failures.
