### PR TITLE
fix(whatsapp): honor mentionPatterns with third-party native mentions

### DIFF
--- a/extensions/whatsapp/src/auto-reply/mentions.ts
+++ b/extensions/whatsapp/src/auto-reply/mentions.ts
@@ -68,19 +68,29 @@ function isBotMentionedFromTargets(
     : isSelfChatMode(targets.self.e164, mentionCfg.allowFrom) && !isGroupConversation;
 
   const hasMentions = targets.normalizedMentions.length > 0;
+  // Evaluate configured text patterns once so the third-party-native-mention
+  // branch can honor mentionPatterns without also enabling the numeric
+  // self-E.164 fallback (which would over-trigger on incidental numbers).
+  const bodyClean = clean(msg.payload.body);
+  const matchesConfiguredMention = mentionCfg.mentionRegexes.some((re) => re.test(bodyClean));
   if (hasMentions && !isSelfChat) {
     for (const mention of targets.normalizedMentions) {
       if (identitiesOverlap(targets.self, mention)) {
         return true;
       }
     }
-    // If the message explicitly mentions someone else, do not fall back to regex matches.
+    // Native @-mentions of other participants must not suppress operator
+    // mentionPatterns (requireMention groups). Numeric self fallback stays
+    // off in this branch so a third-party @mention + phone-looking body text
+    // does not accidentally admit the message (#109488).
+    if (matchesConfiguredMention) {
+      return true;
+    }
     return false;
   } else if (hasMentions && isSelfChat) {
     // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in self-chat triggers the bot.
   }
-  const bodyClean = clean(msg.payload.body);
-  if (mentionCfg.mentionRegexes.some((re) => re.test(bodyClean))) {
+  if (matchesConfiguredMention) {
     return true;
   }
 

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -565,7 +565,7 @@ describe("applyGroupGating", () => {
     expect(result.shouldProcess).toBe(true);
   });
 
-  it("does not treat group mention gating as self-chat under implicit self fallback", async () => {
+  it("uses configured mention patterns when native mentions target another group member", async () => {
     const cfg = makeConfig({
       channels: {
         whatsapp: {
@@ -580,6 +580,55 @@ describe("applyGroupGating", () => {
       msg: createGroupMessage({
         id: "g-other-mention",
         body: "@openclaw please check this",
+        mentionedJids: ["15550000000@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(true);
+    expect(groupHistories.get("whatsapp:default:group:123@g.us")).toBeUndefined();
+  });
+
+  it("rejects third-party native mentions when configured mention patterns do not match", async () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          groups: { "*": { requireMention: true } },
+        },
+      },
+      messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+    });
+
+    const { result, groupHistories } = await runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "g-other-mention-no-pattern",
+        body: "@someone please check this",
+        mentionedJids: ["15550000000@s.whatsapp.net"],
+        selfE164: "+15551234567",
+        selfJid: "15551234567@s.whatsapp.net",
+      }),
+    });
+
+    expect(result.shouldProcess).toBe(false);
+    expect(groupHistories.get("whatsapp:default:group:123@g.us")?.length).toBe(1);
+  });
+
+  it("does not use numeric self fallback when native mentions target another group member", async () => {
+    const cfg = makeConfig({
+      channels: {
+        whatsapp: {
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+
+    const { result, groupHistories } = await runGroupGating({
+      cfg,
+      msg: createGroupMessage({
+        id: "g-other-mention-self-number",
+        body: "please check +1 555 123 4567",
         mentionedJids: ["15550000000@s.whatsapp.net"],
         selfE164: "+15551234567",
         selfJid: "15551234567@s.whatsapp.net",

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -136,14 +136,34 @@ describe("isBotMentionedFromTargets", () => {
     expect(debugMention(msg, cfg).wasMentioned).toBe(expected);
   }
 
-  it("ignores regex matches when other mentions are present", () => {
+  it("falls through to regex matches when native mentions target another participant", () => {
     const msg = makeMsg({
       body: "@OpenClaw please help",
       mentionedJids: ["19998887777@s.whatsapp.net"],
       selfE164: "+15551234567",
       selfJid: "15551234567@s.whatsapp.net",
     });
+    expectMentioned(msg, mentionCfg, true);
+  });
+
+  it("rejects third-party native mentions when regexes do not match", () => {
+    const msg = makeMsg({
+      body: "please help",
+      mentionedJids: ["19998887777@s.whatsapp.net"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
     expectMentioned(msg, mentionCfg, false);
+  });
+
+  it("does not use numeric self fallback when native mentions target another participant", () => {
+    const msg = makeMsg({
+      body: "please check +1 555 123 4567",
+      mentionedJids: ["19998887777@s.whatsapp.net"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
+    expectMentioned(msg, { mentionRegexes: [] }, false);
   });
 
   it("matches explicit self mentions", () => {


### PR DESCRIPTION
Closes #109488

## What Problem This Solves

Fixes an issue where users in a WhatsApp group with `requireMention: true` would have their message silently dropped when they addressed the bot with a configured text mention pattern **and** also natively @-mentioned another group member.

## Why This Change Was Made

The WhatsApp mention gate now evaluates operator-configured `mentionPatterns` after native mention metadata fails to match the bot. Third-party native mentions still reject the message when no configured pattern matches, and the numeric self-E.164 body fallback stays suppressed in that branch so incidental phone-looking text cannot over-admit messages. No new config or native-identity matching changes.

## User Impact

Operators can keep `requireMention: true` with configured mention patterns, and group users can ask the bot about another mentioned participant without the message disappearing before agent dispatch.

## Evidence

Primary focused tests (local macOS, Node v24.17.0):

```text
$ node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
 ✓ |extension-whatsapp| .../web-auto-reply-utils.test.ts (31 tests) 341ms
 Test Files  1 passed (1)
      Tests  31 passed (31)

$ node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
 ✓ |extension-whatsapp| .../web-auto-reply-monitor.test.ts (25 tests) 1332ms
 Test Files  1 passed (1)
      Tests  25 passed (25)

$ git diff --check
(empty — clean)
```

New/updated cases cover: third-party native mention + matching pattern admits; third-party native mention without pattern rejects; third-party native mention + self-number body does not use numeric fallback.

## Real behavior proof

- Behavior addressed: WhatsApp `requireMention` groups no longer drop messages that match configured `mentionPatterns` solely because the message also natively @-mentions a non-bot participant.
- Environment: local macOS checkout of openclaw @ `95e32ee52`, Node v24.17.0, focused Vitest via `node scripts/run-vitest.mjs` (Crabbox not used).
- Current-main contrast: on main, `isBotMentionedFromTargets` returns `false` as soon as native mentions exist and none match the bot, so `@OpenClaw please help` with `mentionedJids` pointing at another user is treated as not-mentioned and `applyGroupGating` rejects with `shouldProcess: false`.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts -t "isBotMentionedFromTargets"`
  2. `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts -t "mention"`
  3. Full files: both test paths above without filter.
- Evidence after fix: 9 `isBotMentionedFromTargets` cases pass (including fall-through to regex with third-party native mention = true; reject when pattern does not match = false; no numeric self fallback = false). Group gating admits `@openclaw please check this` with another member's JID (`shouldProcess: true`) and still rejects non-matching / numeric-only third-party cases.
- Control check: self native-mention path, no-mention regex path, and true 1:1 self-chat JID-suppression cases remain covered and green in the same suite.
- Observed result after fix: configured text patterns trigger the bot even when the message also @-tags someone else; unrelated third-party-only mentions still drop under `requireMention`.
- What was not tested: live WhatsApp Web/group tenant end-to-end send; multi-account LID edge cases beyond existing suite coverage.

## AI disclosure

This PR was authored with AI assistance (Grok).
