### PR TITLE
feat(mac): Quick Chat — global-shortcut floating composer for the main session

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -29931,7 +29931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 72,
+      "line": 73,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "General",
       "surface": "apple",
@@ -29939,7 +29939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 73,
+      "line": 74,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Everyday OpenClaw app behavior.",
       "surface": "apple",
@@ -29947,7 +29947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 77,
+      "line": 78,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "App",
       "surface": "apple",
@@ -29955,7 +29955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 79,
+      "line": 80,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Launch at login",
       "surface": "apple",
@@ -29963,7 +29963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 81,
+      "line": 82,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Automatically start OpenClaw after you sign in.",
       "surface": "apple",
@@ -29971,7 +29971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 82,
+      "line": 83,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Move OpenClaw to Applications before enabling launch at login.",
       "surface": "apple",
@@ -29979,7 +29979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 87,
+      "line": 88,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Show Dock icon",
       "surface": "apple",
@@ -29987,7 +29987,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 88,
+      "line": 89,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Keep OpenClaw visible in the Dock. When off, windows still show the Dock icon while open.",
       "surface": "apple",
@@ -29995,7 +29995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 94,
+      "line": 95,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Play menu bar icon animations",
       "surface": "apple",
@@ -30003,15 +30003,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 95,
+      "line": 96,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable idle blinks and wiggles on the status icon.",
       "surface": "apple",
       "id": "native.apple.bdb0b9020356722a"
     },
     {
-      "kind": "ui-call",
+      "kind": "ui-named-argument",
       "line": 100,
+      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
+      "source": "Quick Chat shortcut",
+      "surface": "apple",
+      "id": "native.apple.d908ab245711bbd2"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 101,
+      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "surface": "apple",
+      "id": "native.apple.6ae77665b5f4490f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 108,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Capabilities",
       "surface": "apple",
@@ -30019,7 +30035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 102,
+      "line": 110,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Canvas",
       "surface": "apple",
@@ -30027,7 +30043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 103,
+      "line": 111,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow the agent to show and control the Canvas panel.",
       "surface": "apple",
@@ -30035,7 +30051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 107,
+      "line": 115,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Camera",
       "surface": "apple",
@@ -30043,7 +30059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 108,
+      "line": 116,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow the agent to capture a photo or short video via the built-in camera.",
       "surface": "apple",
@@ -30051,7 +30067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 112,
+      "line": 120,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Computer Control",
       "surface": "apple",
@@ -30059,7 +30075,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 113,
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Let an authorized agent move the pointer, click, and type on this Mac. Also requires Accessibility, Screen Recording, and gateway command authorization. High risk.",
       "surface": "apple",
@@ -30067,7 +30083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 120,
+      "line": 128,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable Peekaboo Bridge",
       "surface": "apple",
@@ -30075,7 +30091,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 121,
+      "line": 129,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge. Requires Computer Control; otherwise run Peekaboo's own Mac app.",
       "surface": "apple",
@@ -30083,7 +30099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 130,
+      "line": 138,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Browser",
       "surface": "apple",
@@ -30091,7 +30107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 132,
+      "line": 140,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Browser login",
       "surface": "apple",
@@ -30099,7 +30115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 133,
+      "line": 141,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
       "surface": "apple",
@@ -30107,7 +30123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 136,
+      "line": 144,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Import…",
       "surface": "apple",
@@ -30115,7 +30131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 158,
+      "line": 166,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Developer",
       "surface": "apple",
@@ -30123,7 +30139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 160,
+      "line": 168,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable debug tools",
       "surface": "apple",
@@ -30131,7 +30147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 161,
+      "line": 169,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Show the Debug page with development utilities.",
       "surface": "apple",
@@ -30139,7 +30155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 168,
+      "line": 176,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "App session",
       "surface": "apple",
@@ -30147,7 +30163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 170,
+      "line": 178,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Quit only when you want to stop the menu bar app completely.",
       "surface": "apple",
@@ -30155,7 +30171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 175,
+      "line": 183,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Quit",
       "surface": "apple",
@@ -30163,7 +30179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 195,
+      "line": 203,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw paused",
       "surface": "apple",
@@ -30171,7 +30187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 205,
+      "line": 213,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw active",
       "surface": "apple",
@@ -30179,7 +30195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 224,
+      "line": 232,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Processing messages through the local Gateway on this Mac.",
       "surface": "apple",
@@ -30187,7 +30203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 226,
+      "line": 234,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connected to a remote Gateway configuration.",
       "surface": "apple",
@@ -30195,7 +30211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 228,
+      "line": 236,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Ready to run after you choose a Gateway connection.",
       "surface": "apple",
@@ -30203,7 +30219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 235,
+      "line": 243,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connection",
       "surface": "apple",
@@ -30211,7 +30227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 236,
+      "line": 244,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose where the Gateway runs and how this Mac app reaches it.",
       "surface": "apple",
@@ -30219,7 +30235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 301,
+      "line": 309,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "\\(Int(ping)) ms",
       "surface": "apple",
@@ -30227,7 +30243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 335,
+      "line": 343,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local Gateway",
       "surface": "apple",
@@ -30235,7 +30251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 344,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway direct",
       "surface": "apple",
@@ -30243,7 +30259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 344,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway via SSH",
       "surface": "apple",
@@ -30251,7 +30267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 337,
+      "line": 345,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway not configured",
       "surface": "apple",
@@ -30259,7 +30275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 344,
+      "line": 352,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw starts and monitors the Gateway on this Mac.",
       "surface": "apple",
@@ -30267,7 +30283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 353,
+      "line": 361,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose local or remote before the app can attach to a Gateway.",
       "surface": "apple",
@@ -30275,7 +30291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 358,
+      "line": 366,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -30283,7 +30299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 360,
+      "line": 368,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw runs",
       "surface": "apple",
@@ -30291,7 +30307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 361,
+      "line": 369,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Pick whether this app owns a local Gateway or attaches to another host.",
       "surface": "apple",
@@ -30299,7 +30315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 364,
+      "line": 372,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway location",
       "surface": "apple",
@@ -30307,7 +30323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 365,
+      "line": 373,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -30315,7 +30331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 374,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local (this Mac)",
       "surface": "apple",
@@ -30323,7 +30339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 367,
+      "line": 375,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote (another host)",
       "surface": "apple",
@@ -30331,7 +30347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 376,
+      "line": 384,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Setup needed",
       "surface": "apple",
@@ -30339,7 +30355,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 377,
+      "line": 385,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local is best for this Mac. Remote is best when the Gateway already runs on a Mac Studio or server.",
       "surface": "apple",
@@ -30347,7 +30363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 408,
+      "line": 416,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Access",
       "surface": "apple",
@@ -30355,7 +30371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 419,
+      "line": 427,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Discovery & Status",
       "surface": "apple",
@@ -30363,7 +30379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 435,
+      "line": 443,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Nearby gateways",
       "surface": "apple",
@@ -30371,7 +30387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 458,
+      "line": 466,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote test",
       "surface": "apple",
@@ -30379,7 +30395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 465,
+      "line": 473,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Control channel",
       "surface": "apple",
@@ -30387,7 +30403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 492,
+      "line": 500,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recommended setup",
       "surface": "apple",
@@ -30395,7 +30411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 494,
+      "line": 502,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "surface": "apple",
@@ -30403,7 +30419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 495,
+      "line": 503,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
       "surface": "apple",
@@ -30411,7 +30427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 504,
+      "line": 512,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Advanced",
       "surface": "apple",
@@ -30419,7 +30435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 507,
+      "line": 515,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -30427,7 +30443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 509,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -30435,7 +30451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 511,
+      "line": 519,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Project root",
       "surface": "apple",
@@ -30443,7 +30459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 513,
+      "line": 521,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -30451,7 +30467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 515,
+      "line": 523,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -30459,7 +30475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 517,
+      "line": 525,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -30467,7 +30483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 530,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH command details",
       "surface": "apple",
@@ -30475,7 +30491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 542,
+      "line": 550,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Transport",
       "surface": "apple",
@@ -30483,7 +30499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 543,
+      "line": 551,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH keeps the Gateway private; direct is best for HTTPS or Tailscale Serve.",
       "surface": "apple",
@@ -30491,7 +30507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 546,
+      "line": 554,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -30499,7 +30515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 555,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -30507,7 +30523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 560,
+      "line": 568,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -30515,7 +30531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 560,
+      "line": 568,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "User and host for the remote Gateway machine.",
       "surface": "apple",
@@ -30523,7 +30539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 577,
+      "line": 585,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -30531,7 +30547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 577,
+      "line": 585,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The WebSocket URL exposed by the remote Gateway.",
       "surface": "apple",
@@ -30539,7 +30555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 580,
+      "line": 588,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -30547,7 +30563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 586,
+      "line": 594,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use wss:// for public hosts. ws:// is allowed for localhost, LAN, .local, and Tailnet hosts.",
       "surface": "apple",
@@ -30555,7 +30571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 597,
+      "line": 605,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -30563,7 +30579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 598,
+      "line": 606,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
@@ -30571,7 +30587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 601,
+      "line": 609,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
@@ -30579,7 +30595,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 606,
+      "line": 614,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -30587,7 +30603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 633,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Test remote",
       "surface": "apple",
@@ -30595,7 +30611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 648,
+      "line": 656,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Testing…",
       "surface": "apple",
@@ -30603,7 +30619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 686,
+      "line": 694,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Installed: \\(gatewayVersion) · Required: \\(required)",
       "surface": "apple",
@@ -30611,7 +30627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 690,
+      "line": 698,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway \\(gatewayVersion) detected",
       "surface": "apple",
@@ -30619,7 +30635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 696,
+      "line": 704,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Node \\(node)",
       "surface": "apple",
@@ -30627,7 +30643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 708,
+      "line": 716,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Last failure: \\(failure)",
       "surface": "apple",
@@ -30635,7 +30651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 713,
+      "line": 721,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recheck",
       "surface": "apple",
@@ -30643,7 +30659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 716,
+      "line": 724,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway auto-starts in local mode via launchd (\\(gatewayLaunchdLabel)).",
       "surface": "apple",
@@ -30651,7 +30667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 771,
+      "line": 779,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Retry now",
       "surface": "apple",
@@ -30659,7 +30675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 776,
+      "line": 784,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Open logs",
       "surface": "apple",
@@ -31003,7 +31019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 52,
+      "line": 53,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Pairing approval pending (\\(self.pairingPrompter.pendingCount))",
       "surface": "apple",
@@ -31011,7 +31027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 56,
+      "line": 57,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": " · \\(repairCount) repair",
       "surface": "apple",
@@ -31019,7 +31035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 58,
+      "line": 59,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Device pairing pending (\\(self.devicePairingPrompter.pendingCount))\\(repairSuffix)",
       "surface": "apple",
@@ -31027,7 +31043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 67,
+      "line": 68,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Heartbeats",
       "surface": "apple",
@@ -31035,7 +31051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 79,
+      "line": 80,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Browser Control",
       "surface": "apple",
@@ -31043,7 +31059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 82,
+      "line": 83,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Camera",
       "surface": "apple",
@@ -31051,7 +31067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 91,
+      "line": 92,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
@@ -31059,7 +31075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 94,
+      "line": 95,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Loading Exec Approvals…",
       "surface": "apple",
@@ -31067,7 +31083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 100,
+      "line": 101,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Retry Exec Approvals",
       "surface": "apple",
@@ -31075,7 +31091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 114,
+      "line": 115,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Canvas",
       "surface": "apple",
@@ -31083,7 +31099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 122,
+      "line": 123,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -31091,7 +31107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 133,
+      "line": 134,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Dashboard",
       "surface": "apple",
@@ -31099,15 +31115,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 138,
+      "line": 139,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Chat",
       "surface": "apple",
       "id": "native.apple.723e0d2283af1458"
     },
     {
+      "kind": "ui-call",
+      "line": 144,
+      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
+      "source": "Quick Chat",
+      "surface": "apple",
+      "id": "native.apple.22334935d637c907"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 145,
+      "line": 152,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -31115,7 +31139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 145,
+      "line": 152,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Canvas",
       "surface": "apple",
@@ -31123,7 +31147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 152,
+      "line": 159,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Stop Talk Mode",
       "surface": "apple",
@@ -31131,7 +31155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 152,
+      "line": 159,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -31139,7 +31163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 157,
+      "line": 164,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Settings…",
       "surface": "apple",
@@ -31147,7 +31171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 160,
+      "line": 167,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "About OpenClaw",
       "surface": "apple",
@@ -31155,7 +31179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 162,
+      "line": 169,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Update ready, restart now?",
       "surface": "apple",
@@ -31163,7 +31187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 164,
+      "line": 171,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Quit",
       "surface": "apple",
@@ -31171,7 +31195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 197,
+      "line": 204,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Not Configured",
       "surface": "apple",
@@ -31179,7 +31203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 199,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote OpenClaw Active",
       "surface": "apple",
@@ -31187,7 +31211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 201,
+      "line": 208,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Active",
       "surface": "apple",
@@ -31195,7 +31219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 237,
+      "line": 244,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Debug",
       "surface": "apple",
@@ -31203,7 +31227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 241,
+      "line": 248,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Config Folder",
       "surface": "apple",
@@ -31211,7 +31235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 246,
+      "line": 253,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Run Health Check Now",
       "surface": "apple",
@@ -31219,7 +31243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 251,
+      "line": 258,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Heartbeat",
       "surface": "apple",
@@ -31227,7 +31251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 257,
+      "line": 264,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show Pairing Panel (Demo)",
       "surface": "apple",
@@ -31235,7 +31259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 264,
+      "line": 271,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote Tunnel",
       "surface": "apple",
@@ -31243,7 +31267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 267,
+      "line": 274,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Reset Remote Tunnel",
       "surface": "apple",
@@ -31251,7 +31275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 275,
+      "line": 282,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): On",
       "surface": "apple",
@@ -31259,7 +31283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 276,
+      "line": 283,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): Off",
       "surface": "apple",
@@ -31267,7 +31291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 287,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbosity",
       "surface": "apple",
@@ -31275,7 +31299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 288,
+      "line": 295,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: On",
       "surface": "apple",
@@ -31283,7 +31307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 289,
+      "line": 296,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: Off",
       "surface": "apple",
@@ -31291,7 +31315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 293,
+      "line": 300,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "App Logging",
       "surface": "apple",
@@ -31299,7 +31323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 298,
+      "line": 305,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Session Store",
       "surface": "apple",
@@ -31307,7 +31331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 304,
+      "line": 311,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Agent Events…",
       "surface": "apple",
@@ -31315,7 +31339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 309,
+      "line": 316,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Log",
       "surface": "apple",
@@ -31323,7 +31347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 314,
+      "line": 321,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Debug Voice Text",
       "surface": "apple",
@@ -31331,7 +31355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 319,
+      "line": 326,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Notification",
       "surface": "apple",
@@ -31339,7 +31363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 326,
+      "line": 333,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Gateway",
       "surface": "apple",
@@ -31347,7 +31371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 332,
+      "line": 339,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Onboarding",
       "surface": "apple",
@@ -31355,7 +31379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 337,
+      "line": 344,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart App",
       "surface": "apple",
@@ -31363,7 +31387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 376,
+      "line": 383,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
@@ -31371,7 +31395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 376,
+      "line": 383,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
@@ -31379,7 +31403,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 450,
+      "line": 457,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
@@ -31387,7 +31411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 475,
+      "line": 482,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
@@ -31395,7 +31419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 482,
+      "line": 489,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -31403,7 +31427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 507,
+      "line": 514,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
@@ -32861,9 +32885,9 @@
       "kind": "ui-named-argument",
       "line": 918,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
       "surface": "apple",
-      "id": "native.apple.f99e39e248dbc8ed"
+      "id": "native.apple.409bfb3a6e0f9f7c"
     },
     {
       "kind": "ui-named-argument",
@@ -32917,9 +32941,9 @@
       "kind": "ui-named-argument-concatenated",
       "line": 934,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
       "surface": "apple",
-      "id": "native.apple.774cf9fe7e3e289e"
+      "id": "native.apple.6022f5a79ed93235"
     },
     {
       "kind": "ui-named-argument",
@@ -33163,6 +33187,14 @@
     },
     {
       "kind": "ui-call",
+      "line": 24,
+      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
+      "source": "Location",
+      "surface": "apple",
+      "id": "native.apple.fee0f3732a447f35"
+    },
+    {
+      "kind": "ui-call",
       "line": 28,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Setup",
@@ -33291,7 +33323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 190,
+      "line": 203,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Refresh status",
       "surface": "apple",
@@ -33299,7 +33331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 191,
+      "line": 204,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Recheck macOS after approving access in System Settings.",
       "surface": "apple",
@@ -33307,7 +33339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 197,
+      "line": 210,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -33315,7 +33347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 296,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Grant",
       "surface": "apple",
@@ -33323,7 +33355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 293,
+      "line": 306,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Granted",
       "surface": "apple",
@@ -33331,7 +33363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 297,
+      "line": 310,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Checking…",
       "surface": "apple",
@@ -33339,75 +33371,11 @@
     },
     {
       "kind": "ui-call",
-      "line": 301,
+      "line": 314,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Request access",
       "surface": "apple",
       "id": "native.apple.c8a3879230179938"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 328,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Automation (AppleScript)",
-      "surface": "apple",
-      "id": "native.apple.8d8386041799d2b0"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 329,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Notifications",
-      "surface": "apple",
-      "id": "native.apple.bc935384479c2f48"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 330,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Accessibility",
-      "surface": "apple",
-      "id": "native.apple.922a8b5e049ef146"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 331,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Screen Recording",
-      "surface": "apple",
-      "id": "native.apple.c2f2fac8ab1ef9c0"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 332,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Microphone",
-      "surface": "apple",
-      "id": "native.apple.5ec94fe5a6864de7"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 333,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Speech Recognition",
-      "surface": "apple",
-      "id": "native.apple.b27a5cb9cffe05f0"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 334,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Camera",
-      "surface": "apple",
-      "id": "native.apple.3639c706ed77975c"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 335,
-      "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
-      "source": "Location",
-      "surface": "apple",
-      "id": "native.apple.fee0f3732a447f35"
     },
     {
       "kind": "conditional-branch",
@@ -33752,6 +33720,54 @@
       "source": "Continue",
       "surface": "apple",
       "id": "native.apple.144b21229f65f2a4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 60,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "surface": "apple",
+      "id": "native.apple.b3700cf60f4520dc"
+    },
+    {
+      "kind": "ui-call",
+      "line": 76,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "main session",
+      "surface": "apple",
+      "id": "native.apple.c1fec5e4735d8995"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 104,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Send message",
+      "surface": "apple",
+      "id": "native.apple.136cef9f750d3803"
+    },
+    {
+      "kind": "ui-call",
+      "line": 133,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Needs additional permissions",
+      "surface": "apple",
+      "id": "native.apple.024725d220e79697"
+    },
+    {
+      "kind": "ui-call",
+      "line": 140,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Grant",
+      "surface": "apple",
+      "id": "native.apple.84027c0f438c7aaa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 146,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Not now",
+      "surface": "apple",
+      "id": "native.apple.a3332fa4db187973"
     },
     {
       "kind": "conditional-branch",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -18759,6 +18759,16 @@
       "translated": "تمكين الومضات والحركات الخفيفة في أيقونة الحالة أثناء الخمول."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "اختصار الدردشة السريعة"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "اختصار عام يفتح شريط دردشة عائمًا للجلسة الرئيسية."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "الإمكانات"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "فتح الدردشة"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "الدردشة السريعة"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "فتح لوحة شريط القوائم"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "انقر على أيقونة OpenClaw في شريط القوائم للدردشة السريعة والحالة."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "انقر على أيقونة OpenClaw في شريط القوائم لعرض لوحة الدردشة المصغّرة والحالة."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "استخدم اللوحة + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "افتح لوحة الدردشة المصغّرة؛ يمكن للوكيل عرض معاينات ومرئيات أكثر ثراءً في Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "وصول النظام"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "الموقع"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "الإعداد"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "طلب الوصول"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "الأتمتة (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "الإشعارات"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "إمكانية الوصول"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "تسجيل الشاشة"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "الميكروفون"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "التعرّف على الكلام"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "الكاميرا"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "الموقع"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "متابعة"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "مراسلة \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "الجلسة الرئيسية"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "إرسال رسالة"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "يتطلب أذونات إضافية"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "منح الإذن"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "ليس الآن"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -18759,6 +18759,16 @@
       "translated": "Leerlauf-Blinzeln und Wackeln des Statussymbols aktivieren."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Tastenkürzel für Quick Chat"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Globales Tastenkürzel, das eine schwebende Chatleiste für die Hauptsitzung öffnet."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Funktionen"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Chat öffnen"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Quick Chat"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Menüleisten-Panel öffnen"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Klicke auf das OpenClaw-Menüleistensymbol für schnellen Chat und Status."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Klicke auf das OpenClaw-Symbol in der Menüleiste, um das kompakte Chatfenster und den Status anzuzeigen."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Panel + Canvas verwenden"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Öffne das kompakte Chatfenster; der Agent kann Vorschauen und umfangreichere visuelle Inhalte in Canvas anzeigen."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Systemzugriff"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Standort"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Einrichtung"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Zugriff anfordern"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automatisierung (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Mitteilungen"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Bedienungshilfen"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Bildschirmaufnahme"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Spracherkennung"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Kamera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Standort"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Fortfahren"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Nachricht an \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "Hauptsitzung"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Nachricht senden"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Zusätzliche Berechtigungen erforderlich"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Erteilen"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Nicht jetzt"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -18759,6 +18759,16 @@
       "translated": "Activar parpadeos y movimientos en reposo en el icono de estado."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Atajo de Chat rápido"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Atajo global que abre una barra de chat flotante para la sesión principal."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Capacidades"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Abrir chat"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Chat rápido"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Abrir el panel de la barra de menús"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Haz clic en el icono de OpenClaw en la barra de menús para acceder rápidamente al chat y al estado."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Haz clic en el icono de OpenClaw de la barra de menús para acceder al panel de chat compacto y al estado."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Usa el panel + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Abre el panel de chat compacto; el agente puede mostrar vistas previas y contenido visual más completo en Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Acceso del sistema"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Ubicación"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Configuración"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Solicitar acceso"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automatización (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Notificaciones"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Accesibilidad"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Grabación de pantalla"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Micrófono"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Reconocimiento de voz"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Cámara"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Ubicación"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Continuar"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Enviar mensaje a \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "sesión principal"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Enviar mensaje"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Se necesitan permisos adicionales"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Conceder"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Ahora no"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -18759,6 +18759,16 @@
       "translated": "چشمک‌زدن‌ها و تکان‌خوردن‌های حالت بی‌کاری را روی آیکون وضعیت فعال کنید."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "میان‌بر گفت‌وگوی سریع"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "میان‌بر سراسری که نوار گفت‌وگوی شناور را برای نشست اصلی باز می‌کند."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "قابلیت‌ها"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "باز کردن چت"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "گفت‌وگوی سریع"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "باز کردن پنل نوار منو"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "برای گفت‌وگوی سریع و وضعیت، روی آیکن نوار منوی OpenClaw کلیک کنید."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "برای مشاهده پنل فشرده گفت‌وگو و وضعیت، روی نماد OpenClaw در نوار منو کلیک کنید."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "از پنل + Canvas استفاده کنید"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "پنل فشرده گفت‌وگو را باز کنید؛ عامل می‌تواند پیش‌نمایش‌ها و جلوه‌های بصری غنی‌تری را در Canvas نمایش دهد."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "دسترسی سیستم"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "مکان"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "راه‌اندازی"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "درخواست دسترسی"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "اتوماسیون (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "اعلان‌ها"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "دسترس‌پذیری"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "ضبط صفحه"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "میکروفون"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "تشخیص گفتار"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "دوربین"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "مکان"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "ادامه"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "ارسال پیام به \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "نشست اصلی"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "ارسال پیام"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "به مجوزهای بیشتری نیاز دارد"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "اعطا"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "فعلاً نه"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -18759,6 +18759,16 @@
       "translated": "Activer les clignements et mouvements d’inactivité sur l’icône d’état."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Raccourci de discussion rapide"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Raccourci global qui ouvre une barre de discussion flottante pour la session principale."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Capacités"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Ouvrir le chat"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Discussion rapide"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Ouvrir le panneau de la barre des menus"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Cliquez sur l’icône OpenClaw dans la barre des menus pour accéder rapidement au chat et au statut."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Cliquez sur l’icône OpenClaw dans la barre des menus pour afficher le panneau de discussion compact et l’état."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Utiliser le panneau + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Ouvrez le panneau de discussion compact ; l’agent peut afficher des aperçus et des visuels plus riches dans Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Accès système"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Localisation"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Configuration"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Demander l’accès"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automatisation (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Notifications"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Accessibilité"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Enregistrement de l’écran"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Microphone"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Reconnaissance vocale"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Caméra"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Localisation"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Continuer"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Envoyer un message à \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "session principale"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Envoyer le message"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Nécessite des autorisations supplémentaires"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Accorder"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Pas maintenant"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -18759,6 +18759,16 @@
       "translated": "स्टेटस आइकन पर निष्क्रिय ब्लिंक और विगल सक्षम करें।"
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "क्विक चैट शॉर्टकट"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "मुख्य सत्र के लिए फ़्लोटिंग चैट बार खोलने वाला ग्लोबल शॉर्टकट।"
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "क्षमताएँ"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Chat खोलें"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "क्विक चैट"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "मेनू बार पैनल खोलें"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "त्वरित चैट और स्थिति के लिए OpenClaw मेनू बार आइकन पर क्लिक करें।"
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "कॉम्पैक्ट चैट पैनल और स्थिति के लिए OpenClaw मेनू बार आइकन पर क्लिक करें।"
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "पैनल + Canvas का उपयोग करें"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "कॉम्पैक्ट चैट पैनल खोलें; एजेंट Canvas में पूर्वावलोकन और अधिक समृद्ध विज़ुअल दिखा सकता है।"
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "सिस्टम एक्सेस"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "सेटअप"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "एक्सेस का अनुरोध करें"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automation (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Notifications"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Accessibility"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Screen Recording"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Microphone"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Speech Recognition"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Camera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Location"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "जारी रखें"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name) को संदेश भेजें"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "मुख्य सत्र"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "संदेश भेजें"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "अतिरिक्त अनुमतियाँ आवश्यक हैं"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "अनुमति दें"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "अभी नहीं"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -18759,6 +18759,16 @@
       "translated": "Aktifkan kedipan dan gerakan kecil saat idle pada ikon status."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Pintasan Obrolan Cepat"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Pintasan global yang membuka bilah obrolan mengambang untuk sesi utama."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Kapabilitas"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Buka Chat"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Obrolan Cepat"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Buka panel bilah menu"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Klik ikon bilah menu OpenClaw untuk obrolan cepat dan status."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Klik ikon bilah menu OpenClaw untuk membuka panel obrolan ringkas dan melihat status."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Gunakan panel + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Buka panel obrolan ringkas; agen dapat menampilkan pratinjau dan visual yang lebih kaya di Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Akses Sistem"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Lokasi"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Penyiapan"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Minta akses"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automation (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Notifikasi"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Aksesibilitas"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Perekaman Layar"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Pengenalan Ucapan"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Kamera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Lokasi"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Lanjutkan"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Kirim pesan ke \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "sesi utama"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Kirim pesan"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Memerlukan izin tambahan"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Izinkan"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Jangan sekarang"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -18759,6 +18759,16 @@
       "translated": "Abilita lampeggi e oscillazioni in stato di inattività sull'icona di stato."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Scorciatoia di Chat rapida"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Scorciatoia globale che apre una barra di chat mobile per la sessione principale."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Funzionalità"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Apri Chat"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Chat rapida"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Apri il pannello della barra dei menu"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Fai clic sull'icona OpenClaw nella barra dei menu per accedere rapidamente a chat e stato."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Fai clic sull'icona OpenClaw nella barra dei menu per visualizzare il pannello chat compatto e lo stato."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Usa il pannello + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Apri il pannello chat compatto; l'agente può mostrare anteprime e contenuti visivi più dettagliati in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Accesso al sistema"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Posizione"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Configurazione"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Richiedi accesso"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automazione (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Notifiche"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Accessibilità"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Registrazione schermo"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Microfono"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Riconoscimento vocale"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Fotocamera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Posizione"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Continua"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Invia un messaggio a \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "sessione principale"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Invia messaggio"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Sono necessarie autorizzazioni aggiuntive"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Concedi"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Non ora"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -18759,6 +18759,16 @@
       "translated": "ステータスアイコンのアイドル時のまばたきや揺れを有効にします。"
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "クイックチャットのショートカット"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "メインセッション用のフローティングチャットバーを開くグローバルショートカット。"
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "機能"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "チャットを開く"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "クイックチャット"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "メニューバーパネルを開く"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "クイックチャットとステータスを確認するには、OpenClaw メニューバーアイコンをクリックしてください。"
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "コンパクトなチャットパネルとステータスを表示するには、メニューバーのOpenClawアイコンをクリックします。"
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "パネル + Canvas を使用"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "コンパクトなチャットパネルを開きます。エージェントはCanvasでプレビューやよりリッチなビジュアルを表示できます。"
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "システムアクセス"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "位置情報"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "セットアップ"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "アクセスをリクエスト"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "自動化（AppleScript）"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "通知"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "アクセシビリティ"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "画面収録"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "マイク"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "音声認識"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "カメラ"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "位置情報"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "続ける"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name)にメッセージを送信"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "メインセッション"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "メッセージを送信"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "追加の権限が必要です"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "許可"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "後で"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -18759,6 +18759,16 @@
       "translated": "상태 아이콘의 유휴 상태 깜박임 및 흔들림을 활성화합니다."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "빠른 채팅 단축키"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "기본 세션의 플로팅 채팅 바를 여는 전역 단축키입니다."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "기능"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "채팅 열기"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "빠른 채팅"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "메뉴 막대 패널 열기"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "빠른 채팅과 상태 확인을 위해 OpenClaw 메뉴 막대 아이콘을 클릭하세요."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "간결한 채팅 패널과 상태를 보려면 OpenClaw 메뉴 막대 아이콘을 클릭하세요."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "패널 + Canvas 사용"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "간결한 채팅 패널을 엽니다. 에이전트가 Canvas에서 미리보기와 더 풍부한 시각 자료를 표시할 수 있습니다."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "시스템 접근"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "위치"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "설정"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "접근 요청"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "자동화(AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "알림"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "손쉬운 사용"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "화면 기록"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "마이크"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "음성 인식"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "카메라"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "위치"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "계속"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name)에게 메시지 보내기"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "기본 세션"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "메시지 보내기"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "추가 권한이 필요합니다"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "허용"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "나중에"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -18759,6 +18759,16 @@
       "translated": "Schakel inactieve knipper- en wiebelanimaties in voor het statusicoon."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Snelkoppeling voor Quick Chat"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Algemene snelkoppeling die een zwevende chatbalk voor de hoofdsessie opent."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Mogelijkheden"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Chat openen"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Quick Chat"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Open het menubalkpaneel"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Klik op het OpenClaw-menubalkpictogram voor snelle chat en status."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Klik op het OpenClaw-menubalkpictogram voor het compacte chatpaneel en de status."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Gebruik het paneel + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open het compacte chatpaneel; de agent kan voorvertoningen en rijkere visuele elementen in Canvas weergeven."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Systeemtoegang"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Locatie"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Instellen"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Toegang aanvragen"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automatisering (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Meldingen"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Toegankelijkheid"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Schermopname"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Microfoon"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Spraakherkenning"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Camera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Locatie"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Doorgaan"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Bericht aan \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "hoofdsessie"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Bericht verzenden"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Vereist aanvullende machtigingen"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Toestaan"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Niet nu"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -18759,6 +18759,16 @@
       "translated": "Włącz mruganie i poruszanie ikoną statusu w trybie bezczynności."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Skrót szybkiego czatu"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Globalny skrót otwierający pływający pasek czatu dla sesji głównej."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Możliwości"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Otwórz czat"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Szybki czat"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Otwórz panel paska menu"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Kliknij ikonę OpenClaw na pasku menu, aby szybko otworzyć czat i sprawdzić status."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Kliknij ikonę OpenClaw na pasku menu, aby wyświetlić kompaktowy panel czatu i stan."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Użyj panelu + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Otwórz kompaktowy panel czatu; agent może wyświetlać podglądy i bogatsze wizualizacje w Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Dostęp systemowy"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Lokalizacja"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Konfiguracja"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Poproś o dostęp"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automatyzacja (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Powiadomienia"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Dostępność"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Nagrywanie ekranu"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Rozpoznawanie mowy"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Kamera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Lokalizacja"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Kontynuuj"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Napisz do \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "sesja główna"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Wyślij wiadomość"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Wymaga dodatkowych uprawnień"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Przyznaj"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Nie teraz"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -18759,6 +18759,16 @@
       "translated": "Ativar piscadas e movimentos quando o ícone de status estiver ocioso."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Atalho do Chat Rápido"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Atalho global que abre uma barra de chat flutuante para a sessão principal."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Recursos"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Abrir chat"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Chat Rápido"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Abrir o painel da barra de menus"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Clique no ícone do OpenClaw na barra de menus para chat rápido e status."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Clique no ícone do OpenClaw na barra de menus para acessar o painel de chat compacto e o status."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Usar o painel + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Abra o painel de chat compacto; o agente pode mostrar prévias e elementos visuais mais elaborados no Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Acesso ao sistema"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Localização"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Configuração"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Solicitar acesso"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automação (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Notificações"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Acessibilidade"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Gravação de Tela"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Microfone"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Reconhecimento de Fala"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Câmera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Localização"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Continuar"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Enviar mensagem para \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "sessão principal"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Enviar mensagem"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Requer permissões adicionais"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Conceder"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Agora não"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -18759,6 +18759,16 @@
       "translated": "Включить мигания и покачивания значка состояния в режиме ожидания."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Сочетание клавиш для быстрого чата"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Глобальное сочетание клавиш, открывающее плавающую панель чата для основного сеанса."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Возможности"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Открыть чат"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Быстрый чат"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Откройте панель в строке меню"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Нажмите значок OpenClaw в строке меню для быстрого чата и просмотра статуса."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Нажмите значок OpenClaw в строке меню, чтобы открыть компактную панель чата и просмотреть статус."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Используйте панель + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Откройте компактную панель чата; агент может показывать предпросмотры и более наглядные материалы в Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Системный доступ"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Геолокация"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Настройка"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Запросить доступ"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Автоматизация (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Уведомления"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Универсальный доступ"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Запись экрана"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Микрофон"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Распознавание речи"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Камера"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Геолокация"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Продолжить"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Сообщение для \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "основной сеанс"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Отправить сообщение"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Требуются дополнительные разрешения"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Предоставить"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Не сейчас"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -18759,6 +18759,16 @@
       "translated": "Aktivera blinkningar och vickningar vid inaktivitet på statussymbolen."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Kortkommando för snabbchatt"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Globalt kortkommando som öppnar ett flytande chattfält för huvudsessionen."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Funktioner"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Öppna chatt"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Snabbchatt"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Öppna menyfältspanelen"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Klicka på OpenClaw-ikonen i menyfältet för snabbchatt och status."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Klicka på OpenClaw-ikonen i menyraden för att visa den kompakta chattpanelen och statusen."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Använd panelen + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Öppna den kompakta chattpanelen. Agenten kan visa förhandsvisningar och mer avancerad grafik i Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Systemåtkomst"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Plats"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Konfiguration"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Begär åtkomst"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Automatisering (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Notiser"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Hjälpmedel"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Skärminspelning"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Taligenkänning"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Kamera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Plats"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Fortsätt"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Skicka meddelande till \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "huvudsession"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Skicka meddelande"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Ytterligare behörigheter krävs"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Bevilja"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Inte nu"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -18759,6 +18759,16 @@
       "translated": "เปิดใช้งานการกะพริบและขยับเล็กน้อยเมื่อไม่ได้ใช้งานบนไอคอนสถานะ"
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "ปุ่มลัดแชตด่วน"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "ปุ่มลัดส่วนกลางที่เปิดแถบแชตแบบลอยสำหรับเซสชันหลัก"
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "ความสามารถ"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "เปิดแชท"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "แชตด่วน"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "เปิดแผงแถบเมนู"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "คลิกไอคอน OpenClaw บนแถบเมนูเพื่อแชตด่วนและดูสถานะ"
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "คลิกไอคอน OpenClaw บนแถบเมนูเพื่อเปิดแผงแชตขนาดกะทัดรัดและดูสถานะ"
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "ใช้แผง + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "เปิดแผงแชตขนาดกะทัดรัด โดยเอเจนต์สามารถแสดงตัวอย่างและภาพที่มีรายละเอียดมากขึ้นใน Canvas"
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "การเข้าถึงระบบ"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "ตำแหน่งที่ตั้ง"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "ตั้งค่า"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "ขอสิทธิ์เข้าถึง"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "ระบบอัตโนมัติ (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "การแจ้งเตือน"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "การช่วยการเข้าถึง"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "การบันทึกหน้าจอ"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "ไมโครโฟน"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "การรู้จำเสียงพูด"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "กล้อง"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "ตำแหน่งที่ตั้ง"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "ดำเนินการต่อ"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "ส่งข้อความถึง \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "เซสชันหลัก"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "ส่งข้อความ"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "ต้องการสิทธิ์เพิ่มเติม"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "อนุญาต"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "ไว้ภายหลัง"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -18759,6 +18759,16 @@
       "translated": "Durum simgesinde boşta göz kırpmaları ve kıpırdanmaları etkinleştir."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Hızlı Sohbet kestirmesi"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Ana oturum için yüzen bir sohbet çubuğu açan genel kestirme."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Yetenekler"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Chat'i Aç"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Hızlı Sohbet"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Menü çubuğu panelini aç"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Hızlı sohbet ve durum için OpenClaw menü çubuğu simgesine tıklayın."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Kompakt sohbet paneli ve durum bilgisi için OpenClaw menü çubuğu simgesine tıklayın."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Panel + Canvas’ı kullanın"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Kompakt sohbet panelini açın; temsilci, Canvas'ta önizlemeler ve daha zengin görseller gösterebilir."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Sistem Erişimi"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Konum"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Kurulum"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Erişim iste"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Otomasyon (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Bildirimler"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Erişilebilirlik"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Ekran Kaydı"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Konuşma Tanıma"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Kamera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Konum"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Devam et"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "\\(self.model.agentDisplay.name) adlı temsilciye mesaj gönder"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "ana oturum"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Mesaj gönder"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Ek izinler gerekiyor"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "İzin ver"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Şimdi değil"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -18759,6 +18759,16 @@
       "translated": "Увімкнути кліпання та похитування іконки стану під час простою."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Швидка команда Quick Chat"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Глобальна швидка команда, що відкриває плаваючу панель чату для основного сеансу."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Можливості"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Відкрити чат"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Quick Chat"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Відкрити панель у рядку меню"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Натисніть іконку OpenClaw у рядку меню для швидкого чату та стану."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Натисніть піктограму OpenClaw у рядку меню, щоб відкрити компактну панель чату та переглянути стан."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Використовуйте панель + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Відкрийте компактну панель чату; агент може показувати попередні перегляди та розширені візуальні матеріали в Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Системний доступ"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Місцезнаходження"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Налаштування"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Запросити доступ"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Автоматизація (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Сповіщення"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Доступність"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Запис екрана"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Мікрофон"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Розпізнавання мовлення"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Камера"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Місцезнаходження"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Продовжити"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Повідомлення для \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "основний сеанс"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Надіслати повідомлення"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Потрібні додаткові дозволи"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Надати"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Не зараз"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -18759,6 +18759,16 @@
       "translated": "Bật nháy mắt và lắc nhẹ khi không hoạt động trên biểu tượng trạng thái."
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "Phím tắt Trò chuyện nhanh"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Phím tắt toàn cục để mở thanh trò chuyện nổi cho phiên chính."
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "Khả năng"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "Mở Chat"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "Trò chuyện nhanh"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "Mở bảng trên thanh menu"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "Nhấp vào biểu tượng OpenClaw trên thanh menu để trò chuyện nhanh và xem trạng thái."
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "Nhấp vào biểu tượng OpenClaw trên thanh menu để mở bảng trò chuyện thu gọn và xem trạng thái."
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "Dùng bảng điều khiển + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Mở bảng trò chuyện thu gọn; tác tử có thể hiển thị bản xem trước và nội dung trực quan phong phú hơn trong Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "Quyền truy cập hệ thống"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "Vị trí"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "Thiết lập"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "Yêu cầu quyền truy cập"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "Tự động hóa (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "Thông báo"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "Trợ năng"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "Ghi màn hình"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "Micrô"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "Nhận dạng giọng nói"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "Camera"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "Vị trí"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "Tiếp tục"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "Nhắn tin cho \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "phiên chính"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "Gửi tin nhắn"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "Cần thêm quyền"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "Cấp quyền"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "Để sau"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -18759,6 +18759,16 @@
       "translated": "启用状态图标的空闲眨眼和摆动效果。"
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "快速聊天快捷键"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "用于为主会话打开浮动聊天栏的全局快捷键。"
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "功能"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "打开聊天"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "快速聊天"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "打开菜单栏面板"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "点击 OpenClaw 菜单栏图标，快速聊天并查看状态。"
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "点按 OpenClaw 菜单栏图标，打开紧凑型聊天面板并查看状态。"
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "使用面板 + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "打开紧凑型聊天面板；智能体可在 Canvas 中显示预览和更丰富的视觉内容。"
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "系统访问"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "位置"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "设置"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "请求访问权限"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "自动化 (AppleScript)"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "通知"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "辅助功能"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "屏幕录制"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "麦克风"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "语音识别"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "摄像头"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "位置"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "继续"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "给 \\(self.model.agentDisplay.name) 发消息"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "主会话"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "发送消息"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "需要其他权限"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "授予权限"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "暂不"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -18759,6 +18759,16 @@
       "translated": "啟用狀態圖示的閒置眨眼與擺動效果。"
     },
     {
+      "id": "native.apple.d908ab245711bbd2",
+      "source": "Quick Chat shortcut",
+      "translated": "快速聊天快捷鍵"
+    },
+    {
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "可開啟主工作階段浮動聊天列的全域快捷鍵。"
+    },
+    {
       "id": "native.apple.a66c725f98bfa823",
       "source": "Capabilities",
       "translated": "功能"
@@ -19442,6 +19452,11 @@
       "id": "native.apple.723e0d2283af1458",
       "source": "Open Chat",
       "translated": "開啟聊天"
+    },
+    {
+      "id": "native.apple.22334935d637c907",
+      "source": "Quick Chat",
+      "translated": "快速聊天"
     },
     {
       "id": "native.apple.5e3cd7734f27f447",
@@ -20539,9 +20554,9 @@
       "translated": "開啟選單列面板"
     },
     {
-      "id": "native.apple.f99e39e248dbc8ed",
-      "source": "Click the OpenClaw menu bar icon for quick chat and status.",
-      "translated": "按一下 OpenClaw 選單列圖示，即可快速聊天並查看狀態。"
+      "id": "native.apple.409bfb3a6e0f9f7c",
+      "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
+      "translated": "按一下 OpenClaw 選單列圖示，即可查看精簡聊天面板和狀態。"
     },
     {
       "id": "native.apple.1b6cfcf3be8765c2",
@@ -20574,9 +20589,9 @@
       "translated": "使用面板 + Canvas"
     },
     {
-      "id": "native.apple.774cf9fe7e3e289e",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
-      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
+      "id": "native.apple.6022f5a79ed93235",
+      "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
+      "translated": "開啟精簡聊天面板；代理程式可在 Canvas 中顯示預覽和更豐富的視覺內容。"
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -20729,6 +20744,11 @@
       "translated": "系統存取"
     },
     {
+      "id": "native.apple.fee0f3732a447f35",
+      "source": "Location",
+      "translated": "位置"
+    },
+    {
       "id": "native.apple.89a4f5934df8268a",
       "source": "Setup",
       "translated": "設定"
@@ -20842,46 +20862,6 @@
       "id": "native.apple.c8a3879230179938",
       "source": "Request access",
       "translated": "要求存取權限"
-    },
-    {
-      "id": "native.apple.8d8386041799d2b0",
-      "source": "Automation (AppleScript)",
-      "translated": "自動化（AppleScript）"
-    },
-    {
-      "id": "native.apple.bc935384479c2f48",
-      "source": "Notifications",
-      "translated": "通知"
-    },
-    {
-      "id": "native.apple.922a8b5e049ef146",
-      "source": "Accessibility",
-      "translated": "輔助使用"
-    },
-    {
-      "id": "native.apple.c2f2fac8ab1ef9c0",
-      "source": "Screen Recording",
-      "translated": "螢幕錄製"
-    },
-    {
-      "id": "native.apple.5ec94fe5a6864de7",
-      "source": "Microphone",
-      "translated": "麥克風"
-    },
-    {
-      "id": "native.apple.b27a5cb9cffe05f0",
-      "source": "Speech Recognition",
-      "translated": "語音辨識"
-    },
-    {
-      "id": "native.apple.3639c706ed77975c",
-      "source": "Camera",
-      "translated": "相機"
-    },
-    {
-      "id": "native.apple.fee0f3732a447f35",
-      "source": "Location",
-      "translated": "位置"
     },
     {
       "id": "native.apple.4a4c10ca63e99590",
@@ -21097,6 +21077,36 @@
       "id": "native.apple.144b21229f65f2a4",
       "source": "Continue",
       "translated": "繼續"
+    },
+    {
+      "id": "native.apple.b3700cf60f4520dc",
+      "source": "Message \\(self.model.agentDisplay.name)",
+      "translated": "傳訊息給 \\(self.model.agentDisplay.name)"
+    },
+    {
+      "id": "native.apple.c1fec5e4735d8995",
+      "source": "main session",
+      "translated": "主工作階段"
+    },
+    {
+      "id": "native.apple.136cef9f750d3803",
+      "source": "Send message",
+      "translated": "傳送訊息"
+    },
+    {
+      "id": "native.apple.024725d220e79697",
+      "source": "Needs additional permissions",
+      "translated": "需要其他權限"
+    },
+    {
+      "id": "native.apple.84027c0f438c7aaa",
+      "source": "Grant",
+      "translated": "授予"
+    },
+    {
+      "id": "native.apple.a3332fa4db187973",
+      "source": "Not now",
+      "translated": "現在不要"
     },
     {
       "id": "native.apple.1eeca02c45d3db5a",

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -705,7 +705,7 @@
     <string name="native_77ab6bb71f77154d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öppna systemåtkomst"</string>
     <string name="native_7804f7a79a9eee32" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Slutförd"</string>
     <string name="native_7817cd06563196ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bilden är inte tillgänglig"</string>
-    <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Notiser"</string>
+    <string name="native_788011833a5a0f22" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aviseringar"</string>
     <string name="native_78af93f13a7e5044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillämpa, avvisa och sätt i karantän kräver scope operator.admin. Återanslut med delad gateway-autentisering eller godkänn en scope-uppgradering till operator.admin för enheten för att aktivera livscykelåtgärder."</string>
     <string name="native_78f25f393aa9bcbf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker upload"</string>
     <string name="native_792175fb265c32bc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw devices approve %1$s"</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -922,7 +922,7 @@
     <string name="native_a05e2595b1680cfb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Quyền truy cập Gateway cần được xem xét"</string>
     <string name="native_a0946d3da9c32dee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 đang giữ"</string>
     <string name="native_a0d36b5ded4ebcce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Áp dụng đề xuất?"</string>
-    <string name="native_a0e63d7c7125d29a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không phải bây giờ"</string>
+    <string name="native_a0e63d7c7125d29a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Để sau"</string>
     <string name="native_a0f0ae6f5f475c06" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chưa được phê duyệt"</string>
     <string name="native_a10a36fa109818be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm ứng dụng"</string>
     <string name="native_a12db0cfcad2e5f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 mô hình đã được cấu hình"</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -922,7 +922,7 @@
     <string name="native_a05e2595b1680cfb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 存取需要審查"</string>
     <string name="native_a0946d3da9c32dee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 個已保留"</string>
     <string name="native_a0d36b5ded4ebcce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"套用提案？"</string>
-    <string name="native_a0e63d7c7125d29a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暫時不要"</string>
+    <string name="native_a0e63d7c7125d29a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"現在不要"</string>
     <string name="native_a0f0ae6f5f475c06" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未核准"</string>
     <string name="native_a10a36fa109818be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜尋 App"</string>
     <string name="native_a12db0cfcad2e5f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已設定 1 個模型"</string>

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "36b4eed5f0ab5307178cd25e14c3a22f00a5227b5dd462f297531ed701cfa7ef",
+  "originHash" : "f7fca58180a3bae3a12878c2126de5a1e8faeafd7335e79ce92239efa5620148",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "0f1e4c039bd0e22b03c0cb7f43c00c1865858f0b",
         "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
+        "version" : "3.0.1"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .executable(name: "openclaw-mac", targets: ["OpenClawMacCLI"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", exact: "3.0.1"),
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
@@ -58,6 +59,7 @@ let package = Package(
                 .product(name: "PeekabooBridge", package: "Peekaboo"),
                 .product(name: "PeekabooAutomationKit", package: "Peekaboo"),
                 .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+                .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
             ],
             exclude: [
                 "Resources/Info.plist",

--- a/apps/macos/Sources/OpenClaw/ChatSendStatus.swift
+++ b/apps/macos/Sources/OpenClaw/ChatSendStatus.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum ChatSendStatus {
+    enum Acceptance: Equatable {
+        case inFlight
+        case terminalSuccess
+        case terminalFailure
+    }
+
+    static func acceptance(of status: String) -> Acceptance {
+        switch self.normalized(status) {
+        case "ok":
+            .terminalSuccess
+        case "error", "timeout":
+            .terminalFailure
+        default:
+            .inFlight
+        }
+    }
+
+    static func normalized(_ status: String) -> String {
+        status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -155,6 +155,7 @@ actor GatewayConnection {
         case webLoginWait = "web.login.wait"
         case channelsLogout = "channels.logout"
         case modelsList = "models.list"
+        case agentIdentityGet = "agent.identity.get"
         case chatHistory = "chat.history"
         case sessionsPreview = "sessions.preview"
         case chatSend = "chat.send"
@@ -1496,6 +1497,15 @@ extension GatewayConnection {
     }
 
     // MARK: - Chat
+
+    func agentIdentity(sessionKey: String, timeoutMs: Double = 10000) async throws -> AgentIdentityResult {
+        // Identity and chat.send must resolve aliases to the same canonical session target.
+        let resolvedKey = self.canonicalizeSessionKey(sessionKey)
+        return try await self.requestDecoded(
+            method: .agentIdentityGet,
+            params: ["sessionKey": AnyCodable(resolvedKey)],
+            timeoutMs: timeoutMs)
+    }
 
     func chatHistory(
         sessionKey: String,

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -1,4 +1,5 @@
 import AppKit
+import KeyboardShortcuts
 import Observation
 import OpenClawDiscovery
 import OpenClawKit
@@ -93,8 +94,15 @@ struct GeneralSettings: View {
                 SettingsCardToggleRow(
                     title: "Play menu bar icon animations",
                     subtitle: "Enable idle blinks and wiggles on the status icon.",
-                    binding: self.$state.iconAnimationsEnabled,
+                    binding: self.$state.iconAnimationsEnabled)
+
+                SettingsCardRow(
+                    title: "Quick Chat shortcut",
+                    subtitle: "Global shortcut that opens a floating chat bar for the main session.",
                     showsDivider: false)
+                {
+                    KeyboardShortcuts.Recorder(for: .toggleQuickChat)
+                }
             }
 
             SettingsCardGroup("Capabilities") {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -566,6 +566,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ExecApprovalsGatewayPrompter.shared.start()
         MacNodeModeCoordinator.shared.start()
         VoiceWakeGlobalSettingsSync.shared.start()
+        QuickChatController.shared.start()
         Task { PresenceReporter.shared.start() }
         Task { await HealthStore.shared.refresh(onDemand: true) }
         Task { await PortGuardian.shared.sweep(mode: AppStateStore.shared.connectionMode) }
@@ -612,6 +613,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_: Notification) {
+        QuickChatController.shared.stop()
         PresenceReporter.shared.stop()
         NodePairingApprovalPrompter.shared.stop()
         DevicePairingApprovalPrompter.shared.stop()

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import AVFoundation
 import Foundation
+import KeyboardShortcuts
 import Observation
 import OpenClawKit
 import SwiftUI
@@ -137,6 +138,12 @@ struct MenuContent: View {
             } label: {
                 Label("Open Chat", systemImage: "bubble.left.and.bubble.right")
             }
+            Button {
+                QuickChatController.shared.toggle()
+            } label: {
+                Label("Quick Chat", systemImage: "text.bubble")
+            }
+            .globalKeyboardShortcut(.toggleQuickChat)
             if self.state.canvasEnabled {
                 Button {
                     AppNavigationActions.toggleCanvas()

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -915,7 +915,7 @@ extension OnboardingView {
                 }
                 self.featureRow(
                     title: "Open the menu bar panel",
-                    subtitle: "Click the OpenClaw menu bar icon for quick chat and status.",
+                    subtitle: "Click the OpenClaw menu bar icon for the compact chat panel and status.",
                     systemImage: "bubble.left.and.bubble.right")
                 self.featureActionRow(
                     title: "Connect Discord, Slack, Telegram, WhatsApp, …",
@@ -931,7 +931,7 @@ extension OnboardingView {
                     systemImage: "waveform.circle")
                 self.featureRow(
                     title: "Use the panel + Canvas",
-                    subtitle: "Open the menu bar panel for quick chat; the agent can show previews " +
+                    subtitle: "Open the compact chat panel; the agent can show previews " +
                         "and richer visuals in Canvas.",
                     systemImage: "rectangle.inset.filled.and.person.filled")
                 self.featureActionRow(

--- a/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
@@ -166,6 +166,19 @@ extension Capability {
         .camera,
         .location,
     ]
+
+    var permissionDisplayName: String {
+        switch self {
+        case .appleScript: "Automation (AppleScript)"
+        case .notifications: "Notifications"
+        case .accessibility: "Accessibility"
+        case .screenRecording: "Screen Recording"
+        case .microphone: "Microphone"
+        case .speechRecognition: "Speech Recognition"
+        case .camera: "Camera"
+        case .location: "Location"
+        }
+    }
 }
 
 struct PermissionStatusList: View {
@@ -260,7 +273,7 @@ struct PermissionRow: View {
                         .foregroundStyle(self.status ? Color.green : Color.secondary)
                 }
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(self.title).font(.body.weight(.semibold))
+                    Text(self.capability.permissionDisplayName).font(.body.weight(.semibold))
                     Text(self.subtitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -321,19 +334,6 @@ struct PermissionRow: View {
 
     private var iconSize: CGFloat {
         self.compact ? 28 : 32
-    }
-
-    private var title: String {
-        switch self.capability {
-        case .appleScript: "Automation (AppleScript)"
-        case .notifications: "Notifications"
-        case .accessibility: "Accessibility"
-        case .screenRecording: "Screen Recording"
-        case .microphone: "Microphone"
-        case .speechRecognition: "Speech Recognition"
-        case .camera: "Camera"
-        case .location: "Location"
-        }
     }
 
     private var subtitle: String {

--- a/apps/macos/Sources/OpenClaw/QuickChatController+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController+Testing.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+#if DEBUG
+@MainActor
+extension QuickChatController {
+    struct TestingSnapshot: Equatable {
+        let isVisible: Bool
+        let hasGlobalMonitor: Bool
+        let hasLocalMonitor: Bool
+        let hotkeyRegistered: Bool
+    }
+
+    static func exerciseForTesting() -> [TestingSnapshot] {
+        let model = QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentIdentityProvider: { _ in .placeholder },
+            sendProvider: { _, _, _ in "started" },
+            permissionStatusProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            permissionGrantProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { .available })
+        let controller = QuickChatController(
+            enableUI: false,
+            model: model,
+            monitoringEnabled: true,
+            globalMonitorInstaller: { _, _ in NSObject() },
+            localMonitorInstaller: { _, _ in NSObject() },
+            monitorClearer: { $0 = nil })
+        controller.start()
+        let started = controller.testingSnapshot
+        controller.present()
+        let presented = controller.testingSnapshot
+        controller.dismiss()
+        let dismissed = controller.testingSnapshot
+        controller.stop()
+        return [started, presented, dismissed, controller.testingSnapshot]
+    }
+
+    var testingSnapshot: TestingSnapshot {
+        TestingSnapshot(
+            isVisible: self.isVisible,
+            hasGlobalMonitor: self.hasGlobalMonitorForTesting,
+            hasLocalMonitor: self.hasLocalMonitorForTesting,
+            hotkeyRegistered: self.hotkeyRegisteredForTesting)
+    }
+}
+#endif

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -1,0 +1,291 @@
+import AppKit
+import KeyboardShortcuts
+import Observation
+import SwiftUI
+
+private let quickChatLogger = Logger(subsystem: "ai.openclaw", category: "quickchat")
+
+private final class QuickChatPanel: NSPanel {
+    /// Quick Chat must accept typing without behaving like a normal activating app window.
+    override var canBecomeKey: Bool {
+        true
+    }
+}
+
+@MainActor
+@Observable
+final class QuickChatController: NSObject, NSWindowDelegate {
+    typealias GlobalMonitorInstaller = (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> Any?
+    typealias LocalMonitorInstaller = (NSEvent.EventTypeMask, @escaping (NSEvent) -> NSEvent?) -> Any?
+    typealias MonitorClearer = (inout Any?) -> Void
+
+    static let shared = QuickChatController()
+
+    private(set) var isVisible = false
+
+    @ObservationIgnored let model: QuickChatModel
+    @ObservationIgnored private let enableUI: Bool
+    @ObservationIgnored private let monitoringEnabled: Bool
+    @ObservationIgnored private let globalMonitorInstaller: GlobalMonitorInstaller
+    @ObservationIgnored private let localMonitorInstaller: LocalMonitorInstaller
+    @ObservationIgnored private let monitorClearer: MonitorClearer
+    @ObservationIgnored private var panel: QuickChatPanel?
+    @ObservationIgnored private var hostingView: NSHostingView<QuickChatView>?
+    @ObservationIgnored private weak var textView: NSTextView?
+    @ObservationIgnored private var globalMonitor: Any?
+    @ObservationIgnored private var localMonitor: Any?
+    @ObservationIgnored private var presentationTask: Task<Void, Never>?
+    @ObservationIgnored private var visibleFrame = NSRect.zero
+    @ObservationIgnored private var contentHeight: CGFloat = 58
+    @ObservationIgnored private var transitionID = UUID()
+    @ObservationIgnored private var isStarted = false
+    @ObservationIgnored private var hotkeyRegistered = false
+
+    init(
+        enableUI: Bool = true,
+        model: QuickChatModel? = nil,
+        monitoringEnabled: Bool? = nil,
+        globalMonitorInstaller: @escaping GlobalMonitorInstaller = { mask, handler in
+            NSEvent.addGlobalMonitorForEvents(matching: mask, handler: handler)
+        },
+        localMonitorInstaller: @escaping LocalMonitorInstaller = { mask, handler in
+            NSEvent.addLocalMonitorForEvents(matching: mask, handler: handler)
+        },
+        monitorClearer: @escaping MonitorClearer = { monitor in
+            OverlayPanelFactory.clearGlobalEventMonitor(&monitor)
+        })
+    {
+        self.enableUI = enableUI
+        self.model = model ?? QuickChatModel()
+        self.monitoringEnabled = monitoringEnabled ?? (enableUI && !ProcessInfo.processInfo.isRunningTests)
+        self.globalMonitorInstaller = globalMonitorInstaller
+        self.localMonitorInstaller = localMonitorInstaller
+        self.monitorClearer = monitorClearer
+        super.init()
+    }
+
+    func start() {
+        guard !self.isStarted else { return }
+        self.isStarted = true
+        guard !ProcessInfo.processInfo.isRunningTests else { return }
+        KeyboardShortcuts.onKeyUp(for: .toggleQuickChat) { [weak self] in
+            Task { @MainActor in
+                self?.toggle()
+            }
+        }
+        self.hotkeyRegistered = true
+        quickChatLogger.info("quick chat hotkey handler registered")
+    }
+
+    func stop() {
+        if self.hotkeyRegistered {
+            KeyboardShortcuts.removeHandler(for: .toggleQuickChat)
+            self.hotkeyRegistered = false
+        }
+        self.isStarted = false
+        self.dismiss(immediate: true)
+        self.model.cancelAllTasks()
+        self.panel?.delegate = nil
+        self.panel = nil
+        self.hostingView = nil
+        self.textView = nil
+    }
+
+    func toggle() {
+        if self.isVisible {
+            self.dismiss()
+        } else {
+            self.present()
+        }
+    }
+
+    func present() {
+        self.transitionID = UUID()
+        let presentationID = self.model.beginPresentation()
+        self.presentationTask?.cancel()
+        self.presentationTask = Task { [weak self] in
+            guard let self else { return }
+            await self.model.refreshForPresentation(id: presentationID)
+        }
+        let wasVisible = self.isVisible
+        self.isVisible = true
+        self.installDismissMonitors()
+        guard self.enableUI, !ProcessInfo.processInfo.isRunningTests else { return }
+
+        self.visibleFrame = self.cursorScreen()?.visibleFrame ?? .zero
+        self.ensurePanel()
+        let target = self.targetFrame()
+        quickChatLogger.info(
+            "quick chat present visible=\(NSStringFromRect(self.visibleFrame)) target=\(NSStringFromRect(target))")
+        guard let panel = self.panel else { return }
+        panel.alphaValue = 1
+        if wasVisible {
+            OverlayPanelFactory.applyFrame(window: panel, target: target, animate: true)
+            panel.makeKeyAndOrderFront(nil)
+        } else {
+            let start = target.offsetBy(dx: 0, dy: -8)
+            OverlayPanelFactory.animatePresent(window: panel, from: start, to: target, duration: 0.18)
+            panel.makeKeyAndOrderFront(nil)
+        }
+        self.focusEditor()
+    }
+
+    func dismiss() {
+        self.dismiss(immediate: false)
+    }
+
+    func windowDidResignKey(_: Notification) {
+        guard self.isVisible else { return }
+        // System permission dialogs steal key focus mid-grant; the bar must survive that flow.
+        guard !self.model.isGrantingPermissions else { return }
+        self.dismiss()
+    }
+
+    private func dismiss(immediate: Bool) {
+        if self.isVisible {
+            quickChatLogger.info("quick chat dismiss immediate=\(immediate)")
+        }
+        self.presentationTask?.cancel()
+        self.presentationTask = nil
+        self.model.endPresentation()
+        self.removeDismissMonitors()
+        guard self.isVisible else {
+            if immediate { self.panel?.orderOut(nil) }
+            return
+        }
+        self.isVisible = false
+        let dismissalID = UUID()
+        self.transitionID = dismissalID
+        guard self.enableUI, let panel = self.panel, !immediate else {
+            self.panel?.orderOut(nil)
+            return
+        }
+        OverlayPanelFactory.animateDismissAndHide(
+            window: panel,
+            offsetX: 0,
+            offsetY: -6,
+            duration: 0.14)
+        { [weak self, weak panel] in
+            guard let self, let panel else { return }
+            if self.transitionID != dismissalID, self.isVisible {
+                panel.alphaValue = 1
+                panel.setFrame(self.targetFrame(), display: true)
+                panel.makeKeyAndOrderFront(nil)
+                self.focusEditor()
+            }
+        }
+    }
+
+    private func ensurePanel() {
+        guard self.panel == nil else { return }
+        let panel = QuickChatPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 620, height: self.contentHeight),
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false)
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.hidesOnDeactivate = false
+        panel.isMovable = false
+        panel.isFloatingPanel = true
+        panel.becomesKeyOnlyIfNeeded = false
+        panel.delegate = self
+
+        let view = self.makeView()
+        let host = NSHostingView(rootView: view)
+        panel.contentView = host
+        self.panel = panel
+        self.hostingView = host
+    }
+
+    private func makeView() -> QuickChatView {
+        QuickChatView(
+            model: self.model,
+            onDismiss: { [weak self] in self?.dismiss() },
+            onSendAccepted: { [weak self] openChat in
+                guard let self else { return }
+                self.dismiss()
+                if openChat { AppNavigationActions.openChat() }
+            },
+            onContentHeightChange: { [weak self] height in
+                self?.updateContentHeight(height)
+            },
+            onTextViewReady: { [weak self] textView in
+                self?.textView = textView
+                self?.focusEditor()
+            })
+    }
+
+    private func updateContentHeight(_ height: CGFloat) {
+        let resolved = max(1, ceil(height))
+        guard abs(resolved - self.contentHeight) > 0.5 else { return }
+        self.contentHeight = resolved
+        guard self.isVisible else { return }
+        OverlayPanelFactory.applyFrame(window: self.panel, target: self.targetFrame(), animate: true)
+    }
+
+    private func targetFrame() -> NSRect {
+        QuickChatPlacement.barFrame(
+            contentSize: NSSize(width: 620, height: self.contentHeight),
+            visibleFrame: self.visibleFrame)
+    }
+
+    private func cursorScreen() -> NSScreen? {
+        let cursor = NSEvent.mouseLocation
+        return NSScreen.screens.first(where: { $0.frame.contains(cursor) }) ?? NSScreen.main
+    }
+
+    private func focusEditor() {
+        guard self.isVisible, let panel = self.panel, let textView = self.textView else { return }
+        panel.makeKeyAndOrderFront(nil)
+        panel.makeFirstResponder(textView)
+        DispatchQueue.main.async { [weak self, weak panel, weak textView] in
+            guard let self, self.isVisible, let panel, let textView else { return }
+            panel.makeFirstResponder(textView)
+        }
+    }
+
+    private func installDismissMonitors() {
+        guard self.monitoringEnabled, self.globalMonitor == nil, self.localMonitor == nil else { return }
+        let mouseEvents: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        // Global and local monitors are paired because global monitors omit this app's clicks.
+        self.globalMonitor = self.globalMonitorInstaller(mouseEvents) { [weak self] _ in
+            let point = NSEvent.mouseLocation
+            Task { @MainActor in self?.dismissIfClickOutside(at: point) }
+        }
+        self.localMonitor = self.localMonitorInstaller(mouseEvents) { [weak self] event in
+            let point = NSEvent.mouseLocation
+            Task { @MainActor in self?.dismissIfClickOutside(at: point) }
+            return event
+        }
+    }
+
+    private func dismissIfClickOutside(at point: NSPoint) {
+        guard self.isVisible, !self.model.isGrantingPermissions, let panel = self.panel else { return }
+        if !panel.frame.contains(point) {
+            self.dismiss()
+        }
+    }
+
+    private func removeDismissMonitors() {
+        self.monitorClearer(&self.globalMonitor)
+        self.monitorClearer(&self.localMonitor)
+    }
+
+    #if DEBUG
+    var hasGlobalMonitorForTesting: Bool {
+        self.globalMonitor != nil
+    }
+
+    var hasLocalMonitorForTesting: Bool {
+        self.localMonitor != nil
+    }
+
+    var hotkeyRegisteredForTesting: Bool {
+        self.hotkeyRegistered
+    }
+    #endif
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatModel.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatModel.swift
@@ -1,0 +1,330 @@
+import Foundation
+import Observation
+import OpenClawIPC
+
+struct QuickChatAgentDisplay: Equatable {
+    static let placeholder = QuickChatAgentDisplay(name: "Agent", emoji: nil)
+
+    let name: String
+    let emoji: String?
+    let avatarSymbolFallback: String
+
+    init(name: String, emoji: String?, avatarSymbolFallback: String = "sparkles") {
+        self.name = name
+        self.emoji = emoji
+        self.avatarSymbolFallback = avatarSymbolFallback
+    }
+}
+
+enum QuickChatConnectionGate: Equatable {
+    case available
+    case unconfigured
+    case paused
+    case disconnected
+}
+
+enum QuickChatSendState: Equatable {
+    case idle
+    case sending
+    case sent
+    case failed(String)
+}
+
+@MainActor
+@Observable
+final class QuickChatModel {
+    private struct RetryIdentity {
+        let draft: String
+        let sessionKey: String
+        let idempotencyKey: String
+    }
+
+    typealias SessionKeyProvider = @MainActor () async -> String
+    typealias AgentIdentityProvider = @MainActor (String) async throws -> QuickChatAgentDisplay
+    typealias SendProvider = @MainActor (String, String, String) async throws -> String
+    typealias PermissionStatusProvider = @MainActor ([Capability]) async -> [Capability: Bool]
+    typealias PermissionGrantProvider = @MainActor ([Capability]) async -> [Capability: Bool]
+    typealias ConnectionGateProvider = @MainActor () -> QuickChatConnectionGate
+
+    static let trackedPermissions: [Capability] = [.notifications, .accessibility, .screenRecording]
+
+    var text = "" {
+        didSet {
+            if !self.text.isEmpty, self.sendState == .sent {
+                self.sendState = .idle
+            }
+            if self.sendTask == nil, let retryIdentity = self.retryIdentity, retryIdentity.draft != self.text {
+                self.retryIdentity = nil
+            }
+        }
+    }
+
+    private(set) var sessionKey = ""
+    private(set) var agentDisplay = QuickChatAgentDisplay.placeholder
+    private(set) var missingPermissions: [Capability] = []
+    private(set) var permissionsDismissedThisSession = false
+    private(set) var isGrantingPermissions = false
+    private(set) var sendState: QuickChatSendState = .idle
+    private(set) var isPresentationActive = false
+
+    @ObservationIgnored private let sessionKeyProvider: SessionKeyProvider
+    @ObservationIgnored private let agentIdentityProvider: AgentIdentityProvider
+    @ObservationIgnored private let sendProvider: SendProvider
+    @ObservationIgnored private let permissionStatusProvider: PermissionStatusProvider
+    @ObservationIgnored private let permissionGrantProvider: PermissionGrantProvider
+    @ObservationIgnored private let connectionGateProvider: ConnectionGateProvider
+    @ObservationIgnored private var presentationID = UUID()
+    @ObservationIgnored private var agentDisplaySessionKey: String?
+    @ObservationIgnored private var sendTask: Task<String, Error>?
+    @ObservationIgnored private var permissionTask: Task<Void, Never>?
+    @ObservationIgnored private var permissionPollTask: Task<Void, Never>?
+    @ObservationIgnored private var retryIdentity: RetryIdentity?
+
+    init(
+        sessionKeyProvider: @escaping SessionKeyProvider = {
+            await GatewayConnection.shared.mainSessionKey()
+        },
+        agentIdentityProvider: @escaping AgentIdentityProvider = { sessionKey in
+            let identity = try await GatewayConnection.shared.agentIdentity(sessionKey: sessionKey)
+            let name = identity.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let emoji = identity.emoji?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return QuickChatAgentDisplay(
+                name: name.flatMap { $0.isEmpty ? nil : $0 } ?? "Agent",
+                emoji: emoji?.isEmpty == false ? emoji : nil)
+        },
+        sendProvider: @escaping SendProvider = { sessionKey, message, idempotencyKey in
+            let response = try await GatewayConnection.shared.chatSend(
+                sessionKey: sessionKey,
+                message: message,
+                thinking: nil,
+                idempotencyKey: idempotencyKey,
+                attachments: [])
+            return response.status
+        },
+        permissionStatusProvider: @escaping PermissionStatusProvider = { capabilities in
+            await PermissionManager.status(capabilities)
+        },
+        permissionGrantProvider: @escaping PermissionGrantProvider = { capabilities in
+            await PermissionManager.ensure(capabilities, interactive: true)
+        },
+        connectionGateProvider: @escaping ConnectionGateProvider = {
+            let appState = AppStateStore.shared
+            if appState.connectionMode == .unconfigured { return .unconfigured }
+            if appState.isPaused { return .paused }
+            if ControlChannel.shared.state != .connected { return .disconnected }
+            return .available
+        })
+    {
+        self.sessionKeyProvider = sessionKeyProvider
+        self.agentIdentityProvider = agentIdentityProvider
+        self.sendProvider = sendProvider
+        self.permissionStatusProvider = permissionStatusProvider
+        self.permissionGrantProvider = permissionGrantProvider
+        self.connectionGateProvider = connectionGateProvider
+    }
+
+    var connectionGate: QuickChatConnectionGate {
+        self.connectionGateProvider()
+    }
+
+    var connectionStatusMessage: String? {
+        switch self.connectionGate {
+        case .available: nil
+        case .unconfigured: "Not configured"
+        case .paused: "OpenClaw is paused"
+        case .disconnected: "Gateway disconnected"
+        }
+    }
+
+    var shouldShowPermissionStrip: Bool {
+        !self.permissionsDismissedThisSession && !self.missingPermissions.isEmpty
+    }
+
+    var canSend: Bool {
+        !self.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !self.sessionKey.isEmpty &&
+            self.connectionGate == .available &&
+            self.sendState != .sending
+    }
+
+    var activePresentationID: UUID? {
+        self.isPresentationActive ? self.presentationID : nil
+    }
+
+    func beginPresentation() -> UUID {
+        self.presentationID = UUID()
+        self.isPresentationActive = true
+        // Keep the cached agent display so re-opening does not flash the placeholder;
+        // the session key must stay empty until refreshed because routing may have changed.
+        self.sessionKey = ""
+        if self.sendTask == nil { self.sendState = .idle }
+        self.startPermissionPolling(id: self.presentationID)
+        return self.presentationID
+    }
+
+    func refreshForPresentation(id: UUID) async {
+        guard self.isCurrentPresentation(id) else { return }
+        async let sessionKey = self.sessionKeyProvider()
+        // A targeted one-shot avoids PermissionMonitor's unrelated Terminal AppleScript probe.
+        async let permissionStatus = self.permissionStatusProvider(Self.trackedPermissions)
+
+        let (resolvedSessionKey, status) = await (sessionKey, permissionStatus)
+        guard self.isCurrentPresentation(id), !Task.isCancelled else { return }
+        self.sessionKey = resolvedSessionKey
+        // The cached display only describes this session key; routing changes must not
+        // label a send with the previous agent while the fresh identity is in flight.
+        if self.agentDisplaySessionKey != resolvedSessionKey {
+            self.agentDisplay = .placeholder
+            self.agentDisplaySessionKey = nil
+        }
+        self.applyPermissionStatus(status)
+
+        do {
+            let display = try await self.agentIdentityProvider(resolvedSessionKey)
+            guard self.isCurrentPresentation(id), !Task.isCancelled else { return }
+            self.agentDisplay = display
+            self.agentDisplaySessionKey = resolvedSessionKey
+        } catch {
+            // Keep the key-matched display on transient fetch failures; stale beats flashing.
+        }
+    }
+
+    func dismissPermissionsForSession() {
+        self.permissionsDismissedThisSession = true
+    }
+
+    func grantMissingPermissions() {
+        let capabilities = self.missingPermissions
+        guard !capabilities.isEmpty, !self.isGrantingPermissions else { return }
+        let id = self.presentationID
+        self.permissionTask?.cancel()
+        self.isGrantingPermissions = true
+        self.permissionTask = Task { [weak self] in
+            guard let self else { return }
+            _ = await self.permissionGrantProvider(capabilities)
+            // The 1s poll keeps the strip current afterwards; one immediate recheck avoids lag.
+            guard self.isCurrentPresentation(id), !Task.isCancelled else { return }
+            await self.recheckPermissions(id: id)
+            guard self.isCurrentPresentation(id), !Task.isCancelled else { return }
+            self.isGrantingPermissions = false
+            self.permissionTask = nil
+        }
+    }
+
+    func send() async -> Bool {
+        let draft = self.text
+        let message = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty, !self.sessionKey.isEmpty, self.connectionGate == .available else { return false }
+        guard self.sendState != .sending else { return false }
+
+        let sessionKey = self.sessionKey
+        let idempotencyKey: String
+        if let retryIdentity = self.retryIdentity,
+           retryIdentity.draft == draft,
+           retryIdentity.sessionKey == sessionKey
+        {
+            idempotencyKey = retryIdentity.idempotencyKey
+        } else {
+            idempotencyKey = UUID().uuidString
+            self.retryIdentity = RetryIdentity(
+                draft: draft,
+                sessionKey: sessionKey,
+                idempotencyKey: idempotencyKey)
+        }
+        let task = Task {
+            try await self.sendProvider(sessionKey, message, idempotencyKey)
+        }
+        self.sendTask = task
+        self.sendState = .sending
+        do {
+            let status = try await task.value
+            self.sendTask = nil
+            switch ChatSendStatus.acceptance(of: status) {
+            case .terminalFailure:
+                self.retryIdentity = nil
+                let normalized = ChatSendStatus.normalized(status)
+                self.sendState = self.text == draft
+                    ? .failed("Message was not accepted (\(normalized)).")
+                    : .idle
+                return false
+            case .terminalSuccess, .inFlight:
+                // chat.send acknowledges acceptance; the reply completes asynchronously in full chat.
+                self.retryIdentity = nil
+                if self.text == draft {
+                    self.sendState = .sent
+                    self.text = ""
+                } else {
+                    self.sendState = .idle
+                }
+                return true
+            }
+        } catch is CancellationError {
+            self.sendTask = nil
+            self.retryIdentity = nil
+            self.sendState = .idle
+            return false
+        } catch {
+            self.sendTask = nil
+            self.sendState = self.text == draft ? .failed(error.localizedDescription) : .idle
+            return false
+        }
+    }
+
+    func endPresentation() {
+        self.isPresentationActive = false
+        self.presentationID = UUID()
+        self.sessionKey = ""
+        // A dispatched chat.send may already be accepted; cancelling and retrying with a new UUID can duplicate it.
+        self.cancelPermissionTask()
+        self.cancelPermissionPolling()
+    }
+
+    func cancelAllTasks() {
+        self.sendTask?.cancel()
+        self.sendTask = nil
+        self.retryIdentity = nil
+        self.cancelPermissionTask()
+        self.cancelPermissionPolling()
+        if self.sendState == .sending { self.sendState = .idle }
+    }
+
+    private func startPermissionPolling(id: UUID) {
+        guard !ProcessInfo.processInfo.isRunningTests else { return }
+        self.permissionPollTask?.cancel()
+        // TCC posts no change notifications; poll the tracked capabilities (cheap native
+        // checks, no AppleScript probe) only while the bar is presented so the strip
+        // appears and clears live, including grants made from System Settings.
+        self.permissionPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard let self, self.isCurrentPresentation(id), !Task.isCancelled else { return }
+                await self.recheckPermissions(id: id)
+            }
+        }
+    }
+
+    private func cancelPermissionPolling() {
+        self.permissionPollTask?.cancel()
+        self.permissionPollTask = nil
+    }
+
+    private func cancelPermissionTask() {
+        self.permissionTask?.cancel()
+        self.permissionTask = nil
+        self.isGrantingPermissions = false
+    }
+
+    private func recheckPermissions(id: UUID) async {
+        let status = await self.permissionStatusProvider(Self.trackedPermissions)
+        guard self.isCurrentPresentation(id), !Task.isCancelled else { return }
+        self.applyPermissionStatus(status)
+    }
+
+    private func applyPermissionStatus(_ status: [Capability: Bool]) {
+        self.missingPermissions = Self.trackedPermissions.filter { status[$0] != true }
+    }
+
+    private func isCurrentPresentation(_ id: UUID) -> Bool {
+        self.isPresentationActive && self.presentationID == id
+    }
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatPlacement.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatPlacement.swift
@@ -1,0 +1,19 @@
+import AppKit
+
+enum QuickChatPlacement {
+    static func barFrame(contentSize: NSSize, visibleFrame: NSRect) -> NSRect {
+        guard visibleFrame.width > 0, visibleFrame.height > 0 else { return .zero }
+
+        let size = NSSize(
+            width: min(max(0, contentSize.width), visibleFrame.width),
+            height: min(max(0, contentSize.height), visibleFrame.height))
+        let desiredTop = visibleFrame.maxY - (0.22 * visibleFrame.height)
+        let desiredOrigin = NSPoint(
+            x: visibleFrame.midX - (size.width / 2),
+            y: desiredTop - size.height)
+        let origin = NSPoint(
+            x: min(max(desiredOrigin.x, visibleFrame.minX), visibleFrame.maxX - size.width),
+            y: min(max(desiredOrigin.y, visibleFrame.minY), visibleFrame.maxY - size.height))
+        return NSRect(origin: origin, size: size)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatShortcut.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatShortcut.swift
@@ -1,0 +1,8 @@
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    /// KeyboardShortcuts owns UserDefaults persistence for the recorded chord.
+    static let toggleQuickChat = Self(
+        "toggleQuickChat",
+        initial: .init(.space, modifiers: [.option]))
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatTextView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatTextView.swift
@@ -1,0 +1,142 @@
+import AppKit
+import SwiftUI
+
+struct QuickChatTextView: NSViewRepresentable {
+    @Binding var text: String
+    let onSubmit: (Bool) -> Void
+    let onEscape: () -> Void
+    let onHeightChange: (CGFloat) -> Void
+    let onTextViewReady: (NSTextView) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let textView = QuickChatNSTextView()
+        textView.delegate = context.coordinator
+        textView.drawsBackground = false
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.font = .systemFont(ofSize: 13.5)
+        textView.textColor = .labelColor
+        textView.insertionPointColor = .controlAccentColor
+        textView.textContainer?.lineBreakMode = .byWordWrapping
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainerInset = NSSize(width: 2, height: 6)
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude)
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+        textView.focusRingType = .none
+        textView.string = self.text
+        textView.onSubmit = self.onSubmit
+        textView.onEscape = self.onEscape
+
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.hasHorizontalScroller = false
+        scrollView.documentView = textView
+        context.coordinator.scrollView = scrollView
+
+        DispatchQueue.main.async {
+            self.onTextViewReady(textView)
+            context.coordinator.updateHeight(for: textView)
+        }
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = scrollView.documentView as? QuickChatNSTextView else { return }
+        textView.onSubmit = self.onSubmit
+        textView.onEscape = self.onEscape
+        if textView.string != self.text, !textView.hasMarkedText() {
+            context.coordinator.isProgrammaticUpdate = true
+            textView.string = self.text
+            textView.setSelectedRange(NSRange(location: textView.string.utf16.count, length: 0))
+            context.coordinator.isProgrammaticUpdate = false
+        }
+        DispatchQueue.main.async {
+            context.coordinator.updateHeight(for: textView)
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: QuickChatTextView
+        weak var scrollView: NSScrollView?
+        var isProgrammaticUpdate = false
+        private var lastHeight: CGFloat = 0
+
+        init(_ parent: QuickChatTextView) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? QuickChatNSTextView else { return }
+            if !self.isProgrammaticUpdate {
+                self.parent.text = textView.string
+            }
+            self.updateHeight(for: textView)
+        }
+
+        func updateHeight(for textView: NSTextView) {
+            guard let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else { return }
+            layoutManager.ensureLayout(for: textContainer)
+            let font = textView.font ?? .systemFont(ofSize: 13.5)
+            let lineHeight = ceil(layoutManager.defaultLineHeight(for: font))
+            let naturalHeight = ceil(layoutManager.usedRect(for: textContainer).height + 12)
+            let minHeight = lineHeight + 12
+            let maxHeight = (lineHeight * 5) + 12
+            let height = min(max(naturalHeight, minHeight), maxHeight)
+            self.scrollView?.hasVerticalScroller = naturalHeight > maxHeight
+            guard abs(height - self.lastHeight) > 0.5 else { return }
+            self.lastHeight = height
+            self.parent.onHeightChange(height)
+        }
+    }
+}
+
+private final class QuickChatNSTextView: NSTextView {
+    var onSubmit: ((Bool) -> Void)?
+    var onEscape: (() -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 {
+            guard !self.hasMarkedText() else {
+                super.keyDown(with: event)
+                return
+            }
+            self.onEscape?()
+            return
+        }
+
+        guard event.keyCode == 36 || event.keyCode == 76 else {
+            super.keyDown(with: event)
+            return
+        }
+        guard !self.hasMarkedText() else {
+            super.keyDown(with: event)
+            return
+        }
+
+        let modifiers = event.modifierFlags.intersection([.command, .shift])
+        if modifiers.contains(.shift), !modifiers.contains(.command) {
+            self.insertNewline(nil)
+        } else {
+            self.onSubmit?(modifiers.contains(.command))
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/QuickChatView.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatView.swift
@@ -1,0 +1,185 @@
+import AppKit
+import Observation
+import SwiftUI
+
+@MainActor
+struct QuickChatView: View {
+    @Bindable var model: QuickChatModel
+    let onDismiss: () -> Void
+    let onSendAccepted: (Bool) -> Void
+    let onContentHeightChange: (CGFloat) -> Void
+    let onTextViewReady: (NSTextView) -> Void
+
+    @State private var editorHeight: CGFloat = 30
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+
+            VStack(spacing: 0) {
+                self.inputRow
+
+                if let status = self.statusLine {
+                    HStack {
+                        Text(status.message)
+                            .font(.caption)
+                            .foregroundStyle(status.isError ? Color.red : Color.orange)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 9)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+
+                if self.model.shouldShowPermissionStrip {
+                    self.permissionStrip
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+        }
+        .frame(width: 620)
+        .fixedSize(horizontal: false, vertical: true)
+        .animation(.spring(duration: 0.25), value: self.model.shouldShowPermissionStrip)
+        .animation(.easeOut(duration: 0.14), value: self.statusLine?.message)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            self.onContentHeightChange(height)
+        }
+    }
+
+    private var inputRow: some View {
+        HStack(spacing: 10) {
+            self.agentAvatar
+
+            ZStack(alignment: .leading) {
+                if self.model.text.isEmpty {
+                    Text("Message \(self.model.agentDisplay.name)")
+                        .font(.system(size: 13.5))
+                        .foregroundStyle(.tertiary)
+                        .padding(.leading, 2)
+                        .allowsHitTesting(false)
+                }
+                QuickChatTextView(
+                    text: self.$model.text,
+                    onSubmit: self.submit,
+                    onEscape: self.onDismiss,
+                    onHeightChange: { self.editorHeight = $0 },
+                    onTextViewReady: self.onTextViewReady)
+                    .frame(height: self.editorHeight)
+            }
+            .frame(maxWidth: .infinity)
+
+            Text("main session")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(.quaternary, in: Capsule())
+
+            Button {
+                self.submit(openChat: false)
+            } label: {
+                Group {
+                    switch self.model.sendState {
+                    case .sending:
+                        ProgressView()
+                            .controlSize(.small)
+                    case .sent:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    case .idle, .failed:
+                        Image(systemName: "arrow.up.circle.fill")
+                            .foregroundStyle(self.model.canSend ? Color.accentColor : Color.secondary)
+                    }
+                }
+                .font(.system(size: 22))
+                .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .disabled(!self.model.canSend)
+            .accessibilityLabel("Send message")
+        }
+        .padding(14)
+    }
+
+    private var agentAvatar: some View {
+        ZStack {
+            Circle()
+                .fill(Color.primary.opacity(0.07))
+            if let emoji = self.model.agentDisplay.emoji {
+                Text(emoji)
+                    .font(.system(size: 16))
+            } else {
+                Image(systemName: self.model.agentDisplay.avatarSymbolFallback)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: 28, height: 28)
+        .accessibilityLabel(self.model.agentDisplay.name)
+    }
+
+    private var permissionStrip: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.shield")
+                    .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Needs additional permissions")
+                        .font(.caption.weight(.semibold))
+                    Text(self.model.missingPermissions.map(\.permissionDisplayName).joined(separator: ", "))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Grant") {
+                    self.model.grantMissingPermissions()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(self.model.isGrantingPermissions)
+                Button("Not now") {
+                    self.model.dismissPermissionsForSession()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+            .padding(12)
+        }
+    }
+
+    private var statusLine: (message: String, isError: Bool)? {
+        if case let .failed(message) = self.model.sendState {
+            return (message, true)
+        }
+        if let message = self.model.connectionStatusMessage {
+            return (message, false)
+        }
+        return nil
+    }
+
+    private func submit(openChat: Bool) {
+        guard self.model.canSend, let presentationID = self.model.activePresentationID else { return }
+        Task {
+            guard await self.model.send() else { return }
+            if openChat {
+                // The user may have dismissed (or reopened) the bar while the ack was in
+                // flight; acting then would close the wrong presentation or steal focus.
+                guard self.model.activePresentationID == presentationID else { return }
+                self.onSendAccepted(true)
+                return
+            }
+            // Plain Return lingers briefly on the checkmark before the bar dismisses itself.
+            try? await Task.sleep(for: .seconds(0.45))
+            guard self.model.activePresentationID == presentationID,
+                  self.model.sendState == .sent,
+                  self.model.text.isEmpty else { return }
+            self.onSendAccepted(false)
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -396,12 +396,12 @@ extension TalkModeRuntime {
                 idempotencyKey: runId,
                 attachments: [])
             guard self.isCurrent(gen) else { return }
-            let normalizedStatus = Self.normalizedChatSendStatus(response.status)
+            let normalizedStatus = ChatSendStatus.normalized(response.status)
             self.logger.info(
                 "talk chat.send ok runId=\(response.runId, privacy: .public) " +
                     "status=\(normalizedStatus, privacy: .public) " +
                     "session=\(sessionKey, privacy: .public)")
-            if Self.isTerminalChatSendFailure(response.status) {
+            if ChatSendStatus.acceptance(of: response.status) == .terminalFailure {
                 self.logger.warning(
                     "talk chat.send terminal ack runId=\(response.runId, privacy: .public) " +
                         "status=\(normalizedStatus, privacy: .public)")
@@ -410,7 +410,7 @@ extension TalkModeRuntime {
             }
 
             var assistantText: String?
-            if Self.isTerminalChatSendSuccess(response.status) {
+            if ChatSendStatus.acceptance(of: response.status) == .terminalSuccess {
                 self.logger.info(
                     "talk chat.send terminal ok runId=\(response.runId, privacy: .public); " +
                         "using history fallback")
@@ -522,19 +522,6 @@ extension TalkModeRuntime {
             group.cancelAll()
             return result
         }
-    }
-
-    private static func normalizedChatSendStatus(_ status: String) -> String {
-        status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    }
-
-    private static func isTerminalChatSendSuccess(_ status: String) -> Bool {
-        self.normalizedChatSendStatus(status) == "ok"
-    }
-
-    private static func isTerminalChatSendFailure(_ status: String) -> Bool {
-        let normalized = self.normalizedChatSendStatus(status)
-        return normalized == "timeout" || normalized == "error"
     }
 
     private static func matchesSessionKey(_ incoming: String, _ current: String) -> Bool {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -622,7 +622,7 @@ final class WebChatSwiftUIWindowController {
                 userAccent: accent))
             self.contentController = hosting
         case .panel:
-            // Anchored quick-chat panel: compact single-column chat.
+            // Anchored compact chat panel: single-column chat.
             let hosting = NSHostingController(rootView: OpenClawChatView(
                 viewModel: vm,
                 showsSessionSwitcher: true,

--- a/apps/macos/Tests/OpenClawIPCTests/ChatSendStatusTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChatSendStatusTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import OpenClaw
+
+struct ChatSendStatusTests {
+    @Test(arguments: ["ok", " OK ", "\nok\t"])
+    func `ok is terminal success`(_ status: String) {
+        #expect(ChatSendStatus.acceptance(of: status) == .terminalSuccess)
+    }
+
+    @Test(arguments: ["error", " ERROR ", "timeout", " Timeout\n"])
+    func `errors are terminal failures`(_ status: String) {
+        #expect(ChatSendStatus.acceptance(of: status) == .terminalFailure)
+    }
+
+    @Test(arguments: ["started", "in_flight", "queued", "", "  pending  "])
+    func `other statuses remain in flight`(_ status: String) {
+        #expect(ChatSendStatus.acceptance(of: status) == .inFlight)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct QuickChatControllerTests {
+    @Test func `controller lifecycle cleans monitor tokens without UI`() {
+        let snapshots = QuickChatController.exerciseForTesting()
+
+        #expect(snapshots.count == 4)
+        #expect(!snapshots[0].isVisible)
+        #expect(!snapshots[0].hotkeyRegistered)
+        #expect(snapshots[1].isVisible)
+        #expect(snapshots[1].hasGlobalMonitor)
+        #expect(snapshots[1].hasLocalMonitor)
+        #expect(!snapshots[2].isVisible)
+        #expect(!snapshots[2].hasGlobalMonitor)
+        #expect(!snapshots[2].hasLocalMonitor)
+        #expect(!snapshots[3].hotkeyRegistered)
+    }
+
+    @Test func `resign key keeps bar visible while granting permissions`() async {
+        let latch = GrantLatch()
+        let model = QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentIdentityProvider: { _ in .placeholder },
+            sendProvider: { _, _, _ in "ok" },
+            permissionStatusProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, $0 != .notifications) })
+            },
+            permissionGrantProvider: { capabilities in
+                await latch.wait()
+                return Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { .available })
+        let controller = QuickChatController(enableUI: false, model: model, monitoringEnabled: false)
+        controller.present()
+        guard let id = model.activePresentationID else {
+            Issue.record("expected active presentation")
+            return
+        }
+        await model.refreshForPresentation(id: id)
+        #expect(model.missingPermissions == [.notifications])
+
+        model.grantMissingPermissions()
+        #expect(model.isGrantingPermissions)
+        controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        #expect(controller.isVisible)
+
+        latch.finish()
+        while model.isGrantingPermissions {
+            await Task.yield()
+        }
+        controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        #expect(!controller.isVisible)
+        controller.stop()
+    }
+}
+
+@MainActor
+private final class GrantLatch {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var finished = false
+
+    func wait() async {
+        if self.finished { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finish() {
+        self.finished = true
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatModelTests.swift
@@ -1,0 +1,305 @@
+import Foundation
+import OpenClawIPC
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct QuickChatModelTests {
+    @Test(arguments: ["started", "ok", "in_flight"])
+    func `accepted send clears text`(_ status: String) async {
+        let model = self.makeModel(sendStatus: status)
+        await self.prepare(model)
+        model.text = " hello "
+
+        #expect(await model.send())
+        #expect(model.sendState == .sent)
+        #expect(model.text.isEmpty)
+    }
+
+    @Test func `new draft clears sent presentation state`() async {
+        let model = self.makeModel()
+        await self.prepare(model)
+        model.text = "first"
+        #expect(await model.send())
+        #expect(model.sendState == .sent)
+
+        model.text = "second"
+
+        #expect(model.sendState == .idle)
+    }
+
+    @Test(arguments: ["error", "timeout"])
+    func `terminal failure preserves text`(_ status: String) async {
+        let model = self.makeModel(sendStatus: status)
+        await self.prepare(model)
+        model.text = "hello"
+
+        #expect(!(await model.send()))
+        guard case let .failed(message) = model.sendState else {
+            Issue.record("expected failed send state")
+            return
+        }
+        #expect(message.contains(status))
+        #expect(model.text == "hello")
+    }
+
+    @Test func `thrown send error becomes failure`() async {
+        let model = self.makeModel(sendError: FakeSendError.rejected)
+        await self.prepare(model)
+        model.text = "hello"
+
+        #expect(!(await model.send()))
+        #expect(model.sendState == QuickChatSendState.failed("Fake rejection"))
+        #expect(model.text == "hello")
+    }
+
+    @Test func `unchanged draft reuses idempotency key after transport failure`() async {
+        var keys: [String] = []
+        let model = self.makeModel(sendHandler: { _, _, idempotencyKey in
+            keys.append(idempotencyKey)
+            if keys.count == 1 { throw FakeSendError.rejected }
+            return "started"
+        })
+        await self.prepare(model)
+        model.text = "hello"
+
+        #expect(!(await model.send()))
+        #expect(await model.send())
+        #expect(keys.count == 2)
+        #expect(keys[0] == keys[1])
+    }
+
+    @Test func `edited draft gets new idempotency key`() async {
+        var keys: [String] = []
+        let model = self.makeModel(sendHandler: { _, _, idempotencyKey in
+            keys.append(idempotencyKey)
+            throw FakeSendError.rejected
+        })
+        await self.prepare(model)
+        model.text = "first"
+        #expect(!(await model.send()))
+
+        model.text = "second"
+        #expect(!(await model.send()))
+
+        #expect(keys.count == 2)
+        #expect(keys[0] != keys[1])
+    }
+
+    @Test func `empty text does not call gateway`() async {
+        var sendCount = 0
+        let model = self.makeModel(sendHandler: { _, _, _ in
+            sendCount += 1
+            return "ok"
+        })
+        await self.prepare(model)
+        model.text = "  \n "
+
+        #expect(!(await model.send()))
+        #expect(sendCount == 0)
+        #expect(model.sendState == .idle)
+    }
+
+    @Test func `disconnected gateway disables send`() async {
+        var sendCount = 0
+        let model = self.makeModel(
+            gate: .disconnected,
+            sendHandler: { _, _, _ in
+                sendCount += 1
+                return "ok"
+            })
+        await self.prepare(model)
+        model.text = "hello"
+
+        #expect(!model.canSend)
+        #expect(model.connectionStatusMessage == "Gateway disconnected")
+        #expect(!(await model.send()))
+        #expect(sendCount == 0)
+    }
+
+    @Test func `new presentation disables send until session key refreshes`() async {
+        let model = self.makeModel()
+        await self.prepare(model)
+        model.text = "hello"
+        #expect(model.canSend)
+
+        model.endPresentation()
+        _ = model.beginPresentation()
+
+        #expect(model.sessionKey.isEmpty)
+        #expect(!model.canSend)
+    }
+
+    @Test func `dismissal lets dispatched send settle without retry`() async {
+        let latch = SendLatch()
+        let model = self.makeModel(sendHandler: { _, _, _ in
+            try await latch.wait()
+        })
+        await self.prepare(model)
+        model.text = "hello"
+
+        let send = Task { await model.send() }
+        while !latch.started {
+            await Task.yield()
+        }
+        model.endPresentation()
+        latch.finish(with: "started")
+
+        #expect(await send.value)
+        #expect(latch.callCount == 1)
+        #expect(model.text.isEmpty)
+        #expect(model.sendState == .sent)
+    }
+
+    @Test func `cached agent display survives representation for the same session`() async {
+        let model = self.makeModel()
+        await self.prepare(model)
+        #expect(model.agentDisplay.name == "Molty")
+
+        model.endPresentation()
+        _ = model.beginPresentation()
+
+        #expect(model.agentDisplay.name == "Molty")
+    }
+
+    @Test func `routing change resets stale agent display before identity resolves`() async {
+        let keyBox = SessionKeyBox(key: "agent:one:main")
+        let model = QuickChatModel(
+            sessionKeyProvider: { keyBox.key },
+            agentIdentityProvider: { sessionKey in
+                if sessionKey == "agent:two:main" { throw FakeSendError.rejected }
+                return QuickChatAgentDisplay(name: "One", emoji: nil)
+            },
+            sendProvider: { _, _, _ in "ok" },
+            permissionStatusProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            permissionGrantProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { .available })
+        await self.prepare(model)
+        #expect(model.agentDisplay.name == "One")
+
+        model.endPresentation()
+        keyBox.key = "agent:two:main"
+        await self.prepare(model)
+
+        // Identity for the new session failed; the old agent's name must not label sends.
+        #expect(model.agentDisplay == .placeholder)
+        #expect(model.sessionKey == "agent:two:main")
+    }
+
+    @Test func `grant refreshes permission status immediately`() async {
+        let granted = GrantFlag()
+        let model = QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentIdentityProvider: { _ in .placeholder },
+            sendProvider: { _, _, _ in "ok" },
+            permissionStatusProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map {
+                    ($0, granted.value || $0 != .screenRecording)
+                })
+            },
+            permissionGrantProvider: { capabilities in
+                granted.value = true
+                return Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { .available })
+        await self.prepare(model)
+        #expect(model.missingPermissions == [.screenRecording])
+
+        model.grantMissingPermissions()
+        while model.isGrantingPermissions {
+            await Task.yield()
+        }
+
+        #expect(model.missingPermissions.isEmpty)
+        #expect(!model.shouldShowPermissionStrip)
+    }
+
+    @Test func `permission strip tracks missing permissions and session dismissal`() async {
+        let model = self.makeModel(permissionStatus: [
+            .notifications: false,
+            .accessibility: true,
+            .screenRecording: false,
+        ])
+        await self.prepare(model)
+
+        #expect(model.missingPermissions == [.notifications, .screenRecording])
+        #expect(model.shouldShowPermissionStrip)
+        model.dismissPermissionsForSession()
+        #expect(!model.shouldShowPermissionStrip)
+    }
+
+    private func prepare(_ model: QuickChatModel) async {
+        let id = model.beginPresentation()
+        await model.refreshForPresentation(id: id)
+    }
+
+    private func makeModel(
+        gate: QuickChatConnectionGate = .available,
+        sendStatus: String = "ok",
+        sendError: Error? = nil,
+        permissionStatus: [Capability: Bool]? = nil,
+        sendHandler: QuickChatModel.SendProvider? = nil) -> QuickChatModel
+    {
+        QuickChatModel(
+            sessionKeyProvider: { "agent:main:main" },
+            agentIdentityProvider: { _ in QuickChatAgentDisplay(name: "Molty", emoji: "🦞") },
+            sendProvider: sendHandler ?? { _, _, _ in
+                if let sendError { throw sendError }
+                return sendStatus
+            },
+            permissionStatusProvider: { capabilities in
+                permissionStatus ?? Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            permissionGrantProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { gate })
+    }
+}
+
+private enum FakeSendError: LocalizedError {
+    case rejected
+
+    var errorDescription: String? { "Fake rejection" }
+}
+
+@MainActor
+private final class GrantFlag {
+    var value = false
+}
+
+@MainActor
+private final class SessionKeyBox {
+    var key: String
+
+    init(key: String) {
+        self.key = key
+    }
+}
+
+@MainActor
+private final class SendLatch {
+    private var continuation: CheckedContinuation<String, any Error>?
+    private(set) var callCount = 0
+
+    var started: Bool {
+        self.continuation != nil
+    }
+
+    func wait() async throws -> String {
+        self.callCount += 1
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finish(with status: String) {
+        self.continuation?.resume(returning: status)
+        self.continuation = nil
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatPlacementTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatPlacementTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Testing
+@testable import OpenClaw
+
+struct QuickChatPlacementTests {
+    @Test func `centers bar at spotlight height`() {
+        let frame = QuickChatPlacement.barFrame(
+            contentSize: NSSize(width: 620, height: 60),
+            visibleFrame: NSRect(x: 0, y: 0, width: 1000, height: 800))
+
+        #expect(frame == NSRect(x: 190, y: 564, width: 620, height: 60))
+    }
+
+    @Test func `respects visible frame origin`() {
+        let frame = QuickChatPlacement.barFrame(
+            contentSize: NSSize(width: 620, height: 80),
+            visibleFrame: NSRect(x: 1200, y: 40, width: 1400, height: 900))
+
+        #expect(frame.origin.x == 1590)
+        #expect(frame.maxY == 742)
+    }
+
+    @Test func `clamps oversized content to small screen`() {
+        let visible = NSRect(x: 20, y: 30, width: 300, height: 100)
+        let frame = QuickChatPlacement.barFrame(
+            contentSize: NSSize(width: 620, height: 200),
+            visibleFrame: visible)
+
+        #expect(frame == visible)
+    }
+
+    @Test func `zero visible frame returns zero`() {
+        #expect(QuickChatPlacement.barFrame(
+            contentSize: NSSize(width: 620, height: 60),
+            visibleFrame: .zero) == .zero)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatViewSmokeTests.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct QuickChatViewSmokeTests {
+    @Test func `quick chat view builds body`() {
+        let model = QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentIdentityProvider: { _ in QuickChatAgentDisplay(name: "Agent", emoji: nil) },
+            sendProvider: { _, _, _ in "ok" },
+            permissionStatusProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            permissionGrantProvider: { capabilities in
+                Dictionary(uniqueKeysWithValues: capabilities.map { ($0, true) })
+            },
+            connectionGateProvider: { .available })
+        let view = QuickChatView(
+            model: model,
+            onDismiss: {},
+            onSendAccepted: { _ in },
+            onContentHeightChange: { _ in },
+            onTextViewReady: { _ in })
+
+        _ = view.body
+    }
+}

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5381,6 +5381,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 
 - Route: /platforms/mac/webchat
 - Headings:
+  - H2: Quick Chat bar
   - H2: Launch and debugging
   - H2: How it is wired
   - H2: Security surface

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -12,6 +12,7 @@ title: "Menu bar"
 - A root "Context" item opens a submenu with recent sessions instead of expanding them in the root menu.
 - A "Nodes" block in the root menu lists paired **devices** only (from `node.list`), not client/presence entries.
 - A root "Usage" section appears below Context when provider usage snapshots are available, followed by cost details when available.
+- **Quick Chat** opens the floating main-session composer; its current global shortcut appears beside the item.
 
 ## State model
 

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -13,7 +13,13 @@ The full chat window is a native split view:
 - **Window toolbar**: context-usage ring (tokens and session cost, with a compact action), thinking-level picker, model picker, and a session actions menu (new session, refresh, copy session key, export transcript, compact, clear history).
 - **Transcript and composer**: assistant messages render as plain text with an avatar, user messages as accent bubbles. Typing `/` opens slash-command autocomplete backed by `commands.list`, with arrow/Tab/Return/Escape keyboard navigation. Right-click a message to copy it.
 
-The anchored quick-chat panel from the menu bar keeps the compact single-column layout with inline pickers.
+The anchored compact chat panel from the menu bar keeps the compact single-column layout with inline pickers.
+
+## Quick Chat bar
+
+Press Option-Space (⌥Space) or choose **Quick Chat** from the menu bar menu to open a floating composer for the main session. Change the global shortcut with the recorder in **Settings → General → Quick Chat shortcut**.
+
+Quick Chat shows the main session's agent, sends directly to the main session, and leaves replies in the full chat window. Press Return to send, Command-Return to send and open full chat, Shift-Return for a newline, or Escape to dismiss. Clicking outside the bar also dismisses it. When relevant macOS permissions are missing, an attached strip offers **Grant** and **Not now** actions.
 
 - **Local mode**: connects directly to the local Gateway WebSocket.
 - **Remote mode**: forwards the Gateway control port over SSH and uses that tunnel as the data plane.

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -11,6 +11,8 @@ The macOS app is the OpenClaw **menu bar companion**: native tray UI, macOS
 permission prompts, notifications, WebChat, voice input, Canvas, and
 Mac-hosted node tools such as `system.run`.
 
+Use **Quick Chat** for a Spotlight-style main-session composer without opening a full window. Press Option-Space (⌥Space) by default, choose it from the menu bar menu, or record another shortcut in **Settings → General**.
+
 Only need the CLI and Gateway? Start with [Getting started](/start/getting-started).
 
 ## Download
@@ -98,7 +100,7 @@ See [Gateway on macOS](/platforms/mac/bundled-gateway) for manual recovery.
 
 ## What the app owns
 
-- Menu bar status, notifications, health, and WebChat.
+- Menu bar status, notifications, health, WebChat, and the floating Quick Chat bar.
 - macOS permission prompts for screen, microphone, speech, automation, and accessibility.
 - One Mac node that combines native Canvas, camera/screen capture, notifications,
   location, and computer control with the CLI node host's system, browser,


### PR DESCRIPTION
## What Problem This Solves

Sending a quick message to the main-session agent on macOS currently requires opening the full chat window (menu bar → Open Chat) or the dashboard. There is no fast, keyboard-first way to fire off a thought and get back to what you were doing.

## Why This Change Was Made

Adds a **Quick Chat** bar to the macOS app: a Spotlight-style floating composer summoned by a configurable global shortcut (default ⌥Space) or the menu bar item.

- Shows who you're talking to: agent avatar (emoji or fallback symbol) + name fetched via `agent.identity.get`, with a "main session" chip so the routing is explicit.
- Return sends into the main session over the existing `chat.send` path (UUID idempotency key, reused verbatim on ambiguous transport retries so an admitted run is never duplicated). Command-Return sends and opens the full chat window; Shift-Return inserts a newline; Escape, clicking outside, resigning key, or re-pressing the shortcut dismisses.
- When notifications, accessibility, or screen recording are missing, an attached strip below the composer lists them with **Grant** / **Not now**. The bar deliberately avoids `PermissionMonitor` (its 1s poll executes an AppleScript probe against Terminal) and instead does a cheap targeted status poll of just those three capabilities while the bar is visible, so the strip clears live as permissions are granted. Dismissal is suppressed mid-grant so the TCC dialogs don't kill the bar.
- Non-activating key panel (`.nonactivatingPanel` + `canBecomeKey`) so typing works without activating the app — appears on the cursor's screen, top-third, with material background, shadow, and fade+rise animation in / fade-drop out. Panel height animates as the permission strip or multi-line text appears.
- Global shortcut via [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts) 3.0.1 (exact-pinned): Carbon-based, so no Input Monitoring/Accessibility permission is needed, and Settings → General gets a shortcut recorder row.
- Shared `ChatSendStatus` acceptance mapping extracted; `TalkModeRuntime` now uses it instead of private duplicates.
- The status-item-anchored compact panel was previously called "quick chat" in onboarding/docs copy; that wording now says "compact chat panel" and Quick Chat names this feature.

Follow-up (out of scope here): the same bar cross-platform via the Tauri app.

## User Impact

New opt-out-free feature: press ⌥Space (or record another chord in Settings → General, or use the menu bar item) to get a floating composer that sends to the main session. Replies land in the regular chat window. No new TCC permission surface; no config/schema changes; no gateway changes.

Release-note context: `feat(mac): Quick Chat — global-shortcut floating composer for the main session with agent identity and permission guidance`.

## Evidence

Live-tested in a clean macOS 26.5 VM (fresh TCC state, npm-installed gateway, hypervisor-injected keyboard input, host-side screen captures):

| State | Screenshot |
| --- | --- |
| Summoned via ⌥Space — agent identity, main-session chip, permission strip | ![empty](https://gist.githubusercontent.com/steipete/bd16563f5f4f44efd7dbd790af5069e1/raw/quickchat-empty.png) |
| Typed message — send button enabled | ![typed](https://gist.githubusercontent.com/steipete/bd16563f5f4f44efd7dbd790af5069e1/raw/quickchat-typed.png) |
| After Return — accepted, checkmark, text cleared, auto-dismisses | ![sent](https://gist.githubusercontent.com/steipete/bd16563f5f4f44efd7dbd790af5069e1/raw/quickchat-sent.png) |

Full-desktop context shot: [quickchat-desktop.png](https://gist.githubusercontent.com/steipete/bd16563f5f4f44efd7dbd790af5069e1/raw/quickchat-desktop.png)

Verified end to end in the VM:

- Global hotkey consumed and bar presented on the cursor screen (app log: `quick chat present visible={{0, 78}, {1666, 585}} target={{523, 476.3}, {620, 58}}`).
- Typed text lands in the non-activating key panel (not the previously focused app).
- Return → `chat.send` accepted → user turn persisted in the main session store with the bar's idempotency key: `{"role":"user","content":"Ship the release notes draft","idempotencyKey":"04885027-…:user"}` in `~/.openclaw/agents/main/sessions/<id>.jsonl`.
- Permission strip rendered from real missing TCC state (fresh VM, all three missing) and panel height animates when it appears.
- Escape dismisses (log: `quick chat dismiss immediate=false`); re-press toggles.

Local gates (Swift 6.4 toolchain):

- `swift build --package-path apps/macos --product OpenClaw --configuration release` — pass
- `./scripts/lint-swift.sh macos` — 0 violations
- `./scripts/format-swift.sh macos` — 0 files need formatting
- `git diff --check` — clean

Unit tests added (placement math, send acceptance mapping, model send/idempotency/permission logic, controller lifecycle + grant-flow dismissal suppression, view smoke). `swift test` for the whole `apps/macos` target does not compile locally on this machine's Xcode-beta (Swift 6.4) due to pre-existing region-isolation errors in untouched `GatewayChannel*` test files — the macos-swift CI lane on the stable toolchain is the authoritative test run for this PR.
