### PR TITLE
fix(cli): guard secrets plan JSON.parse against malformed input

### DIFF
--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -125,12 +125,15 @@ function createSecretsApplyResult(options?: {
   };
 }
 
-async function withPlanFile(run: (planPath: string) => Promise<void>) {
+async function withPlanFile(
+  run: (planPath: string) => Promise<void>,
+  contents = `${JSON.stringify(createManualSecretsPlan())}\n`,
+) {
   const planPath = path.join(
     os.tmpdir(),
     `openclaw-secrets-cli-test-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
   );
-  await fs.writeFile(planPath, `${JSON.stringify(createManualSecretsPlan())}\n`, "utf8");
+  await fs.writeFile(planPath, contents, "utf8");
   try {
     await run(planPath);
   } finally {
@@ -386,19 +389,14 @@ describe("secrets CLI", () => {
   });
 
   it("shows a user-friendly error when the secrets plan file is malformed JSON", async () => {
-    const planPath = path.join(
-      os.tmpdir(),
-      `openclaw-secrets-cli-test-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
-    );
-    await fs.writeFile(planPath, "{invalid json", "utf8");
-    try {
-      await createProgram().parseAsync(["secrets", "apply", "--from", planPath], { from: "user" });
-    } catch {
-      // exitOverride converts exit(1) to CommanderError
-    }
-    expect(defaultRuntime.error).toHaveBeenCalledWith(
-      expect.stringContaining("Malformed JSON in secrets plan file:"),
-    );
+    await withPlanFile(async (planPath) => {
+      await expect(
+        createProgram().parseAsync(["secrets", "apply", "--from", planPath], { from: "user" }),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runtimeErrors.at(-1)).toContain(`Malformed JSON in secrets plan file: ${planPath}`);
+      expect(runSecretsApply).not.toHaveBeenCalled();
+    }, "{invalid json");
   });
 
   it("does not print skipped-exec note when apply dry-run skippedExecRefs is zero", async () => {

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -385,6 +385,22 @@ describe("secrets CLI", () => {
     });
   });
 
+  it("shows a user-friendly error when the secrets plan file is malformed JSON", async () => {
+    const planPath = path.join(
+      os.tmpdir(),
+      `openclaw-secrets-cli-test-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+    );
+    await fs.writeFile(planPath, "{invalid json", "utf8");
+    try {
+      await createProgram().parseAsync(["secrets", "apply", "--from", planPath], { from: "user" });
+    } catch {
+      // exitOverride converts exit(1) to CommanderError
+    }
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Malformed JSON in secrets plan file:"),
+    );
+  });
+
   it("does not print skipped-exec note when apply dry-run skippedExecRefs is zero", async () => {
     await withPlanFile(async (planPath) => {
       runSecretsApply.mockResolvedValue(createSecretsApplyResult({ resolvabilityComplete: false }));

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -53,7 +53,12 @@ async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
     import("../secrets/plan.js"),
   ]);
   const raw = readFileSync(pathname, "utf8");
-  const parsed = JSON.parse(raw) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Malformed JSON in secrets plan file: ${pathname}`, { cause: err });
+  }
   if (!isSecretsApplyPlan(parsed)) {
     throw new Error(
       `Invalid secrets plan file: ${pathname}. Generate a fresh plan with ${formatCliCommand("openclaw secrets configure --plan-out <path>")}.`,


### PR DESCRIPTION
## What Problem This Solves

`readPlanFile()` in `src/cli/secrets-cli.ts` reads a user-specified plan file and calls `JSON.parse()` on it without a try-catch. If the file is malformed (corrupted on disk, truncated, or hand-edited), the raw `SyntaxError` is not user-actionable.

This follows the established pattern from #98660 (solodmd) and #98587 (lsr911) for guarding JSON.parse against malformed input.

## Evidence

### Test

- `src/cli/secrets-cli.test.ts` — 16 tests pass, including 1 new test:
  - "shows a user-friendly error when the secrets plan file is malformed JSON" — verifies that malformed JSON produces a message containing "Malformed JSON in secrets plan file:" instead of a raw SyntaxError

### CI

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

## Merge Risk

Low. +6 lines in a private helper function, throws a descriptive Error with the malformed JSON cause preserved via `{ cause: err }`.