### PR TITLE
feat(ui): unify sidebar scrolling, move new-thread to brand row, keep Mac titlebar search

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -119,6 +119,14 @@ type TestWebKitWindow = Window & {
   };
 };
 
+type MacosTitlebarControlsState = HTMLElement & {
+  navCollapsed: boolean;
+  historyOnly: boolean;
+  onOpenPalette?: () => void;
+  onOpenNewSession?: () => void;
+  updateComplete: Promise<boolean>;
+};
+
 afterEach(() => {
   Reflect.deleteProperty(window, "webkit");
   document.documentElement.classList.remove(
@@ -624,6 +632,27 @@ describe("OpenClaw shell keyboard shortcuts", () => {
     // preventDefault is the handled signal for the native legacy fallback.
     expect(toggleEvent.defaultPrevented).toBe(true);
     expect(navigate).toHaveBeenCalledWith("new-session", { search: "?agent=agent%2Fa" });
+  });
+
+  it("keeps search and new-session controls in the expanded native titlebar", async () => {
+    const onOpenPalette = vi.fn();
+    const onOpenNewSession = vi.fn();
+    const controls = document.createElement(
+      "openclaw-macos-titlebar-controls",
+    ) as unknown as MacosTitlebarControlsState;
+    controls.navCollapsed = false;
+    controls.historyOnly = false;
+    controls.onOpenPalette = onOpenPalette;
+    controls.onOpenNewSession = onOpenNewSession;
+    document.body.append(controls);
+    await controls.updateComplete;
+
+    controls.querySelector<HTMLButtonElement>(".macos-titlebar-controls__search")?.click();
+    controls.querySelector<HTMLButtonElement>(".macos-titlebar-controls__new-session")?.click();
+
+    expect(onOpenPalette).toHaveBeenCalledOnce();
+    expect(onOpenNewSession).toHaveBeenCalledOnce();
+    controls.remove();
   });
 
   it("retains a native new-session request until a context exists", () => {

--- a/ui/src/components/app-sidebar-session-data.ts
+++ b/ui/src/components/app-sidebar-session-data.ts
@@ -421,7 +421,7 @@ export abstract class AppSidebarSessionDataElement extends AppSidebarBase {
   }
 
   private syncSessionsScrollObserver() {
-    const element = this.querySelector<HTMLElement>(".sidebar-recent-sessions");
+    const element = this.querySelector<HTMLElement>(".sidebar-shell__body");
     if (element !== this.sessionsScrollElement) {
       this.sessionsScrollResizeObserver?.disconnect();
       this.sessionsScrollElement = element;

--- a/ui/src/components/app-sidebar-session-list.ts
+++ b/ui/src/components/app-sidebar-session-list.ts
@@ -490,13 +490,7 @@ export abstract class AppSidebarSessionListElement extends AppSidebarMenusElemen
               </div>
             `
           : nothing}
-        <div
-          class="sidebar-recent-sessions sidebar-recent-sessions--scroll-${this
-            .sessionsScrollState}"
-          aria-label=${titleForRoute("sessions")}
-          @scroll=${(event: Event) =>
-            this.updateSessionsScrollState(event.currentTarget as HTMLElement)}
-        >
+        <div class="sidebar-recent-sessions" aria-label=${titleForRoute("sessions")}>
           <div class="sidebar-recent-sessions__head sidebar-recent-sessions__head--root">
             <span class="sidebar-recent-sessions__label-text">${t("sessionsView.title")}</span>
             <button
@@ -510,16 +504,6 @@ export abstract class AppSidebarSessionListElement extends AppSidebarMenusElemen
                 this.toggleSessionSortMenu(event.currentTarget as HTMLElement)}
             >
               ${icons.listFilter}
-            </button>
-            <button
-              type="button"
-              class="sidebar-session-sort sidebar-session-new"
-              title=${navigationState.newSessionTitle}
-              aria-label=${t("chat.runControls.newSession")}
-              ?disabled=${navigationState.newSessionDisabled}
-              @click=${() => this.onOpenNewSession?.(expandedAgentId)}
-            >
-              ${icons.plus}
             </button>
           </div>
           ${this.renderSessionListBody(visibleSessions, {

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -180,10 +180,6 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
       selectedAgentId: navigation.selectedAgentId,
       visibleSessions,
       toSidebarSession,
-      newSessionDisabled: !this.connected,
-      newSessionTitle: this.connected
-        ? t("chat.runControls.newSession")
-        : t("chat.runControls.newSessionDisconnected"),
     };
   }
 

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -311,6 +311,38 @@ describe("AppSidebar update card wiring", () => {
   });
 });
 
+describe("AppSidebar brand actions", () => {
+  it("starts a session for the active agent and leaves the sessions header sort-only", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const agentsList = {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+      agents: [{ id: "main" }, { id: "research" }],
+    } as AgentsListResult;
+    const { sidebar } = await mountSidebar(
+      gateway,
+      createSessions("research", ["agent:research:main"]),
+      "panel",
+      agentsList,
+    );
+    const onOpenNewSession = vi.fn();
+    sidebar.connected = true;
+    sidebar.onOpenNewSession = onOpenNewSession;
+    await sidebar.updateComplete;
+
+    const button = sidebar.querySelector<HTMLButtonElement>(".sidebar-brand .sidebar-new-session");
+    expect(button?.getAttribute("aria-label")).toBe("New session");
+    expect(button?.disabled).toBe(false);
+    expect(
+      sidebar.querySelector(".sidebar-recent-sessions__head--root .sidebar-session-new"),
+    ).toBeNull();
+
+    button?.click();
+    expect(onOpenNewSession).toHaveBeenCalledExactlyOnceWith("research");
+  });
+});
+
 describe("AppSidebar agent chip", () => {
   const TWO_AGENTS = {
     defaultId: "main",
@@ -1321,9 +1353,9 @@ describe("AppSidebar session scroll fade", () => {
   it("shows fades only toward additional session content", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    const scroller = sidebar.querySelector<HTMLElement>(".sidebar-recent-sessions");
+    const scroller = sidebar.querySelector<HTMLElement>(".sidebar-shell__body");
     if (!scroller) {
-      throw new Error("Expected sidebar session scroller");
+      throw new Error("Expected sidebar body scroller");
     }
 
     let scrollHeight = 100;
@@ -1339,7 +1371,7 @@ describe("AppSidebar session scroll fade", () => {
       scroller.scrollTop = scrollTop;
       scroller.dispatchEvent(new Event("scroll"));
       await sidebar.updateComplete;
-      expect(scroller.classList.contains(`sidebar-recent-sessions--scroll-${expected}`)).toBe(true);
+      expect(scroller.classList.contains(`sidebar-shell__body--scroll-${expected}`)).toBe(true);
     };
 
     await expectScrollState(0, "none");

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -78,6 +78,10 @@ class AppSidebar extends AppSidebarSessionListElement {
 
   private renderBrand() {
     const collapseLabel = t("nav.collapse");
+    const chipAgentId = this.activeChipAgent().activeId;
+    const newSessionTitle = this.connected
+      ? t("chat.runControls.newSession")
+      : t("chat.runControls.newSessionDisconnected");
     return html`
       <div class="sidebar-brand">
         <a
@@ -105,6 +109,17 @@ class AppSidebar extends AppSidebarSessionListElement {
         </a>
         <div class="sidebar-brand__actions">
           ${this.renderSearch()}
+          <openclaw-tooltip .content=${newSessionTitle}>
+            <button
+              class="sidebar-brand__icon sidebar-new-session"
+              type="button"
+              ?disabled=${!this.connected}
+              @click=${() => this.onOpenNewSession?.(chipAgentId)}
+              aria-label=${t("chat.runControls.newSession")}
+            >
+              ${icons.plus}
+            </button>
+          </openclaw-tooltip>
           <openclaw-tooltip .content=${`${collapseLabel} (⌘B)`}>
             <button
               class="sidebar-brand__icon sidebar-brand__collapse"
@@ -155,7 +170,11 @@ class AppSidebar extends AppSidebarSessionListElement {
       <aside class="sidebar">
         <div class="sidebar-shell" @mousedown=${beginNativeWindowDragFromTopInset}>
           ${this.renderBrand()}
-          <div class="sidebar-shell__body">
+          <div
+            class="sidebar-shell__body sidebar-shell__body--scroll-${this.sessionsScrollState}"
+            @scroll=${(event: Event) =>
+              this.updateSessionsScrollState(event.currentTarget as HTMLElement)}
+          >
             <nav class="sidebar-nav" @contextmenu=${this.openCustomizeMenuFromContext}>
               <div class="nav-section__items">
                 ${this.sidebarPinnedRoutes.map((routeId) => this.renderRoute(routeId))}

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -255,7 +255,7 @@ describeBrowserLayout("app chrome interaction styles", () => {
               <input class="settings-sidebar__search-input" value="editable settings search" />
             </aside>
             <aside class="sidebar">
-              <div class="sidebar-recent-sessions">Recent session</div>
+              <div class="sidebar-shell__body">Recent session</div>
             </aside>
             <main class="content" style="height: 100px">
               <div class="settings-card">App chrome tile</div>
@@ -286,8 +286,8 @@ describeBrowserLayout("app chrome interaction styles", () => {
           chromeSelection: style(".settings-card").userSelect,
           contentScrollbar: scrollbarWidth(".content"),
           inputSelection: style(".settings-sidebar__search-input").userSelect,
-          regularSidebarScrollbar: scrollbarWidth(".sidebar-recent-sessions"),
-          regularSidebarSelection: style(".sidebar-recent-sessions").userSelect,
+          regularSidebarScrollbar: scrollbarWidth(".sidebar-shell__body"),
+          regularSidebarSelection: style(".sidebar-shell__body").userSelect,
           settingsSidebarScrollbar: scrollbarWidth(".settings-sidebar__nav"),
           settingsSidebarSelection: style(".settings-sidebar__nav").userSelect,
         };

--- a/ui/src/components/macos-titlebar-controls.ts
+++ b/ui/src/components/macos-titlebar-controls.ts
@@ -42,7 +42,7 @@ class MacosTitlebarControls extends OpenClawLightDomContentsElement {
           onClick: () => globalThis.history.forward(),
           className: "macos-titlebar-controls__forward",
         })}
-        ${this.navCollapsed && !this.historyOnly
+        ${!this.historyOnly
           ? html`
               ${this.renderButton({
                 label: t("chat.openCommandPalette"),
@@ -52,6 +52,9 @@ class MacosTitlebarControls extends OpenClawLightDomContentsElement {
                 className: "macos-titlebar-controls__search",
               })}
               ${this.renderButton({
+                // Deliberately not connection-gated: it mirrors the native
+                // ⌘N menu item (handleNativeNewSession), and the new-session
+                // route is offline-tolerant. Window chrome stays state-free.
                 label: t("chat.runControls.newSession"),
                 icon: icons.plus,
                 onClick: this.onOpenNewSession,

--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -66,8 +66,12 @@ describe("SidebarUpdateCard", () => {
 
     const action = element.querySelector<HTMLButtonElement>(".sidebar-update-card__action");
     expect(element.querySelector(".sidebar-update-card")?.getAttribute("role")).toBe("status");
-    expect(action?.textContent).toContain("Update Gateway");
-    expect(action?.textContent).toContain("v2.0.0");
+    expect(element.querySelector(".sidebar-update-card__text")?.textContent).toBe(
+      "Update Gateway · v2.0.0",
+    );
+    expect(element.querySelector(".sidebar-update-card__copy")).toBeNull();
+    expect(element.querySelector(".sidebar-update-card__subtitle")).toBeNull();
+    expect(element.querySelector(".sidebar-update-card__arrow")).toBeNull();
     action?.click();
 
     expect(onUpdate).toHaveBeenCalledOnce();

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -120,11 +120,7 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
           }}
         >
           <span class="sidebar-update-card__icon" aria-hidden="true">${icons.download}</span>
-          <span class="sidebar-update-card__copy">
-            <span class="sidebar-update-card__title">${title}</span>
-            <span class="sidebar-update-card__subtitle">v${update.latestVersion}</span>
-          </span>
-          <span class="sidebar-update-card__arrow" aria-hidden="true">${icons.chevronRight}</span>
+          <span class="sidebar-update-card__text">${title} · v${update.latestVersion}</span>
         </button>
         <button
           class="sidebar-update-card__dismiss"

--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -95,7 +95,7 @@ describeControlUiE2e("Control UI app chrome interaction mocked Gateway E2E", () 
       await transcript.waitFor();
       const chatStyles = await page.evaluate(() => {
         const sidebar = document.querySelector<HTMLElement>(".sidebar");
-        const sessions = document.querySelector<HTMLElement>(".sidebar-recent-sessions");
+        const sessions = document.querySelector<HTMLElement>(".sidebar-shell__body");
         const thread = document.querySelector<HTMLElement>(".chat-thread");
         if (!sidebar || !sessions || !thread) {
           throw new Error("Missing chat interaction surface");

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1663,7 +1663,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
-      const newSessionButton = page.locator("openclaw-app-sidebar .sidebar-session-new");
+      const newSessionButton = page.locator("openclaw-app-sidebar .sidebar-new-session");
       await newSessionButton.waitFor({ state: "visible", timeout: 10_000 });
       await newSessionButton.click();
 

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -196,14 +196,18 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
 
     const back = toolbar.getByRole("button", { name: "Back" });
     const forward = toolbar.getByRole("button", { name: "Forward" });
+    const search = toolbar.getByRole("button", { name: "Open command palette" });
+    const newSession = toolbar.getByRole("button", { name: "New session" });
     await expect.poll(() => back.isDisabled()).toBe(true);
     await expect.poll(() => forward.isDisabled()).toBe(true);
+    await expect.poll(() => search.isVisible()).toBe(true);
+    await expect.poll(() => newSession.isVisible()).toBe(true);
 
     await toolbar.getByRole("button", { name: "Collapse sidebar" }).click();
     await expect
       .poll(() => page.locator(".shell").getAttribute("class"))
       .toContain("shell--nav-collapsed");
-    await toolbar.getByRole("button", { name: "Open command palette" }).click();
+    await search.click();
     await expect.poll(() => page.locator(".cmd-palette-overlay").isVisible()).toBe(true);
     await page.keyboard.press("Escape");
 
@@ -226,7 +230,7 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
     await expect.poll(() => back.isDisabled()).toBe(true);
     await expect.poll(() => forward.isDisabled()).toBe(false);
 
-    await toolbar.getByRole("button", { name: "New session" }).click();
+    await newSession.click();
     await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
     await toolbar.getByRole("button", { name: "Expand sidebar" }).click();
     await expect

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -1545,7 +1545,7 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       for (let pageIndex = 0; pageIndex < 3; pageIndex += 1) {
         await seeMore.click();
       }
-      await page.locator(".sidebar-recent-sessions").evaluate((element) => {
+      await page.locator(".sidebar-shell__body").evaluate((element) => {
         element.scrollTop = 0;
       });
       await expect
@@ -1577,9 +1577,9 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       expect(overlaps).toBe(0);
 
       // The squeeze regression compressed sections into the viewport with no
-      // overflow; a healthy list is taller than its container and scrolls.
+      // overflow; a healthy sidebar body is taller than its viewport and scrolls.
       const scroll = await page.evaluate(() => {
-        const list = document.querySelector(".sidebar-recent-sessions");
+        const list = document.querySelector(".sidebar-shell__body");
         if (!list) {
           return null;
         }

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -111,7 +111,7 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/components/sidebar-update-card.ts",
-      "text": "v"
+      "text": "· v"
     },
     {
       "count": 1,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -131,12 +131,20 @@ html.openclaw-native-nav .topbar .topbar-nav-toggle {
   display: none;
 }
 
-/* Shipped Mac app builds without web chrome still use openclaw-native-nav
-   above; new hosts render the replacement controls in this document. Unlike
-   that rule this keeps the drawer hamburger: the web toolbar hides in compact
-   layouts, so narrow windows still need the in-page toggle. */
+/* Shipped Mac builds without web chrome only replace the sidebar toggle via
+   openclaw-native-nav. Web-chrome hosts replace toggle, search, and new-session
+   controls in-document; they keep the drawer hamburger because that toolbar
+   hides in compact layouts. */
 html.openclaw-native-web-chrome .shell-nav-expand,
 html.openclaw-native-web-chrome .sidebar-brand__collapse {
+  display: none;
+}
+
+/* The titlebar strip replaces brand search/new-session only while it is
+   visible; compact layouts hide the strip (.shell--mobile-nav), so the drawer
+   keeps its own copies there, matching the plain-browser drawer. */
+html.openclaw-native-web-chrome .shell:not(.shell--mobile-nav) .sidebar-brand .sidebar-search,
+html.openclaw-native-web-chrome .shell:not(.shell--mobile-nav) .sidebar-brand .sidebar-new-session {
   display: none;
 }
 
@@ -803,6 +811,7 @@ html.openclaw-native-web-chrome .sidebar-brand__collapse {
 }
 
 .sidebar-shell {
+  --sidebar-pad-x: 10px;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -810,7 +819,7 @@ html.openclaw-native-web-chrome .sidebar-brand__collapse {
   /* 9px top pad centers the brand row's 30px icons on the app's shared
      24px chrome centerline (pane-header actions, floating toggles). The
      macOS app overrides this with its 50px titlebar clearance. */
-  padding: 9px 10px 12px;
+  padding: 9px var(--sidebar-pad-x) 12px;
   border: none;
   border-radius: 0;
   background: transparent;
@@ -932,21 +941,31 @@ html.openclaw-native-web-chrome .sidebar-brand__collapse {
   stroke-linejoin: round;
 }
 
-.sidebar-shell__footer {
-  flex-shrink: 0;
-}
-
 .sidebar-shell__body {
   min-height: 0;
   flex: 1;
   display: flex;
   flex-direction: column;
-  /* Children manage their own scrolling; clip so an overgrown section can
-     never paint over the sidebar footer. */
-  overflow: hidden;
+  /* Keep the pre-unification horizontal clip: with only overflow-y set,
+     overflow-x would compute to auto and overwide rows would mint a
+     horizontal scrollbar beside the divider. */
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-color: color-mix(in srgb, currentColor 8%, transparent) transparent;
+  scrollbar-width: thin;
+  /* Cancel the shell's horizontal padding so the thumb hugs its right edge;
+     both values share --sidebar-pad-x so they cannot drift. */
+  margin-right: calc(-1 * var(--sidebar-pad-x));
+  padding-right: var(--sidebar-pad-x);
+}
+
+.sidebar-shell__body::-webkit-scrollbar,
+.sidebar-shell__body::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .sidebar-shell__footer {
+  flex-shrink: 0;
   padding: 12px 0 0;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
@@ -1084,11 +1103,11 @@ html.openclaw-native-macos
 
 .sidebar-update-card__action {
   width: 100%;
-  min-height: 62px;
+  min-height: 34px;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 34px 10px 12px;
+  gap: 8px;
+  padding: 4px 34px 4px 8px;
   border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--accent-subtle) 48%, var(--bg-elevated));
@@ -1118,7 +1137,6 @@ html.openclaw-native-macos
 }
 
 .sidebar-update-card__icon,
-.sidebar-update-card__arrow,
 .sidebar-update-card__dismiss {
   display: inline-flex;
   align-items: center;
@@ -1126,44 +1144,31 @@ html.openclaw-native-macos
 }
 
 .sidebar-update-card__icon {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   flex: 0 0 auto;
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--accent) 14%, transparent);
   color: var(--accent);
 }
 
-.sidebar-update-card__copy {
+.sidebar-update-card__text {
   min-width: 0;
-  display: flex;
   flex: 1 1 auto;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.sidebar-update-card__title {
+  overflow: hidden;
   color: var(--text-strong);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.2;
-}
-
-.sidebar-update-card__subtitle {
-  color: var(--muted);
   font-size: 12px;
-  line-height: 1.2;
-}
-
-.sidebar-update-card__arrow {
-  flex: 0 0 auto;
-  color: var(--muted);
+  font-weight: 600;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-update-card__dismiss {
   position: absolute;
-  top: 4px;
-  right: 4px;
+  top: 50%;
+  right: 5px;
+  transform: translateY(-50%);
   width: 24px;
   height: 24px;
   padding: 0;
@@ -1180,7 +1185,6 @@ html.openclaw-native-macos
 }
 
 .sidebar-update-card__icon svg,
-.sidebar-update-card__arrow svg,
 .sidebar-update-card__dismiss svg {
   width: 16px;
   height: 16px;
@@ -1192,23 +1196,13 @@ html.openclaw-native-macos
 }
 
 .sidebar-nav {
-  /* Nav stays pinned above the session list; the cap keeps sessions reachable
-     when an expanded More section outgrows a short window (nav then scrolls). */
-  flex: 0 0 auto;
-  max-height: 60%;
-  overflow-y: auto;
-  overflow-x: hidden;
   padding: 0;
-  scrollbar-width: none;
 }
 
 .sidebar-sessions {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  /* Sessions own the leftover height below the pinned nav and scroll inside. */
-  flex: 1 1 auto;
-  min-height: 0;
   padding: 0 8px;
   margin-top: 10px;
 }
@@ -1231,29 +1225,18 @@ html.openclaw-native-macos
   height: 22px;
 }
 
-/* min-height: 0 down this chain lets the recent list shrink and scroll instead
-   of pushing the sidebar footer out of view. */
 .sidebar-recent-sessions {
   display: flex;
   flex-direction: column;
   gap: 10px;
   margin: 0 -8px;
-  min-height: 0;
-  overflow-y: auto;
-  scrollbar-color: color-mix(in srgb, currentColor 8%, transparent) transparent;
-  scrollbar-width: thin;
   /* Sessions are app chrome, not hyperlinks: the whole region uses the
      default arrow cursor; the pointer hand is reserved for real links. */
   cursor: default;
 }
 
-.sidebar-recent-sessions::-webkit-scrollbar,
-.sidebar-recent-sessions::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.sidebar-recent-sessions--scroll-top {
-  --sidebar-sessions-mask: linear-gradient(
+.sidebar-shell__body--scroll-top {
+  --sidebar-body-mask: linear-gradient(
     to bottom,
     black 0,
     black calc(100% - 23px),
@@ -1261,8 +1244,8 @@ html.openclaw-native-macos
   );
 }
 
-.sidebar-recent-sessions--scroll-middle {
-  --sidebar-sessions-mask: linear-gradient(
+.sidebar-shell__body--scroll-middle {
+  --sidebar-body-mask: linear-gradient(
     to bottom,
     transparent 0,
     black 23px,
@@ -1271,22 +1254,15 @@ html.openclaw-native-macos
   );
 }
 
-.sidebar-recent-sessions--scroll-bottom {
-  --sidebar-sessions-mask: linear-gradient(to bottom, transparent 0, black 23px, black 100%);
+.sidebar-shell__body--scroll-bottom {
+  --sidebar-body-mask: linear-gradient(to bottom, transparent 0, black 23px, black 100%);
 }
 
-.sidebar-recent-sessions--scroll-top,
-.sidebar-recent-sessions--scroll-middle,
-.sidebar-recent-sessions--scroll-bottom {
-  -webkit-mask-image: var(--sidebar-sessions-mask);
-  mask-image: var(--sidebar-sessions-mask);
-}
-
-/* The scroller's children must not flex-shrink: shrink squeezes each section
-   to its min-height while the fixed-height rows inside overflow and paint
-   over the following section. Fixed sizing makes the list scroll instead. */
-.sidebar-recent-sessions > * {
-  flex: 0 0 auto;
+.sidebar-shell__body--scroll-top,
+.sidebar-shell__body--scroll-middle,
+.sidebar-shell__body--scroll-bottom {
+  -webkit-mask-image: var(--sidebar-body-mask);
+  mask-image: var(--sidebar-body-mask);
 }
 
 .sidebar-recent-sessions__group {
@@ -1887,10 +1863,6 @@ html.openclaw-native-macos
 
 .sidebar-recent-session__aside {
   padding-right: 2px;
-}
-
-.sidebar-nav::-webkit-scrollbar {
-  display: none;
 }
 
 .nav-collapse-toggle {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -208,24 +208,9 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
 }
 
 .shell--mobile-nav .sidebar-shell {
-  padding: 18px 16px 14px;
+  --sidebar-pad-x: 16px;
+  padding: 18px var(--sidebar-pad-x) 14px;
   border-radius: 0;
-}
-
-.shell--mobile-nav .sidebar-nav {
-  /* Match the desktop pinned-nav layout so the session list keeps the
-     remaining drawer height. */
-  flex: 0 0 auto;
-  max-height: 60%;
-  display: block;
-  padding: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  scrollbar-width: none;
-}
-
-.shell--mobile-nav .sidebar-nav::-webkit-scrollbar {
-  display: none;
 }
 
 .shell--mobile-nav .nav-item {
@@ -327,7 +312,8 @@ html.openclaw-native-macos body .shell--mobile-nav .topnav-shell__actions {
   }
 
   .shell--mobile-nav .sidebar-shell {
-    padding: 16px 14px 12px;
+    --sidebar-pad-x: 14px;
+    padding: 16px var(--sidebar-pad-x) 12px;
   }
 
   .shell--mobile-nav .nav-item {


### PR DESCRIPTION
## What Problem This Solves

The Control UI sidebar splits scrolling across two nested regions: the pinned nav block caps at 60% height with its own hidden scrollbar, and only the session list actually scrolls, so pinned nav permanently eats vertical space. The scrollbar also sits ~10px inside the draggable resize divider, floating detached from the edge it belongs to. New-thread affordances are scattered (Sessions-header plus, agent-chip plus, macOS titlebar plus only while collapsed, logo click), and on macOS the titlebar search/new-thread buttons vanish whenever the sidebar is expanded. The update card is a chunky two-line banner in an otherwise slim footer.

## Why This Change Was Made

- One scroller for nav + sessions (`.sidebar-shell__body`): only the brand row and footer stay pinned. Deletes the desktop 60% nav cap and the mobile drawer's duplicate of it; scroll-fade masks and scroll-state tracking move up to the body.
- The scrollbar hugs the drag divider: the body cancels the shell's horizontal padding via a shared `--sidebar-pad-x` so the two values cannot drift (desktop 10px, drawer 16/14px).
- New-thread moves next to search in the brand row (disabled while disconnected, same semantics as the removed Sessions-header plus). The agent-scoped plus on the footer chip stays; the Sessions header keeps only sort.
- macOS web-chrome hosts show search + new-thread in the titlebar permanently next to back/forward (previously only while the sidebar was collapsed). The brand-row copies hide only in layouts where that strip is visible — compact drawers keep them, matching the plain-browser drawer. The titlebar plus stays connection-ungated on purpose, mirroring the native ⌘N menu item.
- Update card slims to a single-line pill (icon · title · version · dismiss), logic unchanged.

## User Impact

The sidebar scrolls as one surface with the scrollbar directly at the resize divider; pinned routes no longer consume fixed space. New thread and search are always in the same top-row spot (web) or the titlebar (Mac app). The update notice takes one line instead of three. No config, API, or gateway changes.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/components/sidebar-update-card.test.ts ui/src/app/app-host.test.ts ui/src/components/resizable-divider.test.ts` → 4 files, 133 tests passed. Codex-side run also covered `form-controls.browser.test.ts` + e2e selector updates (138 passed).
- Autoreview (Codex, gpt-5.6-sol, xhigh): clean — "patch is correct (0.9)". Two earlier findings addressed: compact drawers keep brand search/new-thread (hide is scoped to layouts where the titlebar strip is visible), and the ungated titlebar plus is documented as intentional ⌘N parity.
- Diff: non-test LOC net negative (−57 before review fixes).
- Screenshots (dev gateway with sanitized demo data; macOS shots simulated in a browser via the native web-chrome flag + injected titlebar clearance):

| | Before | After |
| --- | --- | --- |
| Web sidebar (top) | ![before web top](https://gist.githubusercontent.com/steipete/89401e669c6d64d50acd5c77f0538c77/raw/before-web-top.png) | ![after web top](https://gist.githubusercontent.com/steipete/89401e669c6d64d50acd5c77f0538c77/raw/after-web-top.png) |
| Web sidebar (scrolled) | ![before web scrolled](https://gist.githubusercontent.com/steipete/89401e669c6d64d50acd5c77f0538c77/raw/before-web-scrolled.png) | ![after web scrolled](https://gist.githubusercontent.com/steipete/89401e669c6d64d50acd5c77f0538c77/raw/after-web-scrolled.png) |
| macOS titlebar (simulated) | ![before native](https://gist.githubusercontent.com/steipete/89401e669c6d64d50acd5c77f0538c77/raw/before-native.png) | ![after native](https://gist.githubusercontent.com/steipete/89401e669c6d64d50acd5c77f0538c77/raw/after-native.png) |

Key after-state details: in "Web sidebar (scrolled)" the pinned routes scroll away while the Sessions header sticks and the brand row (logo · search · plus · collapse) stays; in "macOS titlebar" the brand row is logo-only with search + plus hosted beside back/forward.
