### PR TITLE
fix(channel-selection): bound logged error dedupe cache with FIFO eviction

### DIFF
--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -134,6 +134,7 @@ function formatMultipleConfiguredChannelsMessage(configured: readonly string[]):
 }
 
 const loggedChannelSelectionErrors = new Set<string>();
+const MAX_LOGGED_CHANNEL_SELECTION_ERRORS = 512;
 
 function logChannelSelectionError(params: {
   pluginId: string;
@@ -145,6 +146,10 @@ function logChannelSelectionError(params: {
   const key = `${params.pluginId}:${params.accountId}:${params.operation}:${message}`;
   if (loggedChannelSelectionErrors.has(key)) {
     return;
+  }
+  if (loggedChannelSelectionErrors.size >= MAX_LOGGED_CHANNEL_SELECTION_ERRORS) {
+    const oldest = loggedChannelSelectionErrors.values().next().value;
+    if (oldest !== undefined) loggedChannelSelectionErrors.delete(oldest);
   }
   loggedChannelSelectionErrors.add(key);
   defaultRuntime.error?.(


### PR DESCRIPTION
## What Problem This Solves

The loggedChannelSelectionErrors Set had no capacity limit, allowing unbounded growth driven by outbound message traffic.

## Why This Change Was Made

- Cap at MAX_LOGGED_CHANNEL_SELECTION_ERRORS (512) with FIFO eviction.
- When full, evict the oldest entry before adding a new one so later distinct warnings are still delivered after saturation.
- Test-only clear() preserved.

## Risk / Compatibility

Low. FIFO eviction preserves warning delivery while bounding memory. Evicted entries may produce a duplicate warning if re-encountered, which is the expected dedupe-reset behavior.

AI-assisted: contributor patch used coding agents.