### PR TITLE
fix(secrets): keep gateway alive when web provider refs fail

### DIFF
--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -3,6 +3,7 @@
 import { rm } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { wrapExternalContent } from "../../security/external-content.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import { createWebFetchTool } from "./web-fetch.js";
@@ -32,6 +33,7 @@ describe("web_fetch provider fallback normalization", () => {
     resolveWebFetchDefinitionMock.mockReset();
     runtimeState.activeSecretsRuntimeSnapshot = null;
     runtimeState.activeRuntimeWebToolsMetadata = null;
+    setActiveDegradedSecretOwners([]);
   });
 
   afterEach(() => {
@@ -39,6 +41,35 @@ describe("web_fetch provider fallback normalization", () => {
     vi.restoreAllMocks();
     runtimeState.activeSecretsRuntimeSnapshot = null;
     runtimeState.activeRuntimeWebToolsMetadata = null;
+    setActiveDegradedSecretOwners([]);
+  });
+
+  it("returns typed unavailability for only the isolated fetch provider", async () => {
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "web-fetch:firecrawl",
+        state: "unavailable",
+        paths: ["plugins.entries.firecrawl.config.webFetch.apiKey"],
+        refKeys: ["env:default:MISSING_FIRECRAWL_KEY"],
+        reason: "missing test ref",
+      },
+    ]);
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+      } as OpenClawConfig,
+    });
+
+    await expect(
+      tool?.execute?.("call-provider-fallback", { url: "https://example.com" }),
+    ).rejects.toMatchObject({
+      name: "SecretSurfaceUnavailableError",
+      code: "SECRET_SURFACE_UNAVAILABLE",
+      ownerKind: "capability",
+      ownerId: "web-fetch:firecrawl",
+    });
+    expect(resolveWebFetchDefinitionMock).not.toHaveBeenCalled();
   });
 
   it("re-wraps and truncates provider fallback payloads before caching or returning", async () => {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -15,6 +15,8 @@ import { resolveWebProviderConfig } from "../../../packages/web-content-core/src
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { SsrFBlockedError, type LookupFn, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
+import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
+import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebFetchMetadata } from "../../secrets/runtime-web-tools.types.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -799,16 +801,21 @@ export function createWebFetchTool(options?: {
     description: "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
     parameters: WebFetchSchema,
     execute: async (_toolCallId, args, signal, onUpdate) => {
-      const { config, preferRuntimeProviders, runtimeWebFetch } = resolveWebFetchToolRuntimeContext(
-        {
+      const { config, preferRuntimeProviders, providerSelectionId, runtimeWebFetch } =
+        resolveWebFetchToolRuntimeContext({
           config: options?.config,
           lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
           runtimeWebFetch: options?.runtimeWebFetch,
-        },
-      );
+        });
       const executionFetch = resolveFetchConfig(config);
       if (!resolveFetchEnabled({ fetch: executionFetch, sandboxed: options?.sandboxed })) {
         throw new Error("web_fetch is disabled.");
+      }
+      if (providerSelectionId) {
+        assertSecretOwnerAvailable(
+          "capability",
+          runtimeWebSecretOwnerId("fetch", providerSelectionId),
+        );
       }
       const providerCacheKey =
         normalizeOptionalLowercaseString(runtimeWebFetch?.selectedProvider) ??

--- a/src/agents/tools/web-search.late-bind.test.ts
+++ b/src/agents/tools/web-search.late-bind.test.ts
@@ -1,6 +1,7 @@
 // web_search late-binding tests cover runtime config and provider metadata
 // selection at execution time.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { createWebSearchTool } from "./web-search.js";
 
 const mocks = vi.hoisted(() => ({
@@ -52,6 +53,10 @@ describe("web_search late-bound runtime fallback", () => {
     mocks.getActiveRuntimeWebToolsMetadata.mockReturnValue(null);
     mocks.getActiveSecretsRuntimeConfigSnapshot.mockReset();
     mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    setActiveDegradedSecretOwners([]);
   });
 
   it("falls back to options.runtimeWebSearch when active runtime web tools metadata is absent", async () => {
@@ -169,6 +174,32 @@ describe("web_search late-bound runtime fallback", () => {
     await expect(tool?.execute("call-search", { query: "openclaw" }, undefined)).rejects.toThrow(
       "web_search is disabled.",
     );
+    expect(mocks.runWebSearch).not.toHaveBeenCalled();
+  });
+
+  it("returns typed unavailability for only the isolated search provider", async () => {
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "web-search:brave",
+        state: "unavailable",
+        paths: ["tools.web.search.brave.apiKey"],
+        refKeys: ["env:default:MISSING_BRAVE_KEY"],
+        reason: "missing test ref",
+      },
+    ]);
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { provider: "brave" } } } },
+    });
+
+    await expect(
+      tool?.execute("call-search", { query: "openclaw" }, undefined),
+    ).rejects.toMatchObject({
+      name: "SecretSurfaceUnavailableError",
+      code: "SECRET_SURFACE_UNAVAILABLE",
+      ownerKind: "capability",
+      ownerId: "web-search:brave",
+    });
     expect(mocks.runWebSearch).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -4,6 +4,8 @@
  * Runs the configured runtime provider and returns normalized cached search results.
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
+import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.types.js";
 import { runWebSearch } from "../../web-search/runtime.js";
 import type { AnyAgentTool } from "./common.js";
@@ -94,7 +96,7 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args, signal) => {
       // Late binding lets long-lived agents pick up runtime web-search credentials/config without
       // rebuilding the tool object.
-      const { config, preferRuntimeProviders, runtimeWebSearch } =
+      const { config, preferRuntimeProviders, providerSelectionId, runtimeWebSearch } =
         resolveWebSearchToolRuntimeContext({
           config: options?.config,
           lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
@@ -102,6 +104,12 @@ export function createWebSearchTool(options?: {
         });
       if (isWebSearchDisabled(config)) {
         throw new Error("web_search is disabled.");
+      }
+      if (providerSelectionId) {
+        assertSecretOwnerAvailable(
+          "capability",
+          runtimeWebSecretOwnerId("search", providerSelectionId),
+        );
       }
       const result = await runWebSearch({
         config,

--- a/src/agents/tools/web-tool-runtime-context.ts
+++ b/src/agents/tools/web-tool-runtime-context.ts
@@ -19,6 +19,7 @@ type WebProviderRuntimeMetadata = RuntimeWebFetchMetadata | RuntimeWebSearchMeta
 type ResolvedWebToolRuntimeContext<TMetadata extends WebProviderRuntimeMetadata> = {
   config?: OpenClawConfig;
   preferRuntimeProviders: boolean;
+  providerSelectionId: string;
   runtimeMetadata?: TMetadata;
 };
 
@@ -79,6 +80,7 @@ function resolveWebToolRuntimeContext<TMetadata extends WebProviderRuntimeMetada
       kind: params.kind,
       providerSelectionId,
     }),
+    providerSelectionId,
     runtimeMetadata,
   };
 }
@@ -98,6 +100,7 @@ export function resolveWebSearchToolRuntimeContext(params: {
   return {
     config: resolved.config,
     preferRuntimeProviders: resolved.preferRuntimeProviders,
+    providerSelectionId: resolved.providerSelectionId,
     runtimeWebSearch: resolved.runtimeMetadata,
   };
 }
@@ -117,6 +120,7 @@ export function resolveWebFetchToolRuntimeContext(params: {
   return {
     config: resolved.config,
     preferRuntimeProviders: resolved.preferRuntimeProviders,
+    providerSelectionId: resolved.providerSelectionId,
     runtimeWebFetch: resolved.runtimeMetadata,
   };
 }

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -26,7 +26,14 @@ vi.mock("../gateway/call.js", () => ({
 }));
 
 vi.mock("../secrets/runtime-web-tools.js", () => ({
-  resolveRuntimeWebTools: vi.fn(async () => ({})),
+  resolveRuntimeWebTools: vi.fn(async () => ({
+    metadata: {
+      search: { providerSource: "none", diagnostics: [] },
+      fetch: { providerSource: "none", diagnostics: [] },
+      diagnostics: [],
+    },
+    degradedOwners: [],
+  })),
 }));
 
 vi.mock("../utils/message-channel.js", () => ({

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -806,9 +806,9 @@ describe("gateway startup config secret preflight", () => {
 
   it("does not emit degraded or recovered events for warning-only secret reloads", async () => {
     const warning: SecretResolverWarning = {
-      code: "WEB_SEARCH_KEY_UNRESOLVED_FALLBACK_USED",
-      path: "plugins.entries.google.config.webSearch.apiKey",
-      message: "web search provider fell back to environment credentials",
+      code: "WEB_SEARCH_AUTODETECT_SELECTED",
+      path: "tools.web.search.provider",
+      message: "web search provider was auto-detected",
     };
     const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => ({
       ...preparedSnapshot(config),
@@ -844,7 +844,7 @@ describe("gateway startup config secret preflight", () => {
     expect(result.config).toBe(config);
     expect(result.warnings).toEqual([warning]);
     expect(logSecrets.warn).toHaveBeenCalledWith(
-      "[WEB_SEARCH_KEY_UNRESOLVED_FALLBACK_USED] web search provider fell back to environment credentials",
+      "[WEB_SEARCH_AUTODETECT_SELECTED] web search provider was auto-detected",
     );
     expect(emitStateEvent).not.toHaveBeenCalled();
     const preflightInput = callArg<{ config?: unknown }>(prepareRuntimeSecretsSnapshot);

--- a/src/gateway/server-startup-inactive-web-secret.test.ts
+++ b/src/gateway/server-startup-inactive-web-secret.test.ts
@@ -1,6 +1,7 @@
 /** Gateway startup coverage for active and inactive web-provider SecretRefs. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { getFreePort, installGatewayTestHooks, startGatewayServer } from "./test-helpers.js";
@@ -130,6 +131,7 @@ describe("gateway startup web-provider SecretRefs", () => {
   afterEach(async () => {
     await server?.close();
     server = undefined;
+    setActiveDegradedSecretOwners([]);
   });
 
   it("starts and warns when an unresolved web secret is provably inactive", async () => {
@@ -147,13 +149,27 @@ describe("gateway startup web-provider SecretRefs", () => {
     });
   });
 
-  it("fails closed when the unresolved web secret is active", async () => {
-    await withEnvAsync({ [ACTIVE_SECRET_ENV]: undefined }, async () => {
-      await writeConfig(buildConfig({ enabled: true, envVar: ACTIVE_SECRET_ENV }));
+  it("starts with only the explicit active web provider unavailable", async () => {
+    await withEnvAsync(
+      {
+        [ACTIVE_SECRET_ENV]: undefined,
+        GEMINI_API_KEY: "test-gemini-api-key",
+      },
+      async () => {
+        await writeConfig(buildConfig({ enabled: true, envVar: ACTIVE_SECRET_ENV }));
 
-      await expect(
-        startGatewayServer(await getFreePort(), { auth: { mode: "none" } }),
-      ).rejects.toThrow(/Startup failed: required secrets are unavailable/);
-    });
+        server = await startGatewayServer(await getFreePort(), { auth: { mode: "none" } });
+
+        const snapshot = getActiveSecretsRuntimeSnapshot();
+        expect(snapshot?.degradedOwners).toContainEqual(
+          expect.objectContaining({
+            ownerKind: "capability",
+            ownerId: "web-search:gemini",
+            state: "unavailable",
+            paths: [SECRET_PATH],
+          }),
+        );
+      },
+    );
   });
 });

--- a/src/secrets/runtime-owner-assignments.ts
+++ b/src/secrets/runtime-owner-assignments.ts
@@ -68,7 +68,11 @@ function createDegradedOwner(assignments: SecretAssignment[], reason: string): D
   };
 }
 
-function warnDegradedOwner(context: ResolverContext, owner: DegradedSecretOwner): void {
+/** Emits the canonical warning for one isolated runtime secret owner. */
+export function warnDegradedSecretOwner(
+  context: ResolverContext,
+  owner: DegradedSecretOwner,
+): void {
   pushWarning(context, {
     code: "SECRETS_OWNER_UNAVAILABLE",
     path: owner.paths[0]!,
@@ -159,7 +163,7 @@ export async function resolveAndApplySecretAssignments(params: {
         // would silently route this owner through env/profile fallback after its declared ref failed.
         const degradedOwner = createDegradedOwner(assignments, failureReason);
         degradedOwners.push(degradedOwner);
-        warnDegradedOwner(params.context, degradedOwner);
+        warnDegradedSecretOwner(params.context, degradedOwner);
         continue;
       }
       if (

--- a/src/secrets/runtime-web-secret-owner.ts
+++ b/src/secrets/runtime-web-secret-owner.ts
@@ -1,0 +1,4 @@
+/** Stable degraded-owner id for one configured web provider surface. */
+export function runtimeWebSecretOwnerId(kind: "search" | "fetch", providerId: string): string {
+  return `web-${kind}:${providerId}`;
+}

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -628,7 +628,7 @@ export async function resolveRuntimeWebProviderSelection<
       }
     }
 
-    if (selectedProvider) {
+    if (selectedProvider && !unavailableProvider) {
       params.metadata.selectedProvider = selectedProvider;
       params.metadata.selectedProviderKeySource = selectedResolution?.source;
       if (!params.configuredProvider) {

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -28,9 +28,18 @@ export type SecretResolutionResult<TSource extends string> = {
   value?: string;
   source: TSource;
   secretRefConfigured: boolean;
+  secretRefKey?: string;
   unresolvedRefReason?: string;
   fallbackEnvVar?: string;
-  fallbackUsedAfterRefFailure: boolean;
+};
+
+export type RuntimeWebProviderSelectionResult = {
+  unavailableProvider?: {
+    providerId: string;
+    path: string;
+    refKey: string;
+    reason: string;
+  };
 };
 
 /**
@@ -71,7 +80,8 @@ type RuntimeWebProviderSelectionParams<
   allowKeylessAutoSelect: boolean;
   /** Defer keyless providers until credential-bearing auto-detect candidates are exhausted. */
   deferKeylessFallback: boolean;
-  fallbackUsedCode: RuntimeWebWarningCode;
+  /** Keep cold-start preparation alive when an explicit provider ref cannot resolve. */
+  allowUnavailableExplicitProvider?: boolean;
   noFallbackCode: RuntimeWebWarningCode;
   autoDetectSelectedCode: RuntimeWebWarningCode;
   /** Reads the primary credential location for a provider from source config. */
@@ -388,17 +398,23 @@ export async function resolveRuntimeWebProviderSelection<
   TMetadata extends RuntimeWebProviderMetadataBase<TSource>,
 >(
   params: RuntimeWebProviderSelectionParams<TProvider, TToolConfig, TSource, TMetadata>,
-): Promise<void> {
+): Promise<RuntimeWebProviderSelectionResult> {
   if (params.configuredProvider) {
     params.metadata.providerConfigured = params.configuredProvider;
     params.metadata.providerSource = "configured";
   }
 
+  let unavailableProvider: RuntimeWebProviderSelectionResult["unavailableProvider"];
   if (params.enabled) {
     const candidates = params.configuredProvider
       ? params.providers.filter((provider) => provider.id === params.configuredProvider)
       : params.providers;
-    const unresolvedWithoutFallback: Array<{ provider: string; path: string; reason: string }> = [];
+    const unresolvedWithoutFallback: Array<{
+      provider: string;
+      path: string;
+      refKey?: string;
+      reason: string;
+    }> = [];
 
     let selectedProvider: string | undefined;
     let selectedResolution: SecretResolutionResult<TSource> | undefined;
@@ -472,32 +488,13 @@ export async function resolveRuntimeWebProviderSelection<
 
       if (
         selectedCandidateResolution.secretRefConfigured &&
-        selectedCandidateResolution.fallbackUsedAfterRefFailure
-      ) {
-        const diagnostic: RuntimeWebDiagnostic = {
-          code: params.fallbackUsedCode,
-          message:
-            `${selectedCandidatePath} SecretRef could not be resolved; using ${selectedCandidateResolution.fallbackEnvVar ?? "env fallback"}. ` +
-            (selectedCandidateResolution.unresolvedRefReason ?? "").trim(),
-          path: selectedCandidatePath,
-        };
-        params.diagnostics.push(diagnostic);
-        params.metadata.diagnostics.push(diagnostic);
-        pushWarning(params.context, {
-          code: params.fallbackUsedCode,
-          path: selectedCandidatePath,
-          message: diagnostic.message,
-        });
-      }
-
-      if (
-        selectedCandidateResolution.secretRefConfigured &&
         !selectedCandidateResolution.value &&
         selectedCandidateResolution.unresolvedRefReason
       ) {
         unresolvedWithoutFallback.push({
           provider: provider.id,
           path: selectedCandidatePath,
+          refKey: selectedCandidateResolution.secretRefKey,
           reason: selectedCandidateResolution.unresolvedRefReason,
         });
       }
@@ -572,7 +569,6 @@ export async function resolveRuntimeWebProviderSelection<
       selectedResolution = {
         source: "missing" as TSource,
         secretRefConfigured: false,
-        fallbackUsedAfterRefFailure: false,
       };
     }
 
@@ -595,7 +591,17 @@ export async function resolveRuntimeWebProviderSelection<
     if (params.configuredProvider) {
       const unresolved = unresolvedWithoutFallback[0];
       if (unresolved) {
-        failUnresolvedNoFallback(unresolved);
+        const refKey = unresolved.refKey;
+        if (params.allowUnavailableExplicitProvider && refKey) {
+          unavailableProvider = {
+            providerId: params.configuredProvider,
+            path: unresolved.path,
+            refKey,
+            reason: unresolved.reason,
+          };
+        } else {
+          failUnresolvedNoFallback(unresolved);
+        }
       }
     } else {
       if (!selectedProvider && unresolvedWithoutFallback.length > 0) {
@@ -629,7 +635,7 @@ export async function resolveRuntimeWebProviderSelection<
         params.metadata.providerSource = "auto-detect";
       }
       const provider = params.providers.find((entry) => entry.id === selectedProvider);
-      if (provider && params.mergeRuntimeMetadata) {
+      if (provider && params.mergeRuntimeMetadata && !unavailableProvider) {
         await params.mergeRuntimeMetadata({
           provider,
           metadata: params.metadata,
@@ -660,4 +666,6 @@ export async function resolveRuntimeWebProviderSelection<
       details: `${params.scopePath}.provider is "${params.configuredProvider}".`,
     });
   }
+
+  return unavailableProvider ? { unavailableProvider } : {};
 }

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -899,6 +899,39 @@ describe("runtime web tools resolution", () => {
     );
   });
 
+  it("keeps unresolved auto-detected providers strict during cold-start isolation", async () => {
+    await expect(
+      runRuntimeWebTools({
+        config: asConfig({
+          tools: {
+            web: {
+              search: {
+                enabled: true,
+              },
+            },
+          },
+          plugins: {
+            entries: {
+              google: {
+                enabled: true,
+                config: {
+                  webSearch: {
+                    apiKey: {
+                      source: "env",
+                      provider: "default",
+                      id: "MISSING_GEMINI_API_KEY_REF",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+        allowUnavailableSecretOwners: true,
+      }),
+    ).rejects.toThrow("[WEB_SEARCH_KEY_UNRESOLVED_NO_FALLBACK]");
+  });
+
   it("auto-detects Gemini from the Google model provider key after env fallbacks", async () => {
     const { metadata, resolvedConfig } = await runRuntimeWebTools({
       config: asConfig({

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -281,19 +281,24 @@ function buildTestWebFetchProviders(): PluginWebFetchProviderEntry[] {
   ];
 }
 
-async function runRuntimeWebTools(params: { config: OpenClawConfig; env?: NodeJS.ProcessEnv }) {
+async function runRuntimeWebTools(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  allowUnavailableSecretOwners?: boolean;
+}) {
   const sourceConfig = structuredClone(params.config);
   const resolvedConfig = structuredClone(params.config);
   const context = createResolverContext({
     sourceConfig,
     env: params.env ?? {},
   });
-  const metadata = await resolveRuntimeWebTools({
+  const result = await resolveRuntimeWebTools({
     sourceConfig,
     resolvedConfig,
     context,
+    allowUnavailableSecretOwners: params.allowUnavailableSecretOwners,
   });
-  return { metadata, resolvedConfig, context };
+  return { ...result, resolvedConfig, context };
 }
 
 function createProviderSecretRefConfig(
@@ -409,7 +414,7 @@ describe("runtime web tools resolution", () => {
             firecrawl: {
               config: {
                 webFetch: {
-                  apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY_REF" },
+                  apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
                 },
               },
             },
@@ -431,7 +436,7 @@ describe("runtime web tools resolution", () => {
     expect(metadata.search.selectedProvider).toBeUndefined();
     expect(metadata.search.providerSource).toBe("none");
     expect(metadata.fetch.selectedProvider).toBe("firecrawl");
-    expect(metadata.fetch.selectedProviderKeySource).toBe("env");
+    expect(metadata.fetch.selectedProviderKeySource).toBe("secretRef");
     expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
@@ -1475,8 +1480,8 @@ describe("runtime web tools resolution", () => {
     expect(firstMockArg(resolvePluginWebFetchProvidersMock).sandboxed).toBe(true);
   });
 
-  it("uses env fallback for unresolved web fetch provider SecretRef when active", async () => {
-    const { metadata, resolvedConfig, context } = await runRuntimeWebTools({
+  it("isolates an explicit web fetch provider instead of using env after its ref fails", async () => {
+    const { metadata, resolvedConfig, context, degradedOwners } = await runRuntimeWebTools({
       config: asConfig({
         plugins: {
           entries: {
@@ -1500,19 +1505,31 @@ describe("runtime web tools resolution", () => {
       env: {
         FIRECRAWL_API_KEY: "firecrawl-fallback-key", // pragma: allowlist secret
       },
+      allowUnavailableSecretOwners: true,
     });
 
-    expect(metadata.fetch.selectedProvider).toBe("firecrawl");
-    expect(metadata.fetch.selectedProviderKeySource).toBe("env");
+    expect(metadata.fetch.providerConfigured).toBe("firecrawl");
+    expect(metadata.fetch.selectedProvider).toBeUndefined();
+    expect(metadata.fetch.selectedProviderKeySource).toBeUndefined();
     expect(
       (
         resolvedConfig.plugins?.entries?.firecrawl?.config as
           | { webFetch?: { apiKey?: unknown } }
           | undefined
       )?.webFetch?.apiKey,
-    ).toBe("firecrawl-fallback-key");
+    ).toEqual({ source: "env", provider: "default", id: "MISSING_FIRECRAWL_REF" });
+    expect(degradedOwners).toContainEqual(
+      expect.objectContaining({
+        ownerKind: "capability",
+        ownerId: "web-fetch:firecrawl",
+        state: "unavailable",
+        paths: ["plugins.entries.firecrawl.config.webFetch.apiKey"],
+        reason: expect.stringContaining("MISSING_FIRECRAWL_REF"),
+      }),
+    );
+    expect(degradedOwners[0]?.refKeys).toEqual(["env:default:MISSING_FIRECRAWL_REF"]);
     expectDiagnostic(context.warnings, {
-      code: "WEB_FETCH_PROVIDER_KEY_UNRESOLVED_FALLBACK_USED",
+      code: "SECRETS_OWNER_UNAVAILABLE",
       path: "plugins.entries.firecrawl.config.webFetch.apiKey",
     });
   });

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -64,7 +64,7 @@ type SecretResolutionSource =
   | WebSearchCredentialResolutionSource
   | WebFetchCredentialResolutionSource;
 
-export type ResolvedRuntimeWebTools = {
+type ResolvedRuntimeWebTools = {
   metadata: RuntimeWebToolsMetadata;
   degradedOwners: DegradedSecretOwner[];
 };

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -20,14 +20,18 @@ import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import { secretRefKey } from "./ref-contract.js";
 import { resolveSecretRefValues } from "./resolve.js";
+import type { DegradedSecretOwner } from "./runtime-degraded-state.js";
+import { warnDegradedSecretOwner } from "./runtime-owner-assignments.js";
 import { hasCredentialBearingObjectValue } from "./runtime-secret-scan.js";
 import type { ResolverContext, SecretDefaults } from "./runtime-shared.js";
+import { runtimeWebSecretOwnerId } from "./runtime-web-secret-owner.js";
 import {
   ensureObject,
   hasConfiguredSecretRef,
   isRecord,
   resolveRuntimeWebProviderSurface,
   resolveRuntimeWebProviderSelection,
+  type RuntimeWebProviderSelectionResult,
   type SecretResolutionResult,
 } from "./runtime-web-tools.shared.js";
 import type {
@@ -59,6 +63,33 @@ type FetchConfig = NonNullable<OpenClawConfig["tools"]>["web"] extends infer Web
 type SecretResolutionSource =
   | WebSearchCredentialResolutionSource
   | WebFetchCredentialResolutionSource;
+
+export type ResolvedRuntimeWebTools = {
+  metadata: RuntimeWebToolsMetadata;
+  degradedOwners: DegradedSecretOwner[];
+};
+
+function collectUnavailableWebProvider(params: {
+  kind: "search" | "fetch";
+  result: RuntimeWebProviderSelectionResult;
+  context: ResolverContext;
+  degradedOwners: DegradedSecretOwner[];
+}): void {
+  const unavailable = params.result.unavailableProvider;
+  if (!unavailable) {
+    return;
+  }
+  const owner: DegradedSecretOwner = {
+    ownerKind: "capability",
+    ownerId: runtimeWebSecretOwnerId(params.kind, unavailable.providerId),
+    state: "unavailable",
+    paths: [unavailable.path],
+    refKeys: [unavailable.refKey],
+    reason: unavailable.reason,
+  };
+  params.degradedOwners.push(owner);
+  warnDegradedSecretOwner(params.context, owner);
+}
 
 function needsRuntimeWebFetchProviderDiscovery(params: {
   fetch: FetchConfig;
@@ -230,7 +261,6 @@ async function resolveSecretInputWithEnvFallback(params: {
         value: configValue,
         source: "config",
         secretRefConfigured: false,
-        fallbackUsedAfterRefFailure: false,
       };
     }
     const fallback = readNonEmptyEnvValue(params.context.env, params.envVars);
@@ -240,13 +270,11 @@ async function resolveSecretInputWithEnvFallback(params: {
         source: "env",
         fallbackEnvVar: fallback.envVar,
         secretRefConfigured: false,
-        fallbackUsedAfterRefFailure: false,
       };
     }
     return {
       source: "missing",
       secretRefConfigured: false,
-      fallbackUsedAfterRefFailure: false,
     };
   }
 
@@ -299,29 +327,15 @@ async function resolveSecretInputWithEnvFallback(params: {
       value: resolvedFromRef,
       source: "secretRef",
       secretRefConfigured: true,
-      fallbackUsedAfterRefFailure: false,
-    };
-  }
-
-  const fallback = readNonEmptyEnvValue(params.context.env, params.envVars);
-  if (fallback.value) {
-    // Provider env vars remain the explicit recovery path for unresolved refs so startup can
-    // continue while diagnostics still report which configured SecretRef failed.
-    return {
-      value: fallback.value,
-      source: "env",
-      fallbackEnvVar: fallback.envVar,
-      unresolvedRefReason,
-      secretRefConfigured: true,
-      fallbackUsedAfterRefFailure: true,
+      secretRefKey: secretRefKey(ref),
     };
   }
 
   return {
     source: "missing",
+    secretRefKey: secretRefKey(ref),
     unresolvedRefReason,
     secretRefConfigured: true,
-    fallbackUsedAfterRefFailure: false,
   };
 }
 
@@ -521,9 +535,15 @@ export async function resolveRuntimeWebTools(params: {
   sourceConfig: OpenClawConfig;
   resolvedConfig: OpenClawConfig;
   context: ResolverContext;
-}): Promise<RuntimeWebToolsMetadata> {
+  allowUnavailableSecretOwners?: boolean;
+}): Promise<ResolvedRuntimeWebTools> {
   const defaults = params.sourceConfig.secrets?.defaults;
   const diagnostics: RuntimeWebDiagnostic[] = [];
+  const degradedOwners: DegradedSecretOwner[] = [];
+  const finish = (metadata: RuntimeWebToolsMetadata): ResolvedRuntimeWebTools => ({
+    metadata,
+    degradedOwners,
+  });
   const env = { ...process.env, ...params.context.env };
 
   const sourceTools = isRecord(params.sourceConfig.tools) ? params.sourceConfig.tools : undefined;
@@ -578,7 +598,7 @@ export async function resolveRuntimeWebTools(params: {
   const hasPluginWebSearchConfig = hasPluginScopedWebToolConfig(params.sourceConfig, "webSearch");
   const hasPluginWebFetchConfig = hasPluginScopedWebToolConfig(params.sourceConfig, "webFetch");
   if (!sourceWeb && !hasPluginWebSearchConfig && !hasPluginWebFetchConfig) {
-    return {
+    return finish({
       search: {
         providerSource: "none",
         diagnostics: [],
@@ -588,12 +608,12 @@ export async function resolveRuntimeWebTools(params: {
         diagnostics: [],
       },
       diagnostics,
-    };
+    });
   }
   const search = isRecord(sourceWeb?.search) ? sourceWeb.search : undefined;
   const fetch = isRecord(sourceWeb?.fetch) ? (sourceWeb.fetch as FetchConfig) : undefined;
   if (!search && !fetch && !hasPluginWebSearchConfig && !hasPluginWebFetchConfig) {
-    return {
+    return finish({
       search: {
         providerSource: "none",
         diagnostics: [],
@@ -603,7 +623,7 @@ export async function resolveRuntimeWebTools(params: {
         diagnostics: [],
       },
       diagnostics,
-    };
+    });
   }
   const rawProvider = normalizeLowercaseStringOrEmpty(search?.provider);
   let configuredBundledWebSearchPluginIdHint: string | undefined;
@@ -661,7 +681,7 @@ export async function resolveRuntimeWebTools(params: {
       normalizeConfiguredProviderAgainstActiveProviders: true,
     });
 
-    await resolveRuntimeWebProviderSelection({
+    const searchSelection = await resolveRuntimeWebProviderSelection({
       scopePath: "tools.web.search",
       toolConfig: search,
       enabled: searchSurface.enabled,
@@ -675,7 +695,7 @@ export async function resolveRuntimeWebTools(params: {
       defaults,
       allowKeylessAutoSelect: false,
       deferKeylessFallback: true,
-      fallbackUsedCode: "WEB_SEARCH_KEY_UNRESOLVED_FALLBACK_USED",
+      allowUnavailableExplicitProvider: params.allowUnavailableSecretOwners,
       noFallbackCode: "WEB_SEARCH_KEY_UNRESOLVED_NO_FALLBACK",
       autoDetectSelectedCode: "WEB_SEARCH_AUTODETECT_SELECTED",
       readConfiguredCredential: ({ provider, config, toolConfig }) =>
@@ -728,6 +748,12 @@ export async function resolveRuntimeWebTools(params: {
         );
       },
     });
+    collectUnavailableWebProvider({
+      kind: "search",
+      result: searchSelection,
+      context: params.context,
+      degradedOwners,
+    });
   }
 
   const rawFetchProvider = normalizeLowercaseStringOrEmpty(fetch?.provider);
@@ -774,7 +800,7 @@ export async function resolveRuntimeWebTools(params: {
         }),
     });
 
-    await resolveRuntimeWebProviderSelection({
+    const fetchSelection = await resolveRuntimeWebProviderSelection({
       scopePath: "tools.web.fetch",
       toolConfig: fetch,
       enabled: fetchSurface.enabled,
@@ -788,7 +814,7 @@ export async function resolveRuntimeWebTools(params: {
       defaults,
       allowKeylessAutoSelect: true,
       deferKeylessFallback: false,
-      fallbackUsedCode: "WEB_FETCH_PROVIDER_KEY_UNRESOLVED_FALLBACK_USED",
+      allowUnavailableExplicitProvider: params.allowUnavailableSecretOwners,
       noFallbackCode: "WEB_FETCH_PROVIDER_KEY_UNRESOLVED_NO_FALLBACK",
       autoDetectSelectedCode: "WEB_FETCH_AUTODETECT_SELECTED",
       readConfiguredCredential: ({ provider, config, toolConfig }) =>
@@ -842,12 +868,18 @@ export async function resolveRuntimeWebTools(params: {
         );
       },
     });
+    collectUnavailableWebProvider({
+      kind: "fetch",
+      result: fetchSelection,
+      context: params.context,
+      degradedOwners,
+    });
   }
 
-  return {
+  return finish({
     search: searchMetadata,
     fetch: fetchMetadata,
     diagnostics,
-  };
+  });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/secrets/runtime.auth.integration.test.ts
+++ b/src/secrets/runtime.auth.integration.test.ts
@@ -58,9 +58,12 @@ vi.mock("./runtime-prepare.runtime.js", () => ({
     }
   },
   resolveRuntimeWebTools: async () => ({
-    search: { providerSource: "none", diagnostics: [] },
-    fetch: { providerSource: "none", diagnostics: [] },
-    diagnostics: [],
+    metadata: {
+      search: { providerSource: "none", diagnostics: [] },
+      fetch: { providerSource: "none", diagnostics: [] },
+      diagnostics: [],
+    },
+    degradedOwners: [],
   }),
 }));
 

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -16,9 +16,12 @@ import { asConfig } from "./runtime.test-support.js";
 
 const { resolveRuntimeWebToolsMock, runtimePrepareImportMock } = vi.hoisted(() => ({
   resolveRuntimeWebToolsMock: vi.fn(async () => ({
-    search: { providerSource: "none", diagnostics: [] },
-    fetch: { providerSource: "none", diagnostics: [] },
-    diagnostics: [],
+    metadata: {
+      search: { providerSource: "none", diagnostics: [] },
+      fetch: { providerSource: "none", diagnostics: [] },
+      diagnostics: [],
+    },
+    degradedOwners: [],
   })),
   runtimePrepareImportMock: vi.fn(),
 }));

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -247,18 +247,20 @@ export async function prepareSecretsRuntimeSnapshot(params: {
         })
       : [];
 
+  const webTools = await resolveRuntimeWebTools({
+    sourceConfig,
+    resolvedConfig,
+    context,
+    allowUnavailableSecretOwners: params.allowUnavailableSecretOwners,
+  });
   const snapshot = {
     sourceConfig,
     config: resolvedConfig,
     authStores,
     authStoreCredentialsRevision,
     warnings: context.warnings,
-    degradedOwners,
-    webTools: await resolveRuntimeWebTools({
-      sourceConfig,
-      resolvedConfig,
-      context,
-    }),
+    degradedOwners: [...degradedOwners, ...webTools.degradedOwners],
+    webTools: webTools.metadata,
   };
   setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
     env: runtimeEnv,


### PR DESCRIPTION
Related: #108485
Related: #101265

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Gateway startup failed, or silently used provider environment credentials, when an explicitly configured active web-search or web-fetch SecretRef could not resolve.

## Why This Change Was Made

Cold startup now isolates only the explicitly configured web provider as a degraded capability. The Gateway starts, unrelated providers remain available, and calls to the isolated provider return the canonical typed unavailable error. Strict reload and command resolution remain fail-closed. The legacy environment fallback after a failed explicit ref is removed; ordinary environment auto-detection remains unchanged.

AI-assisted implementation. I reviewed the owner boundary, runtime callers, command callers, web-tool execution paths, sibling search/fetch behavior, startup activation, tests, and current SecretRef degradation contract.

## User Impact

Operators can start the Gateway when one web provider credential ref is temporarily broken. Only that exact provider stays cold, with degraded-owner visibility, instead of blocking the whole Gateway or silently switching credential sources.

## Evidence

- Autoreview: clean, no accepted/actionable findings (confidence 0.91).
- Focused Testbox proof: 59 tests passed across Gateway startup, web SecretRef resolution, and typed web-search/web-fetch unavailability.
- Full Testbox changed gate: green in 19m10s, including format, Plugin SDK baseline, production and test typechecks, all core lint shards, plugin boundaries, database-first guards, runtime import cycles, and webhook/pairing guards.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29557117928
- Final rebase preserved the exact patch (`git patch-id --stable`: `69fc3d30ad67e44d56fe0b8df2cc6d6d2792e4e9`).
- After the final rebase, the Plugin SDK baseline mismatch reproduces on clean latest `origin/main`; generated branch and main baseline JSON/JSONL are byte-for-byte identical. No SDK surface change comes from this patch.
