### PR TITLE
refactor(tui): unify local queue fallback admission

### DIFF
--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -468,7 +468,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (queuedAfter) {
       const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
       const { cfg, canonicalKey, entry } = loadSessionEntry(opts.sessionKey, loadOptions);
-      const queueSettings = resolveQueueSettings({
+      let queueSettings = resolveQueueSettings({
         cfg,
         channel: INTERNAL_MESSAGE_CHANNEL,
         sessionEntry: entry,
@@ -488,17 +488,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
             return { runId: queuedAfter.runId };
           }
         }
-        const queued = this.enqueuePendingLocalMessage({
-          runScope,
-          message: opts.message,
-          settings: { ...queueSettings, mode: "followup" },
-          fallbackRunId: queuedAfter.runId,
-        });
-        if (queued.kind === "handled") {
-          return { runId: queued.runId };
-        }
-        pendingQueue = queued.queue;
-      } else if (queueSettings.mode === "interrupt") {
+        queueSettings = { ...queueSettings, mode: "followup" };
+      }
+      if (queueSettings.mode === "interrupt") {
         this.abortSessionRuns(runScope);
       } else {
         const queued = this.enqueuePendingLocalMessage({


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated local queue fallback admission in the embedded TUI backend. Steering rejection and ordinary queued modes previously maintained separate copies of the same bounded enqueue/result handling path, making later queue-policy changes easier to apply one-sidedly.

## Why This Change Was Made

After an active-runtime steering attempt fails, the resolved mode is normalized to `followup` and then enters the same pending-admission branch as `followup` and `collect`. `interrupt` remains separate. This is behavior-neutral and removes eight net lines without adding an abstraction.

## User Impact

No user-visible behavior change. Local steering fallback and configured queue modes retain their existing behavior through one canonical admission path.

## Evidence

- `node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts`: 60 tests passed.
- `git diff --check`: passed.
- Fresh structured autoreview: no accepted or actionable findings.
- Hosted changed gate requested; exact PR-head CI remains the landing gate.
