### PR TITLE
improve: speed up Teams lifecycle tests

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -54,6 +54,18 @@ const expressControl = vi.hoisted(() => ({
 }));
 
 const isDangerousNameMatchingEnabled = vi.hoisted(() => vi.fn());
+const keepHttpServerTaskAliveMock = vi.hoisted(() =>
+  vi.fn(async (params: { abortSignal?: AbortSignal; onAbort?: () => Promise<void> | void }) => {
+    await new Promise<void>((resolve) => {
+      if (params.abortSignal?.aborted) {
+        resolve();
+        return;
+      }
+      params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+    });
+    await params.onAbort?.();
+  }),
+);
 
 vi.mock("../runtime-api.js", () => ({
   DEFAULT_WEBHOOK_MAX_BODY_BYTES: 1024 * 1024,
@@ -64,18 +76,7 @@ vi.mock("../runtime-api.js", () => ({
     typeof value === "string" && value.trim().length > 0,
   normalizeResolvedSecretInputString: (params: { value?: unknown }) =>
     typeof params?.value === "string" && params.value.trim() ? params.value.trim() : undefined,
-  keepHttpServerTaskAlive: vi.fn(
-    async (params: { abortSignal?: AbortSignal; onAbort?: () => Promise<void> | void }) => {
-      await new Promise<void>((resolve) => {
-        if (params.abortSignal?.aborted) {
-          resolve();
-          return;
-        }
-        params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
-      });
-      await params.onAbort?.();
-    },
-  ),
+  keepHttpServerTaskAlive: keepHttpServerTaskAliveMock,
   mergeAllowlist: (params: { existing?: string[]; additions?: string[] }) =>
     Array.from(new Set([...(params.existing ?? []), ...(params.additions ?? [])])),
   summarizeMapping: vi.fn(),
@@ -221,6 +222,10 @@ vi.mock("./sso-token-store.js", () => ({
 
 import { monitorMSTeamsProvider } from "./monitor.js";
 
+async function waitForMSTeamsTestState(assertion: () => void | Promise<void>): Promise<void> {
+  await vi.waitFor(assertion, { interval: 1 });
+}
+
 function createConfig(port: number): OpenClawConfig {
   return {
     channels: {
@@ -308,13 +313,20 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: stores.pollStore,
     });
 
-    const early = await Promise.race([
-      task.then(() => "resolved"),
-      new Promise<"pending">((resolve) => {
-        setTimeout(() => resolve("pending"), 50);
-      }),
-    ]);
-    expect(early).toBe("pending");
+    let taskSettled = false;
+    void task.then(
+      () => {
+        taskSettled = true;
+      },
+      () => {
+        taskSettled = true;
+      },
+    );
+    await waitForMSTeamsTestState(() => {
+      expect(keepHttpServerTaskAliveMock).toHaveBeenCalledTimes(1);
+    });
+    await Promise.resolve();
+    expect(taskSettled).toBe(false);
 
     abort.abort();
     const result = await task;
@@ -347,7 +359,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(expressControl.apps.length).toBeGreaterThan(0);
     });
 
@@ -396,7 +408,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(expressControl.apps.length).toBeGreaterThan(0);
     });
 
@@ -435,7 +447,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(expressControl.apps.length).toBeGreaterThan(0);
     });
 
@@ -476,7 +488,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -524,7 +536,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(isSigninInvokeAuthorized).toHaveBeenCalledTimes(2);
       expect(ssoTokenStore.save).toHaveBeenCalledTimes(2);
     });
@@ -565,7 +577,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -590,7 +602,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(isSigninInvokeAuthorized).toHaveBeenCalledTimes(1);
     });
     expect(ssoTokenStore.save).not.toHaveBeenCalled();
@@ -615,7 +627,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -654,7 +666,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -722,7 +734,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -759,7 +771,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -827,7 +839,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -887,7 +899,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -956,7 +968,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -1014,7 +1026,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 
@@ -1068,7 +1080,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await vi.waitFor(() => {
+    await waitForMSTeamsTestState(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## What Problem This Solves

The Microsoft Teams monitor lifecycle suite spent roughly 50 ms on every default `vi.waitFor` poll, even though its mocked asynchronous state advances within microtasks. Sixteen tests accumulated about 0.88 seconds of test-body time.

## Why This Change Was Made

Use a shared 1 ms test polling interval while retaining Vitest's existing timeout bound. Replace the lifecycle test's fixed 50 ms pending race with an explicit readiness signal from the existing keep-alive mock, then prove the monitor remains unsettled until abort.

## User Impact

No user-visible or production behavior changes. The focused suite's median test-body time drops from 882 ms to 52 ms.

## Evidence

- Before: 887/855/882 ms; median 882 ms.
- After: 52/51/72 ms; median 52 ms (about 94% faster).
- Testbox `tbx_01kxq8zzs05d48wkm7tt3mpckp`: `node scripts/run-vitest.mjs extensions/msteams/src/monitor.lifecycle.test.ts` — 16/16 passed across each run.
- Same Testbox: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed.
- Autoreview: clean, 0.98 confidence.
