### PR TITLE
fix(agents): bound tool result warning caches with FIFO eviction

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -562,6 +562,7 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 const aggregateToolResultPressureWarnings = new Set<string>();
+const MAX_TOOL_RESULT_PRESSURE_WARNINGS = 512;
 
 function pluginMetadataSnapshotCoversProvider(
   snapshot: PluginMetadataSnapshot | undefined,
@@ -4381,6 +4382,10 @@ export async function runEmbeddedAttempt(
               `aggregate=${promptToolResultTruncation.aggregateTruncatedCount}) ` +
               `sessionKey=${sessionLogKey}`;
             if (aggregatePressureEngaged) {
+              if (aggregateToolResultPressureWarnings.size >= MAX_TOOL_RESULT_PRESSURE_WARNINGS) {
+                const oldest = aggregateToolResultPressureWarnings.values().next().value;
+                if (oldest !== undefined) aggregateToolResultPressureWarnings.delete(oldest);
+              }
               if (!aggregateToolResultPressureWarnings.has(sessionLogKey)) {
                 aggregateToolResultPressureWarnings.add(sessionLogKey);
                 log.warn(

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -58,6 +58,7 @@ const AGGREGATE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
 const MIN_KEEP_CHARS = 2_000;
 const RECOVERY_MIN_KEEP_CHARS = 0;
 const aggregateToolResultRecoveryWarnings = new Set<string>();
+const MAX_TOOL_RESULT_RECOVERY_WARNINGS = 512;
 
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
@@ -91,6 +92,10 @@ function logToolResultSessionTruncation(params: {
   if (params.aggregateReplacementCount <= 0) {
     log.info(message);
     return;
+  }
+  if (aggregateToolResultRecoveryWarnings.size >= MAX_TOOL_RESULT_RECOVERY_WARNINGS) {
+    const oldest = aggregateToolResultRecoveryWarnings.values().next().value;
+    if (oldest !== undefined) aggregateToolResultRecoveryWarnings.delete(oldest);
   }
   if (aggregateToolResultRecoveryWarnings.has(sessionLogKey)) {
     log.info(message);


### PR DESCRIPTION
FIFO eviction preserves warning delivery after capacity. Both aggregateToolResultRecoveryWarnings and aggregateToolResultPressureWarnings capped at 512. AI-assisted.