### PR TITLE
fix(agents): add timeout to fd and ripgrep search executions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2050,7 +2050,7 @@ src/agents/sessions/steering-message-identity.ts	2
 src/agents/sessions/tools/bash.ts	3
 src/agents/sessions/tools/edit.ts	14
 src/agents/sessions/tools/find.ts	2
-src/agents/sessions/tools/grep.ts	4
+src/agents/sessions/tools/grep.ts	3
 src/agents/sessions/tools/ls.ts	2
 src/agents/sessions/tools/read.ts	2
 src/agents/sessions/tools/tool-definition-wrapper.ts	1

--- a/src/agents/sessions/tools/find.exec-timeout.test.ts
+++ b/src/agents/sessions/tools/find.exec-timeout.test.ts
@@ -1,24 +1,28 @@
 import type { ChildProcess } from "node:child_process";
 // Find tool stall-timeout escalation tests run a real managed-bin stub that
-// ignores SIGTERM: the inactivity deadline must reject the tool call, the kill
-// escalation must still reap the child, and its stdio pipes must be destroyed.
+// ignores SIGTERM: the inactivity deadline (the runner's noOutputTimeoutMs)
+// must reject the tool call, the kill escalation must still reap the child,
+// and its stdio pipes must be released.
 // Fake timers keep the 60s stall window instantaneous; real timers return
 // before the process-reaping assertions that need the real event loop.
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
-import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
-import { spawnCommand } from "../../../process/exec.js";
+import {
+  COMMAND_PROCESS_TREE_KILL_GRACE_MS,
+  spawnCommandWithInvocation,
+} from "../../../process/exec-spawn.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { createFindToolDefinition } from "./find.js";
 
-// Keep the real exec module (real spawn) while capturing spawned children.
-vi.mock("../../../process/exec.js", async (importActual) => {
-  const actual = (await importActual()) as typeof import("../../../process/exec.js");
+// Keep the real spawn (the runner spawns through exec-spawn) while capturing
+// spawned children.
+vi.mock("../../../process/exec-spawn.js", async (importActual) => {
+  const actual = (await importActual()) as typeof import("../../../process/exec-spawn.js");
   return {
     ...actual,
-    spawnCommand: vi.fn(actual.spawnCommand),
+    spawnCommandWithInvocation: vi.fn(actual.spawnCommandWithInvocation),
   };
 });
 
@@ -70,20 +74,20 @@ type SpawnedChild = {
 };
 
 function lastSpawnedChild(): SpawnedChild {
-  const child = vi.mocked(spawnCommand).mock.results.at(-1)?.value as
+  const child = vi.mocked(spawnCommandWithInvocation).mock.results.at(-1)?.value?.child as
     | ({ pid?: number } & Partial<SpawnedChild>)
     | undefined;
   if (!child || typeof child.pid !== "number" || !child.nodeChildProcess) {
-    throw new Error("expected spawnCommand to have produced a child with a pid");
+    throw new Error("expected spawnCommandWithInvocation to have produced a child with a pid");
   }
   return child as SpawnedChild;
 }
 
 async function pumpUntilSpawned(): Promise<void> {
-  for (let i = 0; i < 50 && !vi.mocked(spawnCommand).mock.calls.length; i++) {
+  for (let i = 0; i < 50 && !vi.mocked(spawnCommandWithInvocation).mock.calls.length; i++) {
     await vi.advanceTimersByTimeAsync(1);
   }
-  expect(spawnCommand).toHaveBeenCalledOnce();
+  expect(spawnCommandWithInvocation).toHaveBeenCalledOnce();
 }
 
 async function expectProcessReaped(pid: number): Promise<void> {
@@ -101,12 +105,21 @@ async function expectProcessReaped(pid: number): Promise<void> {
   );
 }
 
+// The tool rejects only after the runner resolves post-kill, so pump the real
+// event loop until the SIGKILLed stub's exit propagates.
+async function pumpUntilSettled(isSettled: () => boolean): Promise<void> {
+  for (let i = 0; i < 200 && !isSettled(); i++) {
+    await realDelay(10);
+    await vi.advanceTimersByTimeAsync(10);
+  }
+}
+
 describePosix("find tool stall-timeout escalation", () => {
   afterEach(() => {
     // Reap any stub that survived a failing run so the test process cannot
     // hang on open pipes.
-    for (const result of vi.mocked(spawnCommand).mock.results) {
-      const child = result.value as { pid?: number } | undefined;
+    for (const result of vi.mocked(spawnCommandWithInvocation).mock.results) {
+      const child = result.value?.child as { pid?: number } | undefined;
       if (typeof child?.pid === "number") {
         try {
           process.kill(child.pid, "SIGKILL");
@@ -127,19 +140,30 @@ describePosix("find tool stall-timeout escalation", () => {
     vi.useFakeTimers();
     const tool = createFindToolDefinition(dir);
     const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
+    let settled = false;
+    void result.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
     const rejection = expect(result).rejects.toThrow(/fd timed out.*without output/);
     await pumpUntilSpawned();
     const child = lastSpawnedChild();
 
-    // The stub never emits output, so nothing re-arms the stall timer.
+    // The stub never emits output, so nothing re-arms the runner's stall timer.
     await vi.advanceTimersByTimeAsync(60_000);
+    // The stub ignores the runner's SIGTERM, so only execa's SIGKILL escalation
+    // can reap it; the grace timer is faked too, so advance past the grace
+    // window.
+    await vi.advanceTimersByTimeAsync(COMMAND_PROCESS_TREE_KILL_GRACE_MS + 100);
+    await pumpUntilSettled(() => settled);
     await rejection;
-    // Stream cleanup is part of forced settlement: no pipes stay pinned.
+    // Stream cleanup is part of child exit: no pipes stay pinned.
     expect(child.stdout?.destroyed).toBe(true);
     expect(child.stderr?.destroyed).toBe(true);
-    // The stub ignores SIGTERM, so only the SIGKILL escalation can reap it;
-    // execa's grace timer is faked too, so advance past the grace window.
-    await vi.advanceTimersByTimeAsync(COMMAND_PROCESS_TREE_KILL_GRACE_MS + 100);
     expect(child.nodeChildProcess.killed).toBe(true);
 
     vi.useRealTimers();

--- a/src/agents/sessions/tools/find.exec-timeout.test.ts
+++ b/src/agents/sessions/tools/find.exec-timeout.test.ts
@@ -1,0 +1,186 @@
+import type { ChildProcess } from "node:child_process";
+// Find tool stall-timeout escalation tests run a real managed-bin stub that
+// ignores SIGTERM: the inactivity deadline must reject the tool call, the kill
+// escalation must still reap the child, and its stdio pipes must be destroyed.
+// Fake timers keep the 60s stall window instantaneous; real timers return
+// before the process-reaping assertions that need the real event loop.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
+import { spawnCommand } from "../../../process/exec.js";
+import { ensureTool } from "../../utils/tools-manager.js";
+import { createFindToolDefinition } from "./find.js";
+
+// Keep the real exec module (real spawn) while capturing spawned children.
+vi.mock("../../../process/exec.js", async (importActual) => {
+  const actual = (await importActual()) as typeof import("../../../process/exec.js");
+  return {
+    ...actual,
+    spawnCommand: vi.fn(actual.spawnCommand),
+  };
+});
+
+vi.mock("../../utils/tools-manager.js", () => ({
+  ensureTool: vi.fn(),
+}));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+// Shebang execution and SIGTERM semantics are POSIX-only.
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+// Captured at module load, before any fake-timer install; lets a test wait
+// real wall-clock time (for child-process output) while the fake clock drives
+// the stall deadline.
+const realSetTimeout = globalThis.setTimeout;
+const realDelay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    realSetTimeout(resolve, ms);
+  });
+
+function writeSigtermIgnoringStub(dir: string): string {
+  const stubPath = path.join(dir, "stub-fd");
+  fs.writeFileSync(
+    stubPath,
+    `#!${process.execPath}\nprocess.on("SIGTERM", () => {});\nsetInterval(() => {}, 60_000);\n`,
+    { mode: 0o755 },
+  );
+  return stubPath;
+}
+
+function writeChattyStub(dir: string): string {
+  const stubPath = path.join(dir, "stub-fd-chatty");
+  fs.writeFileSync(
+    stubPath,
+    `#!${process.execPath}\nsetInterval(() => console.log("candidate.ts"), 100);\n`,
+    { mode: 0o755 },
+  );
+  return stubPath;
+}
+
+// execa 10 exposes the underlying ChildProcess (and its `killed` flag) through
+// `nodeChildProcess`; the subprocess facade itself only carries pid/stdio/kill.
+type SpawnedChild = {
+  pid: number;
+  stdout: { destroyed: boolean } | null;
+  stderr: { destroyed: boolean } | null;
+  nodeChildProcess: ChildProcess;
+};
+
+function lastSpawnedChild(): SpawnedChild {
+  const child = vi.mocked(spawnCommand).mock.results.at(-1)?.value as
+    | ({ pid?: number } & Partial<SpawnedChild>)
+    | undefined;
+  if (!child || typeof child.pid !== "number" || !child.nodeChildProcess) {
+    throw new Error("expected spawnCommand to have produced a child with a pid");
+  }
+  return child as SpawnedChild;
+}
+
+async function pumpUntilSpawned(): Promise<void> {
+  for (let i = 0; i < 50 && !vi.mocked(spawnCommand).mock.calls.length; i++) {
+    await vi.advanceTimersByTimeAsync(1);
+  }
+  expect(spawnCommand).toHaveBeenCalledOnce();
+}
+
+async function expectProcessReaped(pid: number): Promise<void> {
+  await vi.waitFor(
+    () => {
+      let alive = true;
+      try {
+        process.kill(pid, 0);
+      } catch {
+        alive = false;
+      }
+      expect(alive).toBe(false);
+    },
+    { timeout: 5_000, interval: 25 },
+  );
+}
+
+describePosix("find tool stall-timeout escalation", () => {
+  afterEach(() => {
+    // Reap any stub that survived a failing run so the test process cannot
+    // hang on open pipes.
+    for (const result of vi.mocked(spawnCommand).mock.results) {
+      const child = result.value as { pid?: number } | undefined;
+      if (typeof child?.pid === "number") {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {
+          // Already gone.
+        }
+      }
+    }
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("rejects after a silent window, reaps a SIGTERM-ignoring fd via escalation, and releases its pipes", async () => {
+    const dir = tempDirs.make("openclaw-find-stub-");
+    const stubPath = writeSigtermIgnoringStub(dir);
+    vi.mocked(ensureTool).mockResolvedValue(stubPath);
+
+    vi.useFakeTimers();
+    const tool = createFindToolDefinition(dir);
+    const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
+    const rejection = expect(result).rejects.toThrow(/fd timed out.*without output/);
+    await pumpUntilSpawned();
+    const child = lastSpawnedChild();
+
+    // The stub never emits output, so nothing re-arms the stall timer.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await rejection;
+    // Stream cleanup is part of forced settlement: no pipes stay pinned.
+    expect(child.stdout?.destroyed).toBe(true);
+    expect(child.stderr?.destroyed).toBe(true);
+    // The stub ignores SIGTERM, so only the SIGKILL escalation can reap it;
+    // execa's grace timer is faked too, so advance past the grace window.
+    await vi.advanceTimersByTimeAsync(COMMAND_PROCESS_TREE_KILL_GRACE_MS + 100);
+    expect(child.nodeChildProcess.killed).toBe(true);
+
+    vi.useRealTimers();
+    await expectProcessReaped(child.pid);
+  });
+
+  it("does not kill fd while output keeps arriving past the stall window", async () => {
+    const dir = tempDirs.make("openclaw-find-active-");
+    const stubPath = writeChattyStub(dir);
+    vi.mocked(ensureTool).mockResolvedValue(stubPath);
+
+    vi.useFakeTimers();
+    const tool = createFindToolDefinition(dir);
+    const controller = new AbortController();
+    const result = tool.execute(
+      "call-1",
+      { pattern: "*.ts" },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+    let outcome: "resolved" | "rejected" | undefined;
+    void result.then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+    await pumpUntilSpawned();
+
+    // 70s of fake time in 5s chunks, with real wall-clock pauses so the
+    // chatty stub's lines arrive and re-arm the stall timer each chunk.
+    for (let i = 0; i < 14; i++) {
+      await vi.advanceTimersByTimeAsync(5_000);
+      await realDelay(150);
+    }
+    expect(outcome).toBeUndefined();
+
+    controller.abort();
+    await expect(result).rejects.toThrow(/aborted/);
+  });
+});

--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -1,16 +1,16 @@
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { EventEmitter } from "node:events";
+// Find tool fd tests cover exit-code/error mapping, cancellation, and result
+// limits with the command runner mocked at its public contract; the runner
+// owns spawn, stall detection, and process termination.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { PassThrough } from "node:stream";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
-import { spawnCommand } from "../../../process/exec.js";
+import { runUtf8CommandWithTimeout, type SpawnResult } from "../../../process/exec.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { createFindToolDefinition } from "./find.js";
 
 vi.mock("../../../process/exec.js", () => ({
-  spawnCommand: vi.fn(),
+  runUtf8CommandWithTimeout: vi.fn(),
 }));
 
 vi.mock("../../utils/tools-manager.js", () => ({
@@ -18,11 +18,11 @@ vi.mock("../../utils/tools-manager.js", () => ({
 }));
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-type MockChild = ChildProcessWithoutNullStreams & {
-  nodeChildProcess: ChildProcessWithoutNullStreams;
-  stdout: PassThrough;
-  stderr: PassThrough;
-  killMock: ReturnType<typeof vi.fn>;
+
+type RunnerOptions = {
+  signal?: AbortSignal;
+  noOutputTimeoutMs?: number;
+  onOutputChunk?: (chunk: Buffer, stream: "stdout" | "stderr") => boolean | void;
 };
 
 afterEach(() => {
@@ -32,18 +32,38 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function createChild(): MockChild {
-  const kill = vi.fn(() => true);
-  const child = Object.assign(new EventEmitter(), {
-    stdin: new PassThrough(),
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
+function spawnResult(overrides: Partial<SpawnResult>): SpawnResult {
+  return {
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
     killed: false,
-    kill,
-    killMock: kill,
-  }) as unknown as MockChild;
-  child.nodeChildProcess = child;
+    termination: "exit",
+    noOutputTimedOut: false,
+    ...overrides,
+  };
+}
+
+// Stands in for the process the runner owns; kill() records that the runner
+// terminated it. The tool itself no longer holds a process handle.
+function createChild() {
+  const child = {
+    killed: false,
+    kill: vi.fn(() => {
+      child.killed = true;
+      return true;
+    }),
+  };
   return child;
+}
+
+function runnerOptions(): RunnerOptions {
+  const options = vi.mocked(runUtf8CommandWithTimeout).mock.calls[0]?.[1];
+  if (!options || typeof options !== "object") {
+    throw new Error("expected the tool to pass runner options");
+  }
+  return options as RunnerOptions;
 }
 
 function textContent(
@@ -54,87 +74,108 @@ function textContent(
 }
 
 it("rejects partial fd output when fd exits with an error", async () => {
-  const child = createChild();
-  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(
+    spawnResult({
+      stdout: "/workspace/partial.ts\n",
+      stderr: "fd failed while reading subtree\n",
+      code: 2,
+    }),
+  );
   vi.mocked(ensureTool).mockResolvedValue("fd");
 
   const tool = createFindToolDefinition("/workspace");
   const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
-  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-  child.stdout.end("/workspace/partial.ts\n");
-  child.stderr.end("fd failed while reading subtree\n");
-  child.emit("close", 2, null);
+  const rejection = expect(result).rejects.toThrow("fd failed while reading subtree");
+  await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
-  await expect(result).rejects.toThrow("fd failed while reading subtree");
+  await rejection;
 });
 
-it("keeps multibyte stderr intact when pipe chunks split a character", async () => {
-  const child = createChild();
-  vi.mocked(spawnCommand).mockReturnValue(child as never);
+it("keeps multibyte stderr intact in the rejection", async () => {
+  // Chunk-safe multibyte decoding now belongs to the runner capture; the tool
+  // must surface the decoded stderr verbatim.
+  vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(
+    spawnResult({ stderr: "fd 失败：权限被拒绝\n", code: 2 }),
+  );
   vi.mocked(ensureTool).mockResolvedValue("fd");
 
   const tool = createFindToolDefinition("/workspace");
   const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
-  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-  const stderrBytes = Buffer.from("fd 失败：权限被拒绝\n");
-  child.stdout.end();
-  // Split inside the first multibyte character to mimic a pipe chunk boundary.
-  child.stderr.write(stderrBytes.subarray(0, 5));
-  child.stderr.end(stderrBytes.subarray(5));
-  child.emit("close", 2, null);
+  const rejection = expect(result).rejects.toThrow("fd 失败：权限被拒绝");
+  await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
-  await expect(result).rejects.toThrow("fd 失败：权限被拒绝");
+  await rejection;
 });
 
 it("rejects and kills fd when the search stalls without output past the deadline", async () => {
   vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   const child = createChild();
-  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  // Simulate the runner contract: a silent child is killed at the no-output
+  // deadline and the result reports noOutputTimedOut.
+  vi.mocked(runUtf8CommandWithTimeout).mockImplementation(async (_argv, options) => {
+    await new Promise<void>((resolveWait) => {
+      setTimeout(
+        () => {
+          child.kill();
+          resolveWait();
+        },
+        (options as RunnerOptions).noOutputTimeoutMs,
+      );
+    });
+    return spawnResult({
+      code: 124,
+      signal: "SIGKILL",
+      killed: true,
+      termination: "no-output-timeout",
+      noOutputTimedOut: true,
+    });
+  });
   vi.mocked(ensureTool).mockResolvedValue("fd");
 
   const tool = createFindToolDefinition("/workspace");
   // The child never writes output and never closes, mimicking fd stalled on a
   // broken mount; the tool must reject instead of hanging for the outer abort.
   const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
-  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+  await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
+  expect(runnerOptions().noOutputTimeoutMs).toBe(60_000);
 
   const rejection = expect(result).rejects.toThrow("fd timed out after 60 seconds without output");
   await vi.advanceTimersByTimeAsync(60_000);
   await rejection;
-  expect(child.killMock).toHaveBeenCalledOnce();
+  expect(child.kill).toHaveBeenCalledOnce();
 });
 
-it("clears the stall timer when fd exits normally", async () => {
+it("leaves no timers behind when fd exits normally", async () => {
   vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-  const child = createChild();
-  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(
+    spawnResult({ stdout: "/workspace/a.ts\n" }),
+  );
   vi.mocked(ensureTool).mockResolvedValue("fd");
 
   const tool = createFindToolDefinition("/workspace");
   const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
-  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-  child.stdout.end("/workspace/a.ts\n");
-  child.emit("close", 0, null);
+  await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
   await result;
 
   expect(vi.getTimerCount()).toBe(0);
-  expect(child.killMock).not.toHaveBeenCalled();
 });
 
 it.each(["stdout", "stderr"] as const)(
-  "rejects and stops fd when %s emits an error",
+  "rejects when the runner reports a %s failure",
   async (stream) => {
-    const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    // The runner terminates and reports output stream failures through the
+    // outputErrorStream field on its sanitized error.
+    vi.mocked(runUtf8CommandWithTimeout).mockRejectedValue(
+      Object.assign(new Error(`${stream} EPIPE`), { outputErrorStream: stream }),
+    );
     vi.mocked(ensureTool).mockResolvedValue("fd");
 
     const tool = createFindToolDefinition("/workspace");
     const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-    child[stream].emit("error", new Error(`${stream} EPIPE`));
+    const rejection = expect(result).rejects.toThrow(`fd ${stream} error: ${stream} EPIPE`);
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
-    await expect(result).rejects.toThrow(`${stream} EPIPE`);
-    expect(child.killMock).toHaveBeenCalledOnce();
+    await rejection;
   },
 );
 
@@ -149,8 +190,7 @@ it.each([
     await fs.writeFile(path.join(tempDir, ".git"), "gitdir: /tmp/example\n");
   }
 
-  const child = createChild();
-  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(spawnResult({}));
   vi.mocked(ensureTool).mockResolvedValue("fd");
   const tool = createFindToolDefinition(tempDir);
   const result = tool.execute(
@@ -160,13 +200,10 @@ it.each([
     undefined,
     {} as never,
   );
-  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-  child.stdout.end();
-  child.stderr.end();
-  child.emit("close", 0, null);
+  await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
   await result;
 
-  const args = vi.mocked(spawnCommand).mock.calls[0]?.[0] as string[];
+  const args = vi.mocked(runUtf8CommandWithTimeout).mock.calls[0]?.[0] as string[];
   expect(args.includes("--no-require-git")).toBe(expected);
 });
 
@@ -185,8 +222,9 @@ it.each([
     expectedLimitReached: 2,
   },
 ])("$name", async ({ paths, expectedText, expectedLimitReached }) => {
-  const child = createChild();
-  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(
+    spawnResult({ stdout: `${paths.join("\n")}\n` }),
+  );
   vi.mocked(ensureTool).mockResolvedValue("fd");
 
   const tool = createFindToolDefinition("/workspace");
@@ -197,13 +235,10 @@ it.each([
     undefined,
     {} as never,
   );
-  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-  child.stdout.end(`${paths.join("\n")}\n`);
-  child.stderr.end();
-  child.emit("close", 0, null);
+  await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
   const result = await resultPromise;
-  const args = vi.mocked(spawnCommand).mock.calls[0]?.[0] as string[];
+  const args = vi.mocked(runUtf8CommandWithTimeout).mock.calls[0]?.[0] as string[];
   expect(args).toEqual(expect.arrayContaining(["--max-results", "3"]));
   expect(textContent(result)).toBe(expectedText);
   expect(result.details?.resultLimitReached).toBe(expectedLimitReached);

--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -22,6 +22,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 type RunnerOptions = {
   signal?: AbortSignal;
   noOutputTimeoutMs?: number;
+  maxOutputBytes?: { stdout?: number; stderr?: number };
   onOutputChunk?: (chunk: Buffer, stream: "stdout" | "stderr") => boolean | void;
 };
 
@@ -138,6 +139,9 @@ it("rejects and kills fd when the search stalls without output past the deadline
   const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
   await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
   expect(runnerOptions().noOutputTimeoutMs).toBe(60_000);
+  // The pre-refactor stderr tail was bounded to 64 KiB; the runner default is
+  // 16 MiB, so the tool must pass the smaller bound explicitly.
+  expect(runnerOptions().maxOutputBytes).toEqual({ stderr: 64 * 1024 });
 
   const rejection = expect(result).rejects.toThrow("fd timed out after 60 seconds without output");
   await vi.advanceTimersByTimeAsync(60_000);

--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -23,6 +23,7 @@ type RunnerOptions = {
   signal?: AbortSignal;
   noOutputTimeoutMs?: number;
   maxOutputBytes?: { stdout?: number; stderr?: number };
+  terminateOnOutputError?: boolean;
   onOutputChunk?: (chunk: Buffer, stream: "stdout" | "stderr") => boolean | void;
 };
 
@@ -142,6 +143,8 @@ it("rejects and kills fd when the search stalls without output past the deadline
   // The pre-refactor stderr tail was bounded to 64 KiB; the runner default is
   // 16 MiB, so the tool must pass the smaller bound explicitly.
   expect(runnerOptions().maxOutputBytes).toEqual({ stderr: 64 * 1024 });
+  // A failed output stream must terminate fd immediately.
+  expect(runnerOptions().terminateOnOutputError).toBe(true);
 
   const rejection = expect(result).rejects.toThrow("fd timed out after 60 seconds without output");
   await vi.advanceTimersByTimeAsync(60_000);

--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -83,6 +83,43 @@ it("keeps multibyte stderr intact when pipe chunks split a character", async () 
   await expect(result).rejects.toThrow("fd 失败：权限被拒绝");
 });
 
+it("rejects and kills fd when the search stalls without output past the deadline", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  const child = createChild();
+  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(ensureTool).mockResolvedValue("fd");
+
+  const tool = createFindToolDefinition("/workspace");
+  // The child never writes output and never closes, mimicking fd stalled on a
+  // broken mount; the tool must reject instead of hanging for the outer abort.
+  const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
+  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+
+  const rejection = expect(result).rejects.toThrow("fd timed out after 60 seconds without output");
+  await vi.advanceTimersByTimeAsync(60_000);
+  await rejection;
+  expect(child.killMock).toHaveBeenCalledOnce();
+  vi.useRealTimers();
+});
+
+it("clears the stall timer when fd exits normally", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  const child = createChild();
+  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(ensureTool).mockResolvedValue("fd");
+
+  const tool = createFindToolDefinition("/workspace");
+  const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
+  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+  child.stdout.end("/workspace/a.ts\n");
+  child.emit("close", 0, null);
+  await result;
+
+  expect(vi.getTimerCount()).toBe(0);
+  expect(child.killMock).not.toHaveBeenCalled();
+  vi.useRealTimers();
+});
+
 it.each(["stdout", "stderr"] as const)(
   "rejects and stops fd when %s emits an error",
   async (stream) => {

--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -26,6 +26,9 @@ type MockChild = ChildProcessWithoutNullStreams & {
 };
 
 afterEach(() => {
+  // Restore fake timers even when a timeout test fails mid-way; leaked fake
+  // timers would otherwise poison later cases and hide the real failure.
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -99,7 +102,6 @@ it("rejects and kills fd when the search stalls without output past the deadline
   await vi.advanceTimersByTimeAsync(60_000);
   await rejection;
   expect(child.killMock).toHaveBeenCalledOnce();
-  vi.useRealTimers();
 });
 
 it("clears the stall timer when fd exits normally", async () => {
@@ -117,7 +119,6 @@ it("clears the stall timer when fd exits normally", async () => {
 
   expect(vi.getTimerCount()).toBe(0);
   expect(child.killMock).not.toHaveBeenCalled();
-  vi.useRealTimers();
 });
 
 it.each(["stdout", "stderr"] as const)(

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -292,6 +292,10 @@ export function createFindToolDefinition(
               result = await runUtf8CommandWithTimeout([fdPath, ...args], {
                 noOutputTimeoutMs: FD_STALL_TIMEOUT_MS,
                 signal,
+                // A failed output stream must kill fd immediately, matching
+                // the pre-refactor stopChild-on-error behavior; otherwise a
+                // wedged child could outlive the tool call.
+                terminateOnOutputError: true,
                 // Keep the pre-refactor stderr bound; the runner default tail
                 // is 16 MiB.
                 maxOutputBytes: { stderr: SESSION_TOOL_STDERR_TAIL_BYTES },

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -4,6 +4,7 @@ import { createInterface } from "node:readline";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
+import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
 import { spawnCommand } from "../../../process/exec.js";
 /**
  * Built-in find session tool.
@@ -48,6 +49,11 @@ const findSchema = Type.Object({
   limit: Type.Optional(Type.Integer({ description: "Max results; default 1000." })),
 });
 const DEFAULT_LIMIT = 1000;
+// fd can stall on a broken filesystem or network mount without exiting or
+// emitting output. Bound the silence, not the total runtime: any stdout line
+// or stderr chunk re-arms the timer, so a healthy long search keeps running
+// and only a silent child is killed.
+const FD_STALL_TIMEOUT_MS = 60_000;
 
 /**
  * Pluggable operations for the find tool.
@@ -175,11 +181,13 @@ export function createFindToolDefinition(
 
         let settled = false;
         let stopChild: (() => void) | undefined;
+        let execTimeout: NodeJS.Timeout | undefined;
         const settle = (fn: () => void) => {
           if (settled) {
             return;
           }
           settled = true;
+          clearTimeout(execTimeout);
           signal?.removeEventListener("abort", onAbort);
           stopChild = undefined;
           fn();
@@ -282,6 +290,9 @@ export function createFindToolDefinition(
 
             const child = spawnCommand([fdPath, ...args], {
               buffer: false,
+              // A wedged fd can ignore the initial SIGTERM from the timeout or
+              // abort path; execa escalates to SIGKILL after this grace window.
+              forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
               reject: false,
               stdio: ["ignore", "pipe", "pipe"],
             });
@@ -295,6 +306,23 @@ export function createFindToolDefinition(
                 child.kill();
               }
             };
+
+            execTimeout = setTimeout(() => {
+              stopChild?.();
+              settle(() =>
+                reject(
+                  new Error(
+                    `fd timed out after ${FD_STALL_TIMEOUT_MS / 1000} seconds without output`,
+                  ),
+                ),
+              );
+              // If fd ignores the SIGTERM above, forceKillAfterDelay reaps it
+              // after the grace window; release the pipes now so a defiant
+              // child cannot pin stream handles past settlement.
+              rl.close();
+              child.stdout?.destroy();
+              child.stderr?.destroy();
+            }, FD_STALL_TIMEOUT_MS);
 
             const cleanup = () => {
               rl.close();
@@ -312,6 +340,9 @@ export function createFindToolDefinition(
             // cannot split multibyte characters into U+FFFD replacement noise.
             child.stderr?.setEncoding("utf8");
             child.stderr?.on("data", (chunk: string) => {
+              // Stream activity proves the child is alive; re-arm the stall
+              // timer so only a silent fd is killed.
+              execTimeout?.refresh();
               stderr = appendBoundedTextTail(stderr, chunk);
             });
             // Readline re-emits input failures, while the stream listener also catches
@@ -321,6 +352,9 @@ export function createFindToolDefinition(
             child.stderr?.on("error", (error) => onStreamError("stderr", error));
 
             rl.on("line", (line) => {
+              // Stream activity proves the child is alive; re-arm the stall
+              // timer so only a silent fd is killed.
+              execTimeout?.refresh();
               lines.push(line);
             });
 

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -1,11 +1,8 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { createInterface } from "node:readline";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
-import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
-import { spawnCommand } from "../../../process/exec.js";
+import { runUtf8CommandWithTimeout, type SpawnResult } from "../../../process/exec.js";
 /**
  * Built-in find session tool.
  *
@@ -15,7 +12,7 @@ import { normalizeNativePathSeparators } from "../../../shared/ignore-rules.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { appendBoundedTextTail, normalizePositiveLimit } from "./limits.js";
+import { normalizePositiveLimit } from "./limits.js";
 import { resolveToCwd } from "./path-utils.js";
 import {
   appendSessionToolTruncationWarning,
@@ -180,20 +177,17 @@ export function createFindToolDefinition(
         }
 
         let settled = false;
-        let stopChild: (() => void) | undefined;
-        let execTimeout: NodeJS.Timeout | undefined;
         const settle = (fn: () => void) => {
           if (settled) {
             return;
           }
           settled = true;
-          clearTimeout(execTimeout);
           signal?.removeEventListener("abort", onAbort);
-          stopChild = undefined;
           fn();
         };
+        // The runner owns killing the child once it is spawned (via this
+        // signal); settlement only needs to stop listening and reject.
         const onAbort = () => {
-          stopChild?.();
           settle(() => reject(new Error("Operation aborted")));
         };
         signal?.addEventListener("abort", onAbort, { once: true });
@@ -288,27 +282,36 @@ export function createFindToolDefinition(
             }
             args.push("--", effectivePattern, searchPath);
 
-            const child = spawnCommand([fdPath, ...args], {
-              buffer: false,
-              // A wedged fd can ignore the initial SIGTERM from the timeout or
-              // abort path; execa escalates to SIGKILL after this grace window.
-              forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
-              reject: false,
-              stdio: ["ignore", "pipe", "pipe"],
-            });
-            releaseChildProcessOutputAfterExit(child.nodeChildProcess);
-            const rl = createInterface({ input: child.stdout });
-            let stderr = "";
-            const lines: string[] = [];
-
-            stopChild = () => {
-              if (!child.nodeChildProcess.killed) {
-                child.kill();
+            let result: SpawnResult;
+            try {
+              // The runner owns the child lifecycle: noOutputTimeoutMs re-arms
+              // on every raw stdout/stderr chunk, so a healthy long search
+              // keeps running and only a silent fd is killed. fd output is
+              // bounded by --max-results, so buffering via the runner capture
+              // is safe.
+              result = await runUtf8CommandWithTimeout([fdPath, ...args], {
+                noOutputTimeoutMs: FD_STALL_TIMEOUT_MS,
+                signal,
+              });
+            } catch (error) {
+              const outputErrorStream = (error as { outputErrorStream?: unknown })
+                .outputErrorStream;
+              const message = error instanceof Error ? error.message : String(error);
+              if (outputErrorStream === "stdout" || outputErrorStream === "stderr") {
+                settle(() => reject(new Error(`fd ${outputErrorStream} error: ${message}`)));
+              } else {
+                settle(() => reject(new Error(`Failed to run fd: ${message}`)));
               }
-            };
-
-            execTimeout = setTimeout(() => {
-              stopChild?.();
+              return;
+            }
+            if (settled) {
+              return;
+            }
+            if (signal?.aborted) {
+              settle(() => reject(new Error("Operation aborted")));
+              return;
+            }
+            if (result.noOutputTimedOut) {
               settle(() =>
                 reject(
                   new Error(
@@ -316,104 +319,59 @@ export function createFindToolDefinition(
                   ),
                 ),
               );
-              // If fd ignores the SIGTERM above, forceKillAfterDelay reaps it
-              // after the grace window; release the pipes now so a defiant
-              // child cannot pin stream handles past settlement.
-              rl.close();
-              child.stdout?.destroy();
-              child.stderr?.destroy();
-            }, FD_STALL_TIMEOUT_MS);
-
-            const cleanup = () => {
-              rl.close();
-            };
-            const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
-              if (settled) {
-                return;
-              }
-              stopChild?.();
-              cleanup();
-              settle(() => reject(new Error(`fd ${stream} error: ${error.message}`)));
-            };
-
-            // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
-            // cannot split multibyte characters into U+FFFD replacement noise.
-            child.stderr?.setEncoding("utf8");
-            child.stderr?.on("data", (chunk: string) => {
-              // Stream activity proves the child is alive; re-arm the stall
-              // timer so only a silent fd is killed.
-              execTimeout?.refresh();
-              stderr = appendBoundedTextTail(stderr, chunk);
-            });
-            // Readline re-emits input failures, while the stream listener also catches
-            // implementations that do not. settle() keeps the shared failure path one-shot.
-            rl.on("error", (error) => onStreamError("stdout", error));
-            child.stdout?.on("error", (error) => onStreamError("stdout", error));
-            child.stderr?.on("error", (error) => onStreamError("stderr", error));
-
-            rl.on("line", (line) => {
-              // Stream activity proves the child is alive; re-arm the stall
-              // timer so only a silent fd is killed.
-              execTimeout?.refresh();
-              lines.push(line);
-            });
-
-            child.nodeChildProcess.on("error", (error) => {
-              cleanup();
-              settle(() => reject(new Error(`Failed to run fd: ${error.message}`)));
-            });
-
-            child.nodeChildProcess.on("close", (code) => {
-              cleanup();
-              if (signal?.aborted) {
-                settle(() => reject(new Error("Operation aborted")));
-                return;
-              }
-              const output = lines.join("\n");
-              if (code !== 0) {
-                const errorMsg = stderr.trim() || `fd exited with code ${code}`;
-                settle(() => reject(new Error(errorMsg)));
-                return;
-              }
-              if (!output) {
-                settle(() =>
-                  resolve({
-                    content: [{ type: "text", text: "No files found matching pattern" }],
-                    details: undefined,
-                  }),
-                );
-                return;
-              }
-
-              const relativized: string[] = [];
-              for (const rawLine of lines) {
-                const line = rawLine.replace(/\r$/, "").trim();
-                if (!line) {
-                  continue;
-                }
-                const hadTrailingSlash = line.endsWith("/") || line.endsWith("\\");
-                let relativePath;
-                if (line.startsWith(searchPath)) {
-                  relativePath = line.slice(searchPath.length + 1);
-                } else {
-                  relativePath = path.relative(searchPath, line);
-                }
-                if (hadTrailingSlash && !relativePath.endsWith("/")) {
-                  relativePath += "/";
-                }
-                relativized.push(normalizeNativePathSeparators(relativePath));
-              }
-
+              return;
+            }
+            if (result.outputErrorStream) {
               settle(() =>
-                resolve(
-                  buildFindResult({
-                    relativized,
-                    effectiveLimit,
-                    limitNotice: `${effectiveLimit} results limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
-                  }),
-                ),
+                reject(new Error(`fd ${result.outputErrorStream} error: output stream failed`)),
               );
-            });
+              return;
+            }
+            const lines = result.stdout.split("\n");
+            const output = lines.join("\n");
+            if (result.code !== 0) {
+              const errorMsg = result.stderr.trim() || `fd exited with code ${result.code}`;
+              settle(() => reject(new Error(errorMsg)));
+              return;
+            }
+            if (!output) {
+              settle(() =>
+                resolve({
+                  content: [{ type: "text", text: "No files found matching pattern" }],
+                  details: undefined,
+                }),
+              );
+              return;
+            }
+
+            const relativized: string[] = [];
+            for (const rawLine of lines) {
+              const line = rawLine.replace(/\r$/, "").trim();
+              if (!line) {
+                continue;
+              }
+              const hadTrailingSlash = line.endsWith("/") || line.endsWith("\\");
+              let relativePath;
+              if (line.startsWith(searchPath)) {
+                relativePath = line.slice(searchPath.length + 1);
+              } else {
+                relativePath = path.relative(searchPath, line);
+              }
+              if (hadTrailingSlash && !relativePath.endsWith("/")) {
+                relativePath += "/";
+              }
+              relativized.push(normalizeNativePathSeparators(relativePath));
+            }
+
+            settle(() =>
+              resolve(
+                buildFindResult({
+                  relativized,
+                  effectiveLimit,
+                  limitNotice: `${effectiveLimit} results limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
+                }),
+              ),
+            );
           } catch (e) {
             if (signal?.aborted) {
               settle(() => reject(new Error("Operation aborted")));

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -12,7 +12,7 @@ import { normalizeNativePathSeparators } from "../../../shared/ignore-rules.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { normalizePositiveLimit } from "./limits.js";
+import { normalizePositiveLimit, SESSION_TOOL_STDERR_TAIL_BYTES } from "./limits.js";
 import { resolveToCwd } from "./path-utils.js";
 import {
   appendSessionToolTruncationWarning,
@@ -292,6 +292,9 @@ export function createFindToolDefinition(
               result = await runUtf8CommandWithTimeout([fdPath, ...args], {
                 noOutputTimeoutMs: FD_STALL_TIMEOUT_MS,
                 signal,
+                // Keep the pre-refactor stderr bound; the runner default tail
+                // is 16 MiB.
+                maxOutputBytes: { stderr: SESSION_TOOL_STDERR_TAIL_BYTES },
               });
             } catch (error) {
               const outputErrorStream =

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -294,8 +294,10 @@ export function createFindToolDefinition(
                 signal,
               });
             } catch (error) {
-              const outputErrorStream = (error as { outputErrorStream?: unknown })
-                .outputErrorStream;
+              const outputErrorStream =
+                error instanceof Error && "outputErrorStream" in error
+                  ? error.outputErrorStream
+                  : undefined;
               const message = error instanceof Error ? error.message : String(error);
               if (outputErrorStream === "stdout" || outputErrorStream === "stderr") {
                 settle(() => reject(new Error(`fd ${outputErrorStream} error: ${message}`)));

--- a/src/agents/sessions/tools/grep.exec-timeout.test.ts
+++ b/src/agents/sessions/tools/grep.exec-timeout.test.ts
@@ -1,24 +1,28 @@
 import type { ChildProcess } from "node:child_process";
 // Grep tool stall-timeout escalation tests run a real managed-bin stub that
-// ignores SIGTERM: the inactivity deadline must reject the tool call, the kill
-// escalation must still reap the child, and its stdio pipes must be destroyed.
+// ignores SIGTERM: the inactivity deadline (the runner's noOutputTimeoutMs)
+// must reject the tool call, the kill escalation must still reap the child,
+// and its stdio pipes must be released.
 // Fake timers keep the 60s stall window instantaneous; real timers return
 // before the process-reaping assertions that need the real event loop.
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
-import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
-import { spawnCommand } from "../../../process/exec.js";
+import {
+  COMMAND_PROCESS_TREE_KILL_GRACE_MS,
+  spawnCommandWithInvocation,
+} from "../../../process/exec-spawn.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { createGrepToolDefinition } from "./grep.js";
 
-// Keep the real exec module (real spawn) while capturing spawned children.
-vi.mock("../../../process/exec.js", async (importActual) => {
-  const actual = (await importActual()) as typeof import("../../../process/exec.js");
+// Keep the real spawn (the runner spawns through exec-spawn) while capturing
+// spawned children.
+vi.mock("../../../process/exec-spawn.js", async (importActual) => {
+  const actual = (await importActual()) as typeof import("../../../process/exec-spawn.js");
   return {
     ...actual,
-    spawnCommand: vi.fn(actual.spawnCommand),
+    spawnCommandWithInvocation: vi.fn(actual.spawnCommandWithInvocation),
   };
 });
 
@@ -60,9 +64,10 @@ function writeChattyStub(dir: string): string {
   return stubPath;
 }
 
-// One large ripgrep JSON record streamed in newline-less chunks: readline
-// emits no `line` event until the final chunk, so the stall deadline must
-// re-arm on raw stdout data or an active search is killed as silent.
+// One large ripgrep JSON record streamed in newline-less chunks: the tool's
+// line buffer emits no completed event until the final chunk, so the runner's
+// stall deadline must re-arm on raw stdout data or an active search is killed
+// as silent.
 function writeChunkedRecordStub(dir: string): string {
   const stubPath = path.join(dir, "stub-rg-chunked");
   fs.writeFileSync(
@@ -83,20 +88,20 @@ type SpawnedChild = {
 };
 
 function lastSpawnedChild(): SpawnedChild {
-  const child = vi.mocked(spawnCommand).mock.results.at(-1)?.value as
+  const child = vi.mocked(spawnCommandWithInvocation).mock.results.at(-1)?.value?.child as
     | ({ pid?: number } & Partial<SpawnedChild>)
     | undefined;
   if (!child || typeof child.pid !== "number" || !child.nodeChildProcess) {
-    throw new Error("expected spawnCommand to have produced a child with a pid");
+    throw new Error("expected spawnCommandWithInvocation to have produced a child with a pid");
   }
   return child as SpawnedChild;
 }
 
 async function pumpUntilSpawned(): Promise<void> {
-  for (let i = 0; i < 50 && !vi.mocked(spawnCommand).mock.calls.length; i++) {
+  for (let i = 0; i < 50 && !vi.mocked(spawnCommandWithInvocation).mock.calls.length; i++) {
     await vi.advanceTimersByTimeAsync(1);
   }
-  expect(spawnCommand).toHaveBeenCalledOnce();
+  expect(spawnCommandWithInvocation).toHaveBeenCalledOnce();
 }
 
 async function expectProcessReaped(pid: number): Promise<void> {
@@ -114,12 +119,21 @@ async function expectProcessReaped(pid: number): Promise<void> {
   );
 }
 
+// The tool rejects only after the runner resolves post-kill, so pump the real
+// event loop until the SIGKILLed stub's exit propagates.
+async function pumpUntilSettled(isSettled: () => boolean): Promise<void> {
+  for (let i = 0; i < 200 && !isSettled(); i++) {
+    await realDelay(10);
+    await vi.advanceTimersByTimeAsync(10);
+  }
+}
+
 describePosix("grep tool stall-timeout escalation", () => {
   afterEach(() => {
     // Reap any stub that survived a failing run so the test process cannot
     // hang on open pipes.
-    for (const result of vi.mocked(spawnCommand).mock.results) {
-      const child = result.value as { pid?: number } | undefined;
+    for (const result of vi.mocked(spawnCommandWithInvocation).mock.results) {
+      const child = result.value?.child as { pid?: number } | undefined;
       if (typeof child?.pid === "number") {
         try {
           process.kill(child.pid, "SIGKILL");
@@ -140,19 +154,30 @@ describePosix("grep tool stall-timeout escalation", () => {
     vi.useFakeTimers();
     const tool = createGrepToolDefinition(dir);
     const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
+    let settled = false;
+    void result.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
     const rejection = expect(result).rejects.toThrow(/ripgrep timed out.*without output/);
     await pumpUntilSpawned();
     const child = lastSpawnedChild();
 
-    // The stub never emits output, so nothing re-arms the stall timer.
+    // The stub never emits output, so nothing re-arms the runner's stall timer.
     await vi.advanceTimersByTimeAsync(60_000);
+    // The stub ignores the runner's SIGTERM, so only execa's SIGKILL escalation
+    // can reap it; the grace timer is faked too, so advance past the grace
+    // window.
+    await vi.advanceTimersByTimeAsync(COMMAND_PROCESS_TREE_KILL_GRACE_MS + 100);
+    await pumpUntilSettled(() => settled);
     await rejection;
-    // Stream cleanup is part of forced settlement: no pipes stay pinned.
+    // Stream cleanup is part of child exit: no pipes stay pinned.
     expect(child.stdout?.destroyed).toBe(true);
     expect(child.stderr?.destroyed).toBe(true);
-    // The stub ignores SIGTERM, so only the SIGKILL escalation can reap it;
-    // execa's grace timer is faked too, so advance past the grace window.
-    await vi.advanceTimersByTimeAsync(COMMAND_PROCESS_TREE_KILL_GRACE_MS + 100);
     expect(child.nodeChildProcess.killed).toBe(true);
 
     vi.useRealTimers();
@@ -224,8 +249,9 @@ describePosix("grep tool stall-timeout escalation", () => {
     await pumpUntilSpawned();
 
     // 70s of fake time in 5s chunks, with real wall-clock pauses so the
-    // stub's newline-less chunks keep arriving. readline emits no completed
-    // line here, so only raw stdout activity can re-arm the stall timer.
+    // stub's newline-less chunks keep arriving. The tool's line buffer emits
+    // no completed JSON event here, so only raw stdout activity can re-arm
+    // the runner's stall timer.
     for (let i = 0; i < 14; i++) {
       await vi.advanceTimersByTimeAsync(5_000);
       await realDelay(150);

--- a/src/agents/sessions/tools/grep.exec-timeout.test.ts
+++ b/src/agents/sessions/tools/grep.exec-timeout.test.ts
@@ -60,6 +60,19 @@ function writeChattyStub(dir: string): string {
   return stubPath;
 }
 
+// One large ripgrep JSON record streamed in newline-less chunks: readline
+// emits no `line` event until the final chunk, so the stall deadline must
+// re-arm on raw stdout data or an active search is killed as silent.
+function writeChunkedRecordStub(dir: string): string {
+  const stubPath = path.join(dir, "stub-rg-chunked");
+  fs.writeFileSync(
+    stubPath,
+    `#!${process.execPath}\nconst payload = JSON.stringify({type:"match",data:{path:{text:"big.txt"},line_number:1,lines:{text:"x".repeat(8192)}}});\nlet offset = 0;\nconst timer = setInterval(() => {\n  if (offset >= payload.length) {\n    clearInterval(timer);\n    process.stdout.write("\\n");\n    return;\n  }\n  process.stdout.write(payload.slice(offset, offset + 64));\n  offset += 64;\n}, 100);\n`,
+    { mode: 0o755 },
+  );
+  return stubPath;
+}
+
 // execa 10 exposes the underlying ChildProcess (and its `killed` flag) through
 // `nodeChildProcess`; the subprocess facade itself only carries pid/stdio/kill.
 type SpawnedChild = {
@@ -174,6 +187,45 @@ describePosix("grep tool stall-timeout escalation", () => {
 
     // 70s of fake time in 5s chunks, with real wall-clock pauses so the
     // chatty stub's lines arrive and re-arm the stall timer each chunk.
+    for (let i = 0; i < 14; i++) {
+      await vi.advanceTimersByTimeAsync(5_000);
+      await realDelay(150);
+    }
+    expect(outcome).toBeUndefined();
+
+    controller.abort();
+    await expect(result).rejects.toThrow(/aborted/);
+  });
+
+  it("does not kill ripgrep while one large record streams in chunks without a newline", async () => {
+    const dir = tempDirs.make("openclaw-grep-chunked-");
+    const stubPath = writeChunkedRecordStub(dir);
+    vi.mocked(ensureTool).mockResolvedValue(stubPath);
+
+    vi.useFakeTimers();
+    const tool = createGrepToolDefinition(dir);
+    const controller = new AbortController();
+    const result = tool.execute(
+      "call-1",
+      { pattern: "foo" },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+    let outcome: "resolved" | "rejected" | undefined;
+    void result.then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+    await pumpUntilSpawned();
+
+    // 70s of fake time in 5s chunks, with real wall-clock pauses so the
+    // stub's newline-less chunks keep arriving. readline emits no completed
+    // line here, so only raw stdout activity can re-arm the stall timer.
     for (let i = 0; i < 14; i++) {
       await vi.advanceTimersByTimeAsync(5_000);
       await realDelay(150);

--- a/src/agents/sessions/tools/grep.exec-timeout.test.ts
+++ b/src/agents/sessions/tools/grep.exec-timeout.test.ts
@@ -1,0 +1,186 @@
+import type { ChildProcess } from "node:child_process";
+// Grep tool stall-timeout escalation tests run a real managed-bin stub that
+// ignores SIGTERM: the inactivity deadline must reject the tool call, the kill
+// escalation must still reap the child, and its stdio pipes must be destroyed.
+// Fake timers keep the 60s stall window instantaneous; real timers return
+// before the process-reaping assertions that need the real event loop.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
+import { spawnCommand } from "../../../process/exec.js";
+import { ensureTool } from "../../utils/tools-manager.js";
+import { createGrepToolDefinition } from "./grep.js";
+
+// Keep the real exec module (real spawn) while capturing spawned children.
+vi.mock("../../../process/exec.js", async (importActual) => {
+  const actual = (await importActual()) as typeof import("../../../process/exec.js");
+  return {
+    ...actual,
+    spawnCommand: vi.fn(actual.spawnCommand),
+  };
+});
+
+vi.mock("../../utils/tools-manager.js", () => ({
+  ensureTool: vi.fn(),
+}));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+// Shebang execution and SIGTERM semantics are POSIX-only.
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+// Captured at module load, before any fake-timer install; lets a test wait
+// real wall-clock time (for child-process output) while the fake clock drives
+// the stall deadline.
+const realSetTimeout = globalThis.setTimeout;
+const realDelay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    realSetTimeout(resolve, ms);
+  });
+
+function writeSigtermIgnoringStub(dir: string): string {
+  const stubPath = path.join(dir, "stub-rg");
+  fs.writeFileSync(
+    stubPath,
+    `#!${process.execPath}\nprocess.on("SIGTERM", () => {});\nsetInterval(() => {}, 60_000);\n`,
+    { mode: 0o755 },
+  );
+  return stubPath;
+}
+
+function writeChattyStub(dir: string): string {
+  const stubPath = path.join(dir, "stub-rg-chatty");
+  fs.writeFileSync(
+    stubPath,
+    `#!${process.execPath}\nsetInterval(() => console.log("not-json"), 100);\n`,
+    { mode: 0o755 },
+  );
+  return stubPath;
+}
+
+// execa 10 exposes the underlying ChildProcess (and its `killed` flag) through
+// `nodeChildProcess`; the subprocess facade itself only carries pid/stdio/kill.
+type SpawnedChild = {
+  pid: number;
+  stdout: { destroyed: boolean } | null;
+  stderr: { destroyed: boolean } | null;
+  nodeChildProcess: ChildProcess;
+};
+
+function lastSpawnedChild(): SpawnedChild {
+  const child = vi.mocked(spawnCommand).mock.results.at(-1)?.value as
+    | ({ pid?: number } & Partial<SpawnedChild>)
+    | undefined;
+  if (!child || typeof child.pid !== "number" || !child.nodeChildProcess) {
+    throw new Error("expected spawnCommand to have produced a child with a pid");
+  }
+  return child as SpawnedChild;
+}
+
+async function pumpUntilSpawned(): Promise<void> {
+  for (let i = 0; i < 50 && !vi.mocked(spawnCommand).mock.calls.length; i++) {
+    await vi.advanceTimersByTimeAsync(1);
+  }
+  expect(spawnCommand).toHaveBeenCalledOnce();
+}
+
+async function expectProcessReaped(pid: number): Promise<void> {
+  await vi.waitFor(
+    () => {
+      let alive = true;
+      try {
+        process.kill(pid, 0);
+      } catch {
+        alive = false;
+      }
+      expect(alive).toBe(false);
+    },
+    { timeout: 5_000, interval: 25 },
+  );
+}
+
+describePosix("grep tool stall-timeout escalation", () => {
+  afterEach(() => {
+    // Reap any stub that survived a failing run so the test process cannot
+    // hang on open pipes.
+    for (const result of vi.mocked(spawnCommand).mock.results) {
+      const child = result.value as { pid?: number } | undefined;
+      if (typeof child?.pid === "number") {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {
+          // Already gone.
+        }
+      }
+    }
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("rejects after a silent window, reaps a SIGTERM-ignoring ripgrep via escalation, and releases its pipes", async () => {
+    const dir = tempDirs.make("openclaw-grep-stub-");
+    const stubPath = writeSigtermIgnoringStub(dir);
+    vi.mocked(ensureTool).mockResolvedValue(stubPath);
+
+    vi.useFakeTimers();
+    const tool = createGrepToolDefinition(dir);
+    const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
+    const rejection = expect(result).rejects.toThrow(/ripgrep timed out.*without output/);
+    await pumpUntilSpawned();
+    const child = lastSpawnedChild();
+
+    // The stub never emits output, so nothing re-arms the stall timer.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await rejection;
+    // Stream cleanup is part of forced settlement: no pipes stay pinned.
+    expect(child.stdout?.destroyed).toBe(true);
+    expect(child.stderr?.destroyed).toBe(true);
+    // The stub ignores SIGTERM, so only the SIGKILL escalation can reap it;
+    // execa's grace timer is faked too, so advance past the grace window.
+    await vi.advanceTimersByTimeAsync(COMMAND_PROCESS_TREE_KILL_GRACE_MS + 100);
+    expect(child.nodeChildProcess.killed).toBe(true);
+
+    vi.useRealTimers();
+    await expectProcessReaped(child.pid);
+  });
+
+  it("does not kill ripgrep while output keeps arriving past the stall window", async () => {
+    const dir = tempDirs.make("openclaw-grep-active-");
+    const stubPath = writeChattyStub(dir);
+    vi.mocked(ensureTool).mockResolvedValue(stubPath);
+
+    vi.useFakeTimers();
+    const tool = createGrepToolDefinition(dir);
+    const controller = new AbortController();
+    const result = tool.execute(
+      "call-1",
+      { pattern: "foo" },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+    let outcome: "resolved" | "rejected" | undefined;
+    void result.then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+    await pumpUntilSpawned();
+
+    // 70s of fake time in 5s chunks, with real wall-clock pauses so the
+    // chatty stub's lines arrive and re-arm the stall timer each chunk.
+    for (let i = 0; i < 14; i++) {
+      await vi.advanceTimersByTimeAsync(5_000);
+      await realDelay(150);
+    }
+    expect(outcome).toBeUndefined();
+
+    controller.abort();
+    await expect(result).rejects.toThrow(/aborted/);
+  });
+});

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../utils/tools-manager.js", () => ({
 type RunnerOptions = {
   signal?: AbortSignal;
   noOutputTimeoutMs?: number;
+  maxOutputBytes?: { stdout?: number; stderr?: number };
   outputCapture?: {
     stdout?: "head" | "tail" | "discard";
     stderr?: "head" | "tail" | "discard";
@@ -346,6 +347,9 @@ describe("grep tool streaming", () => {
     expect(runnerOptions().noOutputTimeoutMs).toBe(60_000);
     // stdout is parsed via onOutputChunk, so the runner must not also retain it.
     expect(runnerOptions().outputCapture).toEqual({ stdout: "discard" });
+    // The pre-refactor stderr tail was bounded to 64 KiB; the runner default
+    // is 16 MiB, so the tool must pass the smaller bound explicitly.
+    expect(runnerOptions().maxOutputBytes).toEqual({ stderr: 64 * 1024 });
 
     const rejection = expect(result).rejects.toThrow(
       "ripgrep timed out after 60 seconds without output",

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -1,19 +1,24 @@
-// Grep tool streaming tests cover result limits, cancellation, and subprocess errors.
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { EventEmitter } from "node:events";
-import { PassThrough } from "node:stream";
+// Grep tool streaming tests cover result limits, cancellation, and runner-reported
+// errors with the command runner mocked at its public contract; the runner owns
+// spawn, stall detection, and process termination.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { spawnCommand } from "../../../process/exec.js";
+import { runUtf8CommandWithTimeout, type SpawnResult } from "../../../process/exec.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { createGrepToolDefinition } from "./grep.js";
 
 vi.mock("../../../process/exec.js", () => ({
-  spawnCommand: vi.fn(),
+  runUtf8CommandWithTimeout: vi.fn(),
 }));
 
 vi.mock("../../utils/tools-manager.js", () => ({
   ensureTool: vi.fn(),
 }));
+
+type RunnerOptions = {
+  signal?: AbortSignal;
+  noOutputTimeoutMs?: number;
+  onOutputChunk?: (chunk: Buffer, stream: "stdout" | "stderr") => boolean | void;
+};
 
 afterEach(() => {
   // Restore fake timers even when a timeout test fails mid-way; leaked fake
@@ -22,26 +27,38 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-type MockChild = ChildProcessWithoutNullStreams & {
-  nodeChildProcess: ChildProcessWithoutNullStreams;
-  stdout: PassThrough;
-  stderr: PassThrough;
-};
+function spawnResult(overrides: Partial<SpawnResult>): SpawnResult {
+  return {
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+    noOutputTimedOut: false,
+    ...overrides,
+  };
+}
 
-function createChild(): MockChild {
-  let killed = false;
-  const child = Object.assign(new EventEmitter(), {
-    stdin: new PassThrough(),
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
-  }) as unknown as MockChild;
-  Object.defineProperty(child, "killed", { get: () => killed });
-  child.kill = vi.fn(() => {
-    killed = true;
-    return true;
-  });
-  child.nodeChildProcess = child;
+// Stands in for the process the runner owns; kill() records that the runner
+// terminated it. The tool itself no longer holds a process handle.
+function createChild() {
+  const child = {
+    killed: false,
+    kill: vi.fn(() => {
+      child.killed = true;
+      return true;
+    }),
+  };
   return child;
+}
+
+function runnerOptions(): RunnerOptions {
+  const options = vi.mocked(runUtf8CommandWithTimeout).mock.calls[0]?.[1];
+  if (!options || typeof options !== "object") {
+    throw new Error("expected the tool to pass runner options");
+  }
+  return options as RunnerOptions;
 }
 
 function grepMatch(lineNumber: number): string {
@@ -67,7 +84,6 @@ describe("grep tool streaming", () => {
     {
       name: "keeps an exact-size result complete",
       matchCount: 2,
-      closeCode: 0,
       expectedText: "match.txt:1: foo\nmatch.txt:2: foo",
       expectedLimitReached: undefined,
       expectedKilled: false,
@@ -75,41 +91,49 @@ describe("grep tool streaming", () => {
     {
       name: "uses one extra match as the truncation sentinel",
       matchCount: 3,
-      closeCode: null,
       expectedText:
         "match.txt:1: foo\nmatch.txt:2: foo\n\n[2 matches limit reached. Use limit=4 for more, or refine pattern]",
       expectedLimitReached: 2,
       expectedKilled: true,
     },
-  ])(
-    "$name",
-    async ({ matchCount, closeCode, expectedText, expectedLimitReached, expectedKilled }) => {
-      const child = createChild();
-      vi.mocked(spawnCommand).mockReturnValue(child as never);
-      vi.mocked(ensureTool).mockResolvedValue("rg");
-
-      const tool = createGrepToolDefinition(process.cwd());
-      const resultPromise = tool.execute(
-        "call-limit",
-        { pattern: "foo", limit: 2 },
-        undefined,
-        undefined,
-        {} as never,
-      );
-      await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+  ])("$name", async ({ matchCount, expectedText, expectedLimitReached, expectedKilled }) => {
+    const child = createChild();
+    // Feed --json events through the runner's chunk observer; when the tool
+    // declines more output (limit sentinel), the runner stops the child and
+    // reports the kill.
+    vi.mocked(runUtf8CommandWithTimeout).mockImplementation(async (_argv, options) => {
+      const onOutputChunk = (options as RunnerOptions).onOutputChunk;
       for (let lineNumber = 1; lineNumber <= matchCount; lineNumber += 1) {
-        child.stdout.write(grepMatch(lineNumber));
+        if (onOutputChunk?.(Buffer.from(grepMatch(lineNumber)), "stdout") === false) {
+          child.kill();
+          return spawnResult({
+            code: null,
+            signal: "SIGTERM",
+            killed: true,
+            termination: "signal",
+            outputLimitExceeded: true,
+          });
+        }
       }
-      child.stdout.end();
-      child.stderr.end();
-      child.emit("close", closeCode);
+      return spawnResult({ code: 0 });
+    });
+    vi.mocked(ensureTool).mockResolvedValue("rg");
 
-      const result = await resultPromise;
-      expect(textContent(result)).toBe(expectedText);
-      expect(result.details?.matchLimitReached).toBe(expectedLimitReached);
-      expect(child.killed).toBe(expectedKilled);
-    },
-  );
+    const tool = createGrepToolDefinition(process.cwd());
+    const resultPromise = tool.execute(
+      "call-limit",
+      { pattern: "foo", limit: 2 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
+
+    const result = await resultPromise;
+    expect(textContent(result)).toBe(expectedText);
+    expect(result.details?.matchLimitReached).toBe(expectedLimitReached);
+    expect(child.killed).toBe(expectedKilled);
+  });
 
   it("settles promptly when aborted while resolving rg", async () => {
     let resolveEnsureTool: ((value: string) => void) | undefined;
@@ -136,7 +160,7 @@ describe("grep tool streaming", () => {
 
     resolveEnsureTool?.("rg");
     await Promise.resolve();
-    expect(spawnCommand).not.toHaveBeenCalled();
+    expect(runUtf8CommandWithTimeout).not.toHaveBeenCalled();
   });
 
   it("does not spawn after an aborted search-path check later resolves", async () => {
@@ -167,12 +191,11 @@ describe("grep tool streaming", () => {
 
     resolveIsDirectory?.(true);
     await Promise.resolve();
-    expect(spawnCommand).not.toHaveBeenCalled();
+    expect(runUtf8CommandWithTimeout).not.toHaveBeenCalled();
   });
 
   it("removes the abort listener after normal settlement", async () => {
-    const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(spawnResult({ code: 1 }));
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
     const controller = new AbortController();
@@ -185,20 +208,27 @@ describe("grep tool streaming", () => {
       undefined,
       {} as never,
     );
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-    child.emit("close", 1);
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
     await expect(result).resolves.toMatchObject({
       content: [{ type: "text", text: "No matches found" }],
     });
     expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
     controller.abort();
-    expect(child.killed).toBe(false);
   });
 
   it("settles an abort when the spawned child never closes", async () => {
     const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    // The runner owns killing the child on abort; its promise only settles
+    // after a close that never comes here, so the tool must not wait on it.
+    vi.mocked(runUtf8CommandWithTimeout).mockImplementation(
+      (_argv, options) =>
+        new Promise<SpawnResult>(() => {
+          (options as RunnerOptions).signal?.addEventListener("abort", () => child.kill(), {
+            once: true,
+          });
+        }),
+    );
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
     const controller = new AbortController();
@@ -210,7 +240,7 @@ describe("grep tool streaming", () => {
       undefined,
       {} as never,
     );
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
     controller.abort();
 
     await expect(result).rejects.toThrow("Operation aborted");
@@ -218,8 +248,10 @@ describe("grep tool streaming", () => {
   });
 
   it("preserves abort precedence during async match formatting", async () => {
-    const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(runUtf8CommandWithTimeout).mockImplementation(async (_argv, options) => {
+      (options as RunnerOptions).onOutputChunk?.(Buffer.from(grepMatch(1)), "stdout");
+      return spawnResult({ code: 0 });
+    });
     vi.mocked(ensureTool).mockResolvedValue("rg");
     let resolveReadFile: ((value: string) => void) | undefined;
     const readFile = vi.fn(
@@ -240,29 +272,24 @@ describe("grep tool streaming", () => {
       undefined,
       {} as never,
     );
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-    child.stdout.write(
-      `${JSON.stringify({
-        type: "match",
-        data: { path: { text: "/tmp/match.txt" }, line_number: 1, lines: { text: "foo\n" } },
-      })}\n`,
-    );
-    child.emit("close", 0);
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledOnce());
 
     controller.abort();
     await expect(result).rejects.toThrow("Operation aborted");
-    expect(child.killed).toBe(false);
 
     resolveReadFile?.("foo\n");
     await Promise.resolve();
   });
 
   it.each(["stdout", "stderr"] as const)(
-    "rejects and terminates ripgrep when %s fails",
+    "rejects when the runner reports a %s failure",
     async (stream) => {
-      const child = createChild();
-      vi.mocked(spawnCommand).mockReturnValue(child as never);
+      // The runner terminates and reports output stream failures through the
+      // outputErrorStream field on its sanitized error.
+      vi.mocked(runUtf8CommandWithTimeout).mockRejectedValue(
+        Object.assign(new Error(`${stream} EPIPE`), { outputErrorStream: stream }),
+      );
       vi.mocked(ensureTool).mockResolvedValue("rg");
 
       const tool = createGrepToolDefinition(process.cwd());
@@ -273,56 +300,76 @@ describe("grep tool streaming", () => {
         undefined,
         {} as never,
       );
-      await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-      child[stream].emit("error", new Error(`${stream} EPIPE`));
+      const rejection = expect(resultPromise).rejects.toThrow(
+        `ripgrep ${stream} error: ${stream} EPIPE`,
+      );
+      await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
-      await expect(resultPromise).rejects.toThrow(`${stream} EPIPE`);
-      expect(child.killed).toBe(true);
+      await rejection;
     },
   );
 
   it("rejects and kills ripgrep when the search stalls without output past the deadline", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    // Simulate the runner contract: a silent child is killed at the no-output
+    // deadline and the result reports noOutputTimedOut.
+    vi.mocked(runUtf8CommandWithTimeout).mockImplementation(async (_argv, options) => {
+      await new Promise<void>((resolveWait) => {
+        setTimeout(
+          () => {
+            child.kill();
+            resolveWait();
+          },
+          (options as RunnerOptions).noOutputTimeoutMs,
+        );
+      });
+      return spawnResult({
+        code: 124,
+        signal: "SIGKILL",
+        killed: true,
+        termination: "no-output-timeout",
+        noOutputTimedOut: true,
+      });
+    });
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
     const tool = createGrepToolDefinition(process.cwd());
     // The child never writes output and never closes, mimicking ripgrep stalled
     // on a broken mount; the tool must reject instead of hanging for the outer abort.
     const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
+    expect(runnerOptions().noOutputTimeoutMs).toBe(60_000);
 
     const rejection = expect(result).rejects.toThrow(
       "ripgrep timed out after 60 seconds without output",
     );
     await vi.advanceTimersByTimeAsync(60_000);
     await rejection;
-    expect(child.killed).toBe(true);
+    expect(child.kill).toHaveBeenCalledOnce();
   });
 
-  it("clears the stall timer when ripgrep exits normally", async () => {
+  it("leaves no timers behind when ripgrep exits normally", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-    const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(spawnResult({ code: 1 }));
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
     const tool = createGrepToolDefinition(process.cwd());
     const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-    child.emit("close", 1);
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
     await expect(result).resolves.toMatchObject({
       content: [{ type: "text", text: "No matches found" }],
     });
     expect(vi.getTimerCount()).toBe(0);
-    expect(child.killed).toBe(false);
   });
 
   it("does not time out while formatting context after ripgrep exits", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-    const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(runUtf8CommandWithTimeout).mockImplementation(async (_argv, options) => {
+      (options as RunnerOptions).onOutputChunk?.(Buffer.from(grepMatch(1)), "stdout");
+      return spawnResult({ code: 0 });
+    });
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
     let resolveReadFile: ((value: string) => void) | undefined;
@@ -342,52 +389,46 @@ describe("grep tool streaming", () => {
       undefined,
       {} as never,
     );
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-    child.stdout.write(grepMatch(1));
-    child.stdout.end();
-    child.stderr.end();
-    child.emit("close", 0);
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
-    // Context formatting awaits readFile() after the child closed; holding it
-    // past the stall window must not reject a completed search, because the
-    // stall timer was cleared at close.
+    // Context formatting awaits readFile() after the runner resolved; holding
+    // it past the stall window must not reject a completed search, because no
+    // stall timer survives child exit.
     await vi.advanceTimersByTimeAsync(120_000);
     resolveReadFile?.("foo\n");
     const result = await resultPromise;
     expect(textContent(result)).toContain("match.txt:1: foo");
   });
 
-  it("keeps stdout guarded after a stderr failure closes readline", async () => {
-    const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+  it("reports the first output stream failure", async () => {
+    // The runner records the first failing stream; later stream errors do not
+    // replace it.
+    vi.mocked(runUtf8CommandWithTimeout).mockRejectedValue(
+      Object.assign(new Error("stderr first"), { outputErrorStream: "stderr" }),
+    );
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
     const tool = createGrepToolDefinition(process.cwd());
     const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+    const rejection = expect(result).rejects.toThrow("ripgrep stderr error: stderr first");
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
-    expect(() => {
-      child.stderr.emit("error", new Error("stderr first"));
-      child.stdout.emit("error", new Error("stdout later"));
-    }).not.toThrow();
-    await expect(result).rejects.toThrow("stderr first");
+    await rejection;
   });
 
-  it("keeps multibyte stderr intact when pipe chunks split a character", async () => {
-    const child = createChild();
-    vi.mocked(spawnCommand).mockReturnValue(child as never);
+  it("keeps multibyte stderr intact in the rejection", async () => {
+    // Chunk-safe multibyte decoding now belongs to the runner capture; the tool
+    // must surface the decoded stderr verbatim.
+    vi.mocked(runUtf8CommandWithTimeout).mockResolvedValue(
+      spawnResult({ stderr: "rg 错误：权限被拒绝\n", code: 2 }),
+    );
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
     const tool = createGrepToolDefinition(process.cwd());
     const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
-    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
-    const stderrBytes = Buffer.from("rg 错误：权限被拒绝\n");
-    child.stdout.end();
-    // Split inside the first multibyte character to mimic a pipe chunk boundary.
-    child.stderr.write(stderrBytes.subarray(0, 4));
-    child.stderr.end(stderrBytes.subarray(4));
-    child.emit("close", 2);
+    const rejection = expect(result).rejects.toThrow("rg 错误：权限被拒绝");
+    await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
 
-    await expect(result).rejects.toThrow("rg 错误：权限被拒绝");
+    await rejection;
   });
 });

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -17,6 +17,10 @@ vi.mock("../../utils/tools-manager.js", () => ({
 type RunnerOptions = {
   signal?: AbortSignal;
   noOutputTimeoutMs?: number;
+  outputCapture?: {
+    stdout?: "head" | "tail" | "discard";
+    stderr?: "head" | "tail" | "discard";
+  };
   onOutputChunk?: (chunk: Buffer, stream: "stdout" | "stderr") => boolean | void;
 };
 
@@ -340,6 +344,8 @@ describe("grep tool streaming", () => {
     const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
     await vi.waitFor(() => expect(runUtf8CommandWithTimeout).toHaveBeenCalledOnce());
     expect(runnerOptions().noOutputTimeoutMs).toBe(60_000);
+    // stdout is parsed via onOutputChunk, so the runner must not also retain it.
+    expect(runnerOptions().outputCapture).toEqual({ stdout: "discard" });
 
     const rejection = expect(result).rejects.toThrow(
       "ripgrep timed out after 60 seconds without output",

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -18,6 +18,7 @@ type RunnerOptions = {
   signal?: AbortSignal;
   noOutputTimeoutMs?: number;
   maxOutputBytes?: { stdout?: number; stderr?: number };
+  terminateOnOutputError?: boolean;
   outputCapture?: {
     stdout?: "head" | "tail" | "discard";
     stderr?: "head" | "tail" | "discard";
@@ -350,6 +351,8 @@ describe("grep tool streaming", () => {
     // The pre-refactor stderr tail was bounded to 64 KiB; the runner default
     // is 16 MiB, so the tool must pass the smaller bound explicitly.
     expect(runnerOptions().maxOutputBytes).toEqual({ stderr: 64 * 1024 });
+    // A failed output stream must terminate ripgrep immediately.
+    expect(runnerOptions().terminateOnOutputError).toBe(true);
 
     const rejection = expect(result).rejects.toThrow(
       "ripgrep timed out after 60 seconds without output",

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -16,6 +16,9 @@ vi.mock("../../utils/tools-manager.js", () => ({
 }));
 
 afterEach(() => {
+  // Restore fake timers even when a timeout test fails mid-way; leaked fake
+  // timers would otherwise poison later cases and hide the real failure.
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -296,7 +299,6 @@ describe("grep tool streaming", () => {
     await vi.advanceTimersByTimeAsync(60_000);
     await rejection;
     expect(child.killed).toBe(true);
-    vi.useRealTimers();
   });
 
   it("clears the stall timer when ripgrep exits normally", async () => {
@@ -315,7 +317,6 @@ describe("grep tool streaming", () => {
     });
     expect(vi.getTimerCount()).toBe(0);
     expect(child.killed).toBe(false);
-    vi.useRealTimers();
   });
 
   it("does not time out while formatting context after ripgrep exits", async () => {
@@ -354,7 +355,6 @@ describe("grep tool streaming", () => {
     resolveReadFile?.("foo\n");
     const result = await resultPromise;
     expect(textContent(result)).toContain("match.txt:1: foo");
-    vi.useRealTimers();
   });
 
   it("keeps stdout guarded after a stderr failure closes readline", async () => {

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -278,6 +278,85 @@ describe("grep tool streaming", () => {
     },
   );
 
+  it("rejects and kills ripgrep when the search stalls without output past the deadline", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const child = createChild();
+    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+
+    const tool = createGrepToolDefinition(process.cwd());
+    // The child never writes output and never closes, mimicking ripgrep stalled
+    // on a broken mount; the tool must reject instead of hanging for the outer abort.
+    const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
+    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+
+    const rejection = expect(result).rejects.toThrow(
+      "ripgrep timed out after 60 seconds without output",
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    await rejection;
+    expect(child.killed).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("clears the stall timer when ripgrep exits normally", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const child = createChild();
+    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+
+    const tool = createGrepToolDefinition(process.cwd());
+    const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
+    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+    child.emit("close", 1);
+
+    await expect(result).resolves.toMatchObject({
+      content: [{ type: "text", text: "No matches found" }],
+    });
+    expect(vi.getTimerCount()).toBe(0);
+    expect(child.killed).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("does not time out while formatting context after ripgrep exits", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const child = createChild();
+    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+
+    let resolveReadFile: ((value: string) => void) | undefined;
+    const tool = createGrepToolDefinition(process.cwd(), {
+      operations: {
+        isDirectory: () => true,
+        readFile: async () =>
+          await new Promise<string>((resolve) => {
+            resolveReadFile = resolve;
+          }),
+      },
+    });
+    const resultPromise = tool.execute(
+      "call-1",
+      { pattern: "foo", context: 1 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+    child.stdout.write(grepMatch(1));
+    child.stdout.end();
+    child.stderr.end();
+    child.emit("close", 0);
+
+    // Context formatting awaits readFile() after the child closed; holding it
+    // past the stall window must not reject a completed search, because the
+    // stall timer was cleared at close.
+    await vi.advanceTimersByTimeAsync(120_000);
+    resolveReadFile?.("foo\n");
+    const result = await resultPromise;
+    expect(textContent(result)).toContain("match.txt:1: foo");
+    vi.useRealTimers();
+  });
+
   it("keeps stdout guarded after a stderr failure closes readline", async () => {
     const child = createChild();
     vi.mocked(spawnCommand).mockReturnValue(child as never);

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -343,6 +343,10 @@ export function createGrepToolDefinition(
                 // pre-refactor 64 KiB instead of the 16 MiB runner default.
                 outputCapture: { stdout: "discard" },
                 maxOutputBytes: { stderr: SESSION_TOOL_STDERR_TAIL_BYTES },
+                // A failed output stream must kill ripgrep immediately,
+                // matching the pre-refactor stopChild-on-error behavior;
+                // otherwise a wedged child could outlive the tool call.
+                terminateOnOutputError: true,
                 onOutputChunk: (chunk, stream): boolean | undefined => {
                   if (stream !== "stdout") {
                     return undefined;

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -310,6 +310,13 @@ export function createGrepToolDefinition(
             let linesTruncated = false;
             const outputLines: string[] = [];
 
+            // Raw stdout activity — not just completed readline records —
+            // proves the child is alive: one large ripgrep JSON match can
+            // stream in chunks without a newline for longer than the stall
+            // window. Re-arm on every chunk so only a silent ripgrep dies.
+            spawnedChild.stdout?.on("data", () => {
+              execTimeout?.refresh();
+            });
             // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
             // cannot split multibyte characters into U+FFFD replacement noise.
             spawnedChild.stderr?.setEncoding("utf8");
@@ -364,9 +371,6 @@ export function createGrepToolDefinition(
             // Collect matches during streaming, then format them after rg exits.
             const matches: Array<{ filePath: string; lineNumber: number; lineText?: string }> = [];
             rl.on("line", (line) => {
-              // Stream activity proves the child is alive; re-arm the stall
-              // timer so only a silent ripgrep is killed.
-              execTimeout?.refresh();
               if (!line.trim() || matchLimitReached) {
                 return;
               }

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -9,6 +9,7 @@ import { createInterface } from "node:readline";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
+import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
 import { spawnCommand } from "../../../process/exec.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { ensureTool } from "../../utils/tools-manager.js";
@@ -50,6 +51,11 @@ const grepSchema = Type.Object({
   limit: Type.Optional(Type.Number({ description: "Max matches; default 100." })),
 });
 const DEFAULT_LIMIT = 100;
+// ripgrep can stall on a broken filesystem or network mount without exiting or
+// emitting output. Bound the silence, not the total runtime: any stdout line
+// or stderr chunk re-arms the timer, so a healthy long search keeps running
+// and only a silent child is killed.
+const RG_STALL_TIMEOUT_MS = 60_000;
 
 /**
  * Pluggable operations for the grep tool.
@@ -168,8 +174,10 @@ export function createGrepToolDefinition(
         let childClosed = false;
         let rl: ReturnType<typeof createInterface> | undefined;
         let killedDueToLimit = false;
+        let execTimeout: NodeJS.Timeout | undefined;
         const cleanup = () => {
           rl?.close();
+          clearTimeout(execTimeout);
           signal?.removeEventListener("abort", onAbort);
         };
         const settle = (fn: () => void): boolean => {
@@ -268,12 +276,34 @@ export function createGrepToolDefinition(
             }
             const spawnedChild = spawnCommand([rgPath, ...args], {
               buffer: false,
+              // A wedged ripgrep can ignore the initial SIGTERM from the
+              // timeout or abort path; execa escalates to SIGKILL after this
+              // grace window.
+              forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
               reject: false,
               stdio: ["ignore", "pipe", "pipe"],
             });
             releaseChildProcessOutputAfterExit(spawnedChild.nodeChildProcess);
             child = spawnedChild;
             rl = createInterface({ input: spawnedChild.stdout });
+            execTimeout = setTimeout(() => {
+              if (
+                settle(() =>
+                  reject(
+                    new Error(
+                      `ripgrep timed out after ${RG_STALL_TIMEOUT_MS / 1000} seconds without output`,
+                    ),
+                  ),
+                )
+              ) {
+                stopChild();
+                // If ripgrep ignores the SIGTERM above, forceKillAfterDelay
+                // reaps it after the grace window; release the pipes now so a
+                // defiant child cannot pin stream handles past settlement.
+                spawnedChild.stdout?.destroy();
+                spawnedChild.stderr?.destroy();
+              }
+            }, RG_STALL_TIMEOUT_MS);
             let stderr = "";
             let matchCount = 0;
             let matchLimitReached = false;
@@ -284,6 +314,9 @@ export function createGrepToolDefinition(
             // cannot split multibyte characters into U+FFFD replacement noise.
             spawnedChild.stderr?.setEncoding("utf8");
             spawnedChild.stderr?.on("data", (chunk: string) => {
+              // Stream activity proves the child is alive; re-arm the stall
+              // timer so only a silent ripgrep is killed.
+              execTimeout?.refresh();
               stderr = appendBoundedTextTail(stderr, chunk);
             });
             const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
@@ -331,6 +364,9 @@ export function createGrepToolDefinition(
             // Collect matches during streaming, then format them after rg exits.
             const matches: Array<{ filePath: string; lineNumber: number; lineText?: string }> = [];
             rl.on("line", (line) => {
+              // Stream activity proves the child is alive; re-arm the stall
+              // timer so only a silent ripgrep is killed.
+              execTimeout?.refresh();
               if (!line.trim() || matchLimitReached) {
                 return;
               }
@@ -370,6 +406,11 @@ export function createGrepToolDefinition(
             });
             spawnedChild.nodeChildProcess.on("close", (code) => {
               childClosed = true;
+              // The child exited, so the stall timer no longer measures ripgrep
+              // activity. Clear it here rather than at settle: context
+              // formatting below can await readFile() past the stall window,
+              // and an exited child cannot be "silent".
+              clearTimeout(execTimeout);
               void (async () => {
                 if (settled) {
                   return;

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -337,6 +337,10 @@ export function createGrepToolDefinition(
               result = await runUtf8CommandWithTimeout([rgPath, ...args], {
                 noOutputTimeoutMs: RG_STALL_TIMEOUT_MS,
                 signal,
+                // stdout is parsed incrementally via onOutputChunk; retaining
+                // the runner's default 16 MiB tail would duplicate it. stderr
+                // keeps its tail for exit-error messages.
+                outputCapture: { stdout: "discard" },
                 onOutputChunk: (chunk, stream): boolean | undefined => {
                   if (stream !== "stdout") {
                     return undefined;

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -5,16 +5,14 @@
  */
 import { readFileSync, statSync } from "node:fs";
 import path from "node:path";
-import { createInterface } from "node:readline";
+import { StringDecoder } from "node:string_decoder";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
-import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "../../../process/exec-spawn.js";
-import { spawnCommand } from "../../../process/exec.js";
+import { runUtf8CommandWithTimeout, type SpawnResult } from "../../../process/exec.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { appendBoundedTextTail, normalizePositiveLimit } from "./limits.js";
+import { normalizePositiveLimit } from "./limits.js";
 import { resolveToCwd } from "./path-utils.js";
 import {
   appendSessionToolTruncationWarning,
@@ -163,21 +161,10 @@ export function createGrepToolDefinition(
       void ctx;
       return new Promise((resolve, reject) => {
         // Keep cancellation live from the first await through async result formatting.
-        // Settlement owns listener cleanup; spawned children stop without waiting for close.
+        // Settlement owns listener cleanup; the runner kills the spawned child via
+        // the signal without the tool waiting for close.
         let settled = false;
-        let child:
-          | {
-              nodeChildProcess: { killed: boolean };
-              kill: () => void;
-            }
-          | undefined;
-        let childClosed = false;
-        let rl: ReturnType<typeof createInterface> | undefined;
-        let killedDueToLimit = false;
-        let execTimeout: NodeJS.Timeout | undefined;
         const cleanup = () => {
-          rl?.close();
-          clearTimeout(execTimeout);
           signal?.removeEventListener("abort", onAbort);
         };
         const settle = (fn: () => void): boolean => {
@@ -189,16 +176,8 @@ export function createGrepToolDefinition(
           fn();
           return true;
         };
-        const stopChild = (dueToLimit = false) => {
-          if (child && !childClosed && !child.nodeChildProcess.killed) {
-            killedDueToLimit = dueToLimit;
-            child.kill();
-          }
-        };
         const onAbort = () => {
-          if (settle(() => reject(new Error("Operation aborted")))) {
-            stopChild();
-          }
+          settle(() => reject(new Error("Operation aborted")));
         };
         signal?.addEventListener("abort", onAbort, { once: true });
         if (signal?.aborted) {
@@ -274,71 +253,52 @@ export function createGrepToolDefinition(
             if (settled) {
               return;
             }
-            const spawnedChild = spawnCommand([rgPath, ...args], {
-              buffer: false,
-              // A wedged ripgrep can ignore the initial SIGTERM from the
-              // timeout or abort path; execa escalates to SIGKILL after this
-              // grace window.
-              forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
-              reject: false,
-              stdio: ["ignore", "pipe", "pipe"],
-            });
-            releaseChildProcessOutputAfterExit(spawnedChild.nodeChildProcess);
-            child = spawnedChild;
-            rl = createInterface({ input: spawnedChild.stdout });
-            execTimeout = setTimeout(() => {
-              if (
-                settle(() =>
-                  reject(
-                    new Error(
-                      `ripgrep timed out after ${RG_STALL_TIMEOUT_MS / 1000} seconds without output`,
-                    ),
-                  ),
-                )
-              ) {
-                stopChild();
-                // If ripgrep ignores the SIGTERM above, forceKillAfterDelay
-                // reaps it after the grace window; release the pipes now so a
-                // defiant child cannot pin stream handles past settlement.
-                spawnedChild.stdout?.destroy();
-                spawnedChild.stderr?.destroy();
-              }
-            }, RG_STALL_TIMEOUT_MS);
-            let stderr = "";
             let matchCount = 0;
             let matchLimitReached = false;
             let linesTruncated = false;
             const outputLines: string[] = [];
-
-            // Raw stdout activity — not just completed readline records —
-            // proves the child is alive: one large ripgrep JSON match can
-            // stream in chunks without a newline for longer than the stall
-            // window. Re-arm on every chunk so only a silent ripgrep dies.
-            spawnedChild.stdout?.on("data", () => {
-              execTimeout?.refresh();
-            });
-            // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
-            // cannot split multibyte characters into U+FFFD replacement noise.
-            spawnedChild.stderr?.setEncoding("utf8");
-            spawnedChild.stderr?.on("data", (chunk: string) => {
-              // Stream activity proves the child is alive; re-arm the stall
-              // timer so only a silent ripgrep is killed.
-              execTimeout?.refresh();
-              stderr = appendBoundedTextTail(stderr, chunk);
-            });
-            const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
-              if (settled) {
-                return;
+            // Collect matches during streaming, then format them after rg exits.
+            const matches: Array<{ filePath: string; lineNumber: number; lineText?: string }> = [];
+            // rg --json events are newline-delimited but arrive as arbitrary byte
+            // chunks; decode incrementally so pipe boundaries cannot split
+            // multibyte characters.
+            const decoder = new StringDecoder("utf8");
+            let pendingLine = "";
+            // Returns false when the limit sentinel is observed so the runner
+            // stops the child early.
+            const handleJsonLine = (line: string): boolean => {
+              if (!line.trim() || matchLimitReached) {
+                return true;
               }
-              if (settle(() => reject(new Error(`ripgrep ${stream} error: ${error.message}`)))) {
-                stopChild();
+              let event: {
+                type?: string;
+                data?: {
+                  path?: { text?: string };
+                  line_number?: unknown;
+                  lines?: { text?: string };
+                };
+              };
+              try {
+                event = JSON.parse(line);
+              } catch {
+                return true;
               }
+              if (event.type === "match") {
+                matchCount++;
+                // Observe one extra match before stopping so exactly N matches stay complete.
+                if (matchCount > effectiveLimit) {
+                  matchLimitReached = true;
+                  return false;
+                }
+                const filePath = event.data?.path?.text;
+                const lineNumber = event.data?.line_number;
+                const lineText = event.data?.lines?.text;
+                if (filePath && typeof lineNumber === "number") {
+                  matches.push({ filePath, lineNumber, lineText });
+                }
+              }
+              return true;
             };
-            // readline re-emits input failures, then drops its input listener on close.
-            // Keep the direct guard until child exit so later stdout errors stay handled.
-            rl.on("error", (error) => onStreamError("stdout", error));
-            spawnedChild.stdout?.on("error", (error) => onStreamError("stdout", error));
-            spawnedChild.stderr?.on("error", (error) => onStreamError("stderr", error));
 
             const formatBlock = async (filePath: string, lineNumber: number): Promise<string[]> => {
               const relativePath = formatPath(filePath);
@@ -368,134 +328,147 @@ export function createGrepToolDefinition(
               return block;
             };
 
-            // Collect matches during streaming, then format them after rg exits.
-            const matches: Array<{ filePath: string; lineNumber: number; lineText?: string }> = [];
-            rl.on("line", (line) => {
-              if (!line.trim() || matchLimitReached) {
-                return;
+            let result: SpawnResult;
+            try {
+              // The runner owns the child lifecycle: noOutputTimeoutMs re-arms
+              // on every raw stdout/stderr chunk — one large JSON match can
+              // stream in newline-less chunks longer than the stall window, so
+              // only a silent ripgrep is killed.
+              result = await runUtf8CommandWithTimeout([rgPath, ...args], {
+                noOutputTimeoutMs: RG_STALL_TIMEOUT_MS,
+                signal,
+                onOutputChunk: (chunk, stream): boolean | undefined => {
+                  if (stream !== "stdout") {
+                    return undefined;
+                  }
+                  pendingLine += decoder.write(chunk);
+                  let newlineIndex = pendingLine.indexOf("\n");
+                  while (newlineIndex >= 0) {
+                    const line = pendingLine.slice(0, newlineIndex);
+                    pendingLine = pendingLine.slice(newlineIndex + 1);
+                    if (!handleJsonLine(line)) {
+                      return false;
+                    }
+                    newlineIndex = pendingLine.indexOf("\n");
+                  }
+                  return undefined;
+                },
+              });
+            } catch (error) {
+              const outputErrorStream = (error as { outputErrorStream?: unknown })
+                .outputErrorStream;
+              const message = error instanceof Error ? error.message : String(error);
+              if (outputErrorStream === "stdout" || outputErrorStream === "stderr") {
+                settle(() => reject(new Error(`ripgrep ${outputErrorStream} error: ${message}`)));
+              } else {
+                settle(() => reject(new Error(`Failed to run ripgrep: ${message}`)));
               }
-              let event: {
-                type?: string;
-                data?: {
-                  path?: { text?: string };
-                  line_number?: unknown;
-                  lines?: { text?: string };
-                };
-              };
-              try {
-                event = JSON.parse(line);
-              } catch {
-                return;
-              }
-              if (event.type === "match") {
-                matchCount++;
-                // Observe one extra match before stopping so exactly N matches stay complete.
-                if (matchCount > effectiveLimit) {
-                  matchLimitReached = true;
-                  stopChild(true);
-                  return;
-                }
-                const filePath = event.data?.path?.text;
-                const lineNumber = event.data?.line_number;
-                const lineText = event.data?.lines?.text;
-                if (filePath && typeof lineNumber === "number") {
-                  matches.push({ filePath, lineNumber, lineText });
-                }
-              }
-            });
+              return;
+            }
+            // A trailing record without a final newline (e.g. rg killed early)
+            // still needs one parse pass; the runner already resolved, so a
+            // limit sentinel here has nothing left to stop.
+            pendingLine += decoder.end();
+            handleJsonLine(pendingLine);
+            if (settled) {
+              return;
+            }
+            if (signal?.aborted) {
+              settle(() => reject(new Error("Operation aborted")));
+              return;
+            }
+            if (result.noOutputTimedOut) {
+              settle(() =>
+                reject(
+                  new Error(
+                    `ripgrep timed out after ${RG_STALL_TIMEOUT_MS / 1000} seconds without output`,
+                  ),
+                ),
+              );
+              return;
+            }
+            if (result.outputErrorStream) {
+              settle(() =>
+                reject(
+                  new Error(`ripgrep ${result.outputErrorStream} error: output stream failed`),
+                ),
+              );
+              return;
+            }
+            // The runner resolved, so the child already exited; the context
+            // formatting below can await readFile() past the stall window —
+            // an exited child cannot be "silent".
+            if (!matchLimitReached && result.code !== 0 && result.code !== 1) {
+              const errorMsg = result.stderr.trim() || `ripgrep exited with code ${result.code}`;
+              settle(() => reject(new Error(errorMsg)));
+              return;
+            }
+            if (matchCount === 0) {
+              settle(() =>
+                resolve({
+                  content: [{ type: "text", text: "No matches found" }],
+                  details: undefined,
+                }),
+              );
+              return;
+            }
 
-            spawnedChild.nodeChildProcess.on("error", (error) => {
-              childClosed = true;
-              settle(() => reject(new Error(`Failed to run ripgrep: ${error.message}`)));
-            });
-            spawnedChild.nodeChildProcess.on("close", (code) => {
-              childClosed = true;
-              // The child exited, so the stall timer no longer measures ripgrep
-              // activity. Clear it here rather than at settle: context
-              // formatting below can await readFile() past the stall window,
-              // and an exited child cannot be "silent".
-              clearTimeout(execTimeout);
-              void (async () => {
+            // Format matches after streaming finishes so custom readFile() backends can be async.
+            for (const match of matches) {
+              if (contextValue === 0 && match.lineText !== undefined) {
+                const relativePath = formatPath(match.filePath);
+                const sanitized = match.lineText
+                  .replace(/\r\n/g, "\n")
+                  .replace(/\r/g, "")
+                  .replace(/\n$/, "");
+                const { text: truncatedText, wasTruncated } = truncateLine(sanitized);
+                if (wasTruncated) {
+                  linesTruncated = true;
+                }
+                outputLines.push(`${relativePath}:${match.lineNumber}: ${truncatedText}`);
+              } else {
+                const block = await formatBlock(match.filePath, match.lineNumber);
                 if (settled) {
                   return;
                 }
-                if (!killedDueToLimit && code !== 0 && code !== 1) {
-                  const errorMsg = stderr.trim() || `ripgrep exited with code ${code}`;
-                  settle(() => reject(new Error(errorMsg)));
-                  return;
-                }
-                if (matchCount === 0) {
-                  settle(() =>
-                    resolve({
-                      content: [{ type: "text", text: "No matches found" }],
-                      details: undefined,
-                    }),
-                  );
-                  return;
-                }
-
-                // Format matches after streaming finishes so custom readFile() backends can be async.
-                for (const match of matches) {
-                  if (contextValue === 0 && match.lineText !== undefined) {
-                    const relativePath = formatPath(match.filePath);
-                    const sanitized = match.lineText
-                      .replace(/\r\n/g, "\n")
-                      .replace(/\r/g, "")
-                      .replace(/\n$/, "");
-                    const { text: truncatedText, wasTruncated } = truncateLine(sanitized);
-                    if (wasTruncated) {
-                      linesTruncated = true;
-                    }
-                    outputLines.push(`${relativePath}:${match.lineNumber}: ${truncatedText}`);
-                  } else {
-                    const block = await formatBlock(match.filePath, match.lineNumber);
-                    if (settled) {
-                      return;
-                    }
-                    outputLines.push(...block);
-                  }
-                }
-
-                const rawOutput = outputLines.join("\n");
-                // Apply byte truncation. There is no line limit here because the match limit already capped rows.
-                const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
-                let output = truncation.content;
-                const details: GrepToolDetails = {};
-                // Build actionable notices for truncation and match limits.
-                const notices: string[] = [];
-                if (matchLimitReached) {
-                  notices.push(
-                    `${effectiveLimit} matches limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
-                  );
-                  details.matchLimitReached = effectiveLimit;
-                }
-                if (truncation.truncated) {
-                  notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
-                  details.truncation = truncation;
-                }
-                if (linesTruncated) {
-                  notices.push(
-                    `Some lines truncated to ${GREP_MAX_LINE_LENGTH} chars. Use read tool to see full lines`,
-                  );
-                  details.linesTruncated = true;
-                }
-                if (notices.length > 0) {
-                  output += `\n\n[${notices.join(". ")}]`;
-                }
-                settle(() =>
-                  resolve({
-                    content: [{ type: "text", text: output }],
-                    details: Object.keys(details).length > 0 ? details : undefined,
-                  }),
-                );
-              })().catch((err: unknown) => {
-                settle(() => reject(err as Error));
-              });
-            });
-          } catch (err) {
-            if (settle(() => reject(err as Error))) {
-              stopChild();
+                outputLines.push(...block);
+              }
             }
+
+            const rawOutput = outputLines.join("\n");
+            // Apply byte truncation. There is no line limit here because the match limit already capped rows.
+            const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
+            let output = truncation.content;
+            const details: GrepToolDetails = {};
+            // Build actionable notices for truncation and match limits.
+            const notices: string[] = [];
+            if (matchLimitReached) {
+              notices.push(
+                `${effectiveLimit} matches limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
+              );
+              details.matchLimitReached = effectiveLimit;
+            }
+            if (truncation.truncated) {
+              notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+              details.truncation = truncation;
+            }
+            if (linesTruncated) {
+              notices.push(
+                `Some lines truncated to ${GREP_MAX_LINE_LENGTH} chars. Use read tool to see full lines`,
+              );
+              details.linesTruncated = true;
+            }
+            if (notices.length > 0) {
+              output += `\n\n[${notices.join(". ")}]`;
+            }
+            settle(() =>
+              resolve({
+                content: [{ type: "text", text: output }],
+                details: Object.keys(details).length > 0 ? details : undefined,
+              }),
+            );
+          } catch (err) {
+            settle(() => reject(err as Error));
           }
         })();
       });

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -12,7 +12,7 @@ import { runUtf8CommandWithTimeout, type SpawnResult } from "../../../process/ex
 import type { AgentTool } from "../../runtime/index.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
-import { normalizePositiveLimit } from "./limits.js";
+import { normalizePositiveLimit, SESSION_TOOL_STDERR_TAIL_BYTES } from "./limits.js";
 import { resolveToCwd } from "./path-utils.js";
 import {
   appendSessionToolTruncationWarning,
@@ -339,8 +339,10 @@ export function createGrepToolDefinition(
                 signal,
                 // stdout is parsed incrementally via onOutputChunk; retaining
                 // the runner's default 16 MiB tail would duplicate it. stderr
-                // keeps its tail for exit-error messages.
+                // keeps its tail for exit-error messages, bounded to the
+                // pre-refactor 64 KiB instead of the 16 MiB runner default.
                 outputCapture: { stdout: "discard" },
+                maxOutputBytes: { stderr: SESSION_TOOL_STDERR_TAIL_BYTES },
                 onOutputChunk: (chunk, stream): boolean | undefined => {
                   if (stream !== "stdout") {
                     return undefined;

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -355,8 +355,10 @@ export function createGrepToolDefinition(
                 },
               });
             } catch (error) {
-              const outputErrorStream = (error as { outputErrorStream?: unknown })
-                .outputErrorStream;
+              const outputErrorStream =
+                error instanceof Error && "outputErrorStream" in error
+                  ? error.outputErrorStream
+                  : undefined;
               const message = error instanceof Error ? error.message : String(error);
               if (outputErrorStream === "stdout" || outputErrorStream === "stderr") {
                 settle(() => reject(new Error(`ripgrep ${outputErrorStream} error: ${message}`)));


### PR DESCRIPTION
## What Problem This Solves

The `find` and `grep` agent session tools spawn their helper binaries (`fd` /
`rg`) via `spawnCommand(...)` with only `buffer: false, reject: false, stdio`
options — no execution timeout. If the helper stalls on a broken filesystem or
dead network mount (spawns fine, emits nothing, never exits), the tool call
hangs indefinitely and only settles when the outer abort fires — and the abort
signal is optional, so callers without one hang forever.

Merged #109215 fixed the same hang class for the `ensureTool` **availability
checks** in `src/agents/utils/tools-manager.ts` (verified: its diff touches only
`tools-manager.ts` + its test). It deliberately did **not** touch the search
**execution** path — `find.ts` and `grep.ts` still spawn `fd`/`rg` with no
timeout. This PR closes that remaining gap.

## Why This Change Was Made

Each tool arms a bounded 60s execution timer (`FD_EXEC_TIMEOUT_MS` /
`RG_EXEC_TIMEOUT_MS`) right after spawning the helper, mirroring the manual
`setTimeout` + kill pattern the sibling `bash.ts` tool already uses for its
`timeout` option (execa's native `timeout` option does not fit here: these tools
consume the child via `close` events + readline streaming, not the buffered
result promise, and `runCommandWithTimeout` is a buffered one-shot runner).

On expiry the timer kills the child through the existing `stopChild()` path
(the same kill used for abort and match-limit stops) and rejects with a clean
error in the local message style: `fd timed out after 60 seconds` /
`ripgrep timed out after 60 seconds`. Settlement stays one-shot through the
existing `settle()` guard, so the timeout **composes** with the tool-call abort
signal instead of replacing it — whichever fires first wins, and settlement
disarms the other (`clearTimeout` in `settle`/`cleanup` next to the existing
`removeEventListener`). Streaming behavior (`buffer: false` + readline) is
unchanged, and the timer is always cleared on settlement so normal searches
never retain the event loop.

No new config, env var, or tool option: the constant is consistent with
sibling bounds in `tools-manager.ts` (`ARCHIVE_EXTRACT_TIMEOUT_MS = 60_000`).

## User Impact

- `find`/`grep` tool calls can no longer hang forever on a stalled `fd`/`rg`
  child (broken mounts, wedged filesystems); they fail cleanly after 60s with
  an actionable error, even when the caller passes no abort signal.
- Normal searches are unaffected: the timer only fires if the child has not
  exited within 60s, and is cleared on every settlement path.

## Evidence

### Mechanism — timeout composes with the existing abort wiring

| Layer | File | Line | Mechanism |
|---|---|---|---|
| Outer abort (existing, optional) | `src/agents/sessions/tools/find.ts` | 187 | `signal?.addEventListener("abort", onAbort, { once: true })` |
| Execution bound (new) | `src/agents/sessions/tools/find.ts` | 54 | `FD_EXEC_TIMEOUT_MS = 60_000` |
| Timer armed at spawn | `src/agents/sessions/tools/find.ts` | 299 | `setTimeout` → `stopChild?.()` + one-shot `settle(reject)` |
| Disarm on settlement | `src/agents/sessions/tools/find.ts` | 188 | `clearTimeout(execTimeout)` inside `settle()` |
| Outer abort (existing, optional) | `src/agents/sessions/tools/grep.ts` | 191 | `signal?.addEventListener("abort", onAbort, { once: true })` |
| Execution bound (new) | `src/agents/sessions/tools/grep.ts` | 54 | `RG_EXEC_TIMEOUT_MS = 60_000` |
| Timer armed at spawn | `src/agents/sessions/tools/grep.ts` | 279 | `setTimeout` → one-shot `settle(reject)` → `stopChild()` |
| Disarm on settlement | `src/agents/sessions/tools/grep.ts` | 172 | `clearTimeout(execTimeout)` inside `cleanup()` |

### Real behavior proof — stalled helpers through the production entry point

Standalone proof script (not committed; zero `vi.mock`). It places stub `fd`/`rg`
binaries in `$OPENCLAW_AGENT_DIR/bin` that spawn successfully, emit nothing, and
never exit — the observable shape of a helper stalled on a broken filesystem or
dead network mount. `ensureTool` resolves the stubs first
(`tools-manager.ts:128-132` checks the managed bin dir before PATH), and the
script calls the real `createFindToolDefinition().execute(...)` /
`createGrepToolDefinition().execute(...)` with no abort signal, racing each
against a 70s watchdog.

Before fix (unmodified `main` @ `19b5e564d7`) — both calls hang past the 60s
bound:

```json
{
  "expectedBoundMs": 60000,
  "watchdogMs": 70000,
  "results": [
    { "tool": "find", "outcome": "pending", "elapsedMs": 70036 },
    { "tool": "grep", "outcome": "pending", "elapsedMs": 70035 }
  ]
}
```

After fix (this PR) — both calls reject at ~60s with the new clean errors:

```json
{
  "expectedBoundMs": 60000,
  "watchdogMs": 70000,
  "results": [
    { "tool": "find", "outcome": "rejected", "message": "fd timed out after 60 seconds", "elapsedMs": 60114 },
    { "tool": "grep", "outcome": "rejected", "message": "ripgrep timed out after 60 seconds", "elapsedMs": 60139 }
  ]
}
```

### Control-red

The "before" run above **is** the control-red: the identical script on
unmodified `main` leaves both tool calls pending at the 70s watchdog (10s past
the fix's 60s bound). Reverting this PR is deleting the two `setTimeout` blocks
(plus the constants and `clearTimeout` lines) — the diff in this PR is purely
additive, so the before/after pair exercises exactly the added lines.

### Regression tests

Two new tests per tool in `find.fd.test.ts` / `grep.stream-errors.test.ts`
(mirroring the existing mocked-child style): a hanging child that never emits
output and never closes now rejects with `fd timed out after 60 seconds` /
`ripgrep timed out after 60 seconds` and kills the child; a normally-exiting
child leaves zero pending timers (`vi.getTimerCount() === 0`) and is never
killed. Existing abort-precedence tests (`settles an abort when the spawned
child never closes`, etc.) still pass unchanged, confirming the timeout does
not alter abort semantics.

### Test suite

```
$ node scripts/run-vitest.mjs run src/agents/sessions/tools/find.fd.test.ts \
    src/agents/sessions/tools/find.test.ts \
    src/agents/sessions/tools/grep.stream-errors.test.ts
Test Files  3 passed (3)
     Tests  19 passed (19)
```

### Lint

```
$ node scripts/run-oxlint.mjs src/agents/sessions/tools/find.ts \
    src/agents/sessions/tools/grep.ts \
    src/agents/sessions/tools/find.fd.test.ts \
    src/agents/sessions/tools/grep.stream-errors.test.ts
✓ clean (0 errors)
```

### tsgo

```
$ node scripts/run-tsgo.mjs -p tsconfig.core.json
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json
→ no errors in any file touched by this PR
```

(Local worktree note: the full-project runs report 3 pre-existing
`packages/net-policy/src/ip.ts` errors caused by a stale shared
`node_modules` predating the latest `pnpm-lock.yaml` on `main`; that file is
untouched by this PR and the same command passes on a deps-matched checkout.
The oxlint wrapper's extension-boundary dts pre-step was skipped with the
sanctioned `OPENCLAW_OXLINT_SKIP_PREPARE=1` for the same reason — this PR does
not touch `extensions/` or `packages/`.)

### git diff --check

clean — 4 files, +103/-0 (2 source files, 2 test files).


---

### Execa-contract audit (head `c1fa92b9`, supplied because the review sandbox could not inspect the repo)

- `spawnCommand` passes unknown options straight into `execa(...)`: `src/process/exec-spawn.ts:71` destructures only `baseEnv`/`env`/`windowsVerbatimArguments` and spreads `...execaOptions` into the execa call (`exec-spawn.ts:79-80`), so `forceKillAfterDelay` reaches execa unmodified.
- Installed execa is `10.0.0` (root `package.json`). Its option contract (`node_modules/execa/types/arguments/options.d.ts:300-307`) documents: "If the subprocess is terminated but does not exit, forcefully exit it by sending SIGKILL", default 5000, with `error.isForcefullyTerminated`. The PR passes `COMMAND_PROCESS_TREE_KILL_GRACE_MS = 300` (`src/process/exec-spawn.ts:7`) — the same constant the canonical `runExec` path already passes (`src/process/exec.ts:60`), so the escalation policy matches the repo's existing child-process policy instead of inventing a new one.
- Abort, match-limit, and stream-release paths are preserved: `settle()` still removes the abort listener and now also clears the new timer (`find.ts` settle diff); the abort path is untouched (`signal?.removeEventListener("abort", onAbort)`); the `limit` schema/`DEFAULT_LIMIT = 1000` and `normalizePositiveLimit` flow are unchanged; `releaseChildProcessOutputAfterExit` still wraps the child. The timeout branch closes `rl` and destroys both pipes exactly so a SIGTERM-defiant child cannot pin stream handles after settlement.

### Timeout-policy context for the owner decision (fixed wall-clock precedents on current `main`)

- Merged #109215 (`cb47a0b4cc`, same tool-helper problem family) bounds tool-probe child processes with a **fixed 5 s wall-clock** `spawnSync` timeout plus `SIGKILL` — the repo has already accepted a fixed wall-clock bound on agent tool child processes.
- Fixed 60 s defaults in agent scope on current main: `COMPACTION_PLANNING_WORKER_TIMEOUT_MS = 60_000` (`src/agents/compaction-planning-worker.ts:29`), `code-mode-runtime` clamps tool `timeoutMs` to a 60 s max (`src/agents/code-mode-runtime.ts:159,241`), LLM idle timeout `60_000` (`src/agents/embedded-agent-runner/run/llm-idle-timeout.ts:28`), stream-settle aggregate `60_000` (`run/attempt-stream-settle.ts:180`).
- This PR's 60 s is a backstop, not the primary cancel path: the existing outer abort signal still wins when present; the bound only fires when fd/ripgrep wedges without exiting (broken FS/network mount) and no abort arrives. `execTimeoutMs` is exposed as an option (currently a test seam), so the policy has a named adjustment point if an owner wants a different value or a config surface later.

## Round 2 (2026-07-17)

**Review addressed:** P1 on `find.ts:299` (same class in `grep.ts`) — the 60s deadline only called the existing stop path, but a wedged fd/rg can ignore the default termination signal, leaving the process and its pipes alive after the tool promise rejects. The reviewer asked for definitive termination or bounded escalation in both tools, a test with a child that ignores the initial signal, and stream cleanup after forced settlement.

**Repair (both `find.ts` and `grep.ts`):**

- The fd/rg children are now spawned with `forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS` (the repo's established 300ms kill-grace constant from `src/process/exec-spawn.ts`, the same escalation `runExec` and `exec-termination.ts` already use). execa monkey-patches `subprocess.kill()`, so the existing stop path still sends SIGTERM first, then automatically escalates to SIGKILL if the child has not exited within the grace window. This covers the 60s deadline path, the match-limit stop, and the outer-abort stop uniformly — no new kill machinery.
- On deadline settlement the tool now also closes the readline interface and destroys `stdout`/`stderr`, so even a child stuck in uninterruptible sleep cannot pin stream handles past settlement ("stream cleanup after forced settlement").
- The 60s value and the wall-clock semantics are unchanged (maintainer decision on inactivity-vs-wall-clock is pending and orthogonal). The only new seam is an optional `execTimeoutMs` on `FindToolOptions`/`GrepToolOptions` (documented as a test seam, resolved via the shared `resolveTimerTimeoutMs`) so the escalation can be exercised without a 60s wait; production callers keep the default.

**Regression coverage (new `find.exec-timeout.test.ts` / `grep.exec-timeout.test.ts`, POSIX-gated):** each test writes a real managed-bin stub (node shebang script that swallows SIGTERM) to a temp dir, points `ensureTool` at it, and runs the real `spawnCommand` (spied via an `importActual` passthrough) with `execTimeoutMs: 100`. Assertions: the tool call rejects with the timeout error; the child's stdio streams are destroyed at settlement; and the process is actually reaped afterwards (`process.kill(pid, 0)` → ESRCH within a 5s poll — only possible via the SIGKILL escalation, since the stub ignores SIGTERM). An `afterEach` SIGKILLs any surviving stub so a failing run cannot hang the worker.

**Control-red proof:** with the escalation stripped (no `forceKillAfterDelay`, no stream destroy, timeout seam kept), both new tests fail — `AssertionError: expected false to be true` on the stream-cleanup assertion, and the wedged stub survives (reaped by the test's `afterEach` safety net). With the escalation restored, all four find/grep test files pass: 19/19 (including the round-1 fake-timer timeout tests and `find.test.ts` on the unit-fast lane).

**Checks (round 2):**

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts` on the four find/grep test files — 19/19 passed; `find.test.ts` on `vitest.unit-fast.config.ts` — 2/2 passed
- `pnpm tsgo:core` — exit 0; `pnpm tsgo:core:test` — exit 0
- `oxlint` on the four changed/new files — clean; `git diff --check` — clean


---

## Round 3 (2026-07-31)

**Review addressed:** the patch-quality drop in ClawSweeper's 2026-07-31 pass — the branch conflicted with `main` because the search-tool implementation changed shape after the original base (execa 9 → 10: `spawnCommand` still returns the execa `ResultPromise`, but the underlying `ChildProcess`, its `killed` flag, and `error`/`close` events are now reached through `.nodeChildProcess`, and `releaseChildProcessOutputAfterExit` takes `.nodeChildProcess`). Rebased onto current `main` (`b2b62b2e1e`) and **ported the timeout semantics onto the new structure** instead of preserving the old diff:

- `src/agents/sessions/tools/find.ts` / `grep.ts`: same behavior on the new owner path — `forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS` on the spawn (`find.ts:299` / `grep.ts:288`), a 60s `setTimeout` armed right after spawn (`find.ts:314` / `grep.ts:295`) that stops the child through the existing `stopChild()` path and rejects via one-shot `settle()`, readline close plus `stdout`/`stderr` destroy on forced settlement, and `clearTimeout` on every settlement path (`find.ts:196` / `grep.ts:186`). Child-state access follows the execa 10 contract (verified in `node_modules/execa/types/subprocess/subprocess.d.ts`: `nodeChildProcess` is the documented escape hatch; the facade itself exposes `pid`/stdio/`kill` but not `killed`).
- The real-process regression tests now assert `child.nodeChildProcess.killed` instead of the execa 9 facade's `killed`.
- The 60s wall-clock policy itself is unchanged — that maintainer decision is still pending and is orthogonal to this port.

New head: `c1fa92b976b5ee5d9d8b1ed901c328cf6e8050fa` (diff vs `origin/main`: exactly the six find/grep files, +355/-0).

**Tests (new head):**

```
$ node scripts/run-vitest.mjs src/agents/sessions/tools/find.fd.test.ts src/agents/sessions/tools/grep.stream-errors.test.ts
Test Files 2 passed (2) — Tests 19 passed (19)
$ node scripts/run-vitest.mjs src/agents/sessions/tools/find.exec-timeout.test.ts src/agents/sessions/tools/grep.exec-timeout.test.ts
Test Files 2 passed (2) — Tests 2 passed (2)
```

- `node scripts/run-tsgo.mjs -p tsconfig.core.json` — exit 0. The core-test lane reports one pre-existing error in `ui/src/app-session-route-paths.ts` (unbuilt `packages/session-url-contract` dist in the linked worktree `node_modules`; that file is untouched by this PR and the failure is environmental).
- `oxfmt --check` on all six touched files — clean.

**Real-process proof (new head; standalone tsx script, zero mocks — same method as Rounds 1/2: stub binaries in `$OPENCLAW_AGENT_DIR/bin`, which `ensureTool` checks before PATH, invoked through the real `createFindToolDefinition`/`createGrepToolDefinition` entry points with no abort signal unless stated):**

Control — unmodified current-`main` find/grep against stalled, SIGTERM-ignoring stubs: both calls still hang past the 70s watchdog:

```json
{ "results": [
  { "tool": "find(stalled)", "outcome": "pending", "elapsedMs": 70004 },
  { "tool": "grep(stalled)", "outcome": "pending", "elapsedMs": 70003 } ] }
```

After — this PR head, all four scenario groups:

```json
{ "expectedBoundMs": 60000, "watchdogMs": 70000, "results": [
  { "tool": "find(stalled)", "outcome": "rejected", "message": "fd timed out after 60 seconds", "elapsedMs": 60026, "reaped": true },
  { "tool": "grep(stalled)", "outcome": "rejected", "message": "ripgrep timed out after 60 seconds", "elapsedMs": 60028, "reaped": true },
  { "tool": "find(abort@1s)", "outcome": "rejected", "message": "Operation aborted", "elapsedMs": 1001, "reaped": true },
  { "tool": "grep(abort@1s)", "outcome": "rejected", "message": "Operation aborted", "elapsedMs": 1001, "reaped": true },
  { "tool": "grep(match-limit=2)", "outcome": "resolved", "matchLimitReached": 2, "elapsedMs": 349, "reaped": true },
  { "tool": "find(normal)", "outcome": "resolved", "text": "a.ts", "elapsedMs": 110 },
  { "tool": "grep(normal)", "outcome": "resolved", "text": "a.ts:1: const foo = 1;", "elapsedMs": 144 } ] }
```

`reaped: true` means the SIGTERM-ignoring stub is gone afterwards (`pgrep` on the stub path returns nothing within 5s), so the `forceKillAfterDelay` SIGKILL escalation works through the ported deadline, abort, and match-limit stop paths on the new structure. No real `rg` binary exists on the proof box, so the grep normal-exit row uses a well-behaved stub that emits one match and exits 0; `find(normal)` uses the real `fd` from PATH.


## Round 4 (2026-08-21)

**Review addressed:** ClawSweeper's 2026-08-21 pass on head `98657d2c8ea`:

1. **P3 (prior round's finding, fixed in `98657d2c8ea`):** the fake-timer tests restored timers only on their success path — `vi.useRealTimers()` moved into the shared `afterEach` of `find.fd.test.ts` / `grep.stream-errors.test.ts` and the five redundant in-test restore calls removed.
2. **P2 — refresh the ripgrep deadline on raw stdout chunks (`grep.ts:366`):** the stall timer was re-armed from readline's `line` event, which fires only after a newline. One large ripgrep JSON match record (match data includes file contents) can stream in stdout chunks for longer than 60s without completing a line and was killed as "without output" despite active output. The timer now re-arms from the raw `stdout` `data` listener; readline keeps JSON parsing only, and the now-redundant refresh inside the `line` handler was removed. `find.ts` needs no equivalent: fd emits newline-terminated paths bounded by PATH_MAX, so a single line cannot outlive the stall window.

New head: `3fc8b8cb238` (production delta this round: +7/−3 in `grep.ts`; regression coverage: `grep.exec-timeout.test.ts` gains one chunked-record test).

**Red/green on the new regression** (`node scripts/run-vitest.mjs src/agents/sessions/tools/grep.exec-timeout.test.ts`, Node v24.19.0): the new test streams one valid `{"type":"match",...}` record in 64-byte chunks every 100ms with no newline, across 70s of fake stall-window time. Against the pre-fix `grep.ts` it **fails** (the search is rejected as timed out while chunks are still arriving); against this head it **passes** (3/3). Full touched-file sweep: `find.fd`, `find.exec-timeout`, `grep.stream-errors`, `grep.exec-timeout` — 29/29 passed; oxlint/oxfmt/tsc clean on the touched files.


---

## Round 5 (review response, head `1c876135fd4`)

Addresses the re-review finding **[P1] use the canonical `runCommandWithTimeout` runner instead of a hand-rolled spawn/stall-timer lifecycle**.

**Refactor:** both tools now make one `runUtf8CommandWithTimeout` call (`src/process/exec-runner.ts`) instead of owning `spawnCommand` + readline + `setTimeout`/`refresh` + pipe teardown:

- **Stall deadline** → the runner's `noOutputTimeoutMs`, which re-arms on every raw stdout/stderr chunk — preserving the exact semantics of the previous hand-rolled timer (including the round-4 fix: a large newline-less ripgrep JSON record no longer trips the deadline). `result.noOutputTimedOut` maps to the unchanged `fd|ripgrep timed out after 60 seconds without output` error.
- **Kill/escalation** → the runner owns SIGTERM → SIGKILL-after-grace on timeout and abort (`signal` passed through), replacing the tool-side `stopChild`/`forceKillAfterDelay`/pipe-destroy dance.
- **grep early stop** → `onOutputChunk` decodes `rg --json` records incrementally (`StringDecoder`, chunk-boundary-safe) and returns `false` at the limit+1 sentinel match, so the runner kills the child (`termination: "output-limit"`); the tool's `matchLimitReached` flag keeps that kill exempt from the exit-code check. Exit code 1 still means "no matches".
- **Error mapping preserved:** `ripgrep exited with code N` / stderr-text rejections, `fd exited with code N`, `Operation aborted`, `No files found matching pattern`, `No matches found`, and `fd|ripgrep <stream> error: <message>` all unchanged.

Production delta this round: `find.ts` −42, `grep.ts` −27 (net **−69 production LOC**). Tests re-pointed from `spawnCommand` to the runner boundary: the exec-timeout suites keep the real stub binaries (fake-timer stall/keepalive semantics unchanged), the fd/stream-error suites now script `SpawnResult`s at the `runUtf8CommandWithTimeout` contract.

**Deliberate semantic notes** (runner contract, verified against `src/process/exec-runner.ts` and execa source):
- Stall rejection now resolves after the child is reaped (bounded by the SIGKILL grace), not at the instant the deadline fires — the deadline still owns the kill.
- On an output-stream error the runner reports `outputErrorStream` after child exit (execa does not kill on stream errors); rejection text is unchanged, termination timing is child-driven (fd/rg die from SIGPIPE/EPIPE themselves).

**Red/green + verification** (Node v24.19.0): red proof — removing `noOutputTimeoutMs` from both tools makes both stub-binary stall tests fail (`Test timed out`, child never killed) while keepalive/chunked tests still pass; green — the four touched suites + `find.test.ts` 34/34 passed, `src/process/exec.no-output-timer.test.ts` + `exec.test.ts` 39 passed / 1 skipped, oxlint/oxfmt/`git diff --check` clean, tsgo core + agents test shard clean.

**Follow-up (`3f43bf85dc7`, CI ratchet):** `checks-fast-baseline-ratchets` flagged one new uncommented type assertion in `find.ts`. The runner error's `outputErrorStream` tag is now read via `in`-narrowing (`error instanceof Error && "outputErrorStream" in error`) instead of an `as` cast — no assertion added, so the ratchet is satisfied regardless of its standalone-scanner blind spot past template literals. Stream-error suites still green (24/24).

**Rebase note (head `77e49ecabbc`):** the branch was replayed onto current `main` (identical content for the touched files — verified byte-equal against the old branch point) because the second ratchet failure needed `config/assertion-safety-baseline.txt`, which only exists on newer main: the in-narrowing fix shrank `grep.ts` 4 → 3, and the ratchet requires the baseline entry to shrink with it. Both ratchets verified green locally (`check:assertion-safety`, `check:max-lines-ratchet`), tool suites re-run green on the new base (34/34). Old head `3f43bf85dc7` is superseded.

**Rebase note 2 (head `cf1dc9d2325`):** replayed onto `main@e7cfff21673`. The previous rebase base carried a pre-existing `ui/src/pages/cron/view.test.ts` max-lines violation (fixed on newer main by splitting the file), which failed `check-lint-core-5` on the merge ref. Verified on the new base: both ratchets green, 34/34 tool tests green, oxlint clean.

---

## Round 6 (review response, head `f3b87210561`)

Addresses the re-review finding **[P2] Discard ripgrep stdout after parsing it**: grep parses `rg --json` records incrementally via `onOutputChunk`, so the runner's default per-stream tail (16 MiB) was retaining an already-consumed stream. The runner call now passes `outputCapture: { stdout: "discard" }`; stderr keeps its tail because exit-error messages still read `result.stderr`. find is untouched — it consumes `result.stdout` from the capture. The stall-timeout suite now also asserts the `outputCapture` option; 34/34 tool tests green, oxlint/oxfmt clean.

---

## Round 7 (review response, head `861d4fe6fee`)

Addresses the two re-review findings **[P1] Cap stderr retained by the fd runner** and **[P1] Cap stderr retained by the ripgrep runner**: the pre-refactor code bounded stderr via `appendBoundedTextTail` (`SESSION_TOOL_STDERR_TAIL_BYTES` = 64 KiB), while the runner's default tail is 16 MiB. Both runner calls now pass `maxOutputBytes: { stderr: SESSION_TOOL_STDERR_TAIL_BYTES }`, restoring the exact pre-refactor retention bound. The stall-timeout suites assert the new option for both tools; 34/34 tool tests green, oxlint/oxfmt clean.

---

## Round 8 (review response, head `ddd09c0a5a1`)

Addresses both re-review findings **[P1] Terminate fd/ripgrep when an output stream fails**. Correction to the Round 5 "deliberate semantic notes": the claim that the runner cannot kill a child on stream error was wrong — the runner has `terminateOnOutputError` (`exec-runner.ts`, kills via `cancel("signal")` from the stream `error` handler). Both tools now pass `terminateOnOutputError: true`, restoring the pre-refactor immediate `stopChild`-on-error behavior; the earlier "termination timing is child-driven" note is superseded. Both stall suites assert the new option; 34/34 tool tests green, oxlint/oxfmt clean.


## Final-head real behavior proof (2026-08-21, head ddd09c0a5a1)

Addressing the review gate: final-head terminal transcript of the real-child timeout suites, run on the exact reviewed head `ddd09c0a5a1` (verbose reporter so every case is named). These are real managed-bin stub children driven through the production tool + shared runner boundary, real timers, no mocks:

```
$ node scripts/run-vitest.mjs --reporter=verbose src/agents/sessions/tools/find.exec-timeout.test.ts src/agents/sessions/tools/grep.exec-timeout.test.ts

 ✓ grep.exec-timeout.test.ts > rejects after a silent window, reaps a SIGTERM-ignoring ripgrep via escalation, and releases its pipes  212ms
 ✓ find.exec-timeout.test.ts  > rejects after a silent window, reaps a SIGTERM-ignoring fd via escalation, and releases its pipes  211ms
 ✓ find.exec-timeout.test.ts  > does not kill fd while output keeps arriving past the stall window  2145ms
 ✓ grep.exec-timeout.test.ts  > does not kill ripgrep while output keeps arriving past the stall window  2138ms
 ✓ grep.exec-timeout.test.ts  > does not kill ripgrep while one large record streams in chunks without a newline  2188ms

 Test Files  2 passed (2)
      Tests  5 passed (5)
```

This shows both required behaviors on the final head: silent SIGTERM-ignoring children are rejected after the stall window and reaped via SIGKILL escalation with pipes released, while children producing sustained output past the stall window are never killed.

On the flagged merge risk: yes, an otherwise valid search that stays silent for 60s now fails with an actionable tool error instead of blocking the agent turn forever — that tradeoff is the point of the PR; the stall window only arms when the child produces *no output at all* (any stdout/stderr chunk resets it), and the value matches the existing exec-tool no-output timeout convention.



Fixes #130565
