### PR TITLE
refactor(docker): isolate E2E diagnostic artifacts

### DIFF
--- a/scripts/lib/docker-e2e-resource-diagnostics.sh
+++ b/scripts/lib/docker-e2e-resource-diagnostics.sh
@@ -23,17 +23,17 @@ docker_e2e_resource_limit_error_file() {
   return 1
 }
 
-docker_e2e_resource_limit_stderr_file() {
+docker_e2e_resource_limit_temp_dir() {
   local template="${TMPDIR:-/tmp}/openclaw-docker-resource-limits.XXXXXX"
   if command -v mktemp >/dev/null 2>&1; then
-    mktemp "$template"
+    mktemp -d "$template"
     return
   fi
   if [ -x /usr/bin/mktemp ]; then
-    /usr/bin/mktemp "$template"
+    /usr/bin/mktemp -d "$template"
     return
   fi
-  echo "mktemp command not found; cannot capture Docker resource-limit diagnostics" >&2
+  echo "mktemp command not found; cannot create Docker resource-limit diagnostics" >&2
   return 127
 }
 
@@ -61,12 +61,12 @@ docker_e2e_tail_bin() {
   return 1
 }
 
-docker_e2e_remove_diagnostic_file() {
+docker_e2e_remove_diagnostic_dir() {
   if command -v rm >/dev/null 2>&1; then
-    rm -f "$@"
+    rm -rf "$1"
     return
   fi
-  /bin/rm -f "$@"
+  /bin/rm -rf "$1"
 }
 
 docker_e2e_print_resource_limit_error() {
@@ -81,8 +81,8 @@ docker_e2e_docker_run_with_resource_diagnostics() {
     return
   fi
 
-  local stderr_file=""
-  if ! stderr_file="$(docker_e2e_resource_limit_stderr_file)"; then
+  local diagnostic_dir=""
+  if ! diagnostic_dir="$(docker_e2e_resource_limit_temp_dir)"; then
     docker_e2e_timeout_cmd \
       "$timeout_value" \
       docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
@@ -90,7 +90,7 @@ docker_e2e_docker_run_with_resource_diagnostics() {
   fi
   local tee_bin=""
   if ! tee_bin="$(docker_e2e_tee_bin)"; then
-    docker_e2e_remove_diagnostic_file "$stderr_file"
+    docker_e2e_remove_diagnostic_dir "$diagnostic_dir"
     docker_e2e_timeout_cmd \
       "$timeout_value" \
       docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
@@ -98,30 +98,23 @@ docker_e2e_docker_run_with_resource_diagnostics() {
   fi
   local tail_bin=""
   if ! tail_bin="$(docker_e2e_tail_bin)"; then
-    docker_e2e_remove_diagnostic_file "$stderr_file"
+    docker_e2e_remove_diagnostic_dir "$diagnostic_dir"
     docker_e2e_timeout_cmd \
       "$timeout_value" \
       docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
     return
   fi
-  local stderr_fifo="${stderr_file}.stderr.pipe"
-  local capture_fifo="${stderr_file}.capture.pipe"
+  local stderr_file="${diagnostic_dir}/stderr"
+  local stderr_fifo="${diagnostic_dir}/stderr.pipe"
+  local capture_fifo="${diagnostic_dir}/capture.pipe"
   local mkfifo_bin=""
   if command -v mkfifo >/dev/null 2>&1; then
     mkfifo_bin="$(command -v mkfifo)"
   elif [ -x /usr/bin/mkfifo ]; then
     mkfifo_bin=/usr/bin/mkfifo
   fi
-  local fifo_status=1
-  if [ -n "$mkfifo_bin" ]; then
-    local previous_umask=""
-    previous_umask="$(umask)"
-    umask 077
-    "$mkfifo_bin" "$stderr_fifo" "$capture_fifo" && fifo_status=0 || fifo_status="$?"
-    umask "$previous_umask"
-  fi
-  if [ "$fifo_status" -ne 0 ]; then
-    docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo" "$capture_fifo"
+  if [ -z "$mkfifo_bin" ] || ! "$mkfifo_bin" "$stderr_fifo" "$capture_fifo"; then
+    docker_e2e_remove_diagnostic_dir "$diagnostic_dir"
     docker_e2e_timeout_cmd \
       "$timeout_value" \
       docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
@@ -147,6 +140,6 @@ docker_e2e_docker_run_with_resource_diagnostics() {
   if docker_e2e_resource_limit_error_file "$run_status" "$stderr_file"; then
     docker_e2e_print_resource_limit_error
   fi
-  docker_e2e_remove_diagnostic_file "$stderr_file" "$stderr_fifo" "$capture_fifo"
+  docker_e2e_remove_diagnostic_dir "$diagnostic_dir"
   return "$run_status"
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1336,9 +1336,12 @@ docker() {
   return 125
 }
 
-mkfifo() {
-  umask >"$TMPDIR/mkfifo-umask"
-  /usr/bin/mkfifo "$@"
+mktemp() {
+  local dir=""
+  dir="$(/usr/bin/mktemp "$@")" || return
+  printf "%s\\n" "$*" >"$TMPDIR/mktemp-seen"
+  printf "%s\\n" "$dir" >"$TMPDIR/diagnostic-dir"
+  printf "%s\\n" "$dir"
 }
 
 tail() {
@@ -1366,7 +1369,8 @@ stderr="$(<"$TMPDIR/stderr")"
 [[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
 [[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
 [[ "$(<"$TMPDIR/tail-seen")" = "-c 65536" ]]
-[[ "$(<"$TMPDIR/mkfifo-umask")" = "0077" ]]
+[[ "$(<"$TMPDIR/mktemp-seen")" = -d* ]]
+[[ ! -e "$(<"$TMPDIR/diagnostic-dir")" ]]
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });


### PR DESCRIPTION
Related: #109587

AI-assisted maintainer follow-up approved by Peter.

## What Problem This Solves

The Docker E2E resource-limit diagnostic currently creates a private capture file plus sibling FIFOs whose privacy depends on temporary umask choreography and whose cleanup must enumerate every artifact.

## Why This Change Was Made

Create one private `mktemp -d` directory and place the bounded stderr capture and both FIFOs inside it. This makes access control structural, reduces cleanup to one directory removal, preserves every fallback and execution branch, and removes three net lines.

## User Impact

No user-visible behavior changes. Docker E2E diagnostics retain the same output, bounded capture, explicit opt-out guidance, and exit status.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` — 173 passed.
- `bash -n scripts/lib/docker-e2e-resource-diagnostics.sh` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- Regression proof verifies `mktemp -d` use and removal of the private diagnostic directory.
