### PR TITLE
improve: speed up Google Chat timeout proof

### DIFF
--- a/extensions/googlechat/src/auth.proof.test.ts
+++ b/extensions/googlechat/src/auth.proof.test.ts
@@ -36,6 +36,7 @@ import { verifyGoogleChatRequest } from "./auth.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -177,21 +178,29 @@ async function verifyOutcomeWithin(
   | { status: "rejected"; error: unknown }
   | { status: "pending" }
 > {
-  return await Promise.race([
-    promise.then(
-      (value) => ({ status: "resolved" as const, value }),
-      (error: unknown) => ({ status: "rejected" as const, error }),
-    ),
-    new Promise<{ status: "pending" }>((resolve) => {
-      setTimeout(() => resolve({ status: "pending" as const }), timeoutMs);
-    }),
-  ]);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        (value) => ({ status: "resolved" as const, value }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      ),
+      new Promise<{ status: "pending" }>((resolve) => {
+        timeout = setTimeout(() => resolve({ status: "pending" as const }), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 describe("googlechat cert-fetch — real guard proof", () => {
   it("times out a stalled cert fetch through the real production guard", async () => {
     const realFetch = globalThis.fetch;
     const server = await startHangingLoopbackServer();
+    vi.useFakeTimers({ toFake: ["setTimeout"] });
     const certFetchTimeout = captureCertFetchTimeout();
     let pendingVerify: Promise<{ ok: boolean; reason?: string }> | undefined;
 
@@ -219,10 +228,19 @@ describe("googlechat cert-fetch — real guard proof", () => {
       expect(certFetchTimeout.scheduled()).toBe(true);
       expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
 
-      // Mutation control: without firing the deadline the verification stays
-      // pending, proving the rejection below comes from the real timeout.
-      const beforeFire = await verifyOutcomeWithin(pendingVerify, 500);
-      expect(beforeFire.status).toBe("pending");
+      // Mutation control: advance the original 500ms pending window without
+      // sleeping, then prove only the production deadline can settle it.
+      let verifySettled = false;
+      void pendingVerify.then(
+        () => {
+          verifySettled = true;
+        },
+        () => {
+          verifySettled = true;
+        },
+      );
+      await vi.advanceTimersByTimeAsync(500);
+      expect(verifySettled).toBe(false);
 
       // Fire the captured production deadline; the composed signal aborts the
       // in-flight loopback request and verifyGoogleChatRequest returns ok:false.


### PR DESCRIPTION
## What Problem This Solves

The Google Chat certificate-timeout proof spent 500 ms of wall time waiting to confirm that its deliberately hanging request was still pending.

## Why This Change Was Made

Advance the same 500 ms mutation-control window with fake timers, while preserving the real SSRF guard, loopback HTTP request, production abort signal, and timeout-driven settlement. Completed deadline timers are also cleared, and timer teardown restores spies before returning to real timers.

## User Impact

No user-visible or production behavior changes. The focused test body drops from a 531 ms median to 29 ms on the exact-head Testbox proof.

## Evidence

- Before: three focused runs, 532/533/~531 ms test body; median 531 ms.
- After: focused runs at 24-33 ms; exact-head run 29 ms (about 95% faster).
- Exact-head Testbox `tbx_01kxq82qzjt86zarnj3k1nzxgj`: `node scripts/run-vitest.mjs extensions/googlechat/src/auth.proof.test.ts extensions/googlechat/src/actions.test.ts` — 12/12 tests passed.
- Same Testbox: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed.
- Autoreview: clean, 0.94 confidence.
