### PR TITLE
improve: accelerate active-memory timeout cleanup test

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -4533,6 +4533,10 @@ describe("active-memory plugin", () => {
     const lateWriteDone = new Promise<void>((resolve) => {
       resolveLateWrite = resolve;
     });
+    let releaseLateWrite: () => void = () => {};
+    const lateWriteRelease = new Promise<void>((resolve) => {
+      releaseLateWrite = resolve;
+    });
     runEmbeddedAgent.mockImplementationOnce(
       async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
         await new Promise<void>((resolve) => {
@@ -4550,9 +4554,7 @@ describe("active-memory plugin", () => {
             },
           },
         ]);
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 100);
-        });
+        await lateWriteRelease;
         await writeTranscriptJsonl(params.sessionFile, [
           {
             message: {
@@ -4573,16 +4575,20 @@ describe("active-memory plugin", () => {
       },
     );
 
-    const result = await requireHook("before_prompt_build")(
-      { prompt: "what food do i usually order? unsettled timeout", messages: [] },
-      { agentId: "main", trigger: "user", sessionKey, messageProvider: "webchat" },
-    );
+    try {
+      const result = await requireHook("before_prompt_build")(
+        { prompt: "what food do i usually order? unsettled timeout", messages: [] },
+        { agentId: "main", trigger: "user", sessionKey, messageProvider: "webchat" },
+      );
 
-    expect(result).toBeUndefined();
-    const lines = getActiveMemoryLines(sessionKey);
-    expectLinesToContain(lines, "Active Memory: status=timeout");
-    expectLinesNotToContain(lines, "timeout_partial");
-    await lateWriteDone;
+      expect(result).toBeUndefined();
+      const lines = getActiveMemoryLines(sessionKey);
+      expectLinesToContain(lines, "Active Memory: status=timeout");
+      expectLinesNotToContain(lines, "timeout_partial");
+    } finally {
+      releaseLateWrite();
+      await lateWriteDone;
+    }
   });
 
   it("does not recover a timeout partial after an unmirrored custom memory tool fails", async () => {


### PR DESCRIPTION
## What Problem This Solves

One active-memory abort-cleanup test used a blind 100 ms sleep to keep a mocked subagent unsettled past timeout recovery. That made the test slower and coupled correctness to wall-clock scheduling.

## Why This Change Was Made

The mock now waits on an explicit release promise. The test holds that gate until the hook has classified the unsettled transcript, then releases and joins the late write in `finally`. This preserves the tested production ordering while removing the artificial sleep. Product code and CI configuration are unchanged.

## User Impact

No user-visible behavior change. Developers and CI get faster, more deterministic active-memory timeout coverage.

## Evidence

- Controlled same-Testbox baseline: 360 ms, 360 ms, 355 ms; median 360 ms.
- Patched: 310 ms, 299 ms, 300 ms; median 300 ms, 16.7% faster.
- Full active-memory file passed: 174/174 tests.
- `pnpm check:changed` passed on the rebased head.
- Testbox: `tbx_01kxq3czv9myq39x8j8pm13xyj`; run `29553544866`.
- Fresh branch autoreview: no accepted/actionable findings; correctness 0.94.
- AI-assisted: yes.
