### PR TITLE
fix(ui): avoid broken assistant avatars in Personal settings

### DIFF
--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -2,13 +2,13 @@
 import { describe, expect, it } from "vitest";
 import { AVATAR_MAX_DATA_URL_CHARS } from "../../../../src/shared/avatar-limits.js";
 import {
+  assistantAvatarFallbackUrl,
   isRenderableControlUiAvatarUrl,
   resolveAgentAvatarUrl,
   resolveAssistantTextAvatar,
   resolveChatAvatarRenderUrl,
 } from "../avatar.ts";
 import {
-  assistantAvatarFallbackUrl,
   buildAgentContext,
   formatBytes,
   resolveEffectiveModelFallbacks,

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -14,7 +14,6 @@ import type {
   ToolCatalogProfile,
   ToolsCatalogResult,
 } from "../../api/types.ts";
-import { controlUiPublicAssetPath } from "../../app/public-assets.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveAgentAvatarUrl, resolveAssistantTextAvatar } from "../avatar.ts";
 import { buildQualifiedChatModelValue } from "../chat/model-ref.ts";
@@ -295,10 +294,6 @@ export function normalizeAgentLabel(agent: {
   return (
     normalizeOptionalString(agent.name) ?? normalizeOptionalString(agent.identity?.name) ?? agent.id
   );
-}
-
-export function assistantAvatarFallbackUrl(basePath: string): string {
-  return controlUiPublicAssetPath("apple-touch-icon.png", basePath);
 }
 
 export function resolveAgentTextAvatar(

--- a/ui/src/lib/avatar.ts
+++ b/ui/src/lib/avatar.ts
@@ -1,10 +1,15 @@
 import { isRenderableAvatarImageDataUrl } from "../../../src/shared/avatar-limits.js";
 import type { AgentIdentityResult } from "../api/types.ts";
+import { controlUiPublicAssetPath } from "../app/public-assets.ts";
 import { DEFAULT_ASSISTANT_AVATAR } from "./assistant-identity.ts";
 import { normalizeOptionalString } from "./string-coerce.ts";
 
 const CONTROL_UI_SAME_ORIGIN_AVATAR_URL_RE = /^\/(?!\/)/;
 const UNSAFE_ASSISTANT_TEXT_AVATAR_CHARS = /[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/u;
+
+export function assistantAvatarFallbackUrl(basePath: string): string {
+  return controlUiPublicAssetPath("apple-touch-icon.png", basePath);
+}
 
 export function isRenderableControlUiAvatarUrl(value: string): boolean {
   return isRenderableAvatarImageDataUrl(value) || CONTROL_UI_SAME_ORIGIN_AVATAR_URL_RE.test(value);

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -1,10 +1,8 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { renderChatAvatar } from "./chat-avatar.ts";
-
-vi.unmock("../../lib/agents/display.ts");
 
 function renderAvatar(params: Parameters<typeof renderChatAvatar>) {
   const container = document.createElement("div");

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -8,9 +8,12 @@ import {
   resolveLocalUserAvatarUrl,
   resolveLocalUserName,
 } from "../../app/user-identity.ts";
-import { assistantAvatarFallbackUrl } from "../../lib/agents/display.ts";
 import type { AssistantIdentity } from "../../lib/assistant-identity.ts";
-import { isRenderableControlUiAvatarUrl, resolveAssistantTextAvatar } from "../../lib/avatar.ts";
+import {
+  assistantAvatarFallbackUrl,
+  isRenderableControlUiAvatarUrl,
+  resolveAssistantTextAvatar,
+} from "../../lib/avatar.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import {
   DEFAULT_AGENT_ID,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -295,10 +295,6 @@ vi.mock("../../lib/agents/tools-effective.ts", () => ({
   refreshVisibleToolsEffectiveForCurrentSession: refreshVisibleToolsEffectiveForCurrentSessionMock,
 }));
 
-vi.mock("../../lib/agents/display.ts", () => ({
-  assistantAvatarFallbackUrl: () => "apple-touch-icon.png",
-}));
-
 function createSessionsResultFromRows(
   sessions: GatewaySessionRow[],
   overrides: Partial<

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -707,6 +707,36 @@ describe("renderQuickSettings", () => {
     ).toBe("/avatar/main");
   });
 
+  it("falls back to the built-in logo when the assistant avatar request fails", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderQuickSettings(
+        createProps({
+          assistantName: "Nova",
+          assistantAvatar: "assets/avatars/nova-portrait.png",
+          assistantAvatarUrl: "/openclaw/avatar/main",
+          assistantAvatarStatus: "local",
+          basePath: "/openclaw",
+        }),
+      ),
+      container,
+    );
+
+    const avatar = container.querySelector<HTMLImageElement>(
+      ".config-identity--assistant .config-identity__avatar",
+    );
+    expect(avatar?.getAttribute("src")).toBe("/openclaw/avatar/main");
+
+    avatar?.dispatchEvent(new Event("error"));
+
+    expect(avatar?.getAttribute("src")).toBe("/openclaw/apple-touch-icon.png");
+    expect(avatar?.classList.contains("config-identity__avatar--fallback")).toBe(true);
+
+    avatar?.dispatchEvent(new Event("error"));
+    expect(avatar?.getAttribute("src")).toBe("/openclaw/apple-touch-icon.png");
+  });
+
   it("shows the configured avatar source when the assistant falls back to the logo", () => {
     const container = document.createElement("div");
 

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -737,6 +737,51 @@ describe("renderQuickSettings", () => {
     expect(avatar?.getAttribute("src")).toBe("/openclaw/apple-touch-icon.png");
   });
 
+  it("clears the fallback class after a rerendered assistant avatar loads", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderQuickSettings(
+        createProps({
+          assistantName: "Nova",
+          assistantAvatar: "/avatar/main",
+          assistantAvatarUrl: "/avatar/main",
+          assistantAvatarStatus: "local",
+        }),
+      ),
+      container,
+    );
+
+    const avatar = container.querySelector<HTMLImageElement>(
+      ".config-identity--assistant .config-identity__avatar",
+    );
+    avatar?.dispatchEvent(new Event("error"));
+    expect(avatar?.classList.contains("config-identity__avatar--fallback")).toBe(true);
+
+    render(
+      renderQuickSettings(
+        createProps({
+          assistantName: "Nova",
+          assistantAvatar: "/avatar/recovered",
+          assistantAvatarUrl: "/avatar/recovered",
+          assistantAvatarStatus: "local",
+        }),
+      ),
+      container,
+    );
+
+    const recoveredAvatar = container.querySelector<HTMLImageElement>(
+      ".config-identity--assistant .config-identity__avatar",
+    );
+    expect(recoveredAvatar).toBe(avatar);
+    expect(recoveredAvatar?.getAttribute("src")).toBe("/avatar/recovered");
+    expect(recoveredAvatar?.classList.contains("config-identity__avatar--fallback")).toBe(true);
+
+    recoveredAvatar?.dispatchEvent(new Event("load"));
+
+    expect(recoveredAvatar?.classList.contains("config-identity__avatar--fallback")).toBe(false);
+  });
+
   it("shows the configured avatar source when the assistant falls back to the logo", () => {
     const container = document.createElement("div");
 

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -9,7 +9,6 @@ import { html, nothing, type TemplateResult } from "lit";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { formatFastModeValue } from "../../../../src/shared/fast-mode.js";
 import type { FastMode } from "../../api/types.ts";
-import { controlUiPublicAssetPath } from "../../app/public-assets.ts";
 import type { TextScaleStop } from "../../app/settings.ts";
 import type { ThemeTransitionContext } from "../../app/theme-transition.ts";
 import type { ThemeMode, ThemeName } from "../../app/theme.ts";
@@ -40,7 +39,11 @@ import {
 } from "../../components/settings-ui.ts";
 import { t, type Locale } from "../../i18n/index.ts";
 import { formatBytes } from "../../lib/agents/display.ts";
-import { resolveAssistantTextAvatar, resolveChatAvatarRenderUrl } from "../../lib/avatar.ts";
+import {
+  assistantAvatarFallbackUrl,
+  resolveAssistantTextAvatar,
+  resolveChatAvatarRenderUrl,
+} from "../../lib/avatar.ts";
 import type { ConfigAutoSaveStatus } from "../../lib/config/index.ts";
 import { formatDurationHuman } from "../../lib/format.ts";
 import { normalizeOptionalString } from "../../lib/string-coerce.ts";
@@ -287,12 +290,23 @@ function handleAssistantAvatarPreviewError(event: Event, props: QuickSettingsPro
   if (!(image instanceof HTMLImageElement)) {
     return;
   }
-  const fallbackUrl = controlUiPublicAssetPath("apple-touch-icon.png", props.basePath ?? "");
+  const fallbackUrl = assistantAvatarFallbackUrl(props.basePath ?? "");
   if (image.getAttribute("src") === fallbackUrl) {
     return;
   }
   image.src = fallbackUrl;
   image.classList.add("config-identity__avatar--fallback");
+}
+
+function handleAssistantAvatarPreviewLoad(event: Event, props: QuickSettingsProps) {
+  const image = event.currentTarget;
+  if (!(image instanceof HTMLImageElement)) {
+    return;
+  }
+  // Lit reuses this image across URL rerenders, including classes added after an earlier failure.
+  if (image.getAttribute("src") !== assistantAvatarFallbackUrl(props.basePath ?? "")) {
+    image.classList.remove("config-identity__avatar--fallback");
+  }
 }
 
 function renderAssistantAvatarPreview(props: QuickSettingsProps) {
@@ -306,6 +320,7 @@ function renderAssistantAvatarPreview(props: QuickSettingsProps) {
       src=${assistantAvatarUrl}
       alt=${assistantName}
       @error=${(event: Event) => handleAssistantAvatarPreviewError(event, props)}
+      @load=${(event: Event) => handleAssistantAvatarPreviewLoad(event, props)}
     />`;
   }
   const assistantAvatarText = resolveAssistantTextAvatar(
@@ -322,7 +337,7 @@ function renderAssistantAvatarPreview(props: QuickSettingsProps) {
   return html`
     <img
       class="config-identity__avatar config-identity__avatar--fallback"
-      src=${controlUiPublicAssetPath("apple-touch-icon.png", props.basePath ?? "")}
+      src=${assistantAvatarFallbackUrl(props.basePath ?? "")}
       alt=${assistantName}
     />
   `;

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -282,6 +282,19 @@ function formatAssistantAvatarIssue(
   return reason ? t("quickSettings.personal.avatarIssues.cannotRender") : null;
 }
 
+function handleAssistantAvatarPreviewError(event: Event, props: QuickSettingsProps) {
+  const image = event.currentTarget;
+  if (!(image instanceof HTMLImageElement)) {
+    return;
+  }
+  const fallbackUrl = controlUiPublicAssetPath("apple-touch-icon.png", props.basePath ?? "");
+  if (image.getAttribute("src") === fallbackUrl) {
+    return;
+  }
+  image.src = fallbackUrl;
+  image.classList.add("config-identity__avatar--fallback");
+}
+
 function renderAssistantAvatarPreview(props: QuickSettingsProps) {
   const assistantName =
     normalizeOptionalString(props.assistantName) ?? t("quickSettings.personal.assistant");
@@ -292,6 +305,7 @@ function renderAssistantAvatarPreview(props: QuickSettingsProps) {
       class="config-identity__avatar"
       src=${assistantAvatarUrl}
       alt=${assistantName}
+      @error=${(event: Event) => handleAssistantAvatarPreviewError(event, props)}
     />`;
   }
   const assistantAvatarText = resolveAssistantTextAvatar(


### PR DESCRIPTION
Related: #107853

## What Problem This Solves

Fixes an issue where users opening Settings > Simple > Personal would see a broken assistant image when a previously resolved avatar became unavailable or failed to load.

## Why This Change Was Made

The Personal card now keeps the resolved assistant avatar URL for the initial request, then switches the failed image to the existing base-path-aware OpenClaw fallback logo. The fallback is idempotent, so a failure of the fallback asset does not keep rewriting the image source.

## User Impact

Users see a stable assistant identity card instead of a browser broken-image indicator when an avatar file is deleted, moved, or temporarily unavailable.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/config/quick.test.ts` - 36 tests passed.
- Focused Chromium proof with a mocked Gateway and a forced `404` for `/avatar/main` - the Personal card rendered the fallback logo, retained the assistant name, and produced the redacted 728x303 screenshot below.

![Personal settings avatar fallback after forced 404](https://raw.githubusercontent.com/DaigoSoup/openclaw/b4b507eb9269f4660b34cc20c7400db83960ec5e/avatar-fallback.png)
- Source-blind behavior contract - passed initial resolved-avatar rendering, failed-request fallback, base-path preservation, identity text preservation, and repeated-error idempotence.
- Targeted `oxfmt --check` for `ui/src/pages/config/quick.ts` and `ui/src/pages/config/quick.test.ts` - passed.
- `git diff --check` - passed.
- Autoreview was attempted with `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`, but Codex Responses WebSocket access returned HTTP `403 Forbidden`. The benign smoke harness failed through the same transport path, so no structured review verdict or findings were produced. PR CI remains the review backstop.

AI-assisted: yes. I reviewed the implementation and understand the change.