### PR TITLE
fix(node-host): bound safeBin trusted dir warning cache with FIFO eviction

### DIFF
--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -136,6 +136,7 @@ type SystemRunPolicyPhase = SystemRunParsePhase & {
 };
 
 const safeBinTrustedDirWarningCache = new Set<string>();
+const MAX_SAFE_BIN_TRUSTED_DIR_WARNINGS = 256;
 const APPROVAL_CWD_DRIFT_DENIED_MESSAGE =
   "SYSTEM_RUN_DENIED: approval cwd changed before execution";
 const APPROVAL_SCRIPT_OPERAND_BINDING_DENIED_MESSAGE =
@@ -154,6 +155,10 @@ type EffectiveSystemRunExecPolicy = {
 };
 
 function warnWritableTrustedDirOnce(message: string): void {
+  if (safeBinTrustedDirWarningCache.size >= MAX_SAFE_BIN_TRUSTED_DIR_WARNINGS) {
+    const oldest = safeBinTrustedDirWarningCache.values().next().value;
+    if (oldest !== undefined) safeBinTrustedDirWarningCache.delete(oldest);
+  }
   if (safeBinTrustedDirWarningCache.has(message)) {
     return;
   }


### PR DESCRIPTION
FIFO eviction preserves warning delivery for security-relevant diagnostics after capacity. MAX_SAFE_BIN_TRUSTED_DIR_WARNINGS=256. AI-assisted.