### PR TITLE
fix: guard forceFreePort and killPids against ESRCH race

### DIFF
--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -241,6 +241,9 @@ export function forceFreePort(port: number): PortProcess[] {
     try {
       process.kill(proc.pid, "SIGTERM");
     } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") {
+        continue;
+      }
       throw new Error(
         `failed to kill pid ${proc.pid}${proc.command ? ` (${proc.command})` : ""}: ${String(err)}`,
         { cause: err },
@@ -255,6 +258,9 @@ function killPids(listeners: PortProcess[], signal: NodeJS.Signals) {
     try {
       process.kill(proc.pid, signal);
     } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") {
+        continue;
+      }
       throw new Error(
         `failed to kill pid ${proc.pid}${proc.command ? ` (${proc.command})` : ""}: ${String(err)}`,
         { cause: err },

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -189,6 +189,40 @@ describe("gateway --force helpers", () => {
     expect(() => forceFreePort(18789)).toThrow(/lsof not found/);
   });
 
+  it("swallows ESRCH when a listener exits between port listing and signal", () => {
+    (execFileSync as unknown as Mock).mockReturnValue(
+      ["p42", "cnode", "p99", "cssh", ""].join("\n"),
+    );
+    const esrchErr = Object.assign(new Error("no such process"), { code: "ESRCH" });
+    const killMock = vi
+      .fn()
+      .mockReturnValueOnce(undefined) // PID 42 — success
+      .mockImplementationOnce(() => {
+        throw esrchErr; // PID 99 — exited after listing
+      });
+    process.kill = killMock;
+
+    const killed = forceFreePort(18789);
+
+    expect(killMock).toHaveBeenCalledTimes(2);
+    expect(killMock).toHaveBeenCalledWith(42, "SIGTERM");
+    expect(killMock).toHaveBeenCalledWith(99, "SIGTERM");
+    expect(killed).toEqual<PortProcess[]>([
+      { pid: 42, command: "node" },
+      { pid: 99, command: "ssh" },
+    ]);
+  });
+
+  it("re-throws non-ESRCH kill errors", () => {
+    (execFileSync as unknown as Mock).mockReturnValue(["p42", "cnode", ""].join("\n"));
+    const epermErr = Object.assign(new Error("permission denied"), { code: "EPERM" });
+    process.kill = vi.fn().mockImplementation(() => {
+      throw epermErr;
+    });
+
+    expect(() => forceFreePort(18789)).toThrow(/failed to kill pid 42/);
+  });
+
   it("kills each listener and returns metadata", () => {
     (execFileSync as unknown as Mock).mockReturnValue(
       ["p42", "cnode", "p99", "cssh", ""].join("\n"),


### PR DESCRIPTION
## What Problem This Solves

`forceFreePort()` and `killPids()` in `src/cli/ports.ts` have a TOCTOU race condition: between calling `listPortListeners()` and `process.kill()`, the target process can exit. When this happens, `process.kill()` throws ESRCH, but the catch block re-wraps it as a generic error instead of recognizing that an already-exited process has freed the port.

The same pattern was fixed in the gateway process signaling path (#109590).

## Evidence

### Tests

- `src/cli/program.force.test.ts` — 28 tests pass, including 2 new tests:
  - "swallows ESRCH when a listener exits between port listing and signal" — verifies both PIDs are still returned and no error is thrown
  - "re-throws non-ESRCH kill errors" — verifies EPERM is still propagated
- All 5 `src/cli/ports.test.ts` tests continue to pass

### CI

```
 Test Files  1 passed
      Tests  28 passed
```

## Why This Change Was Made

This is a targeted guard: check for ESRCH code in the catch block and `continue` to the next PID, since the port is already freed by the exited process. Non-ESRCH errors (EPERM, etc.) are still re-thrown.

## Merge Risk

Low. The change is +6 lines across 2 production functions and follows an established pattern already accepted in the codebase.