### PR TITLE
fix(cli): oversized secrets plans consume unbounded memory

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -108,6 +108,7 @@ Notes:
 - Supports creating new `auth-profiles.json` mappings directly in the picker flow.
 - Runs preflight resolution before apply.
 - Generated plans default to scrub options enabled (`scrubEnv`, `scrubAuthProfilesForProviderTargets`, `scrubLegacyAuthJson`). Apply is one-way for scrubbed plaintext values.
+- `--plan-out` refuses to create a plan whose UTF-8 serialized form exceeds 16 MiB (16,777,216 bytes), matching the `apply --from` input limit.
 - Without `--apply`, the CLI still prompts `Apply this plan now?` after preflight.
 - With `--apply` (and no `--yes`), the CLI prompts an extra irreversible-migration confirmation.
 - `--json` prints the plan + preflight report, but still requires an interactive TTY.
@@ -127,6 +128,8 @@ openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --json
 ```
 
 `--dry-run` validates preflight without writing files; exec SecretRef checks are skipped by default in dry-run. Write mode rejects plans containing exec SecretRefs/providers unless `--allow-exec`. Use `--allow-exec` to opt in to exec provider checks/execution in either mode.
+
+`--from` must point to a regular file no larger than 16 MiB (16,777,216 bytes). The byte limit applies to the complete serialized file, including whitespace.
 
 What `apply` may update:
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3877,6 +3877,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 
 - Route: /gateway/secrets-plan-contract
 - Headings:
+  - H2: Plan file requirements
   - H2: Plan file shape
   - H2: Provider upserts and deletes
   - H2: Supported target scope

--- a/docs/gateway/secrets-plan-contract.md
+++ b/docs/gateway/secrets-plan-contract.md
@@ -9,6 +9,12 @@ title: "Secrets apply plan contract"
 
 This page defines the strict contract enforced by `openclaw secrets apply`. If a target does not match these rules, apply fails before mutating any file.
 
+## Plan file requirements
+
+`openclaw secrets apply --from <plan.json>` accepts regular files up to 16 MiB (16,777,216 bytes). The limit applies to the complete serialized file, including whitespace. Directories, FIFOs, device files, and files larger than the limit are rejected before JSON parsing or target validation.
+
+`openclaw secrets configure --plan-out <plan.json>` enforces the same limit on the UTF-8 serialized output before creating the file. Hand-written plans and external plan generators must also keep the serialized file within this boundary.
+
 ## Plan file shape
 
 `openclaw secrets apply --from <plan.json>` expects a `targets` array of plan targets:

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -357,6 +357,20 @@ describe("secrets CLI", () => {
     });
   });
 
+  it("rejects oversized secrets plan files before parsing", async () => {
+    await withPlanFile(async (planPath) => {
+      await fs.truncate(planPath, 16 * 1024 * 1024 + 1);
+      await expect(
+        createProgram().parseAsync(["secrets", "apply", "--from", planPath, "--dry-run"], {
+          from: "user",
+        }),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runSecretsApply).not.toHaveBeenCalled();
+      expect(runtimeErrors.at(-1)).toContain("Secrets plan file exceeds 16777216 bytes");
+    });
+  });
+
   it("forwards --allow-exec to secrets apply dry-run", async () => {
     await withPlanFile(async (planPath) => {
       runSecretsApply.mockResolvedValue(createSecretsApplyResult());

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -1,7 +1,9 @@
 // Secrets CLI tests cover secret command registration, reads, writes, and redaction.
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -10,6 +12,8 @@ import {
   mockFirstObjectArg,
 } from "../test-utils/mock-call-assertions.js";
 import { registerSecretsCli } from "./secrets-cli.js";
+
+const execFileAsync = promisify(execFile);
 
 const mocks = await vi.hoisted(async () => {
   const { createCliRuntimeMock } = await import("./test-runtime-mock.js");
@@ -441,6 +445,58 @@ describe("secrets CLI", () => {
       expect(runtimeErrors.at(-1)).toContain("Secrets plan file exceeds 16777216 bytes");
     });
   });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects FIFO secrets plan paths without blocking",
+    async () => {
+      runSecretsApply.mockResolvedValue(createSecretsApplyResult());
+      await withPlanFile(async (planPath) => {
+        await createProgram().parseAsync(["secrets", "apply", "--from", planPath, "--dry-run"], {
+          from: "user",
+        });
+      });
+      runSecretsApply.mockReset();
+      runtimeLogs.length = 0;
+      runtimeErrors.length = 0;
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-secrets-cli-fifo-"));
+      const fifoPath = path.join(tmpDir, "plan.json");
+      await execFileAsync("mkfifo", [fifoPath]);
+
+      let timedOut = false;
+      let timeout: NodeJS.Timeout | undefined;
+      const parse = createProgram().parseAsync(
+        ["secrets", "apply", "--from", fifoPath, "--dry-run"],
+        { from: "user" },
+      );
+
+      try {
+        await expect(
+          Promise.race([
+            parse,
+            new Promise<never>((_, reject) => {
+              timeout = setTimeout(() => {
+                timedOut = true;
+                reject(new Error("Timed out waiting for FIFO plan rejection"));
+              }, 1_000);
+            }),
+          ]),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(runSecretsApply).not.toHaveBeenCalled();
+        expect(runtimeErrors.at(-1)).toContain("Secrets plan path is not a regular file");
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        if (timedOut) {
+          const releaseWriter = execFileAsync("sh", ["-c", 'printf x > "$1"', "sh", fifoPath]);
+          await Promise.allSettled([parse, releaseWriter]);
+        }
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("forwards --allow-exec to secrets apply dry-run", async () => {
     await withPlanFile(async (planPath) => {

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -105,6 +105,29 @@ function createConfigureInteractiveResult(options?: {
   };
 }
 
+function createConfigureInteractiveResultWithPlanBytes(bytes: number) {
+  const configured = createConfigureInteractiveResult({
+    targets: [
+      {
+        type: "models.providers.apiKey",
+        path: "models.providers.openai.apiKey",
+        pathSegments: ["models", "providers", "openai", "apiKey"],
+        ref: {
+          source: "file",
+          provider: "default",
+          id: "",
+        },
+        providerId: "openai",
+      },
+    ],
+  });
+  const target = configured.plan.targets[0] as { ref: { id: string } };
+  const emptyBytes = Buffer.byteLength(`${JSON.stringify(configured.plan, null, 2)}\n`, "utf8");
+  target.ref.id = "x".repeat(bytes - emptyBytes);
+  expect(Buffer.byteLength(`${JSON.stringify(configured.plan, null, 2)}\n`, "utf8")).toBe(bytes);
+  return configured;
+}
+
 function createSecretsApplyResult(options?: {
   mode?: "dry-run" | "write";
   changed?: boolean;
@@ -355,6 +378,54 @@ describe("secrets CLI", () => {
       agentId: "ops",
       allowExecInPreflight: false,
     });
+  });
+
+  it("writes generated secrets plan files at the apply limit", async () => {
+    const planPath = path.join(
+      os.tmpdir(),
+      `openclaw-secrets-configure-test-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+    );
+    runSecretsConfigureInteractive.mockResolvedValue(
+      createConfigureInteractiveResultWithPlanBytes(16 * 1024 * 1024),
+    );
+    confirm.mockResolvedValue(false);
+
+    try {
+      await createProgram().parseAsync(["secrets", "configure", "--plan-out", planPath], {
+        from: "user",
+      });
+
+      expect((await fs.stat(planPath)).size).toBe(16 * 1024 * 1024);
+      expect(runtimeLogs).toContain(`Plan written to ${planPath}`);
+      expect(runSecretsApply).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(planPath, { force: true });
+    }
+  });
+
+  it("rejects generated secrets plan files that exceed the apply limit", async () => {
+    const planPath = path.join(
+      os.tmpdir(),
+      `openclaw-secrets-configure-test-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+    );
+    runSecretsConfigureInteractive.mockResolvedValue(
+      createConfigureInteractiveResultWithPlanBytes(16 * 1024 * 1024 + 1),
+    );
+
+    try {
+      await expect(
+        createProgram().parseAsync(["secrets", "configure", "--plan-out", planPath], {
+          from: "user",
+        }),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runtimeErrors.at(-1)).toContain("Secrets plan exceeds 16777216 bytes");
+      await expect(fs.access(planPath)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(confirm).not.toHaveBeenCalled();
+      expect(runSecretsApply).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(planPath, { force: true });
+    }
   });
 
   it("rejects oversized secrets plan files before parsing", async () => {

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -62,13 +62,15 @@ function serializePlanFile(plan: SecretsApplyPlan, pathname: string): string {
 
 async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
   // Apply consumes a generated plan shape, not arbitrary JSON.
-  const [{ promises: fs }, { readFileDescriptorBounded }, { isSecretsApplyPlan }] =
-    await Promise.all([
-      fsModuleLoader.load(),
-      import("../infra/file-descriptor-read.js"),
-      import("../secrets/plan.js"),
-    ]);
-  const file = await fs.open(pathname, "r").catch((err: unknown) => {
+  const [fsModule, { readFileDescriptorBounded }, { isSecretsApplyPlan }] = await Promise.all([
+    fsModuleLoader.load(),
+    import("../infra/file-descriptor-read.js"),
+    import("../secrets/plan.js"),
+  ]);
+  const fsConstants = fsModule.constants as typeof fsModule.constants & { O_NONBLOCK?: number };
+  // Non-blocking open lets descriptor stat reject special files without a FIFO stalling first.
+  const openFlags = fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK ?? 0);
+  const file = await fsModule.promises.open(pathname, openFlags).catch((err: unknown) => {
     if (hasErrnoCode(err, "ENOENT")) {
       throw new SecretsPlanFileNotFoundError(`Secrets plan file not found: ${pathname}`, {
         cause: err,

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -48,7 +48,17 @@ const secretsApplyLoader = createLazyImportLoader<SecretsApplyModule>(
 
 class SecretsPlanFileNotFoundError extends Error {}
 
-const SECRETS_APPLY_PLAN_MAX_BYTES = 16 * 1024 * 1024;
+const SECRETS_PLAN_MAX_BYTES = 16 * 1024 * 1024;
+
+function serializePlanFile(plan: SecretsApplyPlan, pathname: string): string {
+  const raw = `${JSON.stringify(plan, null, 2)}\n`;
+  if (Buffer.byteLength(raw, "utf8") > SECRETS_PLAN_MAX_BYTES) {
+    throw new RangeError(
+      `Secrets plan exceeds ${SECRETS_PLAN_MAX_BYTES} bytes and cannot be written: ${pathname}`,
+    );
+  }
+  return raw;
+}
 
 async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
   // Apply consumes a generated plan shape, not arbitrary JSON.
@@ -72,14 +82,12 @@ async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
     if (!stat.isFile()) {
       throw new Error(`Secrets plan path is not a regular file: ${pathname}`);
     }
-    if (stat.size > SECRETS_APPLY_PLAN_MAX_BYTES) {
+    if (stat.size > SECRETS_PLAN_MAX_BYTES) {
       throw new RangeError(
-        `Secrets plan file exceeds ${SECRETS_APPLY_PLAN_MAX_BYTES} bytes: ${pathname}`,
+        `Secrets plan file exceeds ${SECRETS_PLAN_MAX_BYTES} bytes: ${pathname}`,
       );
     }
-    raw = (await readFileDescriptorBounded(file.fd, SECRETS_APPLY_PLAN_MAX_BYTES)).toString(
-      "utf8",
-    );
+    raw = (await readFileDescriptorBounded(file.fd, SECRETS_PLAN_MAX_BYTES)).toString("utf8");
   } finally {
     await file.close();
   }
@@ -216,7 +224,7 @@ export function registerSecretsCli(program: Command): void {
       "Allow exec SecretRef preflight checks (may execute provider commands)",
       false,
     )
-    .option("--plan-out <path>", "Write generated plan JSON to a file")
+    .option("--plan-out <path>", "Write generated plan JSON to a file (max 16 MiB)")
     .option("--json", "Output JSON", false)
     .action(async (opts: SecretsConfigureOptions) => {
       try {
@@ -229,7 +237,7 @@ export function registerSecretsCli(program: Command): void {
         });
         if (opts.planOut) {
           const { writeFileSync } = await fsModuleLoader.load();
-          writeFileSync(opts.planOut, `${JSON.stringify(configured.plan, null, 2)}\n`, "utf8");
+          writeFileSync(opts.planOut, serializePlanFile(configured.plan, opts.planOut), "utf8");
         }
 
         let shouldApply = Boolean(opts.apply || opts.yes);

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -48,22 +48,40 @@ const secretsApplyLoader = createLazyImportLoader<SecretsApplyModule>(
 
 class SecretsPlanFileNotFoundError extends Error {}
 
+const SECRETS_APPLY_PLAN_MAX_BYTES = 16 * 1024 * 1024;
+
 async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
   // Apply consumes a generated plan shape, not arbitrary JSON.
-  const [{ readFileSync }, { isSecretsApplyPlan }] = await Promise.all([
-    fsModuleLoader.load(),
-    import("../secrets/plan.js"),
-  ]);
-  let raw: string;
-  try {
-    raw = readFileSync(pathname, "utf8");
-  } catch (err) {
+  const [{ promises: fs }, { readFileDescriptorBounded }, { isSecretsApplyPlan }] =
+    await Promise.all([
+      fsModuleLoader.load(),
+      import("../infra/file-descriptor-read.js"),
+      import("../secrets/plan.js"),
+    ]);
+  const file = await fs.open(pathname, "r").catch((err: unknown) => {
     if (hasErrnoCode(err, "ENOENT")) {
       throw new SecretsPlanFileNotFoundError(`Secrets plan file not found: ${pathname}`, {
         cause: err,
       });
     }
     throw err;
+  });
+  let raw: string;
+  try {
+    const stat = await file.stat();
+    if (!stat.isFile()) {
+      throw new Error(`Secrets plan path is not a regular file: ${pathname}`);
+    }
+    if (stat.size > SECRETS_APPLY_PLAN_MAX_BYTES) {
+      throw new RangeError(
+        `Secrets plan file exceeds ${SECRETS_APPLY_PLAN_MAX_BYTES} bytes: ${pathname}`,
+      );
+    }
+    raw = (await readFileDescriptorBounded(file.fd, SECRETS_APPLY_PLAN_MAX_BYTES)).toString(
+      "utf8",
+    );
+  } finally {
+    await file.close();
   }
   let parsed: unknown;
   try {
@@ -307,7 +325,7 @@ export function registerSecretsCli(program: Command): void {
   secrets
     .command("apply")
     .description("Apply a previously generated secrets plan")
-    .requiredOption("--from <path>", "Path to plan JSON")
+    .requiredOption("--from <path>", "Path to plan JSON (max 16 MiB)")
     .option("--dry-run", "Validate/preflight only", false)
     .option("--allow-exec", "Allow exec SecretRef checks (may execute provider commands)", false)
     .option("--json", "Output JSON", false)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw secrets apply --from <path>` could make the CLI fully allocate and parse an arbitrarily large plan file before its shape was validated. A 32 MiB valid JSON file reached plan validation instead of being rejected at the file boundary, creating avoidable memory pressure before either dry-run or mutation could begin.

## Why This Change Was Made

The serialized plan-file boundary now has one 16 MiB contract for both commands that own it. `secrets configure --plan-out` measures the exact UTF-8 bytes of its pretty-printed JSON before writing, while `secrets apply --from` opens the path non-blockingly, verifies the pinned descriptor is a regular file, and uses the existing bounded reader. This prevents configure from emitting a plan file that apply would reject solely because of its size, and prevents FIFO paths from stalling before regular-file validation.

The limit is shown in both CLI help paths and documented in the canonical plan contract and Secrets CLI reference for hand-written plans and external generators. Plan schema, target validation, provider behavior, in-memory configure/apply behavior, and apply semantics are unchanged.

A fresh semantic recall checked 26 open pull requests. The closest changes improve malformed-JSON and missing-file diagnostics in the same reader, but neither bounds successful file reads or aligns generated-plan output with an apply-time byte contract.

## User Impact

Oversized secrets plans now fail early with a clear byte-limit error instead of being fully loaded and parsed. FIFO and other special-file paths are rejected without waiting for a writer. Plans at or below 16 MiB can still be generated and applied. If interactive configuration would produce a larger file, `--plan-out` now fails before creating an unusable artifact.

## Evidence

Real CLI proof on the fixed apply path:

```text
$ openclaw secrets apply --from small-plan.json --dry-run
Secrets apply dry run: no changes.
exit=0

$ openclaw secrets apply --from 32MiB-plan.json --dry-run
Secrets apply failed: Secrets plan file exceeds 16777216 bytes: ...
exit=1
```

The 32 MiB fixture was valid JSON (whitespace followed by `{}`), and the output did not reach the previous `Invalid secrets plan file` diagnostic. The same real CLI check on the pinned latest-main snapshot still reached `Invalid secrets plan file`, confirming the problem remained upstream before this patch.

Focused validation after review feedback:

```text
node node_modules/vitest/vitest.mjs run src/cli/secrets-cli.test.ts
Test Files  1 passed (1)
Tests       19 passed (19)

node_modules/.bin/oxfmt --check src/cli/secrets-cli.ts src/cli/secrets-cli.test.ts docs/cli/secrets.md docs/gateway/secrets-plan-contract.md
All matched files use the correct format.

node_modules/.bin/oxlint --quiet src/cli/secrets-cli.ts src/cli/secrets-cli.test.ts
exit=0

pnpm docs:check-mdx
Docs MDX check passed (732 files).

git diff --check 7f50fb6bfec6f686ee4cf7bdc966f8056e2aabc9 HEAD
exit=0
```

The regression coverage drives the real Commander actions and locks both sides of the serialized contract: configure writes an exact 16 MiB plan, rejects a 16 MiB + 1 byte plan without creating the output file, apply rejects an oversized input before `runSecretsApply` is called, and a writerless Unix FIFO is rejected within a one-second bound. Gateway startup is not part of this behavior because plan-file serialization and loading complete in the standalone CLI before apply or any Gateway interaction begins.
