### PR TITLE
fix(copilot): resolve transport routing bug for issue #99240

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -334,6 +334,23 @@ describe("github-copilot plugin", () => {
     expect(profile?.levels.map((level) => level.id)).toContain("max");
   });
 
+  it("keeps Copilot Claude thinking provider-owned when catalog reasoning is stale", () => {
+    const provider = registerProviderWithPluginConfig({});
+
+    const profile = provider.resolveThinkingProfile({
+      provider: "github-copilot",
+      modelId: "claude-sonnet-4.6",
+      api: "anthropic-messages",
+      reasoning: false,
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "max"] },
+    });
+
+    expect(profile?.preserveWhenCatalogReasoningFalse).toBe(true);
+    expect(profile?.levels.map((level) => level.id)).toEqual(
+      expect.arrayContaining(["high", "adaptive", "max"]),
+    );
+  });
+
   it("does not expose max for non-adaptive Claude Copilot models", () => {
     const provider = registerProviderWithPluginConfig({});
 

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -22,8 +22,9 @@ import {
 import { PUBLIC_GITHUB_COPILOT_DOMAIN, resolveGithubCopilotDomain } from "./domain.js";
 import { createGithubCopilotDynamicModelHooks } from "./dynamic-models.js";
 import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
-import { DEFAULT_COPILOT_MODEL, resolveCopilotExtendedThinkingLevels } from "./model-metadata.js";
+import { DEFAULT_COPILOT_MODEL } from "./model-metadata.js";
 import { PROVIDER_ID } from "./models.js";
+import { resolveThinkingProfile as resolveGithubCopilotThinkingProfile } from "./provider-policy-api.js";
 import {
   buildGithubCopilotReplayPolicy,
   sanitizeGithubCopilotReplayHistory,
@@ -605,19 +606,8 @@ export default definePluginEntry({
       wrapStreamFn: wrapCopilotProviderStream,
       buildReplayPolicy: ({ modelId }) => buildGithubCopilotReplayPolicy(modelId),
       sanitizeReplayHistory: sanitizeGithubCopilotReplayHistory,
-      resolveThinkingProfile: ({ modelId, compat }) => {
-        const extendedLevels = resolveCopilotExtendedThinkingLevels(modelId, compat);
-        return {
-          levels: [
-            { id: "off" },
-            { id: "minimal" },
-            { id: "low" },
-            { id: "medium" },
-            { id: "high" },
-            ...extendedLevels.map((id) => ({ id })),
-          ],
-        };
-      },
+      resolveThinkingProfile: (context) =>
+        resolveGithubCopilotThinkingProfile(context) ?? undefined,
       prepareRuntimeAuth: async (ctx) => {
         const { resolveCopilotRuntimeAuth } = await loadGithubCopilotRuntime();
         const auth = await resolveCopilotRuntimeAuth({

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -690,6 +690,46 @@ describe("fetchCopilotModelCatalog", () => {
     expect(fetchImpl.mock.calls[0]?.[0]).toBe("https://api.githubcopilot.com/models");
   });
 
+  it("uses advertised supported_endpoints to resolve live transport", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      makeResponse(200, {
+        data: [
+          {
+            id: "claude-sonnet-4.6",
+            name: "Claude Sonnet 4.6",
+            object: "model",
+            supported_endpoints: ["/v1/messages"],
+            capabilities: { type: "chat" },
+          },
+          {
+            id: "gpt-responses-only",
+            name: "GPT Responses Only",
+            object: "model",
+            supported_endpoints: ["/v1/responses"],
+            capabilities: { type: "chat" },
+          },
+          {
+            id: "gemini-chat-completions",
+            name: "Gemini Chat Completions",
+            object: "model",
+            supported_endpoints: ["/v1/responses", "/v1/chat/completions"],
+            capabilities: { type: "chat" },
+          },
+        ],
+      }),
+    );
+
+    const out = await fetchCopilotModelCatalog({
+      copilotApiToken: "tid=test",
+      baseUrl: "https://api.githubcopilot.com",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(out.find((m) => m.id === "claude-sonnet-4.6")?.api).toBe("anthropic-messages");
+    expect(out.find((m) => m.id === "gpt-responses-only")?.api).toBe("openai-responses");
+    expect(out.find((m) => m.id === "gemini-chat-completions")?.api).toBe("openai-completions");
+  });
+
   it("dedupes by id when API returns duplicates", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       makeResponse(200, {

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -101,6 +101,7 @@ type CopilotApiModelEntry = {
   vendor?: string;
   preview?: boolean;
   model_picker_enabled?: boolean;
+  supported_endpoints?: string[];
   capabilities?: {
     type?: string;
     family?: string;
@@ -129,9 +130,20 @@ type CopilotCatalogModel = Omit<ModelDefinitionConfig, "input"> & {
 function resolveCopilotApiForVendor(
   vendor: string | undefined,
   modelId: string,
+  supportedEndpoints?: string[],
 ): "anthropic-messages" | "openai-completions" | "openai-responses" {
   if (vendor && vendor.toLowerCase() === "anthropic") {
     return "anthropic-messages";
+  }
+  if (Array.isArray(supportedEndpoints)) {
+    const hasResponses = supportedEndpoints.some((ep) => ep.includes("responses"));
+    const hasCompletions = supportedEndpoints.some((ep) => ep.includes("completions"));
+    if (hasResponses && !hasCompletions) {
+      return "openai-responses";
+    }
+    if (hasCompletions) {
+      return "openai-completions";
+    }
   }
   return resolveCopilotTransportApi(modelId);
 }
@@ -205,7 +217,7 @@ function mapCopilotApiModelToDefinition(
   const contextTokens = asPositiveSafeInteger(limits?.max_prompt_tokens);
   const maxTokens = asPositiveSafeInteger(limits?.max_output_tokens) ?? DEFAULT_MAX_TOKENS;
   const compat = mergeCopilotCompat(resolveCopilotModelCompat(id), supports?.reasoning_effort);
-  const api = resolveCopilotApiForVendor(entry.vendor, id);
+  const api = resolveCopilotApiForVendor(entry.vendor, id, entry.supported_endpoints);
   const thinkingLevelMap = resolveCopilotThinkingLevelMap(api, id, compat);
 
   const definition: CopilotCatalogModel = {

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -136,6 +136,10 @@ function resolveCopilotApiForVendor(
     return "anthropic-messages";
   }
   if (Array.isArray(supportedEndpoints)) {
+    const hasMessages = supportedEndpoints.some((ep) => ep.includes("messages"));
+    if (hasMessages) {
+      return "anthropic-messages";
+    }
     const hasResponses = supportedEndpoints.some((ep) => ep.includes("responses"));
     const hasCompletions = supportedEndpoints.some((ep) => ep.includes("completions"));
     if (hasResponses && !hasCompletions) {

--- a/extensions/github-copilot/provider-policy-api.test.ts
+++ b/extensions/github-copilot/provider-policy-api.test.ts
@@ -51,6 +51,40 @@ describe("github-copilot provider-policy-api", () => {
     ).toContain("max");
   });
 
+  it("uses the Claude profile for Copilot Claude models on anthropic-messages", () => {
+    const profile = resolveThinkingProfile({
+      provider: "github-copilot",
+      modelId: "claude-sonnet-4.6",
+      api: "anthropic-messages",
+      reasoning: false,
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "max"] },
+    });
+
+    expect(profile?.preserveWhenCatalogReasoningFalse).toBe(true);
+    expect(profile?.levels.map((level) => level.id)).toEqual(
+      expect.arrayContaining(["off", "minimal", "low", "medium", "high", "adaptive", "max"]),
+    );
+  });
+
+  it("keeps non-Claude Copilot profiles from overriding catalog reasoning=false", () => {
+    const profile = resolveThinkingProfile({
+      provider: "github-copilot",
+      modelId: "gpt-5-mini",
+      api: "openai-responses",
+      reasoning: false,
+      compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
+    });
+
+    expect(profile?.preserveWhenCatalogReasoningFalse).toBeUndefined();
+    expect(profile?.levels.map((level) => level.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
   it("does not expose max for non-Anthropic Copilot transports", () => {
     expect(
       resolveThinkingProfile({

--- a/extensions/github-copilot/provider-policy-api.ts
+++ b/extensions/github-copilot/provider-policy-api.ts
@@ -1,11 +1,31 @@
 // Github Copilot API module exposes the plugin public contract.
-import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
+import type {
+  ProviderDefaultThinkingPolicyContext,
+  ProviderThinkingProfile,
+} from "openclaw/plugin-sdk/core";
+import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/provider-model-shared";
 import { resolveCopilotExtendedThinkingLevels } from "./model-metadata.js";
 
-export function resolveThinkingProfile(context: ProviderDefaultThinkingPolicyContext) {
+function isCopilotClaudeAnthropicMessagesModel({
+  api,
+  modelId,
+}: ProviderDefaultThinkingPolicyContext): boolean {
+  return api === "anthropic-messages" && modelId.trim().toLowerCase().includes("claude");
+}
+
+export function resolveThinkingProfile(
+  context: ProviderDefaultThinkingPolicyContext,
+): ProviderThinkingProfile | null {
   if (context.provider.trim().toLowerCase() !== "github-copilot") {
     return null;
   }
+  if (isCopilotClaudeAnthropicMessagesModel(context)) {
+    return {
+      ...resolveClaudeThinkingProfile(context.modelId, context.params, { includeNativeMax: true }),
+      preserveWhenCatalogReasoningFalse: true,
+    };
+  }
+
   const extendedLevels = resolveCopilotExtendedThinkingLevels(context.modelId, context.compat);
 
   return {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -600,7 +600,39 @@ describe("listThinkingLevels", () => {
       }),
     ).toBe(true);
   });
+  it("keeps Copilot Claude thinking levels when catalog reasoning is false", () => {
+    const catalog = [
+      {
+        provider: "github-copilot",
+        id: "claude-sonnet-4.6",
+        api: "anthropic-messages",
+        reasoning: false,
+        compat: { supportedReasoningEfforts: ["low", "medium", "high", "max"] },
+      },
+    ];
 
+    const levels = listThinkingLevels("github-copilot", "claude-sonnet-4.6", catalog);
+    expect(levels).toContain("high");
+    expect(levels).toContain("adaptive");
+    expect(levels).toContain("max");
+    expect(levels).not.toEqual(["off"]);
+  });
+
+  it("keeps Copilot Claude thinking levels when reasoning metadata is stale", () => {
+    const catalog = [
+      {
+        provider: "github-copilot",
+        id: "claude-sonnet-4.6",
+        api: "anthropic-messages",
+        reasoning: false,
+      },
+    ];
+
+    const levels = listThinkingLevels("github-copilot", "claude-sonnet-4.6", catalog);
+    expect(levels).toContain("high");
+    expect(levels).toContain("adaptive");
+    expect(levels).not.toEqual(["off"]);
+  });
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -600,38 +600,20 @@ describe("listThinkingLevels", () => {
       }),
     ).toBe(true);
   });
-  it("keeps Copilot Claude thinking levels when catalog reasoning is false", () => {
+  it("does not let catalog reasoning efforts bypass explicit reasoning=false", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
+      levels: [{ id: "off" }, { id: "low" }],
+    });
     const catalog = [
       {
-        provider: "github-copilot",
-        id: "claude-sonnet-4.6",
-        api: "anthropic-messages",
+        provider: "openai",
+        id: "gpt-subscription-model",
         reasoning: false,
-        compat: { supportedReasoningEfforts: ["low", "medium", "high", "max"] },
+        compat: { supportedReasoningEfforts: ["low"] },
       },
     ];
 
-    const levels = listThinkingLevels("github-copilot", "claude-sonnet-4.6", catalog);
-    expect(levels).toContain("high");
-    expect(levels).toContain("adaptive");
-    expect(levels).toContain("max");
-    expect(levels).not.toEqual(["off"]);
-  });
-
-  it("keeps Copilot Claude thinking levels when reasoning metadata is stale", () => {
-    const catalog = [
-      {
-        provider: "github-copilot",
-        id: "claude-sonnet-4.6",
-        api: "anthropic-messages",
-        reasoning: false,
-      },
-    ];
-
-    const levels = listThinkingLevels("github-copilot", "claude-sonnet-4.6", catalog);
-    expect(levels).toContain("high");
-    expect(levels).toContain("adaptive");
-    expect(levels).not.toEqual(["off"]);
+    expect(listThinkingLevels("openai", "gpt-subscription-model", catalog)).toEqual(["off"]);
   });
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -201,33 +201,16 @@ export function resolveThinkingProfile(params: {
         })
       : undefined;
   const pluginProfile = providerProfile ?? anthropicMessagesProfile;
-  const allowCopilotClaudeThinking =
-    context.normalizedProvider === "github-copilot" &&
-    context.api === "anthropic-messages" &&
-    (normalizeOptionalLowercaseString(context.modelId)?.includes("claude") ?? false);
   if (pluginProfile) {
     const normalized = normalizeThinkingProfile(pluginProfile);
-    const hasReasoningEfforts =
-      Array.isArray(context.compat?.supportedReasoningEfforts) &&
-      context.compat.supportedReasoningEfforts.length > 0;
     if (
       normalized.levels.length > 0 &&
-      (context.reasoning !== false ||
-        hasReasoningEfforts ||
-        allowCopilotClaudeThinking ||
-        pluginProfile.preserveWhenCatalogReasoningFalse === true)
+      (context.reasoning !== false || pluginProfile.preserveWhenCatalogReasoningFalse === true)
     ) {
       return normalized;
     }
   }
-  if (
-    context.reasoning === false &&
-    !allowCopilotClaudeThinking &&
-    !(
-      Array.isArray(context.compat?.supportedReasoningEfforts) &&
-      context.compat.supportedReasoningEfforts.length > 0
-    )
-  ) {
+  if (context.reasoning === false) {
     return buildOffOnlyThinkingProfile();
   }
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -201,16 +201,33 @@ export function resolveThinkingProfile(params: {
         })
       : undefined;
   const pluginProfile = providerProfile ?? anthropicMessagesProfile;
+  const allowCopilotClaudeThinking =
+    context.normalizedProvider === "github-copilot" &&
+    context.api === "anthropic-messages" &&
+    (normalizeOptionalLowercaseString(context.modelId)?.includes("claude") ?? false);
   if (pluginProfile) {
     const normalized = normalizeThinkingProfile(pluginProfile);
+    const hasReasoningEfforts =
+      Array.isArray(context.compat?.supportedReasoningEfforts) &&
+      context.compat.supportedReasoningEfforts.length > 0;
     if (
       normalized.levels.length > 0 &&
-      (context.reasoning !== false || pluginProfile.preserveWhenCatalogReasoningFalse === true)
+      (context.reasoning !== false ||
+        hasReasoningEfforts ||
+        allowCopilotClaudeThinking ||
+        pluginProfile.preserveWhenCatalogReasoningFalse === true)
     ) {
       return normalized;
     }
   }
-  if (context.reasoning === false) {
+  if (
+    context.reasoning === false &&
+    !allowCopilotClaudeThinking &&
+    !(
+      Array.isArray(context.compat?.supportedReasoningEfforts) &&
+      context.compat.supportedReasoningEfforts.length > 0
+    )
+  ) {
     return buildOffOnlyThinkingProfile();
   }
 


### PR DESCRIPTION
## What Problem This Solves
Fixes #99240 by ensuring the Copilot transport is selected from advertised endpoint capabilities, including stale-catalog fallback handling for Anthropic-compatible paths.

## Why This Change Was Made
- Resolve endpoint/transport mismatches that caused incorrect routing behavior.
- Preserve Claude thinking controls while handling stale catalog metadata safely.
- Keep transport resolution dynamic and capability-driven.

## User Impact
Users get reliable provider routing and expected behavior when endpoint capabilities differ or metadata is stale.

## Evidence
- Includes the three commits currently ahead of origin/main on this branch.
