### PR TITLE
fix(acp): persist failed bound turns so transcripts match the channel

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -611,6 +611,45 @@ describe("tryDispatchAcpReply", () => {
     expect(routeCall().mirror).toBe(false);
   });
 
+  it("persists the failed turn so the bound transcript matches the channel reply", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(async () => {
+      throw new Error("acp exploded mid-turn");
+    });
+
+    await runDispatch({ bodyForAgent: "reply" });
+
+    // A failed bound turn used to deliver an error to the channel while writing
+    // nothing to the transcript, so the next resume replayed history that never
+    // mentioned the failure.
+    expect(transcriptMocks.persistAcpDispatchTranscript).toHaveBeenCalledTimes(1);
+    const transcript = requireRecord(
+      mockArg(transcriptMocks.persistAcpDispatchTranscript, 0, 0, "transcript call"),
+      "transcript call",
+    );
+    expect(transcript.sessionKey).toBe(sessionKey);
+    expect(transcript.promptText).toBe("reply");
+    expect(String(transcript.finalText)).toContain("acp exploded mid-turn");
+  });
+
+  it("keeps streamed output ahead of the error when a turn fails mid-stream", async () => {
+    setReadyAcpResolution();
+    managerMocks.runTurn.mockImplementation(async (params: unknown) => {
+      const handler = params as { onEvent?: (event: unknown) => void };
+      handler.onEvent?.({ type: "text_delta", stream: "output", text: "partial answer" });
+      throw new Error("acp died after streaming");
+    });
+
+    await runDispatch({ bodyForAgent: "reply" });
+
+    const transcript = requireRecord(
+      mockArg(transcriptMocks.persistAcpDispatchTranscript, 0, 0, "transcript call"),
+      "transcript call",
+    );
+    expect(String(transcript.finalText)).toContain("partial answer");
+    expect(String(transcript.finalText)).toContain("acp died after streaming");
+  });
+
   it("adds source delivery guidance to tool-only ACP turns", async () => {
     setReadyAcpResolution();
 

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -616,7 +616,7 @@ export async function tryDispatchAcpReply(params: {
         sessionKey: canonicalSessionKey,
         promptText: transcriptPromptText,
         finalText,
-        meta: acpResolution.meta,
+        meta: acpResolution.kind === "ready" ? acpResolution.meta : undefined,
         threadId: params.ctx.MessageThreadId,
       });
     } catch (error) {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -595,6 +595,38 @@ export async function tryDispatchAcpReply(params: {
       error,
     });
   };
+  // Hoisted so the failure path can persist the same user turn the success path
+  // records: a bound ACP session must not silently diverge from the channel.
+  let transcriptPromptText = "";
+  // Set once the turn is actually dispatched. Attachment-only turns carry an
+  // empty prompt, so prompt text alone cannot stand in for "a turn happened".
+  let turnDispatched = false;
+  // Exactly one transcript record per turn: a failure after the success write
+  // (e.g. finalization throwing) must not append the same user turn twice.
+  let transcriptPersisted = false;
+  const persistTranscript = async (finalText: string): Promise<void> => {
+    if (transcriptPersisted) {
+      return;
+    }
+    transcriptPersisted = true;
+    try {
+      const { persistAcpDispatchTranscript } = await loadDispatchAcpTranscriptRuntime();
+      await persistAcpDispatchTranscript({
+        cfg: params.cfg,
+        sessionKey: canonicalSessionKey,
+        promptText: transcriptPromptText,
+        finalText,
+        meta: acpResolution.meta,
+        threadId: params.ctx.MessageThreadId,
+      });
+    } catch (error) {
+      logVerbose(
+        `dispatch-acp: transcript persistence failed for ${canonicalSessionKey}: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+    }
+  };
   try {
     const dispatchPolicyError = resolveAcpDispatchPolicyError(params.cfg);
     if (dispatchPolicyError) {
@@ -694,6 +726,7 @@ export async function tryDispatchAcpReply(params: {
           images: resolvedTurnAttachments.recentHistoryImages,
         })
       : promptText;
+    transcriptPromptText = turnPromptText;
     if (!turnPromptText && attachments.length === 0) {
       const counts = params.dispatcher.getQueuedCounts();
       delivery.applyRoutedCounts(counts);
@@ -709,6 +742,7 @@ export async function tryDispatchAcpReply(params: {
       logVerbose(`dispatch-acp: start reply lifecycle failed: ${formatErrorMessage(error)}`);
     }
 
+    turnDispatched = true;
     await acpManager.runTurn({
       cfg: params.cfg,
       sessionKey: canonicalSessionKey,
@@ -751,23 +785,6 @@ export async function tryDispatchAcpReply(params: {
       emitAuditEnd();
       return { queuedFinal, counts };
     }
-    try {
-      const { persistAcpDispatchTranscript } = await loadDispatchAcpTranscriptRuntime();
-      await persistAcpDispatchTranscript({
-        cfg: params.cfg,
-        sessionKey: canonicalSessionKey,
-        promptText: turnPromptText,
-        finalText: delivery.getAccumulatedFinalText() || delivery.getAccumulatedBlockText(),
-        meta: acpResolution.meta,
-        threadId: params.ctx.MessageThreadId,
-      });
-    } catch (error) {
-      logVerbose(
-        `dispatch-acp: transcript persistence failed for ${canonicalSessionKey}: ${formatErrorMessage(
-          error,
-        )}`,
-      );
-    }
     queuedFinal =
       (await finalizeAcpTurnOutput({
         cfg: params.cfg,
@@ -780,6 +797,12 @@ export async function tryDispatchAcpReply(params: {
         ttsAccountId: effectiveDispatchAccountId,
         shouldEmitResolvedIdentityNotice,
       })) || queuedFinal;
+
+    // Persist once the turn's outcome is settled. Writing before finalization
+    // would leave a finalizer failure recorded as a clean success.
+    await persistTranscript(
+      delivery.getAccumulatedFinalText() || delivery.getAccumulatedBlockText(),
+    );
 
     const result = finishAttempt({
       queuedFinal,
@@ -799,10 +822,21 @@ export async function tryDispatchAcpReply(params: {
       targetSessionKey: canonicalSessionKey,
       error: acpError,
     });
+    const errorText = formatAcpRuntimeErrorText(acpError);
+    // Snapshot streamed output before delivering the error: delivery accumulates
+    // what it sends, so reading after would fold the error text in twice.
+    const partialText = delivery.getAccumulatedFinalText() || delivery.getAccumulatedBlockText();
     const delivered = await delivery.deliver("final", {
-      text: formatAcpRuntimeErrorText(acpError),
+      text: errorText,
       isError: true,
     });
+    // Record what the channel actually showed. Without this a failed bound turn
+    // leaves the ACP transcript empty while the user sees the reply, and the next
+    // turn resumes from history that never mentions it. Setup failures before
+    // dispatch have no user turn to attach the error to.
+    if (turnDispatched) {
+      await persistTranscript(partialText ? `${partialText}\n\n${errorText}` : errorText);
+    }
     queuedFinal = queuedFinal || delivered;
     return finishAttempt({
       queuedFinal,


### PR DESCRIPTION
## What Problem This Solves

A bound ACP turn that fails delivers an error reply to the channel but writes **nothing** to the session transcript. The bound transcript silently diverges from what the user saw, and the next turn resumes from history that never mentions the failure. Persist failures were also swallowed at verbose level, so the divergence left no trace.

Root cause: `persistAcpDispatchTranscript` ran only on the success path (`dispatch-acp.ts`), and `turnPromptText` was block-scoped inside the `try`, so the `catch` structurally could not persist the user turn even if it wanted to.

## Why This Change Was Made

Found while live-testing the ACP connectors against real auth: the codex and gemini bind lanes pass 5/5, but claude times out with turns that "complete" and never appear in the bound transcript — a failure mode that is invisible by construction today. This PR fixes the silent-divergence class and makes that category of failure observable. (The claude-specific trigger is separate and tracked in the issue linked below; this PR does not claim to fix it.)

The design is now **persist exactly once, after the turn's outcome settles**:

- **Success writes after finalization** — previously the transcript was committed *before* `finalizeAcpTurnOutput`, so a finalizer failure was recorded as a clean success.
- **Failures record streamed output ahead of the error text**, snapshotted *before* `delivery.deliver` so the delivery accumulator cannot fold the error text in twice.
- **A dispatch flag gates the failure write** (not prompt-text truthiness): attachment-only turns legitimately carry an empty prompt and are now covered, while pre-dispatch setup failures don't mint blank-prompt records that would poison resume.

## User Impact

When a bound ACP turn fails, the session transcript now matches what the channel showed — including any partial output that streamed before the failure. Resumes no longer replay a history that omits the error.

## Evidence

- New regressions: a failed turn persists once with the error text; a turn that streams then dies keeps its output ahead of the error.
- Focused suites green: `dispatch-acp` (61), `dispatch-acp-delivery`, `dispatch-acp-command-bypass`, `plugin-sdk/acp-runtime` — 126 tests total.
- Live context: codex bind lane 5/5 and gemini bind lane 5/5 on current main with real auth; claude bind lane times out (tracked separately).
- Autoreview (gpt-5.6-sol, xhigh) iterated six rounds and caught five real defects in earlier revisions of this fix — duplicate user-turn writes, lost partial output, blank-prompt records, a dispatch marker set too early, and a finalizer failure recorded as success. Final pass clean.
