### PR TITLE
perf(ci): cut cli-startup-metadata and preflight fixed costs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
                 -c protocol.version=2 \
-                fetch --no-tags --prune --no-recurse-submodules --depth=2 origin \
+                fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
                 "+${ref}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"
               if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
@@ -190,6 +190,25 @@ jobs:
                 return "$fetch_status"
               fi
               echo "::warning::checkout fetch for '$ref' timed out on attempt $attempt; retrying"
+              sleep 5
+            done
+          }
+
+          # Diff-base resolution needs the head's parent commits and trees
+          # (merge-head-diff-base.mjs and the name-only diffs), but not the
+          # parents' blobs. Fetching them blob-less keeps preflight several
+          # times faster than a full --depth=2 snapshot fetch.
+          fetch_parent_metadata() {
+            local sha="$1"
+            for attempt in 1 2 3; do
+              timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
+                -c protocol.version=2 \
+                fetch --no-tags --prune --no-recurse-submodules --depth=2 \
+                --filter=blob:none origin "$sha" && return 0
+              if [ "$attempt" = "3" ]; then
+                return 1
+              fi
+              echo "::warning::parent metadata fetch for '$sha' failed on attempt $attempt; retrying"
               sleep 5
             done
           }
@@ -239,6 +258,7 @@ jobs:
               exit 1
             fi
           fi
+          fetch_parent_metadata "$(git -C "$GITHUB_WORKSPACE" rev-parse refs/remotes/origin/checkout)"
           git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
 
       - name: Resolve checkout SHA

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -2,6 +2,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { availableParallelism } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import pMap from "p-map";
@@ -30,11 +31,13 @@ const distDir = path.join(rootDir, "dist");
 const outputPath = path.join(distDir, "cli-startup-metadata.json");
 const extensionsDir = path.join(rootDir, "extensions");
 const ROOT_HELP_RENDER_TIMEOUT_MS = 120_000;
-const BROWSER_HELP_RENDER_TIMEOUT_MS = 120_000;
 const COMMAND_HELP_RENDER_TIMEOUT_MS = 120_000;
 const COMMAND_HELP_RENDER_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const COMMAND_HELP_RENDER_KILL_GRACE_MS = 5_000;
-const COMMAND_HELP_RENDER_CONCURRENCY = 2;
+// Each help render is an isolated CLI boot; concurrency only bounds process
+// fan-out, not output content, so scale with the host instead of serializing
+// eight boots two at a time.
+const COMMAND_HELP_RENDER_CONCURRENCY = Math.min(8, Math.max(2, availableParallelism()));
 const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = [
   "doctor",
   "gateway",
@@ -70,7 +73,7 @@ type PrecomputedSubcommandHelpCommand = (typeof PRECOMPUTED_SUBCOMMAND_HELP_COMM
 type PrecomputedSubcommandHelpText = Record<PrecomputedSubcommandHelpCommand, string>;
 type RootHelpRenderContext = Pick<RootHelpRenderOptions, "config" | "env">;
 type Awaitable<T> = T | Promise<T>;
-type SourceCommandHelpCommand = "nodes" | "secrets" | PrecomputedSubcommandHelpCommand;
+type SourceCommandHelpCommand = "browser" | "nodes" | "secrets" | PrecomputedSubcommandHelpCommand;
 type SourceCommandHelpText = Record<SourceCommandHelpCommand, string>;
 type SpawnTextParentSignalState = {
   done: boolean;
@@ -589,23 +592,12 @@ export async function renderBundledRootHelpText(
     `await mod.outputRootHelp(${JSON.stringify(renderOptions)});`,
     "process.exit(0);",
   ].join("\n");
-  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", inlineModule], {
+  return await spawnText(["--input-type=module", "--eval", inlineModule], {
     cwd: _distDirOverride,
-    encoding: "utf8",
     env: renderContext.env,
-    timeout: ROOT_HELP_RENDER_TIMEOUT_MS,
+    failureMessage: `Failed to render bundled root help from ${bundleIdentity.bundleName}`,
+    timeoutMs: ROOT_HELP_RENDER_TIMEOUT_MS,
   });
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    const stderr = result.stderr?.trim();
-    throw new Error(
-      `Failed to render bundled root help from ${bundleIdentity.bundleName}` +
-        (stderr ? `: ${stderr}` : result.signal ? `: terminated by ${result.signal}` : ""),
-    );
-  }
-  return result.stdout ?? "";
 }
 
 function renderSourceRootHelpText(
@@ -652,33 +644,11 @@ function renderSourceRootHelpText(
 async function renderSourceBrowserHelpText(
   renderContext: RootHelpRenderContext = createIsolatedRootHelpRenderContext(),
 ): Promise<string> {
-  const browserCliUrl = pathToFileURL(
-    path.join(rootDir, "extensions/browser/src/cli/browser-cli.ts"),
-  ).href;
-  const helpUrl = pathToFileURL(path.join(rootDir, "src/cli/program/help.ts")).href;
-  const contextUrl = pathToFileURL(path.join(rootDir, "src/cli/program/context.ts")).href;
-  const inlineModule = [
-    `const { Command } = await import("commander");`,
-    `const { registerBrowserCli } = await import(${JSON.stringify(browserCliUrl)});`,
-    `const { configureProgramHelp } = await import(${JSON.stringify(helpUrl)});`,
-    `const { createProgramContext } = await import(${JSON.stringify(contextUrl)});`,
-    `const program = new Command();`,
-    `configureProgramHelp(program, createProgramContext());`,
-    `registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);`,
-    `const browser = program.commands.find((cmd) => cmd.name() === "browser");`,
-    `if (!browser) throw new Error("Browser command was not registered.");`,
-    `browser.outputHelp();`,
-    "process.exit(0);",
-  ].join("\n");
-  return await spawnText(["--import", "tsx", "--input-type=module", "--eval", inlineModule], {
-    cwd: rootDir,
-    env: {
-      ...renderContext.env,
-      OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH: "1",
-    },
-    failureMessage: "Failed to render source browser help",
-    timeoutMs: BROWSER_HELP_RENDER_TIMEOUT_MS,
-  });
+  // The launcher CLI boot renders byte-identical browser help to a direct
+  // tsx source render (registerBrowserCli + configureProgramHelp) while
+  // avoiding a tsx evaluation of the whole browser CLI import graph, which
+  // dominated this script's wall time.
+  return await renderSourceCommandHelpText("browser", renderContext);
 }
 
 async function renderSourceCommandHelpText(
@@ -807,27 +777,34 @@ export async function writeCliStartupMetadata(options?: {
     // Missing or malformed existing metadata means we should regenerate it.
   }
 
-  let rootHelpText: string;
-  try {
-    rootHelpText = await (options?.renderBundledRootHelpText ?? renderBundledRootHelpText)(
-      resolvedDistDir,
-      renderContext,
-    );
-  } catch {
-    rootHelpText = (options?.renderSourceRootHelpText ?? renderSourceRootHelpText)(renderContext);
-  }
-  const browserHelpTextPromise = Promise.resolve(
-    (options?.renderSourceBrowserHelpText ?? renderSourceBrowserHelpText)(renderContext),
-  );
+  const rootHelpTextPromise = (async () => {
+    try {
+      return await (options?.renderBundledRootHelpText ?? renderBundledRootHelpText)(
+        resolvedDistDir,
+        renderContext,
+      );
+    } catch {
+      // The spawnSync source fallback blocks the event loop; that is fine for
+      // this rare recovery path (missing/broken bundle) and only delays
+      // draining sibling render output, not its correctness.
+      return (options?.renderSourceRootHelpText ?? renderSourceRootHelpText)(renderContext);
+    }
+  })();
   const hasCustomCommandRenderer =
+    options?.renderSourceBrowserHelpText ||
     options?.renderSourceSecretsHelpText ||
     options?.renderSourceNodesHelpText ||
     options?.renderSourceSubcommandHelpTextRecord;
   const commandHelpTextPromise = hasCustomCommandRenderer
     ? null
     : renderSourceCommandHelpTextRecord(
-        ["secrets", "nodes", ...PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS],
+        ["browser", "secrets", "nodes", ...PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS],
         renderContext,
+      );
+  const browserHelpTextPromise = commandHelpTextPromise
+    ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.browser)
+    : Promise.resolve(
+        (options?.renderSourceBrowserHelpText ?? renderSourceBrowserHelpText)(renderContext),
       );
   const secretsHelpTextPromise = commandHelpTextPromise
     ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.secrets)
@@ -854,12 +831,14 @@ export async function writeCliStartupMetadata(options?: {
           renderContext,
         ),
       );
-  const [browserHelpText, secretsHelpText, nodesHelpText, subcommandHelpText] = await Promise.all([
-    browserHelpTextPromise,
-    secretsHelpTextPromise,
-    nodesHelpTextPromise,
-    subcommandHelpTextPromise,
-  ]);
+  const [rootHelpText, browserHelpText, secretsHelpText, nodesHelpText, subcommandHelpText] =
+    await Promise.all([
+      rootHelpTextPromise,
+      browserHelpTextPromise,
+      secretsHelpTextPromise,
+      nodesHelpTextPromise,
+      subcommandHelpTextPromise,
+    ]);
 
   mkdirSync(resolvedDistDir, { recursive: true });
   writeFileSync(

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -594,7 +594,8 @@ export async function renderBundledRootHelpText(
   ].join("\n");
   return await spawnText(["--input-type=module", "--eval", inlineModule], {
     cwd: _distDirOverride,
-    env: renderContext.env,
+    // RootHelpRenderOptions marks env optional; spawnText requires one.
+    env: renderContext.env ?? process.env,
     failureMessage: `Failed to render bundled root help from ${bundleIdentity.bundleName}`,
     timeoutMs: ROOT_HELP_RENDER_TIMEOUT_MS,
   });

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2302,10 +2302,16 @@ describe("ci workflow guards", () => {
       expect(checkoutStep.run, jobName).toContain("timed out on attempt $attempt; retrying");
       expect(checkoutStep.run, jobName).not.toContain("if timeout --signal=TERM");
       expect(checkoutStep.run, jobName).toContain("-c protocol.version=2");
-      const expectedDepth = jobName === "skills-python" ? 1 : 2;
+      // preflight fetches the head at depth 1 and supplements the parents
+      // blob-less; security-fast keeps depth 2 for its diff-base needs.
+      const expectedDepth = jobName === "security-fast" ? 2 : 1;
       expect(checkoutStep.run, jobName).toContain(
         `fetch --no-tags --prune --no-recurse-submodules --depth=${expectedDepth} origin`,
       );
+      if (jobName === "preflight") {
+        expect(checkoutStep.run, jobName).toContain("--filter=blob:none");
+        expect(checkoutStep.run, jobName).toContain("fetch_parent_metadata");
+      }
       if (jobName !== "skills-python") {
         expect(checkoutStep.run, jobName).toContain('if [ "$fetch_status" = "124" ]');
         expect(checkoutStep.run, jobName).toContain("timed out");


### PR DESCRIPTION
## What Problem This Solves

Two measured fixed costs on the PR critical path:
1. `write-cli-startup-metadata` ran ~25s inside every build-artifacts job (77.5s cold locally). Profiling found one whale: the browser CLI's help text was rendered by evaluating its entire TypeScript import graph from source via tsx (39s), while the other eight helps boot the built dist CLI in ~1.3s each — and those were throttled at concurrency 2 behind a blocking root-help render.
2. The preflight job — which every lane waits on (`needs: [preflight]`) — spent 16s of its 24s in a `--depth=2` checkout fetch: GitHub packs full snapshots of the head *and its parents* (three snapshots for PR merge commits), while sibling depth-1 checkouts take 4–5s.

## Why This Change Was Made

- **Metadata**: browser help now renders through the same dist-CLI launcher boot as every other command — byte-identity proven three ways (tsx source render, dist boot, esbuild-bundled render) before switching. All nine boots share one `pMap` at `min(8, availableParallelism())`, and the root-help render overlaps them (async `spawnText` instead of blocking `spawnSync`). Net −21 LOC. Cold: **77.5s → 18.3s** locally; output byte-identical modulo the expected `generatorSignature`.
- **Preflight**: fetch the head at `--depth=1`, then supplement the resolved SHA's parents with a `--depth=2 --filter=blob:none` fetch (commits+trees, no blobs) under the same retry/timeout discipline. Everything preflight does afterward is commit/tree-level (`merge-head-diff-base.mjs`, name-only diffs, changed-scope) — verified zero lazy blob fetches on a real PR merge ref. Measured: depth-2 55.4s vs depth-1 32.0s + **1.2s** supplement. `security-fast` has the same copy-pasted checkout but is off the critical path — left as follow-up to keep this minimal.

## User Impact

None at runtime. Build-artifacts drops ~17–20s; preflight ~10–12s off **every** lane's start.

## Evidence

- Byte-identity proof for all nine help texts; `test/scripts/write-cli-startup-metadata.test.ts`, `test/scripts/ensure-cli-startup-build.test.ts`, `src/cli/startup-metadata.test.ts` — 21/21.
- Real-network fetch timings above; parent resolution + name-only diffs verified lazy-fetch-free on a PR merge ref.
- `test/scripts/ci-workflow-guards.test.ts` updated for the depth-1+blob-less shape and green.
- Worker autoreview (gpt-5.6-sol, xhigh): clean, 0.86.
