### PR TITLE
fix(elevenlabs): stop oversized streaming TTS audio

### DIFF
--- a/extensions/elevenlabs/tts.test.ts
+++ b/extensions/elevenlabs/tts.test.ts
@@ -220,6 +220,67 @@ describe("elevenlabs tts diagnostics", () => {
     }
   });
 
+  it("releases an unread provider stream when the public release hook runs", async () => {
+    const cancel = vi.fn();
+    const audioStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+      cancel,
+    });
+    const fetchMock = vi.fn(
+      async () => new Response(audioStream, { headers: { "content-type": "audio/mpeg" } }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await elevenLabsTTSStream(createDefaultTtsRequest());
+    try {
+      expect(audioStream.locked).toBe(true);
+
+      await result.release();
+      await result.release();
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(audioStream.locked).toBe(false);
+    } finally {
+      await result.audioStream.cancel().catch(() => undefined);
+      await result.release();
+    }
+  });
+
+  it("releases a partially consumed provider stream while its consumer holds a reader", async () => {
+    const cancel = vi.fn();
+    const audioStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+      cancel,
+    });
+    const fetchMock = vi.fn(
+      async () => new Response(audioStream, { headers: { "content-type": "audio/mpeg" } }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await elevenLabsTTSStream(createDefaultTtsRequest());
+    const reader = result.audioStream.getReader();
+    try {
+      await expect(reader.read()).resolves.toEqual({
+        done: false,
+        value: new Uint8Array([1, 2, 3]),
+      });
+
+      await result.release();
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(audioStream.locked).toBe(false);
+      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+    } finally {
+      await reader.cancel().catch(() => undefined);
+      reader.releaseLock();
+      await result.release();
+    }
+  });
+
   it("cancels streamed audio before delivering bytes beyond the audio limit", async () => {
     const cancel = vi.fn();
     const audioStream = new ReadableStream<Uint8Array>({

--- a/extensions/elevenlabs/tts.test.ts
+++ b/extensions/elevenlabs/tts.test.ts
@@ -1,4 +1,5 @@
 // Elevenlabs tests cover tts plugin behavior.
+import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingErrorResponse } from "../test-support/streaming-error-response.js";
 import { elevenLabsTTS, elevenLabsTTSStream } from "./tts.js";
@@ -207,7 +208,39 @@ describe("elevenlabs tts diagnostics", () => {
     const url = getUrlFromFirstFetchCall(fetchMock);
     expect(url.pathname).toBe("/v1/text-to-speech/pMsXgVXv3BLzUgSXRplE/stream");
     expect(url.searchParams.get("optimize_streaming_latency")).toBe("2");
-    expect(result.audioStream).toBeInstanceOf(ReadableStream);
+    const reader = result.audioStream.getReader();
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: new Uint8Array([1, 2, 3]),
+    });
+    await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+    await result.release();
+  });
+
+  it("cancels streamed audio before delivering bytes beyond the audio limit", async () => {
+    const cancel = vi.fn();
+    const audioStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(MAX_AUDIO_BYTES));
+        controller.enqueue(new Uint8Array([1]));
+      },
+      cancel,
+    });
+    const fetchMock = vi.fn(
+      async () => new Response(audioStream, { headers: { "content-type": "audio/mpeg" } }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await elevenLabsTTSStream(createDefaultTtsRequest());
+    const reader = result.audioStream.getReader();
+
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(first.value).toHaveLength(MAX_AUDIO_BYTES);
+    await expect(reader.read()).rejects.toThrow(
+      `ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`,
+    );
+    expect(cancel).toHaveBeenCalledOnce();
     await result.release();
   });
 

--- a/extensions/elevenlabs/tts.test.ts
+++ b/extensions/elevenlabs/tts.test.ts
@@ -204,17 +204,20 @@ describe("elevenlabs tts diagnostics", () => {
       ...createDefaultTtsRequest(),
       latencyTier: 2,
     });
-
-    const url = getUrlFromFirstFetchCall(fetchMock);
-    expect(url.pathname).toBe("/v1/text-to-speech/pMsXgVXv3BLzUgSXRplE/stream");
-    expect(url.searchParams.get("optimize_streaming_latency")).toBe("2");
-    const reader = result.audioStream.getReader();
-    await expect(reader.read()).resolves.toEqual({
-      done: false,
-      value: new Uint8Array([1, 2, 3]),
-    });
-    await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
-    await result.release();
+    try {
+      const url = getUrlFromFirstFetchCall(fetchMock);
+      expect(url.pathname).toBe("/v1/text-to-speech/pMsXgVXv3BLzUgSXRplE/stream");
+      expect(url.searchParams.get("optimize_streaming_latency")).toBe("2");
+      const reader = result.audioStream.getReader();
+      await expect(reader.read()).resolves.toEqual({
+        done: false,
+        value: new Uint8Array([1, 2, 3]),
+      });
+      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+      expect(audioStream.locked).toBe(false);
+    } finally {
+      await result.release();
+    }
   });
 
   it("cancels streamed audio before delivering bytes beyond the audio limit", async () => {
@@ -232,16 +235,20 @@ describe("elevenlabs tts diagnostics", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const result = await elevenLabsTTSStream(createDefaultTtsRequest());
-    const reader = result.audioStream.getReader();
+    try {
+      const reader = result.audioStream.getReader();
 
-    const first = await reader.read();
-    expect(first.done).toBe(false);
-    expect(first.value).toHaveLength(MAX_AUDIO_BYTES);
-    await expect(reader.read()).rejects.toThrow(
-      `ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`,
-    );
-    expect(cancel).toHaveBeenCalledOnce();
-    await result.release();
+      const first = await reader.read();
+      expect(first.done).toBe(false);
+      expect(first.value).toHaveLength(MAX_AUDIO_BYTES);
+      await expect(reader.read()).rejects.toThrow(
+        `ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`,
+      );
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(audioStream.locked).toBe(false);
+    } finally {
+      await result.release();
+    }
   });
 
   it("rejects JSON success stream responses as malformed audio", async () => {

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -1,4 +1,5 @@
 // Elevenlabs plugin module implements tts behavior.
+import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import {
   assertOkOrThrowProviderError,
   assertProviderBinaryResponseContent,
@@ -46,6 +47,29 @@ function normalizeElevenLabsLatencyTier(latencyTier: number | undefined): number
   }
   requireInRange(latencyTier, 0, 4, "latencyTier");
   return latencyTier;
+}
+
+// The buffered path rejects provider audio above MAX_AUDIO_BYTES. Enforce the same cap
+// without buffering and stop upstream before any byte beyond the cap reaches playback.
+function limitElevenLabsAudioStream(
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  let totalBytes = 0;
+  return stream.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        const remainingBytes = MAX_AUDIO_BYTES - totalBytes;
+        if (chunk.byteLength > remainingBytes) {
+          if (remainingBytes > 0) {
+            controller.enqueue(chunk.subarray(0, remainingBytes));
+          }
+          throw new Error(`ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`);
+        }
+        totalBytes += chunk.byteLength;
+        controller.enqueue(chunk);
+      },
+    }),
+  );
 }
 
 type ElevenLabsTtsRequestParams = {
@@ -193,7 +217,7 @@ export async function elevenLabsTTSStream(params: ElevenLabsTtsRequestParams): P
     }
     handedOff = true;
     return {
-      audioStream: response.body,
+      audioStream: limitElevenLabsAudioStream(response.body),
       release,
     };
   } finally {

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -272,7 +272,13 @@ export async function elevenLabsTTSStream(params: ElevenLabsTtsRequestParams): P
     const boundedStream = createBoundedElevenLabsAudioStream(response.body);
     let releasePromise: Promise<void> | undefined;
     const releaseAll = () => {
-      releasePromise ??= boundedStream.release().finally(release);
+      releasePromise ??= (async () => {
+        try {
+          await boundedStream.release();
+        } finally {
+          await release();
+        }
+      })();
       return releasePromise;
     };
     handedOff = true;

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -51,16 +51,31 @@ function normalizeElevenLabsLatencyTier(latencyTier: number | undefined): number
 
 // Mirror the buffered cap without buffering. Own the reader because Node can leak
 // transform writer rejections when playback cancellation races an overflow.
-function limitElevenLabsAudioStream(
+function createBoundedElevenLabsAudioStream(
   stream: ReadableStream<Uint8Array>,
 ): ReadableStream<Uint8Array> {
-  const reader = stream.getReader();
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let totalBytes = 0;
+
+  const releaseReader = () => {
+    reader?.releaseLock();
+    reader = undefined;
+  };
+
   return new ReadableStream<Uint8Array>({
+    start() {
+      reader = stream.getReader();
+    },
     async pull(controller) {
+      const activeReader = reader;
+      if (!activeReader) {
+        controller.close();
+        return;
+      }
       try {
-        const chunk = await reader.read();
+        const chunk = await activeReader.read();
         if (chunk.done) {
+          releaseReader();
           controller.close();
           return;
         }
@@ -72,19 +87,28 @@ function limitElevenLabsAudioStream(
           const error = new Error(
             `ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`,
           );
+          await activeReader.cancel(error).catch(() => undefined);
+          releaseReader();
           controller.error(error);
-          void reader.cancel(error).catch(() => undefined);
           return;
         }
         totalBytes += chunk.value.byteLength;
         controller.enqueue(chunk.value);
       } catch (error) {
+        releaseReader();
         controller.error(error);
-        void reader.cancel(error).catch(() => undefined);
       }
     },
     async cancel(reason) {
-      await reader.cancel(reason).catch(() => undefined);
+      const activeReader = reader;
+      if (!activeReader) {
+        return;
+      }
+      try {
+        await activeReader.cancel(reason).catch(() => undefined);
+      } finally {
+        releaseReader();
+      }
     },
   });
 }
@@ -234,7 +258,7 @@ export async function elevenLabsTTSStream(params: ElevenLabsTtsRequestParams): P
     }
     handedOff = true;
     return {
-      audioStream: limitElevenLabsAudioStream(response.body),
+      audioStream: createBoundedElevenLabsAudioStream(response.body),
       release,
     };
   } finally {

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -49,27 +49,44 @@ function normalizeElevenLabsLatencyTier(latencyTier: number | undefined): number
   return latencyTier;
 }
 
-// The buffered path rejects provider audio above MAX_AUDIO_BYTES. Enforce the same cap
-// without buffering and stop upstream before any byte beyond the cap reaches playback.
+// Mirror the buffered cap without buffering. Own the reader because Node can leak
+// transform writer rejections when playback cancellation races an overflow.
 function limitElevenLabsAudioStream(
   stream: ReadableStream<Uint8Array>,
 ): ReadableStream<Uint8Array> {
+  const reader = stream.getReader();
   let totalBytes = 0;
-  return stream.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        const remainingBytes = MAX_AUDIO_BYTES - totalBytes;
-        if (chunk.byteLength > remainingBytes) {
-          if (remainingBytes > 0) {
-            controller.enqueue(chunk.subarray(0, remainingBytes));
-          }
-          throw new Error(`ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`);
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          controller.close();
+          return;
         }
-        totalBytes += chunk.byteLength;
-        controller.enqueue(chunk);
-      },
-    }),
-  );
+        const remainingBytes = MAX_AUDIO_BYTES - totalBytes;
+        if (chunk.value.byteLength > remainingBytes) {
+          if (remainingBytes > 0) {
+            controller.enqueue(chunk.value.subarray(0, remainingBytes));
+          }
+          const error = new Error(
+            `ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`,
+          );
+          controller.error(error);
+          void reader.cancel(error).catch(() => undefined);
+          return;
+        }
+        totalBytes += chunk.value.byteLength;
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        controller.error(error);
+        void reader.cancel(error).catch(() => undefined);
+      }
+    },
+    async cancel(reason) {
+      await reader.cancel(reason).catch(() => undefined);
+    },
+  });
 }
 
 type ElevenLabsTtsRequestParams = {

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -51,18 +51,34 @@ function normalizeElevenLabsLatencyTier(latencyTier: number | undefined): number
 
 // Mirror the buffered cap without buffering. Own the reader because Node can leak
 // transform writer rejections when playback cancellation races an overflow.
-function createBoundedElevenLabsAudioStream(
-  stream: ReadableStream<Uint8Array>,
-): ReadableStream<Uint8Array> {
+function createBoundedElevenLabsAudioStream(stream: ReadableStream<Uint8Array>): {
+  audioStream: ReadableStream<Uint8Array>;
+  release: () => Promise<void>;
+} {
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let totalBytes = 0;
 
-  const releaseReader = () => {
-    reader?.releaseLock();
+  const releaseReader = (activeReader: ReadableStreamDefaultReader<Uint8Array>) => {
+    if (reader !== activeReader) {
+      return;
+    }
     reader = undefined;
+    activeReader.releaseLock();
   };
 
-  return new ReadableStream<Uint8Array>({
+  const cancelReader = async (reason?: unknown) => {
+    const activeReader = reader;
+    if (!activeReader) {
+      return;
+    }
+    try {
+      await activeReader.cancel(reason).catch(() => undefined);
+    } finally {
+      releaseReader(activeReader);
+    }
+  };
+
+  const audioStream = new ReadableStream<Uint8Array>({
     start() {
       reader = stream.getReader();
     },
@@ -75,7 +91,7 @@ function createBoundedElevenLabsAudioStream(
       try {
         const chunk = await activeReader.read();
         if (chunk.done) {
-          releaseReader();
+          releaseReader(activeReader);
           controller.close();
           return;
         }
@@ -88,29 +104,26 @@ function createBoundedElevenLabsAudioStream(
             `ElevenLabs API error: audio response exceeds ${MAX_AUDIO_BYTES} bytes`,
           );
           await activeReader.cancel(error).catch(() => undefined);
-          releaseReader();
+          releaseReader(activeReader);
           controller.error(error);
           return;
         }
         totalBytes += chunk.value.byteLength;
         controller.enqueue(chunk.value);
       } catch (error) {
-        releaseReader();
+        releaseReader(activeReader);
         controller.error(error);
       }
     },
     async cancel(reason) {
-      const activeReader = reader;
-      if (!activeReader) {
-        return;
-      }
-      try {
-        await activeReader.cancel(reason).catch(() => undefined);
-      } finally {
-        releaseReader();
-      }
+      await cancelReader(reason);
     },
   });
+
+  return {
+    audioStream,
+    release: () => cancelReader(new Error("ElevenLabs TTS stream released")),
+  };
 }
 
 type ElevenLabsTtsRequestParams = {
@@ -256,10 +269,16 @@ export async function elevenLabsTTSStream(params: ElevenLabsTtsRequestParams): P
     if (!response.body) {
       throw new Error("ElevenLabs API response missing audio stream");
     }
+    const boundedStream = createBoundedElevenLabsAudioStream(response.body);
+    let releasePromise: Promise<void> | undefined;
+    const releaseAll = () => {
+      releasePromise ??= boundedStream.release().finally(release);
+      return releasePromise;
+    };
     handedOff = true;
     return {
-      audioStream: createBoundedElevenLabsAudioStream(response.body),
-      release,
+      audioStream: boundedStream.audioStream,
+      release: releaseAll,
     };
   } finally {
     if (!handedOff) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where ElevenLabs streaming TTS could continue delivering provider
audio beyond the 16 MiB limit already enforced by the buffered path. An
oversized or unbounded response could therefore keep consuming network and
Discord playback resources.

## Why This Change Was Made

The ElevenLabs stream owner now enforces the shared `MAX_AUDIO_BYTES` policy
without buffering. It owns the provider-body reader, waits for upstream
cancellation before surfacing an overflow, and releases the reader lock on
normal completion, read failure, overflow, consumer cancellation, and early
public release. The release hook composes reader cleanup with transport cleanup
and remains safe to call more than once.

Provider configuration, request/response types, output formats, and other
speech providers are unchanged.

## User Impact

Normal ElevenLabs voice replies continue streaming into playback unchanged.
Oversized responses now fail at a deterministic 16 MiB boundary, close the
provider response, stop Discord playback, and complete transport cleanup.

## Evidence

### Actual OpenClaw streaming consumer

A guarded local ElevenLabs-compatible HTTP fixture exercised the production
provider and Discord consumer chain on the rebased head:

```text
buildElevenLabsSpeechProvider().streamSynthesize
  -> fetchWithSsrFGuard
  -> Readable.fromWeb
  -> createDiscordOpusPlaybackStream
```

Observed after the final diff:

```text
normal: completed=true, opus_packets=15, playback_ended=true, release_settled=true
overflow: error="ElevenLabs API error: audio response exceeds 16777216 bytes"
overflow: provider_connection_closed_before_release=true
overflow: node_input_destroyed=true, playback_destroyed=true
overflow: ffmpeg_stopped=true, release_settled=true
```

The normal response used generated valid MP3 audio. The overflow response used
a valid oversized ID3 metadata prefix so the byte boundary was reached without
an external service. Credentials, loopback endpoint details, and local paths
are omitted; no live ElevenLabs key or external Discord account was used.

### Regression and extension coverage

- Before the lifecycle repair, the overflow regression observed the upstream
  provider stream still locked after cancellation (`expected false`, received
  `true`).
- Before the release-hook repair, both early-release regressions observed zero
  upstream cancellations and a still-locked provider stream.
- Complete ElevenLabs TTS file on the final candidate: 15/15 tests passed,
  including unread and partially consumed early-release cleanup.
- ElevenLabs plugin lane on the final candidate: 5 files and 36/36 tests passed.
- Targeted formatting and lint checks passed on the submitted files.
- The max-lines ratchet passed on the exact current-main merge preview with
  1,184 grandfathered suppressions.
