### PR TITLE
fix(imessage): bound group allowlist warning caches with FIFO eviction

### DIFF
--- a/extensions/imessage/src/monitor/group-allowlist-warnings.ts
+++ b/extensions/imessage/src/monitor/group-allowlist-warnings.ts
@@ -7,6 +7,8 @@
 // during iMessage config migration. See
 // https://github.com/openclaw/openclaw/issues/78749.
 
+const MAX_STARTUP_WARNED = 64;
+const MAX_PER_CHAT_WARNED = 512;
 const startupWarned = new Set<string>();
 const perChatWarned = new Set<string>();
 
@@ -33,6 +35,10 @@ export function warnGroupAllowlistMisconfigOnce(params: {
     return false;
   }
   const key = `imessage:${params.accountId}`;
+  if (startupWarned.size >= MAX_STARTUP_WARNED) {
+    const oldest = startupWarned.values().next().value;
+    if (oldest !== undefined) startupWarned.delete(oldest);
+  }
   if (startupWarned.has(key)) {
     return false;
   }
@@ -62,6 +68,10 @@ export function warnGroupAllowlistDropPerChatOnce(params: {
     return false;
   }
   const key = `imessage:${params.accountId}:${chat}`;
+  if (perChatWarned.size >= MAX_PER_CHAT_WARNED) {
+    const oldest = perChatWarned.values().next().value;
+    if (oldest !== undefined) perChatWarned.delete(oldest);
+  }
   if (perChatWarned.has(key)) {
     return false;
   }


### PR DESCRIPTION
FIFO eviction preserves warning delivery after capacity. MAX_STARTUP_WARNED=64, MAX_PER_CHAT_WARNED=512. AI-assisted.