### PR TITLE
perf(ci): move the three light-run pole jobs to 32 vCPU runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -992,7 +992,10 @@ jobs:
       contents: read
     needs: [preflight]
     if: needs.preflight.outputs.run_build_artifacts == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    # 32 vCPU: the dist build sits on the light-run critical path alongside
+    # check-lint/check-dependencies; tsdown parallelizes across the extra
+    # cores for roughly the same billed core-minutes.
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-32vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     outputs:
       channels-result: ${{ steps.built_artifact_checks.outputs['channels-result'] }}
@@ -1902,12 +1905,14 @@ jobs:
             runner: blacksmith-4vcpu-ubuntu-2404
           - check_name: check-lint
             task: lint
-            runner: blacksmith-16vcpu-ubuntu-2404
+            # Top light-run pole (~186s of shard work); oxlint shard
+            # concurrency scales with cores at similar billed core-minutes.
+            runner: blacksmith-32vcpu-ubuntu-2404
           - check_name: check-dependencies
             task: dependencies
             # Concurrent Knip scans need cores and memory headroom; the wall
             # clock roughly halves for similar billed core-minutes.
-            runner: blacksmith-16vcpu-ubuntu-2404
+            runner: blacksmith-32vcpu-ubuntu-2404
           - check_name: check-test-types
             task: test-types
             # Slowest static lane (~3.5min on 4 vCPU); extra cores shorten the

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2163,7 +2163,7 @@ describe("ci workflow guards", () => {
     const source = readFileSync(".github/workflows/ci.yml", "utf8");
 
     expect(source).toContain("createNodeTestShardBundles");
-    expect(workflow.jobs["build-artifacts"]["runs-on"]).toContain("blacksmith-16vcpu-ubuntu-2404");
+    expect(workflow.jobs["build-artifacts"]["runs-on"]).toContain("blacksmith-32vcpu-ubuntu-2404");
     expect(buildArtifactsTestbox.jobs["build-artifacts"]["runs-on"]).toBe(
       "blacksmith-16vcpu-ubuntu-2404",
     );
@@ -2179,7 +2179,7 @@ describe("ci workflow guards", () => {
       check_name: "check-dependencies",
       task: "dependencies",
       // Concurrent Knip scans need cores and memory headroom.
-      runner: "blacksmith-16vcpu-ubuntu-2404",
+      runner: "blacksmith-32vcpu-ubuntu-2404",
     });
     expect(workflow.jobs["check-additional-shard"]["runs-on"]).toContain("matrix.runner");
     expect(workflow.jobs["check-additional-shard"].strategy.matrix.include).toContainEqual({

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -414,7 +414,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
       check_name: "check-dependencies",
       task: "dependencies",
       // Concurrent Knip scans need cores and memory headroom.
-      runner: "blacksmith-16vcpu-ubuntu-2404",
+      runner: "blacksmith-32vcpu-ubuntu-2404",
     });
     expect(
       workflow.jobs["check-shard"].steps.find(


### PR DESCRIPTION
## What Problem This Solves

Post-batch job census (runs 29557967446/29557929941): the light-run critical path is now check-lint (186s shard work), check-dependencies (157s), and build-artifacts (73s build + 53s checks), all on 16 vCPU. These three jobs bound the median PR run at ~4.2min of job time.

## Why This Change Was Made

All three workloads parallelize with cores — oxlint shard concurrency scales with `nproc` (CI thresholds: 8+ cpus), knip scans run concurrently, tsdown fans out — so a 32 vCPU class roughly halves wall clock at similar billed core-minutes (same rationale as the earlier 4→16 bump on check-dependencies/check-test-types, which behaved as predicted). Fork PRs and dispatch runs stay on GitHub-hosted runners as before.

## User Impact

None at runtime — CI-only. Light-run PR CI median should drop ~1–1.5min once warm.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 75 passed, 1 skipped (runner-size guards updated with the change).
- This PR's own CI provides the live before/after: compare its check-lint/check-dependencies/build-artifacts durations against the 186s/157s/126s baselines above.
- `git diff --check` clean; YAML matrix rows carry site comments for the sizing rationale.
