### PR TITLE
fix(parallels): keep host server stderr tails UTF-8 safe

### DIFF
--- a/scripts/e2e/lib/text-file-utils.mjs
+++ b/scripts/e2e/lib/text-file-utils.mjs
@@ -1,7 +1,7 @@
 // Text file tail helpers for E2E assertions.
 import fs from "node:fs";
 
-function decodeUtf8Tail(buffer, truncated) {
+export function decodeUtf8Tail(buffer, truncated) {
   let start = 0;
   if (truncated) {
     while (start < buffer.length && (buffer[start] & 0b1100_0000) === 0b1000_0000) {

--- a/scripts/e2e/parallels/host-server.ts
+++ b/scripts/e2e/parallels/host-server.ts
@@ -14,6 +14,11 @@ import type { HostServer, NpmRegistryPackage, NpmRegistryServer } from "./types.
 const HOST_SERVER_STDERR_LIMIT_BYTES = 64 * 1024;
 const HOST_SERVER_STDERR_DRAIN_MS = 5_000;
 type HostServerChild = ChildProcess & { stderr: Readable };
+type BoundedOutputTail = {
+  buffer: Buffer;
+  limitBytes: number;
+  truncated: boolean;
+};
 
 export function resolveHostIp(explicit = ""): string {
   if (explicit) {
@@ -176,9 +181,9 @@ function hasHostServerChildExited(child: HostServerChild): boolean {
 }
 
 async function waitForHostServer(child: HostServerChild, port: number): Promise<void> {
-  let stderr = "";
+  const stderr = createBoundedOutputTail(HOST_SERVER_STDERR_LIMIT_BYTES);
   child.stderr.on("data", (chunk: Buffer) => {
-    stderr = appendBoundedOutput(stderr, chunk, HOST_SERVER_STDERR_LIMIT_BYTES);
+    appendBoundedOutput(stderr, chunk);
   });
   let childClosed = false;
   const childClose = new Promise<void>((resolve) => {
@@ -193,7 +198,11 @@ async function waitForHostServer(child: HostServerChild, port: number): Promise<
       if (!childClosed) {
         await Promise.race([childClose, delay(HOST_SERVER_STDERR_DRAIN_MS)]);
       }
-      die(`host artifact server exited early: ${stderr.trim() || formatHostServerExit(child)}`);
+      die(
+        `host artifact server exited early: ${
+          readBoundedOutput(stderr).trim() || formatHostServerExit(child)
+        }`,
+      );
     }
     if (await canConnect(port)) {
       return;
@@ -203,15 +212,40 @@ async function waitForHostServer(child: HostServerChild, port: number): Promise<
     });
   }
   child.kill("SIGTERM");
-  die(`host artifact server did not start on port ${port}: ${stderr.trim()}`);
+  die(`host artifact server did not start on port ${port}: ${readBoundedOutput(stderr).trim()}`);
 }
 
-function appendBoundedOutput(previous: string, chunk: Buffer, limitBytes: number): string {
-  const combined = Buffer.concat([Buffer.from(previous, "utf8"), chunk]);
-  if (combined.byteLength <= limitBytes) {
-    return combined.toString("utf8");
+function createBoundedOutputTail(limitBytes: number): BoundedOutputTail {
+  return {
+    buffer: Buffer.alloc(0),
+    limitBytes,
+    truncated: false,
+  };
+}
+
+function appendBoundedOutput(tail: BoundedOutputTail, chunk: Buffer): void {
+  const combined = Buffer.concat([tail.buffer, chunk]);
+  if (combined.byteLength <= tail.limitBytes) {
+    tail.buffer = combined;
+    return;
   }
-  return combined.subarray(combined.byteLength - limitBytes).toString("utf8");
+  tail.buffer = Buffer.from(combined.subarray(combined.byteLength - tail.limitBytes));
+  tail.truncated = true;
+}
+
+function readBoundedOutput(tail: BoundedOutputTail): string {
+  return decodeUtf8Tail(tail.buffer, tail.truncated);
+}
+
+function decodeUtf8Tail(buffer: Buffer, truncated: boolean): string {
+  if (!truncated) {
+    return buffer.toString("utf8");
+  }
+  let start = 0;
+  while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
+    start += 1;
+  }
+  return buffer.subarray(start).toString("utf8");
 }
 
 function formatHostServerExit(child: HostServerChild): string {
@@ -235,5 +269,7 @@ async function canConnect(port: number): Promise<boolean> {
 
 export const testing = {
   appendBoundedOutput,
+  createBoundedOutputTail,
+  readBoundedOutput,
   stopHostServerChild,
 };

--- a/scripts/e2e/parallels/host-server.ts
+++ b/scripts/e2e/parallels/host-server.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { sleep as delay } from "../../lib/sleep.mjs";
+import { decodeUtf8Tail } from "../lib/text-file-utils.mjs";
 import { die, run, say, sh, warn } from "./host-command.ts";
 import type { HostServer, NpmRegistryPackage, NpmRegistryServer } from "./types.ts";
 
@@ -235,17 +236,6 @@ function appendBoundedOutput(tail: BoundedOutputTail, chunk: Buffer): void {
 
 function readBoundedOutput(tail: BoundedOutputTail): string {
   return decodeUtf8Tail(tail.buffer, tail.truncated);
-}
-
-function decodeUtf8Tail(buffer: Buffer, truncated: boolean): string {
-  if (!truncated) {
-    return buffer.toString("utf8");
-  }
-  let start = 0;
-  while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
-    start += 1;
-  }
-  return buffer.subarray(start).toString("utf8");
 }
 
 function formatHostServerExit(child: HostServerChild): string {

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -525,12 +525,21 @@ fetch_host_metadata "https://example.test/metadata"`,
   });
 
   it("bounds host artifact server startup stderr", () => {
-    const retained = hostServerTesting.appendBoundedOutput(
-      "a".repeat(10),
-      Buffer.from("b".repeat(10)),
-      12,
-    );
-    expect(retained).toBe(`${"a".repeat(2)}${"b".repeat(10)}`);
+    const retained = hostServerTesting.createBoundedOutputTail(12);
+    hostServerTesting.appendBoundedOutput(retained, Buffer.from("a".repeat(10)));
+    hostServerTesting.appendBoundedOutput(retained, Buffer.from("b".repeat(10)));
+    expect(hostServerTesting.readBoundedOutput(retained)).toBe(`${"a".repeat(2)}${"b".repeat(10)}`);
+
+    const emojiTail = hostServerTesting.createBoundedOutputTail(7);
+    hostServerTesting.appendBoundedOutput(emojiTail, Buffer.from("prefix "));
+    hostServerTesting.appendBoundedOutput(emojiTail, Buffer.from("\u{1f600}tail", "utf8"));
+    expect(hostServerTesting.readBoundedOutput(emojiTail)).toBe("tail");
+
+    const splitEmoji = Buffer.from("\u{1f600}", "utf8");
+    const splitTail = hostServerTesting.createBoundedOutputTail(4);
+    hostServerTesting.appendBoundedOutput(splitTail, splitEmoji.subarray(0, 2));
+    hostServerTesting.appendBoundedOutput(splitTail, splitEmoji.subarray(2));
+    expect(hostServerTesting.readBoundedOutput(splitTail)).toBe("\u{1f600}");
   });
 
   it("accepts npm 10/11 array and npm 12 workspace result shapes", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Parallels host artifact server startup diagnostics could show replacement characters when the bounded stderr tail started in the middle of a UTF-8 character. It also avoids losing a multibyte character when the process stream splits that character across chunks.

Related independent bug-family PRs: this PR and #109669 both keep byte-bounded diagnostic tails UTF-8 safe. They touch separate script helpers and are not stacked; either can merge first.

## Why This Change Was Made

The host server startup path now retains stderr as a bounded raw byte tail and decodes it only when formatting the failure message. That preserves byte caps, keeps split UTF-8 sequences reconstructable across chunks, and drops only leading continuation bytes after truncation.

## User Impact

Developers debugging Parallels smoke setup failures get readable stderr tails instead of corrupted UTF-8 at the diagnostic boundary.

## Evidence

- `git diff --check`
- `Real behavior proof` workflow succeeded on current head `35fe91cfa3d4f0280c914993e120c568fba14e0b` (`29613805592`, job `87994309921`).