### PR TITLE
fix(apple): prevent silent OpenClawKit test regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2839,6 +2839,9 @@ jobs:
           fi
           swift build --package-path apps/shared/OpenClawKit --target OpenClawKit --disable-default-traits
 
+      - name: OpenClawKit tests
+        run: swift test --package-path apps/shared/OpenClawKit --parallel
+
       - name: Swift test
         run: |
           set -euo pipefail

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -447,7 +447,9 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         }
         await MainActor.run { viewModel.load() }
         try await waitUntil("legacy gateway bootstrap completed") {
-            await MainActor.run { viewModel.healthOK && !viewModel.isLoading }
+            await MainActor.run {
+                viewModel.healthOK && !viewModel.isLoading && viewModel.hasRestoredOutboxMessages
+            }
         }
         await MainActor.run {
             viewModel.attachments = [

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -9539,7 +9539,9 @@ struct ChatViewModelTests {
         }
         await MainActor.run { vm.switchSession(to: "other") }
         try await waitUntil("Beta other session opens") {
-            await MainActor.run { vm.sessionKey == "other" && vm.sessionId == "sess-other" }
+            await MainActor.run {
+                vm.sessionKey == "other" && vm.sessionId == "sess-other" && !vm.isLoading
+            }
         }
         let betaLevelsBeforeOldFailure = await MainActor.run {
             vm.sessions.map { "\($0.key)=\($0.thinkingLevel ?? "nil")" }.sorted()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
@@ -56,9 +56,9 @@ struct GatewayErrorsTests {
 
         let problem = try #require(GatewayConnectionProblemMapper.map(error: error))
 
-        #expect(problem.titlePresentation == .localized("Pairing approval required"))
+        #expect(problem.titlePresentation == .localized("This device is not approved yet"))
         #expect(problem.messagePresentation == .localized(
-            "Approve this device on the gateway, then reconnect."))
+            "The gateway received the connection request, but this device must be approved first."))
         #expect(problem.actionLabelPresentation == .localized("Approve on gateway"))
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/WatchCommandsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/WatchCommandsTests.swift
@@ -71,7 +71,7 @@ struct WatchCommandsTests {
     @Test func `unknown semantic statuses fall back to legacy text`() throws {
         let json = """
         {
-          "type": "watch.appSnapshot",
+          "type": "watch.app.snapshot",
           "gatewayStatus": {"code": "futureGateway", "arguments": []},
           "gatewayStatusText": "Future gateway state",
           "gatewayConnected": true,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the standalone OpenClawKit test suite drifted red without detection because the macOS CI lane tested only the app package. The suite also contained two bootstrap ordering races that could fail under parallel load.

## Why This Change Was Made

The assertions now match current gateway copy, and the watch fallback fixture uses the canonical `watch.app.snapshot` wire value. History shows `watch.appSnapshot` was never emitted by a shipped producer, so no compatibility alias is added. The attachment and replacement-agent tests now wait for their actual bootstrap-owned readiness states before exercising later behavior. The existing macOS runner also executes OpenClawKit tests directly; this adds only an incremental SwiftPM step instead of another runner.

## User Impact

No runtime behavior changes. Apple shared-library regressions now fail CI, while the affected parallel tests no longer race incomplete bootstrap work.

AI-assisted: yes.

## Evidence

- Before: `swift test --package-path apps/shared/OpenClawKit --parallel` failed with two stale gateway-copy expectations and the invalid watch payload type.
- After: five consecutive full parallel runs passed, 827 tests in 73 suites each.
- The newly exposed replacement-agent ordering test passed 30 consecutive focused runs after synchronizing on bootstrap completion.
- SwiftLint: 0 violations. SwiftFormat: 0 files requiring formatting. `actionlint`: clean.
- Changed gate: https://github.com/openclaw/openclaw/actions/runs/29558298713 (exit 0; 5 Vitest shards passed).
- Autoreview: clean, no accepted/actionable findings.
