### PR TITLE
fix(chutes): cancel userinfo error response body before returning null

### DIFF
--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -270,6 +270,47 @@ describe("chutes plugin OAuth", () => {
     expect(timeoutSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("cancels the userinfo error response body when profile lookup fails", async () => {
+    let canceled = false;
+    let bytesPulled = 0;
+    const userInfoResponse = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (bytesPulled > 0) {
+            controller.close();
+            return;
+          }
+          bytesPulled += 1;
+          controller.enqueue(new TextEncoder().encode("temporarily unavailable"));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 503 },
+    );
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = fetchInputUrl(input);
+      if (url === CHUTES_TOKEN_ENDPOINT) {
+        return new Response(
+          '{"access_token":"at_123","refresh_token":"rt_123","expires_in":3600}',
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url === CHUTES_USERINFO_ENDPOINT) {
+        return userInfoResponse;
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const credentials = await loginWithFetch(fetchFn);
+
+    expect(canceled).toBe(true);
+    expect(credentials.access).toBe("at_123");
+    expect(credentials.email).toBeUndefined();
+    expect(credentials.accountId).toBeUndefined();
+  });
+
   it("cancels authentication when the caller aborts during userinfo", async () => {
     const controller = new AbortController();
     const reason = new Error("cancelled by caller");

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -129,6 +129,8 @@ async function fetchChutesUserInfo(params: {
     }),
   });
   if (!response.ok) {
+    // Release the connection instead of leaving the error body to idle timeout.
+    await response.body?.cancel().catch(() => undefined);
     return null;
   }
   const data = await readProviderJsonResponse<unknown>(response, "Chutes userinfo");


### PR DESCRIPTION
## What Problem This Solves

The bundled Chutes OAuth plugin leaks an HTTP connection every time the userinfo probe returns a non-2xx response. `fetchChutesUserInfo` (`extensions/chutes/oauth.ts:131`) did `if (!response.ok) { return null; }` without consuming or cancelling `response.body`, so the underlying connection stays attached until the server's idle timeout reaps it. The userinfo probe runs on every login / token exchange and fails in normal operation (IdP throttling, transient 5xx, or tokens without profile scope), so repeated login or probe attempts accumulate half-open connections.

The core helper copy (`src/agents/chutes-oauth.ts`) received exactly this fix in 6467c1962a ("fix(chutes): cancel userinfo error bodies"), but the extension copy — the file the bundled plugin actually loads via `extensions/chutes/index.ts:16` — was left behind. This PR ports the same cancel to the extension sibling.

## Why This Change Was Made

Adds `await response.body?.cancel().catch(() => undefined);` before `return null` on the non-ok userinfo path. Cancelling the unread body releases the connection immediately instead of waiting for idle timeout, and the `.catch(() => undefined)` keeps a broken stream from changing the established "failed userinfo resolves to null" contract.

This mirrors the merged error-body cancel pattern from #109196 (reef guard denial), #109071 (GitHub Copilot catalog error streams), and #109007 (Telegram getChat), and matches the core sibling fix 6467c1962a. No new abstraction: the plugin SDK exposes no shared cancel helper, each fixed surface keeps the same inline one-liner, and extensions cannot import `src/**` internals.

The other non-ok path in the same file — token exchange via `assertOkOrThrowProviderError` (`extensions/chutes/oauth.ts:172`) — already consumes the error body through the bounded, redacted provider error reader (#97808, #103569), so it needs no change. Scope stays on the userinfo early return: 2 production lines.

## User Impact

- Failed Chutes userinfo probes no longer pin HTTP connections until idle timeout; repeated login/probe attempts stop accumulating sockets.
- Login behavior is otherwise unchanged: a failed userinfo lookup still resolves to `null`, and issued tokens are kept without profile enrichment.

## Evidence

### Code path (source verified)

| Layer | File | Line | Behavior |
|---|---|---|---|
| Plugin entry | `extensions/chutes/index.ts` | 16 | bundled plugin imports `loginChutes` from this file |
| Login flow | `extensions/chutes/oauth.ts` | 194 | `exchangeChutesCodeForTokens` awaits `fetchChutesUserInfo` (optional enrichment; errors swallowed unless caller aborted) |
| Probe | `extensions/chutes/oauth.ts` | 124-130 | `fetch(CHUTES_USERINFO_ENDPOINT)` with bearer token |
| Bug (before) | `extensions/chutes/oauth.ts` | 131-133 | non-ok → `return null` with body unread → connection held until idle timeout |
| Fix (after) | `extensions/chutes/oauth.ts` | 131-135 | non-ok → `await response.body?.cancel().catch(() => undefined)` → `return null` |
| Unaffected sibling path | `extensions/chutes/oauth.ts` | 172 | token exchange non-ok goes through `assertOkOrThrowProviderError`, which reads the error body under the provider cap |

### Regression test — cancel observed through the production login flow

`extensions/chutes/oauth.test.ts` gains "cancels the userinfo error response body when profile lookup fails": the stubbed fetch returns a 200 token response, then a 503 `Response` whose body is a real `ReadableStream` with a `cancel()` tracker. The test drives the production wrapper `loginChutes` → `exchangeChutesCodeForTokens` → `fetchChutesUserInfo` and asserts the stream was cancelled, while the issued credentials survive without email/accountId enrichment.

### Control-red

Same test against the unfixed source (the two production lines reverted): `Tests 1 failed | 6 skipped (7)` — the new test fails at `expect(canceled).toBe(true)` because nothing cancels the stream on the unfixed path. With the fix: `Tests 7 passed (7)`.

### Test suite

```
$ node scripts/run-vitest.mjs run extensions/chutes/oauth.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

### Lint / typecheck / whitespace

```
$ node scripts/run-oxlint.mjs extensions/chutes/oauth.ts extensions/chutes/oauth.test.ts
(exit 0, no findings)
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
(exit 0, no errors)
$ git diff --check origin/main
(clean)
```

### What was not tested

- Live Chutes IdP behavior — no credentials available; the regression test uses a real `ReadableStream` body, which exercises the same `response.body.cancel()` path a wire response would.
- The core `src/agents/chutes-oauth.ts` copy — already fixed in 6467c1962a with its own regression test; this PR only brings the extension sibling to parity.

AI-assisted; reviewed before submission.
