### PR TITLE
fix(msteams): cancel non-OK consent upload response body before throwing

### DIFF
--- a/extensions/msteams/src/file-consent.test.ts
+++ b/extensions/msteams/src/file-consent.test.ts
@@ -519,6 +519,23 @@ describe("uploadToConsentUrl", () => {
     ).rejects.toThrow("File upload to consent URL failed: 403 Forbidden");
   });
 
+  it("cancels a non-OK consent upload response body before throwing", async () => {
+    const response = new Response("upload rejected", { status: 403, statusText: "Forbidden" });
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    const fetchFn = vi.fn<typeof fetch>(async () => response);
+
+    await expect(
+      uploadToConsentUrl({
+        url: "https://contoso.sharepoint.com/sites/uploads/file.pdf",
+        buffer: Buffer.from("data"),
+        fetchFn,
+        validationOpts: { resolveFn: publicResolve },
+      }),
+    ).rejects.toThrow("File upload to consent URL failed: 403 Forbidden");
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("blocks HTTP (non-HTTPS) upload before fetch is called", async () => {
     const mockFetch = vi.fn();
     await expect(

--- a/extensions/msteams/src/file-consent.test.ts
+++ b/extensions/msteams/src/file-consent.test.ts
@@ -51,6 +51,12 @@ const firstFetchCall = (fetchFn: ReturnType<typeof vi.fn<typeof fetch>>) => {
   return call;
 };
 
+const responseWithCancel = (status: number, statusText?: string) => {
+  const cancel = vi.fn();
+  const body = new ReadableStream<Uint8Array>({ cancel });
+  return { response: new Response(body, { status, statusText }), cancel };
+};
+
 // ─── isPrivateOrReservedIP ───────────────────────────────────────────────────
 
 describe("isPrivateOrReservedIP", () => {
@@ -477,7 +483,8 @@ describe("uploadToConsentUrl", () => {
   });
 
   it("allows upload to a valid SharePoint URL and performs PUT", async () => {
-    const mockFetch = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+    const { response, cancel } = responseWithCancel(200);
+    const mockFetch = vi.fn<typeof fetch>(async () => response);
     const buffer = Buffer.from("file content");
 
     await uploadToConsentUrl({
@@ -500,14 +507,12 @@ describe("uploadToConsentUrl", () => {
     expect(opts?.body).toEqual(new Uint8Array(buffer));
     expect(opts?.signal).toBeInstanceOf(AbortSignal);
     expect(opts?.signal?.aborted).toBe(false);
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("throws on non-OK response after passing validation", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 403,
-      statusText: "Forbidden",
-    });
+    const { response, cancel } = responseWithCancel(403, "Forbidden");
+    const mockFetch = vi.fn<typeof fetch>(async () => response);
 
     await expect(
       uploadToConsentUrl({
@@ -517,22 +522,6 @@ describe("uploadToConsentUrl", () => {
         validationOpts: { resolveFn: publicResolve },
       }),
     ).rejects.toThrow("File upload to consent URL failed: 403 Forbidden");
-  });
-
-  it("cancels a non-OK consent upload response body before throwing", async () => {
-    const response = new Response("upload rejected", { status: 403, statusText: "Forbidden" });
-    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
-    const fetchFn = vi.fn<typeof fetch>(async () => response);
-
-    await expect(
-      uploadToConsentUrl({
-        url: "https://contoso.sharepoint.com/sites/uploads/file.pdf",
-        buffer: Buffer.from("data"),
-        fetchFn,
-        validationOpts: { resolveFn: publicResolve },
-      }),
-    ).rejects.toThrow("File upload to consent URL failed: 403 Forbidden");
-
     expect(cancel).toHaveBeenCalledOnce();
   });
 

--- a/extensions/msteams/src/file-consent.ts
+++ b/extensions/msteams/src/file-consent.ts
@@ -225,8 +225,10 @@ export async function uploadToConsentUrl(params: {
     fetchFn,
   );
 
+  // Consent uploads never consume the response payload. Cancel it on every
+  // status so the fetch implementation can release the underlying connection.
+  await res.body?.cancel().catch(() => undefined);
   if (!res.ok) {
-    await res.body?.cancel().catch(() => undefined);
     throw new Error(`File upload to consent URL failed: ${res.status} ${res.statusText}`);
   }
 }

--- a/extensions/msteams/src/file-consent.ts
+++ b/extensions/msteams/src/file-consent.ts
@@ -226,6 +226,7 @@ export async function uploadToConsentUrl(params: {
   );
 
   if (!res.ok) {
+    await res.body?.cancel().catch(() => undefined);
     throw new Error(`File upload to consent URL failed: ${res.status} ${res.statusText}`);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

When `uploadToConsentUrl` receives a non-OK response (e.g. 403, 503), it throws immediately without canceling the response body. The unconsumed stream holds a connection open until garbage collection.

## Why This Change Was Made

Follows the same pattern as #109519 (Google Chat cert fetch), #109508 (docs search), and #109677 (Chutes userinfo) — cancel the response body before throwing so that upstream streams are drained and connections released.

## User Impact

No user-facing change. Prevents resource leaks from unconsumed response bodies when SharePoint/OneDrive consent uploads fail with non-OK status codes.

## Evidence

```
$ npx vitest run extensions/msteams/src/file-consent.test.ts

 Test Files  1 passed (1)
      Tests  82 passed (82)
```

New test ("cancels a non-OK consent upload response body before throwing") verifies:
- A real `Response` with status 403 is returned by the fetch mock
- `response.body.cancel()` is called exactly once before the error is thrown
- The error message preserves the status code and text