### PR TITLE
test: session freshness fixtures flake near the daily-reset boundary

### DIFF
--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -1,7 +1,7 @@
 // Agent session command tests cover session resolution, agent scoping, and temp-home session stores.
 import path from "node:path";
 import { withTempHome as withTempHomeBase } from "openclaw/plugin-sdk/test-env";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentDir, resolveSessionAgentId } from "../agents/agent-scope.js";
 import { updateSessionStoreAfterAgentRun } from "../agents/command/session-store.js";
 import { resolveSession } from "../agents/command/session.js";
@@ -74,6 +74,17 @@ async function withCrossAgentResumeFixture(
 
 beforeEach(() => {
   clearSessionStoreCacheForTest();
+  // Freshness fixtures seed times relative to Date.now(); near the 04:00
+  // local daily-reset boundary the seeded window straddles it and reuse
+  // scenarios flip to new sessions. Pin local noon so no timezone can hit it.
+  vi.useFakeTimers({ toFake: ["Date"] });
+  const localNoon = new Date();
+  localNoon.setHours(12, 0, 0, 0);
+  vi.setSystemTime(localNoon);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("agent session resolution", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes a time-of-day CI flake: `src/commands/agent.session.test.ts` freshness scenarios seed session timestamps relative to `Date.now()`. When a CI run starts within ~70 seconds after the 04:00 local daily-reset boundary, the seeded session-start falls before the boundary, the resolver correctly rolls a new session, and the "reuse" scenarios fail. This flaked `checks-node-compact-large-1` on unrelated PRs tonight (runs starting 04:00:33 UTC).

## Why This Change Was Made

The failure is deterministic when the clock sits just past the boundary (reproduced on a clean main checkout with a forced clock: `TZ=UTC` + `Date.now` pinned to `04:00:30Z` fails identically). Tests should not depend on the wall clock's position relative to the reset boundary.

## User Impact

None at runtime — test-only. CI stops failing spuriously for ~70 seconds every day per timezone.

## Evidence

- Pinned local noon (faking only `Date`, real timers restored per test): file passes in `TZ=UTC`, `TZ=Etc/GMT+2`, and `TZ=Asia/Kathmandu`, and under the exact boundary repro (`Date.now` forced to `2026-07-17T04:00:30Z`): 7/7 in all four runs.
- Before the fix, the boundary repro fails the "transcript newer than registry" scenario with `expected true to be false`.
