### PR TITLE
perf(ci): cache packaged dependency reify in the docker e2e functional image

### DIFF
--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -39,21 +39,68 @@ FROM bare AS build
 
 CMD ["bash"]
 
+FROM bare AS functional-manifest
+
+# Per-PR tarballs differ only in built app bytes. Extract the dependency
+# manifest alone so the expensive install layer below is keyed on it and stays
+# a warm-cache hit until dependencies actually change.
+COPY --from=openclaw_package --chown=appuser:appuser openclaw-current.tgz /tmp/openclaw-current.tgz
+# Bundled dependencies ship inside the tarball and are absent from the
+# shrinkwrap, and the packaged lifecycle scripts reference files outside this
+# manifest-only tree; drop both (plus dev deps, which the shrinkwrap omits) so
+# the install below reifies registry dependencies only.
+RUN <<'PREPARE_MANIFEST'
+set -eu
+mkdir -p /tmp/openclaw-deps
+tar -xzf /tmp/openclaw-current.tgz -C /tmp/openclaw-deps --strip-components=1 \
+  package/package.json package/npm-shrinkwrap.json
+node - <<'NODE'
+const fs = require("node:fs");
+const manifestPath = "/tmp/openclaw-deps/package.json";
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+for (const name of manifest.bundleDependencies ?? []) {
+  delete manifest.dependencies?.[name];
+}
+delete manifest.bundleDependencies;
+delete manifest.devDependencies;
+delete manifest.scripts;
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+PREPARE_MANIFEST
+
+FROM bare AS functional-deps
+
+# Cache key: normalized manifest + shrinkwrap contents only (COPY hashes file
+# content, not the tarball), so unchanged dependencies skip the full reify.
+COPY --from=functional-manifest --chown=appuser:appuser /tmp/openclaw-deps /tmp/openclaw-deps
+# `npm install` (not `npm ci`) because the generated shrinkwrap is not
+# guaranteed to pass `npm ci`'s strict manifest sync check; the shrinkwrap
+# still pins every synced edge, and this reify follows it more faithfully than
+# `npm install -g <tarball>` does. Drop npm's hidden tree manifest so the
+# copied node_modules matches a plain package install.
+# The pinned Node image owns uid 1000, so useradd assigns appuser uid/gid 1001.
+RUN --mount=type=cache,target=/home/appuser/.npm,uid=1001,gid=1001,sharing=locked \
+    cd /tmp/openclaw-deps \
+ && npm install --omit=dev --no-fund --no-audit \
+ && rm -f node_modules/.package-lock.json
+
 FROM bare AS functional
 
 # The app under test enters through the named BuildKit context, not by copying
 # checkout sources into the image.
 COPY --from=openclaw_package --chown=appuser:appuser openclaw-current.tgz /tmp/openclaw-current.tgz
-# Preserve package self-reference imports such as openclaw/plugin-sdk/* after
-# copying the installed package out of npm's global node_modules tree.
-# The pinned Node image owns uid 1000, so useradd assigns appuser uid/gid 1001.
-RUN --mount=type=cache,target=/home/appuser/.npm,uid=1001,gid=1001,sharing=locked \
-    npm install -g --prefix /tmp/openclaw-prefix /tmp/openclaw-current.tgz --no-fund --no-audit \
- && cp -a /tmp/openclaw-prefix/lib/node_modules/openclaw/. /app/ \
+COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules
+# Extract the package over the prebuilt dependency tree (bundled deps ship in
+# the tarball), then run its packaged postinstall exactly as `npm install -g`
+# would. The /app/node_modules/openclaw self-link preserves package
+# self-reference imports such as openclaw/plugin-sdk/*; create it after
+# postinstall so its prune walks cannot cycle through the link.
+RUN tar -xzf /tmp/openclaw-current.tgz -C /app --strip-components=1 \
+ && chmod +x /app/openclaw.mjs \
+ && node /app/scripts/postinstall-bundled-plugins.mjs \
+ && ln -sfn /app /app/node_modules/openclaw \
  && mkdir -p "$HOME/.local/bin" \
  && ln -sf /app/openclaw.mjs "$HOME/.local/bin/openclaw" \
- && rm -rf /app/node_modules/openclaw \
- && ln -sf /app /app/node_modules/openclaw \
- && rm -rf /tmp/openclaw-prefix /tmp/openclaw-current.tgz
+ && rm -f /tmp/openclaw-current.tgz
 
 CMD ["bash"]

--- a/src/docker-build-cache.test.ts
+++ b/src/docker-build-cache.test.ts
@@ -129,15 +129,24 @@ describe("docker build cache layout", () => {
     expect(dockerfile).toMatch(
       /^COPY --from=openclaw_package --chown=appuser:appuser openclaw-current\.tgz \/tmp\/openclaw-current\.tgz$/m,
     );
+    // The dependency reify layer must key on the extracted manifest, not the
+    // per-PR tarball bytes, so warm builders skip the full npm install.
     expect(dockerfile).toContain(
-      "npm install -g --prefix /tmp/openclaw-prefix /tmp/openclaw-current.tgz --no-fund --no-audit",
+      "COPY --from=functional-manifest --chown=appuser:appuser /tmp/openclaw-deps /tmp/openclaw-deps",
     );
-    expect(dockerfile).not.toContain(
-      "cp -a /tmp/openclaw-prefix/lib/node_modules/. /app/node_modules/",
+    expect(dockerfile).toContain("npm install --omit=dev --no-fund --no-audit");
+    expect(dockerfile).not.toContain("npm install -g --prefix");
+    expect(dockerfile).toContain(
+      "COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules",
     );
-    expect(dockerfile).toContain("cp -a /tmp/openclaw-prefix/lib/node_modules/openclaw/. /app/");
-    expect(dockerfile).toContain("rm -rf /app/node_modules/openclaw");
-    expect(dockerfile).toContain("ln -sf /app /app/node_modules/openclaw");
+    // Packaged postinstall must run before the self-link exists so its prune
+    // walks cannot cycle through /app/node_modules/openclaw -> /app.
+    const postinstallIndex = dockerfile.indexOf(
+      "node /app/scripts/postinstall-bundled-plugins.mjs",
+    );
+    const selfLinkIndex = dockerfile.indexOf("ln -sfn /app /app/node_modules/openclaw");
+    expect(postinstallIndex).toBeGreaterThan(-1);
+    expect(selfLinkIndex).toBeGreaterThan(postinstallIndex);
   });
 
   it("copies manifests before install in the qr-import image", async () => {


### PR DESCRIPTION
## What Problem This Solves

The shared Docker E2E `functional` image re-ran a full 328-package npm reify on every build because the install layer was keyed on the per-PR tarball, whose bytes change with every PR. That reify was the flagged fixed cost inside the QA ring-zero lane's 120–182s image-build pole, and the same image feeds ~20 other Docker E2E lanes.

## Why This Change Was Made

Split `functional` into three stages — `functional-manifest` (extracts only `package.json` + `npm-shrinkwrap.json` from the tarball; strips bundled deps, dev deps, and lifecycle scripts), `functional-deps` (`npm install --omit=dev` keyed by COPY content-hash on the manifest alone, so it stays a warm-layer hit until dependencies actually change), and `functional` (extracts the tarball over the prebuilt tree, runs the packaged postinstall, then creates the `openclaw` self-link after postinstall so its prune walks cannot cycle).

`npm install` rather than `npm ci` because the generated shrinkwrap fails `npm ci`'s strict manifest sync (`p-retry` pins `@types/retry@0.12.0` while the shrinkwrap resolves `0.12.5`).

**Correctness bonus:** the old `npm install -g <tarball>` path silently drifted ~15 transitive packages to newer registry versions than the shipped shrinkwrap (protobufjs 7.6.5 vs 7.6.3, hono 4.12.30 vs 4.12.25, …) and dropped the `node-domexception → @nolyfill/domexception` override. The deps stage now matches the shrinkwrap exactly, so E2E images test what users actually install.

## User Impact

None at runtime — CI-only. Warm Docker E2E builds skip the ~29s npm reify per build across every lane sharing the `functional` target; the first build after merge re-reifies once to seed the new layer key.

## Evidence

- Local proof (Apple Silicon, docker-container builder): per-PR warm image build 59s → 43s with the npm layer CACHED; QA ring-zero lane total 164s → 139s warm, 229s → 160s cold; same-input rebuild 8s.
- Lane passed end-to-end on every post-change run (fail-closed empty state dir, packaged activation, typed ops, Discord SecretRef, audit entries all green); container phase (~84s proof surface) unchanged.
- Installed tree deep-diffed against the old image: structurally identical except the documented shrinkwrap-faithful version fixes.
- `test/scripts/docker-build-helper.test.ts` — 169 passed (includes the cache-mount assertion); `git diff --check` clean; autoreview (codex, gpt-5.6-sol) clean, 0 findings.
- Blacksmith warm-layer behavior validates live on this PR's own CI (persistent buildkitd via `useblacksmith/setup-docker-builder` + docker sticky disk).
