### PR TITLE
feat(plugins): consume hosted listing metadata

### DIFF
--- a/src/plugins/management-service-featured.test.ts
+++ b/src/plugins/management-service-featured.test.ts
@@ -15,7 +15,7 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
     mocks.officialCatalog(...args),
 }));
 
-const { clearManagedPluginOfficialCatalogCache, listManagedPlugins } =
+const { clearManagedPluginOfficialCatalogCache, listManagedPlugins, resolveManagedPluginIconUrl } =
   await import("./management-service.js");
 
 function metadataSnapshot(params: {
@@ -25,6 +25,8 @@ function metadataSnapshot(params: {
   packageName?: string | null;
   installRecord?: Record<string, unknown>;
   featured?: boolean;
+  description?: string;
+  icon?: string;
 }) {
   const id = params.id ?? "workboard";
   const packageName =
@@ -32,8 +34,9 @@ function metadataSnapshot(params: {
   const manifest = {
     id,
     name: params.name ?? "Workboard",
-    description: "Coordinate agent work in a shared board.",
+    description: params.description ?? "Coordinate agent work in a shared board.",
     catalog: { featured: params.featured ?? true, order: 10 },
+    ...(params.icon ? { icon: params.icon } : {}),
     channels: [],
     providers: [],
     cliBackends: [],
@@ -89,10 +92,14 @@ function hostedFeedEntry(params: {
   pluginId?: string;
   catalogFeatured?: boolean;
   order?: number;
+  description?: string;
+  icon?: string;
 }) {
   return {
     id: params.packageName,
     title: params.title,
+    ...(params.description ? { description: params.description } : {}),
+    ...(params.icon ? { icon: params.icon } : {}),
     state: "available",
     ...(params.featured === undefined ? {} : { featured: params.featured }),
     publisher: { id: "openclaw", trust: "official" },
@@ -134,6 +141,42 @@ const hostedImpostorEntry = hostedFeedEntry({
 });
 
 describe("plugin management Featured authority", () => {
+  it("projects listing metadata from a top-level hosted feed entry", async () => {
+    const icon = "https://cdn.example.test/expedia.png";
+    const officialCatalog = {
+      entries: [
+        hostedFeedEntry({
+          packageName: "@expediagroup/expedia-openclaw",
+          title: "Expedia Travel",
+          featured: true,
+          pluginId: "@expediagroup/expedia-openclaw",
+          order: 10,
+          description: "Search flights, stays, and travel options.",
+          icon,
+        }),
+      ],
+    };
+    mocks.metadata.mockReturnValue(emptyMetadataSnapshot());
+
+    const catalog = await listManagedPlugins({ config: {}, env: {}, officialCatalog });
+    const resolved = await resolveManagedPluginIconUrl({
+      config: {},
+      env: {},
+      pluginId: "@expediagroup/expedia-openclaw",
+      officialCatalog,
+    });
+
+    expect(catalog.plugins[0]).toMatchObject({
+      id: "@expediagroup/expedia-openclaw",
+      name: "Expedia Travel",
+      description: "Search flights, stays, and travel options.",
+      featured: true,
+      order: 10,
+      hasIcon: true,
+    });
+    expect(resolved).toBe(icon);
+  });
+
   beforeEach(() => {
     clearManagedPluginOfficialCatalogCache();
     mocks.metadata.mockReset();
@@ -335,12 +378,15 @@ describe("plugin management Featured authority", () => {
   });
 
   it("applies hosted curation to the exact published package for bundled FireCrawl", async () => {
+    const hostedIcon = "https://cdn.example.test/firecrawl-company.png";
     mocks.metadata.mockReturnValue(
       metadataSnapshot({
         id: "firecrawl",
-        name: "FireCrawl",
+        name: "firecrawl",
         packageName: "@openclaw/firecrawl-plugin",
         featured: false,
+        description: "Optional OpenClaw capability.",
+        icon: "https://cdn.example.test/firecrawl-bundled.png",
       }),
     );
     mocks.officialCatalog.mockResolvedValue(
@@ -350,21 +396,31 @@ describe("plugin management Featured authority", () => {
           title: "FireCrawl",
           featured: true,
           pluginId: "firecrawl",
+          description: "Crawl, scrape, search, and extract web content with FireCrawl.",
+          icon: hostedIcon,
         }),
       ]),
     );
 
     const catalog = await listManagedPlugins({ config: {}, env: {} });
+    const resolvedIcon = await resolveManagedPluginIconUrl({
+      config: {},
+      env: {},
+      pluginId: "firecrawl",
+    });
 
     expect(catalog.plugins).toEqual([
       expect.objectContaining({
         id: "firecrawl",
         name: "FireCrawl",
+        description: "Crawl, scrape, search, and extract web content with FireCrawl.",
         packageName: "@openclaw/firecrawl-plugin",
         featured: true,
         order: 10,
+        hasIcon: true,
       }),
     ]);
+    expect(resolvedIcon).toBe(hostedIcon);
   });
 
   it("keeps local curation for an unproven global package identity", async () => {
@@ -392,18 +448,42 @@ describe("plugin management Featured authority", () => {
   });
 
   it("does not identify a package-less private bundled plugin by hosted runtime id", async () => {
-    mocks.metadata.mockReturnValue(metadataSnapshot({ packageName: null }));
-    mocks.officialCatalog.mockResolvedValue(hostedCatalog([hostedImpostorEntry]));
+    const localIcon = "https://cdn.example.test/private-workboard.png";
+    mocks.metadata.mockReturnValue(
+      metadataSnapshot({
+        packageName: null,
+        description: "Private local workboard.",
+        icon: localIcon,
+      }),
+    );
+    mocks.officialCatalog.mockResolvedValue(
+      hostedCatalog([
+        {
+          ...hostedImpostorEntry,
+          title: "Hosted impostor",
+          description: "Untrusted hosted copy.",
+          icon: "https://cdn.example.test/impostor.png",
+        },
+      ]),
+    );
 
     const catalog = await listManagedPlugins({ config: {}, env: {} });
+    const resolvedIcon = await resolveManagedPluginIconUrl({
+      config: {},
+      env: {},
+      pluginId: "workboard",
+    });
 
     expect(catalog.plugins).toEqual([
       expect.objectContaining({
         id: "workboard",
+        name: "Workboard",
+        description: "Private local workboard.",
         featured: true,
         order: 10,
       }),
     ]);
+    expect(resolvedIcon).toBe(localIcon);
   });
 
   it("does not identify a package-less global plugin by hosted runtime id alone", async () => {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -149,6 +149,13 @@ function resolveCatalogManifestIcon(manifest: unknown): string | undefined {
   return normalizeOptionalString((manifest as { icon?: unknown }).icon);
 }
 
+function resolveCatalogEntryIcon(entry: OfficialExternalPluginCatalogEntry | undefined) {
+  return (
+    normalizeOptionalString(entry?.icon) ??
+    resolveCatalogManifestIcon(getOfficialExternalPluginCatalogManifest(entry ?? {}))
+  );
+}
+
 function mergeCatalogMetadata(
   hosted: OfficialExternalPluginCatalogEntry,
   bundled: OfficialExternalPluginCatalogEntry,
@@ -408,19 +415,116 @@ function resolveOfficialCatalogIconUrl(
   const entry = entries.find(
     (candidate) => resolveOfficialExternalPluginId(candidate) === pluginId,
   );
-  return resolveCatalogManifestIcon(getOfficialExternalPluginCatalogManifest(entry ?? {}));
+  return resolveCatalogEntryIcon(entry);
+}
+
+type PluginMetadataSnapshot = ReturnType<typeof loadPluginMetadataSnapshot>;
+type PluginIndexRecord = PluginMetadataSnapshot["index"]["plugins"][number];
+
+function resolveInstalledHostedOfficialEntry(params: {
+  record: PluginIndexRecord;
+  installRecord?: PluginInstallRecord;
+  officialEntries: readonly OfficialExternalPluginCatalogEntry[];
+  bundledOfficialEntries: readonly OfficialExternalPluginCatalogEntry[];
+}): {
+  entry?: OfficialExternalPluginCatalogEntry;
+  hasPublishedIdentity: boolean;
+} {
+  const trustedOfficialClawHubSpec = params.installRecord
+    ? resolveTrustedSourceLinkedOfficialClawHubSpec({
+        pluginId: params.record.pluginId,
+        record: params.installRecord,
+      })
+    : undefined;
+  const trustedOfficialNpmSpec = params.installRecord
+    ? resolveTrustedSourceLinkedOfficialNpmSpec({
+        pluginId: params.record.pluginId,
+        record: params.installRecord,
+      })
+    : undefined;
+  const sourceLinkedOfficialClawHubPackage = trustedOfficialClawHubSpec
+    ? parseClawHubPluginSpec(trustedOfficialClawHubSpec)?.name
+    : undefined;
+  const currentOfficialClawHubPackage = params.installRecord
+    ? resolveTrustedOfficialClawHubPackageName(params.installRecord)
+    : undefined;
+  const trustedOfficialNpmPackage = trustedOfficialNpmSpec
+    ? parseRegistryNpmSpec(trustedOfficialNpmSpec)?.name
+    : undefined;
+  const bundledPublishedEntry =
+    params.record.origin === "bundled"
+      ? resolveInstalledOfficialCatalogEntry({
+          entries: params.bundledOfficialEntries,
+          packageName: params.record.packageName,
+          source: "npm",
+        })
+      : undefined;
+  const installedOfficialIdentity = sourceLinkedOfficialClawHubPackage
+    ? { source: "clawhub" as const, packageName: sourceLinkedOfficialClawHubPackage }
+    : trustedOfficialNpmPackage
+      ? { source: "npm" as const, packageName: trustedOfficialNpmPackage }
+      : currentOfficialClawHubPackage &&
+          (!params.record.packageName ||
+            params.record.packageName === currentOfficialClawHubPackage)
+        ? { source: "clawhub" as const, packageName: currentOfficialClawHubPackage }
+        : bundledPublishedEntry && params.record.packageName
+          ? { source: "npm" as const, packageName: params.record.packageName }
+          : undefined;
+  const hasInstalledOfficialProvenance = Boolean(
+    installedOfficialIdentity &&
+    (!params.record.packageName ||
+      params.record.packageName === installedOfficialIdentity.packageName),
+  );
+  const bundledOfficialEntry =
+    bundledPublishedEntry ??
+    resolveInstalledOfficialCatalogEntry({
+      entries: params.bundledOfficialEntries,
+      packageName: hasInstalledOfficialProvenance
+        ? installedOfficialIdentity?.packageName
+        : undefined,
+      source: installedOfficialIdentity?.source ?? "clawhub",
+    });
+  const hostedPackageName =
+    installedOfficialIdentity?.source === "npm"
+      ? (bundledOfficialEntry
+          ? resolveCatalogPackageSourceIdentities(bundledOfficialEntry)
+          : []
+        ).find((identity) => identity.source === "clawhub")?.packageName
+      : installedOfficialIdentity?.packageName;
+  return {
+    entry: resolveInstalledOfficialCatalogEntry({
+      entries: params.officialEntries,
+      packageName: hasInstalledOfficialProvenance ? hostedPackageName : undefined,
+      source: "clawhub",
+    }),
+    hasPublishedIdentity: Boolean(hasInstalledOfficialProvenance && hostedPackageName),
+  };
 }
 
 function resolvePluginIconUrlFromCatalogFacts(params: {
-  metadata: ReturnType<typeof loadPluginMetadataSnapshot>;
+  metadata: PluginMetadataSnapshot;
   officialEntries: readonly OfficialExternalPluginCatalogEntry[];
+  bundledOfficialEntries?: readonly OfficialExternalPluginCatalogEntry[];
   pluginId: string;
 }): string | undefined {
   const normalizedPluginId = params.metadata.normalizePluginId(params.pluginId);
-  return (
-    normalizeOptionalString(params.metadata.byPluginId.get(normalizedPluginId)?.icon) ??
-    resolveOfficialCatalogIconUrl(params.officialEntries, normalizedPluginId)
+  const record = params.metadata.index.plugins.find(
+    (candidate) => params.metadata.normalizePluginId(candidate.pluginId) === normalizedPluginId,
   );
+  const localIcon = normalizeOptionalString(
+    params.metadata.byPluginId.get(normalizedPluginId)?.icon,
+  );
+  if (!record) {
+    return resolveOfficialCatalogIconUrl(params.officialEntries, normalizedPluginId);
+  }
+  const { entry: officialEntry } = resolveInstalledHostedOfficialEntry({
+    record,
+    installRecord: params.metadata.index.installRecords[record.pluginId],
+    officialEntries: params.officialEntries,
+    bundledOfficialEntries:
+      params.bundledOfficialEntries ?? listOfficialExternalPluginCatalogEntries(),
+  });
+  return resolveCatalogEntryIcon(officialEntry) ?? localIcon;
 }
 
 /** Resolve the current manifest/catalog icon URL without accepting a caller-provided URL. */
@@ -436,6 +540,7 @@ export async function resolveManagedPluginIconUrl(params: {
   return resolvePluginIconUrlFromCatalogFacts({
     metadata,
     officialEntries: officialCatalog.entries,
+    bundledOfficialEntries: listOfficialExternalPluginCatalogEntries(),
     pluginId: params.pluginId,
   });
 }
@@ -454,71 +559,13 @@ export async function listManagedPlugins(params: {
     const manifest = metadata.byPluginId.get(record.pluginId);
     const localCatalog = normalizeCatalogMetadata(manifest?.catalog);
     const installRecord = metadata.index.installRecords[record.pluginId];
-    const trustedOfficialClawHubSpec = installRecord
-      ? resolveTrustedSourceLinkedOfficialClawHubSpec({
-          pluginId: record.pluginId,
-          record: installRecord,
-        })
-      : undefined;
-    const trustedOfficialNpmSpec = installRecord
-      ? resolveTrustedSourceLinkedOfficialNpmSpec({
-          pluginId: record.pluginId,
-          record: installRecord,
-        })
-      : undefined;
-    const sourceLinkedOfficialClawHubPackage = trustedOfficialClawHubSpec
-      ? parseClawHubPluginSpec(trustedOfficialClawHubSpec)?.name
-      : undefined;
-    const currentOfficialClawHubPackage = installRecord
-      ? resolveTrustedOfficialClawHubPackageName(installRecord)
-      : undefined;
-    const trustedOfficialNpmPackage = trustedOfficialNpmSpec
-      ? parseRegistryNpmSpec(trustedOfficialNpmSpec)?.name
-      : undefined;
-    const bundledPublishedEntry =
-      record.origin === "bundled"
-        ? resolveInstalledOfficialCatalogEntry({
-            entries: bundledOfficialEntries,
-            packageName: record.packageName,
-            source: "npm",
-          })
-        : undefined;
-    const installedOfficialIdentity = sourceLinkedOfficialClawHubPackage
-      ? { source: "clawhub" as const, packageName: sourceLinkedOfficialClawHubPackage }
-      : trustedOfficialNpmPackage
-        ? { source: "npm" as const, packageName: trustedOfficialNpmPackage }
-        : currentOfficialClawHubPackage &&
-            (!record.packageName || record.packageName === currentOfficialClawHubPackage)
-          ? { source: "clawhub" as const, packageName: currentOfficialClawHubPackage }
-          : bundledPublishedEntry && record.packageName
-            ? { source: "npm" as const, packageName: record.packageName }
-            : undefined;
-    const hasInstalledOfficialProvenance = Boolean(
-      installedOfficialIdentity &&
-      (!record.packageName || record.packageName === installedOfficialIdentity.packageName),
-    );
-    const bundledOfficialEntry =
-      bundledPublishedEntry ??
-      resolveInstalledOfficialCatalogEntry({
-        entries: bundledOfficialEntries,
-        packageName: hasInstalledOfficialProvenance
-          ? installedOfficialIdentity?.packageName
-          : undefined,
-        source: installedOfficialIdentity?.source ?? "clawhub",
-      });
-    const hostedPackageName =
-      installedOfficialIdentity?.source === "npm"
-        ? (bundledOfficialEntry
-            ? resolveCatalogPackageSourceIdentities(bundledOfficialEntry)
-            : []
-          ).find((identity) => identity.source === "clawhub")?.packageName
-        : installedOfficialIdentity?.packageName;
-    const officialEntry = resolveInstalledOfficialCatalogEntry({
-      entries: officialCatalog.entries,
-      packageName: hasInstalledOfficialProvenance ? hostedPackageName : undefined,
-      source: "clawhub",
+    const { entry: officialEntry, hasPublishedIdentity } = resolveInstalledHostedOfficialEntry({
+      record,
+      installRecord,
+      officialEntries: officialCatalog.entries,
+      bundledOfficialEntries,
     });
-    const hasHostedOfficialIdentity = Boolean(hasInstalledOfficialProvenance && hostedPackageName);
+    const hasHostedOfficialIdentity = hasPublishedIdentity;
     const officialCatalogMetadata = officialEntry
       ? normalizeCatalogMetadata(getOfficialExternalPluginCatalogManifest(officialEntry)?.catalog)
       : undefined;
@@ -545,9 +592,18 @@ export async function listManagedPlugins(params: {
     // spec rather than a display name.
     const manifestName =
       manifest?.name && manifest.name !== record.packageName ? manifest.name : undefined;
-    const name = manifestName ?? manifest?.channelCatalogMeta?.label ?? record.pluginId;
-    const description =
+    const localName = manifestName ?? manifest?.channelCatalogMeta?.label ?? record.pluginId;
+    const localDescription =
       manifest?.description ?? manifest?.channelCatalogMeta?.blurb ?? manifest?.packageDescription;
+    const hostedListingAuthoritative =
+      hasHostedOfficialIdentity && officialCatalog.hostedFeaturedAuthoritative;
+    const name =
+      (hostedListingAuthoritative ? normalizeOptionalString(officialEntry?.title) : undefined) ??
+      localName;
+    const description =
+      (hostedListingAuthoritative
+        ? normalizeOptionalString(officialEntry?.description)
+        : undefined) ?? localDescription;
     return {
       id: record.pluginId,
       name,
@@ -566,6 +622,7 @@ export async function listManagedPlugins(params: {
       ...(resolvePluginIconUrlFromCatalogFacts({
         metadata,
         officialEntries: officialCatalog.entries,
+        bundledOfficialEntries,
         pluginId: record.pluginId,
       })
         ? { hasIcon: true }
@@ -588,7 +645,16 @@ export async function listManagedPlugins(params: {
   for (const entry of officialCatalog.entries) {
     const pluginId = resolveOfficialExternalPluginId(entry);
     const manifest = getOfficialExternalPluginCatalogManifest(entry);
-    const catalog = normalizeCatalogMetadata(manifest?.catalog);
+    const manifestCatalog = normalizeCatalogMetadata(manifest?.catalog);
+    const catalog =
+      manifestCatalog || typeof entry.featured === "boolean"
+        ? {
+            ...manifestCatalog,
+            ...(manifestCatalog?.featured === undefined && typeof entry.featured === "boolean"
+              ? { featured: entry.featured }
+              : {}),
+          }
+        : undefined;
     if (!pluginId || !catalog || installedIds.has(pluginId) || entryPackageInstalled(entry)) {
       continue;
     }
@@ -608,7 +674,7 @@ export async function listManagedPlugins(params: {
       state: "not-installed",
       ...(catalog.featured !== undefined ? { featured: catalog.featured } : {}),
       ...(catalog.order !== undefined ? { order: catalog.order } : {}),
-      ...(resolveCatalogManifestIcon(manifest) ? { hasIcon: true } : {}),
+      ...(resolveCatalogEntryIcon(entry) ? { hasIcon: true } : {}),
       ...(install ? { install } : {}),
     });
   }

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -107,6 +107,7 @@ export type OfficialExternalPluginCatalogEntry = {
   name?: string;
   version?: string;
   description?: string;
+  icon?: string;
   source?: string;
   kind?: string;
   featured?: boolean;


### PR DESCRIPTION
## Summary
- consume top-level hosted plugin descriptions and icon URLs
- prefer hosted title, description, icon, and Featured state only for trusted published package identity
- retain local metadata for private/offline bundled plugins
- keep Control's secure icon proxy contract (`hasIcon`, no remote URL exposure)

## Validation
- `node scripts/run-vitest.mjs src/plugins/management-service-featured.test.ts src/plugins/management-service.test.ts` (47/47)
- targeted `oxfmt`, `oxlint`, and `git diff --check`
- autoreview clean

The ClawHub producer PR must merge/deploy before final production UI verification.
