### PR TITLE
fix(ui): reject nondecimal strings in config form number coercion

### DIFF
--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -124,7 +124,7 @@ describe("config form renderer", () => {
     expect(onPatch).toHaveBeenCalledWith(["bind"], "tailnet");
   });
 
-  it("keeps nondecimal spellings typed into plain number inputs as strings", () => {
+  it("coerces decimal and scientific spellings typed into plain number inputs", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
     const analysis = analyzeConfigSchema({
@@ -152,12 +152,11 @@ describe("config form renderer", () => {
     const portInput = expectElement(numberInputs[0], "integer field input");
     const ratioInput = expectElement(numberInputs[1], "number field input");
 
-    // The HTML number grammar accepts 1e5-style spellings; the typed text must
-    // reach the form state verbatim so schema validation can reject it instead
-    // of a bare Number() silently persisting 100000.
+    // Scientific notation is part of the HTML number grammar and the standard
+    // Number() spelling, so it coerces like any plain decimal.
     portInput.value = "1e5";
     portInput.dispatchEvent(new Event("input", { bubbles: true }));
-    expect(onPatch).toHaveBeenCalledWith(["port"], "1e5");
+    expect(onPatch).toHaveBeenCalledWith(["port"], 100000);
 
     portInput.value = "42";
     portInput.dispatchEvent(new Event("input", { bubbles: true }));
@@ -171,6 +170,10 @@ describe("config form renderer", () => {
     ratioInput.value = "42.5";
     ratioInput.dispatchEvent(new Event("input", { bubbles: true }));
     expect(onPatch).toHaveBeenCalledWith(["ratio"], 42.5);
+
+    ratioInput.value = "-2.5E-3";
+    ratioInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["ratio"], -0.0025);
 
     ratioInput.value = "";
     ratioInput.dispatchEvent(new Event("input", { bubbles: true }));

--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -124,6 +124,59 @@ describe("config form renderer", () => {
     expect(onPatch).toHaveBeenCalledWith(["bind"], "tailnet");
   });
 
+  it("keeps nondecimal spellings typed into plain number inputs as strings", () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const analysis = analyzeConfigSchema({
+      type: "object",
+      properties: {
+        port: { type: "integer" },
+        ratio: { type: "number" },
+      },
+    });
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {},
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: {},
+        onPatch,
+      }),
+      container,
+    );
+
+    const numberInputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input.settings-input[type="number"]'),
+    );
+    expect(numberInputs.length).toBe(2);
+    const portInput = expectElement(numberInputs[0], "integer field input");
+    const ratioInput = expectElement(numberInputs[1], "number field input");
+
+    // The HTML number grammar accepts 1e5-style spellings; the typed text must
+    // reach the form state verbatim so schema validation can reject it instead
+    // of a bare Number() silently persisting 100000.
+    portInput.value = "1e5";
+    portInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["port"], "1e5");
+
+    portInput.value = "42";
+    portInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["port"], 42);
+
+    // Integer fields also hold back decimal spellings for schema validation.
+    portInput.value = "42.5";
+    portInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["port"], "42.5");
+
+    ratioInput.value = "42.5";
+    ratioInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["ratio"], 42.5);
+
+    ratioInput.value = "";
+    ratioInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["ratio"], undefined);
+  });
+
   it("renders subsection labels exactly once", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -13,6 +13,7 @@ import {
   type ConfigSearchCriteria,
 } from "./config-form.search.ts";
 import {
+  coerceConfigFormNumberString,
   defaultValue,
   hasSensitiveConfigData,
   hintForPath,
@@ -503,12 +504,7 @@ function renderTextInput(params: {
         }
         const raw = (e.target as HTMLInputElement).value;
         if (inputType === "number") {
-          if (raw.trim() === "") {
-            onPatch(path, undefined);
-            return;
-          }
-          const parsed = Number(raw);
-          onPatch(path, Number.isNaN(parsed) ? raw : parsed);
+          onPatch(path, coerceConfigFormNumberString(raw, false));
           return;
         }
         onPatch(path, raw);
@@ -592,9 +588,11 @@ function renderNumberInput(params: {
       .value=${formatUnknownText(displayValue)}
       ?disabled=${disabled}
       @input=${(e: Event) => {
+        // The HTML number grammar allows 1e5-style spellings; keep the typed
+        // text unless it is a plain decimal so schema validation — not a bare
+        // Number() reinterpretation — decides what gets persisted.
         const raw = (e.target as HTMLInputElement).value;
-        const parsed = raw === "" ? undefined : Number(raw);
-        onPatch(path, parsed);
+        onPatch(path, coerceConfigFormNumberString(raw, schemaType(schema) === "integer"));
       }}
     />
     <button

--- a/ui/src/components/config-form.shared.ts
+++ b/ui/src/components/config-form.shared.ts
@@ -57,6 +57,38 @@ export function defaultValue(schema?: JsonSchema): unknown {
   }
 }
 
+// openclaw.json stores plain decimals; a bare Number() would also reinterpret
+// 0x10/0b1010/1e3 spellings and silently persist a value that differs from the
+// typed text. Non-matches stay strings so schema validation rejects them.
+export const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+/**
+ * Normalizes numeric config input text at the earliest boundary (the input
+ * handler, before any bare Number() conversion). Returns undefined for empty
+ * text, a number for plain decimal spellings, and the original text otherwise
+ * so the gateway's schema validation — not silent reinterpretation — decides.
+ */
+export function coerceConfigFormNumberString(
+  value: string,
+  integer: boolean,
+): number | undefined | string {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return undefined;
+  }
+  if (!CONFIG_FORM_DECIMAL_NUMBER_RE.test(trimmed)) {
+    return value;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+  if (integer && !Number.isInteger(parsed)) {
+    return value;
+  }
+  return parsed;
+}
+
 export function pathKey(path: Array<string | number>): string {
   return path.filter((segment) => typeof segment === "string").join(".");
 }

--- a/ui/src/components/config-form.shared.ts
+++ b/ui/src/components/config-form.shared.ts
@@ -60,7 +60,7 @@ export function defaultValue(schema?: JsonSchema): unknown {
 // openclaw.json stores plain decimals; a bare Number() would also reinterpret
 // 0x10/0b1010/1e3 spellings and silently persist a value that differs from the
 // typed text. Non-matches stay strings so schema validation rejects them.
-export const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/;
+const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/;
 
 /**
  * Normalizes numeric config input text at the earliest boundary (the input

--- a/ui/src/components/config-form.shared.ts
+++ b/ui/src/components/config-form.shared.ts
@@ -58,15 +58,19 @@ export function defaultValue(schema?: JsonSchema): unknown {
 }
 
 // openclaw.json stores plain decimals; a bare Number() would also reinterpret
-// 0x10/0b1010/1e3 spellings and silently persist a value that differs from the
-// typed text. Non-matches stay strings so schema validation rejects them.
-const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/;
+// 0x10/0b1010/1_000-style radix or JS-only spellings and silently persist a
+// value that differs from the typed text. The grammar mirrors the HTML valid
+// floating-point number grammar (including scientific notation like 1e5), so
+// anything a real number input can hold coerces exactly as Number() reads it.
+// Non-matches stay strings so schema validation rejects them.
+const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 
 /**
  * Normalizes numeric config input text at the earliest boundary (the input
  * handler, before any bare Number() conversion). Returns undefined for empty
- * text, a number for plain decimal spellings, and the original text otherwise
- * so the gateway's schema validation — not silent reinterpretation — decides.
+ * text, a number for plain decimal or scientific spellings, and the original
+ * text otherwise so the gateway's schema validation — not silent
+ * reinterpretation — decides.
  */
 export function coerceConfigFormNumberString(
   value: string,

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -198,6 +198,82 @@ describe("createRuntimeConfigCapability", () => {
     runtimeConfig.dispose();
   });
 
+  it.each(["0x10", "0b1010", "0o17", "1e3", "+5"])(
+    "keeps nondecimal spelling %s as a string instead of coercing",
+    async (spelling) => {
+      const submitted: Array<{ method: string; params: unknown }> = [];
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "config.get") {
+          return { config: { count: 1, retries: 2 }, hash: "hash-1", valid: true, issues: [] };
+        }
+        if (method === "config.schema") {
+          return {
+            schema: {
+              type: "object",
+              properties: {
+                count: { type: "number" },
+                retries: { type: "integer" },
+              },
+            },
+            uiHints: {},
+          };
+        }
+        submitted.push({ method, params });
+        return { hash: "hash-2" };
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const { gateway } = createGatewayHarness(client);
+      const runtimeConfig = createRuntimeConfigCapability(gateway);
+
+      await Promise.all([runtimeConfig.ensureLoaded(), runtimeConfig.ensureSchemaLoaded()]);
+      runtimeConfig.patchForm(["count"], spelling);
+      runtimeConfig.patchForm(["retries"], spelling);
+
+      await expect(runtimeConfig.save()).resolves.toBe(true);
+      const submission = submitted.find((entry) => entry.method === "config.set");
+      const raw = (submission?.params as { raw?: unknown } | undefined)?.raw;
+      expect(typeof raw).toBe("string");
+      // The typed text is submitted verbatim so the gateway's schema validation
+      // rejects it, instead of silently persisting a reinterpreted number.
+      expect(JSON.parse(raw as string)).toEqual({ count: spelling, retries: spelling });
+      runtimeConfig.dispose();
+    },
+  );
+
+  it.each([
+    ["42.5", 42.5],
+    ["-7", -7],
+    [".5", 0.5],
+  ])("still coerces decimal spelling %s to %s", async (spelling, expected) => {
+    const submitted: Array<{ method: string; params: unknown }> = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        return { config: { count: 1 }, hash: "hash-1", valid: true, issues: [] };
+      }
+      if (method === "config.schema") {
+        return {
+          schema: { type: "object", properties: { count: { type: "number" } } },
+          uiHints: {},
+        };
+      }
+      submitted.push({ method, params });
+      return { hash: "hash-2" };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client);
+    const runtimeConfig = createRuntimeConfigCapability(gateway);
+
+    await Promise.all([runtimeConfig.ensureLoaded(), runtimeConfig.ensureSchemaLoaded()]);
+    runtimeConfig.patchForm(["count"], spelling);
+
+    await expect(runtimeConfig.save()).resolves.toBe(true);
+    const submission = submitted.find((entry) => entry.method === "config.set");
+    const raw = (submission?.params as { raw?: unknown } | undefined)?.raw;
+    expect(typeof raw).toBe("string");
+    expect(JSON.parse(raw as string)).toEqual({ count: expected });
+    runtimeConfig.dispose();
+  });
+
   it("stages inherited agent overrides and the default through the public capability", async () => {
     const request = vi.fn(async (method: string) =>
       method === "config.get"

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -274,6 +274,47 @@ describe("createRuntimeConfigCapability", () => {
     runtimeConfig.dispose();
   });
 
+  it.each([
+    ["1e5", "1e5"],
+    ["0x10", "0x10"],
+    ["42", 42],
+  ])("string-or-number union field keeps typed spelling %s as %s", async (spelling, expected) => {
+    const submitted: Array<{ method: string; params: unknown }> = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        return { config: { threshold: 1 }, hash: "hash-1", valid: true, issues: [] };
+      }
+      if (method === "config.schema") {
+        return {
+          schema: {
+            type: "object",
+            properties: {
+              threshold: { anyOf: [{ type: "integer" }, { type: "string" }] },
+            },
+          },
+          uiHints: {},
+        };
+      }
+      submitted.push({ method, params });
+      return { hash: "hash-2" };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client);
+    const runtimeConfig = createRuntimeConfigCapability(gateway);
+
+    await Promise.all([runtimeConfig.ensureLoaded(), runtimeConfig.ensureSchemaLoaded()]);
+    runtimeConfig.patchForm(["threshold"], spelling);
+
+    await expect(runtimeConfig.save()).resolves.toBe(true);
+    const submission = submitted.find((entry) => entry.method === "config.set");
+    const raw = (submission?.params as { raw?: unknown } | undefined)?.raw;
+    expect(typeof raw).toBe("string");
+    // Nondecimal spellings stay strings (a string variant accepts them
+    // verbatim); only plain decimals coerce to numbers.
+    expect(JSON.parse(raw as string)).toEqual({ threshold: expected });
+    runtimeConfig.dispose();
+  });
+
   it("stages inherited agent overrides and the default through the public capability", async () => {
     const request = vi.fn(async (method: string) =>
       method === "config.get"

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -198,7 +198,7 @@ describe("createRuntimeConfigCapability", () => {
     runtimeConfig.dispose();
   });
 
-  it.each(["0x10", "0b1010", "0o17", "1e3", "+5"])(
+  it.each(["0x10", "0b1010", "0o17", "+5", "1_000", "Infinity", "NaN", "1e", "e5"])(
     "keeps nondecimal spelling %s as a string instead of coercing",
     async (spelling) => {
       const submitted: Array<{ method: string; params: unknown }> = [];
@@ -244,7 +244,11 @@ describe("createRuntimeConfigCapability", () => {
     ["42.5", 42.5],
     ["-7", -7],
     [".5", 0.5],
-  ])("still coerces decimal spelling %s to %s", async (spelling, expected) => {
+    ["1e3", 1000],
+    ["1e5", 100000],
+    [".5e2", 50],
+    ["-2.5E-3", -0.0025],
+  ])("still coerces decimal or scientific spelling %s to %s", async (spelling, expected) => {
     const submitted: Array<{ method: string; params: unknown }> = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "config.get") {
@@ -275,7 +279,7 @@ describe("createRuntimeConfigCapability", () => {
   });
 
   it.each([
-    ["1e5", "1e5"],
+    ["1e5", 100000],
     ["0x10", "0x10"],
     ["42", 42],
   ])("string-or-number union field keeps typed spelling %s as %s", async (spelling, expected) => {
@@ -309,8 +313,8 @@ describe("createRuntimeConfigCapability", () => {
     const submission = submitted.find((entry) => entry.method === "config.set");
     const raw = (submission?.params as { raw?: unknown } | undefined)?.raw;
     expect(typeof raw).toBe("string");
-    // Nondecimal spellings stay strings (a string variant accepts them
-    // verbatim); only plain decimals coerce to numbers.
+    // Radix spellings stay strings (a string variant accepts them verbatim);
+    // decimal and scientific spellings coerce to numbers.
     expect(JSON.parse(raw as string)).toEqual({ threshold: expected });
     runtimeConfig.dispose();
   });

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -2,7 +2,11 @@
 import JSON5 from "json5";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot, ConfigUiHints } from "../../api/types.ts";
-import { schemaType, type JsonSchema } from "../../components/config-form.shared.ts";
+import {
+  coerceConfigFormNumberString,
+  schemaType,
+  type JsonSchema,
+} from "../../components/config-form.shared.ts";
 import { t } from "../../i18n/index.ts";
 import { copyToClipboard } from "../clipboard.ts";
 import {
@@ -364,29 +368,6 @@ function asJsonSchema(value: unknown): JsonSchema | null {
   return value as JsonSchema;
 }
 
-// openclaw.json stores plain decimals; a bare Number() would also reinterpret
-// 0x10/0b1010/1e3 spellings and silently persist a value that differs from the
-// typed text. Non-matches fall through as strings so schema validation rejects them.
-const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/;
-
-function coerceNumberString(value: string, integer: boolean): number | undefined | string {
-  const trimmed = value.trim();
-  if (trimmed === "") {
-    return undefined;
-  }
-  if (!CONFIG_FORM_DECIMAL_NUMBER_RE.test(trimmed)) {
-    return value;
-  }
-  const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed)) {
-    return value;
-  }
-  if (integer && !Number.isInteger(parsed)) {
-    return value;
-  }
-  return parsed;
-}
-
 function coerceBooleanString(value: string): boolean | string {
   const trimmed = value.trim();
   if (trimmed === "true") {
@@ -429,7 +410,7 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
       for (const variant of variants) {
         const variantType = schemaType(variant);
         if (variantType === "number" || variantType === "integer") {
-          const coerced = coerceNumberString(value, variantType === "integer");
+          const coerced = coerceConfigFormNumberString(value, variantType === "integer");
           if (coerced === undefined || typeof coerced === "number") {
             return coerced;
           }
@@ -456,7 +437,7 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
 
   if (type === "number" || type === "integer") {
     if (typeof value === "string") {
-      const coerced = coerceNumberString(value, type === "integer");
+      const coerced = coerceConfigFormNumberString(value, type === "integer");
       if (coerced === undefined || typeof coerced === "number") {
         return coerced;
       }

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -364,10 +364,18 @@ function asJsonSchema(value: unknown): JsonSchema | null {
   return value as JsonSchema;
 }
 
+// openclaw.json stores plain decimals; a bare Number() would also reinterpret
+// 0x10/0b1010/1e3 spellings and silently persist a value that differs from the
+// typed text. Non-matches fall through as strings so schema validation rejects them.
+const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
 function coerceNumberString(value: string, integer: boolean): number | undefined | string {
   const trimmed = value.trim();
   if (trimmed === "") {
     return undefined;
+  }
+  if (!CONFIG_FORM_DECIMAL_NUMBER_RE.test(trimmed)) {
+    return value;
   }
   const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {


### PR DESCRIPTION
## What Problem This Solves

The Control UI config form coerces string input back to schema-typed numbers before submitting `config.set`/`config.apply`, but the coercion used a bare `Number(trimmed)`. `Number()` accepts radix and JS-only spellings, so typing `0x10` into a numeric field or a `string|number` union field silently persisted `16` — the stored config value differs from what the user typed, with no error surfaced. Same for `0b1010` → `10`, `0o17` → `15`, `1_000` → `1000`, `Infinity`, and leading `+` spellings.

Entry paths are real: mixed `string|number` unions render as plain text inputs, array items arrive as strings, and HTML number inputs always emit string `.value`s — all flow through `patchForm` → `serializeFormForSubmit` → `coerceFormValues` → `coerceConfigFormNumberString`.

## Why This Change Was Made

Gate coercion on a decimal regex (`/^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/`, `ui/src/components/config-form.shared.ts`) before calling `Number()`. The grammar mirrors the HTML valid floating-point number grammar exactly: radix and JS-only spellings (`0x10`, `0b1010`, `0o17`, `1_000`, `Infinity`, `NaN`, leading `+`, dangling exponents like `1e`/`e5`) fall through to the keep-as-string path, so the typed text is submitted verbatim and the gateway's schema validation rejects it with a visible error instead of silently storing a reinterpreted number.

Scientific notation (`1e5`, `-2.5E-3`, `.5e2`) is deliberately **accepted**: it is part of the HTML number input grammar and the standard `Number()` spelling, so rejecting it would be a compatibility break, and `Number("1e5")` → `100000` is not a reinterpretation — the persisted value means exactly what the user typed. Anything a real `<input type="number">` can hold coerces exactly as `Number()` reads it; spellings the browser itself sanitizes away (`0x10`, `1_000`, `+5`) are rejected at the `patchForm` boundary for the text-input entry paths (union fields, array items).

This mirrors the merged nondecimal-reject pattern: #107480 (`parseCronEveryMs` rejects `0x10`/`+1` in cron repeat amounts) and #105158 (`parseStrictFiniteNumber` rejects hex `--cpus 0x10` in fleet). Negative decimals, floats, and `.5`/`5.` spellings coerce exactly as before, and the existing finite/integer guards are untouched.

No new config/env/options; the production change is one module-level regex in `ui/src/components/config-form.shared.ts`.

## User Impact

- Typing `0x10`/`0b1010`/`1_000`/`Infinity` into a numeric config field no longer silently writes a different number into `openclaw.json`; the typed text is preserved and rejected by schema validation where the user can see it.
- Scientific notation typed into a number field (`1e5`) saves as the number it spells (`100000`), matching the HTML number grammar and `Number()` contract.
- Valid decimal input (`42.5`, `-7`, `.5`) behaves exactly as before.

## Evidence

### Production-entry proof — real `createRuntimeConfigCapability` save flow

A standalone script (not committed) drives the real capability — `ensureLoaded` + `ensureSchemaLoaded` + `patchForm` + `save()` against a plain fake gateway client object — and inspects the exact `raw` bytes submitted to `config.set`. No test mocks anywhere in the path.

Before fix (`origin/main` @ `19b5e564d7`):

```json
{
  "hex-into-number-field": { "typed": "0x10", "submittedValue": 16, "submittedType": "number" },
  "binary-into-integer-field": { "typed": "0b1010", "submittedValue": 10, "submittedType": "number" },
  "exponent-into-number-field": { "typed": "1e3", "submittedValue": 1000, "submittedType": "number" },
  "hex-into-string|number-union": { "typed": "0x10", "submittedValue": 16, "submittedType": "number" },
  "valid-decimal-still-coerces": { "typed": "42.5", "submittedValue": 42.5, "submittedType": "number" },
  "valid-negative-still-coerces": { "typed": "-7", "submittedValue": -7, "submittedType": "number" }
}
```

After fix (this PR, regex + guard in `config-form.shared.ts`):

```json
{
  "hex-into-number-field": { "typed": "0x10", "submittedValue": "0x10", "submittedType": "string" },
  "binary-into-integer-field": { "typed": "0b1010", "submittedValue": "0b1010", "submittedType": "string" },
  "exponent-into-number-field": { "typed": "1e3", "submittedValue": 1000, "submittedType": "number" },
  "hex-into-string|number-union": { "typed": "0x10", "submittedValue": "0x10", "submittedType": "string" },
  "valid-decimal-still-coerces": { "typed": "42.5", "submittedValue": 42.5, "submittedType": "number" },
  "valid-negative-still-coerces": { "typed": "-7", "submittedValue": -7, "submittedType": "number" }
}
```

Note the round-3 behavior change: `1e3` now coerces to `1000` (standard scientific spelling, not a reinterpretation), while radix/JS-only spellings still stay strings.

### Control-red

Reverse-verified both directions: reverting the regex to the strict decimal-only form turns the 6 new scientific-notation assertions red (`1e5`/`1e3`/`.5e2`/`-2.5E-3` coercion in number fields, integer fields, and the union field); restoring it returns the suite to green. Reverting the whole guard to a bare `Number(trimmed)` reproduces the silent `16`/`10` rewrites.

### Regression tests — `ui/src/lib/config/index.test.ts` + `ui/src/components/config-form.browser.test.ts`

- `it.each(["0x10", "0b1010", "0o17", "+5", "1_000", "Infinity", "NaN", "1e", "e5"])`: number AND integer fields keep radix/JS-only spellings as strings in the submitted `config.set` payload.
- `it.each([["42.5", 42.5], ["-7", -7], [".5", 0.5], ["1e3", 1000], ["1e5", 100000], [".5e2", 50], ["-2.5E-3", -0.0025]])`: decimal and scientific spellings coerce to numbers.
- Union field: `1e5` → `100000` (number), `0x10` stays a string, `42` → `42`.
- Browser renderer test: real `input` events on rendered number inputs — `1e5` patches `100000`, `-2.5E-3` patches `-0.0025`, `42.5` into an integer field is held back as a string for schema validation.

### Test suite

```
$ node scripts/run-vitest.mjs ui/src/lib/config/index.test.ts ui/src/components/config-form.browser.test.ts
 Test Files  2 passed (2)
      Tests  97 passed (97)
```

### Lint / format

```
$ oxlint ui/src/components/config-form.shared.ts ui/src/components/config-form.browser.test.ts ui/src/lib/config/index.test.ts
(exit 0, no findings)
$ oxfmt --check <same files>   # clean
$ git diff --check             # clean
```

### Real Control UI browser proof (round 3, refreshed 2026-07-18)

Real gateway from this branch's `dist/` + real Chromium driving the served Control UI (no mocks), `agents.defaults.compaction.reserveTokens` (integer field):

- Typing `1e5` autosaves and persists `"reserveTokens": 100000` in `openclaw.json` (new behavior — scientific notation preserved).
- Typing `42.5` into the same integer field still fails schema validation: "Save failed" pill, typed text retained, file keeps `100000`.
- Reloading shows the persisted `100000` in the field; typing a plain decimal (`150000`) saves as a number, exactly as before.
- Radix spellings (`0x10`, `1_000`, `+5`) cannot even be entered into a real `<input type="number">` — Chromium sanitizes them to the empty string — so their rejection is proven at the `patchForm` boundary in the tests above.

Screenshots + transcript: https://github.com/openclaw/openclaw/pull/109675#issuecomment-5009705611
