### PR TITLE
perf(test): poll subagent lifecycle state faster

### DIFF
--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -26,6 +26,10 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 type LifecycleControllerParams = Parameters<typeof createSubagentRegistryLifecycleController>[0];
 
+function waitForLifecycleState<T>(assertion: () => T | Promise<T>): Promise<T> {
+  return vi.waitFor(assertion, { interval: 1 });
+}
+
 const taskExecutorMocks = vi.hoisted(() => ({
   completeTaskRunByRunId: vi.fn(),
   failTaskRunByRunId: vi.fn(),
@@ -319,7 +323,7 @@ describe("subagent registry lifecycle hardening", () => {
       triggerCleanup: true,
     });
 
-    await vi.waitFor(() =>
+    await waitForLifecycleState(() =>
       expect(
         browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd,
       ).toHaveBeenCalledOnce(),
@@ -328,12 +332,12 @@ describe("subagent registry lifecycle hardening", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(1);
 
     releaseBrowserCleanup?.();
-    await vi.waitFor(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
+    await waitForLifecycleState(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
     await completion;
     expect(getActiveGatewayRootWorkCount()).toBe(1);
 
     releaseAnnounce?.(true);
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
     expect(entry.cleanupCompletedAt).toBeTypeOf("number");
   });
 
@@ -358,11 +362,11 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(releaseDelete).toBeTypeOf("function"));
+    await waitForLifecycleState(() => expect(releaseDelete).toBeTypeOf("function"));
     expect(getActiveGatewayRootWorkCount()).toBe(1);
 
     releaseDelete?.();
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
     expect(runs.has(entry.runId)).toBe(false);
   });
 
@@ -394,11 +398,11 @@ describe("subagent registry lifecycle hardening", () => {
         reason: SUBAGENT_ENDED_REASON_COMPLETE,
         triggerCleanup: true,
       });
-      await vi.waitFor(() => expect(releaseBrowserCleanup).toBeTypeOf("function"));
+      await waitForLifecycleState(() => expect(releaseBrowserCleanup).toBeTypeOf("function"));
       markGatewayRestartDraining();
       releaseBrowserCleanup?.();
       await completion;
-      await vi.waitFor(() =>
+      await waitForLifecycleState(() =>
         expect(runtimeMocks.log).toHaveBeenCalledWith(
           expect.stringContaining("subagent cleanup admission failed"),
         ),
@@ -408,8 +412,8 @@ describe("subagent registry lifecycle hardening", () => {
 
       resetGatewayWorkAdmission();
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
-      await vi.waitFor(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+      await waitForLifecycleState(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
+      await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
       expect(resumeSubagentRun).toHaveBeenCalledWith(entry.runId);
       expect(getActiveGatewayRootWorkCount()).toBe(0);
     } finally {
@@ -503,7 +507,7 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: false,
     });
-    await vi.waitFor(() => expect(finishCapture).toBeTypeOf("function"));
+    await waitForLifecycleState(() => expect(finishCapture).toBeTypeOf("function"));
     const interruptedRecovery = controller.completeSubagentRun({
       runId: entry.runId,
       endedAt: 4_001,
@@ -1064,7 +1068,9 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: false,
     });
-    await vi.waitFor(() => expect(captureSubagentCompletionReply).toHaveBeenCalledOnce());
+    await waitForLifecycleState(() =>
+      expect(captureSubagentCompletionReply).toHaveBeenCalledOnce(),
+    );
     const killed = controller.completeSubagentRun({
       runId: entry.runId,
       endedAt: 4_001,
@@ -1127,7 +1133,7 @@ describe("subagent registry lifecycle hardening", () => {
         }),
       ).toBe(true);
       finishAnnounce?.(true);
-      await vi.waitFor(() => expect(entry.pauseReason).toBe("sessions_yield"));
+      await waitForLifecycleState(() => expect(entry.pauseReason).toBe("sessions_yield"));
 
       expect(runs.get(entry.runId)).toBe(entry);
       expect(entry.cleanupHandled).toBe(false);
@@ -1160,14 +1166,14 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(entry.deleteCleanupDispatchedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() => expect(entry.deleteCleanupDispatchedAt).toBeTypeOf("number"));
 
     expect(markSubagentRunPausedAfterYield({ entry, endedAt: 4_001 })).toBe(false);
     expect(entry.pauseReason).toBeUndefined();
     expect(entry.endedReason).toBe(SUBAGENT_ENDED_REASON_COMPLETE);
 
     releaseDelete?.();
-    await vi.waitFor(() => expect(runs.has(entry.runId)).toBe(false));
+    await waitForLifecycleState(() => expect(runs.has(entry.runId)).toBe(false));
   });
 
   it("rejects a yield after announce cleanup hands off delete dispatch", async () => {
@@ -1190,14 +1196,14 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(entry.deleteCleanupDispatchedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() => expect(entry.deleteCleanupDispatchedAt).toBeTypeOf("number"));
 
     expect(markSubagentRunPausedAfterYield({ entry, endedAt: 4_001 })).toBe(false);
     expect(entry.pauseReason).toBeUndefined();
     expect(entry.endedReason).toBe(SUBAGENT_ENDED_REASON_COMPLETE);
 
     releaseAnnounce?.();
-    await vi.waitFor(() => expect(runs.has(entry.runId)).toBe(false));
+    await waitForLifecycleState(() => expect(runs.has(entry.runId)).toBe(false));
   });
 
   it("discards completion capture when an authoritative yield arrives during the await", async () => {
@@ -1221,7 +1227,9 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(captureSubagentCompletionReply).toHaveBeenCalledOnce());
+    await waitForLifecycleState(() =>
+      expect(captureSubagentCompletionReply).toHaveBeenCalledOnce(),
+    );
     expect(markSubagentRunPausedAfterYield({ entry, endedAt: 4_001 })).toBe(true);
     finishCapture?.("stale pre-yield reply");
     await completion;
@@ -1260,7 +1268,9 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_KILLED,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledOnce());
+    await waitForLifecycleState(() =>
+      expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledOnce(),
+    );
     const success = controller.completeSubagentRun({
       runId: entry.runId,
       endedAt: 4_001,
@@ -1268,7 +1278,7 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() =>
+    await waitForLifecycleState(() =>
       expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledTimes(2),
     );
     releaseKilledTiming?.();
@@ -1317,7 +1327,7 @@ describe("subagent registry lifecycle hardening", () => {
       triggerCleanup: true,
     });
 
-    await vi.waitFor(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
     expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
     expect(entry.delivery?.status).toBe("not_required");
     expect(entry.suppressCompletionDelivery).toBeUndefined();
@@ -1626,7 +1636,7 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(captureSubagentCompletionReply).toHaveBeenCalled());
+    await waitForLifecycleState(() => expect(captureSubagentCompletionReply).toHaveBeenCalled());
     expect(entry).toMatchObject({
       endedAt: 4_000,
       endedReason: SUBAGENT_ENDED_REASON_KILLED,
@@ -1682,7 +1692,9 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_KILLED,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalled());
+    await waitForLifecycleState(() =>
+      expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalled(),
+    );
 
     cancellationStable = true;
     await controller.completeSubagentRun({
@@ -1944,7 +1956,7 @@ describe("subagent registry lifecycle hardening", () => {
       triggerCleanup: true,
     });
 
-    await vi.waitFor(() => {
+    await waitForLifecycleState(() => {
       expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith({
         runId: "run-before-replacement",
         runtime: "subagent",
@@ -2009,7 +2021,7 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(captureSubagentCompletionReply).toHaveBeenCalled());
+    await waitForLifecycleState(() => expect(captureSubagentCompletionReply).toHaveBeenCalled());
     const newer = createRunEntry({ runId: "run-2", createdAt: 5_000, startedAt: 5_000 });
     runs.set(newer.runId, newer);
     finishCapture?.("new generation result");
@@ -2045,7 +2057,9 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledOnce());
+    await waitForLifecycleState(() =>
+      expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledOnce(),
+    );
     const newer = createRunEntry({
       runId: "run-same-millisecond-newer",
       generation: 2,
@@ -2352,7 +2366,7 @@ describe("subagent registry lifecycle hardening", () => {
       }),
     ).resolves.toBeUndefined();
 
-    await vi.waitFor(() => expect(entry.delivery?.announcedAt).toBe(12_300));
+    await waitForLifecycleState(() => expect(entry.delivery?.announcedAt).toBe(12_300));
     expect(entry.delivery?.enqueuedAt).toBe(4_100);
     expect(entry.delivery?.deliveredAt).toBe(12_300);
     expect(entry.delivery?.lastDropReason).toBeUndefined();
@@ -2393,7 +2407,7 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
     const newer = createRunEntry({
       runId: "run-2",
       childSessionKey: entry.childSessionKey,
@@ -2403,10 +2417,12 @@ describe("subagent registry lifecycle hardening", () => {
 
     onDeliveryResult?.({ delivered: false, path: "none" });
 
-    await vi.waitFor(() => expect(retireSupersededRun).toHaveBeenCalledWith(entry.runId, entry));
+    await waitForLifecycleState(() =>
+      expect(retireSupersededRun).toHaveBeenCalledWith(entry.runId, entry),
+    );
     expect(getActiveGatewayRootWorkCount()).toBe(1);
     releaseRetirement();
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("finalizes terminal visible-send failures without scheduling completion retry", async () => {
@@ -2440,7 +2456,7 @@ describe("subagent registry lifecycle hardening", () => {
       }),
     ).resolves.toBeUndefined();
 
-    await vi.waitFor(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
     expect(entry.delivery?.status).toBe("delivered");
     expect(entry.delivery?.lastError).toBeUndefined();
     expect(entry.delivery?.payload).toBeUndefined();
@@ -2480,7 +2496,7 @@ describe("subagent registry lifecycle hardening", () => {
     expect(browserCleanupArg.onWarn).toBeTypeOf("function");
     expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
     expect(hasDeliveredTaskStatusUpdate(entry.runId)).toBe(false);
-    await vi.waitFor(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
     expect(entry.delivery?.status).toBe("not_required");
     expect(entry.delivery?.announcedAt).toBeUndefined();
   });
@@ -2512,7 +2528,7 @@ describe("subagent registry lifecycle hardening", () => {
       }),
     ).resolves.toBeUndefined();
 
-    await vi.waitFor(() =>
+    await waitForLifecycleState(() =>
       expect(gatewayMocks.callGateway).toHaveBeenCalledWith({
         method: "sessions.delete",
         params: {
@@ -2525,7 +2541,7 @@ describe("subagent registry lifecycle hardening", () => {
     );
     expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
     expect(hasDeliveredTaskStatusUpdate(entry.runId)).toBe(false);
-    await vi.waitFor(() => expect(runs.has(entry.runId)).toBe(false));
+    await waitForLifecycleState(() => expect(runs.has(entry.runId)).toBe(false));
     expect(entry.delivery?.announcedAt).toBeUndefined();
   });
 
@@ -2551,7 +2567,9 @@ describe("subagent registry lifecycle hardening", () => {
     });
     runs.set(newer.runId, newer);
 
-    await vi.waitFor(() => expect(retireSupersededRun).toHaveBeenCalledWith(entry.runId, entry));
+    await waitForLifecycleState(() =>
+      expect(retireSupersededRun).toHaveBeenCalledWith(entry.runId, entry),
+    );
     expect(runs.get(newer.runId)).toBe(newer);
     expect(gatewayMocks.callGateway).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: "sessions.delete" }),
@@ -2867,7 +2885,7 @@ describe("subagent registry lifecycle hardening", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(emitSubagentEndedHookForRun).toHaveBeenCalled());
+    await waitForLifecycleState(() => expect(emitSubagentEndedHookForRun).toHaveBeenCalled());
     runs.set(
       "run-2",
       createRunEntry({
@@ -3162,7 +3180,7 @@ describe("subagent registry lifecycle hardening", () => {
   it("credits only current-run requester delivery mirrors before retrying NO_REPLY", async () => {
     const entry = await runNoReplyMirrorScenario({ timestamp: 12_345 });
 
-    await vi.waitFor(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
     expect(gatewayMocks.callGateway).toHaveBeenCalledWith({
       method: "chat.history",
       params: { sessionKey: entry.requesterSessionKey, limit: 25, maxChars: 128 * 1024 },
@@ -3183,7 +3201,9 @@ describe("subagent registry lifecycle hardening", () => {
       text: "long completion reply ".repeat(500),
     });
 
-    await vi.waitFor(() => expect(longMirrorEntry.cleanupCompletedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() =>
+      expect(longMirrorEntry.cleanupCompletedAt).toBeTypeOf("number"),
+    );
     expect(longMirrorEntry.delivery?.deliveredAt).toBe(12_345);
     expect(gatewayMocks.callGateway).toHaveBeenCalledWith({
       method: "chat.history",
@@ -3199,7 +3219,7 @@ describe("subagent registry lifecycle hardening", () => {
         `${buildExpectedAnnounceIdempotencyKey(candidate)}:message-tool:internal-source-reply:0`,
     });
 
-    await vi.waitFor(() =>
+    await waitForLifecycleState(() =>
       expect(messageToolAnnounceEntry.cleanupCompletedAt).toBeTypeOf("number"),
     );
     expect(messageToolAnnounceEntry.delivery?.deliveredAt).toBe(12_345);
@@ -3211,7 +3231,9 @@ describe("subagent registry lifecycle hardening", () => {
       idempotencyKeyForEntry: (candidate) => `${candidate.runId}:message-tool:1`,
     });
 
-    await vi.waitFor(() => expect(childRunMirrorEntry.cleanupCompletedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() =>
+      expect(childRunMirrorEntry.cleanupCompletedAt).toBeTypeOf("number"),
+    );
     expect(childRunMirrorEntry.delivery?.deliveredAt).toBe(12_345);
 
     vi.clearAllMocks();
@@ -3219,7 +3241,9 @@ describe("subagent registry lifecycle hardening", () => {
     gatewayMocks.callGateway.mockResolvedValue({});
     const staleEntry = await runNoReplyMirrorScenario({ timestamp: 1_999 });
 
-    await vi.waitFor(() => expect(staleEntry.delivery?.suspendedAt).toBeTypeOf("number"));
+    await waitForLifecycleState(() =>
+      expect(staleEntry.delivery?.suspendedAt).toBeTypeOf("number"),
+    );
     expect(staleEntry.delivery?.deliveredAt).toBeUndefined();
     expect(staleEntry.delivery?.announcedAt).toBeUndefined();
     expect(staleEntry.delivery?.lastError).toBe("completion agent did not produce a visible reply");
@@ -3252,7 +3276,7 @@ describe("subagent registry lifecycle hardening", () => {
       )}:internal-source-reply:0`,
     });
 
-    await vi.waitFor(() =>
+    await waitForLifecycleState(() =>
       expect(sameWindowSiblingEntry.delivery?.suspendedAt).toBeTypeOf("number"),
     );
     expect(sameWindowSiblingEntry.delivery?.deliveredAt).toBeUndefined();
@@ -3404,7 +3428,9 @@ describe("subagent registry lifecycle hardening", () => {
     };
 
     const firstCompletion = controller.completeSubagentRun(completeParams);
-    await vi.waitFor(() => expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledOnce());
+    await waitForLifecycleState(() =>
+      expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledOnce(),
+    );
     entry.endedHookEmittedAt = 4_000;
 
     await controller.completeSubagentRun(completeParams);
@@ -3521,7 +3547,7 @@ describe("requester settle wake trigger", () => {
       completedAt: 5_000,
     });
 
-    await vi.waitFor(() => expect(settleWake).toHaveBeenCalledTimes(2));
+    await waitForLifecycleState(() => expect(settleWake).toHaveBeenCalledTimes(2));
     expect(settleWake.mock.calls.map(([params]) => params.settledEntry.runId)).toEqual([
       "run-first",
       "run-later",
@@ -3552,7 +3578,7 @@ describe("requester settle wake trigger", () => {
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       triggerCleanup: true,
     });
-    await vi.waitFor(() => expect(settleWake).toHaveBeenCalledTimes(1));
+    await waitForLifecycleState(() => expect(settleWake).toHaveBeenCalledTimes(1));
 
     // Delete-mode keeps the canonical row and result until the durable wake
     // outbox reaches success or a terminal/no-wake disposition.
@@ -3816,7 +3842,7 @@ describe("requester settle wake trigger", () => {
       }),
     ).not.toThrow();
 
-    return vi.waitFor(() => {
+    return waitForLifecycleState(() => {
       expect(warn).toHaveBeenCalledWith("requester settle wake failed", expect.anything());
     });
   });
@@ -3849,7 +3875,7 @@ describe("requester settle wake trigger", () => {
         });
       });
       expect(settleWake).toHaveBeenCalledTimes(1);
-      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
+      await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
 
       // A restart drain arriving between scheduling and the wake's gateway
       // turn must wait for the wake instead of reporting quiescence.
@@ -3857,7 +3883,7 @@ describe("requester settle wake trigger", () => {
       expect((await waitForActiveGatewayRootWork(25)).drained).toBe(false);
 
       releaseWake?.();
-      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       expect((await waitForActiveGatewayRootWork(1_000)).drained).toBe(true);
     } finally {
       resetGatewayWorkAdmission();


### PR DESCRIPTION
## What Problem This Solves

The subagent registry lifecycle suite used Vitest's 50 ms default polling interval in 46 asynchronous state assertions. The repeated latency accumulated across the 100-test file.

## Why This Change Was Made

Route those existing assertions through a test-local helper with a 1 ms interval while preserving Vitest's default timeout, callback result, and every assertion.

## User Impact

No user-visible or production behavior changes. Controlled same-Testbox median test-body time drops from 1.35 seconds to 0.18 seconds.

## Evidence

- Before: 1.49/1.34/1.35 seconds; median 1.35 seconds.
- After: 0.20/0.17/0.18 seconds; median 0.18 seconds (about 87% faster).
- Testbox `tbx_01kxqc7ewemhwgy8s0vp1argpy`: 100/100 tests passed across all three final comparison runs.
- Same Testbox: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed.
- Autoreview: clean, 0.98 confidence.
