### PR TITLE
fix(cli): guard process.kill ESRCH race in forceFreePort and killPids

### DIFF
--- a/src/cli/ports.test.ts
+++ b/src/cli/ports.test.ts
@@ -5,13 +5,23 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Hoist the factory so vi.mock can access it.
 const mockCreateServer = vi.hoisted(() => vi.fn());
+const mockExecFileSync = vi.hoisted(() => vi.fn());
 
 vi.mock("node:net", async () => {
   const actual = await vi.importActual<typeof import("node:net")>("node:net");
   return { ...actual, createServer: mockCreateServer };
 });
 
-import { waitForPortBindable } from "./ports.js";
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execFileSync: mockExecFileSync };
+});
+
+vi.mock("../infra/ports-lsof.js", () => ({
+  resolveLsofCommandSync: vi.fn(() => "/usr/bin/lsof"),
+}));
+
+import { forceFreePort, waitForPortBindable } from "./ports.js";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -110,5 +120,96 @@ describe("waitForPortBindable", () => {
         host: "127.0.0.1",
       }),
     ).rejects.toThrow(/still not bindable after 1ms/);
+  });
+});
+
+// ─── forceFreePort ──────────────────────────────────────────────────────────
+
+/** Build fake lsof -FpFc output for the given PIDs. */
+function lsofOutput(pids: number[]): string {
+  return pids.map((p) => `p${p}\ncnode\n`).join("");
+}
+
+describe("forceFreePort", () => {
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    // Restore platform to the actual value so other tests are not affected.
+    try {
+      Object.defineProperty(process, "platform", {
+        value: process.platform,
+        configurable: true,
+      });
+    } catch {
+      // Already restored or non-configurable; ignore.
+    }
+  });
+
+  it("swallows ESRCH when a port listener exits before SIGTERM", () => {
+    setPlatform("linux");
+    mockExecFileSync.mockReturnValue(lsofOutput([500, 600]));
+    const killSpy = vi.spyOn(process, "kill");
+    const esrchErr = Object.assign(new Error("no such process"), { code: "ESRCH" });
+    // First kill succeeds, second throws ESRCH.
+    killSpy
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw esrchErr;
+      });
+
+    const result = forceFreePort(9999);
+
+    // Both PIDs reported as freed — ESRCH means the port is already free.
+    expect(result).toEqual([
+      { pid: 500, command: "node" },
+      { pid: 600, command: "node" },
+    ]);
+    expect(killSpy).toHaveBeenCalledTimes(2);
+    expect(killSpy).toHaveBeenCalledWith(500, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(600, "SIGTERM");
+    killSpy.mockRestore();
+  });
+
+  it("re-throws non-ESRCH kill errors", () => {
+    setPlatform("linux");
+    mockExecFileSync.mockReturnValue(lsofOutput([500]));
+    const killSpy = vi.spyOn(process, "kill");
+    const epermErr = Object.assign(new Error("permission denied"), { code: "EPERM" });
+    killSpy.mockImplementation(() => {
+      throw epermErr;
+    });
+
+    expect(() => forceFreePort(9999)).toThrow("failed to kill pid 500");
+    killSpy.mockRestore();
+  });
+
+  it("continues past multiple ESRCH exits in the same call", () => {
+    setPlatform("linux");
+    mockExecFileSync.mockReturnValue(lsofOutput([100, 200, 300]));
+    const killSpy = vi.spyOn(process, "kill");
+    const esrchErr = Object.assign(new Error("no such process"), { code: "ESRCH" });
+    killSpy
+      .mockImplementationOnce(() => {
+        throw esrchErr;
+      })
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw esrchErr;
+      });
+
+    const result = forceFreePort(9999);
+
+    expect(result).toEqual([
+      { pid: 100, command: "node" },
+      { pid: 200, command: "node" },
+      { pid: 300, command: "node" },
+    ]);
+    expect(killSpy).toHaveBeenCalledTimes(3);
+    killSpy.mockRestore();
   });
 });

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -299,6 +299,7 @@ function killPids(
       beforeSignal?.({ port, pid: proc.pid, signal });
       process.kill(proc.pid, signal);
     } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") continue;
       throw new Error(
         `failed to kill pid ${proc.pid}${proc.command ? ` (${proc.command})` : ""}: ${String(err)}`,
         { cause: err },


### PR DESCRIPTION
## What Problem This Solves

`forceFreePort` and `killPids` in the CLI port utilities inspect listeners via `lsof`/`netstat` and then signal each PID. A process can exit between inspection and signaling — `process.kill` throws ESRCH ("no such process"), which the current code re-throws as a fatal error, aborting the entire port-free operation. This is a TOCTOU race.

## Why This Change Was Made

ESRCH means the process already exited — the port is already free. There is no reason to abort. Catching ESRCH and continuing is the correct narrow fix.

## User Impact

`openclaw gateway run --force` no longer crashes when a port listener exits between lsof discovery and SIGTERM delivery. The operation now correctly treats the port as freed.

## Evidence

### Real process-race proof

```
$ node scripts/proofs/ports-esrch-guard-proof.mjs
=== PR #109713: guard process.kill ESRCH race ===

Scenario: lsof finds PID X on port → PID X exits → SIGTERM hits ESRCH

  1. lsof discovers 3 PIDs on port: 186516, 186523, 186530
  2. All processes exited before SIGTERM delivered

── BEFORE (main branch) ──
  PID 186516: process.kill threw ESRCH → ❌ FATAL
  Result: port-free operation aborted on first ESRCH

── AFTER (PR branch) ──
  PID 186516: ESRCH caught ✓ → continue (port already free)
  PID 186523: ESRCH caught ✓ → continue (port already free)
  PID 186530: ESRCH caught ✓ → continue (port already free)
  Result: 3/3 ESRCH swallowed, port-free completed ✅
```

The proof script spawns 3 short-lived child processes, lets them all exit (simulating the TOCTOU race), then demonstrates: BEFORE — first ESRCH aborts the operation; AFTER — all 3 ESRCH are caught, port-free completes.

### Unit tests

Three new tests in `ports.test.ts`:
- "swallows ESRCH when a port listener exits before SIGTERM" — single ESRCH
- "re-throws non-ESRCH kill errors" — EPERM still propagates
- "continues past multiple ESRCH exits in the same call" — batch resilience