### PR TITLE
feat(ui): make sidebar catalog project groups collapsible

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -305,9 +305,10 @@ normal plugin node policy and isolates failures by host.
 
 Paired-node rows appear as a **Codex** group in the normal sessions sidebar.
 Within each host, rows group by project folder by default; a working directory
-under `.claude/worktrees/<name>` folds into its origin repository. Use the
-folder icon in the catalog header to flatten or restore the project groups.
-The same grouping applies to the Claude sessions catalog.
+under `.claude/worktrees/<name>` folds into its origin repository, and project
+groups collapse like other sidebar sections. Use the folder icon in the catalog
+header to flatten or restore the project groups. The same grouping applies to
+the Claude sessions catalog.
 By default, selecting a row opens the normal Chat pane and reads its persisted transcript
 through bounded, cursor-paginated
 `thread/turns/list` calls with full item projection. Use the row menu, the viewer header, or the **Open Codex/Claude sessions in** preference to start `codex resume <thread-id>` in the operator terminal on the computer that owns the session. The paired-node terminal path is an allowlisted PTY relay owned by the Codex plugin, not arbitrary node command execution.

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -292,23 +292,33 @@ function renderCatalogHostGroup(
       </div>
       <div class="sidebar-session-catalog-host__sessions" role="list" aria-label=${host.label}>
         ${projectGroups
-          ? html`${projectGroups.groups.map(
-              (group) => html`
-                <div
+          ? html`${projectGroups.groups.map((group) => {
+              const sectionId = `catalog-project:${catalog.id}:${host.hostId}:${group.key}`;
+              const collapsed = params.collapsedSections.has(sectionId);
+              return html`
+                <button
+                  type="button"
                   class="sidebar-session-catalog-project__head"
                   data-session-catalog-project=${group.key}
+                  aria-expanded=${String(!collapsed)}
                   title=${group.title}
+                  @click=${() => params.onToggleSection(sectionId)}
                 >
+                  <span class="sidebar-session-catalog-project__icon" aria-hidden="true"
+                    >${collapsed ? icons.chevronRight : icons.chevronDown}</span
+                  >
                   <span class="sidebar-session-catalog-project__label">${group.label}</span>
                   <span class="sidebar-session-catalog-project__count" aria-hidden="true"
                     >${group.sessions.length}</span
                   >
-                </div>
-                ${group.sessions.map((session) =>
-                  renderCatalogSessionRow(catalog, host, session, liveRowsByKey, params),
-                )}
-              `,
-            )}
+                </button>
+                ${collapsed
+                  ? nothing
+                  : group.sessions.map((session) =>
+                      renderCatalogSessionRow(catalog, host, session, liveRowsByKey, params),
+                    )}
+              `;
+            })}
             ${projectGroups.ungrouped.map((session) =>
               renderCatalogSessionRow(catalog, host, session, liveRowsByKey, params),
             )}`

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -19,6 +19,7 @@ let browser: Browser;
 let server: ControlUiE2eServer;
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const catalogGroupingStorageKey = "openclaw:sidebar:sessions:catalog-grouping";
+const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
 const uiProofArtifactDir = path.join(
   process.cwd(),
   ".artifacts",
@@ -92,6 +93,10 @@ suite("Codex native session catalog", () => {
   it("groups sessions by host and hides empty offline nodes", async () => {
     const page = await browser.newPage({ viewport: { height: 1100, width: 1440 } });
     await page.addInitScript((key) => localStorage.removeItem(key), catalogGroupingStorageKey);
+    await page.addInitScript(
+      (key) => localStorage.removeItem(key),
+      collapsedSessionSectionsStorageKey,
+    );
     await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
       methodResponses: {
@@ -229,6 +234,33 @@ suite("Codex native session catalog", () => {
       expect(
         await page.evaluate((key) => localStorage.getItem(key), catalogGroupingStorageKey),
       ).toBe("project");
+
+      await openclawProject.click();
+      await expect.poll(() => openclawProject.getAttribute("aria-expanded")).toBe("false");
+      expect(await section.getByText("Local planning session", { exact: true }).count()).toBe(0);
+      expect(await section.getByText("Worktree fix session", { exact: true }).count()).toBe(0);
+      expect(await section.getByText("Other project session", { exact: true }).count()).toBe(1);
+      expect(await openclawProject.count()).toBe(1);
+      expect(
+        await openclawProject.locator(".sidebar-session-catalog-project__count").textContent(),
+      ).toBe("2");
+      expect(
+        await page.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
+          collapsedSessionSectionsStorageKey,
+        ),
+      ).toContain("catalog-project:codex:gateway:local:/Users/dev/openclaw");
+
+      await openclawProject.click();
+      await expect.poll(() => openclawProject.getAttribute("aria-expanded")).toBe("true");
+      expect(await section.getByText("Local planning session", { exact: true }).count()).toBe(1);
+      expect(await section.getByText("Worktree fix session", { exact: true }).count()).toBe(1);
+      expect(
+        await page.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
+          collapsedSessionSectionsStorageKey,
+        ),
+      ).not.toContain("catalog-project:codex:gateway:local:/Users/dev/openclaw");
 
       if (captureUiProofEnabled) {
         await mkdir(uiProofArtifactDir, { recursive: true });

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1630,10 +1630,40 @@ html.openclaw-native-macos
 .sidebar-session-catalog-project__head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 5px;
+  width: 100%;
   min-height: 18px;
-  padding: 2px 12px 0 28px;
+  padding: 2px 12px 0 20px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: color-mix(in srgb, var(--muted) 90%, var(--text) 10%);
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.sidebar-session-catalog-project__head:hover,
+.sidebar-session-catalog-project__head:focus-visible {
+  background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
+  color: var(--text);
+}
+
+.sidebar-session-catalog-project__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  opacity: 0.75;
+}
+
+.sidebar-session-catalog-project__icon svg {
+  width: 10px;
+  height: 10px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8px;
 }
 
 .sidebar-session-catalog-project__label {


### PR DESCRIPTION
## What Problem This Solves

PR #109575 grouped the native session catalogs (Codex + Claude) by project under each host, but the groups are static headers: a node with many sessions in one busy repo still forces scrolling past all of them to reach the next project. Every other sidebar section (catalogs, pinned, categories) collapses; project groups should too.

## Why This Change Was Made

Follow-up agreed in #109575. The project head becomes a collapse toggle reusing the existing section-collapse machinery — no new state surface:

- `renderCatalogHostGroup` renders each head as a `<button>` with a chevron and `aria-expanded`; clicking calls the existing `onToggleSection` with id `catalog-project:<catalogId>:<hostId>:<projectKey>`, persisted in the existing `openclaw:sidebar:sessions:collapsed-sections` localStorage set.
- Collapsed groups keep the head with its session count; rows unmount. The ungrouped tail and the flatten toggle are unaffected.
- CSS converts the head to a button (reset + hover/focus-visible affordance consistent with the other sidebar toggles).

## User Impact

Project groups under each node in the Codex/Claude session catalogs now collapse and expand like every other sidebar section, and the collapsed set survives reloads. No config or protocol changes; docs updated in `docs/nodes/index.md`.

Live proof (real gateway from this branch on a Testbox, real seeded `~/.claude/projects` store with a worktree session, Chromium via Playwright):

| Grouped (live) | `openclaw` collapsed (live) | Flattened (live) |
| --- | --- | --- |
| ![grouped](https://gist.githubusercontent.com/steipete/2504344f444df4613ab427787a5ecb62/raw/live-grouped.png) | ![collapsed](https://gist.githubusercontent.com/steipete/2504344f444df4613ab427787a5ecb62/raw/live-collapsed.png) | ![flat](https://gist.githubusercontent.com/steipete/2504344f444df4613ab427787a5ecb62/raw/live-flat.png) |

## Evidence

- Live end-to-end on Blacksmith Testbox `tbx_01kxq4qp88ctde1t04zw50mn8k`: built the branch (`pnpm build`), seeded `~/.claude/projects` with three sessions across two projects (one in `.claude/worktrees/fix-sidebar`), ran `node openclaw.mjs gateway --bind loopback` with a token, drove the real dashboard in Chromium: 2 project heads, worktree folded (`openclaw` count 2), collapse hid its 2 rows (`aria-expanded=false`, other project untouched), flatten removed heads with all 3 rows present. Screenshots above are from that run.
- Playwright e2e extended in `ui/src/e2e/codex-sessions.e2e.test.ts`: collapse hides only that group's rows, head + count persist, `collapsed-sections` storage gains/loses `catalog-project:codex:gateway:local:/Users/dev/openclaw`, expand restores. Green on the Testbox alongside scoped `run-oxlint`, `tsgo:ui`, and `tsgo:test:ui`.
- `node scripts/run-vitest.mjs ui/src/lib/sessions/catalog-project-grouping.test.ts` — 12/12 (helper untouched, no regression).
- Autoreview (Codex gpt-5.6-sol): clean, no findings ("patch is correct", 0.96).
