### PR TITLE
fix(e2e): keep text file tails UTF-8 safe

### DIFF
--- a/scripts/e2e/lib/text-file-utils.mjs
+++ b/scripts/e2e/lib/text-file-utils.mjs
@@ -1,11 +1,23 @@
 // Text file tail helpers for E2E assertions.
 import fs from "node:fs";
+import { StringDecoder } from "node:string_decoder";
+
+function decodeUtf8Tail(buffer, truncated) {
+  if (!truncated) {
+    return buffer.toString("utf8");
+  }
+  let start = 0;
+  while (start < buffer.length && (buffer[start] & 0b1100_0000) === 0b1000_0000) {
+    start += 1;
+  }
+  return new StringDecoder("utf8").write(buffer.subarray(start));
+}
 
 export function tailText(text, maxBytes) {
   if (Buffer.byteLength(text, "utf8") <= maxBytes) {
     return text;
   }
-  return Buffer.from(text, "utf8").subarray(-maxBytes).toString("utf8");
+  return decodeUtf8Tail(Buffer.from(text, "utf8").subarray(-maxBytes), true);
 }
 
 export function readTextFileTail(file, maxBytes) {
@@ -26,7 +38,7 @@ export function readTextFileTail(file, maxBytes) {
     fd = fs.openSync(file, "r");
     const buffer = Buffer.alloc(length);
     const bytesRead = fs.readSync(fd, buffer, 0, length, start);
-    return buffer.subarray(0, bytesRead).toString("utf8");
+    return decodeUtf8Tail(buffer.subarray(0, bytesRead), start > 0);
   } catch {
     return "";
   } finally {

--- a/scripts/e2e/lib/text-file-utils.mjs
+++ b/scripts/e2e/lib/text-file-utils.mjs
@@ -1,16 +1,14 @@
 // Text file tail helpers for E2E assertions.
 import fs from "node:fs";
-import { StringDecoder } from "node:string_decoder";
 
 function decodeUtf8Tail(buffer, truncated) {
-  if (!truncated) {
-    return buffer.toString("utf8");
-  }
   let start = 0;
-  while (start < buffer.length && (buffer[start] & 0b1100_0000) === 0b1000_0000) {
-    start += 1;
+  if (truncated) {
+    while (start < buffer.length && (buffer[start] & 0b1100_0000) === 0b1000_0000) {
+      start += 1;
+    }
   }
-  return new StringDecoder("utf8").write(buffer.subarray(start));
+  return buffer.subarray(start).toString("utf8");
 }
 
 export function tailText(text, maxBytes) {

--- a/test/scripts/e2e-text-file-utils.test.ts
+++ b/test/scripts/e2e-text-file-utils.test.ts
@@ -24,6 +24,7 @@ describe("e2e text file utilities", () => {
     expect(tailText("short", 8)).toBe("short");
     expect(tailText("prefix-tail", 4)).toBe("tail");
     expect(tailText("prefix \u{1f600}tail", 7)).toBe("tail");
+    expect(tailText("prefix \u{1f600}tail", 8)).toBe("\u{1f600}tail");
   });
 
   it("reads only the requested file tail and treats missing or non-file paths as empty", () => {
@@ -36,6 +37,9 @@ describe("e2e text file utilities", () => {
     expect(readTextFileTail(file, 10)).toBe("line-three");
     writeFileSync(file, "prefix \u{1f600}tail", "utf8");
     expect(readTextFileTail(file, 7)).toBe("tail");
+    expect(readTextFileTail(file, 8)).toBe("\u{1f600}tail");
+    writeFileSync(file, Buffer.concat([Buffer.from("prefix tail"), Buffer.from([0xf0])]));
+    expect(readTextFileTail(file, 5)).toBe("tail\ufffd");
     expect(readTextFileTail(path.join(root, "missing.log"), 10)).toBe("");
     expect(readTextFileTail(directory, 10)).toBe("");
   });

--- a/test/scripts/e2e-text-file-utils.test.ts
+++ b/test/scripts/e2e-text-file-utils.test.ts
@@ -23,6 +23,7 @@ describe("e2e text file utilities", () => {
   it("keeps short diagnostic text intact and trims long text by byte count", () => {
     expect(tailText("short", 8)).toBe("short");
     expect(tailText("prefix-tail", 4)).toBe("tail");
+    expect(tailText("prefix \u{1f600}tail", 7)).toBe("tail");
   });
 
   it("reads only the requested file tail and treats missing or non-file paths as empty", () => {
@@ -33,6 +34,8 @@ describe("e2e text file utilities", () => {
     writeFileSync(file, "line-one\nline-two\nline-three", "utf8");
 
     expect(readTextFileTail(file, 10)).toBe("line-three");
+    writeFileSync(file, "prefix \u{1f600}tail", "utf8");
+    expect(readTextFileTail(file, 7)).toBe("tail");
     expect(readTextFileTail(path.join(root, "missing.log"), 10)).toBe("");
     expect(readTextFileTail(directory, 10)).toBe("");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where E2E diagnostics that keep only the last N bytes of a text string or log file could show replacement characters when the retained byte window started in the middle of a UTF-8 character.

Related independent bug-family PRs: this PR and #109670 both keep byte-bounded diagnostic tails UTF-8 safe. They touch separate script helpers and are not stacked; either can merge first.

## Why This Change Was Made

The text-file helper now decodes truncated byte tails by dropping only leading UTF-8 continuation bytes before decoding, so byte caps stay unchanged while diagnostics remain readable. The change stays local to the E2E text-file utility and its focused tests.

## User Impact

Developers reading failed E2E diagnostics get clean tail text instead of a leading replacement character when multibyte text appears at a byte cutoff.

## Evidence

- `git diff --check`
- `node --input-type=module` direct proof: `tailText("prefix \\u{1f600}tail", 7)` and `readTextFileTail(file, 7)` both returned `tail`.
- `node scripts/run-vitest.mjs test/scripts/e2e-text-file-utils.test.ts` passed in the first clean lane before the dependency-install cleanup issue: 1 file, 3 tests.
- `autoreview --mode local --engine codex` via `C:\Users\86158\.codex\codex-pixel-autoreview.cmd`: clean, no accepted/actionable findings.
