### PR TITLE
fix(gateway): config hot-reload permanently disables after sporadic recovered watcher errors

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3819,14 +3819,19 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
       const watchOptions = (index: number) =>
         watchSpy.mock.calls[index]?.[1] as { usePolling?: boolean } | undefined;
 
-      // Four error/recovery rounds — one more than the retry budget. Each
-      // re-created watcher proves it works by delivering a file event before
-      // the next transient error, so the budget must refill every round.
-      for (let round = 0; round < 4; round += 1) {
+      // The initial error consumes one attempt. Every replacement then proves
+      // itself before failing, so each new episode must restart at attempt one.
+      watchers[0]?.emit("error");
+      expect(log.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("re-creating watcher (attempt 1/3 in 500ms)"),
+      );
+      await vi.advanceTimersByTimeAsync(500);
+
+      for (let round = 1; round < 4; round += 1) {
         watchers[round]?.emit("change");
         await vi.advanceTimersByTimeAsync(0);
         watchers[round]?.emit("error");
-        expect(log.warn).toHaveBeenCalledWith(
+        expect(log.warn).toHaveBeenLastCalledWith(
           expect.stringContaining("re-creating watcher (attempt 1/3 in 500ms)"),
         );
         await vi.advanceTimersByTimeAsync(500);
@@ -3835,6 +3840,7 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
 
       // Hot-reload survives in native mode: no polling degradation, no disable.
       expect(reloader.hotReloadStatus()).toBe("active");
+      expect(log.warn).toHaveBeenCalledTimes(4);
       expect(watchOptions(4)?.usePolling).toBe(false);
       expect(log.warn).not.toHaveBeenCalledWith(
         expect.stringContaining("degrading to polling mode"),

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3804,6 +3804,57 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     await reloader.stop();
   });
 
+  it("keeps hot-reload active when transient errors are separated by working watchers", async () => {
+    const originalVitest = process.env.VITEST;
+    const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
+    delete process.env.VITEST;
+    delete process.env.CHOKIDAR_USEPOLLING;
+    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    try {
+      // One initial watcher plus one re-create per error/recovery round.
+      const watchers = Array.from({ length: 5 }, () => createWatcherMock());
+      const started = startReloaderWithWatchers(watchers);
+      const { watchSpy, log } = started;
+      reloader = started.reloader;
+      const watchOptions = (index: number) =>
+        watchSpy.mock.calls[index]?.[1] as { usePolling?: boolean } | undefined;
+
+      // Four error/recovery rounds — one more than the retry budget. Each
+      // re-created watcher proves it works by delivering a file event before
+      // the next transient error, so the budget must refill every round.
+      for (let round = 0; round < 4; round += 1) {
+        watchers[round]?.emit("change");
+        await vi.advanceTimersByTimeAsync(0);
+        watchers[round]?.emit("error");
+        expect(log.warn).toHaveBeenCalledWith(
+          expect.stringContaining("re-creating watcher (attempt 1/3 in 500ms)"),
+        );
+        await vi.advanceTimersByTimeAsync(500);
+        expect(watchSpy).toHaveBeenCalledTimes(round + 2);
+      }
+
+      // Hot-reload survives in native mode: no polling degradation, no disable.
+      expect(reloader.hotReloadStatus()).toBe("active");
+      expect(watchOptions(4)?.usePolling).toBe(false);
+      expect(log.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("degrading to polling mode"),
+      );
+      expect(log.error).not.toHaveBeenCalled();
+    } finally {
+      if (originalVitest === undefined) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = originalVitest;
+      }
+      if (originalChokidarPolling === undefined) {
+        delete process.env.CHOKIDAR_USEPOLLING;
+      } else {
+        process.env.CHOKIDAR_USEPOLLING = originalChokidarPolling;
+      }
+      await reloader?.stop();
+    }
+  });
+
   it("degrades to polling then disables after both native and polling retries are exhausted", async () => {
     const originalVitest = process.env.VITEST;
     const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -913,9 +913,19 @@ export function startGatewayConfigReloader(opts: {
       awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
       usePolling,
     });
-    next.on("add", scheduleExternalRefresh);
-    next.on("change", scheduleExternalRefresh);
-    next.on("unlink", scheduleExternalRefresh);
+    // A delivered file event proves the current watcher works, so refill the
+    // re-create budget. Without this, transient errors spread over a long
+    // gateway lifetime accumulate and permanently disable hot-reload even
+    // though every recovery succeeded. Only watcher events refill the budget;
+    // plugin-metadata refreshes route through scheduleExternalRefresh alone,
+    // and errors without any event in between still consume the bounded budget.
+    const scheduleFromWatcherEvent = () => {
+      watcherRecreateRetries = 0;
+      scheduleExternalRefresh();
+    };
+    next.on("add", scheduleFromWatcherEvent);
+    next.on("change", scheduleFromWatcherEvent);
+    next.on("unlink", scheduleFromWatcherEvent);
     next.on("error", (err) => {
       handleWatcherError(next, err);
     });

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -913,12 +913,8 @@ export function startGatewayConfigReloader(opts: {
       awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
       usePolling,
     });
-    // A delivered file event proves the current watcher works, so refill the
-    // re-create budget. Without this, transient errors spread over a long
-    // gateway lifetime accumulate and permanently disable hot-reload even
-    // though every recovery succeeded. Only watcher events refill the budget;
-    // plugin-metadata refreshes route through scheduleExternalRefresh alone,
-    // and errors without any event in between still consume the bounded budget.
+    // A file event proves this watcher recovered. Reset only here so plugin
+    // metadata refreshes and consecutive watcher errors cannot refill the budget.
     const scheduleFromWatcherEvent = () => {
       watcherRecreateRetries = 0;
       scheduleExternalRefresh();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running a long-lived gateway would silently lose config hot-reload: after a handful of transient file-watcher errors spread over the process lifetime, edits to `openclaw.json` stop being picked up until the gateway is restarted, even though every watcher recovery in between succeeded and served reloads normally.

The watcher re-create retry budget (3 attempts native, then degrade to polling, then 3 attempts polling, then `hot-reload disabled`) is consumed cumulatively across the whole process lifetime. A gateway that hits one recoverable inotify/kqueue error every few days — each followed by days of healthy watching — still marches irreversibly toward polling degradation and then permanent disable, because nothing ever refills the budget.

## Why This Change Was Made

Watcher events (`add`/`change`/`unlink`) now route through a small wrapper that resets the re-create retry counter before scheduling the shared refresh path. A delivered file event is proof the recovered watcher works, so the bounded budget applies per failure episode instead of per process lifetime. Consecutive errors with no event in between still consume the same bounded budget, so genuinely persistent failures (e.g. exhausted inotify watches) degrade and disable exactly as before.

The reset intentionally hangs off the watcher event path only: `notifyPluginMetadataChanged` (added on current `main`) also calls the shared `scheduleExternalRefresh`, and a plugin-metadata refresh proves nothing about watcher health, so it does not touch the budget. The branch is rebased onto current `main` with that newer lifecycle behavior preserved.

## User Impact

Config hot-reload on long-lived gateways now survives sporadic recoverable watcher errors indefinitely. Persistent watcher failures behave exactly as before: bounded native retries, polling fallback, then a logged `config hot-reload disabled` with `hotReloadStatus()` reporting `disabled`.

## Evidence

### Live behavior proof (real chokidar watcher, real file, real timers)

Driver: the production `startGatewayConfigReloader` watching a real temp `openclaw.json` with a real chokidar FSWatcher in native (non-polling) mode and real backoff timers. Each round performs a real `fs.writeFile` config edit (delivered by the real watcher and consumed by the reloader), then injects one transient error on the live FSWatcher instance — the same `error`-event path a kernel-level failure takes. Four rounds, one more than the retry budget.

Before (current `main`): the budget never refills, so recovered episodes still march toward degradation — the attempt counter climbs every round and round 4 exhausts native mode:

```
[proof] real watcher delivered a file event (#1)
[proof] config file edit consumed by reloader (commit #1)
[gateway-log][warn] config watcher error; re-creating watcher (attempt 1/3 in 500ms): Error: simulated transient watcher failure #1
[proof] config file edit consumed by reloader (commit #2)
[gateway-log][warn] config watcher error; re-creating watcher (attempt 2/3 in 2000ms): Error: simulated transient watcher failure #2
[proof] config file edit consumed by reloader (commit #3)
[gateway-log][warn] config watcher error; re-creating watcher (attempt 3/3 in 5000ms): Error: simulated transient watcher failure #3
[proof] config file edit consumed by reloader (commit #4)
[gateway-log][warn] config watcher native retries exhausted; degrading to polling mode: Error: simulated transient watcher failure #4
```

Four more sporadic-but-recovered errors in polling mode reach `config hot-reload disabled` permanently.

After (this patch): every recovered episode refills the budget — each error is `attempt 1/3`, the watcher stays in native mode, and hot reload stays active:

```
[proof] real watcher delivered a file event (#1)
[proof] config file edit consumed by reloader (commit #1)
[gateway-log][warn] config watcher error; re-creating watcher (attempt 1/3 in 500ms): Error: simulated transient watcher failure #1
[proof] config file edit consumed by reloader (commit #2)
[gateway-log][warn] config watcher error; re-creating watcher (attempt 1/3 in 500ms): Error: simulated transient watcher failure #2
[proof] config file edit consumed by reloader (commit #3)
[gateway-log][warn] config watcher error; re-creating watcher (attempt 1/3 in 500ms): Error: simulated transient watcher failure #3
[proof] config file edit consumed by reloader (commit #4)
[gateway-log][warn] config watcher error; re-creating watcher (attempt 1/3 in 500ms): Error: simulated transient watcher failure #4
[proof] round 4: hotReloadStatus=active watchersCreated=5
[proof] FINAL hotReloadStatus=active after 4 recovered errors
[proof] file events delivered=4, reload commits=4
```

### Regression coverage

- New test in `src/gateway/config-reload.test.ts` (`keeps hot-reload active when transient errors are separated by working watchers`): four error/recovery rounds, each recovered watcher proving itself with a delivered file event before the next error. Fails against unfixed `main` (fourth error degrades to polling despite every recovery working); passes with the fix.
- The pre-existing exhaustion tests (back-to-back errors with no event in between: degrade to polling, then disable) pass unchanged, proving persistent-failure behavior is preserved.
- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts` → 134 passed on the rebased head.
- Scoped `oxlint`, `oxfmt --check`, and `git diff --check` pass on the two changed files.

