### PR TITLE
fix(browser): honor abortSignal during Playwright click-and-hold delay

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.interactions.click-delay.abort.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.click-delay.abort.test.ts
@@ -1,0 +1,94 @@
+// Browser tests cover pw tools core.interactions click hold-delay abort behavior.
+import { describe, expect, it, vi } from "vitest";
+import {
+  getPwToolsCoreSessionMocks,
+  installPwToolsCoreTestHooks,
+  setPwToolsCoreCurrentPage,
+  setPwToolsCoreCurrentRefLocator,
+} from "./pw-tools-core.test-harness.js";
+
+installPwToolsCoreTestHooks();
+const mod = await import("./pw-tools-core.interactions.js");
+
+describe("clickViaPlaywright (hold-delay abort)", () => {
+  it("unwinds the hold-delay action chain promptly when aborted mid-delay", async () => {
+    vi.useFakeTimers();
+    try {
+      const hover = vi.fn(async () => {});
+      const click = vi.fn(async () => {});
+      setPwToolsCoreCurrentRefLocator({ hover, click });
+      setPwToolsCoreCurrentPage({ url: vi.fn(() => "https://example.test/hold") });
+
+      const ctrl = new AbortController();
+      const task = mod.clickViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "1",
+        delayMs: 5_000,
+        ssrfPolicy: { allowPrivateNetwork: false },
+        signal: ctrl.signal,
+      });
+      const settled = task.then(
+        () => ({ status: "fulfilled" as const }),
+        (reason: unknown) => ({ status: "rejected" as const, reason }),
+      );
+
+      // Enter the click-and-hold delay, then abort 100ms into the 5s hold.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(hover).toHaveBeenCalledTimes(1);
+      ctrl.abort(new Error("aborted by test"));
+
+      const outcome = await settled;
+      expect(outcome.status).toBe("rejected");
+      if (outcome.status === "rejected") {
+        expect(outcome.reason).toBeInstanceOf(Error);
+        expect((outcome.reason as Error).message).toContain("aborted by test");
+      }
+      expect(click).not.toHaveBeenCalled();
+      expect(getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ssrfPolicy: { allowPrivateNetwork: false },
+        reason: "click aborted",
+      });
+
+      // The aborted action chain must unwind right away: the post-action
+      // navigation recheck runs after the 250ms delayed-navigation observation
+      // plus the 250ms grace, not after the remaining 4900ms of the hold.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(
+        getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely,
+      ).toHaveBeenCalledTimes(1);
+      expect(click).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still waits the full hold delay before clicking when not aborted", async () => {
+    vi.useFakeTimers();
+    try {
+      const hover = vi.fn(async () => {});
+      const click = vi.fn(async () => {});
+      setPwToolsCoreCurrentRefLocator({ hover, click });
+      setPwToolsCoreCurrentPage({ url: vi.fn(() => "https://example.test/hold") });
+
+      const task = mod.clickViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "1",
+        delayMs: 5_000,
+      });
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(hover).toHaveBeenCalledTimes(1);
+      expect(click).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await task;
+      expect(click).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -3,6 +3,7 @@
  * screenshots, batch actions, and SSRF-aware post-interaction navigation checks.
  */
 import { resolveNonNegativeIntegerOption } from "openclaw/plugin-sdk/number-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { FileChooser, Frame, Page } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -751,9 +752,10 @@ export async function clickViaPlaywright(
           if (delayMs > 0) {
             await locator.hover({ timeout });
             throwIfInteractionAborted(signal);
-            await new Promise((resolve) => {
-              setTimeout(resolve, delayMs);
-            });
+            // Abortable hold: a bare setTimeout would keep the orphaned action
+            // chain (and its navigation-guard teardown) alive for the full
+            // delayMs after the caller already lost the abort race.
+            await sleepWithAbort(delayMs, signal);
             throwIfInteractionAborted(signal);
           }
           if (opts.doubleClick) {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -706,38 +706,19 @@ export async function clickViaPlaywright(
     : page.locator(resolved.selector!);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   const signal = opts.signal;
-  let abortListener: (() => void) | undefined;
-  let abortReject: ((reason: unknown) => void) | undefined;
-  let abortPromise: Promise<never> | undefined;
-  if (signal) {
-    abortPromise = new Promise((_, reject) => {
-      abortReject = reject;
-    });
-    void abortPromise.catch(() => {});
-    const disconnect = () => {
-      if (isBrowserObservedDialogBlockedError(signal.reason)) {
-        return;
-      }
-      void forceDisconnectPlaywrightForTarget({
-        cdpUrl: opts.cdpUrl,
-        targetId: opts.targetId,
-        ssrfPolicy: opts.ssrfPolicy,
-        reason: "click aborted",
-      }).catch(() => {});
-    };
-    if (signal.aborted) {
-      disconnect();
-      throw signal.reason ?? new Error("aborted");
+  const { abortPromise, cleanup } = createAbortPromiseWithListener(signal, (reason) => {
+    if (isBrowserObservedDialogBlockedError(reason)) {
+      return;
     }
-    abortListener = () => {
-      disconnect();
-      abortReject?.(signal.reason ?? new Error("aborted"));
-    };
-    signal.addEventListener("abort", abortListener, { once: true });
-    if (signal.aborted) {
-      abortListener();
-      throw signal.reason ?? new Error("aborted");
-    }
+    void forceDisconnectPlaywrightForTarget({
+      cdpUrl: opts.cdpUrl,
+      targetId: opts.targetId,
+      ssrfPolicy: opts.ssrfPolicy,
+      reason: "click aborted",
+    }).catch(() => {});
+  });
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("aborted");
   }
   const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, signal);
   try {
@@ -784,9 +765,7 @@ export async function clickViaPlaywright(
   } catch (err) {
     throw toFriendlyInteractionError(err, label);
   } finally {
-    if (signal && abortListener) {
-      signal.removeEventListener("abort", abortListener);
-    }
+    cleanup();
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`clickViaPlaywright`'s click-and-hold delay in `extensions/browser/src/browser/pw-tools-core.interactions.ts` slept with a bare `setTimeout(resolve, delayMs)`, where `delayMs` can be up to `ACT_MAX_CLICK_DELAY_MS = 5_000` (`act-policy.ts:22`). The interaction `AbortSignal` is already in scope and is checked via `throwIfInteractionAborted(signal)` right before and after the sleep — but the sleep itself was not abortable.

When the signal fires mid-hold, the caller-visible promise does reject promptly (the `abortPromise` race in `awaitActionWithAbort`, `pw-tools-core.interactions.ts:488`), but the *action chain* is orphaned: the ref'd 5 s timer keeps sleeping after the caller is gone, then throws at the post-delay check. While orphaned it pins the event loop for the remainder of the hold, and it delays the navigation-guard teardown that only runs after the action settles — the delayed-navigation observation plus the 250 ms grace and the final `assertPageNavigationCompletedSafely` (`pw-tools-core.interactions.ts:569-590`), and with an SSRF policy active the `page.route("**")` interception installed by `withPageNavigationRequestGuard` (`pw-session.ts:1663`) stays attached to the tab for the rest of the hold as well.

## Why This Change Was Made

The hold is now `await sleepWithAbort(delayMs, signal)` (`packages/retry/src/index.ts:21`, re-exported via `openclaw/plugin-sdk/runtime-env`, already imported elsewhere in this plugin, e.g. `sleep` in `cdp.helpers.ts`). `sleepWithAbort` clears its timer and rejects on abort, so the orphaned chain unwinds at the abort event instead of after the full remaining delay. The pre/post `throwIfInteractionAborted(signal)` checks are unchanged, so behavior with no signal or no abort is identical.

The surfaced error is unchanged: `clickViaPlaywright` registers its abort listener (which rejects the race with `signal.reason`) before the action starts, so the race still rejects with the original abort reason — the proof below shows byte-identical rejection messages before and after. No new config, no new env, no SDK surface change.

Pattern reference: #108561 (merged) did the same `setTimeout` → `sleepWithAbort` swap for the Discord gateway READY backoff. Sibling #109617 covers the browser tab-discovery poll; this PR covers the click-and-hold hold delay — disjoint code paths.

## User Impact

- Cancelling an agent browser click with a hold delay (e.g. a 5 s click-and-hold) no longer leaves an orphaned action chain sleeping in the background: the timer is cleared at the abort event and the event loop can drain ~immediately (proof: 5010 ms → 338 ms).
- The post-interaction navigation guard (delayed-navigation observation, grace window, final safety recheck, and request interception when an SSRF policy is configured) is released at the abort instead of up to 5 s later, so follow-up interactions on the same tab no longer run under a stale, aborted interaction's guard state.
- Happy path is untouched: without an abort the click still waits the full `delayMs` before dispatching (locked by regression test).

## Evidence

### Signal path — full chain (source verified)

| Layer | File | Line | Mechanism |
|---|---|---|---|
| Tool opts | `pw-tools-core.interactions.ts` | 708 | `const signal = opts.signal` |
| Abort race | `pw-tools-core.interactions.ts` | 713-740 | `abortPromise` rejects with `signal.reason`; listener registered before the action runs |
| Hold delay (this PR) | `pw-tools-core.interactions.ts` | 758 | `await sleepWithAbort(delayMs, signal)` — timer cleared + rejection on abort |
| Sleep impl | `packages/retry/src/index.ts` | 21 | `sleepWithAbort`: `clearTimeout` + `reject(new Error("aborted", { cause: signal.reason }))` on the abort event |
| Race | `pw-tools-core.interactions.ts` | 488-506 | `Promise.race([actionPromise, abortPromise])`; late action rejection swallowed to avoid unhandled rejections |
| Guard teardown | `pw-tools-core.interactions.ts` | 569-590 | grace + `assertPageNavigationCompletedSafely` run in `finally` once the action settles — now reached at abort time |

### Real behavior proof — production `clickViaPlaywright`, real `AbortController`, wall-clock

Uncommitted proof script drives the production `clickViaPlaywright` (`resolvedPage` stub whose `locator()` returns an observed locator, `selector` + `delayMs: 5000`, no CDP connection), aborts 100 ms into the 5 000 ms hold, then measures `process.getActiveResourcesInfo()` Timeout entries and the `beforeExit` timestamp (when the event loop could actually drain). No mocks, no vitest.

**Before fix (main @ 9638c3ae07)**

```json
{
  "delayMs": 5000,
  "abortAtMs": 100,
  "events": [["hover", 2], ["abort()", 106], ["settled", 149]],
  "callerRejected": true,
  "rejectionMessage": "proof: user cancelled click-and-hold",
  "rejectElapsedMs": 149,
  "hoverFired": true,
  "clickFired": false,
  "timeoutResourcesAfterReject": 1,
  "eventLoopDrainedAtMs": 5010,
  "verdict": "BUG: caller rejected but the orphaned hold-delay timer pins the event loop for the full 5000ms"
}
```

**After fix (this PR)**

```json
{
  "delayMs": 5000,
  "abortAtMs": 100,
  "events": [["hover", 4], ["abort()", 106], ["settled", 138]],
  "callerRejected": true,
  "rejectionMessage": "proof: user cancelled click-and-hold",
  "rejectElapsedMs": 138,
  "hoverFired": true,
  "clickFired": false,
  "timeoutResourcesAfterReject": 0,
  "eventLoopDrainedAtMs": 338,
  "verdict": "FIXED: abort clears the hold-delay timer; event loop drains right after the abort"
}
```

Every field is independently checkable: `timeoutResourcesAfterReject` counts `"Timeout"` entries in `process.getActiveResourcesInfo()` after the caller already rejected (1 = the orphaned 5 000 ms sleep; 0 = cleared by the abort), and `eventLoopDrainedAtMs` is the `process.beforeExit` timestamp relative to t0. The rejection message is byte-identical before/after — the abort-reason error surface is unchanged.

### Control-red (mutation) verification

The new regression test fails on the unpatched code and passes on this branch:

| Version | `unwinds the hold-delay action chain promptly when aborted mid-delay` | `still waits the full hold delay before clicking when not aborted` |
|---|---|---|
| main @ 9638c3ae07 | **fails** — post-abort navigation recheck still pending 1 000 ms after the abort (orphan sleeps the full 5 000 ms first) | passes |
| this PR | **passes** — recheck completes within the 250 ms observation + 250 ms grace after the abort | passes |

Revert is exactly the production hunk above (`sleepWithAbort(delayMs, signal)` → bare `setTimeout(resolve, delayMs)`); no test edits between runs.

### Regression test

`extensions/browser/src/browser/pw-tools-core.interactions.click-delay.abort.test.ts` (colocated, uses the shared `pw-tools-core.test-harness.ts` mocks): aborts a real `AbortController` 100 ms into a 5 000 ms hold and asserts (a) rejection with the original abort reason, (b) `locator.click` never fires, (c) the existing force-disconnect-on-abort call still happens with `reason: "click aborted"`, and (d) the orphaned chain's navigation recheck settles promptly instead of after the full hold. Second test locks the happy path: without abort, the click fires only after the full 5 000 ms.

### Test suite

```
$ node scripts/run-vitest.mjs run \
    extensions/browser/src/browser/pw-tools-core.interactions.click-delay.abort.test.ts \
    extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts \
    extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts \
    extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts \
    extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts

 Test Files  5 passed (5)
      Tests  60 passed (60)
```

### Lint

```
$ node scripts/run-oxlint.mjs extensions/browser/src/browser/pw-tools-core.interactions.ts \
    extensions/browser/src/browser/pw-tools-core.interactions.click-delay.abort.test.ts
(exit 0, no findings)
```

### tsgo

```
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
(exit 0, 0 errors)
```
