### PR TITLE
fix(telegram): bound invalid allowFrom warn dedupe with the shared dedupe cache

### DIFF
--- a/extensions/telegram/src/bot-access.ts
+++ b/extensions/telegram/src/bot-access.ts
@@ -9,6 +9,7 @@ import type {
   TelegramDirectConfig,
   TelegramGroupConfig,
 } from "openclaw/plugin-sdk/config-contracts";
+import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 
@@ -19,18 +20,29 @@ export type NormalizedAllowFrom = {
   invalidEntries: string[];
 };
 
-const warnedInvalidEntries = new Set<string>();
+const MAX_WARNED_INVALID_ENTRIES = 256;
+// Retain warn-once state for recently seen invalid entries without letting
+// config churn accumulate keys for the process lifetime. LRU eviction
+// intentionally lets long-evicted invalid entries warn again.
+const warnedInvalidEntries = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_INVALID_ENTRIES,
+});
 const log = createSubsystemLogger("telegram/bot-access");
+
+/** @internal Reset the invalid-entry warn dedupe state. Exported for tests only. */
+export function resetInvalidAllowFromWarnings(): void {
+  warnedInvalidEntries.clear();
+}
 
 function warnInvalidAllowFromEntries(entries: string[]) {
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return;
   }
   for (const entry of entries) {
-    if (warnedInvalidEntries.has(entry)) {
+    if (warnedInvalidEntries.check(entry)) {
       continue;
     }
-    warnedInvalidEntries.add(entry);
     log.warn(
       [
         "Invalid allowFrom entry:",

--- a/extensions/telegram/src/bot-access.ts
+++ b/extensions/telegram/src/bot-access.ts
@@ -9,6 +9,7 @@ import type {
   TelegramDirectConfig,
   TelegramGroupConfig,
 } from "openclaw/plugin-sdk/config-contracts";
+import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 
@@ -19,7 +20,8 @@ export type NormalizedAllowFrom = {
   invalidEntries: string[];
 };
 
-const warnedInvalidEntries = new Set<string>();
+// Telegram owns this process-local warning bound; authorization output stays unchanged.
+const warnedInvalidEntries = createDedupeCache({ ttlMs: 0, maxSize: 256 });
 const log = createSubsystemLogger("telegram/bot-access");
 
 function warnInvalidAllowFromEntries(entries: string[]) {
@@ -27,10 +29,9 @@ function warnInvalidAllowFromEntries(entries: string[]) {
     return;
   }
   for (const entry of entries) {
-    if (warnedInvalidEntries.has(entry)) {
+    if (warnedInvalidEntries.check(entry)) {
       continue;
     }
-    warnedInvalidEntries.add(entry);
     log.warn(
       [
         "Invalid allowFrom entry:",

--- a/extensions/telegram/src/bot-access.warn-dedupe.test.ts
+++ b/extensions/telegram/src/bot-access.warn-dedupe.test.ts
@@ -1,0 +1,86 @@
+// Telegram tests cover bot access invalid allowFrom warn dedupe bounds.
+import { withEnv } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeAllowFrom, resetInvalidAllowFromWarnings } from "./bot-access.js";
+
+const { warnMock } = vi.hoisted(() => ({
+  warnMock: vi.fn(),
+}));
+
+// bot-access.ts creates its subsystem logger at module load, so the logger
+// must be replaced by the hoisted module factory rather than a beforeEach spy.
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  const createSubsystemLogger = () => {
+    const logger = { warn: warnMock, child: () => logger };
+    return logger as unknown as ReturnType<typeof actual.createSubsystemLogger>;
+  };
+  return { ...actual, createSubsystemLogger };
+});
+
+const WARN_CACHE_MAX = 256;
+
+function warnedEntries(): string[] {
+  return warnMock.mock.calls.map(([line]) => {
+    const quoted = /Invalid allowFrom entry: ("[^"]*")/.exec(String(line))?.[1];
+    return quoted ? (JSON.parse(quoted) as string) : String(line);
+  });
+}
+
+function normalizeOutsideTestGuard(list: Array<string | number>) {
+  return withEnv({ VITEST: undefined, NODE_ENV: "development" }, () => normalizeAllowFrom(list));
+}
+
+afterEach(() => {
+  warnMock.mockClear();
+  resetInvalidAllowFromWarnings();
+});
+
+describe("normalizeAllowFrom invalid-entry warn dedupe", () => {
+  it("warns once per invalid entry across repeated calls", () => {
+    normalizeOutsideTestGuard(["@someone", "12345"]);
+    normalizeOutsideTestGuard(["@someone"]);
+    normalizeOutsideTestGuard(["@someone", "@other"]);
+
+    expect(warnedEntries()).toEqual(["@someone", "@other"]);
+  });
+
+  it("keeps cached entries suppressed when a duplicate hits the full cache", () => {
+    for (let i = 0; i < WARN_CACHE_MAX; i++) {
+      normalizeOutsideTestGuard([`@user${i}`]);
+    }
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX);
+
+    // Duplicate hits at capacity must not evict unrelated entries or re-warn.
+    normalizeOutsideTestGuard(["@user0"]);
+    normalizeOutsideTestGuard([`@user${WARN_CACHE_MAX - 1}`]);
+    for (let i = 0; i < WARN_CACHE_MAX; i++) {
+      normalizeOutsideTestGuard([`@user${i}`]);
+    }
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX);
+  });
+
+  it("stays bounded and lets evicted entries warn again", () => {
+    for (let i = 0; i < WARN_CACHE_MAX; i++) {
+      normalizeOutsideTestGuard([`@user${i}`]);
+    }
+
+    // A new entry past capacity still warns (cache stays bounded, not frozen).
+    normalizeOutsideTestGuard(["@overflow"]);
+    expect(warnedEntries()).toContain("@overflow");
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX + 1);
+
+    // "@user0" was the oldest entry and got evicted by "@overflow"; it may
+    // warn again, while still-cached entries remain suppressed.
+    normalizeOutsideTestGuard(["@user1"]);
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX + 1);
+    normalizeOutsideTestGuard(["@user0"]);
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX + 2);
+    expect(warnedEntries().at(-1)).toBe("@user0");
+  });
+
+  it("does not warn under the test-environment guard", () => {
+    normalizeAllowFrom(["@someone"]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/bot-access.warn-dedupe.test.ts
+++ b/extensions/telegram/src/bot-access.warn-dedupe.test.ts
@@ -1,0 +1,62 @@
+// Telegram tests cover invalid allowFrom warning dedupe bounds.
+import { withEnv } from "openclaw/plugin-sdk/test-env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { warnMock } = vi.hoisted(() => ({
+  warnMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  const createSubsystemLogger = () => {
+    const logger = { warn: warnMock, child: () => logger };
+    return logger as unknown as ReturnType<typeof actual.createSubsystemLogger>;
+  };
+  return { ...actual, createSubsystemLogger };
+});
+
+const WARN_CACHE_MAX = 256;
+let normalizeAllowFrom: typeof import("./bot-access.js").normalizeAllowFrom;
+
+function normalizeOutsideTestGuard(list: Array<string | number>) {
+  return withEnv({ VITEST: undefined, NODE_ENV: "development" }, () => normalizeAllowFrom(list));
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  warnMock.mockReset();
+  ({ normalizeAllowFrom } = await import("./bot-access.js"));
+});
+
+describe("normalizeAllowFrom invalid-entry warn dedupe", () => {
+  it("warns once per invalid entry across repeated calls", () => {
+    normalizeOutsideTestGuard(["@someone", "12345"]);
+    normalizeOutsideTestGuard(["@someone"]);
+    normalizeOutsideTestGuard(["@someone", "@other"]);
+
+    expect(warnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the oldest warning while keeping recent duplicates suppressed", () => {
+    for (let i = 0; i <= WARN_CACHE_MAX; i++) {
+      normalizeOutsideTestGuard([`@user${i}`]);
+    }
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX + 1);
+
+    normalizeOutsideTestGuard([`@user${WARN_CACHE_MAX}`]);
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX + 1);
+
+    normalizeOutsideTestGuard(["@user0"]);
+    expect(warnMock).toHaveBeenCalledTimes(WARN_CACHE_MAX + 2);
+  });
+
+  it("does not change normalization or warn under the test guard", () => {
+    expect(normalizeAllowFrom(["*", " tg:12345 ", "@someone"])).toEqual({
+      entries: ["12345"],
+      hasWildcard: true,
+      hasEntries: true,
+      invalidEntries: ["@someone"],
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-lived Telegram gateways retained every distinct invalid `allowFrom` or `groupAllowFrom` warning key for the process lifetime. Repeated config churn could therefore grow warning-deduplication memory without a bound.

## Why This Change Was Made

Telegram now uses the shared process-local dedupe cache with no TTL and a 256-entry LRU bound. This preserves warn-once behavior for recent invalid values while allowing old evicted values to warn again. Tests reload the owner module between cases, so no test-only reset API is exported from production.

Authorization normalization and access decisions are unchanged. The production diff is `+4/-3` (net `+1`): the shared cache import and owner-bound cache replace the unbounded `Set`.

## User Impact

Telegram gateways no longer accumulate invalid allow-list warning keys indefinitely. Recent duplicate warnings remain suppressed, and operators can still see a warning again after an old key is evicted.

Release note: bound Telegram invalid allow-list warning deduplication for long-running gateways.

## Evidence

Current-main reproduction before the production fix:

- `bot-access.warn-dedupe.test.ts`: failed because replaying the oldest key after 257 distinct invalid values emitted `257` warnings instead of the expected `258`, proving the process-lifetime `Set` never evicted it.

Focused passing proof:

- `bot-access.warn-dedupe.test.ts`: 3/3
- shared `src/infra/dedupe.test.ts`: 7/7
- Telegram DM/group access: 21/21
- Telegram helper/message-context callers: 104/104
- formatting and `git diff --check`: pass
- autoreview: clean, no actionable findings, correctness confidence 0.99
- Blacksmith Testbox changed-surface gate: pass, including extension/test typechecks, lint, dead exports, plugin boundaries, database-first guard, and runtime import cycles
  - https://github.com/openclaw/openclaw/actions/runs/32677363243
- exact-head hosted CI: 83 passing, 0 failing, 0 pending
  - https://github.com/openclaw/openclaw/actions/runs/32677866981
- exact-head ClawSweeper: no actionable findings or rank-up moves; live regression proof 3/3
  - https://github.com/openclaw/clawsweeper/actions/runs/32677953803

Punchcard-Session: clear-valley-lantern-qm
