### PR TITLE
fix(reef): prevent blank guard keys from denying every message

### DIFF
--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -42,7 +42,7 @@ describe("createConfiguredGuard", () => {
 
   it("trims a configured guard credential before requests", async () => {
     vi.stubEnv("REEF_TEST_KEY", "  guard-key  ");
-    const fetcher = vi.fn(async () => new Response("", { status: 401 }));
+    const fetcher = vi.fn<typeof fetch>(async () => new Response("", { status: 401 }));
     const classifier = createConfiguredGuard(config(), fetcher);
 
     await classifier.classify({

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -9,7 +9,7 @@ import {
   verifyReceipt,
   type Verdict,
 } from "../protocol/index.js";
-import { ReefMessageFlow } from "./flow.js";
+import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
 import {
   allow,
   config,
@@ -26,7 +26,37 @@ import type { ReefTransportClient } from "./transport.js";
 import type { InboxEntry } from "./types.js";
 
 beforeEach(resetFlowStoresForTests);
-afterEach(resetFlowStoresForTests);
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetFlowStoresForTests();
+});
+
+describe("createConfiguredGuard", () => {
+  it("rejects a whitespace-only guard credential", () => {
+    vi.stubEnv("REEF_TEST_KEY", "   ");
+
+    expect(() => createConfiguredGuard(config())).toThrow(
+      "Reef guard credential environment variable REEF_TEST_KEY is unset",
+    );
+  });
+
+  it("trims a configured guard credential before requests", async () => {
+    vi.stubEnv("REEF_TEST_KEY", "  guard-key  ");
+    const fetcher = vi.fn(async () => new Response("", { status: 401 }));
+    const classifier = createConfiguredGuard(config(), fetcher);
+
+    await classifier.classify({
+      direction: "outbound",
+      source: "alice#1",
+      destination: "bob#1",
+      text: "hello",
+      policyVersion: "v1",
+    });
+
+    const init = fetcher.mock.calls[0]?.[1];
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer guard-key");
+  });
+});
 
 describe("ReefMessageFlow inbound", () => {
   it("delivers and persists before ack, then acks duplicate redelivery without delivering twice", async () => {

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -409,7 +409,7 @@ export function createConfiguredGuard(
   if (!config.guard) {
     throw new Error("Reef guard is not configured");
   }
-  const apiKey = process.env[config.guard.apiKeyEnv];
+  const apiKey = process.env[config.guard.apiKeyEnv]?.trim();
   if (!apiKey) {
     throw new Error(
       `Reef guard credential environment variable ${config.guard.apiKeyEnv} is unset`,

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   appendAudit,
   appendInboxRead,
@@ -409,14 +410,14 @@ export function createConfiguredGuard(
   if (!config.guard) {
     throw new Error("Reef guard is not configured");
   }
-  const apiKey = process.env[config.guard.apiKeyEnv]?.trim();
-  if (!apiKey) {
+  const guardCredential = normalizeOptionalString(process.env[config.guard.apiKeyEnv]);
+  if (!guardCredential) {
     throw new Error(
       `Reef guard credential environment variable ${config.guard.apiKeyEnv} is unset`,
     );
   }
   const options = {
-    apiKey,
+    apiKey: guardCredential,
     pinnedModel: config.guard.pinnedModel,
     timeoutMs: config.guard.timeoutMs,
     fetch: fetcher,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Reef users with a whitespace-only guard API-key environment variable would start the channel successfully, but every guarded message would be denied as `guard_failure` after an unauthenticated provider request.

## Why This Change Was Made

Reef now trims the dynamically named guard credential when constructing the guard. Blank values follow the existing missing-credential error path before the channel starts, while valid values with accidental surrounding whitespace are sent in normalized form.

## User Impact

Operators get the existing actionable `credential environment variable ... is unset` startup error instead of a running Reef channel that rejects otherwise valid messages. Valid padded credentials continue to work after normalization.

## Evidence

- Real production-function proof before on `5199bfafea6`: with `OPENAI_API_KEY='   '`, `createConfiguredGuard` accepted the credential, produced an authorization request that normalized to bare `Bearer`, and the real guard boundary returned `{ decision: "deny", category: "guard_failure" }`.
- Real production-function proof after on `44b79d44ae1`: the same input is rejected before any request with `Reef guard credential environment variable OPENAI_API_KEY is unset`.
- Mutation proof: reverting the one-line normalization makes `rejects a whitespace-only guard credential` fail with `expected [Function] to throw an error`.
- Focused tests: `node scripts/run-vitest.mjs extensions/reef/src/flow.test.ts extensions/reef/protocol/guard.test.ts` — 28 passed, 2 skipped.
- Targeted formatting and `git diff --check` passed.

AI-assisted: built with Codex.
