### PR TITLE
fix(config): preserve Unicode in validation received values

### DIFF
--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -255,9 +255,7 @@ describe("appendReceivedValueHint", () => {
       "gateway.bind",
       `${"x".repeat(155)}🎉tail`,
     );
-    expect(message).not.toMatch(
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
-    );
+    expect(message).toBe(`invalid input, got: "${"x".repeat(155)}...`);
   });
 
   it("skips when message already mentions received", () => {

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -249,6 +249,17 @@ describe("appendReceivedValueHint", () => {
     ).toBe('Invalid input (allowed: "minimal", "coding"), got: "none"');
   });
 
+  it("keeps truncated received values on a valid UTF-16 boundary", () => {
+    const message = appendReceivedValueHint(
+      "invalid input",
+      "gateway.bind",
+      `${"x".repeat(155)}🎉tail`,
+    );
+    expect(message).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+
   it("skips when message already mentions received", () => {
     expect(appendReceivedValueHint("expected string, received number", "gateway.port", 18789)).toBe(
       "expected string, received number",

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import JSON5 from "json5";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import type { ConfigValidationIssue } from "./types.js";
@@ -255,7 +256,7 @@ function stringifyReceivedValue(value: unknown): string | null {
     if (serialized === undefined) {
       return null;
     }
-    return serialized.length > 160 ? `${serialized.slice(0, 157)}...` : serialized;
+    return serialized.length > 160 ? `${truncateUtf16Safe(serialized, 157)}...` : serialized;
   } catch {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw config validate` could see a replacement character (`�`) when an invalid received value was long enough for the diagnostic preview to truncate inside an emoji.

## Why This Change Was Made

The validation diagnostic now uses the shared UTF-16-safe truncation helper before appending its existing ellipsis. The 160-code-unit preview limit and all non-truncated output remain unchanged.

## User Impact

Long invalid configuration values are still summarized, but their diagnostics no longer emit malformed Unicode when the cutoff lands inside a surrogate pair.

## Evidence

- Real CLI before: `openclaw config validate` with an invalid `gateway.bind` value of 155 ASCII characters followed by `🎉tail` emitted `�` in the `got:` preview.
- Real CLI after on `0e9db600595`: the same command exits 1 as expected, while an output probe reports `replacementCharacter=false` and `unpairedSurrogate=false`.
- Focused test: `node scripts/run-vitest.mjs src/config/issue-location.test.ts` — 54/54 passed.
- Formatting: `./node_modules/.bin/oxfmt --check src/config/issue-location.ts src/config/issue-location.test.ts`.
- `git diff --check` passed.

AI-assisted: built with Codex.
