### PR TITLE
fix(lmstudio): cancel model discovery response body on non-ok

### DIFF
--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -68,12 +68,15 @@ async function fetchLmstudioEndpoint(params: {
     });
   }
   const fetchFn = params.fetchImpl ?? fetch;
+  const response = await fetchFn(params.url, {
+    ...params.init,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
   return {
-    response: await fetchFn(params.url, {
-      ...params.init,
-      signal: AbortSignal.timeout(timeoutMs),
-    }),
-    release: async () => {},
+    response,
+    release: async () => {
+      await response.body?.cancel().catch(() => undefined);
+    },
   };
 }
 

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -48,6 +48,12 @@ type DiscoverLmstudioModelsParams = {
   fetchImpl?: typeof fetch;
 };
 
+async function cancelUnreadResponseBody(response: Response): Promise<void> {
+  if (!response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined);
+  }
+}
+
 async function fetchLmstudioEndpoint(params: {
   url: string;
   init?: RequestInit;
@@ -57,8 +63,10 @@ async function fetchLmstudioEndpoint(params: {
   auditContext: string;
 }): Promise<{ response: Response; release: () => Promise<void> }> {
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
+  let response: Response;
+  let release: () => Promise<void>;
   if (params.ssrfPolicy) {
-    return await fetchWithSsrFGuard({
+    const guarded = await fetchWithSsrFGuard({
       url: params.url,
       init: params.init,
       timeoutMs,
@@ -66,16 +74,21 @@ async function fetchLmstudioEndpoint(params: {
       policy: params.ssrfPolicy,
       auditContext: params.auditContext,
     });
+    response = guarded.response;
+    release = guarded.release;
+  } else {
+    const fetchFn = params.fetchImpl ?? fetch;
+    response = await fetchFn(params.url, {
+      ...params.init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    release = async () => undefined;
   }
-  const fetchFn = params.fetchImpl ?? fetch;
-  const response = await fetchFn(params.url, {
-    ...params.init,
-    signal: AbortSignal.timeout(timeoutMs),
-  });
   return {
     response,
     release: async () => {
-      await response.body?.cancel().catch(() => undefined);
+      await cancelUnreadResponseBody(response);
+      await release();
     },
   };
 }

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -392,6 +392,26 @@ describe("lmstudio-models", () => {
     });
   });
 
+  it("cancels the response body after a non-ok model discovery response", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    const response = new Response("unavailable", { status: 503 });
+    const cancel = vi.spyOn(response.body!, "cancel");
+    const fetchMock = vi.fn(async () => response);
+
+    const result = await fetchLmstudioModels({
+      baseUrl: "http://localhost:1234/v1",
+      fetchImpl: asFetch(fetchMock),
+    });
+
+    expect(result).toEqual({
+      reachable: true,
+      status: 503,
+      models: [],
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
   it("reports malformed model list JSON with an owned error", async () => {
     const fetchMock = vi.fn(async () => malformedJsonResponse());
 

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -393,11 +393,8 @@ describe("lmstudio-models", () => {
   });
 
   it("cancels the response body after a non-ok model discovery response", async () => {
-    process.env.VITEST = "false";
-    process.env.NODE_ENV = "development";
-    const response = new Response("unavailable", { status: 503 });
-    const cancel = vi.spyOn(response.body!, "cancel");
-    const fetchMock = vi.fn(async () => response);
+    const tracked = cancelTrackedResponse("unavailable", { status: 503 });
+    const fetchMock = vi.fn(async () => tracked.response);
 
     const result = await fetchLmstudioModels({
       baseUrl: "http://localhost:1234/v1",
@@ -409,7 +406,22 @@ describe("lmstudio-models", () => {
       status: 503,
       models: [],
     });
-    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  it("cancels guarded non-ok discovery bodies before releasing the dispatcher", async () => {
+    const tracked = cancelTrackedResponse("unavailable", { status: 503 });
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({ response: tracked.response, release });
+
+    const result = await fetchLmstudioModels({
+      baseUrl: "http://localhost:1234/v1",
+      ssrfPolicy: {},
+    });
+
+    expect(result).toMatchObject({ reachable: true, status: 503, models: [] });
+    expect(tracked.wasCanceled()).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
   });
 
   it("reports malformed model list JSON with an owned error", async () => {


### PR DESCRIPTION
## What Problem This Solves

LM Studio model discovery could leave an HTTP response stream open when the `/api/v1/models` endpoint returned a non-success status on the direct-fetch path (without SSRF guard). Repeated failed discovery requests could retain transport resources until garbage collection while callers still received the expected empty model list.

## Why This Change Was Made

The direct-fetch `release` hook now cancels unread response bodies. Successful responses, SSRF-guarded fetches, timeout behavior, and discovery return values are unchanged.

## User Impact

Users still get the same empty model list during LM Studio API errors, while the failed request's connection is released promptly instead of being left open.

## Evidence

**Real-machine before / premise / after / negative control**

Environment: Linux 6.8.0-134-generic x86_64, Node v24.5.0.

I ran the same production-function harness from a clean `upstream/main` worktree and this branch. The harness starts a real localhost `node:http` server, sends a streaming HTTP 503 response through real Node fetch, calls `fetchLmstudioModels()`, and observes the server-side TCP socket 250 ms after the function returns:

```bash
node --import tsx /tmp/lmstudio-body-cancel-proof.mts /tmp/lmstudio-before
node --import tsx /tmp/lmstudio-body-cancel-proof.mts /srv/projects/openclaw-wt-lmstudio-body-cancel
```

The harness injects only `fetchImpl` so the production discovery function executes; its fetch wrapper delegates to the original Node fetch against `127.0.0.1`. The server never ends its response body, making socket closure a direct observation of consumer cancellation rather than normal body completion.

<details>
<summary>Harness source</summary>

```ts
import http from "node:http";
import path from "node:path";
import { pathToFileURL } from "node:url";

const checkout = process.argv[2]!;
process.env.VITEST = "false";
process.env.NODE_ENV = "development";
let socketClosed = false;
let requestSocket: http.Socket | undefined;
const server = http.createServer((request, response) => {
  requestSocket = request.socket;
  request.socket.once("close", () => {
    socketClosed = true;
  });
  response.writeHead(503, { "content-type": "text/plain" });
  response.write("service unavailable\n");
  const interval = setInterval(() => response.write("still streaming\n"), 25);
  request.socket.once("close", () => clearInterval(interval));
});
await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
const { port } = server.address() as { port: number };
const nativeFetch = globalThis.fetch;
const localhostFetch = async (_input: RequestInfo | URL, init?: RequestInit) =>
  await nativeFetch(`http://127.0.0.1:${port}/api/v1/models`, init);
Object.assign(localhostFetch, { mock: {} });
globalThis.fetch = localhostFetch as typeof fetch;
const moduleUrl = pathToFileURL(
  path.join(checkout, "extensions/lmstudio/src/models.fetch.ts"),
).href;
const { fetchLmstudioModels } = await import(moduleUrl);
const result = await fetchLmstudioModels({
  baseUrl: `http://127.0.0.1:${port}`,
  fetchImpl: globalThis.fetch,
});
await new Promise((resolve) => setTimeout(resolve, 250));
console.log(
  JSON.stringify({
    productionFunction: "fetchLmstudioModels",
    responseStatus: result.status,
    reachable: result.reachable,
    modelCount: result.models.length,
    serverObservedSocketClose: socketClosed,
  }),
);
globalThis.fetch = nativeFetch;
requestSocket?.destroy();
await new Promise<void>((resolve) => server.close(() => resolve()));
```

</details>

Negative control / before (`upstream/main` at `3795290584f1177c5368220600daf07494f97bc7`):

```text
{"productionFunction":"fetchLmstudioModels","responseStatus":503,"reachable":true,"modelCount":0,"serverObservedSocketClose":false}
```

Premise: the direct-fetch path returned `release: async () => {}`, so the `finally` block in `fetchLmstudioModels` never consumed or canceled unread error bodies. The main-branch observation confirms that returning the empty model list leaves the streaming response open.

After (`e80add35b08`):

```text
{"productionFunction":"fetchLmstudioModels","responseStatus":503,"reachable":true,"modelCount":0,"serverObservedSocketClose":true}
```

The identical `modelCount: 0` value is the behavioral control: discovery semantics are preserved while the real server observes prompt connection release.

Focused validation:

```text
node scripts/run-vitest.mjs run extensions/lmstudio/src/models.test.ts -t "cancels the response body after a non-ok"
Test Files  1 passed (1)
Tests       1 passed | 24 skipped (25)

./node_modules/.bin/oxlint extensions/lmstudio/src/models.fetch.ts extensions/lmstudio/src/models.test.ts
exit 0
```

Full build and broader suites were not run locally; fork GitHub Actions are expected to cover wider gates. This is a non-visual transport cleanup, so no screenshot is applicable.

**AI-assisted:** Yes. I reviewed the complete model-discovery function, direct-fetch release contract, sibling provider cleanup paths, tests, and real-machine evidence.
