### PR TITLE
fix: provider local service host test times out under CI load

### DIFF
--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -1,5 +1,6 @@
 // Verifies managed local provider services start, lease, probe, and stop safely.
 import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
@@ -22,6 +23,10 @@ import {
   hasLocalServiceProcessExited,
   stopManagedProviderLocalServicesForTest,
 } from "./provider-local-service.js";
+
+const ONE_SHOT_HOST_READY_TIMEOUT_MS = 30_000;
+const ONE_SHOT_HOST_EXIT_TIMEOUT_MS = 5_000;
+const ONE_SHOT_HOST_READY_KIND = "ready-for-exit";
 
 async function freePort(): Promise<number> {
   // Allocate a real loopback port to exercise child process health probes.
@@ -101,6 +106,75 @@ async function withSpawnReadyHealthProbe<T>(run: () => Promise<T>): Promise<T> {
     return await run();
   } finally {
     fetchSpy.mockRestore();
+  }
+}
+
+async function waitForReadyOneShotHostExit(
+  child: ReturnType<typeof spawn>,
+  readStderr: () => string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("message", onMessage);
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+    const finish = (error?: Error) => {
+      cleanup();
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    const onMessage = (message: unknown) => {
+      if (
+        message &&
+        typeof message === "object" &&
+        (message as { kind?: unknown }).kind === ONE_SHOT_HOST_READY_KIND
+      ) {
+        finish();
+      }
+    };
+    const onError = (error: Error) => finish(error);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish(
+        new Error(
+          `one-shot host exited before readiness (code=${String(code)} signal=${String(signal)})${readStderr()}`,
+        ),
+      );
+    };
+    const timeout = setTimeout(() => {
+      finish(new Error(`one-shot host did not become ready${readStderr()}`));
+    }, ONE_SHOT_HOST_READY_TIMEOUT_MS);
+
+    child.on("message", onMessage);
+    child.on("error", onError);
+    child.on("exit", onExit);
+  });
+
+  const exitPromise = waitForOneShotHostExit(child, readStderr);
+  // The fixture-owned IPC channel gates the exit deadline. Once removed,
+  // only the managed service's diagnostic pipes can keep this host alive.
+  child.disconnect();
+  return await exitPromise;
+}
+
+async function waitForOneShotHostExit(
+  child: ReturnType<typeof spawn>,
+  readStderr: () => string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  try {
+    const [code, signal] = (await once(child, "exit", {
+      signal: AbortSignal.timeout(ONE_SHOT_HOST_EXIT_TIMEOUT_MS),
+    })) as [number | null, NodeJS.Signals | null];
+    return { code, signal };
+  } catch (error) {
+    throw new Error(`one-shot host did not exit after readiness${readStderr()}`, { cause: error });
   }
 }
 
@@ -693,6 +767,8 @@ describe("provider local service", () => {
     const script = [
       `import fs from "node:fs/promises";`,
       `import { ensureProviderLocalService, getManagedProviderLocalServiceDiagnosticsForTest } from ${JSON.stringify(moduleUrl)};`,
+      `if (!process.send) throw new Error("missing one-shot host IPC");`,
+      `process.on("disconnect", () => {});`,
       `const port = ${port};`,
       `const lease = await ensureProviderLocalService({`,
       `  providerId: "local-unref",`,
@@ -709,37 +785,28 @@ describe("provider local service", () => {
       `if (diagnostics.stdoutTail || diagnostics.stderrTail) throw new Error("runtime output was retained");`,
       `await fs.writeFile(${JSON.stringify(servicePidPath)}, String(diagnostics.pid));`,
       `lease?.release();`,
+      `process.send({ kind: ${JSON.stringify(ONE_SHOT_HOST_READY_KIND)} });`,
     ].join("\n");
     const parent = spawn(
       process.execPath,
       ["--import", "tsx", "--input-type=module", "-e", script],
       {
         cwd: process.cwd(),
-        stdio: ["ignore", "ignore", "pipe"],
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
       },
     );
     let stderr = "";
-    parent.stderr.on("data", (chunk: Buffer | string) => {
+    parent.stderr?.on("data", (chunk: Buffer | string) => {
       stderr += chunk.toString();
     });
     let servicePid: number | undefined;
-    let exitTimeout: NodeJS.Timeout | undefined;
 
     try {
-      const result = await Promise.race([
-        new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-          parent.once("exit", (code, signal) => resolve({ code, signal }));
-        }),
-        new Promise<"timeout">((resolve) => {
-          exitTimeout = setTimeout(() => resolve("timeout"), 5_000);
-        }),
-      ]);
-      clearTimeout(exitTimeout);
+      const result = await waitForReadyOneShotHostExit(parent, () => stderr);
       expect(result, stderr).toEqual({ code: 0, signal: null });
       servicePid = await readPidFile(servicePidPath);
       expect(await waitForPidToExit(servicePid)).toBe(true);
     } finally {
-      clearTimeout(exitTimeout);
       killPidIfAlive(parent.pid);
       if (servicePid === undefined) {
         servicePid = await readPidFile(servicePidPath).catch(() => undefined);
@@ -761,6 +828,8 @@ describe("provider local service", () => {
     ].join("");
     const script = [
       `import { ensureProviderLocalService } from ${JSON.stringify(moduleUrl)};`,
+      `if (!process.send) throw new Error("missing one-shot host IPC");`,
+      `process.on("disconnect", () => {});`,
       `try {`,
       `  await ensureProviderLocalService({`,
       `    providerId: "local-failed-unref",`,
@@ -772,32 +841,27 @@ describe("provider local service", () => {
       `    },`,
       `  });`,
       `} catch {}`,
+      `process.send({ kind: ${JSON.stringify(ONE_SHOT_HOST_READY_KIND)} });`,
     ].join("\n");
     const parent = spawn(
       process.execPath,
       ["--import", "tsx", "--input-type=module", "-e", script],
       {
         cwd: process.cwd(),
-        stdio: ["ignore", "ignore", "ignore"],
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
       },
     );
+    let stderr = "";
+    parent.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
     let servicePid: number | undefined;
-    let exitTimeout: NodeJS.Timeout | undefined;
 
     try {
-      const result = await Promise.race([
-        new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-          parent.once("exit", (code, signal) => resolve({ code, signal }));
-        }),
-        new Promise<"timeout">((resolve) => {
-          exitTimeout = setTimeout(() => resolve("timeout"), 5_000);
-        }),
-      ]);
-      clearTimeout(exitTimeout);
-      expect(result).toEqual({ code: 0, signal: null });
+      const result = await waitForReadyOneShotHostExit(parent, () => stderr);
+      expect(result, stderr).toEqual({ code: 0, signal: null });
       servicePid = await readPidFile(servicePidPath);
     } finally {
-      clearTimeout(exitTimeout);
       killPidIfAlive(parent.pid);
       if (servicePid === undefined) {
         servicePid = await readPidFile(servicePidPath).catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational problem where the provider-local-service one-shot host test could time out in the agents-core-models CI shard under load, even though the diagnostic pipes were released correctly. The original five-second deadline included TypeScript loader startup, module import, probing, service startup, and readiness work before it measured host exit.

Failure evidence: https://github.com/openclaw/openclaw/actions/runs/29554604965/attempts/1

## Why This Change Was Made

The fixture now uses an IPC readiness handshake to keep the one-shot host alive until service startup and diagnostic cleanup have completed. The parent installs its exit listener before disconnecting IPC, then applies the unchanged five-second exit deadline. A real diagnostic-pipe retention regression still fails the exact exit assertion. The failed-start sibling uses the same lifecycle contract.

No product runtime change. Raising the timeout or weakening the assertion was intentionally avoided.

## User Impact

No user-visible behavior change. Maintainers get deterministic CI coverage of one-shot provider local service cleanup without reruns.

## Evidence

- Focused run: `node scripts/run-vitest.mjs src/agents/provider-local-service.test.ts` — 22/22 passed.
- Bounded repeat: the same focused command ran 10 times in a fail-fast loop — 220/220 passed.
- Final Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29556349757
- Changed gate: formatting, core-test typecheck, and lint passed.
- Fresh autoreview: no accepted/actionable findings.
- AI-assisted; implementation and lifecycle behavior reviewed and understood.
