### PR TITLE
fix(plugins): accept npm 12 json shapes in install metadata reads

### DIFF
--- a/src/gateway/worker-environments/bundle.ts
+++ b/src/gateway/worker-environments/bundle.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
 import { resolveStateDir } from "../../config/paths.js";
-import { isExactSemverVersion } from "../../infra/npm-registry-spec.js";
+import { isExactSemverVersion, resolveNpmJsonEntries } from "../../infra/npm-registry-spec.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { VERSION } from "../../version.js";
@@ -116,6 +116,12 @@ function parseNpmPackageIdentity(value: unknown): NpmPackageIdentity | undefined
   return name && version && integrity ? { name, version, integrity, filename } : undefined;
 }
 
+// Single-spec view/pack proofs return exactly one entry; npm 12 shape drift is
+// normalized by the shared resolver so identity verification survives upgrades.
+function unwrapNpmJsonEntry(value: unknown): unknown {
+  return resolveNpmJsonEntries(value)[0];
+}
+
 async function runNpmProofCommand(params: {
   argv: string[];
   cwd: string;
@@ -175,21 +181,23 @@ async function verifyPublishedNpmRelease(params: {
   const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-npm-proof-"));
   try {
     const published = parseNpmPackageIdentity(
-      await runNpmProofCommand({
-        argv: [
-          "npm",
-          "view",
-          `openclaw@${params.version}`,
-          "name",
-          "version",
-          "dist.integrity",
-          "--json",
-          `--registry=${OPENCLAW_NPM_REGISTRY}`,
-        ],
-        cwd: temporaryRoot,
-        failureMessage: `OpenClaw ${params.version} is not published; use the worker bundle install`,
-        runCommand,
-      }),
+      unwrapNpmJsonEntry(
+        await runNpmProofCommand({
+          argv: [
+            "npm",
+            "view",
+            `openclaw@${params.version}`,
+            "name",
+            "version",
+            "dist.integrity",
+            "--json",
+            `--registry=${OPENCLAW_NPM_REGISTRY}`,
+          ],
+          cwd: temporaryRoot,
+          failureMessage: `OpenClaw ${params.version} is not published; use the worker bundle install`,
+          runCommand,
+        }),
+      ),
     );
     if (
       published?.name !== "openclaw" ||
@@ -216,7 +224,7 @@ async function verifyPublishedNpmRelease(params: {
         "Unable to verify the installed OpenClaw package; use the worker bundle install",
       runCommand,
     });
-    const packed = Array.isArray(packedValue) ? parseNpmPackageIdentity(packedValue[0]) : undefined;
+    const packed = parseNpmPackageIdentity(unwrapNpmJsonEntry(packedValue));
     if (!packed?.filename || path.basename(packed.filename) !== packed.filename) {
       throw new Error("npm pack returned incomplete worker package metadata");
     }

--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -6,6 +6,7 @@ import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
   packNpmSpecToArchive,
   resolveArchiveSourcePath,
+  resolveNpmPackArchiveMetadata,
   resolveNpmSpecMetadata,
   withTempDir,
 } from "./install-source-utils.js";
@@ -409,6 +410,38 @@ describe("packNpmSpecToArchive", () => {
     );
   });
 
+  it("unpacks npm 12 name-keyed pack json output", async () => {
+    const cwd = await createFixtureDir();
+    const archivePath = path.join(cwd, "openclaw-plugin-1.2.3.tgz");
+    await fs.writeFile(archivePath, "", "utf-8");
+    mockPackCommandResult({
+      stdout: JSON.stringify({
+        "openclaw-plugin": {
+          id: "openclaw-plugin@1.2.3",
+          name: "openclaw-plugin",
+          version: "1.2.3",
+          filename: "openclaw-plugin-1.2.3.tgz",
+          integrity: "sha512-test-integrity",
+          shasum: "abc123",
+        },
+      }),
+    });
+
+    const result = await runPack("openclaw-plugin@1.2.3", cwd);
+
+    expect(result).toEqual({
+      ok: true,
+      archivePath,
+      metadata: {
+        name: "openclaw-plugin",
+        version: "1.2.3",
+        resolvedSpec: "openclaw-plugin@1.2.3",
+        integrity: "sha512-test-integrity",
+        shasum: "abc123",
+      },
+    });
+  });
+
   it("falls back to parsing final stdout line when npm json output is unavailable", async () => {
     const cwd = await createFixtureDir();
     const expectedArchivePath = path.join(cwd, "openclaw-plugin-1.2.3.tgz");
@@ -529,6 +562,74 @@ describe("packNpmSpecToArchive", () => {
     expect(result).toEqual({
       ok: false,
       error: "npm pack failed: network timeout",
+    });
+  });
+});
+
+describe("resolveNpmPackArchiveMetadata", () => {
+  it("reads archive metadata from npm <=11 array pack output", async () => {
+    const cwd = await createFixtureDir();
+    const archivePath = path.join(cwd, "openclaw-plugin-1.2.3.tgz");
+    await fs.writeFile(archivePath, "tar-bytes", "utf-8");
+    mockPackCommandResult({
+      stdout: JSON.stringify([
+        {
+          id: "openclaw-plugin@1.2.3",
+          name: "openclaw-plugin",
+          version: "1.2.3",
+          filename: "openclaw-plugin-1.2.3.tgz",
+          integrity: "sha512-test-integrity",
+          shasum: "abc123",
+        },
+      ]),
+    });
+
+    const result = await resolveNpmPackArchiveMetadata({ archivePath, timeoutMs: 1000 });
+
+    expect(result).toEqual({
+      ok: true,
+      archivePath,
+      tarballName: "openclaw-plugin-1.2.3.tgz",
+      metadata: {
+        name: "openclaw-plugin",
+        version: "1.2.3",
+        resolvedSpec: "openclaw-plugin@1.2.3",
+        integrity: "sha512-test-integrity",
+        shasum: "abc123",
+      },
+    });
+  });
+
+  it("reads archive metadata from npm 12 name-keyed pack output", async () => {
+    const cwd = await createFixtureDir();
+    const archivePath = path.join(cwd, "openclaw-plugin-1.2.3.tgz");
+    await fs.writeFile(archivePath, "tar-bytes", "utf-8");
+    mockPackCommandResult({
+      stdout: JSON.stringify({
+        "openclaw-plugin": {
+          id: "openclaw-plugin@1.2.3",
+          name: "openclaw-plugin",
+          version: "1.2.3",
+          filename: "openclaw-plugin-1.2.3.tgz",
+          integrity: "sha512-test-integrity",
+          shasum: "abc123",
+        },
+      }),
+    });
+
+    const result = await resolveNpmPackArchiveMetadata({ archivePath, timeoutMs: 1000 });
+
+    expect(result).toEqual({
+      ok: true,
+      archivePath,
+      tarballName: "openclaw-plugin-1.2.3.tgz",
+      metadata: {
+        name: "openclaw-plugin",
+        version: "1.2.3",
+        resolvedSpec: "openclaw-plugin@1.2.3",
+        integrity: "sha512-test-integrity",
+        shasum: "abc123",
+      },
     });
   });
 });

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -14,6 +14,7 @@ import { resolveUserPath } from "../utils.js";
 import { resolveArchiveKind } from "./archive.js";
 import { pathExists } from "./fs-safe.js";
 import { applyNpmFreshnessBypassEnv, type NpmProjectInstallEnvOptions } from "./npm-install-env.js";
+import { resolveNpmJsonEntries } from "./npm-registry-spec.js";
 import { withTempWorkspace } from "./private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 
@@ -283,7 +284,7 @@ function parseNpmPackJsonOutput(
       continue;
     }
 
-    const entries = Array.isArray(parsed) ? parsed : [parsed];
+    const entries = resolveNpmJsonEntries(parsed);
     let fallback: { filename?: string; metadata: NpmSpecResolution } | null = null;
     for (let i = entries.length - 1; i >= 0; i -= 1) {
       const normalized = normalizeNpmPackEntry(entries[i]);

--- a/src/infra/npm-registry-spec.test.ts
+++ b/src/infra/npm-registry-spec.test.ts
@@ -8,6 +8,7 @@ import {
   isPrereleaseSemverVersion,
   isPrereleaseResolutionAllowed,
   parseRegistryNpmSpec,
+  resolveNpmJsonEntries,
   validateRegistryNpmSpec,
 } from "./npm-registry-spec.js";
 
@@ -212,5 +213,42 @@ describe("npm prerelease resolution policy", () => {
         resolvedVersion,
       }),
     ).toContain(expected);
+  });
+});
+
+describe("resolveNpmJsonEntries", () => {
+  it("passes entry arrays through (npm <=11 pack shape)", () => {
+    const entries = [{ name: "openclaw", version: "2026.7.1", filename: "openclaw-2026.7.1.tgz" }];
+    expect(resolveNpmJsonEntries(entries)).toBe(entries);
+  });
+
+  it("keeps a bare entry object as a single entry (npm <=11 view shape)", () => {
+    const entry = { name: "openclaw", version: "2026.7.1", "dist.integrity": "sha512-x" };
+    expect(resolveNpmJsonEntries(entry)).toEqual([entry]);
+  });
+
+  it("unwraps the npm 12 singleton view array", () => {
+    const entry = { name: "openclaw", version: "2026.7.1", "dist.integrity": "sha512-x" };
+    expect(resolveNpmJsonEntries([entry])).toEqual([entry]);
+  });
+
+  it("unwraps the npm 12 name-keyed pack object", () => {
+    const entry = {
+      id: "openclaw@2026.7.1",
+      name: "openclaw",
+      version: "2026.7.1",
+      filename: "openclaw-2026.7.1.tgz",
+    };
+    expect(resolveNpmJsonEntries({ openclaw: entry })).toEqual([entry]);
+  });
+
+  it("unwraps scoped name keys in the npm 12 pack object", () => {
+    const entry = { id: "@openclaw/voice-call@1.2.3", name: "@openclaw/voice-call" };
+    expect(resolveNpmJsonEntries({ "@openclaw/voice-call": entry })).toEqual([entry]);
+  });
+
+  it("falls back to the raw value when no entries are recognizable", () => {
+    expect(resolveNpmJsonEntries("not-json-shaped")).toEqual(["not-json-shaped"]);
+    expect(resolveNpmJsonEntries(null)).toEqual([null]);
   });
 });

--- a/src/infra/npm-registry-spec.ts
+++ b/src/infra/npm-registry-spec.ts
@@ -12,6 +12,36 @@ const OPENCLAW_RELEASE_PREFIX_RE = /^\d{4}\./;
 const DIST_TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 /**
+ * npm ≤11 prints `npm view`/`npm pack` `--json` results as a bare entry object
+ * or an entry array; npm 12 wraps view results in a singleton array and keys
+ * pack results by package name. Normalize both shapes to the entry list, or
+ * metadata reads mistake the wrapper for an entry and fail closed with
+ * incomplete-metadata errors.
+ */
+export function resolveNpmJsonEntries(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const looksLikeEntry =
+      typeof record.id === "string" ||
+      typeof record.name === "string" ||
+      typeof record.version === "string" ||
+      typeof record.filename === "string";
+    if (!looksLikeEntry) {
+      const entries = Object.values(record).filter(
+        (entry) => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+      );
+      if (entries.length > 0) {
+        return entries;
+      }
+    }
+  }
+  return [value];
+}
+
+/**
  * Parsed registry-only npm spec accepted by plugin install flows.
  * Selectors are limited to exact versions and dist-tags; URL/git/file specs
  * are rejected before they can execute on the gateway host.


### PR DESCRIPTION
Fixes #109550.

> **Relationship to #106189 / #107063 (2026-07-17):** #109550 was closed as a duplicate of #106189, and the install/update `npm view` array failure from #106189 is already fixed on main by #107063 (`selectNpmViewMetadataEntry`). This PR covers the npm 12 shapes that **remain broken on current main**:
>
> - `npm pack` name-keyed object in `parseNpmPackJsonOutput` (`src/infra/install-source-utils.ts`): main wraps non-array JSON as `[parsed]`, so `{"openclaw": {...}}` is normalized as if the wrapper itself were an entry -> empty metadata -> `packNpmSpecToArchive` silently returns `metadata: {}` and `resolveNpmPackArchiveMetadata` fails closed with `npm pack metadata read produced incomplete package metadata`.
> - `verifyPublishedNpmRelease` (`src/gateway/worker-environments/bundle.ts`): `parseNpmPackageIdentity` rejects arrays, so the npm 12 `npm view` singleton array fails identity parsing, and the name-keyed `npm pack` object reads `name`/`version` off the wrapper -> `npm pack returned incomplete worker package metadata`.

## What Problem This Solves

npm 12 changed the `--json` output shapes of `npm view` and `npm pack`:

- `npm view <spec> ... --json` now wraps the result in a **singleton array** (`[{...}]`) instead of a bare object.
- `npm pack <spec> --json` now returns an **object keyed by package name** (`{"openclaw": {...}}`) instead of an entry array (`[{...}]`).

The install metadata readers assumed the npm ≤11 shapes, so on npm 12:

- `resolveNpmPackArchiveMetadata` fails closed with `npm pack metadata read produced incomplete package metadata` (the wrapper object is normalized as if it were an entry, producing empty metadata).
- `packNpmSpecToArchive` succeeds but silently returns `metadata: {}`, so plugin install/update flows lose the resolved name/version/integrity.
- Worker release verification (`verifyPublishedNpmRelease`) rejects published packages: the npm 12 view array fails `parseNpmPackageIdentity`, and the name-keyed pack object fails the array check, ending in `npm pack returned incomplete worker package metadata`.

This is what users hit as `openclaw update` / `openclaw plugins install` failing with incomplete-metadata errors on npm 12 (#109550).

## Why This Change Was Made

Both call sites need the same normalization, so it lives in one shared resolver (`resolveNpmJsonEntries` in `src/infra/npm-registry-spec.ts`, next to the other npm registry contract helpers) instead of two local copies. The resolver keeps the npm ≤11 shapes working unchanged and unwraps the npm 12 singleton array / name-keyed object only when the value does not itself look like an entry (`id`/`name`/`version`/`filename` present), so a package legitimately named like a wrapper key cannot be mistaken for one.

## Changes

- `src/infra/npm-registry-spec.ts`: add exported `resolveNpmJsonEntries(value)` that passes arrays through, keeps bare entry objects as single entries, and unwraps npm 12 name-keyed wrapper objects into their entry values.
- `src/infra/install-source-utils.ts`: `parseNpmPackJsonOutput` now resolves entries via the shared resolver, fixing both `packNpmSpecToArchive` and `resolveNpmPackArchiveMetadata` on npm 12.
- `src/gateway/worker-environments/bundle.ts`: `verifyPublishedNpmRelease` unwraps the `npm view` singleton array and the `npm pack` name-keyed object through the same resolver before identity parsing.
- Regression tests: `resolveNpmJsonEntries` shape table (npm ≤11 array, bare object, npm 12 singleton array, npm 12 name-keyed object, scoped name key, junk passthrough), plus npm 12 pack-shape cases for `packNpmSpecToArchive` and `resolveNpmPackArchiveMetadata`.

## User Impact

Users on npm 12 can install and update plugins and gateway packages again; metadata (name/version/resolvedSpec/integrity) is read correctly from both npm 12 output shapes. Behavior on npm ≤11 is unchanged (verified against a real npm 10.9.4 below). No config, migration, or API changes.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs src/infra/npm-registry-spec.test.ts src/infra/install-source-utils.test.ts src/gateway/worker-environments/bundle.test.ts` — 93/93 passed on Node 22.22.0.
- Real npm 12 driver proof below (real `npm@12.0.1` binary + real registry + real `openclaw-2026.7.1.tgz`), before/after this patch.
- Real npm 10.9.4 regression run: identical correct metadata after the patch (no behavior change for npm ≤11).
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check` passed for the changed files. `tsgo` core lane reports only pre-existing `packages/net-policy/src/ip.ts` errors from a stale local dependency install; the changed files are clean.

## Real behavior proof

**Behavior addressed:** On npm 12, plugin/gateway install metadata reads failed with `npm pack metadata read produced incomplete package metadata` or silently returned empty metadata because `npm pack --json` output is keyed by package name and `npm view --json` output is a singleton array instead of the npm ≤11 shapes.

**Real environment tested:** Linux x86_64, Node v22.22.0, real `npm@12.0.1` binary (installed via `npm install --prefix /tmp/npm12-test npm@12`), real npmjs.org registry, real published `openclaw-2026.7.1.tgz`, plus real `npm@10.9.4` as the npm ≤11 baseline. Current head: `df3783503fb204166f6c80190a93db58fa4b0668`.

**Exact steps or command run after this patch:** `PATH="/tmp/npm12-test/node_modules/.bin:$PATH" node --import tsx /tmp/npm12-proof/proof.mts`, where the driver imports the production functions from `src/infra/install-source-utils.js` and calls `resolveNpmPackArchiveMetadata({ archivePath: "/tmp/npm12-test/openclaw-2026.7.1.tgz" })` and `packNpmSpecToArchive({ spec: "is-odd@3.0.1", timeoutMs: 60_000, cwd })`, spawning the real npm 12 subprocess and reading the real tarball back from disk.

**Evidence after fix:** Before the patch (same driver, base revision): `resolveNpmPackArchiveMetadata => {"ok":false,"error":"npm pack metadata read produced incomplete package metadata"}` and `packNpmSpecToArchive => {"ok":true,...,"metadata":{}}`. After the patch: `resolveNpmPackArchiveMetadata => {"ok":true,"archivePath":"/tmp/npm12-test/openclaw-2026.7.1.tgz","tarballName":"openclaw-2026.7.1.tgz","metadata":{"name":"openclaw","version":"2026.7.1","resolvedSpec":"openclaw@2026.7.1","integrity":"sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==","shasum":"172e412fa905d8f5bddb46e94e2b15497b2fb768"}}` and `packNpmSpecToArchive => {"ok":true,...,"metadata":{"name":"is-odd","version":"3.0.1","resolvedSpec":"is-odd@3.0.1","integrity":"sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==","shasum":"65101baf3727d728b66fa62f50cda7f2d3989601"}}`.

**Observed result after fix:** Both production functions return complete, correct metadata under the real npm 12 binary: the archive path resolves from disk, and name/version/resolvedSpec/integrity/shasum match the real published packages (integrity for `openclaw@2026.7.1` matches the npmjs registry value). The same driver under real npm 10.9.4 returns identical correct metadata, so npm ≤11 behavior is preserved.

**What was not tested:** The full worker-bundle extraction pipeline (`tar` extraction + bundle-hash comparison inside `verifyPublishedNpmRelease`) was not run end-to-end on npm 12; those stages are independent of the npm output shape, and the shape-sensitive parsing it performs is covered by the shared-resolver unit tests and the real-npm-12 driver above. No UI changes. Non-npm package managers (pnpm/yarn/bun) were not exercised; the changed readers only invoke `npm`.

## Intentionally out of scope

- npm's human (non-JSON) output formats and other package managers.
- The already-npm-12-aware `npm view` handling in `src/infra/update-check.ts` and the `versions` list readers (verified correct on npm 12 while scoping this fix).
- Any retry/backoff policy for registry failures (orthogonal; see #105167 for timeout bounding of metadata reads).