### PR TITLE
fix(agents): preserve thinking default precedence for listed agents

### DIFF
--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1101,6 +1101,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
             },
           },
         },
+        list: [{ id: "main" }],
       },
     } as OpenClawConfig;
     sessionMocks.loadSessionStore.mockReturnValue({

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -3,8 +3,8 @@ import { randomUUID } from "node:crypto";
 import type { Bot, Context } from "grammy";
 import {
   loadPreparedModelCatalog,
-  resolveAgentConfig,
   resolveAgentDir,
+  resolveAgentThinkingDefaultOverride,
   resolveDefaultModelForAgent,
   resolveThinkingDefaultWithRuntimeCatalog,
 } from "openclaw/plugin-sdk/agent-runtime";
@@ -444,7 +444,7 @@ async function resolveTelegramThinkMenuCurrentLevel(params: {
     return explicit;
   }
   const agentThinkingDefault = normalizeOptionalString(
-    resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault,
+    resolveAgentThinkingDefaultOverride(params.cfg, params.agentId),
   );
   if (agentThinkingDefault) {
     return agentThinkingDefault;

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -113,6 +113,14 @@ function resolveAgentEntry(cfg: OpenClawConfig, agentId: string): AgentEntry | u
   return listAgentEntries(cfg).find((entry) => normalizeAgentId(entry.id) === id);
 }
 
+/** Resolves only the explicit per-agent thinking default, without global fallback. */
+export function resolveAgentThinkingDefaultOverride(
+  cfg: OpenClawConfig,
+  agentId: string,
+): AgentEntry["thinkingDefault"] | undefined {
+  return resolveAgentEntry(cfg, agentId)?.thinkingDefault;
+}
+
 /** Resolves merged config for one agent id. */
 export function resolveAgentConfig(
   cfg: OpenClawConfig,
@@ -135,7 +143,7 @@ export function resolveAgentConfig(
     ...(entry.models ? { models: entry.models } : {}),
     ...(hasExplicitModelPolicyAllow(entry.modelPolicy) ? { modelPolicy: entry.modelPolicy } : {}),
     utilityModel: readStringValue(entry.utilityModel),
-    thinkingDefault: entry.thinkingDefault,
+    thinkingDefault: entry.thinkingDefault ?? agentDefaults?.thinkingDefault,
     verboseDefault: entry.verboseDefault ?? agentDefaults?.verboseDefault,
     reasoningDefault: entry.reasoningDefault,
     fastModeDefault: entry.fastModeDefault,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { withEnv } from "../test-utils/env.js";
+import { resolveAgentThinkingDefaultOverride } from "./agent-scope-config.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   hasLegacyAutoFallbackWithoutOrigin,
@@ -93,6 +94,34 @@ describe("resolveAgentConfig", () => {
       },
     };
     expect(resolveAgentConfig(cfg, "main")?.verboseDefault).toBe("on");
+  });
+
+  it("inherits the global thinking default for a listed agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          thinkingDefault: "high",
+        },
+        list: [{ id: "inherited" }],
+      },
+    };
+
+    expect(resolveAgentConfig(cfg, "inherited")?.thinkingDefault).toBe("high");
+    expect(resolveAgentThinkingDefaultOverride(cfg, "inherited")).toBeUndefined();
+  });
+
+  it("preserves an explicit per-agent off thinking default", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          thinkingDefault: "high",
+        },
+        list: [{ id: "explicit", thinkingDefault: "off" }],
+      },
+    };
+
+    expect(resolveAgentConfig(cfg, "explicit")?.thinkingDefault).toBe("off");
+    expect(resolveAgentThinkingDefaultOverride(cfg, "explicit")).toBe("off");
   });
 
   it("merges contextLimits from defaults with per-agent overrides", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -27,6 +27,7 @@ import { resolveUserPath } from "../utils.js";
 import {
   listAgentIds,
   resolveAgentConfig,
+  resolveAgentThinkingDefaultOverride,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "./agent-scope-config.js";
@@ -36,6 +37,7 @@ export {
   resolveAgentConfig,
   resolveAgentContextLimits,
   resolveAgentDir,
+  resolveAgentThinkingDefaultOverride,
   resolveDefaultAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -17,12 +17,12 @@ import {
   repairProviderWrappedModelOverride,
 } from "../../sessions/model-overrides.js";
 import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
+import { resolveAgentThinkingDefaultOverride } from "../agent-scope-config.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   hasLegacyAutoFallbackWithoutOrigin,
   hasSessionAutoModelFallbackProvenance,
   resolveAutoFallbackPrimaryProbe,
-  resolveAgentConfig,
   resolveAgentEffectiveModelPrimary,
 } from "../agent-scope.js";
 import { isStoredCredentialCompatibleWithAuthProvider } from "../auth-profiles/order.js";
@@ -452,7 +452,7 @@ export async function resolveEmbeddedModelSelection(params: {
     sessionEntry: sessionEntryForAttempt,
   });
   const configuredThinkLevel = normalizeThinkLevel(
-    resolveAgentConfig(params.cfg, params.sessionAgentId)?.thinkingDefault,
+    resolveAgentThinkingDefaultOverride(params.cfg, params.sessionAgentId),
   );
   const immutableThinkLevel = params.requestedThinkLevel ?? configuredThinkLevel;
   const primaryThinkLevel =

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -29,7 +29,11 @@ import { recordSubagentSpawned } from "../sessions/session-state-events.js";
 import type { FastMode } from "../shared/fast-mode.js";
 import { resolveUserPath } from "../utils.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
-import { listAgentIds, resolveAgentDir } from "./agent-scope-config.js";
+import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveAgentThinkingDefaultOverride,
+} from "./agent-scope-config.js";
 import type { BootstrapContextMode } from "./bootstrap-files.js";
 import { resolveFastModeState } from "./fast-mode.js";
 import {
@@ -469,7 +473,7 @@ function readRequesterThinkingLevel(params: {
     return entry.thinkingLevel.trim();
   }
   const requesterAgentThinking = params.requesterAgentId
-    ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
+    ? resolveAgentThinkingDefaultOverride(params.cfg, params.requesterAgentId)
     : undefined;
   if (requesterAgentThinking) {
     return requesterAgentThinking;

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -184,6 +184,7 @@ describe("createModelSelectionState catalog loading", () => {
               },
             },
           },
+          list: [{ id: "alpha" }],
         },
         models: {
           providers: {
@@ -197,6 +198,7 @@ describe("createModelSelectionState catalog loading", () => {
 
       const state = await createModelSelectionState({
         cfg,
+        agentId: "alpha",
         agentCfg: cfg.agents?.defaults,
         defaultProvider: "openai-codex",
         defaultModel: "gpt-5.4",

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -3,6 +3,7 @@ import {
   hasLegacyAutoFallbackWithoutOrigin,
   resolveAgentConfig,
   resolveAgentDir,
+  resolveAgentThinkingDefaultOverride,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import { isStoredCredentialCompatibleWithAuthProvider } from "../../agents/auth-profiles/order.js";
@@ -235,6 +236,9 @@ export async function createModelSelectionState(params: {
   let resetModelOverride = false;
   let resetModelOverrideRef: string | undefined;
   let resetModelOverrideReason: "disallowed" | "stale" | "temporarily-unavailable" | undefined;
+  const agentThinkingDefaultOverride = params.agentId
+    ? resolveAgentThinkingDefaultOverride(cfg, params.agentId)
+    : undefined;
   const normalizedDirectStoredOverride = normalizeStoredOverrideModel({
     providerOverride: sessionEntry?.providerOverride,
     modelOverride: sessionEntry?.modelOverride,
@@ -592,7 +596,7 @@ export async function createModelSelectionState(params: {
     if (cached) {
       return cached;
     }
-    const agentThinkingDefault = agentEntry?.thinkingDefault as ThinkLevel | undefined;
+    const agentThinkingDefault = agentThinkingDefaultOverride as ThinkLevel | undefined;
     if (agentThinkingDefault) {
       defaultThinkingLevels.set(cacheKey, agentThinkingDefault);
       return agentThinkingDefault;
@@ -684,7 +688,7 @@ export async function createModelSelectionState(params: {
     configuredModels?.[canonicalKey]?.params?.thinking ??
     (legacyKey ? configuredModels?.[legacyKey]?.params?.thinking : undefined);
   const hasConfiguredThinkingDefault =
-    agentEntry?.thinkingDefault !== undefined ||
+    agentThinkingDefaultOverride !== undefined ||
     resolveConfiguredModelThinkingDefault(configuredModelThinkingDefault) !== undefined ||
     agentCfg?.thinkingDefault !== undefined;
 

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -3,7 +3,10 @@
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import chalk from "chalk";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
-import { resolveDefaultAgentId, resolveAgentConfig } from "../agents/agent-scope.js";
+import {
+  resolveAgentThinkingDefaultOverride,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope-config.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { formatFastModeValue, resolveFastModeState } from "../agents/fast-mode.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
@@ -139,12 +142,11 @@ export function formatAgentModelStartupDetails(params: {
   model: string;
 }): string {
   const defaultAgentId = resolveDefaultAgentId(params.cfg);
-  const defaultAgentConfig = resolveAgentConfig(params.cfg, defaultAgentId);
   const explicitThinking = resolveExplicitStartupThinking({
     cfg: params.cfg,
     provider: params.provider,
     model: params.model,
-    defaultAgentThinking: defaultAgentConfig?.thinkingDefault,
+    defaultAgentThinking: resolveAgentThinkingDefaultOverride(params.cfg, defaultAgentId),
   });
   let thinking = explicitThinking;
   if (thinking === undefined) {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -14,9 +14,9 @@ import {
   repairAcpSessionMetaKeyForMigration,
 } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
+import { resolveAgentThinkingDefaultOverride } from "../agents/agent-scope-config.js";
 import {
   listAgentIds,
-  resolveAgentConfig,
   resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
@@ -1605,7 +1605,7 @@ function resolveGatewaySessionThinkingDefault(params: {
   agentRuntime: string;
 }) {
   const agentThinkingDefault = params.agentId
-    ? resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault
+    ? resolveAgentThinkingDefaultOverride(params.cfg, params.agentId)
     : undefined;
   const defaultLevel =
     agentThinkingDefault ??

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -122,6 +122,7 @@ export { readStringParam } from "../agents/tools/common.js";
 export {
   resolveAgentConfig,
   resolveAgentDir,
+  resolveAgentThinkingDefaultOverride,
   resolveDefaultAgentId,
 } from "../agents/agent-scope-config.js";
 export { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";


### PR DESCRIPTION
<!-- submission-timestamps:start -->
First submitted: July 17, 2026, 12:05 AM (US Eastern Time) / 04:05 UTC.
Last body edit: July 17, 2026, 6:58 AM (US Eastern Time) / 10:58 UTC.
Latest head commit: July 17, 2026, 6:57 AM (US Eastern Time) / 10:57 UTC.
<!-- submission-timestamps:end -->

Closes #109276

## What Problem This Solves

Fixes an inconsistency where `resolveAgentConfig()` returned only an explicit
`agents.list[].thinkingDefault` value even though its contract says that agent
defaults have already been applied. Callers that inspect the resolved config
could therefore observe `undefined` for a listed agent while the effective
runtime later inherited `agents.defaults.thinkingDefault` through another
resolution path.

## Why This Change Was Made

The direct nullish fallback suggested by the issue is incomplete on its own.
Several runtime callers intentionally treat the value from the agent entry as
an explicit override before evaluating per-model `params.thinking`, the global
default, and provider/model defaults. Returning the merged global value through
those override-sensitive paths would make the global default incorrectly win
over a per-model setting.

This change separates the two contracts:

- `resolveAgentConfig()` now returns the documented merged value.
- `resolveAgentThinkingDefaultOverride()` returns only the explicit per-agent
  value for precedence-sensitive runtime paths.

The command, reply model-selection, subagent inheritance, gateway session, and
startup-summary paths use the explicit helper where provenance matters.

## User Impact

Consumers of `resolveAgentConfig()` can now rely on a listed agent inheriting
`agents.defaults.thinkingDefault`. Existing runtime precedence remains intact:

1. session or message override
2. explicit per-agent default
3. per-model `params.thinking`
4. global `agents.defaults.thinkingDefault`
5. provider/model default

Explicit `off` values remain authoritative because the merge uses nullish, not
truthy, fallback semantics.

## Breaking Changes

None expected. This restores the documented merged-config contract while
preserving the existing runtime precedence order.

## Implementation

- Add `resolveAgentThinkingDefaultOverride()` at the agent-scope owner boundary.
- Merge `thinkingDefault` in `resolveAgentConfig()` with agent-over-global
  nullish precedence.
- Route precedence-sensitive callers through the explicit override helper.
- Add focused tests for merged inheritance, explicit `off`, and a listed agent
  whose per-model thinking setting must still outrank the global default.

## Code-Path Analysis

- Owner: `src/agents/agent-scope-config.ts`
- Public facade: `src/agents/agent-scope.ts`
- Runtime callers: `src/auto-reply/reply/model-selection.ts`,
  `src/agents/command/model-selection.ts`, `src/agents/subagent-spawn.ts`,
  `src/gateway/session-utils.ts`, `src/gateway/server-startup-log.ts`
- Adjacent precedence owner: `src/agents/model-thinking-default.ts`
- Tests: `src/agents/agent-scope.test.ts`,
  `src/auto-reply/reply/model-selection.test.ts`, plus existing command,
  subagent, gateway-session, and startup-summary coverage
- Contract: `src/config/types.agents.ts` and `docs/tools/thinking.md`

## Mainline Comparison

- Official base: `OpenClaw/OpenClaw:main@b2e34b03b5cbb3491d4cdc9388c2694b52084158`
- Base fetched/verified: July 17, 2026, 10:58 UTC
- Current main still returned only `entry.thinkingDefault` from the merged
  resolver. Recent same-surface changes did not implement this provenance split.

## Branch/Base Provenance

- Base: `OpenClaw/OpenClaw:main@b2e34b03b5cbb3491d4cdc9388c2694b52084158`
- Head: `snowzlmbot/OpenClaw:fix/109276-thinking-default-fallback@0c6470542b2a055c60d3a009cdc5991366705056`
- The head branch was created/replayed directly from the official base.
- The fork default branch was not used as the implementation baseline and was
  not modified by this work.

## Dependency/Contract Verification

No external dependency contract changed. The configuration type already states
that `agents.list[].thinkingDefault` overrides
`agents.defaults.thinkingDefault`, and the thinking documentation already
defines per-model thinking ahead of the global default. The implementation now
preserves both contracts explicitly.

## Labels Considered

- `agents`
- `P2`
- `impact:auth-provider`
- `merge-risk: compatibility` because configuration-default precedence is
  compatibility-sensitive

These are suggestions only; this contribution does not claim maintainer label
authority.

## Validation

- `node scripts/run-vitest.mjs src/agents/agent-scope.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/model-selection.test.ts`
- `node scripts/run-vitest.mjs src/commands/agent.test.ts`
- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts`
- focused gateway session/startup and subagent tests selected by changed-file CI
- `node scripts/check-changed.mjs -- src/agents/agent-scope-config.ts src/agents/agent-scope.test.ts src/auto-reply/reply/model-selection.ts src/auto-reply/reply/model-selection.test.ts src/agents/command/model-selection.ts src/agents/subagent-spawn.ts src/gateway/session-utils.ts src/gateway/server-startup-log.ts`
- `git diff --check`

## Evidence Source Map

- Current patch comparison: [patch workflow run](https://github.com/snowzlmbot/openclaw/actions/runs/29563846578)
  - Tested head: `93fbf1ac7276ff1afb6bbc22e4a0aae1979e89fc`
  - Tested base: `2b18ef7426484caadc0b4568f1b768b22898fe10`
  - Latest attempt failed only `control-ui-i18n`; plugin SDK and build-artifacts passed on the rerun.
- Matching official-base comparison: [baseline workflow run](https://github.com/snowzlmbot/openclaw/actions/runs/29570168401)
  - Tested base: `2b18ef7426484caadc0b4568f1b768b22898fe10`
  - Failed `control-ui-i18n` with the same catalog-fallback baseline-drift message; `build-artifacts` also exceeded the startup-memory threshold on the unpatched base.
  - Therefore the comparison contains no patch-only failing job or failure signature.
- Prior all-green exact-head run: [successful evidence workflow](https://github.com/snowzlmbot/openclaw/actions/runs/29557157953)
  - Passed lint, agent command, reply/model-selection, subagent, gateway, plugin SDK, Control UI i18n, type/check, and `openclaw/ci-gate` lanes.
- Current head provenance:
  - Current head `0c6470542b2a055c60d3a009cdc5991366705056` is a clean rebase onto `b2e34b03b5cbb3491d4cdc9388c2694b52084158`.
  - The intervening upstream range modified none of this PR's changed files, the thinking-default contract, or the Control UI i18n baseline file.
  - Upstream PR checks triggered by the current-head push provide the final current-SHA validation.

## Sanitized Logs

```text
Merged config: listed agent without thinkingDefault -> global value
Explicit override: listed agent thinkingDefault=off -> off
Precedence guard: listed agent without override + per-model thinking + global default -> per-model value
git diff --check -> passed
```

No credentials, hostnames, internal paths, account identifiers, or private
runtime data are included.

## Media Evidence

This is a non-visual configuration-resolution change. The linked Actions run
provides the complete reproducible source-level flow and exact-head result;
there is no UI state or dynamic interaction for a screenshot or recording to
clarify.

## Risk

- Compatibility: callers that intentionally inspect merged config now observe
  the documented global fallback.
- Precedence: mitigated by keeping explicit agent provenance in a dedicated
  helper and by regression coverage for per-model-over-global behavior.
- Performance: one normalized agent-entry lookup replaces an equivalent config
  lookup at the affected callers; no new I/O or runtime catalog loading.
- Security/privacy: no authorization, secret, persistence, or transport changes.

## Rollback

Revert this PR. No schema migration, persisted-data rewrite, config migration,
or irreversible operation is introduced.

## Documentation Updated

No documentation change is required. `docs/tools/thinking.md` and the config
type comments already describe the precedence restored by this implementation.

## Related Issue/PR

- Closes #109276
- Historical same-area fixes: #86689 and #63418
- Adjacent but distinct reports: #80377, #30398, #73529, and #108337

## Not Tested / Limitations

- No live provider call is required to establish this deterministic config and
  precedence behavior.
- Provider-specific transport payloads are unchanged and are not revalidated by
  this PR.
