### PR TITLE
perf(test): poll gateway startup state faster

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -263,6 +263,13 @@ const { createChatRunState } = await import("./server-chat-state.js");
 type PostAttachParams = Parameters<typeof startGatewayPostAttachRuntime>[0];
 type PostAttachRuntimeDeps = NonNullable<Parameters<typeof startGatewayPostAttachRuntime>[1]>;
 
+async function waitForGatewayTestState<T>(
+  assertion: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+): Promise<T> {
+  return await vi.waitFor(assertion, { ...options, interval: 1 });
+}
+
 function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0, argIndex = 0): unknown {
   const call = mock.mock.calls.at(index);
   if (!call) {
@@ -401,7 +408,7 @@ describe("startGatewayPostAttachRuntime", () => {
       onSidecarsReady,
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(onSidecarsReady).toHaveBeenCalledTimes(1);
     });
     expect([...unavailableGatewayMethods]).toStrictEqual([]);
@@ -514,7 +521,7 @@ describe("startGatewayPostAttachRuntime", () => {
     events.push("returned");
     expect(refreshLatestUpdateRestartSentinel).not.toHaveBeenCalled();
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(refreshLatestUpdateRestartSentinel).toHaveBeenCalledTimes(1);
     });
     expect(events).toEqual(["sidecars", "returned", "sentinel"]);
@@ -538,7 +545,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(1);
 
     finishWake?.();
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(getActiveGatewayRootWorkCount()).toBe(0);
     });
   });
@@ -570,7 +577,7 @@ describe("startGatewayPostAttachRuntime", () => {
       }),
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(logGatewayStartup).toHaveBeenCalledTimes(1);
       expect(startGatewaySidecarsScoped).toHaveBeenCalledTimes(1);
     });
@@ -610,7 +617,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(scheduleGatewayUpdateCheck).not.toHaveBeenCalled();
     expect(events).toEqual(["sidecars", "returned"]);
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(scheduleGatewayUpdateCheck).toHaveBeenCalledTimes(1);
     });
     expect(events).toEqual(["sidecars", "returned", "update-check"]);
@@ -637,7 +644,7 @@ describe("startGatewayPostAttachRuntime", () => {
       }),
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(scheduleGatewayUpdateCheck).toHaveBeenCalledTimes(1);
     });
     result.stopGatewayUpdateCheck();
@@ -648,7 +655,7 @@ describe("startGatewayPostAttachRuntime", () => {
     }
     finishUpdateCheckSchedule();
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(stopUpdateCheck).toHaveBeenCalledTimes(1);
     });
   });
@@ -676,7 +683,7 @@ describe("startGatewayPostAttachRuntime", () => {
       }),
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(log.warn).toHaveBeenCalledWith("gateway update check failed to start: Error: boom");
     });
   });
@@ -889,7 +896,7 @@ describe("startGatewayPostAttachRuntime", () => {
       createPostAttachRuntimeDeps({ startGatewaySidecars: startGatewaySidecarsEntry }),
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(events).toEqual(["startup-loaded-start"]);
     });
     expect(startGatewaySidecarsEntry).not.toHaveBeenCalled();
@@ -937,7 +944,7 @@ describe("startGatewayPostAttachRuntime", () => {
       } as never,
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.startGatewayMemoryBackend).toHaveBeenCalledTimes(1);
     });
   });
@@ -951,7 +958,7 @@ describe("startGatewayPostAttachRuntime", () => {
       } as never,
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.startGatewayMemoryBackend).toHaveBeenCalledTimes(1);
     });
   });
@@ -985,7 +992,7 @@ describe("startGatewayPostAttachRuntime", () => {
       expect(hoisted.startGatewayMemoryBackend).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1);
 
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.startGatewayMemoryBackend).toHaveBeenCalledTimes(1);
       });
     } finally {
@@ -1032,14 +1039,14 @@ describe("startGatewayPostAttachRuntime", () => {
       concurrency: 2,
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(cleanStaleLockFiles).toHaveBeenCalledTimes(2);
     });
     expect(maxActive).toBe(2);
 
     releaseQueue.shift()?.();
     releaseQueue.shift()?.();
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(cleanStaleLockFiles).toHaveBeenCalledTimes(4);
     });
     releaseQueue.shift()?.();
@@ -1109,7 +1116,7 @@ describe("startGatewayPostAttachRuntime", () => {
       returned = true;
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(startGatewaySidecarsResult).toHaveBeenCalledTimes(1);
     });
     await Promise.resolve();
@@ -1151,13 +1158,13 @@ describe("startGatewayPostAttachRuntime", () => {
       expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
       expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
       await vi.dynamicImportSettled();
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
       expect(hoisted.warmCurrentProviderAuthStateOffMainThread).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(1);
       });
     } finally {
@@ -1178,7 +1185,7 @@ describe("startGatewayPostAttachRuntime", () => {
       });
 
       await vi.dynamicImportSettled();
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
       expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
@@ -1191,7 +1198,7 @@ describe("startGatewayPostAttachRuntime", () => {
       expect(hoisted.clearCurrentProviderAuthState).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(1);
       });
     } finally {
@@ -1215,7 +1222,7 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
         config: currentConfig,
         workspaceDir: "/tmp/openclaw-workspace",
@@ -1244,7 +1251,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
     await vi.dynamicImportSettled();
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.ensureContextWindowCacheLoaded).toHaveBeenCalledWith(cfg);
     });
     await sidecar.stop();
@@ -1294,7 +1301,7 @@ describe("startGatewayPostAttachRuntime", () => {
       });
 
       await vi.advanceTimersToNextTimerAsync();
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(onPostReadySidecars).toHaveBeenCalledTimes(1);
         expect(onGatewayLifetimeSidecars).toHaveBeenCalledTimes(1);
       });
@@ -1311,24 +1318,24 @@ describe("startGatewayPostAttachRuntime", () => {
         sidecar.stop();
       }
       await vi.dynamicImportSettled();
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
 
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(1);
       });
 
       const hook = hoisted.setAuthProfileFailureHook.mock.calls[0]?.[0] as (() => void) | undefined;
       hook?.();
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.clearCurrentProviderAuthState).toHaveBeenCalledTimes(1);
       });
       expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(2);
       });
     } finally {
@@ -1369,7 +1376,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(gmailSidecars).toHaveLength(1);
     expect(lifetimeSidecars).toHaveLength(3);
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.transcriptsAutoStartService.start).toHaveBeenCalledTimes(1);
     });
 
@@ -1396,7 +1403,7 @@ describe("startGatewayPostAttachRuntime", () => {
         startupWarmEnabled: true,
       });
       await vi.dynamicImportSettled();
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
 
@@ -1435,11 +1442,11 @@ describe("startGatewayPostAttachRuntime", () => {
       });
       currentCfg = reloadedCfg;
       await vi.dynamicImportSettled();
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
       await vi.advanceTimersByTimeAsync(0);
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(1);
       });
 
@@ -1455,7 +1462,7 @@ describe("startGatewayPostAttachRuntime", () => {
       expect(hoisted.clearCurrentProviderAuthState).toHaveBeenCalledTimes(2);
 
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(2);
       });
       expect(hoisted.warmCurrentProviderAuthStateOffMainThread.mock.calls[0]?.[0]).toBe(
@@ -1540,7 +1547,7 @@ describe("startGatewayPostAttachRuntime", () => {
           startChannels,
         });
 
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(startChannels).toHaveBeenCalledTimes(1);
         });
         expect(hoisted.startPluginServices).not.toHaveBeenCalled();
@@ -1551,7 +1558,7 @@ describe("startGatewayPostAttachRuntime", () => {
           throw new Error("Expected channel startup release callback to be initialized");
         }
         releaseChannels();
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(hoisted.startPluginServices).toHaveBeenCalledTimes(1);
           expect(onPluginServices).toHaveBeenCalledWith(pluginServices);
           expect(onSidecarsReady).toHaveBeenCalledTimes(1);
@@ -1592,7 +1599,7 @@ describe("startGatewayPostAttachRuntime", () => {
           isClosing: () => closing,
         });
 
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(startChannels).toHaveBeenCalledTimes(1);
         });
         closing = true;
@@ -1602,7 +1609,7 @@ describe("startGatewayPostAttachRuntime", () => {
         }
         releaseChannels();
 
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(onSidecarsReady).toHaveBeenCalledTimes(1);
         });
         expect(hoisted.startPluginServices).not.toHaveBeenCalled();
@@ -1646,7 +1653,7 @@ describe("startGatewayPostAttachRuntime", () => {
           },
         });
 
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(hoisted.startPluginServices).toHaveBeenCalledTimes(1);
         });
         shouldStartPluginServices = false;
@@ -1701,7 +1708,7 @@ describe("startGatewayPostAttachRuntime", () => {
           }),
         );
 
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(startChannels).toHaveBeenCalledTimes(1);
         });
 
@@ -1709,7 +1716,7 @@ describe("startGatewayPostAttachRuntime", () => {
           throw new Error("Expected channel startup release callback to be initialized");
         }
         releaseChannels();
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(onPluginServices).toHaveBeenCalledWith(pluginServices);
         });
 
@@ -1718,7 +1725,7 @@ describe("startGatewayPostAttachRuntime", () => {
         }
         releaseStartupLog();
         await expect(runtimePromise).resolves.toMatchObject({ pluginServices });
-        await vi.waitFor(() => {
+        await waitForGatewayTestState(() => {
           expect(onSidecarsReady).toHaveBeenCalledTimes(1);
         });
       },
@@ -1755,7 +1762,7 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(prewarmPrimaryModel).toHaveBeenCalledOnce();
     });
     expect(trace.measures).toContain("sidecars.channels");
@@ -1800,7 +1807,7 @@ describe("startGatewayPostAttachRuntime", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(events).toEqual(["main-session-mark:start"]);
     });
     expect(startChannels).not.toHaveBeenCalled();
@@ -1928,7 +1935,7 @@ describe("startGatewayPostAttachRuntime", () => {
     onPostReadySidecars(result.postReadySidecars);
     expect(onPostReadySidecars).toHaveBeenCalledWith(result.postReadySidecars);
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.startGmailWatcherWithLogs).toHaveBeenCalledTimes(1);
     });
     expect(watcherSignal?.aborted).toBe(false);
@@ -1967,7 +1974,7 @@ describe("startGatewayPostAttachRuntime", () => {
     });
 
     expect(result.postReadySidecars).toHaveLength(1);
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(log.warn).toHaveBeenCalledWith(
         "sidecars.gmail-watch failed after gateway ready: Error: boom",
       );
@@ -2039,7 +2046,7 @@ describe("startGatewayPostAttachRuntime", () => {
         },
       });
 
-      await vi.waitFor(() => {
+      await waitForGatewayTestState(() => {
         expect(releaseImport).toBeDefined();
       });
       await result.postReadySidecars[0]?.stop();
@@ -2125,7 +2132,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(result.postReadySidecars).toHaveLength(1);
     expect(hoisted.loadModelCatalog).not.toHaveBeenCalled();
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.loadModelCatalog).toHaveBeenCalledTimes(1);
     });
     expect(hoisted.getModelRefStatus).toHaveBeenCalledWith(
@@ -2154,7 +2161,7 @@ describe("startGatewayPostAttachRuntime", () => {
       createPostAttachRuntimeDeps({ startGatewaySidecars: startGatewaySidecarsValue }),
     );
 
-    await vi.waitFor(
+    await waitForGatewayTestState(
       () => {
         expect(startGatewaySidecarsValue).toHaveBeenCalledTimes(1);
       },
@@ -2168,7 +2175,7 @@ describe("startGatewayPostAttachRuntime", () => {
       throw new Error("Expected gateway sidecar resume callback to be initialized");
     }
     resumeSidecars();
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect([...unavailableGatewayMethods]).toStrictEqual([]);
     });
     expect([...unavailableGatewayMethods]).toStrictEqual([]);
@@ -2211,7 +2218,7 @@ describe("startGatewayPostAttachRuntime", () => {
       }),
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(startWorkerEnvironmentRuntime).toHaveBeenCalledTimes(1);
     });
     expect(startGatewaySidecarsValue).not.toHaveBeenCalled();
@@ -2219,7 +2226,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect([...unavailableGatewayMethods]).toEqual([...STARTUP_UNAVAILABLE_GATEWAY_METHODS]);
 
     finishReconcile?.();
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(startGatewaySidecarsValue).toHaveBeenCalledTimes(1);
     });
     expect(startupOrder).toEqual(["worker-reconcile", "worker-ready", "gateway-sidecars"]);
@@ -2265,7 +2272,7 @@ describe("startGatewayPostAttachRuntime", () => {
       createPostAttachRuntimeDeps({ startGatewaySidecars: startGatewaySidecarsValue }),
     );
 
-    await vi.waitFor(() => expect(startGatewaySidecarsValue).toHaveBeenCalledTimes(1));
+    await waitForGatewayTestState(() => expect(startGatewaySidecarsValue).toHaveBeenCalledTimes(1));
     expect(startWorkerEnvironmentRuntime).not.toHaveBeenCalled();
   });
 
@@ -2297,7 +2304,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(onStartupPluginsLoaded).toHaveBeenCalledWith(loaded);
     expect(startGatewaySidecarsLocal).not.toHaveBeenCalled();
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(startGatewaySidecarsLocal).toHaveBeenCalledTimes(1);
     });
   });
@@ -2352,7 +2359,7 @@ describe("startGatewayPostAttachRuntime", () => {
       expect(hoisted.triggerInternalHook).toHaveBeenCalledWith(hoisted.startupHookEvent);
       expect(getActiveGatewayRootWorkCount()).toBe(1);
       releaseHook();
-      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await waitForGatewayTestState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
     } finally {
       releaseHook();
       vi.useRealTimers();
@@ -2390,13 +2397,13 @@ describe("startGatewayPostAttachRuntime", () => {
       startupTrace: trace.startupTrace,
     });
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx");
     });
     expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
 
     healthy = true;
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(hoisted.reconcilePendingSessionIdentities).toHaveBeenCalledTimes(1);
     });
     expect(trace.measures).toContain("sidecars.acp.runtime-ready");
@@ -2438,7 +2445,7 @@ describe("startGatewayPostAttachRuntime", () => {
       }),
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(runGatewayStart).toHaveBeenCalledTimes(1);
     });
 
@@ -2499,7 +2506,7 @@ describe("startGatewayPostAttachRuntime", () => {
       }),
     );
 
-    await vi.waitFor(() => {
+    await waitForGatewayTestState(() => {
       expect(runGatewayStart).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## What Problem This Solves

The gateway post-attach startup suite used Vitest's 50 ms default polling interval in 56 asynchronous state assertions. The repeated latency accumulated across the 60-test file.

## Why This Change Was Made

Route those existing assertions through a test-local helper with a 1 ms interval. Preserve each assertion, Vitest's default timeout, and the one explicit 10-second timeout.

## User Impact

No user-visible or production behavior changes. Controlled same-Testbox median test-body time drops from 3.45 seconds to 1.75 seconds.

## Evidence

- Before: 3.68/3.32/3.45 seconds; median 3.45 seconds.
- After: 1.78/1.74/1.75 seconds; median 1.75 seconds (about 49% faster).
- Testbox `tbx_01kxqbbb2zdjga5ktbzwje1snm`: 60/60 tests passed across all three final comparison runs.
- Same Testbox: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed.
- Autoreview: clean, 0.98 confidence.
