### PR TITLE
fix(browser): stop agent-launched managed Chrome

### DIFF
--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -11,11 +11,18 @@ import { WebSocketServer } from "ws";
 import { rawDataToString } from "../infra/ws.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
+    execFileSync: (...args: unknown[]) => {
+      const mock = execFileSyncMock.getMockImplementation();
+      return mock
+        ? mock(...args)
+        : (actual.execFileSync as unknown as (...actualArgs: unknown[]) => unknown)(...args);
+    },
     spawn: (...args: unknown[]) => spawnMock(...args),
   };
 });
@@ -65,6 +72,7 @@ import {
   launchOpenClawChrome,
   ManagedChromeCleanupError,
   resolveOpenClawUserDataDir,
+  stopOwnedOpenClawChrome,
 } from "./chrome.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import { BROWSER_ERROR_REASONS, BrowserProfileUnavailableError } from "./errors.js";
@@ -339,6 +347,7 @@ describe("chrome.ts internal", () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     spawnMock.mockReset();
+    execFileSyncMock.mockReset();
     ensurePortAvailableMock.mockReset();
     ensurePortAvailableMock.mockImplementation(async () => {});
     registerManagedProxyBrowserCdpBypassMock.mockReset();
@@ -1102,6 +1111,103 @@ describe("chrome.ts internal", () => {
               expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
               expect(fs.existsSync(path.join(userDataDir, "SingletonSocket"))).toBe(false);
               running.proc.kill?.("SIGTERM");
+            } finally {
+              await fsp.rm(userDataDir, { recursive: true, force: true });
+            }
+          },
+        });
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
+    });
+
+    it("stops a managed Chrome launched by another process on macOS", async () => {
+      const originalPlatform = process.platform;
+      const executablePath = path.join(tmpDir, "chrome");
+      await fsp.writeFile(executablePath, "");
+      const existsSync = fs.existsSync.bind(fs);
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return existsSync(p);
+      });
+
+      const managedPid = 43213;
+      let managedProcessAlive = true;
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid, signal) => {
+        if (pid !== managedPid) {
+          return true;
+        }
+        if (signal === 0) {
+          if (managedProcessAlive) {
+            return true;
+          }
+          const err = new Error("no such process") as NodeJS.ErrnoException;
+          err.code = "ESRCH";
+          throw err;
+        }
+        return true;
+      }) as typeof process.kill);
+
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      try {
+        await withMockChromeCdpServer({
+          wsPath: "/devtools/browser/CROSS_PROCESS_OWNER",
+          onConnection: (wss) => {
+            wss.on("connection", (ws) => {
+              ws.on("message", (raw) => {
+                const message = JSON.parse(rawDataToString(raw)) as {
+                  id: number;
+                  method: string;
+                };
+                if (message.method === "SystemInfo.getProcessInfo") {
+                  ws.send(
+                    JSON.stringify({
+                      id: message.id,
+                      result: { processInfo: [{ type: "browser", id: managedPid }] },
+                    }),
+                  );
+                  return;
+                }
+                expect(message.method).toBe("Browser.close");
+                managedProcessAlive = false;
+                ws.send(JSON.stringify({ id: message.id, result: {} }));
+              });
+            });
+          },
+          run: async (baseUrl) => {
+            const port = Number(new URL(baseUrl).port);
+            const profile = {
+              ...makeProfile(port),
+              cdpUrl: baseUrl,
+              driver: "openclaw",
+              executablePath,
+            } as ResolvedBrowserProfile;
+            const userDataDir = resolveOpenClawUserDataDir(profile.name);
+            execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+              if (command === "ps" && args.includes("command=")) {
+                return `${executablePath} --remote-debugging-port=${port} --user-data-dir=${userDataDir}\n`;
+              }
+              if (command === "ps" && args.includes("lstart=")) {
+                return "Fri Jul 17 12:00:00 2026\n";
+              }
+              if (command === "lsof") {
+                return `p${managedPid}\n`;
+              }
+              throw new Error(`unexpected command: ${command}`);
+            });
+            await fsp.mkdir(userDataDir, { recursive: true });
+            await fsp.symlink(
+              `${os.hostname()}-${managedPid}`,
+              path.join(userDataDir, "SingletonLock"),
+            );
+
+            try {
+              await expect(stopOwnedOpenClawChrome(makeResolved(), profile)).resolves.toBe(true);
+              expect(killSpy).not.toHaveBeenCalledWith(managedPid, "SIGTERM");
+              expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
             } finally {
               await fsp.rm(userDataDir, { recursive: true, force: true });
             }

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -3,7 +3,7 @@ import { execFile } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
-import { createServer } from "node:http";
+import { Agent, createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -13,11 +13,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
+    execFileSync: (...args: unknown[]) => {
+      const mock = execFileSyncMock.getMockImplementation();
+      return mock
+        ? mock(...args)
+        : (actual.execFileSync as unknown as (...actualArgs: unknown[]) => unknown)(...args);
+    },
     spawn: (...args: unknown[]) => spawnMock(...args),
   };
 });
@@ -67,6 +74,7 @@ import {
   launchOpenClawChrome,
   ManagedChromeCleanupError,
   resolveOpenClawUserDataDir,
+  stopOwnedOpenClawChrome,
 } from "./chrome.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import { BROWSER_ERROR_REASONS, BrowserProfileUnavailableError } from "./errors.js";
@@ -401,6 +409,7 @@ describe("chrome.ts internal", () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     spawnMock.mockReset();
+    execFileSyncMock.mockReset();
     ensurePortAvailableMock.mockReset();
     ensurePortAvailableMock.mockImplementation(async () => {});
     registerManagedProxyBrowserCdpBypassMock.mockReset();
@@ -1251,6 +1260,116 @@ describe("chrome.ts internal", () => {
               expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
               expect(fs.existsSync(path.join(userDataDir, "SingletonSocket"))).toBe(false);
               running.proc.kill?.("SIGTERM");
+            } finally {
+              await fsp.rm(userDataDir, { recursive: true, force: true });
+            }
+          },
+        });
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
+    });
+
+    it("stops a managed Chrome from another runtime through a pinned CDP connection", async () => {
+      const originalPlatform = process.platform;
+      const executablePath = path.join(tmpDir, "chrome");
+      await fsp.writeFile(executablePath, "");
+      const existsSync = fs.existsSync.bind(fs);
+      vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
+        const value = String(candidate);
+        return (
+          value.endsWith("Local State") || value.endsWith("Preferences") || existsSync(candidate)
+        );
+      });
+
+      const managedPid = 43213;
+      let managedProcessAlive = true;
+      let processStartTime = "Fri Jul 17 12:00:00 2026";
+      let rotateProcessIdentity = true;
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid, signal) => {
+        if (pid === managedPid && signal === 0 && !managedProcessAlive) {
+          const error = new Error("no such process") as NodeJS.ErrnoException;
+          error.code = "ESRCH";
+          throw error;
+        }
+        return true;
+      }) as typeof process.kill);
+      const connectionSpy = vi.spyOn(Agent.prototype, "createConnection");
+
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      try {
+        await withMockChromeCdpServer({
+          wsPath: "/devtools/browser/CROSS_PROCESS_OWNER",
+          onConnection: (server) => {
+            server.on("connection", (socket) => {
+              socket.on("message", (raw) => {
+                const message = JSON.parse(rawDataToString(raw)) as {
+                  id: number;
+                  method: string;
+                };
+                if (message.method === "SystemInfo.getProcessInfo") {
+                  if (rotateProcessIdentity) {
+                    processStartTime = "Fri Jul 17 12:01:00 2026";
+                    rotateProcessIdentity = false;
+                  }
+                  socket.send(
+                    JSON.stringify({
+                      id: message.id,
+                      result: { processInfo: [{ type: "browser", id: managedPid }] },
+                    }),
+                  );
+                  return;
+                }
+                expect(message.method).toBe("Browser.close");
+                managedProcessAlive = false;
+                socket.send(JSON.stringify({ id: message.id, result: {} }));
+              });
+            });
+          },
+          run: async (baseUrl) => {
+            const port = Number(new URL(baseUrl).port);
+            const profile = {
+              ...makeProfile(port),
+              cdpUrl: baseUrl,
+              driver: "openclaw",
+              executablePath,
+            } as ResolvedBrowserProfile;
+            const userDataDir = resolveOpenClawUserDataDir(profile.name);
+            execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+              if (command === "ps" && args.includes("command=")) {
+                return `${executablePath} --remote-debugging-port=${port} --user-data-dir=${userDataDir}\n`;
+              }
+              if (command === "ps" && args.includes("lstart=")) {
+                return `${processStartTime}\n`;
+              }
+              if (command === "lsof") {
+                return `p${managedPid}\n`;
+              }
+              throw new Error(`unexpected command: ${command}`);
+            });
+            await fsp.mkdir(userDataDir, { recursive: true });
+            await fsp.symlink(
+              `${os.hostname()}-${managedPid}`,
+              path.join(userDataDir, "SingletonLock"),
+            );
+
+            try {
+              const resolved = makeResolved({
+                ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+              });
+              await expect(stopOwnedOpenClawChrome(resolved, profile)).resolves.toBe(false);
+              expect(managedProcessAlive).toBe(true);
+              expect(killSpy).not.toHaveBeenCalledWith(managedPid, "SIGTERM");
+              await expect(
+                fsp.lstat(path.join(userDataDir, "SingletonLock")),
+              ).resolves.toBeTruthy();
+
+              await expect(stopOwnedOpenClawChrome(resolved, profile)).resolves.toBe(true);
+              expect(
+                connectionSpy.mock.calls.some(([options]) => typeof options.lookup === "function"),
+              ).toBe(true);
+              expect(killSpy).not.toHaveBeenCalledWith(managedPid, "SIGTERM");
+              expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
             } finally {
               await fsp.rm(userDataDir, { recursive: true, force: true });
             }

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -1379,19 +1379,22 @@ export async function isChromeCdpOwnedByPid(
   }
 }
 
-async function requestGracefulChromeClose(
-  running: RunningChrome,
-  timeoutMs: number,
-): Promise<boolean> {
+async function requestGracefulChromeClose(params: {
+  cdpUrl: string;
+  pid: number;
+  timeoutMs: number;
+  ssrfPolicy?: SsrFPolicy;
+}): Promise<boolean> {
   const commandTimeoutMs = Math.max(
     1,
-    Math.min(timeoutMs, CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS),
+    Math.min(params.timeoutMs, CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS),
   );
   let commandSent = false;
   try {
     const wsUrl = await getChromeWebSocketUrl(
-      cdpUrlForPort(running.cdpPort),
+      params.cdpUrl,
       Math.min(commandTimeoutMs, CHROME_STOP_PROBE_TIMEOUT_MS),
+      params.ssrfPolicy,
     );
     if (!wsUrl) {
       return false;
@@ -1402,7 +1405,7 @@ async function requestGracefulChromeClose(
         // The fixed port can be rebound while this handle remains retained.
         // Never ask a replacement browser to close on behalf of the old child.
         const processInfo = await send("SystemInfo.getProcessInfo");
-        if (!cdpProcessListOwnsBrowser(processInfo, running.pid)) {
+        if (!cdpProcessListOwnsBrowser(processInfo, params.pid)) {
           return;
         }
         commandSent = true;
@@ -1423,6 +1426,59 @@ async function requestGracefulChromeClose(
   }
 }
 
+/** Stop the exact managed Chrome owned by a profile, even without its launch handle. */
+export async function stopOwnedOpenClawChrome(
+  resolved: ResolvedBrowserConfig,
+  profile: ResolvedBrowserProfile,
+  timeoutMs = CHROME_STOP_TIMEOUT_MS,
+): Promise<boolean> {
+  if (!profile.cdpIsLoopback || profile.attachOnly || profile.driver !== "openclaw") {
+    return false;
+  }
+  let exe: BrowserExecutable | null;
+  try {
+    exe = resolveBrowserExecutable(resolved, profile);
+  } catch {
+    return false;
+  }
+  if (!exe) {
+    return false;
+  }
+  const userDataDir = resolveOpenClawUserDataDir(profile.name);
+  const pid = readCurrentHostSingletonPid(userDataDir);
+  if (pid == null) {
+    return false;
+  }
+  const identity = readOwnedManagedChromeIdentity({ pid, exe, profile, userDataDir });
+  if (!identity) {
+    return false;
+  }
+
+  // Browser runtimes can live in separate Node processes, so this stopper may
+  // lack the launch handle. Re-prove exact process identity before any signal.
+  const gracefulCloseRequested = await requestGracefulChromeClose({
+    cdpUrl: profile.cdpUrl,
+    pid,
+    timeoutMs,
+    ssrfPolicy: resolved.ssrfPolicy,
+  });
+  if (gracefulCloseRequested && (await waitForPidExit(pid, timeoutMs))) {
+    clearRecoveredChromeSingletonArtifacts(userDataDir, pid);
+    return true;
+  }
+  if (!processExists(pid)) {
+    clearRecoveredChromeSingletonArtifacts(userDataDir, pid);
+    return true;
+  }
+  if (
+    !(await terminateOwnedStaleChromeProcess({ identity, exe, profile, userDataDir }, timeoutMs))
+  ) {
+    return false;
+  }
+  clearRecoveredChromeSingletonArtifacts(userDataDir, pid);
+  return true;
+}
+
 /** Stop a managed Chrome process and wait for shutdown. */
 export async function stopOpenClawChrome(
   running: RunningChrome,
@@ -1438,7 +1494,11 @@ export async function stopOpenClawChrome(
   // Gateway shutdown/restart awaits the Browser plugin stop chain into this
   // method. Browser.close keeps cookies in Chromium's protected profile;
   // signals remain a bounded fallback without duplicating credentials.
-  const gracefulCloseRequested = await requestGracefulChromeClose(running, timeoutMs);
+  const gracefulCloseRequested = await requestGracefulChromeClose({
+    cdpUrl: cdpUrlForPort(running.cdpPort),
+    pid: running.pid,
+    timeoutMs,
+  });
   if (gracefulCloseRequested && (await waitForChromeProcessExit(proc, timeoutMs))) {
     return;
   }

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -1351,8 +1351,10 @@ export async function isChromeCdpOwnedByPid(
 }
 
 async function requestGracefulChromeClose(
-  running: RunningChrome,
+  running: Pick<RunningChrome, "pid" | "cdpPort">,
   timeoutMs: number,
+  ssrfPolicy?: SsrFPolicy,
+  ownsCurrentProcess?: () => boolean,
 ): Promise<boolean> {
   const commandTimeoutMs = Math.max(
     1,
@@ -1363,6 +1365,7 @@ async function requestGracefulChromeClose(
     const endpoint = await getChromeWebSocketEndpoint(
       cdpUrlForPort(running.cdpPort),
       Math.min(commandTimeoutMs, CHROME_STOP_PROBE_TIMEOUT_MS),
+      ssrfPolicy,
     );
     if (!endpoint) {
       return false;
@@ -1373,7 +1376,10 @@ async function requestGracefulChromeClose(
         // The fixed port can be rebound while this handle remains retained.
         // Never ask a replacement browser to close on behalf of the old child.
         const processInfo = await send("SystemInfo.getProcessInfo");
-        if (!cdpProcessListOwnsBrowser(processInfo, running.pid)) {
+        if (
+          !cdpProcessListOwnsBrowser(processInfo, running.pid) ||
+          (ownsCurrentProcess && !ownsCurrentProcess())
+        ) {
           return;
         }
         commandSent = true;
@@ -1393,6 +1399,59 @@ async function requestGracefulChromeClose(
     // command was sent, still give it time to flush the profile and exit.
     return commandSent;
   }
+}
+
+/** Stop only the exact managed Chrome owned by this profile across runtimes. */
+export async function stopOwnedOpenClawChrome(
+  resolved: ResolvedBrowserConfig,
+  profile: ResolvedBrowserProfile,
+  timeoutMs = CHROME_STOP_TIMEOUT_MS,
+): Promise<boolean> {
+  if (!profile.cdpIsLoopback || profile.attachOnly || profile.driver !== "openclaw") {
+    return false;
+  }
+
+  let exe: BrowserExecutable | null;
+  try {
+    exe = resolveBrowserExecutable(resolved, profile);
+  } catch {
+    return false;
+  }
+  if (!exe) {
+    return false;
+  }
+
+  const userDataDir = resolveOpenClawUserDataDir(profile.name);
+  const pid = readCurrentHostSingletonPid(userDataDir);
+  if (pid == null) {
+    return false;
+  }
+  const identity = readOwnedManagedChromeIdentity({ pid, exe, profile, userDataDir });
+  if (!identity) {
+    return false;
+  }
+
+  // Browser runtimes do not share child handles; revalidate the exact process
+  // before either CDP close or signal-based cleanup can affect a replacement.
+  const gracefulCloseRequested = await requestGracefulChromeClose(
+    { pid, cdpPort: profile.cdpPort },
+    timeoutMs,
+    resolved.ssrfPolicy,
+    () => {
+      const current = readOwnedManagedChromeIdentity({ pid, exe, profile, userDataDir });
+      return current !== null && sameManagedChromeIdentity(identity, current);
+    },
+  );
+  const stoppedGracefully = gracefulCloseRequested && (await waitForPidExit(pid, timeoutMs));
+  if (
+    !stoppedGracefully &&
+    isPidAlive(pid) &&
+    !(await terminateOwnedStaleChromeProcess({ identity, exe, profile, userDataDir }, timeoutMs))
+  ) {
+    return false;
+  }
+  clearRecoveredChromeSingletonArtifacts(userDataDir, pid);
+  return true;
 }
 
 /** Stop a managed Chrome process and wait for shutdown. */

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -19,6 +19,7 @@ import {
   isChromeReachable,
   launchOpenClawChrome,
   ManagedChromeCleanupError,
+  stopOwnedOpenClawChrome,
   stopOpenClawChrome,
 } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
@@ -584,14 +585,24 @@ export function createProfileAvailability({
   };
 
   const stopRunningBrowser = async (): Promise<{ stopped: boolean }> => {
-    assertProfileLifecycleContext({ state: state(), runtime, configRevision });
+    const current = state();
+    assertProfileLifecycleContext({ state: current, runtime, configRevision });
     resetManagedLaunchFailure(runtime);
+    let stoppedOwnedProcess = false;
     const result = await beginProfileTransition({
-      state: state(),
+      state: current,
       runtime,
       reason: "stop requested",
+      afterCleanup: async () => {
+        if (profile.attachOnly || capabilities.mode !== "local-managed") {
+          return;
+        }
+        stoppedOwnedProcess = await stopOwnedOpenClawChrome(current.resolved, profile);
+      },
     });
-    return { stopped: result.stopped || profile.attachOnly || capabilities.isRemote };
+    return {
+      stopped: result.stopped || stoppedOwnedProcess || profile.attachOnly || capabilities.isRemote,
+    };
   };
 
   return {

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -22,6 +22,7 @@ import {
   isChromeReachable,
   launchOpenClawChrome,
   ManagedChromeCleanupError,
+  stopOwnedOpenClawChrome,
   stopOpenClawChrome,
 } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
@@ -624,14 +625,24 @@ export function createProfileAvailability({
   };
 
   const stopRunningBrowser = async (): Promise<{ stopped: boolean }> => {
-    assertProfileLifecycleContext({ state: state(), runtime, configRevision });
+    const current = state();
+    assertProfileLifecycleContext({ state: current, runtime, configRevision });
     resetManagedLaunchFailure(runtime);
+    let stoppedOwnedProcess = false;
     const result = await beginProfileTransition({
-      state: state(),
+      state: current,
       runtime,
       reason: "stop requested",
+      afterCleanup: async () => {
+        if (profile.attachOnly || capabilities.mode !== "local-managed") {
+          return;
+        }
+        stoppedOwnedProcess = await stopOwnedOpenClawChrome(current.resolved, profile);
+      },
     });
-    return { stopped: result.stopped || profile.attachOnly || capabilities.isRemote };
+    return {
+      stopped: result.stopped || stoppedOwnedProcess || profile.attachOnly || capabilities.isRemote,
+    };
   };
 
   return {

--- a/extensions/browser/src/browser/server-context.chrome-test-harness.ts
+++ b/extensions/browser/src/browser/server-context.chrome-test-harness.ts
@@ -41,5 +41,6 @@ vi.mock("./chrome.js", () => ({
     throw new Error("unexpected launch");
   }),
   resolveOpenClawUserDataDir: vi.fn(() => chromeUserDataDir.dir),
+  stopOwnedOpenClawChrome: vi.fn(async () => false),
   stopOpenClawChrome: vi.fn(async () => {}),
 }));

--- a/extensions/browser/src/browser/server-context.stop-running-browser.test.ts
+++ b/extensions/browser/src/browser/server-context.stop-running-browser.test.ts
@@ -18,6 +18,10 @@ const pwAiMocks = vi.hoisted(() => {
   };
 });
 
+const chromeMocks = vi.hoisted(() => ({
+  stopOwnedOpenClawChrome: vi.fn(async () => false),
+}));
+
 vi.mock("./pw-ai.js", () => ({ pwAi: pwAiMocks }));
 vi.mock("./chrome.js", () => ({
   isChromeCdpOwnedByPid: vi.fn(async () => true),
@@ -27,6 +31,7 @@ vi.mock("./chrome.js", () => ({
     throw new Error("unexpected launch");
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw-test"),
+  stopOwnedOpenClawChrome: chromeMocks.stopOwnedOpenClawChrome,
   stopOpenClawChrome: vi.fn(async () => {}),
 }));
 vi.mock("./chrome-mcp.js", () => ({
@@ -38,6 +43,7 @@ vi.mock("./chrome-mcp.js", () => ({
 
 afterEach(() => {
   vi.clearAllMocks();
+  chromeMocks.stopOwnedOpenClawChrome.mockResolvedValue(false);
 });
 
 function createStopHarness(profile: ReturnType<typeof makeBrowserProfile>) {
@@ -78,6 +84,16 @@ describe("createProfileAvailability.stopRunningBrowser", () => {
     const { profileCtx } = createStopHarness(profile);
 
     await expect(profileCtx.stopRunningBrowser()).resolves.toEqual({ stopped: false });
+    expect(pwAiMocks.closePlaywrightBrowserConnection).not.toHaveBeenCalled();
+  });
+
+  it("stops a local managed profile launched by another browser runtime", async () => {
+    chromeMocks.stopOwnedOpenClawChrome.mockResolvedValue(true);
+    const profile = makeBrowserProfile();
+    const { profileCtx } = createStopHarness(profile);
+
+    await expect(profileCtx.stopRunningBrowser()).resolves.toEqual({ stopped: true });
+    expect(chromeMocks.stopOwnedOpenClawChrome).toHaveBeenCalledOnce();
     expect(pwAiMocks.closePlaywrightBrowserConnection).not.toHaveBeenCalled();
   });
 });

--- a/extensions/browser/src/browser/server-context.stop-running-browser.test.ts
+++ b/extensions/browser/src/browser/server-context.stop-running-browser.test.ts
@@ -18,6 +18,10 @@ const pwAiMocks = vi.hoisted(() => {
   };
 });
 
+const chromeMocks = vi.hoisted(() => ({
+  stopOwnedOpenClawChrome: vi.fn(async () => false),
+}));
+
 vi.mock("./pw-ai.js", () => ({ pwAi: pwAiMocks }));
 vi.mock("./chrome.js", () => ({
   isChromeCdpOwnedByPid: vi.fn(async () => true),
@@ -27,6 +31,7 @@ vi.mock("./chrome.js", () => ({
     throw new Error("unexpected launch");
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw-test"),
+  stopOwnedOpenClawChrome: chromeMocks.stopOwnedOpenClawChrome,
   stopOpenClawChrome: vi.fn(async () => {}),
 }));
 vi.mock("./chrome-mcp.js", () => ({
@@ -38,6 +43,7 @@ vi.mock("./chrome-mcp.js", () => ({
 
 afterEach(() => {
   vi.clearAllMocks();
+  chromeMocks.stopOwnedOpenClawChrome.mockResolvedValue(false);
 });
 
 function createStopHarness(profile: ReturnType<typeof makeBrowserProfile>) {
@@ -58,6 +64,7 @@ describe("createProfileAvailability.stopRunningBrowser", () => {
 
     await expect(profileCtx.stopRunningBrowser()).resolves.toEqual({ stopped: true });
     expect(pwAiMocks.closePlaywrightBrowserConnection).not.toHaveBeenCalled();
+    expect(chromeMocks.stopOwnedOpenClawChrome).not.toHaveBeenCalled();
   });
 
   it("stops an unused remote CDP profile without loading Playwright", async () => {
@@ -71,6 +78,7 @@ describe("createProfileAvailability.stopRunningBrowser", () => {
 
     await expect(profileCtx.stopRunningBrowser()).resolves.toEqual({ stopped: true });
     expect(pwAiMocks.closePlaywrightBrowserConnection).not.toHaveBeenCalled();
+    expect(chromeMocks.stopOwnedOpenClawChrome).not.toHaveBeenCalled();
   });
 
   it("keeps never-started local managed profiles as not stopped", async () => {
@@ -80,4 +88,26 @@ describe("createProfileAvailability.stopRunningBrowser", () => {
     await expect(profileCtx.stopRunningBrowser()).resolves.toEqual({ stopped: false });
     expect(pwAiMocks.closePlaywrightBrowserConnection).not.toHaveBeenCalled();
   });
+
+  it("stops a local managed browser launched by another runtime", async () => {
+    chromeMocks.stopOwnedOpenClawChrome.mockResolvedValue(true);
+    const profile = makeBrowserProfile();
+    const { profileCtx } = createStopHarness(profile);
+
+    await expect(profileCtx.stopRunningBrowser()).resolves.toEqual({ stopped: true });
+    expect(chromeMocks.stopOwnedOpenClawChrome).toHaveBeenCalledOnce();
+    expect(pwAiMocks.closePlaywrightBrowserConnection).not.toHaveBeenCalled();
+  });
+
+  it.each(["existing-session", "extension"] as const)(
+    "does not attempt to terminate a personal %s browser",
+    async (driver) => {
+      const profile = makeBrowserProfile({ driver });
+      const { profileCtx } = createStopHarness(profile);
+
+      await profileCtx.stopRunningBrowser();
+
+      expect(chromeMocks.stopOwnedOpenClawChrome).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -530,6 +530,7 @@ vi.mock("./chrome.js", () => ({
     };
   }),
   resolveOpenClawUserDataDir: vi.fn(() => chromeUserDataDir.dir),
+  stopOwnedOpenClawChrome: vi.fn(async () => false),
   stopOpenClawChrome: vi.fn(async () => {
     state.reachable = false;
   }),


### PR DESCRIPTION
Closes #109678

## What Problem This Solves

An OpenClaw-managed Chrome browser launched by an agent can belong to a different browser runtime than the one handling `openclaw browser stop`. The stopping runtime has no retained child-process handle, so the stop operation reports failure while Chrome and its DevTools listener remain alive.

## Why This Change Was Made

Recover and stop the exact locally managed Chrome inside the existing serialized profile lifecycle transition. Process ownership requires the current-host profile singleton, live PID, configured browser executable, exact user-data directory and DevTools port, listening-socket ownership, process start identity, and matching browser-reported PID. The graceful DevTools socket retains the current DNS-pinned endpoint transport, then synchronously revalidates the complete process identity immediately before `Browser.close`; signal escalation separately revalidates identity before every signal.

Attach-only, remote, existing-session/Chrome-MCP, and browser-extension profiles never enter this managed-process recovery path. Existing retained process handles keep their canonical shutdown flow.

## User Impact

`openclaw browser stop` now shuts down an agent-launched managed Chrome even when another runtime owns its launch handle, while preserving personal, attach-only, and remote browsers.

## Evidence

- Confirmed the owner-boundary regression failed on current `main`: the new cross-runtime stop test expected `stopped: true` but received `stopped: false`.
- Confirmed the DNS-pinning regression independently fails when the DevTools socket's pinned lookup is removed.
- Confirmed the PID-recycling regression independently fails when immediate process-identity revalidation is removed: the replacement browser is incorrectly closed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/cdp.helpers.internal.test.ts extensions/browser/src/browser/server-context.stop-running-browser.test.ts extensions/browser/src/browser/server-context.existing-session.test.ts` — **150 passed, 1 skipped**.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/cdp.helpers.internal.test.ts extensions/browser/src/browser/server-context.stop-running-browser.test.ts extensions/browser/src/browser/server-context.existing-session.test.ts` — **213 passed, 1 skipped**, including both originally failing CI suites.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/browser` — **193 passed, 2 skipped test files; 2,727 passed, 6 skipped tests** across the complete changed-browser CI shard.
- `node scripts/run-tsgo.mjs -p extensions/browser/tsconfig.json --noEmit` — passed.
- Targeted typed oxlint, oxfmt, and `git diff --check` — passed.
- Fresh structured Codex review and independent owner-boundary security review — no remaining findings.

The first exact-head CI run exposed two older shared Chrome test harnesses that had not yet exported the new lifecycle helper. Both canonical test doubles now model the no-owned-browser case directly; the production implementation and security invariants were unchanged, and the original failing suites plus the entire affected browser shard pass.

Real isolated macOS Chrome proof against the current implementation:

```text
BASELINE_MANAGED_STOP stopped=false process=ALIVE listener=OPEN
REAL_MACOS_MANAGED before=OPEN stopped=true process=EXITED listener=CLOSED
REAL_MACOS_ATTACH_ONLY before=OPEN stopped=true process=ALIVE listener=OPEN
FINAL_REAL_MACOS_MANAGED stopped=true process=EXITED listener=CLOSED
```

Both Chrome processes used temporary OpenClaw-owned profiles and randomly allocated loopback DevTools ports; all proof processes and temporary state were cleaned up. The managed-process recovery is currently available only on macOS and Linux, where existing executable, argument, process-start, and listener-ownership proof is supported.

Thanks to @NianJiuZst for the original owner-boundary fix and reproduction. Both repair commits preserve the contributor's co-author credit.
