### PR TITLE
fix(mattermost): keep finalized preview when a trailing tool-error warning falls back

### DIFF
--- a/extensions/mattermost/src/delivery-trace.test.ts
+++ b/extensions/mattermost/src/delivery-trace.test.ts
@@ -24,7 +24,7 @@ import {
 } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
-import { describe, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createMattermostPost, type MattermostClient } from "./mattermost/client.js";
 import {
   createMattermostDraftPreviewBoundaryController,
@@ -270,4 +270,48 @@ describe("mattermost delivery trace goldens", () => {
       });
     });
   }
+});
+
+describe("mattermost finalized preview survives a trailing tool-error warning", () => {
+  // Real-path proof for #109471: drive the real draft stream + real delivery
+  // wiring (only the Mattermost HTTP endpoint is recorded) through the reported
+  // ordered sequence — a successful final that finalizes the preview in place,
+  // then a trailing isError tool-warning on the same draft. Before the fix the
+  // warning fallback cleared (deleted) the finalized answer post; after the fix
+  // the answer is preserved and the warning lands as a separate durable post.
+  it("edits the finalized answer in place and posts the warning separately without deleting the answer", async () => {
+    const events = await runDeliveryTraceScenario({
+      scenario: {
+        name: "final-then-error",
+        steps: [
+          { kind: "reply-start" },
+          { kind: "partial", text: "Chrome is open at the Amazon" },
+          { kind: "advance", ms: 1300 },
+          {
+            kind: "final",
+            text: "Chrome is open at the Amazon KDP login page, ready for you to log in via remote desktop.",
+          },
+          {
+            kind: "final",
+            text: "⚠️ 🛠️ Bash failed: openclaw browser (agent)",
+            isError: true,
+          },
+          { kind: "idle" },
+        ],
+      },
+      setup: setupMattermostTrace,
+    });
+
+    const wireMethods = events.filter((event) => event.dir === "out").map((event) => event.kind);
+
+    // The successful final finalizes the preview by editing it in place.
+    expect(wireMethods).toContainEqual(expect.stringMatching(/^PUT \/posts\//));
+    // The trailing tool-error warning is delivered as its own durable post.
+    expect(wireMethods.filter((method) => method === "POST /posts").length).toBeGreaterThanOrEqual(
+      1,
+    );
+    // Regression invariant (#109471): the finalized answer post is never deleted
+    // by the warning fallback. Before the fix this emitted DELETE /posts/post-1.
+    expect(wireMethods.filter((method) => method.startsWith("DELETE /posts/"))).toEqual([]);
+  });
 });

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
@@ -50,7 +50,16 @@ export async function deliverMattermostReplyWithDraftPreview(
     adapter: defineFinalizableLivePreviewAdapter<ReplyPayload, string, { message: string }>({
       draft: {
         flush: params.draftStream.flush,
-        clear: params.draftStream.clear,
+        clear: async () => {
+          // Once an earlier payload on this same draft finalized the preview post
+          // in place as the durable answer, a later non-terminal payload's fallback
+          // cleanup (for example a trailing tool-error warning) must not delete it.
+          // The warning is still delivered as a separate post by deliverNormally.
+          if (params.previewState.finalizedViaPreviewPost) {
+            return;
+          }
+          await params.draftStream.clear();
+        },
         discardPending: params.draftStream.discardPending,
         seal: params.draftStream.seal,
         id: params.draftStream.postId,

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -492,6 +492,57 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a finalized preview post when a later tool-error warning falls back", async () => {
+    // Regression for #109471: a turn can emit a successful assistant final followed
+    // by a trailing isError tool-warning payload on the same draft. The first final
+    // finalizes the preview in place; the warning cannot, so it falls back to a
+    // normal send. That fallback must not clear (delete) the finalized answer post.
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = vi.fn(async () => {});
+    const previewState = { finalizedViaPreviewPost: false };
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Chrome is open at the Amazon KDP login page." } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text) => text?.trim(),
+      previewState,
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    // The successful final landed by editing the preview post, making it the answer.
+    expect(updateMattermostPostSpy).toHaveBeenCalledWith(expect.anything(), "preview-post-1", {
+      message: "Chrome is open at the Amazon KDP login page.",
+    });
+    expect(previewState.finalizedViaPreviewPost).toBe(true);
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: {
+        text: "⚠️ Bash failed: openclaw browser (agent)",
+        isError: true,
+      } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text) => text?.trim(),
+      previewState,
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    // The warning is delivered as its own post; the finalized answer post survives.
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
+  });
+
   it("finalizes the preview in place when the final targets the same thread", async () => {
     const draftStream = createDraftStreamMock();
     const deliverFinal = vi.fn(async () => {});


### PR DESCRIPTION
## What Problem This Solves

Closes #109471.

Fixes an issue where Mattermost preview streaming **deletes a successfully finalized assistant reply** when a later tool-error warning payload reuses the same draft. With partial preview streaming (the default), a turn that completes successfully after a tool failure can emit an ordered `[successful final, isError tool-warning]` sequence. The successful final finalizes the preview post in place; the trailing warning cannot finalize in place, so the shared fallback deletes the now-durable preview post and leaves only the `⚠️` warning visible. The reporter had to ask for status even though the agent had succeeded.

## Why This Change Was Made

`deliverMattermostReplyWithDraftPreview` already records `previewState.finalizedViaPreviewPost = true` in `onPreviewFinalized`, but never read that flag. The adapter's `draft.clear` was wired straight to `draftStream.clear`, which deletes the stored preview post. So once a final had landed in place, any later payload's fallback cleanup (`discardPending` → normal send → `clear` in the shared `deliverFinalizableLivePreview`) deleted the finalized answer.

The fix wraps the adapter's `draft.clear` so that when `previewState.finalizedViaPreviewPost` is already `true`, the clear is a no-op. The trailing warning is still delivered as a separate, durable post via `deliverNormally`; only the destructive deletion of the finalized preview is suppressed. `discardPending` is untouched (it stops the stream but does not delete).

The change is confined to the Mattermost plugin (`extensions/mattermost/src/mattermost/monitor-draft-delivery.ts`). The shared core adapter `src/channels/message/live.ts` — which has sibling channel users — is intentionally not modified.

## User Impact

Mattermost users keep the successful assistant answer and receive any later tool-error warning as a separate message, instead of having the answer replaced/removed by the warning. The skill remains usable by the gateway/model throughout; this corrects misleading UI/delivery state, not a functional skill failure.

## Evidence

### Real-path behavior proof (wire-level)
A new real-path test in `delivery-trace.test.ts` drives the **real** draft stream + **real** delivery wiring (`createMattermostDraftStream` + `deliverMattermostReplyWithDraftPreview` + `deliverMattermostReplyPayload`); only the Mattermost HTTP endpoint is a recording client. It runs the reported ordered `[successful final, isError tool-warning]` sequence and asserts the resulting REST calls. Observed wire traces from the harness:

```text
# WITH the fix (current PR):
POST /posts            # streaming preview created (post-1)
PUT  /posts/post-1     # successful final finalizes the answer in place
POST /posts            # trailing tool-error warning delivered as a separate post
# (no DELETE — the finalized answer post is preserved)

# WITH the guard reverted (reproduces the bug):
POST /posts
PUT  /posts/post-1
POST /posts
DELETE /posts/post-1   # finalized answer deleted — the reported symptom
```

The test fails on the reverted code (`expected [ 'DELETE /posts/post-1' ] to deeply equal []`) and passes with the fix. This is an API trace produced by real production code (the recording client stands in for the Mattermost HTTP endpoint, as in the existing delivery-trace goldens); it is not a live Mattermost server run.

### Tests
- **TDD unit test** (`monitor.test.ts`): fails without the fix (`expected vi.fn() to not be called... been called 1 times`), passes with it.
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/delivery-trace.test.ts` — 57/57 pass (includes the golden delivery traces).
- `node scripts/run-vitest.mjs extensions/mattermost` — 598 pass; 3 failures (`model-picker`, `thread-participation` store, `setup` wizard) reproduced identically on clean `origin/main` (verified by stashing this change), so they are pre-existing/environmental and unrelated.
- `oxfmt --check`, targeted `oxlint`, `git diff --check`: clean.
- Autoreview (claude engine, `claude-fable-5`) on the full branch: clean — "patch is correct" (**1.0 confidence**), no accepted/actionable findings.

### Proof gap (CI-gated)
This contribution envelope runs Node 22.22.0, below the repo's `>=22.22.3` requirement, so the root `preinstall` gate blocked `pnpm install` completion and the local `check-changed`/Testbox fan-out. Vitest ran on source via the `openclaw/plugin-sdk/* → src` alias (no build needed). A **live Mattermost server run** (real bot account + gateway round-trip) was not produced in this envelope; GitHub CI provides the full typecheck/lint/build/release lane, and a maintainer may still request a live transcript before merge.

AI-assisted implementation and review; the contributor reviewed the diff and evidence before publishing. This is an independent alternative to #109555 for the same issue — different mechanism (guard `clear` vs. omit the draft handle), same owner boundary — provided for maintainers to choose.
