### PR TITLE
fix(google-meet): report blank Twilio setup credentials as missing

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -2604,6 +2604,47 @@ describe("google-meet plugin", () => {
     expect(requireSetupCheck(result.details.checks, "twilio-voice-call-webhook").ok).toBe(true);
   });
 
+  it("reports whitespace-only Twilio environment credentials as missing", async () => {
+    vi.stubEnv("TWILIO_ACCOUNT_SID", "   ");
+    vi.stubEnv("TWILIO_AUTH_TOKEN", "   ");
+    vi.stubEnv("TWILIO_FROM_NUMBER", "   ");
+    const { tools } = setup(
+      {
+        defaultTransport: "chrome-node",
+        chromeNode: { node: "parallels-macos" },
+      },
+      {
+        fullConfig: {
+          plugins: {
+            allow: ["google-meet", "voice-call"],
+            entries: {
+              "voice-call": {
+                enabled: true,
+                config: {
+                  provider: "twilio",
+                  publicUrl: "https://voice.example.com/voice/webhook",
+                },
+              },
+            },
+          },
+        },
+      },
+    );
+    const tool = tools[0] as {
+      execute: (
+        id: string,
+        params: unknown,
+      ) => Promise<{ details: { ok?: boolean; checks?: unknown[] } }>;
+    };
+
+    const result = await tool.execute("id", { action: "setup_status" });
+
+    expect(result.details.ok).toBe(false);
+    expect(requireSetupCheck(result.details.checks, "twilio-voice-call-credentials").ok).toBe(
+      false,
+    );
+  });
+
   it("reports missing voice-call wiring for explicit Twilio transport", async () => {
     vi.stubEnv("TWILIO_ACCOUNT_SID", "");
     vi.stubEnv("TWILIO_AUTH_TOKEN", "");

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -376,6 +376,57 @@ function requireSetupCheck(checks: unknown[] | undefined, id: string): Record<st
   return check;
 }
 
+type TwilioSetupCredentials = {
+  accountSid: string;
+  authToken: string;
+  fromNumber: string;
+};
+
+async function getTwilioVoiceCallCredentialsCheck(params: {
+  env: TwilioSetupCredentials;
+  configured?: Partial<TwilioSetupCredentials>;
+}): Promise<Record<string, unknown>> {
+  vi.stubEnv("TWILIO_ACCOUNT_SID", params.env.accountSid);
+  vi.stubEnv("TWILIO_AUTH_TOKEN", params.env.authToken);
+  vi.stubEnv("TWILIO_FROM_NUMBER", params.env.fromNumber);
+  const { tools } = setup(
+    {
+      defaultTransport: "chrome-node",
+      chromeNode: { node: "parallels-macos" },
+    },
+    {
+      fullConfig: {
+        plugins: {
+          allow: ["google-meet", "voice-call"],
+          entries: {
+            "voice-call": {
+              enabled: true,
+              config: {
+                provider: "twilio",
+                publicUrl: "https://voice.example.com/voice/webhook",
+                fromNumber: params.configured?.fromNumber,
+                twilio: {
+                  accountSid: params.configured?.accountSid,
+                  authToken: params.configured?.authToken,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+  const tool = tools[0] as {
+    execute: (
+      id: string,
+      params: unknown,
+    ) => Promise<{ details: { checks?: unknown[] } }>;
+  };
+
+  const result = await tool.execute("id", { action: "setup_status" });
+  return requireSetupCheck(result.details.checks, "twilio-voice-call-credentials");
+}
+
 function requireFetchGuardCall(auditContext: string): Record<string, unknown> {
   const call = (
     fetchGuardMocks.fetchWithSsrFGuard.mock.calls as Array<[Record<string, unknown>]>
@@ -2604,45 +2655,62 @@ describe("google-meet plugin", () => {
     expect(requireSetupCheck(result.details.checks, "twilio-voice-call-webhook").ok).toBe(true);
   });
 
-  it("reports whitespace-only Twilio environment credentials as missing", async () => {
-    vi.stubEnv("TWILIO_ACCOUNT_SID", "   ");
-    vi.stubEnv("TWILIO_AUTH_TOKEN", "   ");
-    vi.stubEnv("TWILIO_FROM_NUMBER", "   ");
-    const { tools } = setup(
-      {
-        defaultTransport: "chrome-node",
-        chromeNode: { node: "parallels-macos" },
-      },
-      {
-        fullConfig: {
-          plugins: {
-            allow: ["google-meet", "voice-call"],
-            entries: {
-              "voice-call": {
-                enabled: true,
-                config: {
-                  provider: "twilio",
-                  publicUrl: "https://voice.example.com/voice/webhook",
-                },
-              },
-            },
-          },
-        },
-      },
-    );
-    const tool = tools[0] as {
-      execute: (
-        id: string,
-        params: unknown,
-      ) => Promise<{ details: { ok?: boolean; checks?: unknown[] } }>;
-    };
+  it.each([
+    {
+      label: "environment account SID",
+      env: { accountSid: "   ", authToken: "test-auth-token", fromNumber: "+15550001234" },
+    },
+    {
+      label: "environment auth token",
+      env: { accountSid: "AC123", authToken: "   ", fromNumber: "+15550001234" },
+    },
+    {
+      label: "environment from number",
+      env: { accountSid: "AC123", authToken: "test-auth-token", fromNumber: "   " },
+    },
+    {
+      label: "configured account SID",
+      env: { accountSid: "", authToken: "", fromNumber: "" },
+      configured: { accountSid: "   ", authToken: "test-auth-token", fromNumber: "+15550001234" },
+    },
+    {
+      label: "configured auth token",
+      env: { accountSid: "", authToken: "", fromNumber: "" },
+      configured: { accountSid: "AC123", authToken: "   ", fromNumber: "+15550001234" },
+    },
+    {
+      label: "configured from number",
+      env: { accountSid: "", authToken: "", fromNumber: "" },
+      configured: { accountSid: "AC123", authToken: "test-auth-token", fromNumber: "   " },
+    },
+  ])("reports a blank $label as missing", async ({ env, configured }) => {
+    const check = await getTwilioVoiceCallCredentialsCheck({ env, configured });
 
-    const result = await tool.execute("id", { action: "setup_status" });
+    expect(check.ok).toBe(false);
+  });
 
-    expect(result.details.ok).toBe(false);
-    expect(requireSetupCheck(result.details.checks, "twilio-voice-call-credentials").ok).toBe(
-      false,
-    );
+  it.each([
+    {
+      label: "environment",
+      env: {
+        accountSid: "  AC123  ",
+        authToken: "  test-auth-token  ",
+        fromNumber: "  +15550001234  ",
+      },
+    },
+    {
+      label: "configuration",
+      env: { accountSid: "", authToken: "", fromNumber: "" },
+      configured: {
+        accountSid: "  AC123  ",
+        authToken: "  test-auth-token  ",
+        fromNumber: "  +15550001234  ",
+      },
+    },
+  ])("accepts padded Twilio credentials from $label", async ({ env, configured }) => {
+    const check = await getTwilioVoiceCallCredentialsCheck({ env, configured });
+
+    expect(check.ok).toBe(true);
   });
 
   it("reports missing voice-call wiring for explicit Twilio transport", async () => {

--- a/extensions/google-meet/src/setup.ts
+++ b/extensions/google-meet/src/setup.ts
@@ -240,14 +240,16 @@ export function getGoogleMeetSetupStatus(
 
     const provider = normalizeOptionalString(voiceCallConfig.provider) ?? "twilio";
     if (provider === "twilio") {
-      const accountSid = normalizeOptionalString(voiceCallTwilioConfig.accountSid);
-      const authToken = normalizeOptionalString(voiceCallTwilioConfig.authToken);
-      const fromNumber = normalizeOptionalString(voiceCallConfig.fromNumber);
-      const twilioReady = Boolean(
-        (accountSid || env.TWILIO_ACCOUNT_SID) &&
-        (authToken || env.TWILIO_AUTH_TOKEN) &&
-        (fromNumber || env.TWILIO_FROM_NUMBER),
-      );
+      const accountSid =
+        normalizeOptionalString(voiceCallTwilioConfig.accountSid) ??
+        normalizeOptionalString(env.TWILIO_ACCOUNT_SID);
+      const authToken =
+        normalizeOptionalString(voiceCallTwilioConfig.authToken) ??
+        normalizeOptionalString(env.TWILIO_AUTH_TOKEN);
+      const fromNumber =
+        normalizeOptionalString(voiceCallConfig.fromNumber) ??
+        normalizeOptionalString(env.TWILIO_FROM_NUMBER);
+      const twilioReady = Boolean(accountSid && authToken && fromNumber);
       checks.push({
         id: "twilio-voice-call-credentials",
         ok: twilioReady,

--- a/extensions/google-meet/src/setup.ts
+++ b/extensions/google-meet/src/setup.ts
@@ -36,6 +36,10 @@ function isProviderUnreachableWebhookUrl(webhookUrl: string): boolean {
   }
 }
 
+function resolveVoiceCallSetupValue(configured: unknown, fallback: unknown): string | undefined {
+  return normalizeOptionalString(configured) ?? normalizeOptionalString(fallback);
+}
+
 function getVoiceCallWebhookExposureCheck(voiceCallConfig: Record<string, unknown>): SetupCheck {
   const publicUrl = normalizeOptionalString(voiceCallConfig.publicUrl);
   const tunnel = asRecord(voiceCallConfig.tunnel);
@@ -240,15 +244,18 @@ export function getGoogleMeetSetupStatus(
 
     const provider = normalizeOptionalString(voiceCallConfig.provider) ?? "twilio";
     if (provider === "twilio") {
-      const accountSid =
-        normalizeOptionalString(voiceCallTwilioConfig.accountSid) ??
-        normalizeOptionalString(env.TWILIO_ACCOUNT_SID);
-      const authToken =
-        normalizeOptionalString(voiceCallTwilioConfig.authToken) ??
-        normalizeOptionalString(env.TWILIO_AUTH_TOKEN);
-      const fromNumber =
-        normalizeOptionalString(voiceCallConfig.fromNumber) ??
-        normalizeOptionalString(env.TWILIO_FROM_NUMBER);
+      const accountSid = resolveVoiceCallSetupValue(
+        voiceCallTwilioConfig.accountSid,
+        env.TWILIO_ACCOUNT_SID,
+      );
+      const authToken = resolveVoiceCallSetupValue(
+        voiceCallTwilioConfig.authToken,
+        env.TWILIO_AUTH_TOKEN,
+      );
+      const fromNumber = resolveVoiceCallSetupValue(
+        voiceCallConfig.fromNumber,
+        env.TWILIO_FROM_NUMBER,
+      );
       const twilioReady = Boolean(accountSid && authToken && fromNumber);
       checks.push({
         id: "twilio-voice-call-credentials",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `google_meet` `setup_status` reported Twilio voice-call credentials as configured when the corresponding environment variables contained only whitespace. A later delegated call still had no usable Twilio credentials.

## Why This Change Was Made

The setup check now applies the same optional-string normalization to Twilio environment fallbacks that it already applies to plugin config values. Config precedence and the existing readiness message remain unchanged.

## User Impact

Google Meet setup now reports the missing Twilio credential blocker before users attempt a delegated dial, matching the voice-call runtime's credential resolution.

## Evidence

- Real production-function proof before on `44b79d44ae1`: with all three Twilio environment variables set to whitespace, `getGoogleMeetSetupStatus` returned `{ id: "twilio-voice-call-credentials", ok: true }`, while `resolveVoiceCallConfig({ provider: "twilio" })` returned no `fromNumber` and an empty `twilio` credential object.
- Real `google_meet` tool proof after on `7e34687015a`: `setup_status` reports the same credential check as `false` for whitespace-only environment values; valid values still report ready.
- Mutation proof: restoring the raw environment fallback makes the new public-tool regression test fail with `expected true to be false`.
- Focused test: `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts -t 'Twilio delegation readiness|whitespace-only Twilio environment credentials'` — 2 passed, 143 skipped.
- Targeted formatting and `git diff --check` passed.

AI-assisted: built with Codex.
