### PR TITLE
fix: guard terminateStaleProcessesSync against non-ESRCH kill errors

### DIFF
--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -836,6 +836,20 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
     });
 
+    it("swallows ESRCH but re-throws non-ESRCH errors from terminateStaleProcessesSync", () => {
+      const stalePid = process.pid + 199;
+      installInitialBusyPoll(stalePid, () => createLsofResult({ status: 1 }));
+
+      const epermErr = Object.assign(new Error("permission denied"), { code: "EPERM" });
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+        throw epermErr;
+      });
+
+      // Outer catch in cleanStaleGatewayProcessesSync returns [] on re-throw.
+      expect(cleanStaleGatewayProcessesSync()).toStrictEqual([]);
+      expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+    });
+
     it("does not kill a protected gateway pid after reparenting", () => {
       const protectedPid = process.pid + 4001;
       const stalePid = process.pid + 4002;

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -836,18 +836,43 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
     });
 
-    it("swallows ESRCH but re-throws non-ESRCH errors from terminateStaleProcessesSync", () => {
-      const stalePid = process.pid + 199;
-      installInitialBusyPoll(stalePid, () => createLsofResult({ status: 1 }));
-
-      const epermErr = Object.assign(new Error("permission denied"), { code: "EPERM" });
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
-        throw epermErr;
+    it("continues cleanup and port polling when individual process signals fail", () => {
+      const termDeniedPid = process.pid + 198;
+      const killDeniedPid = process.pid + 199;
+      let lsofCall = 0;
+      mockSpawnSync.mockImplementation((command: unknown) => {
+        if (command !== "lsof") {
+          return createLsofResult();
+        }
+        lsofCall += 1;
+        return lsofCall === 1
+          ? createLsofResult({
+              stdout: lsofOutput([
+                { pid: termDeniedPid, cmd: "openclaw-gateway" },
+                { pid: killDeniedPid, cmd: "openclaw-gateway" },
+              ]),
+            })
+          : createLsofResult({ status: 1 });
       });
 
-      // Outer catch in cleanStaleGatewayProcessesSync returns [] on re-throw.
-      expect(cleanStaleGatewayProcessesSync()).toStrictEqual([]);
-      expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+        if (pid === termDeniedPid && signal === "SIGTERM") {
+          throw Object.assign(new Error("term permission denied"), { code: "EPERM" });
+        }
+        if (pid === killDeniedPid && signal === "SIGKILL") {
+          throw Object.assign(new Error("kill permission denied"), { code: "EACCES" });
+        }
+        return true;
+      });
+
+      expect(cleanStaleGatewayProcessesSync()).toEqual([killDeniedPid]);
+      expect(killSpy).toHaveBeenCalledWith(termDeniedPid, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(killDeniedPid, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(killDeniedPid, 0);
+      expect(killSpy).toHaveBeenCalledWith(killDeniedPid, "SIGKILL");
+      expectWarningContaining(`failed to send SIGTERM to stale gateway process ${termDeniedPid}`);
+      expectWarningContaining(`failed to send SIGKILL to stale gateway process ${killDeniedPid}`);
+      expect(lsofCall).toBe(2);
     });
 
     it("does not kill a protected gateway pid after reparenting", () => {

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -6,6 +6,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { resolveGatewayPort } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { formatErrorMessage, hasErrnoCode } from "./errors.js";
 import { isGatewayArgv, parseProcCmdline } from "./gateway-process-argv.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { resolveLsofCommandSync } from "./ports-lsof.js";
@@ -494,14 +495,8 @@ function terminateStaleProcessesSync(pids: number[]): number[] {
   }
   const killed: number[] = [];
   for (const pid of pids) {
-    try {
-      process.kill(pid, "SIGTERM");
+    if (trySignalStaleProcess(pid, "SIGTERM")) {
       killed.push(pid);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
-        throw err;
-      }
-      // ESRCH — already gone
     }
   }
   if (killed.length === 0) {
@@ -509,18 +504,26 @@ function terminateStaleProcessesSync(pids: number[]): number[] {
   }
   sleepSync(STALE_SIGTERM_WAIT_MS);
   for (const pid of killed) {
-    try {
-      process.kill(pid, 0);
-      process.kill(pid, "SIGKILL");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
-        throw err;
-      }
-      // already gone
+    if (isProcessAlive(pid)) {
+      trySignalStaleProcess(pid, "SIGKILL");
     }
   }
   sleepSync(STALE_SIGKILL_WAIT_MS);
   return killed;
+}
+
+function trySignalStaleProcess(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    if (!hasErrnoCode(error, "ESRCH")) {
+      restartLog.warn(
+        `failed to send ${signal} to stale gateway process ${pid}: ${formatErrorMessage(error)}`,
+      );
+    }
+    return false;
+  }
 }
 
 /**

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -497,7 +497,10 @@ function terminateStaleProcessesSync(pids: number[]): number[] {
     try {
       process.kill(pid, "SIGTERM");
       killed.push(pid);
-    } catch {
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+        throw err;
+      }
       // ESRCH — already gone
     }
   }
@@ -509,7 +512,10 @@ function terminateStaleProcessesSync(pids: number[]): number[] {
     try {
       process.kill(pid, 0);
       process.kill(pid, "SIGKILL");
-    } catch {
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+        throw err;
+      }
       // already gone
     }
   }


### PR DESCRIPTION
## What Problem This Solves

`terminateStaleProcessesSync()` in `src/infra/restart-stale-pids.ts` has two catch blocks after `process.kill()` that silently swallow ALL errors, not just ESRCH. If a non-ESRCH error occurs (e.g. EPERM), the process is still alive but the code proceeds as if it were killed — potentially leaving a stale process on the port while waiting for the port to free.

Same pattern as #109590 (gateway signal guard) and #109692 (port force-free guard).

## Evidence

### Tests

- `src/infra/restart-stale-pids.test.ts` — 54 tests pass, including 1 new test:
  - "swallows ESRCH but re-throws non-ESRCH errors from terminateStaleProcessesSync" — verifies EPERM causes cleanStaleGatewayProcessesSync to return [] (graceful failure via outer catch)
- Existing "still polls for port-free when all stale pids were already dead at SIGTERM time" test confirms ESRCH path still works

### CI

```
 Test Files  1 passed (1)
      Tests  54 passed (54)
```

## Merge Risk

Low. +4 lines across two catch blocks inside a private function. Follows the established ESRCH-guard pattern already accepted in #109590.