### PR TITLE
fix(docker): bound ACP bind droid CLI download with timeout

### DIFF
--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -242,7 +242,7 @@ WRAP
     ;;
   droid)
     if ! command -v droid >/dev/null 2>&1; then
-      run_setup_command bash -lc 'curl -fsSL https://app.factory.ai/cli | sh'
+      run_setup_command bash -lc 'curl -fsSL --connect-timeout 30 --max-time 300 https://app.factory.ai/cli | sh'
       export PATH="$HOME/.local/bin:$PATH"
     fi
     droid --version

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2119,7 +2119,7 @@ describe("package artifact reuse", () => {
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=subscription/g)).toHaveLength(2);
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=api-key/g)).toHaveLength(2);
     expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
-      "run_setup_command bash -lc 'curl -fsSL https://app.factory.ai/cli | sh'",
+      "run_setup_command bash -lc 'curl -fsSL --connect-timeout 30 --max-time 300 https://app.factory.ai/cli | sh'",
     );
     expect(readFileSync("scripts/test-live-codex-harness-docker.sh", "utf8")).toContain(
       "OPENCLAW_LIVE_CODEX_HARNESS_DOCKER_RUN_TIMEOUT:-$((2100 * CODEX_HARNESS_TARGET_COUNT))s",


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

The ACP bind Docker test script downloads the Factory CLI (`droid`) from `app.factory.ai` with no connect or transfer timeout. A stalled TLS handshake or connection could hang the Docker setup indefinitely during live ACP binding tests.

## Why This Change Was Made

Add `--connect-timeout 30` and `--max-time 300` to the curl command that downloads the CLI installer and pipes it to `sh`.

## User Impact

ACI bind Docker setup now fails within a bounded interval when the Factory CLI download endpoint stalls.

## Evidence

- The existing guard test assertion was updated to verify the exact `--connect-timeout 30 --max-time 300` flags.
- `git diff --check`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)