### PR TITLE
fix(plugins): remove abort listener when channel runtime context is disposed

### DIFF
--- a/src/plugins/runtime/channel-runtime-contexts.ts
+++ b/src/plugins/runtime/channel-runtime-contexts.ts
@@ -115,6 +115,9 @@ export function createChannelRuntimeContextRegistry(): ChannelRuntimeContextRegi
           return;
         }
         disposed = true;
+        // Detach before the token check: stale leases disposed after a replacement
+        // registered must still release their listener on long-lived signals.
+        params.abortSignal?.removeEventListener("abort", dispose);
         const current = runtimeContexts.get(normalized.mapKey);
         if (!current || current.token !== token) {
           return;

--- a/src/plugins/runtime/runtime-channel.test.ts
+++ b/src/plugins/runtime/runtime-channel.test.ts
@@ -1,4 +1,5 @@
 // Runtime channel tests cover channel plugin runtime send, reply, and capability behavior.
+import { getEventListeners } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { createRuntimeChannel } from "./runtime-channel.js";
 
@@ -87,6 +88,60 @@ describe("runtimeContexts", () => {
       }),
     ).toBeUndefined();
     lease.dispose();
+  });
+
+  it("removes its abort listener when the lease is disposed", () => {
+    const channel = createRuntimeChannel();
+    const controller = new AbortController();
+    const initialListenerCount = getEventListeners(controller.signal, "abort").length;
+    const lease = channel.runtimeContexts.register({
+      channelId: "telegram",
+      accountId: "default",
+      capability: "approval.native",
+      context: { token: "abc" },
+      abortSignal: controller.signal,
+    });
+
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(initialListenerCount + 1);
+
+    lease.dispose();
+
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(initialListenerCount);
+  });
+
+  it("removes the stale lease abort listener after a replacement registration", () => {
+    const channel = createRuntimeChannel();
+    const controller = new AbortController();
+    const initialListenerCount = getEventListeners(controller.signal, "abort").length;
+    const staleLease = channel.runtimeContexts.register({
+      channelId: "whatsapp",
+      accountId: "default",
+      capability: "connection.controller",
+      context: { token: "stale" },
+      abortSignal: controller.signal,
+    });
+    channel.runtimeContexts.register({
+      channelId: "whatsapp",
+      accountId: "default",
+      capability: "connection.controller",
+      context: { token: "replacement" },
+      abortSignal: controller.signal,
+    });
+
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(initialListenerCount + 2);
+
+    // Channel plugins dispose the previous lease after registering its replacement,
+    // so the stale token check must not skip listener cleanup.
+    staleLease.dispose();
+
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(initialListenerCount + 1);
+    expect(
+      channel.runtimeContexts.get({
+        channelId: "whatsapp",
+        accountId: "default",
+        capability: "connection.controller",
+      }),
+    ).toEqual({ token: "replacement" });
   });
 
   it("does not register contexts when the abort signal is already aborted", () => {


### PR DESCRIPTION
## What Problem This Solves

Channel plugins re-register their plugin runtime context on every reconnect and pass the same long-lived, account-level `AbortSignal` each time. `createChannelRuntimeContextRegistry().register()` attaches `params.abortSignal.addEventListener("abort", dispose, { once: true })`, but `dispose()` never removed that listener. When a lease is disposed manually — which is exactly what channel connection controllers do right after registering a replacement — the listener stays attached to the still-alive signal. Every reconnect leaks one listener (plus the closure over the registry map, key, and token) on a signal that lives as long as the account task.

Concrete path (WhatsApp shown; Slack's monitor provider also passes its abort signal through the same registry at `extensions/slack/src/monitor/provider.ts:516`, and Matrix/GoogleChat/Discord register through the same path):

- `extensions/whatsapp/src/connection-controller.ts:457` stores one account-level `abortSignal` on the controller.
- `openConnection()` runs on every reconnect; it calls `registerChannelRuntimeContext({ ..., abortSignal: this.abortSignal })` (line 612) and then disposes the previous lease (line 623) *after* the replacement has been registered.
- In the registry, the previous lease's `dispose()` took the stale-token early return (`current.token !== token`) — and returned without detaching its listener from `this.abortSignal`, which outlives every individual connection.

This is the same listener-leak class as merged #109108 (`src/channels/run-state-machine.ts`, `extensions/discord/src/monitor/message-run-queue.ts`). That PR fixed the identical add-without-remove pattern in those two files but did not cover the plugin runtime-context registry, where every channel plugin's reconnect path funnels through.

## Why This Change Was Made

Mirror the #109108 shape: detach the abort listener inside the cleanup path, immediately after the `disposed` guard flips:

```ts
params.abortSignal?.removeEventListener("abort", dispose);
```

The call is placed *before* the stale-token map check on purpose: channel plugins dispose the previous lease only after the replacement overwrote the map entry, so the token check fails for exactly the leases whose listeners must be released. On the abort path the `once: true` listener has already auto-removed itself, so the extra `removeEventListener` is a harmless no-op; double-dispose remains guarded by `disposed`.

One production line (plus a comment documenting the ordering invariant). No API or behavior change beyond releasing the listener; registration, replacement, abort auto-dispose, and watcher event semantics are unchanged.

## User Impact

- Long-running channel accounts no longer accumulate one abort listener per reconnect on the account-level signal; listener count stays flat across reconnects instead of growing unboundedly (with the associated `MaxListenersExceededWarning` noise and retained closures).
- Each leaked listener previously retained the registry map, key, and token closure for the lifetime of the account signal; those are now released on dispose.

## Evidence

### Leak path — full chain (source verified on main @ 9638c3ae07)

| Layer | File | Line | Mechanism |
|---|---|---|---|
| Account-level signal | `extensions/whatsapp/src/connection-controller.ts` | 457 | `this.abortSignal = params.abortSignal` set once in the constructor; outlives every connection |
| Re-register per reconnect | same file | 612 | `registerChannelRuntimeContext({ ..., abortSignal: this.abortSignal })` inside `openConnection()` |
| Stale lease disposed after replacement | same file | 621-623 | comment: "Publish the ready replacement before releasing the old lease"; `previousRuntimeContextLease?.dispose()` runs after the new registration overwrote the map entry |
| Listener added per registration | `src/plugins/runtime/channel-runtime-contexts.ts` | 128 | `params.abortSignal?.addEventListener("abort", dispose, { once: true })` |
| Leak (before fix) | same file | 118-121 | stale-token early return in `dispose()`; no `removeEventListener` anywhere in the registry |

### Regression tests

`src/plugins/runtime/runtime-channel.test.ts`, mirroring the `getEventListeners` assertion style that #109108 used in `src/channels/run-state-machine.test.ts`:

- `removes its abort listener when the lease is disposed` — register with a real `AbortController`, assert the signal gained one listener, `dispose()`, assert the count returns to baseline.
- `removes the stale lease abort listener after a replacement registration` — the production reconnect shape: register lease A, register replacement B under the same key, dispose A, assert A's listener is gone while B's registration and context survive.

### Control-red — same tests, fix reverted vs applied

Fix reverted (current main behavior, both new tests fail — the disposed lease's listener remains on the live signal):

```
AssertionError: expected [ [Function dispose] ] to have a length of +0 but got 1
AssertionError: expected [ [Function dispose], …(1) ] to have a length of 1 but got 2
Tests  2 failed | 5 passed (7)
```

Fix applied (this PR):

```
Tests  7 passed (7)
```

### Test suite

```
$ node scripts/run-vitest.mjs run src/plugins/runtime/runtime-channel.test.ts
Test Files  1 passed (1)
     Tests  7 passed (7)
```

### Lint / typecheck / whitespace

```
$ node scripts/run-oxlint.mjs src/plugins/runtime/channel-runtime-contexts.ts src/plugins/runtime/runtime-channel.test.ts
exit 0 (no findings)

$ node scripts/run-tsgo.mjs -p tsconfig.core.json
exit 0, 0 error TS

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json
exit 0, 0 error TS

$ git diff --check origin/main
(clean)
```
