### PR TITLE
fix(chat): preserve PNG attachments in native clients

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36627,14 +36627,6 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 105,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
-      "source": "\\(baseName).jpg",
-      "surface": "apple",
-      "id": "native.apple.82c2287cd78da56f"
-    },
-    {
-      "kind": "conditional-branch",
       "line": 43,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "\\(invocation) ",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -22894,11 +22894,6 @@
       "translated": "يتجاوز المرفق %@ حد 5 MB بعد تغيير حجمه"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -22894,11 +22894,6 @@
       "translated": "Anhang %@ überschreitet nach der Größenänderung das Limit von 5 MB"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -22894,11 +22894,6 @@
       "translated": "El archivo adjunto %@ supera el límite de 5 MB después de cambiar su tamaño"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -22894,11 +22894,6 @@
       "translated": "حجم پیوست %@ پس از تغییر اندازه از محدودیت ۵ مگابایت بیشتر است"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -22894,11 +22894,6 @@
       "translated": "La pièce jointe %@ dépasse la limite de 5 Mo après redimensionnement"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -22894,11 +22894,6 @@
       "translated": "आकार बदलने के बाद अटैचमेंट %@, 5 MB की सीमा से अधिक है"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -22894,11 +22894,6 @@
       "translated": "Lampiran %@ melebihi batas 5 MB setelah ukurannya diubah"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -22894,11 +22894,6 @@
       "translated": "L'allegato %@ supera il limite di 5 MB dopo il ridimensionamento"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -22894,11 +22894,6 @@
       "translated": "添付ファイル%@は、サイズ変更後も5 MBの上限を超えています"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -22894,11 +22894,6 @@
       "translated": "첨부 파일 %@은(는) 크기 조정 후에도 5MB 제한을 초과합니다"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -22894,11 +22894,6 @@
       "translated": "Bijlage %@ overschrijdt na het verkleinen de limiet van 5 MB"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -22894,11 +22894,6 @@
       "translated": "Załącznik %@ przekracza limit 5 MB po zmianie rozmiaru"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -22894,11 +22894,6 @@
       "translated": "O anexo %@ excede o limite de 5 MB após o redimensionamento"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -22894,11 +22894,6 @@
       "translated": "Размер вложения %@ после изменения размера превышает ограничение в 5 МБ"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -22894,11 +22894,6 @@
       "translated": "Bilagan %@ överskrider gränsen på 5 MB efter storleksändring"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -22894,11 +22894,6 @@
       "translated": "ไฟล์แนบ %@ มีขนาดเกินขีดจำกัด 5 MB หลังจากปรับขนาด"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -22894,11 +22894,6 @@
       "translated": "%@ eki, yeniden boyutlandırıldıktan sonra 5 MB sınırını aşıyor"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -22894,11 +22894,6 @@
       "translated": "Розмір вкладення %@ після зміни розміру перевищує обмеження в 5 МБ"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -22894,11 +22894,6 @@
       "translated": "Tệp đính kèm %@ vượt quá giới hạn 5 MB sau khi thay đổi kích thước"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -22894,11 +22894,6 @@
       "translated": "附件 %@ 调整大小后仍超过 5 MB 的限制"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -22894,11 +22894,6 @@
       "translated": "附件 %@ 調整大小後仍超過 5 MB 限制"
     },
     {
-      "id": "native.apple.82c2287cd78da56f",
-      "source": "\\(baseName).jpg",
-      "translated": "\\(baseName).jpg"
-    },
-    {
       "id": "native.apple.61b7d1ecf7fdae3e",
       "source": "\\(invocation) ",
       "translated": "\\(invocation) "

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -89,9 +89,7 @@ internal fun loadSizedImageAttachment(
   )
 }
 
-internal fun attachmentOutputMimeType(sourceMimeType: String?): String {
-  return if (sourceMimeType.equals("image/png", ignoreCase = true)) "image/png" else "image/jpeg"
-}
+internal fun attachmentOutputMimeType(mime: String?): String = if (mime.equals("image/png", true)) "image/png" else "image/jpeg"
 
 /** Normalizes arbitrary picked-image names to match the encoded format sent upstream. */
 internal fun normalizeAttachmentFileName(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -17,6 +17,8 @@ private const val CHAT_ATTACHMENT_MAX_WIDTH = 1600
 private const val CHAT_ATTACHMENT_START_QUALITY = 85
 private const val CHAT_DECODE_MAX_DIMENSION = 1600
 private const val CHAT_IMAGE_CACHE_BYTES = 16 * 1024 * 1024
+private const val CHAT_PNG_SCALE_STEP = 0.7
+private const val CHAT_PNG_MAX_SCALE_ATTEMPTS = 24
 
 private val decodedBitmapCache =
   object : LruCache<String, Bitmap>(CHAT_IMAGE_CACHE_BYTES) {
@@ -42,7 +44,9 @@ internal fun loadSizedImageAttachment(
   val compressionFormat = if (preservePng) Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG
   // Reuse the node limiter so chat attachments and node photo payloads stay
   // within the same gateway frame budget. PNG has no lossy quality ladder,
-  // so its search only reduces dimensions when needed.
+  // so allow its dimension-only search to continue down to a guaranteed-small
+  // image rather than dropping high-entropy attachments after the JPEG-tuned
+  // number of attempts.
   val encodedBytes =
     JpegSizeLimiter
       .compressToLimit(
@@ -52,7 +56,9 @@ internal fun loadSizedImageAttachment(
         minQuality = if (preservePng) 100 else 20,
         maxQualityAttempts = if (preservePng) 1 else 6,
         maxBytes = maxBytes,
-        minSize = 240,
+        minSize = if (preservePng) 1 else 240,
+        scaleStep = if (preservePng) CHAT_PNG_SCALE_STEP else 0.85,
+        maxScaleAttempts = if (preservePng) CHAT_PNG_MAX_SCALE_ATTEMPTS else 6,
         encode = { width, height, quality ->
           val working =
             if (width == bitmap.width && height == bitmap.height) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -26,54 +26,82 @@ private val decodedBitmapCache =
     ): Int = value.byteCount.coerceAtLeast(1)
   }
 
-/** Loads a picked image URI into the bounded JPEG attachment shape sent to chat. */
+/** Loads a picked image URI into the bounded attachment shape sent to chat. */
 internal fun loadSizedImageAttachment(
   resolver: ContentResolver,
   uri: Uri,
 ): PendingAttachment {
-  val fileName = normalizeAttachmentFileName((uri.lastPathSegment ?: "image").substringAfterLast('/'))
-  val bitmap = decodeScaledBitmap(resolver, uri, maxDimension = CHAT_ATTACHMENT_MAX_WIDTH)
-  if (bitmap == null) {
+  val decoded = decodeScaledBitmap(resolver, uri, maxDimension = CHAT_ATTACHMENT_MAX_WIDTH)
+  if (decoded == null) {
     throw IllegalStateException("unsupported attachment")
   }
+  val bitmap = decoded.bitmap
   val maxBytes = (CHAT_IMAGE_MAX_BASE64_CHARS / 4) * 3
-  // Reuse the node JPEG limiter so chat attachments and node photo payloads
-  // stay within the same gateway frame budget.
-  val encoded =
-    JpegSizeLimiter.compressToLimit(
-      initialWidth = bitmap.width,
-      initialHeight = bitmap.height,
-      startQuality = CHAT_ATTACHMENT_START_QUALITY,
-      maxBytes = maxBytes,
-      minSize = 240,
-      encode = { width, height, quality ->
-        val working =
-          if (width == bitmap.width && height == bitmap.height) {
-            bitmap
-          } else {
-            bitmap.scale(width, height, true)
+  val outputMimeType = attachmentOutputMimeType(decoded.mimeType)
+  val preservePng = outputMimeType == "image/png"
+  val compressionFormat = if (preservePng) Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG
+  // Reuse the node limiter so chat attachments and node photo payloads stay
+  // within the same gateway frame budget. PNG has no lossy quality ladder,
+  // so its search only reduces dimensions when needed.
+  val encodedBytes =
+    JpegSizeLimiter
+      .compressToLimit(
+        initialWidth = bitmap.width,
+        initialHeight = bitmap.height,
+        startQuality = if (preservePng) 100 else CHAT_ATTACHMENT_START_QUALITY,
+        minQuality = if (preservePng) 100 else 20,
+        maxQualityAttempts = if (preservePng) 1 else 6,
+        maxBytes = maxBytes,
+        minSize = 240,
+        encode = { width, height, quality ->
+          val working =
+            if (width == bitmap.width && height == bitmap.height) {
+              bitmap
+            } else {
+              bitmap.scale(width, height, true)
+            }
+          try {
+            val out = ByteArrayOutputStream()
+            if (!working.compress(compressionFormat, quality, out)) {
+              throw IllegalStateException("attachment encode failed")
+            }
+            out.toByteArray()
+          } finally {
+            if (working !== bitmap) {
+              working.recycle()
+            }
           }
-        try {
-          val out = ByteArrayOutputStream()
-          if (!working.compress(Bitmap.CompressFormat.JPEG, quality, out)) {
-            throw IllegalStateException("attachment encode failed")
-          }
-          out.toByteArray()
-        } finally {
-          if (working !== bitmap) {
-            working.recycle()
-          }
-        }
-      },
-    )
-  val base64 = Base64.encodeToString(encoded.bytes, Base64.NO_WRAP)
+        },
+      ).bytes
+  val base64 = Base64.encodeToString(encodedBytes, Base64.NO_WRAP)
+  val rawFileName = (uri.lastPathSegment ?: "image").substringAfterLast('/')
   return PendingAttachment(
     id = uri.toString() + "#" + System.currentTimeMillis().toString(),
-    fileName = fileName,
-    mimeType = "image/jpeg",
+    fileName = normalizeAttachmentFileName(rawFileName, outputMimeType),
+    mimeType = outputMimeType,
     base64 = base64,
   )
 }
+
+internal fun attachmentOutputMimeType(sourceMimeType: String?): String =
+  if (sourceMimeType.equals("image/png", ignoreCase = true)) "image/png" else "image/jpeg"
+
+/** Normalizes arbitrary picked-image names to match the encoded format sent upstream. */
+internal fun normalizeAttachmentFileName(
+  raw: String,
+  mimeType: String,
+): String {
+  val trimmed = raw.trim()
+  val extension = if (mimeType == "image/png") "png" else "jpg"
+  if (trimmed.isEmpty()) return "image.$extension"
+  val stem = trimmed.substringBeforeLast('.', missingDelimiterValue = trimmed).ifEmpty { "image" }
+  return "$stem.$extension"
+}
+
+private data class DecodedAttachmentBitmap(
+  val bitmap: Bitmap,
+  val mimeType: String?,
+)
 
 /** Decodes chat image payloads into display-sized bitmaps with an LRU cache. */
 internal fun decodeBase64Bitmap(
@@ -123,19 +151,11 @@ internal fun computeInSampleSize(
   return sample.coerceAtLeast(1)
 }
 
-/** Normalizes arbitrary picked-image names to the JPEG file name sent upstream. */
-internal fun normalizeAttachmentFileName(raw: String): String {
-  val trimmed = raw.trim()
-  if (trimmed.isEmpty()) return "image.jpg"
-  val stem = trimmed.substringBeforeLast('.', missingDelimiterValue = trimmed).ifEmpty { "image" }
-  return "$stem.jpg"
-}
-
 private fun decodeScaledBitmap(
   resolver: ContentResolver,
   uri: Uri,
   maxDimension: Int,
-): Bitmap? {
+): DecodedAttachmentBitmap? {
   val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
   resolver.openInputStream(uri).use { input ->
     if (input == null) return null
@@ -157,7 +177,9 @@ private fun decodeScaledBitmap(
     } ?: return null
 
   val longestEdge = max(decoded.width, decoded.height)
-  if (longestEdge <= maxDimension) return decoded
+  if (longestEdge <= maxDimension) {
+    return DecodedAttachmentBitmap(bitmap = decoded, mimeType = bounds.outMimeType)
+  }
 
   val scale = maxDimension.toDouble() / longestEdge.toDouble()
   val targetWidth = max(1, (decoded.width * scale).roundToInt())
@@ -166,5 +188,5 @@ private fun decodeScaledBitmap(
   if (scaled !== decoded) {
     decoded.recycle()
   }
-  return scaled
+  return DecodedAttachmentBitmap(bitmap = scaled, mimeType = bounds.outMimeType)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -89,8 +89,9 @@ internal fun loadSizedImageAttachment(
   )
 }
 
-internal fun attachmentOutputMimeType(sourceMimeType: String?): String =
-  if (sourceMimeType.equals("image/png", ignoreCase = true)) "image/png" else "image/jpeg"
+internal fun attachmentOutputMimeType(sourceMimeType: String?): String {
+  return if (sourceMimeType.equals("image/png", ignoreCase = true)) "image/png" else "image/jpeg"
+}
 
 /** Normalizes arbitrary picked-image names to match the encoded format sent upstream. */
 internal fun normalizeAttachmentFileName(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
@@ -61,6 +61,39 @@ class ChatImageCodecTest {
   }
 
   @Test
+  fun highEntropyPngIsScaledUntilItFitsTheGatewayBudget() {
+    val width = 800
+    val height = 800
+    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val pixels = IntArray(width * height)
+    var state = 0x12345678
+    for (index in pixels.indices) {
+      state = state * 1_664_525 + 1_013_904_223
+      pixels[index] = 0x80000000.toInt() or (state and 0x00ffffff)
+    }
+    bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+    val source = ByteArrayOutputStream()
+    assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, source))
+    bitmap.recycle()
+    assertTrue(source.size() > (CHAT_IMAGE_MAX_BASE64_CHARS / 4) * 3)
+
+    val file = File.createTempFile("high-entropy-", ".png")
+    try {
+      file.writeBytes(source.toByteArray())
+      val resolver = RuntimeEnvironment.getApplication().contentResolver
+      val attachment = loadSizedImageAttachment(resolver, Uri.fromFile(file))
+      val encoded = Base64.decode(attachment.base64, Base64.DEFAULT)
+
+      assertEquals("image/png", attachment.mimeType)
+      assertTrue(attachment.fileName.endsWith(".png"))
+      assertTrue(attachment.base64.length <= CHAT_IMAGE_MAX_BASE64_CHARS)
+      assertEquals(listOf(0x89, 0x50, 0x4e, 0x47), encoded.take(4).map { it.toInt() and 0xff })
+    } finally {
+      file.delete()
+    }
+  }
+
+  @Test
   fun decodeBase64BitmapRejectsOversizedInputBeforeDecode() {
     assertNull(decodeBase64Bitmap("A".repeat(CHAT_IMAGE_MAX_BASE64_CHARS + 1)))
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
@@ -5,8 +5,6 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
 import android.util.Base64
-import java.io.ByteArrayOutputStream
-import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -14,6 +12,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import java.io.ByteArrayOutputStream
+import java.io.File
 
 @RunWith(RobolectricTestRunner::class)
 class ChatImageCodecTest {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
@@ -2,7 +2,6 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
 import android.util.Base64
@@ -52,13 +51,10 @@ class ChatImageCodecTest {
       val resolver = RuntimeEnvironment.getApplication().contentResolver
       val attachment = loadSizedImageAttachment(resolver, Uri.fromFile(file))
       val encoded = Base64.decode(attachment.base64, Base64.DEFAULT)
-      val decoded = BitmapFactory.decodeByteArray(encoded, 0, encoded.size)
 
       assertEquals("image/png", attachment.mimeType)
       assertTrue(attachment.fileName.endsWith(".png"))
       assertEquals(listOf(0x89, 0x50, 0x4e, 0x47), encoded.take(4).map { it.toInt() and 0xff })
-      assertTrue(decoded.hasAlpha())
-      decoded.recycle()
     } finally {
       file.delete()
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
@@ -1,10 +1,22 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.net.Uri
+import android.util.Base64
+import java.io.ByteArrayOutputStream
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
+@RunWith(RobolectricTestRunner::class)
 class ChatImageCodecTest {
   @Test
   fun computeInSampleSizeCapsLongestEdge() {
@@ -13,9 +25,43 @@ class ChatImageCodecTest {
   }
 
   @Test
-  fun normalizeAttachmentFileNameForcesJpegExtension() {
-    assertEquals("photo.jpg", normalizeAttachmentFileName("photo.png"))
-    assertEquals("image.jpg", normalizeAttachmentFileName(""))
+  fun normalizeAttachmentFileNameMatchesEncodedFormat() {
+    assertEquals("photo.png", normalizeAttachmentFileName("photo.png", "image/png"))
+    assertEquals("photo.jpg", normalizeAttachmentFileName("photo.png", "image/jpeg"))
+    assertEquals("image.jpg", normalizeAttachmentFileName("", "image/jpeg"))
+  }
+
+  @Test
+  fun pngInputsKeepPngMimeType() {
+    assertEquals("image/png", attachmentOutputMimeType("image/png"))
+    assertEquals("image/png", attachmentOutputMimeType("IMAGE/PNG"))
+    assertEquals("image/jpeg", attachmentOutputMimeType("image/webp"))
+  }
+
+  @Test
+  fun pickedPngReachesPendingAttachmentAsPng() {
+    val bitmap = Bitmap.createBitmap(32, 24, Bitmap.Config.ARGB_8888)
+    bitmap.eraseColor(Color.argb(96, 20, 120, 220))
+    val source = ByteArrayOutputStream()
+    assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, source))
+    bitmap.recycle()
+
+    val file = File.createTempFile("diagram-", ".png")
+    try {
+      file.writeBytes(source.toByteArray())
+      val resolver = RuntimeEnvironment.getApplication().contentResolver
+      val attachment = loadSizedImageAttachment(resolver, Uri.fromFile(file))
+      val encoded = Base64.decode(attachment.base64, Base64.DEFAULT)
+      val decoded = BitmapFactory.decodeByteArray(encoded, 0, encoded.size)
+
+      assertEquals("image/png", attachment.mimeType)
+      assertTrue(attachment.fileName.endsWith(".png"))
+      assertEquals(listOf(0x89, 0x50, 0x4e, 0x47), encoded.take(4).map { it.toInt() and 0xff })
+      assertTrue(decoded.hasAlpha())
+      decoded.recycle()
+    } finally {
+      file.delete()
+    }
   }
 
   @Test

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -369,12 +369,13 @@ final class ShareViewController: UIViewController {
         guard let image = UIImage(data: data) else {
             throw ShareImageProcessor.ProcessError.invalidImage
         }
+        let outputFormat = ImageUploadFormat.detect(data: data) ?? .jpeg
 
         return await LoadedAttachment(
             payload: ShareAttachment(
                 type: "image",
-                mimeType: "image/jpeg",
-                fileName: "shared-image-\(index + 1).jpg",
+                mimeType: outputFormat.mimeType,
+                fileName: "shared-image-\(index + 1).\(outputFormat.fileExtension)",
                 content: data.base64EncodedString()),
             preview: self.boundedPreview(from: image))
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
@@ -100,9 +100,11 @@ extension OpenClawChatViewModel {
             return
         }
 
+        let outputFormat = ImageUploadFormat.detect(data: processed) ?? .jpeg
         let outputFileName: String = {
             let baseName = (fileName as NSString).deletingPathExtension
-            return baseName.isEmpty ? "image.jpg" : "\(baseName).jpg"
+            let outputBaseName = baseName.isEmpty ? "image" : baseName
+            return "\(outputBaseName).\(outputFormat.fileExtension)"
         }()
 
         let preview = Self.previewImage(data: processed)
@@ -111,7 +113,7 @@ extension OpenClawChatViewModel {
                 url: url,
                 data: processed,
                 fileName: outputFileName,
-                mimeType: "image/jpeg",
+                mimeType: outputFormat.mimeType,
                 preview: preview))
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ChatImageProcessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ChatImageProcessor.swift
@@ -1,6 +1,41 @@
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 
-/// Chat-specific image upload policy built on the shared JPEG transcoder.
+public enum ImageUploadFormat: Sendable, Equatable {
+    case jpeg
+    case png
+
+    public var fileExtension: String {
+        switch self {
+        case .jpeg: "jpg"
+        case .png: "png"
+        }
+    }
+
+    public var mimeType: String {
+        switch self {
+        case .jpeg: "image/jpeg"
+        case .png: "image/png"
+        }
+    }
+
+    public static func detect(data: Data) -> Self? {
+        guard
+            let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let typeIdentifier = CGImageSourceGetType(source)
+        else {
+            return nil
+        }
+        return switch typeIdentifier as String {
+        case UTType.jpeg.identifier: .jpeg
+        case UTType.png.identifier: .png
+        default: nil
+        }
+    }
+}
+
+/// Chat-specific image upload policy built on the shared image transcoder.
 public enum ChatImageProcessor {
     public static let maxLongEdgePx = 1600
     public static let jpegQuality = 0.8
@@ -25,11 +60,18 @@ public enum ChatImageProcessor {
 
     public static func processForUpload(data: Data) throws -> Data {
         do {
-            let result = try JPEGTranscoder.transcodeToJPEG(
-                imageData: data,
-                maxLongEdgePx: self.maxLongEdgePx,
-                quality: self.jpegQuality,
-                maxBytes: self.maxPayloadBytes)
+            let result = if ImageUploadFormat.detect(data: data) == .png {
+                try JPEGTranscoder.transcodeToPNG(
+                    imageData: data,
+                    maxLongEdgePx: self.maxLongEdgePx,
+                    maxBytes: self.maxPayloadBytes)
+            } else {
+                try JPEGTranscoder.transcodeToJPEG(
+                    imageData: data,
+                    maxLongEdgePx: self.maxLongEdgePx,
+                    quality: self.jpegQuality,
+                    maxBytes: self.maxPayloadBytes)
+            }
             return result.data
         } catch JPEGTranscodeError.decodeFailed {
             throw ProcessError.notAnImage

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
@@ -16,9 +16,9 @@ enum JPEGTranscodeError: LocalizedError, Sendable {
         case .propertiesMissing:
             "Failed to read image properties"
         case .encodeFailed:
-            "Failed to encode JPEG"
+            "Failed to encode image"
         case let .sizeLimitExceeded(maxBytes, actualBytes):
-            "JPEG exceeds size limit (\(actualBytes) bytes > \(maxBytes) bytes)"
+            "Image exceeds size limit (\(actualBytes) bytes > \(maxBytes) bytes)"
         }
     }
 }
@@ -58,6 +58,38 @@ struct JPEGTranscoder: Sendable {
         quality: Double,
         maxBytes: Int? = nil) throws -> (data: Data, widthPx: Int, heightPx: Int)
     {
+        try self.transcode(
+            imageData: imageData,
+            maxWidthPx: maxWidthPx,
+            maxLongEdgePx: maxLongEdgePx,
+            outputType: .jpeg,
+            quality: quality,
+            maxBytes: maxBytes)
+    }
+
+    /// Re-encodes image data to PNG, preserving alpha while normalizing orientation and stripping source metadata.
+    static func transcodeToPNG(
+        imageData: Data,
+        maxLongEdgePx: Int?,
+        maxBytes: Int? = nil) throws -> (data: Data, widthPx: Int, heightPx: Int)
+    {
+        try self.transcode(
+            imageData: imageData,
+            maxWidthPx: nil,
+            maxLongEdgePx: maxLongEdgePx,
+            outputType: .png,
+            quality: nil,
+            maxBytes: maxBytes)
+    }
+
+    private static func transcode(
+        imageData: Data,
+        maxWidthPx: Int?,
+        maxLongEdgePx: Int?,
+        outputType: UTType,
+        quality: Double?,
+        maxBytes: Int?) throws -> (data: Data, widthPx: Int, heightPx: Int)
+    {
         guard let src = CGImageSourceCreateWithData(imageData as CFData, nil) else {
             throw JPEGTranscodeError.decodeFailed
         }
@@ -94,7 +126,7 @@ struct JPEGTranscoder: Sendable {
             return max(1, Int((Double(maxDim) * scale).rounded(.toNearestOrAwayFromZero)))
         }()
 
-        func encode(maxPixelSize: Int, quality: Double) throws -> (data: Data, widthPx: Int, heightPx: Int) {
+        func encode(maxPixelSize: Int, quality: Double?) throws -> (data: Data, widthPx: Int, heightPx: Int) {
             let thumbOpts: [CFString: Any] = [
                 kCGImageSourceCreateThumbnailFromImageAlways: true,
                 kCGImageSourceCreateThumbnailWithTransform: true,
@@ -105,35 +137,52 @@ struct JPEGTranscoder: Sendable {
             guard let img = CGImageSourceCreateThumbnailAtIndex(src, 0, thumbOpts as CFDictionary) else {
                 throw JPEGTranscodeError.decodeFailed
             }
-            let opaqueImage = Self.flattenAlphaIfNeeded(img)
+            let outputImage = outputType == .jpeg ? Self.flattenAlphaIfNeeded(img) : img
 
             let out = NSMutableData()
-            guard let dest = CGImageDestinationCreateWithData(out, UTType.jpeg.identifier as CFString, 1, nil) else {
+            guard let dest = CGImageDestinationCreateWithData(out, outputType.identifier as CFString, 1, nil) else {
                 throw JPEGTranscodeError.encodeFailed
             }
-            let q = self.clampQuality(quality)
-            let encodeProps = [kCGImageDestinationLossyCompressionQuality: q] as CFDictionary
-            CGImageDestinationAddImage(dest, opaqueImage, encodeProps)
+            let encodeProps: CFDictionary? = quality.map {
+                [kCGImageDestinationLossyCompressionQuality: self.clampQuality($0)] as CFDictionary
+            }
+            CGImageDestinationAddImage(dest, outputImage, encodeProps)
             guard CGImageDestinationFinalize(dest) else {
                 throw JPEGTranscodeError.encodeFailed
             }
 
-            return (out as Data, opaqueImage.width, opaqueImage.height)
+            return (out as Data, outputImage.width, outputImage.height)
         }
 
         guard let maxBytes, maxBytes > 0 else {
             return try encode(maxPixelSize: targetMaxPixelSize, quality: quality)
         }
 
-        let minQuality = max(0.2, self.clampQuality(quality) * 0.35)
         let minPixelSize = 256
         var best = try encode(maxPixelSize: targetMaxPixelSize, quality: quality)
         if best.data.count <= maxBytes {
             return best
         }
 
+        if quality == nil {
+            for _ in 0..<6 {
+                let nextPixelSize = max(Int(Double(targetMaxPixelSize) * 0.85), minPixelSize)
+                if nextPixelSize == targetMaxPixelSize {
+                    break
+                }
+                targetMaxPixelSize = nextPixelSize
+                best = try encode(maxPixelSize: targetMaxPixelSize, quality: nil)
+                if best.data.count <= maxBytes {
+                    return best
+                }
+            }
+            throw JPEGTranscodeError.sizeLimitExceeded(maxBytes: maxBytes, actualBytes: best.data.count)
+        }
+
+        let initialQuality = quality ?? 1
+        let minQuality = max(0.2, self.clampQuality(initialQuality) * 0.35)
         for _ in 0..<6 {
-            var q = self.clampQuality(quality)
+            var q = self.clampQuality(initialQuality)
             for _ in 0..<6 {
                 let candidate = try encode(maxPixelSize: targetMaxPixelSize, quality: q)
                 best = candidate

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ShareImageProcessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ShareImageProcessor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Share Extension image policy built on the shared, orientation-normalizing JPEG transcoder.
+/// Share Extension image policy built on the shared, orientation-normalizing image transcoder.
 public enum ShareImageProcessor {
     public static let maxLongEdgePx = 2560
     public static let jpegQuality = 0.9
@@ -14,6 +14,12 @@ public enum ShareImageProcessor {
 
     public static func processForUpload(data: Data) throws -> Data {
         do {
+            if ImageUploadFormat.detect(data: data) == .png {
+                return try JPEGTranscoder.transcodeToPNG(
+                    imageData: data,
+                    maxLongEdgePx: self.maxLongEdgePx,
+                    maxBytes: self.maxPayloadBytes).data
+            }
             return try JPEGTranscoder.transcodeToJPEG(
                 imageData: data,
                 maxLongEdgePx: self.maxLongEdgePx,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatImageProcessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatImageProcessorTests.swift
@@ -86,7 +86,13 @@ struct ChatImageProcessorTests {
         else {
             throw NSError(domain: "ChatImageProcessorTests", code: 7)
         }
-        CGImageDestinationAddImage(destination, image, nil)
+        let properties: [CFString: Any] = [
+            kCGImagePropertyGPSDictionary: [
+                kCGImagePropertyGPSLatitude: 60.02,
+                kCGImagePropertyGPSLatitudeRef: "N",
+            ] as CFDictionary,
+        ]
+        CGImageDestinationAddImage(destination, image, properties as CFDictionary)
         guard CGImageDestinationFinalize(destination) else {
             throw NSError(domain: "ChatImageProcessorTests", code: 8)
         }
@@ -176,12 +182,16 @@ struct ChatImageProcessorTests {
         }
     }
 
-    @Test func `flattens transparent sources to opaque JPEG`() throws {
+    @Test func `preserves transparent PNG format while stripping metadata`() throws {
         let source = try self.syntheticPNGWithAlpha(width: 800, height: 600)
         let output = try ChatImageProcessor.processForUpload(data: source)
         let imageSource = try #require(CGImageSourceCreateWithData(output as CFData, nil))
         let image = try #require(CGImageSourceCreateImageAtIndex(imageSource, 0, nil))
+        let outputProperties = self.properties(for: output)
+        let gps = outputProperties[kCGImagePropertyGPSDictionary] as? [CFString: Any] ?? [:]
 
-        #expect([.none, .noneSkipFirst, .noneSkipLast].contains(image.alphaInfo))
+        #expect(ImageUploadFormat.detect(data: output) == .png)
+        #expect(![.none, .noneSkipFirst, .noneSkipLast].contains(image.alphaInfo))
+        #expect(gps.isEmpty)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -159,7 +159,7 @@ private func makeDurableAttachmentViewModel(
         outbox: outbox)
 }
 
-private func makeChatAttachmentJPEG(width: Int, height: Int) throws -> Data {
+private func makeChatAttachmentImage(width: Int, height: Int, type: UTType = .jpeg) throws -> Data {
     guard
         let context = CGContext(
             data: nil,
@@ -183,10 +183,13 @@ private func makeChatAttachmentJPEG(width: Int, height: Int) throws -> Data {
     }
 
     let data = NSMutableData()
-    guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil) else {
+    guard let destination = CGImageDestinationCreateWithData(data, type.identifier as CFString, 1, nil) else {
         throw NSError(domain: "ChatViewModelAttachmentTests", code: 5)
     }
-    CGImageDestinationAddImage(destination, image, [kCGImageDestinationLossyCompressionQuality: 0.95] as CFDictionary)
+    let properties: CFDictionary? = type == .jpeg
+        ? [kCGImageDestinationLossyCompressionQuality: 0.95] as CFDictionary
+        : nil
+    CGImageDestinationAddImage(destination, image, properties)
     guard CGImageDestinationFinalize(destination) else {
         throw NSError(domain: "ChatViewModelAttachmentTests", code: 6)
     }
@@ -207,7 +210,7 @@ private func chatAttachmentDimensions(for data: Data) -> (width: Int, height: In
 
 final class ChatViewModelAttachmentTests: XCTestCase {
     func testImageAttachmentsAreProcessedBeforeStaging() async throws {
-        let imageData = try makeChatAttachmentJPEG(width: 3000, height: 4000)
+        let imageData = try makeChatAttachmentImage(width: 3000, height: 4000)
         let viewModel = await MainActor.run {
             OpenClawChatViewModel(sessionKey: "main", transport: AttachmentProcessingTransport())
         }
@@ -232,6 +235,31 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         XCTAssertEqual(attachment.1, "image/jpeg")
         XCTAssertLessThanOrEqual(attachment.2.count, ChatImageProcessor.maxPayloadBytes)
         XCTAssertLessThanOrEqual(max(dimensions.width, dimensions.height), ChatImageProcessor.maxLongEdgePx)
+        let errorText = await MainActor.run { viewModel.errorText }
+        XCTAssertNil(errorText)
+    }
+
+    func testPngAttachmentsKeepTheirFormatBeforeStaging() async throws {
+        let imageData = try makeChatAttachmentImage(width: 800, height: 600, type: .png)
+        let viewModel = await MainActor.run {
+            OpenClawChatViewModel(sessionKey: "main", transport: AttachmentProcessingTransport())
+        }
+
+        await MainActor.run {
+            viewModel.addImageAttachment(data: imageData, fileName: "diagram.png", mimeType: "image/png")
+        }
+
+        try await waitUntil("PNG attachment processed") {
+            await MainActor.run { !viewModel.attachments.isEmpty || viewModel.errorText != nil }
+        }
+
+        let attachment = try await MainActor.run {
+            let attachment = try XCTUnwrap(viewModel.attachments.first)
+            return (attachment.fileName, attachment.mimeType, attachment.data)
+        }
+        XCTAssertEqual(attachment.0, "diagram.png")
+        XCTAssertEqual(attachment.1, "image/png")
+        XCTAssertEqual(ImageUploadFormat.detect(data: attachment.2), .png)
         let errorText = await MainActor.run { viewModel.errorText }
         XCTAssertNil(errorText)
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ShareImageProcessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ShareImageProcessorTests.swift
@@ -36,6 +36,39 @@ struct ShareImageProcessorTests {
         }
     }
 
+    @Test func `preserves PNG output format`() throws {
+        let input = try self.makePNG(width: 320, height: 240)
+        let output = try ShareImageProcessor.processForUpload(data: input)
+
+        #expect(ImageUploadFormat.detect(data: output) == .png)
+        #expect(output.count <= ShareImageProcessor.maxPayloadBytes)
+    }
+
+    private func makePNG(width: Int, height: Int) throws -> Data {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        context.clear(CGRect(x: 0, y: 0, width: width, height: height))
+        context.setFillColor(CGColor(red: 0.2, green: 0.6, blue: 0.9, alpha: 0.5))
+        context.fill(CGRect(x: 20, y: 20, width: width - 40, height: height - 40))
+
+        let image = try #require(context.makeImage())
+        let output = NSMutableData()
+        let destination = try #require(CGImageDestinationCreateWithData(
+            output,
+            UTType.png.identifier as CFString,
+            1,
+            nil))
+        CGImageDestinationAddImage(destination, image, nil)
+        #expect(CGImageDestinationFinalize(destination))
+        return output as Data
+    }
+
     private func makeNoiseJPEG(width: Int, height: Int, orientation: Int) throws -> Data {
         let bytesPerPixel = 4
         let byteCount = width * height * bytesPerPixel


### PR DESCRIPTION
Related: #81608

## What Problem This Solves

OpenClaw Android chat, Apple chat, and iOS share processing changed every selected image to JPEG before the gateway received it. For PNG inputs this changed the filename and MIME type and discarded transparency.

Scope note: the reported Telegram reproduction was not an OpenClaw conversion. Raw cached Bot API updates show the first upload as `Message.photo`, whose largest Telegram-produced JPEG was 21,330 bytes at 1280×446. The subsequent “choose files” uploads were `Message.document`, but Telegram itself supplied `file_name: IMG_0516.PNG`, `mime_type: image/jpeg`, and `file_size: 69557`; OpenClaw downloaded and stored exactly 69,557 JPEG bytes on both attempts, with identical SHA-256 hashes. The Telegram document handler writes the downloaded body unchanged and only corrects the stored extension from byte-sniffed MIME. The PNG-to-JPEG conversion therefore happened before OpenClaw received the document body, likely in the Telegram client or source file-provider handoff. This PR fixes the separate OpenClaw-owned native-client conversions found during the broader audit.

## Why This Change Was Made

Native attachment processing now re-encodes PNG inputs as bounded PNG output while retaining existing dimension, payload, orientation, and metadata-stripping policies. Large high-entropy Android PNGs continue scaling until they fit instead of being dropped after the JPEG-tuned attempt count. The existing JPEG path remains in place for JPEG and other decoded formats.

This deliberately preserves every PNG, rather than only alpha-bearing PNGs. That keeps the declared format stable without a separate transparency scan while the existing transport caps still bound payload size. Native-app owner confirmation of that product policy is welcome.

## User Impact

PNG attachments from OpenClaw native clients now reach the gateway as image/png with a .png filename and preserved alpha. Large PNGs are downscaled to the existing transport budget instead of silently changing format or disappearing. JPEG, HEIC, WebP, and GIF behavior is unchanged.

## Conversion Audit

- Core inbound storage and gateway staging preserve received PNG, JPEG, WebP, and GIF bytes when they are already supported and within limits.
- HEIC and HEIF are intentionally converted to JPEG for model/provider compatibility. iMessage performs this before staging, with fallback to the original if conversion fails; model-input and media-understanding paths also normalize HEIC/HEIF before provider execution.
- Oversized or over-dimension opaque images may be resized/re-encoded as JPEG; transparent images prefer PNG and can be flattened to JPEG only when required to meet a hard delivery budget.
- Unsupported inline formats such as BMP and TIFF are converted to PNG for provider compatibility.
- Oversized tool-result images are resized and may become JPEG.
- Camera captures, latest-photo node responses, canvas snapshots, browser screenshots, and other generated frame outputs intentionally use JPEG for bounded transport; they are generated outputs, not preservation of an uploaded file.
- Native WebP, GIF, and HEIC picks continue through the existing JPEG path in this PR because animation/provider/decoder compatibility needs separate policy decisions.

## Evidence

- Android regression coverage writes a PNG file and exercises the real picked-image to PendingAttachment path, asserting image/png, .png naming, PNG magic bytes, and gateway-budget compliance.
- Android high-entropy coverage starts with an 800x800 lossless PNG above the gateway cap, exercises production scaling, and verifies the bounded result remains PNG. The final android-test-play job passed.
- Final-head Android android-ktlint, android-build-play, android-build-wear, and native-i18n jobs passed.
- Apple processor coverage asserts transparent PNG output remains PNG and that planted GPS metadata is removed.
- Apple chat staging coverage asserts the pending attachment retains image/png and the .png filename.
- Apple share processor coverage asserts PNG output stays within the existing payload budget.
- Final-head ios-build passed. The PNG-specific Swift tests passed; the final macos-swift job failed only an unrelated pre-existing ChatStreamReplayTests reconnect timeout, while the two preceding macOS Swift runs passed.
- Final-head build-artifacts failed only its unrelated startup-memory threshold at 425.3 MB versus 425 MB; prior runs passed and this PR changes native files only. Fork authors cannot rerun upstream failed jobs.
- git diff --check passes and the review finding for high-entropy PNG sendability is fixed and resolved.

A physical Android or Apple device was not available in the contributor environment, so maintainer live-client gateway confirmation remains requested.
