### PR TITLE
feat(codex): surface native questions and goals

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -227,9 +227,12 @@ cwd creates a fresh approval.
 
 Codex MCP tool approval elicitations route through OpenClaw's plugin approval
 flow when Codex marks `_meta.codex_approval_kind` as `"mcp_tool_call"`. Codex
-`request_user_input` prompts are sent back to the originating chat, and the
-next queued follow-up message answers that native server request instead of
-being steered as extra context. Other MCP elicitation requests fail closed.
+`request_user_input` prompts are sent back to the originating chat. A single
+non-secret choice uses typed channel buttons when the channel supports them,
+and the Control UI shows non-secret questions as a structured card. The next
+queued follow-up message answers that native server request instead of being
+steered as extra context. Secret questions stay on the warned text-reply path.
+Other MCP elicitation requests fail closed.
 
 For the general plugin approval flow that carries these prompts, see
 [Plugin permission requests](/plugins/plugin-permission-requests).

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -293,6 +293,7 @@ Keep provider refs and runtime policy separate:
 | Attach the current chat                                    | `/codex bind [thread-id] [--cwd <path>] [--model <model>] [--provider <provider>]`                    |
 | Resume an existing Codex thread                            | `/codex resume <thread-id>`                                                                           |
 | List or filter Codex threads                               | `/codex threads [filter]`                                                                             |
+| Read or update the bound thread's native goal              | `/codex goal [status\|start <objective>\|edit <objective>\|pause\|resume\|block\|complete\|clear]`    |
 | List native Codex plugins                                  | `/codex plugins list`                                                                                 |
 | Enable or disable a configured native Codex plugin         | `/codex plugins enable <name>`, `/codex plugins disable <name>`                                       |
 | Resume a stored Codex CLI session as a paired-node turn    | `/codex sessions --host <node> [filter]`, then `/codex resume <session-id> --host <node> --bind here` |
@@ -495,7 +496,8 @@ Native execution and control require an owner or an `operator.admin`
 Gateway client: binding or resuming threads, sending or stopping turns,
 changing model, fast-mode, or permission state, compacting or reviewing, and
 detaching a binding. Other authorized senders keep read-only status, help,
-account, model, thread, MCP server, skill, and binding inspection commands.
+account, model, thread, native goal, MCP server, skill, and binding inspection
+commands.
 
 Common forms:
 
@@ -503,6 +505,7 @@ Common forms:
   limits, MCP servers, and skills.
 - `/codex models` lists live Codex app-server models.
 - `/codex threads [filter]` lists recent Codex app-server threads.
+- `/codex goal` reads or updates the attached thread's native Codex goal.
 - `/codex resume <thread-id>` attaches the current OpenClaw session to an
   existing Codex thread.
 - `/codex bind [thread-id] [--cwd <path>] [--model <model>] [--provider <provider>]`
@@ -629,7 +632,9 @@ normal user-home state.
 Codex dynamic tools default to `searchable` loading. OpenClaw normally does
 not expose dynamic tools that duplicate Codex-native workspace operations:
 `read`, `write`, `edit`, `apply_patch`, `exec`, `process`, `update_plan`,
-`tool_call`, `tool_describe`, `tool_search`, and `tool_search_code`. Most
+`get_goal`, `create_goal`, `update_goal`, `tool_call`, `tool_describe`,
+`tool_search`, and `tool_search_code`. Goal operations stay native to Codex,
+so OpenClaw does not project a second goal store into Codex turns. Most
 remaining OpenClaw integration tools, such as messaging, media, cron,
 browser, nodes, gateway, and `heartbeat_respond`, are available through
 Codex tool search under the `openclaw` namespace, keeping the initial model

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -293,7 +293,7 @@ Keep provider refs and runtime policy separate:
 | Attach the current chat                                    | `/codex bind [thread-id] [--cwd <path>] [--model <model>] [--provider <provider>]`                    |
 | Resume an existing Codex thread                            | `/codex resume <thread-id>`                                                                           |
 | List or filter Codex threads                               | `/codex threads [filter]`                                                                             |
-| Read or update the bound thread's native goal              | `/codex goal [status\|start <objective>\|edit <objective>\|pause\|resume\|block\|complete\|clear]`    |
+| Read or update the bound thread's native goal              | `/codex goal [status\|set <objective>\|pause\|resume\|block\|complete\|clear]`                        |
 | List native Codex plugins                                  | `/codex plugins list`                                                                                 |
 | Enable or disable a configured native Codex plugin         | `/codex plugins enable <name>`, `/codex plugins disable <name>`                                       |
 | Resume a stored Codex CLI session as a paired-node turn    | `/codex sessions --host <node> [filter]`, then `/codex resume <session-id> --host <node> --bind here` |
@@ -505,7 +505,7 @@ Common forms:
   limits, MCP servers, and skills.
 - `/codex models` lists live Codex app-server models.
 - `/codex threads [filter]` lists recent Codex app-server threads.
-- `/codex goal` reads or updates the attached thread's native Codex goal.
+- `/codex goal` reads or updates the attached thread's native Codex goal. Codex automatic goal continuation stays disabled; OpenClaw does not own autonomous follow-on turns yet.
 - `/codex resume <thread-id>` attaches the current OpenClaw session to an
   existing Codex thread.
 - `/codex bind [thread-id] [--cwd <path>] [--model <model>] [--provider <provider>]`

--- a/extensions/codex/src/app-server/capabilities.ts
+++ b/extensions/codex/src/app-server/capabilities.ts
@@ -20,6 +20,9 @@ export const CODEX_CONTROL_METHODS = {
   resumeThread: "thread/resume",
   review: "review/start",
   unarchiveThread: "thread/unarchive",
+  getThreadGoal: "thread/goal/get",
+  setThreadGoal: "thread/goal/set",
+  clearThreadGoal: "thread/goal/clear",
 } as const;
 
 type CodexControlName = keyof typeof CODEX_CONTROL_METHODS;

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -192,6 +192,9 @@ describe("Codex app-server dynamic tool build", () => {
       "exec",
       "process",
       "update_plan",
+      "get_goal",
+      "create_goal",
+      "update_goal",
       "tool_call",
       "tool_describe",
       "tool_search",
@@ -503,7 +506,9 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it("exposes app-server-owned tools directly for forced private QA Codex runtime", () => {
-    const tools = ["read", "write", "image_generate", "message"].map((name) => ({ name }));
+    const tools = ["read", "write", "get_goal", "image_generate", "message"].map((name) => ({
+      name,
+    }));
     const privateQaCodexEnv = {
       OPENCLAW_BUILD_PRIVATE_QA: "1",
       OPENCLAW_QA_FORCE_RUNTIME: "codex",

--- a/extensions/codex/src/app-server/dynamic-tool-profile.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-profile.ts
@@ -21,6 +21,7 @@ const CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES = [
   "tool_search",
   "tool_search_code",
 ] as const;
+const CODEX_NATIVE_GOAL_TOOL_EXCLUDES = ["get_goal", "create_goal", "update_goal"] as const;
 const CODEX_APP_SERVER_OWNED_SHELL_TOOL_EXCLUDES = new Set(["exec", "process"]);
 
 const DYNAMIC_TOOL_NAME_ALIASES: Record<string, string> = {
@@ -138,6 +139,9 @@ function filterCodexDynamicToolsWithOptions<T extends { name: string }>(
   options: { preserveOpenClawShell: boolean },
 ): T[] {
   const excludes = new Set<string>();
+  for (const name of CODEX_NATIVE_GOAL_TOOL_EXCLUDES) {
+    excludes.add(name);
+  }
   if (!isForcedPrivateQaCodexRuntime(env)) {
     for (const name of CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES) {
       if (options.preserveOpenClawShell && CODEX_APP_SERVER_OWNED_SHELL_TOOL_EXCLUDES.has(name)) {

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -256,7 +256,7 @@ export type CodexThreadResumeResponse = {
   modelProvider?: string | null;
 };
 
-export type CodexThreadGoalStatus =
+type CodexThreadGoalStatus =
   | "active"
   | "paused"
   | "blocked"
@@ -264,7 +264,7 @@ export type CodexThreadGoalStatus =
   | "budgetLimited"
   | "complete";
 
-export type CodexThreadGoal = {
+type CodexThreadGoal = {
   threadId: string;
   objective: string;
   status: CodexThreadGoalStatus;

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -256,6 +256,38 @@ export type CodexThreadResumeResponse = {
   modelProvider?: string | null;
 };
 
+export type CodexThreadGoalStatus =
+  | "active"
+  | "paused"
+  | "blocked"
+  | "usageLimited"
+  | "budgetLimited"
+  | "complete";
+
+export type CodexThreadGoal = {
+  threadId: string;
+  objective: string;
+  status: CodexThreadGoalStatus;
+  tokenBudget: number | null;
+  tokensUsed: number;
+  timeUsedSeconds: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type CodexThreadGoalSetParams = JsonObject & {
+  threadId: string;
+  objective?: string;
+  status?: CodexThreadGoalStatus;
+  tokenBudget?: number | null;
+};
+
+type CodexThreadGoalGetParams = JsonObject & { threadId: string };
+type CodexThreadGoalClearParams = JsonObject & { threadId: string };
+type CodexThreadGoalSetResponse = { goal: CodexThreadGoal };
+type CodexThreadGoalGetResponse = { goal: CodexThreadGoal | null };
+type CodexThreadGoalClearResponse = { cleared: boolean };
+
 type CodexThreadInjectItemsParams = JsonObject & {
   threadId: string;
   items: JsonValue[];
@@ -702,6 +734,9 @@ type CodexAppServerRequestParamsOverride = {
   "thread/start": CodexThreadStartParams;
   "thread/unarchive": CodexThreadArchiveParams;
   "thread/unsubscribe": CodexThreadUnsubscribeParams;
+  "thread/goal/set": CodexThreadGoalSetParams;
+  "thread/goal/get": CodexThreadGoalGetParams;
+  "thread/goal/clear": CodexThreadGoalClearParams;
   "turn/interrupt": CodexTurnInterruptParams;
 };
 
@@ -739,6 +774,9 @@ type CodexAppServerRequestResultMap = {
   "thread/start": CodexThreadStartResponse;
   "thread/unarchive": CodexThreadUnarchiveResponse;
   "thread/unsubscribe": JsonValue;
+  "thread/goal/set": CodexThreadGoalSetResponse;
+  "thread/goal/get": CodexThreadGoalGetResponse;
+  "thread/goal/clear": CodexThreadGoalClearResponse;
   "turn/interrupt": JsonValue;
   "turn/start": CodexTurnStartResponse;
   "turn/steer": JsonValue;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -79,8 +79,10 @@ describe("Codex ring-zero thread config", () => {
       cwd: "/repo",
       dynamicTools: [],
       hostSystemAgentActive: false,
+      config: { "features.goals": false },
     });
     expect(normal.baseInstructions).toBeUndefined();
+    expect(normal.config?.["features.goals"]).toBe(true);
   });
 });
 
@@ -638,6 +640,7 @@ describe("Codex app-server native code mode config", () => {
       },
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.goals": true,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -782,6 +785,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.goals": true,
       "features.apply_patch_streaming_events": true,
       "features.multi_agent": false,
       "features.standalone_web_search": false,
@@ -893,6 +897,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": true,
+      "features.goals": true,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -914,6 +919,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": true,
+      "features.goals": true,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -971,6 +977,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.goals": true,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -995,6 +1002,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": false,
       "features.code_mode_only": false,
+      "features.goals": true,
       "features.standalone_web_search": false,
       web_search: "disabled",
     });
@@ -1014,6 +1022,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": false,
       "features.code_mode_only": false,
+      "features.goals": true,
       "features.standalone_web_search": false,
       web_search: "disabled",
     });
@@ -1043,6 +1052,7 @@ describe("Codex app-server native code mode config", () => {
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.goals": true,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -1066,6 +1076,7 @@ describe("Codex app-server native code mode config", () => {
       project_doc_max_bytes: 64_000,
       "features.code_mode": true,
       "features.code_mode_only": false,
+      "features.goals": true,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -1218,6 +1229,7 @@ describe("Codex app-server turn params", () => {
       config: {
         "features.code_mode": true,
         "features.code_mode_only": false,
+        "features.goals": true,
         "features.apply_patch_streaming_events": true,
         "features.standalone_web_search": false,
         web_search: "cached",

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -79,10 +79,10 @@ describe("Codex ring-zero thread config", () => {
       cwd: "/repo",
       dynamicTools: [],
       hostSystemAgentActive: false,
-      config: { "features.goals": false },
+      config: { "features.goals": true },
     });
     expect(normal.baseInstructions).toBeUndefined();
-    expect(normal.config?.["features.goals"]).toBe(true);
+    expect(normal.config?.["features.goals"]).toBe(false);
   });
 });
 
@@ -640,7 +640,7 @@ describe("Codex app-server native code mode config", () => {
       },
       "features.code_mode": true,
       "features.code_mode_only": false,
-      "features.goals": true,
+      "features.goals": false,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -785,7 +785,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
-      "features.goals": true,
+      "features.goals": false,
       "features.apply_patch_streaming_events": true,
       "features.multi_agent": false,
       "features.standalone_web_search": false,
@@ -897,7 +897,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": true,
-      "features.goals": true,
+      "features.goals": false,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -919,7 +919,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": true,
-      "features.goals": true,
+      "features.goals": false,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -977,7 +977,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": false,
-      "features.goals": true,
+      "features.goals": false,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -1002,7 +1002,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": false,
       "features.code_mode_only": false,
-      "features.goals": true,
+      "features.goals": false,
       "features.standalone_web_search": false,
       web_search: "disabled",
     });
@@ -1022,7 +1022,7 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": false,
       "features.code_mode_only": false,
-      "features.goals": true,
+      "features.goals": false,
       "features.standalone_web_search": false,
       web_search: "disabled",
     });
@@ -1052,7 +1052,7 @@ describe("Codex app-server native code mode config", () => {
       "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": false,
-      "features.goals": true,
+      "features.goals": false,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -1076,7 +1076,7 @@ describe("Codex app-server native code mode config", () => {
       project_doc_max_bytes: 64_000,
       "features.code_mode": true,
       "features.code_mode_only": false,
-      "features.goals": true,
+      "features.goals": false,
       "features.apply_patch_streaming_events": true,
       "features.standalone_web_search": false,
       web_search: "cached",
@@ -1229,7 +1229,7 @@ describe("Codex app-server turn params", () => {
       config: {
         "features.code_mode": true,
         "features.code_mode_only": false,
-        "features.goals": true,
+        "features.goals": false,
         "features.apply_patch_streaming_events": true,
         "features.standalone_web_search": false,
         web_search: "cached",

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -87,7 +87,7 @@ describe("Codex ring-zero thread config", () => {
 });
 
 describe("Codex delegation capability", () => {
-  it("disables native delegation on start and resume without disabling other tools", () => {
+  it("disables native delegation and goal continuation on start and resume", () => {
     const params = createAttemptParams({ provider: "openai" });
     params.delegationCapability = "report_only";
     const appServer = createAppServerOptions() as never;
@@ -112,7 +112,7 @@ describe("Codex delegation capability", () => {
     for (const request of [start, resume]) {
       expect(request.config?.["features.multi_agent"]).toBe(false);
       expect(request.config?.["features.multi_agent_v2"]).toBe(false);
-      expect(request.config?.["features.goals"]).toBe(true);
+      expect(request.config?.["features.goals"]).toBe(false);
     }
   });
 });

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -38,8 +38,8 @@ const CODEX_CODE_MODE_THREAD_CONFIG: JsonObject = {
   "features.apply_patch_streaming_events": true,
 };
 
-const CODEX_NATIVE_PROTOCOL_THREAD_CONFIG: JsonObject = {
-  "features.goals": true,
+const CODEX_GOAL_CONTINUATION_DISABLED_THREAD_CONFIG: JsonObject = {
+  "features.goals": false,
 };
 
 const CODEX_CODE_MODE_DISABLED_THREAD_CONFIG: JsonObject = {
@@ -269,8 +269,8 @@ export function buildCodexRuntimeThreadConfig(
     directOnlyToolNamespaces?: readonly string[];
   } = {},
 ): JsonObject {
-  // Native goals replace OpenClaw's projected goal tools for Codex turns.
-  // Keep this final in normal config merges so the model never loses both surfaces.
+  // Native goal RPCs remain available through app-server, but the Codex goals
+  // feature also starts autonomous turns. Keep it disabled until a run owner exists.
   const codeModeConfig: JsonObject = {
     ...CODEX_CODE_MODE_THREAD_CONFIG,
     "features.code_mode_only": options.nativeCodeModeOnlyEnabled === true,
@@ -279,7 +279,7 @@ export function buildCodexRuntimeThreadConfig(
     const disabledConfig = mergeCodexThreadConfigs(
       config,
       CODEX_CODE_MODE_DISABLED_THREAD_CONFIG,
-      CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
+      CODEX_GOAL_CONTINUATION_DISABLED_THREAD_CONFIG,
     ) ?? {
       ...CODEX_CODE_MODE_DISABLED_THREAD_CONFIG,
     };
@@ -292,13 +292,13 @@ export function buildCodexRuntimeThreadConfig(
     const merged = mergeCodexThreadConfigs(
       codeModeConfig,
       config,
-      CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
+      CODEX_GOAL_CONTINUATION_DISABLED_THREAD_CONFIG,
       {
         "features.code_mode_only": true,
       },
     ) ?? {
       ...codeModeConfig,
-      ...CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
+      ...CODEX_GOAL_CONTINUATION_DISABLED_THREAD_CONFIG,
       "features.code_mode_only": true,
     };
     return ensureDirectOnlyToolNamespaces(merged, options.directOnlyToolNamespaces);
@@ -306,10 +306,10 @@ export function buildCodexRuntimeThreadConfig(
   const merged = mergeCodexThreadConfigs(
     codeModeConfig,
     config,
-    CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
+    CODEX_GOAL_CONTINUATION_DISABLED_THREAD_CONFIG,
   ) ?? {
     ...codeModeConfig,
-    ...CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
+    ...CODEX_GOAL_CONTINUATION_DISABLED_THREAD_CONFIG,
   };
   return ensureDirectOnlyToolNamespaces(merged, options.directOnlyToolNamespaces);
 }

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -38,6 +38,10 @@ const CODEX_CODE_MODE_THREAD_CONFIG: JsonObject = {
   "features.apply_patch_streaming_events": true,
 };
 
+const CODEX_NATIVE_PROTOCOL_THREAD_CONFIG: JsonObject = {
+  "features.goals": true,
+};
+
 const CODEX_CODE_MODE_DISABLED_THREAD_CONFIG: JsonObject = {
   "features.code_mode": false,
   "features.code_mode_only": false,
@@ -265,6 +269,8 @@ export function buildCodexRuntimeThreadConfig(
     directOnlyToolNamespaces?: readonly string[];
   } = {},
 ): JsonObject {
+  // Native goals replace OpenClaw's projected goal tools for Codex turns.
+  // Keep this final in normal config merges so the model never loses both surfaces.
   const codeModeConfig: JsonObject = {
     ...CODEX_CODE_MODE_THREAD_CONFIG,
     "features.code_mode_only": options.nativeCodeModeOnlyEnabled === true,
@@ -273,6 +279,7 @@ export function buildCodexRuntimeThreadConfig(
     const disabledConfig = mergeCodexThreadConfigs(
       config,
       CODEX_CODE_MODE_DISABLED_THREAD_CONFIG,
+      CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
     ) ?? {
       ...CODEX_CODE_MODE_DISABLED_THREAD_CONFIG,
     };
@@ -282,16 +289,27 @@ export function buildCodexRuntimeThreadConfig(
     return disabledConfig;
   }
   if (options.nativeCodeModeOnlyEnabled === true) {
-    const merged = mergeCodexThreadConfigs(codeModeConfig, config, {
-      "features.code_mode_only": true,
-    }) ?? {
+    const merged = mergeCodexThreadConfigs(
+      codeModeConfig,
+      config,
+      CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
+      {
+        "features.code_mode_only": true,
+      },
+    ) ?? {
       ...codeModeConfig,
+      ...CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
       "features.code_mode_only": true,
     };
     return ensureDirectOnlyToolNamespaces(merged, options.directOnlyToolNamespaces);
   }
-  const merged = mergeCodexThreadConfigs(codeModeConfig, config) ?? {
+  const merged = mergeCodexThreadConfigs(
+    codeModeConfig,
+    config,
+    CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
+  ) ?? {
     ...codeModeConfig,
+    ...CODEX_NATIVE_PROTOCOL_THREAD_CONFIG,
   };
   return ensureDirectOnlyToolNamespaces(merged, options.directOnlyToolNamespaces);
 }

--- a/extensions/codex/src/app-server/user-input-actions.ts
+++ b/extensions/codex/src/app-server/user-input-actions.ts
@@ -48,14 +48,15 @@ export function buildCodexUserInputPresentation(
     blocks: [
       {
         type: "buttons",
-        buttons: question.options.map((option, index) => ({
-          label: option.label,
-          action: {
+        buttons: question.options.map((option, index) => {
+          const action = {
             type: "command",
             command: `/codex answer ${token} choice:${index}`,
-          },
-          ...(index === 0 ? { style: "primary" as const } : {}),
-        })),
+          } as const;
+          return index === 0
+            ? { label: option.label, action, style: "primary" as const }
+            : { label: option.label, action };
+        }),
       },
     ],
   };

--- a/extensions/codex/src/app-server/user-input-actions.ts
+++ b/extensions/codex/src/app-server/user-input-actions.ts
@@ -1,0 +1,89 @@
+import crypto from "node:crypto";
+import type { AgentHarnessUserInputQuestion } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
+
+export type CodexUserInputActionAnswer =
+  | { type: "choice"; optionIndex: number }
+  | { type: "answers"; answers: Record<string, string> };
+
+type PendingAnswer = (answer: CodexUserInputActionAnswer) => boolean;
+
+const pendingAnswers = new Map<string, PendingAnswer>();
+
+export function registerCodexUserInputActions(answer: PendingAnswer): {
+  token: string;
+  dispose: () => void;
+} {
+  const token = crypto.randomUUID();
+  pendingAnswers.set(token, answer);
+  return {
+    token,
+    dispose: () => pendingAnswers.delete(token),
+  };
+}
+
+export function resolveCodexUserInputAction(
+  token: string,
+  answer: CodexUserInputActionAnswer,
+): boolean {
+  const pending = pendingAnswers.get(token);
+  if (!pending || !pending(answer)) {
+    return false;
+  }
+  pendingAnswers.delete(token);
+  return true;
+}
+
+export function buildCodexUserInputPresentation(
+  questions: readonly AgentHarnessUserInputQuestion[],
+  token: string,
+): MessagePresentation | undefined {
+  const question = questions.length === 1 ? questions[0] : undefined;
+  if (!question || question.isSecret || !question.options?.length) {
+    return undefined;
+  }
+  return {
+    title: question.header,
+    tone: "info",
+    blocks: [
+      {
+        type: "buttons",
+        buttons: question.options.map((option, index) => ({
+          label: option.label,
+          action: {
+            type: "command",
+            command: `/codex answer ${token} choice:${index}`,
+          },
+          ...(index === 0 ? { style: "primary" as const } : {}),
+        })),
+      },
+    ],
+  };
+}
+
+export function parseCodexUserInputActionAnswer(
+  encoded: string,
+): CodexUserInputActionAnswer | undefined {
+  const choiceMatch = encoded.match(/^choice:(\d+)$/u);
+  if (choiceMatch) {
+    const optionIndex = Number(choiceMatch[1]);
+    return Number.isSafeInteger(optionIndex) ? { type: "choice", optionIndex } : undefined;
+  }
+  if (!encoded.startsWith("answers:")) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decodeURIComponent(encoded.slice("answers:".length)));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const entries = Object.entries(parsed);
+  if (entries.length === 0 || entries.some(([key, value]) => !key || typeof value !== "string")) {
+    return undefined;
+  }
+  return { type: "answers", answers: Object.fromEntries(entries) };
+}

--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -163,6 +163,49 @@ describe("Codex app-server user input bridge", () => {
     await expect(response).resolves.toEqual({ answers: { mode: { answers: ["2"] } } });
   });
 
+  it("preserves case-distinct structured option labels", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const response = bridge.handleRequest({
+      id: "input-case-label",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-case-label",
+        questions: [
+          {
+            id: "mode",
+            header: "Mode",
+            question: "Pick a mode",
+            isOther: false,
+            isSecret: false,
+            options: [{ label: "FAST" }, { label: "fast" }],
+          },
+        ],
+      },
+    });
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
+    const event = vi
+      .mocked(params.onAgentEvent!)
+      .mock.calls.find(([payload]) => payload.stream === "question")?.[0];
+    const actionId =
+      event && typeof event.data === "object" && event.data && "actionToken" in event.data
+        ? event.data.actionToken
+        : undefined;
+    expect(
+      resolveCodexUserInputAction(String(actionId), {
+        type: "answers",
+        answers: { mode: "fast" },
+      }),
+    ).toBe(true);
+    await expect(response).resolves.toEqual({ answers: { mode: { answers: ["fast"] } } });
+  });
+
   it("preserves reserved question ids in structured answers", async () => {
     const params = createParams();
     const bridge = createCodexUserInputBridge({

--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -183,7 +183,7 @@ describe("Codex app-server user input bridge", () => {
             question: "Pick a mode",
             isOther: false,
             isSecret: false,
-            options: [{ label: "FAST" }, { label: "fast" }],
+            options: [{ label: "FAST" }, { label: " fast " }],
           },
         ],
       },
@@ -200,10 +200,10 @@ describe("Codex app-server user input bridge", () => {
     expect(
       resolveCodexUserInputAction(String(actionId), {
         type: "answers",
-        answers: { mode: "fast" },
+        answers: { mode: " fast " },
       }),
     ).toBe(true);
-    await expect(response).resolves.toEqual({ answers: { mode: { answers: ["fast"] } } });
+    await expect(response).resolves.toEqual({ answers: { mode: { answers: [" fast "] } } });
   });
 
   it("preserves reserved question ids in structured answers", async () => {

--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover user input bridge plugin behavior.
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { resolveCodexUserInputAction } from "./user-input-actions.js";
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 
 function createParams(): EmbeddedRunAttemptParams {
@@ -8,6 +9,7 @@ function createParams(): EmbeddedRunAttemptParams {
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
     onBlockReply: vi.fn(),
+    onAgentEvent: vi.fn(),
   } as unknown as EmbeddedRunAttemptParams;
 }
 
@@ -61,6 +63,180 @@ describe("Codex app-server user input bridge", () => {
     await expect(response).resolves.toEqual({
       answers: { choice: { answers: ["Deep"] } },
     });
+  });
+
+  it("emits a web question card and typed channel actions", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const response = bridge.handleRequest({
+      id: "input-actions",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-actions",
+        questions: [
+          {
+            id: "mode",
+            header: "Mode",
+            question: "Pick a mode",
+            isOther: false,
+            isSecret: false,
+            options: [{ label: "Fast" }, { label: "Deep" }],
+          },
+        ],
+      },
+    });
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
+    expect(params.onAgentEvent).toHaveBeenCalledWith({
+      stream: "question",
+      data: expect.objectContaining({ phase: "requested", itemId: "tool-actions" }),
+    });
+    const presentation = vi.mocked(params.onBlockReply!).mock.calls[0]?.[0].presentation;
+    const block = presentation?.blocks[0];
+    expect(block?.type).toBe("buttons");
+    if (block?.type !== "buttons") {
+      throw new Error("expected typed question buttons");
+    }
+    const action = block.buttons[1]?.action;
+    expect(action?.type).toBe("command");
+    if (action?.type !== "command") {
+      throw new Error("expected command action");
+    }
+    const match = action.command.match(/^\/codex answer ([0-9a-f-]+) choice:1$/u);
+    expect(match).not.toBeNull();
+    expect(resolveCodexUserInputAction(match![1]!, { type: "choice", optionIndex: 1 })).toBe(true);
+
+    await expect(response).resolves.toEqual({ answers: { mode: { answers: ["Deep"] } } });
+    expect(params.onAgentEvent).toHaveBeenLastCalledWith({
+      stream: "question",
+      data: expect.objectContaining({ phase: "resolved", itemId: "tool-actions" }),
+    });
+  });
+
+  it("keeps numeric labels distinct from typed option indexes", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const response = bridge.handleRequest({
+      id: "input-numeric-label",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-numeric-label",
+        questions: [
+          {
+            id: "mode",
+            header: "Mode",
+            question: "Pick a mode",
+            isOther: false,
+            isSecret: false,
+            options: [{ label: "2" }, { label: "Deep" }],
+          },
+        ],
+      },
+    });
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
+    const event = vi
+      .mocked(params.onAgentEvent!)
+      .mock.calls.find(([payload]) => payload.stream === "question")?.[0];
+    const actionId =
+      event && typeof event.data === "object" && event.data && "actionToken" in event.data
+        ? event.data.actionToken
+        : undefined;
+    expect(typeof actionId).toBe("string");
+    expect(
+      resolveCodexUserInputAction(String(actionId), {
+        type: "answers",
+        answers: { mode: "2" },
+      }),
+    ).toBe(true);
+    await expect(response).resolves.toEqual({ answers: { mode: { answers: ["2"] } } });
+  });
+
+  it("preserves reserved question ids in structured answers", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const response = bridge.handleRequest({
+      id: "input-reserved-id",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-reserved-id",
+        questions: [
+          {
+            id: "__proto__",
+            header: "Mode",
+            question: "Pick a mode",
+            isOther: false,
+            isSecret: false,
+            options: [{ label: "Safe" }],
+          },
+        ],
+      },
+    });
+
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
+    const event = vi
+      .mocked(params.onAgentEvent!)
+      .mock.calls.find(([payload]) => payload.stream === "question")?.[0];
+    const actionId =
+      event && typeof event.data === "object" && event.data && "actionToken" in event.data
+        ? event.data.actionToken
+        : undefined;
+    expect(
+      resolveCodexUserInputAction(String(actionId), {
+        type: "answers",
+        answers: Object.fromEntries([["__proto__", "Safe"]]),
+      }),
+    ).toBe(true);
+    await expect(response).resolves.toEqual({
+      answers: Object.fromEntries([["__proto__", { answers: ["Safe"] }]]),
+    });
+  });
+
+  it("does not expose secret questions as channel buttons", async () => {
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const response = bridge.handleRequest({
+      id: "input-secret",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "tool-secret",
+        questions: [
+          {
+            id: "secret",
+            header: "Secret",
+            question: "Enter it",
+            isOther: true,
+            isSecret: true,
+            options: [{ label: "Stored value" }],
+          },
+        ],
+      },
+    });
+    await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
+    expect(vi.mocked(params.onBlockReply!).mock.calls[0]?.[0].presentation).toBeUndefined();
+    expect(bridge.handleQueuedMessage("private")).toBe(true);
+    await response;
   });
 
   it("does not let a captured handle settle a replacement request", async () => {

--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -235,6 +235,10 @@ describe("Codex app-server user input bridge", () => {
     });
     await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
     expect(vi.mocked(params.onBlockReply!).mock.calls[0]?.[0].presentation).toBeUndefined();
+    expect(params.onAgentEvent).toHaveBeenCalledWith({
+      stream: "question",
+      data: expect.not.objectContaining({ actionToken: expect.anything() }),
+    });
     expect(bridge.handleQueuedMessage("private")).toBe(true);
     await response;
   });

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -112,11 +112,13 @@ export function createCodexUserInputBridge(params: {
           resolve,
           cleanup,
         };
-        const actionRegistration = registerCodexUserInputActions((answer) => {
-          const response = buildUserInputActionResponse(requestParams.questions, answer);
-          return response ? resolvePendingIfCurrent(current, response) : false;
-        });
-        disposeAction = actionRegistration.dispose;
+        const actionRegistration = requestParams.questions.some((question) => question.isSecret)
+          ? undefined
+          : registerCodexUserInputActions((answer) => {
+              const response = buildUserInputActionResponse(requestParams.questions, answer);
+              return response ? resolvePendingIfCurrent(current, response) : false;
+            });
+        disposeAction = actionRegistration?.dispose ?? disposeAction;
         pending = current;
         params.signal?.addEventListener("abort", abortListener, { once: true });
         if (params.signal?.aborted) {
@@ -128,12 +130,12 @@ export function createCodexUserInputBridge(params: {
           "requested",
           requestParams.itemId,
           requestParams.questions,
-          actionRegistration.token,
+          actionRegistration?.token,
         );
         void deliverUserInputPrompt(
           params.paramsForRun,
           requestParams.questions,
-          actionRegistration.token,
+          actionRegistration?.token,
         ).catch((error: unknown) => {
           embeddedAgentLog.warn("failed to deliver codex user input prompt", { error });
         });
@@ -248,12 +250,12 @@ function readOption(value: JsonValue): AgentHarnessUserInputOption | undefined {
 async function deliverUserInputPrompt(
   params: EmbeddedRunAttemptParams,
   questions: AgentHarnessUserInputQuestion[],
-  actionToken: string,
+  actionToken?: string,
 ): Promise<void> {
   await deliverAgentHarnessUserInputPrompt(params, questions, {
     formatText: formatCodexDisplayText,
     intro: "Codex needs input:",
-    presentation: buildCodexUserInputPresentation(questions, actionToken),
+    presentation: actionToken ? buildCodexUserInputPresentation(questions, actionToken) : undefined,
   });
 }
 

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -310,9 +310,7 @@ function buildUserInputActionResponse(
     if (!rawAnswer) {
       return undefined;
     }
-    const exactOption = question.options?.find(
-      (option) => option.label.toLowerCase() === rawAnswer.toLowerCase(),
-    );
+    const exactOption = question.options?.find((option) => option.label === rawAnswer);
     if (!exactOption && question.options?.length && !question.isOther) {
       return undefined;
     }

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -306,8 +306,8 @@ function buildUserInputActionResponse(
   }
   const answerEntries: Array<[string, { answers: string[] }]> = [];
   for (const question of questions) {
-    const rawAnswer = action.answers[question.id]?.trim();
-    if (!rawAnswer) {
+    const rawAnswer = action.answers[question.id];
+    if (!rawAnswer?.trim()) {
       return undefined;
     }
     const exactOption = question.options?.find((option) => option.label === rawAnswer);

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -18,6 +18,12 @@ import {
   type JsonObject,
   type JsonValue,
 } from "./protocol.js";
+import { emitCodexAppServerEvent } from "./run-attempt-lifecycle.js";
+import {
+  buildCodexUserInputPresentation,
+  registerCodexUserInputActions,
+  type CodexUserInputActionAnswer,
+} from "./user-input-actions.js";
 
 type PendingUserInput = {
   requestId: number | string;
@@ -90,8 +96,13 @@ export function createCodexUserInputBridge(params: {
 
       return new Promise<JsonValue>((resolve) => {
         const abortListener = () => resolvePending(emptyUserInputResponse());
-        const cleanup = () => params.signal?.removeEventListener("abort", abortListener);
-        pending = {
+        let disposeAction = () => {};
+        const cleanup = () => {
+          params.signal?.removeEventListener("abort", abortListener);
+          disposeAction();
+          emitQuestionEvent(params.paramsForRun, "resolved", requestParams.itemId);
+        };
+        const current: PendingUserInput = {
           requestId: request.id,
           threadId: requestParams.threadId,
           turnId: requestParams.turnId,
@@ -101,16 +112,31 @@ export function createCodexUserInputBridge(params: {
           resolve,
           cleanup,
         };
+        const actionRegistration = registerCodexUserInputActions((answer) => {
+          const response = buildUserInputActionResponse(requestParams.questions, answer);
+          return response ? resolvePendingIfCurrent(current, response) : false;
+        });
+        disposeAction = actionRegistration.dispose;
+        pending = current;
         params.signal?.addEventListener("abort", abortListener, { once: true });
         if (params.signal?.aborted) {
           resolvePending(emptyUserInputResponse());
           return;
         }
-        void deliverUserInputPrompt(params.paramsForRun, requestParams.questions).catch(
-          (error: unknown) => {
-            embeddedAgentLog.warn("failed to deliver codex user input prompt", { error });
-          },
+        emitQuestionEvent(
+          params.paramsForRun,
+          "requested",
+          requestParams.itemId,
+          requestParams.questions,
+          actionRegistration.token,
         );
+        void deliverUserInputPrompt(
+          params.paramsForRun,
+          requestParams.questions,
+          actionRegistration.token,
+        ).catch((error: unknown) => {
+          embeddedAgentLog.warn("failed to deliver codex user input prompt", { error });
+        });
       });
     },
     claimPendingRequest() {
@@ -222,10 +248,31 @@ function readOption(value: JsonValue): AgentHarnessUserInputOption | undefined {
 async function deliverUserInputPrompt(
   params: EmbeddedRunAttemptParams,
   questions: AgentHarnessUserInputQuestion[],
+  actionToken: string,
 ): Promise<void> {
   await deliverAgentHarnessUserInputPrompt(params, questions, {
     formatText: formatCodexDisplayText,
     intro: "Codex needs input:",
+    presentation: buildCodexUserInputPresentation(questions, actionToken),
+  });
+}
+
+function emitQuestionEvent(
+  params: EmbeddedRunAttemptParams,
+  phase: "requested" | "resolved",
+  itemId: string,
+  questions?: AgentHarnessUserInputQuestion[],
+  actionToken?: string,
+): void {
+  void emitCodexAppServerEvent(params, {
+    stream: "question",
+    data: {
+      phase,
+      itemId,
+      source: "codex-app-server",
+      ...(questions ? { questions } : {}),
+      ...(actionToken ? { actionToken } : {}),
+    },
   });
 }
 
@@ -236,6 +283,40 @@ function buildUserInputResponse(
   // Multi-question replies may use "header: answer" or numbered lines. Keep the
   // parser permissive so chat-channel replies remain ergonomic.
   return buildAgentHarnessUserInputAnswers(questions, inputText) as unknown as JsonObject;
+}
+
+function buildUserInputActionResponse(
+  questions: AgentHarnessUserInputQuestion[],
+  action: CodexUserInputActionAnswer,
+): JsonObject | undefined {
+  if (action.type === "choice") {
+    const question = questions.length === 1 ? questions[0] : undefined;
+    const option = question?.options?.[action.optionIndex];
+    return question && option
+      ? ({ answers: { [question.id]: { answers: [option.label] } } } as JsonObject)
+      : undefined;
+  }
+  if (
+    Object.keys(action.answers).length !== questions.length ||
+    !questions.every((question) => Object.hasOwn(action.answers, question.id))
+  ) {
+    return undefined;
+  }
+  const answerEntries: Array<[string, { answers: string[] }]> = [];
+  for (const question of questions) {
+    const rawAnswer = action.answers[question.id]?.trim();
+    if (!rawAnswer) {
+      return undefined;
+    }
+    const exactOption = question.options?.find(
+      (option) => option.label.toLowerCase() === rawAnswer.toLowerCase(),
+    );
+    if (!exactOption && question.options?.length && !question.isOther) {
+      return undefined;
+    }
+    answerEntries.push([question.id, { answers: [exactOption?.label ?? rawAnswer] }]);
+  }
+  return { answers: Object.fromEntries(answerEntries) } as unknown as JsonObject;
 }
 
 function emptyUserInputResponse(): JsonObject {

--- a/extensions/codex/src/command-formatters.ts
+++ b/extensions/codex/src/command-formatters.ts
@@ -378,6 +378,7 @@ export function buildHelp(): string {
     "- /codex status",
     "- /codex models",
     "- /codex threads [filter]",
+    "- /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]",
     "- /codex sessions --host <node> [filter]",
     "- /codex resume <thread-id>",
     "- /codex resume <session-id> --host <node> --bind here",

--- a/extensions/codex/src/command-formatters.ts
+++ b/extensions/codex/src/command-formatters.ts
@@ -378,7 +378,7 @@ export function buildHelp(): string {
     "- /codex status",
     "- /codex models",
     "- /codex threads [filter]",
-    "- /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]",
+    "- /codex goal [status|set <objective>|pause|resume|block|complete|clear]",
     "- /codex sessions --host <node> [filter]",
     "- /codex resume <thread-id>",
     "- /codex resume <session-id> --host <node> --bind here",

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -966,6 +966,16 @@ async function handleNativeGoal(
   if (requestedStatus && args.length > 1) {
     return `Usage: /codex goal ${action}`;
   }
+  if (action === "start" || action === "set") {
+    // Native set is a partial update. Remove the previous goal first so a new
+    // objective cannot inherit its budget, counters, or terminal state.
+    await deps.codexControlRequest(
+      pluginConfig,
+      CODEX_CONTROL_METHODS.clearThreadGoal,
+      { threadId: binding.threadId },
+      requestOptions,
+    );
+  }
   const response = await deps.codexControlRequest(
     pluginConfig,
     CODEX_CONTROL_METHODS.setThreadGoal,

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -959,23 +959,12 @@ async function handleNativeGoal(
           : action === "complete"
             ? "complete"
             : undefined;
-  const isObjectiveUpdate = action === "start" || action === "edit";
+  const isObjectiveUpdate = action === "set";
   if ((!requestedStatus && !isObjectiveUpdate) || (isObjectiveUpdate && !objective)) {
-    return "Usage: /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]";
+    return "Usage: /codex goal [status|set <objective>|pause|resume|block|complete|clear]";
   }
   if (requestedStatus && args.length > 1) {
     return `Usage: /codex goal ${action}`;
-  }
-  if (action === "start") {
-    const current = await deps.codexControlRequest(
-      pluginConfig,
-      CODEX_CONTROL_METHODS.getThreadGoal,
-      { threadId: binding.threadId },
-      goalRequestOptions,
-    );
-    if (isJsonObject(current) && isJsonObject(current.goal)) {
-      return "A Codex goal already exists. Use `/codex goal edit <objective>` or clear it first.";
-    }
   }
   const response = await deps.codexControlRequest(
     pluginConfig,
@@ -983,13 +972,9 @@ async function handleNativeGoal(
     {
       threadId: binding.threadId,
       ...(objective ? { objective } : {}),
-      // Upstream thread/goal/set is a partial update for existing goals. Edit
-      // omits status and budget so Codex preserves both; start activates.
-      ...(requestedStatus
-        ? { status: requestedStatus }
-        : action === "start"
-          ? { status: "active" }
-          : {}),
+      // Upstream thread/goal/set creates or partially updates the native goal;
+      // omitted status and budget preserve Codex's canonical state.
+      ...(requestedStatus ? { status: requestedStatus } : {}),
     },
     goalRequestOptions,
   );

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -959,22 +959,23 @@ async function handleNativeGoal(
           : action === "complete"
             ? "complete"
             : undefined;
-  const isObjectiveUpdate = action === "start" || action === "set" || action === "edit";
+  const isObjectiveUpdate = action === "start" || action === "edit";
   if ((!requestedStatus && !isObjectiveUpdate) || (isObjectiveUpdate && !objective)) {
     return "Usage: /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]";
   }
   if (requestedStatus && args.length > 1) {
     return `Usage: /codex goal ${action}`;
   }
-  if (action === "start" || action === "set") {
-    // Native set is a partial update. Remove the previous goal first so a new
-    // objective cannot inherit its budget, counters, or terminal state.
-    await deps.codexControlRequest(
+  if (action === "start") {
+    const current = await deps.codexControlRequest(
       pluginConfig,
-      CODEX_CONTROL_METHODS.clearThreadGoal,
+      CODEX_CONTROL_METHODS.getThreadGoal,
       { threadId: binding.threadId },
       goalRequestOptions,
     );
+    if (isJsonObject(current) && isJsonObject(current.goal)) {
+      return "A Codex goal already exists. Use `/codex goal edit <objective>` or clear it first.";
+    }
   }
   const response = await deps.codexControlRequest(
     pluginConfig,
@@ -983,10 +984,10 @@ async function handleNativeGoal(
       threadId: binding.threadId,
       ...(objective ? { objective } : {}),
       // Upstream thread/goal/set is a partial update for existing goals. Edit
-      // omits status and budget so Codex preserves both; start/set reactivate.
+      // omits status and budget so Codex preserves both; start activates.
       ...(requestedStatus
         ? { status: requestedStatus }
-        : action === "start" || action === "set"
+        : action === "start"
           ? { status: "active" }
           : {}),
     },

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -38,6 +38,10 @@ import {
   type CodexAppServerBindingStore,
   type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.js";
+import {
+  parseCodexUserInputActionAnswer,
+  resolveCodexUserInputAction,
+} from "./app-server/user-input-actions.js";
 import { readCodexAccountAuthOverview } from "./command-account.js";
 import { canMutateCodexHost, CODEX_NATIVE_EXECUTION_AUTH_ERROR } from "./command-authorization.js";
 import {
@@ -230,6 +234,7 @@ const CODEX_NATIVE_EXECUTION_SUBCOMMANDS = new Set([
   "permissions",
   "compact",
   "review",
+  "goal",
 ]);
 const CODEX_NATIVE_CONTROL_SUBCOMMANDS = new Set([
   ...CODEX_NATIVE_EXECUTION_SUBCOMMANDS,
@@ -377,9 +382,28 @@ export async function handleCodexSubcommand(
   if (normalized === "help") {
     return { text: buildHelp() };
   }
+  if (normalized === "answer") {
+    if (rest.length !== 2) {
+      return { text: "Usage: /codex answer <request-token> <choice>" };
+    }
+    if (!canMutateCodexHost(ctx)) {
+      return { text: CODEX_NATIVE_EXECUTION_AUTH_ERROR };
+    }
+    const [token = "", encodedAnswer = ""] = rest;
+    const answer = parseCodexUserInputActionAnswer(encodedAnswer);
+    if (!answer) {
+      return { text: "Invalid Codex answer encoding." };
+    }
+    return {
+      text: resolveCodexUserInputAction(token, answer)
+        ? "Answered Codex."
+        : "That Codex question is no longer pending.",
+    };
+  }
   if (
     CODEX_NATIVE_CONTROL_SUBCOMMANDS.has(normalized) &&
     !returnsBeforeNativeCodexExecution(normalized, rest) &&
+    !isReadOnlyCodexGoalCommand(normalized, rest) &&
     !canMutateCodexHost(ctx)
   ) {
     return { text: CODEX_NATIVE_EXECUTION_AUTH_ERROR };
@@ -424,6 +448,9 @@ export async function handleCodexSubcommand(
   }
   if (normalized === "threads") {
     return { text: await buildThreads(deps, ctx, options.pluginConfig, rest.join(" ")) };
+  }
+  if (normalized === "goal") {
+    return { text: await handleNativeGoal(deps, ctx, options.pluginConfig, rest) };
   }
   if (normalized === "sessions") {
     return { text: await buildCodexCliSessions(deps, rest) };
@@ -593,6 +620,9 @@ function resolveCodexNativeCommandSandboxBlock(
   subcommand: string,
   args: readonly string[],
 ): string | undefined {
+  if (isReadOnlyCodexGoalCommand(subcommand, args)) {
+    return undefined;
+  }
   if (!CODEX_NATIVE_EXECUTION_SUBCOMMANDS.has(subcommand)) {
     return undefined;
   }
@@ -614,6 +644,14 @@ function resolveCodexNativeCommandSandboxBlock(
     sessionId: ctx.sessionId,
     surface: `/${["codex", subcommand].join(" ")}`,
   });
+}
+
+function isReadOnlyCodexGoalCommand(subcommand: string, args: readonly string[]): boolean {
+  if (subcommand !== "goal" || args.length > 1) {
+    return false;
+  }
+  const action = (args[0] ?? "status").toLowerCase();
+  return action === "status" || action === "get";
 }
 
 function returnsBeforeNativeCodexExecution(subcommand: string, args: readonly string[]): boolean {
@@ -856,6 +894,108 @@ async function buildThreads(
     { config: ctx.config, ...scope },
   );
   return formatThreads(response);
+}
+
+async function handleNativeGoal(
+  deps: CodexCommandDeps,
+  ctx: PluginCommandContext,
+  pluginConfig: unknown,
+  args: string[],
+): Promise<string> {
+  const action = (args[0] ?? "status").toLowerCase();
+  const objective = args.slice(1).join(" ").trim();
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
+    return "Cannot manage the Codex goal because this command has no stable binding identity.";
+  }
+  const binding = await deps.bindingStore.read(target.identity);
+  if (!binding?.threadId) {
+    return "No Codex thread is attached to this OpenClaw session yet.";
+  }
+  const connection = resolveCodexBindingAppServerConnection({
+    binding,
+    authProfileId: binding.authProfileId,
+    pluginConfig,
+  });
+  const requestOptions: CodexControlRequestOptions = {
+    agentDir: target.agentDir,
+    authProfileId: connection.clientAuthProfileId,
+    config: ctx.config,
+    ...(connection.usesSupervisionConnection ? { startOptions: connection.appServer.start } : {}),
+  };
+  if (action === "status" || action === "get") {
+    if (args.length > 1) {
+      return "Usage: /codex goal [status]";
+    }
+    const response = await deps.codexControlRequest(
+      pluginConfig,
+      CODEX_CONTROL_METHODS.getThreadGoal,
+      { threadId: binding.threadId },
+      requestOptions,
+    );
+    return formatNativeGoal(response);
+  }
+  if (action === "clear") {
+    if (args.length > 1) {
+      return "Usage: /codex goal clear";
+    }
+    const response = await deps.codexControlRequest(
+      pluginConfig,
+      CODEX_CONTROL_METHODS.clearThreadGoal,
+      { threadId: binding.threadId },
+      requestOptions,
+    );
+    return isJsonObject(response) && response.cleared === true
+      ? "Cleared the Codex goal."
+      : "No Codex goal was active.";
+  }
+  const statusByAction = {
+    pause: "paused",
+    resume: "active",
+    block: "blocked",
+    complete: "complete",
+  } as const;
+  const requestedStatus = statusByAction[action as keyof typeof statusByAction];
+  const isObjectiveUpdate = action === "start" || action === "set" || action === "edit";
+  if ((!requestedStatus && !isObjectiveUpdate) || (isObjectiveUpdate && !objective)) {
+    return "Usage: /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]";
+  }
+  if (requestedStatus && args.length > 1) {
+    return `Usage: /codex goal ${action}`;
+  }
+  const response = await deps.codexControlRequest(
+    pluginConfig,
+    CODEX_CONTROL_METHODS.setThreadGoal,
+    {
+      threadId: binding.threadId,
+      ...(objective ? { objective } : {}),
+      // Upstream thread/goal/set is a partial update for existing goals. Edit
+      // omits status and budget so Codex preserves both; start/set reactivate.
+      ...(requestedStatus
+        ? { status: requestedStatus }
+        : action === "start" || action === "set"
+          ? { status: "active" }
+          : {}),
+    },
+    requestOptions,
+  );
+  return formatNativeGoal(response);
+}
+
+function formatNativeGoal(response: JsonValue | undefined): string {
+  const goal = isJsonObject(response) && isJsonObject(response.goal) ? response.goal : undefined;
+  if (!goal) {
+    return "No Codex goal is active.";
+  }
+  const objective = readString(goal, "objective") ?? "unknown";
+  const status = readString(goal, "status") ?? "unknown";
+  const tokensUsed = typeof goal.tokensUsed === "number" ? goal.tokensUsed : 0;
+  const tokenBudget = typeof goal.tokenBudget === "number" ? goal.tokenBudget : undefined;
+  return [
+    `Codex goal: ${formatCodexDisplayText(objective)}`,
+    `- Status: ${formatCodexDisplayText(status)}`,
+    `- Tokens: ${tokensUsed}${tokenBudget === undefined ? "" : ` / ${tokenBudget}`}`,
+  ].join("\n");
 }
 
 async function buildCodexCliSessions(deps: CodexCommandDeps, args: string[]): Promise<string> {

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -949,13 +949,16 @@ async function handleNativeGoal(
       ? "Cleared the Codex goal."
       : "No Codex goal was active.";
   }
-  const statusByAction = {
-    pause: "paused",
-    resume: "active",
-    block: "blocked",
-    complete: "complete",
-  } as const;
-  const requestedStatus = statusByAction[action as keyof typeof statusByAction];
+  const requestedStatus =
+    action === "pause"
+      ? "paused"
+      : action === "resume"
+        ? "active"
+        : action === "block"
+          ? "blocked"
+          : action === "complete"
+            ? "complete"
+            : undefined;
   const isObjectiveUpdate = action === "start" || action === "set" || action === "edit";
   if ((!requestedStatus && !isObjectiveUpdate) || (isObjectiveUpdate && !objective)) {
     return "Usage: /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]";

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -917,7 +917,7 @@ async function handleNativeGoal(
     authProfileId: binding.authProfileId,
     pluginConfig,
   });
-  const requestOptions: CodexControlRequestOptions = {
+  const goalRequestOptions: CodexControlRequestOptions = {
     agentDir: target.agentDir,
     authProfileId: connection.clientAuthProfileId,
     config: ctx.config,
@@ -931,7 +931,7 @@ async function handleNativeGoal(
       pluginConfig,
       CODEX_CONTROL_METHODS.getThreadGoal,
       { threadId: binding.threadId },
-      requestOptions,
+      goalRequestOptions,
     );
     return formatNativeGoal(response);
   }
@@ -943,7 +943,7 @@ async function handleNativeGoal(
       pluginConfig,
       CODEX_CONTROL_METHODS.clearThreadGoal,
       { threadId: binding.threadId },
-      requestOptions,
+      goalRequestOptions,
     );
     return isJsonObject(response) && response.cleared === true
       ? "Cleared the Codex goal."
@@ -973,7 +973,7 @@ async function handleNativeGoal(
       pluginConfig,
       CODEX_CONTROL_METHODS.clearThreadGoal,
       { threadId: binding.threadId },
-      requestOptions,
+      goalRequestOptions,
     );
   }
   const response = await deps.codexControlRequest(
@@ -990,7 +990,7 @@ async function handleNativeGoal(
           ? { status: "active" }
           : {}),
     },
-    requestOptions,
+    goalRequestOptions,
   );
   return formatNativeGoal(response);
 }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -4113,10 +4113,14 @@ describe("codex command", () => {
       createdAt: 1,
       updatedAt: 2,
     };
+    let goalReads = 0;
     const codexControlRequest = vi.fn(
       async (_pluginConfig: unknown, method: string): Promise<JsonValue> => {
         if (method === CODEX_CONTROL_METHODS.clearThreadGoal) {
           return { cleared: true };
+        }
+        if (method === CODEX_CONTROL_METHODS.getThreadGoal && goalReads++ > 0) {
+          return { goal: null };
         }
         return { goal };
       },
@@ -4150,7 +4154,7 @@ describe("codex command", () => {
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       2,
       undefined,
-      CODEX_CONTROL_METHODS.clearThreadGoal,
+      CODEX_CONTROL_METHODS.getThreadGoal,
       { threadId: "thread-goal" },
       expect.any(Object),
     );
@@ -4172,6 +4176,31 @@ describe("codex command", () => {
       5,
       undefined,
       CODEX_CONTROL_METHODS.clearThreadGoal,
+      { threadId: "thread-goal" },
+      expect.any(Object),
+    );
+  });
+
+  it("does not replace an existing native goal from the start command", async () => {
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { threadId: "thread-goal", cwd: "/repo" },
+    );
+    const codexControlRequest = vi.fn(async () => ({
+      goal: { threadId: "thread-goal", objective: "Keep this goal", status: "active" },
+    }));
+
+    await expect(
+      handleCodexCommand(createContext("goal start Replacement"), {
+        deps: createDeps({ codexControlRequest }),
+      }),
+    ).resolves.toEqual({
+      text: "A Codex goal already exists. Use `/codex goal edit <objective>` or clear it first.",
+    });
+    expect(codexControlRequest).toHaveBeenCalledOnce();
+    expect(codexControlRequest).toHaveBeenCalledWith(
+      undefined,
+      CODEX_CONTROL_METHODS.getThreadGoal,
       { threadId: "thread-goal" },
       expect.any(Object),
     );

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -23,6 +23,7 @@ import {
   testCodexAppServerBindingStore,
 } from "./app-server/session-binding.test-helpers.js";
 import { resetSharedCodexAppServerClientForTests } from "./app-server/shared-client.js";
+import { registerCodexUserInputActions } from "./app-server/user-input-actions.js";
 import { codexDiagnosticsFeedbackState } from "./command-diagnostics-state.js";
 import { handleCodexCommand } from "./command-dispatch.js";
 import type { CodexCommandDepsOverride } from "./command-handlers.js";
@@ -386,6 +387,39 @@ describe("codex command", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it("authorizes and decodes request-scoped Codex answers", async () => {
+    const answer = vi.fn(() => true);
+    const registration = registerCodexUserInputActions(answer);
+    await expect(
+      handleCodexCommand(
+        createContext(
+          `answer ${registration.token} answers:%7B%22mode%22%3A%22Deep%20mode%22%7D`,
+          undefined,
+          {
+            senderIsOwner: false,
+          },
+        ),
+        { deps: createDeps() },
+      ),
+    ).resolves.toEqual({
+      text: "Only an owner or operator.admin can control Codex native execution.",
+    });
+    expect(answer).not.toHaveBeenCalled();
+
+    await expect(
+      handleCodexCommand(
+        createContext(`answer ${registration.token} answers:%7B%22mode%22%3A%22Deep%20mode%22%7D`),
+        {
+          deps: createDeps(),
+        },
+      ),
+    ).resolves.toEqual({ text: "Answered Codex." });
+    expect(answer).toHaveBeenCalledWith({
+      type: "answers",
+      answers: { mode: "Deep mode" },
+    });
+  });
+
   it("renders the top-level Codex menu as portable native slash commands", async () => {
     const result = await handleCodexCommand(createContext(""), { deps: createDeps() });
 
@@ -722,6 +756,7 @@ describe("codex command", () => {
     "permissions yolo",
     "compact",
     "review",
+    "goal pause",
   ])("blocks /codex %s in sandboxed sessions before native Codex execution", async (args) => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const codexControlRequest = vi.fn();
@@ -764,6 +799,7 @@ describe("codex command", () => {
     "permissions yolo",
     "compact",
     "review",
+    "goal pause",
   ])("blocks /codex %s when exec host=node is active", async (args) => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const codexControlRequest = vi.fn();
@@ -904,6 +940,28 @@ describe("codex command", () => {
         deps: createDeps(),
       }),
     ).resolves.toEqual({ text: "Codex permissions: full access." });
+    await expect(
+      handleCodexCommand(createSandboxedContext("goal", sessionFile), {
+        deps: createDeps({
+          codexControlRequest: vi.fn(
+            async (): Promise<JsonValue> => ({
+              goal: {
+                threadId: "thread-status",
+                objective: "Inspect status",
+                status: "active",
+                tokenBudget: null,
+                tokensUsed: 0,
+                timeUsedSeconds: 0,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            }),
+          ),
+        }),
+      }),
+    ).resolves.toEqual({
+      text: "Codex goal: Inspect status\n- Status: active\n- Tokens: 0",
+    });
   });
 
   it("lists Codex CLI sessions from a requested node", async () => {
@@ -4037,6 +4095,78 @@ describe("codex command", () => {
         authProfileId: null,
         startOptions: expect.objectContaining({ homeScope: "user" }),
       }),
+    );
+  });
+
+  it("reads, updates, and clears goals through the bound native Codex thread", async () => {
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { threadId: "thread-goal", cwd: "/repo" },
+    );
+    const goal = {
+      threadId: "thread-goal",
+      objective: "Ship native goals",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 120,
+      timeUsedSeconds: 30,
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const codexControlRequest = vi.fn(
+      async (_pluginConfig: unknown, method: string): Promise<JsonValue> => {
+        if (method === CODEX_CONTROL_METHODS.clearThreadGoal) {
+          return { cleared: true };
+        }
+        return { goal };
+      },
+    );
+    const deps = createDeps({ codexControlRequest });
+
+    await expect(handleCodexCommand(createContext("goal"), { deps })).resolves.toEqual({
+      text: "Codex goal: Ship native goals\n- Status: active\n- Tokens: 120",
+    });
+    await expect(
+      handleCodexCommand(createContext("goal start Ship native goals"), { deps }),
+    ).resolves.toEqual({
+      text: "Codex goal: Ship native goals\n- Status: active\n- Tokens: 120",
+    });
+    await expect(
+      handleCodexCommand(createContext("goal edit Refine native goals"), { deps }),
+    ).resolves.toEqual({
+      text: "Codex goal: Ship native goals\n- Status: active\n- Tokens: 120",
+    });
+    await expect(handleCodexCommand(createContext("goal clear"), { deps })).resolves.toEqual({
+      text: "Cleared the Codex goal.",
+    });
+
+    expect(codexControlRequest).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      CODEX_CONTROL_METHODS.getThreadGoal,
+      { threadId: "thread-goal" },
+      expect.any(Object),
+    );
+    expect(codexControlRequest).toHaveBeenNthCalledWith(
+      2,
+      undefined,
+      CODEX_CONTROL_METHODS.setThreadGoal,
+      { threadId: "thread-goal", objective: "Ship native goals", status: "active" },
+      expect.any(Object),
+    );
+    expect(codexControlRequest).toHaveBeenNthCalledWith(
+      3,
+      undefined,
+      CODEX_CONTROL_METHODS.setThreadGoal,
+      { threadId: "thread-goal", objective: "Refine native goals" },
+      expect.any(Object),
+    );
+    expect(codexControlRequest).toHaveBeenNthCalledWith(
+      4,
+      undefined,
+      CODEX_CONTROL_METHODS.clearThreadGoal,
+      { threadId: "thread-goal" },
+      expect.any(Object),
     );
   });
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -4150,19 +4150,26 @@ describe("codex command", () => {
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       2,
       undefined,
-      CODEX_CONTROL_METHODS.setThreadGoal,
-      { threadId: "thread-goal", objective: "Ship native goals", status: "active" },
+      CODEX_CONTROL_METHODS.clearThreadGoal,
+      { threadId: "thread-goal" },
       expect.any(Object),
     );
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       3,
       undefined,
       CODEX_CONTROL_METHODS.setThreadGoal,
-      { threadId: "thread-goal", objective: "Refine native goals" },
+      { threadId: "thread-goal", objective: "Ship native goals", status: "active" },
       expect.any(Object),
     );
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       4,
+      undefined,
+      CODEX_CONTROL_METHODS.setThreadGoal,
+      { threadId: "thread-goal", objective: "Refine native goals" },
+      expect.any(Object),
+    );
+    expect(codexControlRequest).toHaveBeenNthCalledWith(
+      5,
       undefined,
       CODEX_CONTROL_METHODS.clearThreadGoal,
       { threadId: "thread-goal" },

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -4113,14 +4113,10 @@ describe("codex command", () => {
       createdAt: 1,
       updatedAt: 2,
     };
-    let goalReads = 0;
     const codexControlRequest = vi.fn(
       async (_pluginConfig: unknown, method: string): Promise<JsonValue> => {
         if (method === CODEX_CONTROL_METHODS.clearThreadGoal) {
           return { cleared: true };
-        }
-        if (method === CODEX_CONTROL_METHODS.getThreadGoal && goalReads++ > 0) {
-          return { goal: null };
         }
         return { goal };
       },
@@ -4131,12 +4127,12 @@ describe("codex command", () => {
       text: "Codex goal: Ship native goals\n- Status: active\n- Tokens: 120",
     });
     await expect(
-      handleCodexCommand(createContext("goal start Ship native goals"), { deps }),
+      handleCodexCommand(createContext("goal set Ship native goals"), { deps }),
     ).resolves.toEqual({
       text: "Codex goal: Ship native goals\n- Status: active\n- Tokens: 120",
     });
     await expect(
-      handleCodexCommand(createContext("goal edit Refine native goals"), { deps }),
+      handleCodexCommand(createContext("goal set Refine native goals"), { deps }),
     ).resolves.toEqual({
       text: "Codex goal: Ship native goals\n- Status: active\n- Tokens: 120",
     });
@@ -4154,53 +4150,21 @@ describe("codex command", () => {
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       2,
       undefined,
-      CODEX_CONTROL_METHODS.getThreadGoal,
-      { threadId: "thread-goal" },
+      CODEX_CONTROL_METHODS.setThreadGoal,
+      { threadId: "thread-goal", objective: "Ship native goals" },
       expect.any(Object),
     );
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       3,
       undefined,
       CODEX_CONTROL_METHODS.setThreadGoal,
-      { threadId: "thread-goal", objective: "Ship native goals", status: "active" },
+      { threadId: "thread-goal", objective: "Refine native goals" },
       expect.any(Object),
     );
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       4,
       undefined,
-      CODEX_CONTROL_METHODS.setThreadGoal,
-      { threadId: "thread-goal", objective: "Refine native goals" },
-      expect.any(Object),
-    );
-    expect(codexControlRequest).toHaveBeenNthCalledWith(
-      5,
-      undefined,
       CODEX_CONTROL_METHODS.clearThreadGoal,
-      { threadId: "thread-goal" },
-      expect.any(Object),
-    );
-  });
-
-  it("does not replace an existing native goal from the start command", async () => {
-    await writeTestBinding(
-      { kind: "session", agentId: "main", sessionId: "session-1" },
-      { threadId: "thread-goal", cwd: "/repo" },
-    );
-    const codexControlRequest = vi.fn(async () => ({
-      goal: { threadId: "thread-goal", objective: "Keep this goal", status: "active" },
-    }));
-
-    await expect(
-      handleCodexCommand(createContext("goal start Replacement"), {
-        deps: createDeps({ codexControlRequest }),
-      }),
-    ).resolves.toEqual({
-      text: "A Codex goal already exists. Use `/codex goal edit <objective>` or clear it first.",
-    });
-    expect(codexControlRequest).toHaveBeenCalledOnce();
-    expect(codexControlRequest).toHaveBeenCalledWith(
-      undefined,
-      CODEX_CONTROL_METHODS.getThreadGoal,
       { threadId: "thread-goal" },
       expect.any(Object),
     );
@@ -4218,7 +4182,7 @@ describe("codex command", () => {
         deps: createDeps({ codexControlRequest }),
       }),
     ).resolves.toEqual({
-      text: "Usage: /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]",
+      text: "Usage: /codex goal [status|set <objective>|pause|resume|block|complete|clear]",
     });
     expect(codexControlRequest).not.toHaveBeenCalled();
   });

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -4170,6 +4170,23 @@ describe("codex command", () => {
     );
   });
 
+  it("rejects inherited object names as goal actions", async () => {
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { threadId: "thread-goal", cwd: "/repo" },
+    );
+    const codexControlRequest = vi.fn();
+
+    await expect(
+      handleCodexCommand(createContext("goal __proto__"), {
+        deps: createDeps({ codexControlRequest }),
+      }),
+    ).resolves.toEqual({
+      text: "Usage: /codex goal [status|start <objective>|edit <objective>|pause|resume|block|complete|clear]",
+    });
+    expect(codexControlRequest).not.toHaveBeenCalled();
+  });
+
   it("formats every Codex skill as a code-styled bullet and tolerates malformed entries", async () => {
     const malformedSkillEntries: JsonValue[] = [
       null,

--- a/src/agents/embedded-agent-payloads.ts
+++ b/src/agents/embedded-agent-payloads.ts
@@ -1,3 +1,5 @@
+import type { MessagePresentation } from "../interactive/payload.js";
+
 /**
  * Channel-facing reply payload emitted by embedded agents. Keep this type
  * small: channel adapters decide how to render text, media, and reply targets.
@@ -14,4 +16,6 @@ export type BlockReplyPayload = {
   replyToId?: string;
   replyToTag?: boolean;
   replyToCurrent?: boolean;
+  /** Portable controls attached to a harness-owned blocking prompt. */
+  presentation?: MessagePresentation;
 };

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -1,3 +1,4 @@
+import type { MessagePresentation } from "../../interactive/payload.js";
 import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
 
 export type AgentHarnessUserInputOption = {
@@ -23,6 +24,7 @@ export type AgentHarnessUserInputPromptOptions = {
   formatText?: (text: string) => string;
   secretWarning?: string;
   otherLabel?: string;
+  presentation?: MessagePresentation;
 };
 
 type PromptDeliveryParams = Pick<EmbeddedRunAttemptParams, "onBlockReply" | "onPartialReply">;
@@ -69,7 +71,7 @@ export async function deliverAgentHarnessUserInputPrompt(
 ): Promise<void> {
   const text = formatAgentHarnessUserInputPrompt(questions, options);
   if (params.onBlockReply) {
-    await params.onBlockReply({ text });
+    await params.onBlockReply({ text, presentation: options.presentation });
     return;
   }
   await params.onPartialReply?.({ text });

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -63,6 +63,7 @@
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
+    "features.goals": false,
     "features.standalone_web_search": false,
     "web_search": "cached"
   },
@@ -104,6 +105,7 @@
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
+    "features.goals": false,
     "features.standalone_web_search": false,
     "web_search": "cached"
   },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -63,6 +63,7 @@
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
+    "features.goals": false,
     "features.standalone_web_search": false,
     "web_search": "cached"
   },
@@ -104,6 +105,7 @@
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
+    "features.goals": false,
     "features.standalone_web_search": false,
     "web_search": "cached"
   },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -63,6 +63,7 @@
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
+    "features.goals": false,
     "features.standalone_web_search": false,
     "web_search": "cached"
   },
@@ -105,6 +106,7 @@
     "features.apply_patch_streaming_events": true,
     "features.code_mode": true,
     "features.code_mode_only": false,
+    "features.goals": false,
     "features.standalone_web_search": false,
     "web_search": "cached"
   },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3687,6 +3687,11 @@ export const en: TranslationMap = {
       resume: "Resume goal",
       clear: "Clear goal",
     },
+    questions: {
+      title: "Codex needs input",
+      other: "Type another answer",
+      submit: "Submit answer",
+    },
     messages: {
       activity: "Activity",
       deleteMessage: "Delete message",

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -2279,6 +2279,7 @@ class ChatPane extends OpenClawLightDomElement {
       compactionStatus: state.compactionStatus,
       fallbackStatus: state.fallbackStatus,
       planStatus: state.planStatus,
+      questionStatus: state.questionStatus,
       messages: catalogKey ? this.catalogMessages : state.chatMessages,
       historyPagination:
         catalogKey || state.chatHistoryPagination?.hasMore || this.loadingOlder
@@ -2435,6 +2436,11 @@ class ChatPane extends OpenClawLightDomElement {
       onQueueRetry: (id) => void state.retryQueuedChatMessage(id),
       onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
       onGoalCommand: (command) => void state.handleSendChat(command),
+      onQuestionSubmit: (actionToken, answers, onRejected) =>
+        void state.handleSendChat(
+          `/codex answer ${actionToken} answers:${encodeURIComponent(JSON.stringify(answers))}`,
+          { onLocalCommandSendRejected: onRejected },
+        ),
       onSideQuestion: (command, displayQuestion, onSendRejected) =>
         void state.handleSendChat(command, {
           ...(displayQuestion ? { sideQuestionDisplayText: displayQuestion } : {}),

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -209,6 +209,9 @@ type ChatSendOptions = {
   /** Lets the side-chat panel restore its typed follow-up when the detached
    * send is not accepted (the panel input is not a managed draft). */
   onSideQuestionSendRejected?: () => void;
+  /** Lets request-scoped UI actions recover when their local slash command
+   * fails before the Gateway accepts it. */
+  onLocalCommandSendRejected?: () => void;
 };
 
 function normalizeAckTimingValue(value: unknown): number | undefined {
@@ -2316,6 +2319,9 @@ export async function handleSendChat(
               sendResetSlashCommand(host, resetMessage, resetOpts),
           },
         );
+        if (dispatchResult === "failed") {
+          opts?.onLocalCommandSendRejected?.();
+        }
         if (dispatchResult === "failed" && messageOverride == null) {
           const restorePlan = pendingComposerRestorePlan(host, {
             previousAttachments: attachmentsToSend,

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -157,6 +157,7 @@ import {
   type CompactionStatus,
   type FallbackStatus,
   type PlanStatus,
+  type QuestionStatus,
   type ToolStreamEntry,
 } from "./tool-stream.ts";
 import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
@@ -237,6 +238,7 @@ export type ChatPageHost = ChatHost &
     compactionStatus: CompactionStatus | null;
     fallbackStatus: FallbackStatus | null;
     planStatus: PlanStatus | null;
+    questionStatus: QuestionStatus | null;
     chatRunStatus: ChatProps["runStatus"];
     chatNewMessagesBelow: boolean;
     chatMetadataRequestVersion: number;
@@ -1259,6 +1261,7 @@ export function createPageState(
     compactionStatus: null,
     fallbackStatus: null,
     planStatus: null,
+    questionStatus: null,
     chatAvatarUrl: null,
     chatAvatarStatus: null,
     chatAvatarReason: null,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -58,7 +58,12 @@ import type { RealtimeTalkConversationEntry } from "./realtime-talk-conversation
 import type { RealtimeTalkLevelSignal } from "./realtime-talk-level.ts";
 import type { RealtimeTalkStatus } from "./realtime-talk.ts";
 import type { ChatRunUiStatus } from "./run-lifecycle.ts";
-import type { CompactionStatus, FallbackStatus, PlanStatus } from "./tool-stream.ts";
+import type {
+  CompactionStatus,
+  FallbackStatus,
+  PlanStatus,
+  QuestionStatus,
+} from "./tool-stream.ts";
 import "../../components/resizable-divider.ts";
 
 function isFileDrag(dataTransfer: DataTransfer | null): boolean {
@@ -81,6 +86,7 @@ export type ChatProps = {
   compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;
   planStatus?: PlanStatus | null;
+  questionStatus?: QuestionStatus | null;
   messages: unknown[];
   historyPagination?: {
     loading: boolean;
@@ -157,6 +163,11 @@ export type ChatProps = {
   onQueueRetry?: (id: string) => void;
   onQueueSteer?: (id: string) => void;
   onGoalCommand?: (command: string) => void;
+  onQuestionSubmit?: (
+    actionToken: string,
+    answers: Record<string, string>,
+    onRejected: () => void,
+  ) => void;
   onHistoryIntent?: (event: Event) => void;
   /** Sends a detached /btw side question (selection popup or side-chat
    * follow-up). `displayQuestion` overrides the pending-turn display when the
@@ -327,6 +338,7 @@ export function renderChat(props: ChatProps) {
     compactionStatus: props.compactionStatus,
     fallbackStatus: props.fallbackStatus,
     planStatus: props.planStatus,
+    questionStatus: props.questionStatus,
     messages: props.messages,
     stream: props.stream,
     queue: props.queue,
@@ -361,6 +373,7 @@ export function renderChat(props: ChatProps) {
     onQueueRetry: props.onQueueRetry,
     onQueueSteer: props.onQueueSteer,
     onGoalCommand: props.onGoalCommand,
+    onQuestionSubmit: props.onQuestionSubmit,
     onNewSession: props.onNewSession,
     onClearReply: props.onClearReply,
     onAttachmentsChange: props.onAttachmentsChange,

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -59,6 +59,7 @@ import {
   renderMicrophoneActivity,
   voiceStatusLabel,
 } from "./chat-voice-activity.ts";
+import "./chat-question-card.ts";
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
 const FALLBACK_TOAST_DURATION_MS = 8000;
@@ -91,6 +92,7 @@ type ChatComposerProps = {
   compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;
   planStatus?: PlanStatus | null;
+  questionStatus?: import("../tool-stream.ts").QuestionStatus | null;
   messages: unknown[];
   stream: string | null;
   queue: ChatQueueItem[];
@@ -128,6 +130,11 @@ type ChatComposerProps = {
   onClearReply?: () => void;
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
   onGoalCommand?: (command: string) => void;
+  onQuestionSubmit?: (
+    actionToken: string,
+    answers: Record<string, string>,
+    onRejected: () => void,
+  ) => void;
 };
 
 type PendingClearedSubmittedDraft = {
@@ -2224,6 +2231,20 @@ export function renderChatComposer(props: ChatComposerProps) {
             `
           : nothing}
         <div class="agent-chat__composer-status-stack">
+          ${props.questionStatus
+            ? html`<openclaw-chat-question
+                .props=${{
+                  status: props.questionStatus,
+                  disabled: !props.connected,
+                  onSubmit: (answers: Record<string, string>, onRejected: () => void) =>
+                    props.onQuestionSubmit?.(
+                      props.questionStatus!.actionToken,
+                      answers,
+                      onRejected,
+                    ),
+                }}
+              ></openclaw-chat-question>`
+            : nothing}
           ${renderChatPlanChecklist(props.planStatus, {
             active: showAbortableUi,
             variant: "bar",

--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -33,7 +33,7 @@ describe("native Codex question card", () => {
                 header: "Mode",
                 question: "Pick one",
                 isOther: false,
-                options: [{ label: "Fast" }, { label: "Deep", description: "More reasoning" }],
+                options: [{ label: "Fast" }, { label: " Deep ", description: "More reasoning" }],
               },
             ],
           },
@@ -47,7 +47,7 @@ describe("native Codex question card", () => {
     options[1]!.click();
     await card.updateComplete;
     container.querySelector<HTMLButtonElement>(".chat-question__submit")!.click();
-    expect(onSubmit).toHaveBeenCalledWith({ mode: "Deep" }, expect.any(Function));
+    expect(onSubmit).toHaveBeenCalledWith({ mode: " Deep " }, expect.any(Function));
     await card.updateComplete;
     expect(container.querySelector<HTMLButtonElement>(".chat-question__submit")?.disabled).toBe(
       true,

--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -2,8 +2,11 @@
 
 import { html, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChatQuestionCard } from "./chat-question-card.ts";
 import "./chat-question-card.ts";
+
+type ChatQuestionCardElement = HTMLElement & {
+  updateComplete: Promise<unknown>;
+};
 
 describe("native Codex question card", () => {
   let container: HTMLDivElement;
@@ -41,7 +44,7 @@ describe("native Codex question card", () => {
       ></openclaw-chat-question>`,
       container,
     );
-    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCardElement;
     await card.updateComplete;
     const options = container.querySelectorAll<HTMLInputElement>('input[type="radio"]');
     options[1]!.click();
@@ -77,7 +80,7 @@ describe("native Codex question card", () => {
       ></openclaw-chat-question>`,
       container,
     );
-    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCardElement;
     await card.updateComplete;
     expect(container.querySelector<HTMLInputElement>(".chat-question__other")?.type).toBe("text");
   });
@@ -108,7 +111,7 @@ describe("native Codex question card", () => {
       ></openclaw-chat-question>`,
       container,
     );
-    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCardElement;
     await card.updateComplete;
     container.querySelector<HTMLInputElement>('input[type="radio"]')!.click();
     await card.updateComplete;
@@ -139,7 +142,7 @@ describe("native Codex question card", () => {
       html`<openclaw-chat-question .props=${props("first-token")}></openclaw-chat-question>`,
       container,
     );
-    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCardElement;
     await card.updateComplete;
     const input = container.querySelector<HTMLInputElement>(".chat-question__other")!;
     input.value = "stale answer";
@@ -178,7 +181,7 @@ describe("native Codex question card", () => {
       ></openclaw-chat-question>`,
       container,
     );
-    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCardElement;
     await card.updateComplete;
     const input = container.querySelector<HTMLInputElement>(".chat-question__other")!;
     input.value = "No";

--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -1,0 +1,157 @@
+/* @vitest-environment jsdom */
+
+import { html, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatQuestionCard } from "./chat-question-card.ts";
+import "./chat-question-card.ts";
+
+describe("native Codex question card", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("submits a selected native option through the chat reply seam", async () => {
+    const onSubmit = vi.fn();
+    render(
+      html`<openclaw-chat-question
+        .props=${{
+          disabled: false,
+          onSubmit,
+          status: {
+            itemId: "item-1",
+            actionToken: "test-action-token",
+            questions: [
+              {
+                id: "mode",
+                header: "Mode",
+                question: "Pick one",
+                isOther: false,
+                options: [{ label: "Fast" }, { label: "Deep", description: "More reasoning" }],
+              },
+            ],
+          },
+        }}
+      ></openclaw-chat-question>`,
+      container,
+    );
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    await card.updateComplete;
+    const options = container.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    options[1]!.click();
+    await card.updateComplete;
+    container.querySelector<HTMLButtonElement>(".chat-question__submit")!.click();
+    expect(onSubmit).toHaveBeenCalledWith({ mode: "Deep" }, expect.any(Function));
+    await card.updateComplete;
+    expect(container.querySelector<HTMLButtonElement>(".chat-question__submit")?.disabled).toBe(
+      true,
+    );
+  });
+
+  it("renders a free-form answer field", async () => {
+    render(
+      html`<openclaw-chat-question
+        .props=${{
+          disabled: false,
+          onSubmit: vi.fn(),
+          status: {
+            itemId: "item-other",
+            actionToken: "test-action-token",
+            questions: [
+              {
+                id: "other",
+                header: "Alternative",
+                question: "Type another answer",
+                isOther: true,
+                options: [],
+              },
+            ],
+          },
+        }}
+      ></openclaw-chat-question>`,
+      container,
+    );
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    await card.updateComplete;
+    expect(container.querySelector<HTMLInputElement>(".chat-question__other")?.type).toBe("text");
+  });
+
+  it("re-enables submission when the scoped command is rejected", async () => {
+    let reject: (() => void) | undefined;
+    render(
+      html`<openclaw-chat-question
+        .props=${{
+          disabled: false,
+          onSubmit: (_answers: Record<string, string>, onRejected: () => void) => {
+            reject = onRejected;
+          },
+          status: {
+            itemId: "item-retry",
+            actionToken: "test-action-token",
+            questions: [
+              {
+                id: "mode",
+                header: "Mode",
+                question: "Pick one",
+                isOther: false,
+                options: [{ label: "Retry" }],
+              },
+            ],
+          },
+        }}
+      ></openclaw-chat-question>`,
+      container,
+    );
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    await card.updateComplete;
+    container.querySelector<HTMLInputElement>('input[type="radio"]')!.click();
+    await card.updateComplete;
+    const submit = container.querySelector<HTMLButtonElement>(".chat-question__submit")!;
+    submit.click();
+    await card.updateComplete;
+    expect(submit.disabled).toBe(true);
+
+    reject?.();
+    await card.updateComplete;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it("clears free-form text when the request token changes", async () => {
+    const question = {
+      id: "other",
+      header: "Alternative",
+      question: "Type another answer",
+      isOther: true,
+      options: [] as Array<{ label: string }>,
+    };
+    const props = (actionToken: string) => ({
+      disabled: false,
+      onSubmit: vi.fn(),
+      status: { itemId: "reused-item", actionToken, questions: [question] },
+    });
+    render(
+      html`<openclaw-chat-question .props=${props("first-token")}></openclaw-chat-question>`,
+      container,
+    );
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    await card.updateComplete;
+    const input = container.querySelector<HTMLInputElement>(".chat-question__other")!;
+    input.value = "stale answer";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await card.updateComplete;
+    expect(input.value).toBe("stale answer");
+
+    render(
+      html`<openclaw-chat-question .props=${props("second-token")}></openclaw-chat-question>`,
+      container,
+    );
+    await card.updateComplete;
+    expect(container.querySelector<HTMLInputElement>(".chat-question__other")?.value).toBe("");
+  });
+});

--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -154,4 +154,40 @@ describe("native Codex question card", () => {
     await card.updateComplete;
     expect(container.querySelector<HTMLInputElement>(".chat-question__other")?.value).toBe("");
   });
+
+  it("preserves free-form text that begins with an option label", async () => {
+    render(
+      html`<openclaw-chat-question
+        .props=${{
+          disabled: false,
+          onSubmit: vi.fn(),
+          status: {
+            itemId: "item-prefix",
+            actionToken: "test-action-token",
+            questions: [
+              {
+                id: "reason",
+                header: "Decision",
+                question: "Continue?",
+                isOther: true,
+                options: [{ label: "No" }],
+              },
+            ],
+          },
+        }}
+      ></openclaw-chat-question>`,
+      container,
+    );
+    const card = container.querySelector("openclaw-chat-question") as ChatQuestionCard;
+    await card.updateComplete;
+    const input = container.querySelector<HTMLInputElement>(".chat-question__other")!;
+    input.value = "No";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await card.updateComplete;
+    input.value = "No, because the proof failed";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await card.updateComplete;
+
+    expect(input.value).toBe("No, because the proof failed");
+  });
 });

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -38,10 +38,7 @@ class ChatQuestionCard extends LitElement {
       return;
     }
     const answers = Object.fromEntries(
-      status.questions.map((question) => [
-        question.id,
-        this.answers.get(question.id)!.trim().toWellFormed(),
-      ]),
+      status.questions.map((question) => [question.id, this.answers.get(question.id)!.trim()]),
     );
     this.submitted = true;
     this.props?.onSubmit(answers, () => {

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -1,0 +1,123 @@
+import { LitElement, html, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+import { t } from "../../../i18n/index.ts";
+import type { QuestionStatus } from "../tool-stream.ts";
+
+type QuestionCardProps = {
+  status: QuestionStatus;
+  disabled: boolean;
+  onSubmit: (answers: Record<string, string>, onRejected: () => void) => void;
+};
+
+class ChatQuestionCard extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  @property({ attribute: false }) props?: QuestionCardProps;
+  @state() private answers = new Map<string, string>();
+  @state() private submitted = false;
+  private requestKey: string | null = null;
+
+  override willUpdate() {
+    const status = this.props?.status;
+    const nextRequestKey = status ? `${status.itemId}:${status.actionToken}` : null;
+    if (nextRequestKey !== this.requestKey) {
+      this.requestKey = nextRequestKey;
+      this.answers = new Map();
+      this.submitted = false;
+    }
+  }
+
+  private setAnswer(questionId: string, answer: string): void {
+    this.answers = new Map(this.answers).set(questionId, answer);
+  }
+
+  private submit(status: QuestionStatus): void {
+    if (!status.questions.every((question) => this.answers.get(question.id)?.trim())) {
+      return;
+    }
+    const answers = Object.fromEntries(
+      status.questions.map((question) => [
+        question.id,
+        this.answers.get(question.id)!.trim().toWellFormed(),
+      ]),
+    );
+    this.submitted = true;
+    this.props?.onSubmit(answers, () => {
+      this.submitted = false;
+    });
+  }
+
+  override render() {
+    const props = this.props;
+    if (!props) {
+      return nothing;
+    }
+    const complete = props.status.questions.every((question) =>
+      Boolean(this.answers.get(question.id)?.trim()),
+    );
+    return html`
+      <section class="chat-question" role="group" aria-label=${t("chat.questions.title")}>
+        <div class="chat-question__title">${t("chat.questions.title")}</div>
+        ${props.status.questions.map(
+          (question) => html`
+            <fieldset class="chat-question__field">
+              <legend>${question.header}</legend>
+              <div class="chat-question__prompt">${question.question}</div>
+              ${question.options.map(
+                (option) => html`
+                  <label class="chat-question__option">
+                    <input
+                      type="radio"
+                      name=${`${props.status.itemId}-${question.id}`}
+                      .checked=${this.answers.get(question.id) === option.label}
+                      ?disabled=${props.disabled || this.submitted}
+                      @change=${() => this.setAnswer(question.id, option.label)}
+                    />
+                    <span>
+                      <strong>${option.label}</strong>
+                      ${option.description ? html`<small>${option.description}</small>` : nothing}
+                    </span>
+                  </label>
+                `,
+              )}
+              ${question.isOther || question.options.length === 0
+                ? html`
+                    <input
+                      class="chat-question__other"
+                      type="text"
+                      autocomplete="off"
+                      placeholder=${t("chat.questions.other")}
+                      .value=${question.options.some(
+                        (option) => option.label === this.answers.get(question.id),
+                      )
+                        ? ""
+                        : (this.answers.get(question.id) ?? "")}
+                      ?disabled=${props.disabled || this.submitted}
+                      @input=${(event: Event) =>
+                        this.setAnswer(question.id, (event.target as HTMLInputElement).value)}
+                    />
+                  `
+                : nothing}
+            </fieldset>
+          `,
+        )}
+        <button
+          class="btn btn--sm primary chat-question__submit"
+          type="button"
+          ?disabled=${props.disabled || this.submitted || !complete}
+          @click=${() => this.submit(props.status)}
+        >
+          ${t("chat.questions.submit")}
+        </button>
+      </section>
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-chat-question")) {
+  customElements.define("openclaw-chat-question", ChatQuestionCard);
+}
+
+export type { ChatQuestionCard, QuestionCardProps };

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -127,5 +127,3 @@ class ChatQuestionCard extends LitElement {
 if (!customElements.get("openclaw-chat-question")) {
   customElements.define("openclaw-chat-question", ChatQuestionCard);
 }
-
-export type { ChatQuestionCard, QuestionCardProps };

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -47,7 +47,7 @@ class ChatQuestionCard extends LitElement {
       return;
     }
     const answers = Object.fromEntries(
-      status.questions.map((question) => [question.id, this.answers.get(question.id)!.trim()]),
+      status.questions.map((question) => [question.id, this.answers.get(question.id)!]),
     );
     this.submitted = true;
     this.props?.onSubmit(answers, () => {

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -16,6 +16,7 @@ class ChatQuestionCard extends LitElement {
 
   @property({ attribute: false }) props?: QuestionCardProps;
   @state() private answers = new Map<string, string>();
+  @state() private freeFormAnswers = new Set<string>();
   @state() private submitted = false;
   private requestKey: string | null = null;
 
@@ -25,12 +26,20 @@ class ChatQuestionCard extends LitElement {
     if (nextRequestKey !== this.requestKey) {
       this.requestKey = nextRequestKey;
       this.answers = new Map();
+      this.freeFormAnswers = new Set();
       this.submitted = false;
     }
   }
 
-  private setAnswer(questionId: string, answer: string): void {
+  private setAnswer(questionId: string, answer: string, source: "option" | "text"): void {
     this.answers = new Map(this.answers).set(questionId, answer);
+    const freeFormAnswers = new Set(this.freeFormAnswers);
+    if (source === "text") {
+      freeFormAnswers.add(questionId);
+    } else {
+      freeFormAnswers.delete(questionId);
+    }
+    this.freeFormAnswers = freeFormAnswers;
   }
 
   private submit(status: QuestionStatus): void {
@@ -70,7 +79,7 @@ class ChatQuestionCard extends LitElement {
                       name=${`${props.status.itemId}-${question.id}`}
                       .checked=${this.answers.get(question.id) === option.label}
                       ?disabled=${props.disabled || this.submitted}
-                      @change=${() => this.setAnswer(question.id, option.label)}
+                      @change=${() => this.setAnswer(question.id, option.label, "option")}
                     />
                     <span>
                       <strong>${option.label}</strong>
@@ -86,14 +95,16 @@ class ChatQuestionCard extends LitElement {
                       type="text"
                       autocomplete="off"
                       placeholder=${t("chat.questions.other")}
-                      .value=${question.options.some(
-                        (option) => option.label === this.answers.get(question.id),
-                      )
-                        ? ""
-                        : (this.answers.get(question.id) ?? "")}
+                      .value=${this.freeFormAnswers.has(question.id)
+                        ? (this.answers.get(question.id) ?? "")
+                        : ""}
                       ?disabled=${props.disabled || this.submitted}
                       @input=${(event: Event) =>
-                        this.setAnswer(question.id, (event.target as HTMLInputElement).value)}
+                        this.setAnswer(
+                          question.id,
+                          (event.target as HTMLInputElement).value,
+                          "text",
+                        )}
                     />
                   `
                 : nothing}

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -18,6 +18,7 @@ import {
   type CompactionStatus,
   type FallbackStatus,
   type PlanStatus,
+  type QuestionStatus,
 } from "./tool-stream.ts";
 
 export const CHAT_RUN_STATUS_TOAST_DURATION_MS = 5_000;
@@ -56,6 +57,7 @@ type RunLifecycleHost = Omit<
   fallbackStatus?: FallbackStatus | null;
   fallbackClearTimer?: TimerHandle | number | null;
   planStatus?: PlanStatus | null;
+  questionStatus?: QuestionStatus | null;
   chatRunStatus?: ChatRunUiStatus | null;
   chatRunStatusClearTimer?: TimerHandle | number | null;
   sessionsResult?: SessionsListResult | null;
@@ -234,6 +236,10 @@ function clearRunIndicators(host: RunLifecycleHost, runId?: string | null) {
   const planOwner = host.planStatus?.runId;
   if (host.planStatus && (!runId || !planOwner || planOwner === runId)) {
     host.planStatus = null;
+  }
+  const questionOwner = host.questionStatus?.runId;
+  if (host.questionStatus && (!runId || !questionOwner || questionOwner === runId)) {
+    host.questionStatus = null;
   }
 }
 

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -274,11 +274,11 @@ describe("app-tool-stream native questions", () => {
         actionToken: testQuestionActionToken(),
         questions: [
           {
-            id: "mode",
+            id: " mode ",
             header: " Mode ",
             question: " Pick one ",
             isOther: true,
-            options: [{ label: "Fast", description: "Quick" }, { label: "" }],
+            options: [{ label: " Fast ", description: "Quick" }, { label: "" }],
           },
         ],
       }),
@@ -289,11 +289,11 @@ describe("app-tool-stream native questions", () => {
       actionToken: testQuestionActionToken(),
       questions: [
         {
-          id: "mode",
+          id: " mode ",
           header: "Mode",
           question: "Pick one",
           isOther: true,
-          options: [{ label: "Fast", description: "Quick" }],
+          options: [{ label: " Fast ", description: "Quick" }],
         },
       ],
     });

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -6,6 +6,7 @@ import {
   resetToolStream,
   type FallbackStatus,
   type PlanStatus,
+  type QuestionStatus,
   type ToolStreamEntry,
 } from "./tool-stream.ts";
 
@@ -21,9 +22,14 @@ type MutableHost = ToolStreamHost & {
   fallbackStatus?: FallbackStatus | null;
   fallbackClearTimer?: number | null;
   planStatus?: PlanStatus | null;
+  questionStatus?: QuestionStatus | null;
   requestUpdate?: () => void;
 };
 const TOOL_STREAM_TEST_NOW = new Date("2026-05-09T00:00:00.000Z").getTime();
+
+function testQuestionActionToken(): string {
+  return "12345678-1234-4123-8123-123456789abc";
+}
 
 function createHost(overrides?: Partial<MutableHost>): MutableHost {
   const modelOverrides: Record<string, string | null> = {};
@@ -52,6 +58,7 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
     fallbackStatus: null,
     fallbackClearTimer: null,
     planStatus: null,
+    questionStatus: null,
     ...overrides,
   };
 }
@@ -253,6 +260,75 @@ describe("app-tool-stream plan snapshots", () => {
     resetToolStream(host);
 
     expect(host.planStatus).toBeNull();
+  });
+});
+
+describe("app-tool-stream native questions", () => {
+  it("stores structured questions and clears only the matching item", () => {
+    const host = createHost();
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "question", {
+        phase: "requested",
+        itemId: "item-1",
+        actionToken: testQuestionActionToken(),
+        questions: [
+          {
+            id: "mode",
+            header: " Mode ",
+            question: " Pick one ",
+            isOther: true,
+            options: [{ label: "Fast", description: "Quick" }, { label: "" }],
+          },
+        ],
+      }),
+    );
+    expect(host.questionStatus).toEqual({
+      runId: "run-1",
+      itemId: "item-1",
+      actionToken: testQuestionActionToken(),
+      questions: [
+        {
+          id: "mode",
+          header: "Mode",
+          question: "Pick one",
+          isOther: true,
+          options: [{ label: "Fast", description: "Quick" }],
+        },
+      ],
+    });
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "question", { phase: "resolved", itemId: "other" }),
+    );
+    expect(host.questionStatus?.itemId).toBe("item-1");
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 3, "question", { phase: "resolved", itemId: "item-1" }),
+    );
+    expect(host.questionStatus).toBeNull();
+  });
+
+  it("leaves secret questions on the warned text-reply path", () => {
+    const host = createHost();
+    handleAgentEvent(
+      host,
+      agentEvent("run-secret", 1, "question", {
+        phase: "requested",
+        itemId: "item-secret",
+        actionToken: testQuestionActionToken(),
+        questions: [
+          {
+            id: "secret",
+            header: "Secret",
+            question: "Enter it",
+            isSecret: true,
+          },
+        ],
+      }),
+    );
+    expect(host.questionStatus).toBeNull();
   });
 });
 

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -781,18 +781,18 @@ function parseQuestionStatus(
   }
   const questions = data.questions.flatMap((value) => {
     const question = readRecord(value);
-    const id = toTrimmedString(question?.id);
+    const id = typeof question?.id === "string" ? question.id : undefined;
     const header = toTrimmedString(question?.header);
     const prompt = toTrimmedString(question?.question);
-    if (!id || !header || !prompt) {
+    if (!id?.trim() || !header || !prompt) {
       return [];
     }
     const options = Array.isArray(question?.options)
       ? question.options.flatMap((rawOption) => {
           const option = readRecord(rawOption);
-          const label = toTrimmedString(option?.label);
+          const label = typeof option?.label === "string" ? option.label : undefined;
           const description = toTrimmedString(option?.description);
-          return label ? [{ label, ...(description ? { description } : {}) }] : [];
+          return label?.trim() ? [{ label, ...(description ? { description } : {}) }] : [];
         })
       : [];
     return [

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -66,6 +66,7 @@ type ToolStreamHost = {
   chatToolMessages: Record<string, unknown>[];
   toolStreamSyncTimer: number | null;
   planStatus?: PlanStatus | null;
+  questionStatus?: QuestionStatus | null;
   sessions: Pick<SessionCapability, "setModelOverride">;
 };
 
@@ -330,6 +331,7 @@ export function resetToolStream(host: ToolStreamHost) {
   host.chatToolMessages = [];
   host.chatStreamSegments = [];
   host.planStatus = null;
+  host.questionStatus = null;
 }
 
 export type CompactionStatus = {
@@ -359,8 +361,26 @@ export type PlanStatus = {
   }>;
 };
 
+export type QuestionStatus = {
+  runId?: string;
+  itemId: string;
+  actionToken: string;
+  questions: Array<{
+    id: string;
+    header: string;
+    question: string;
+    isOther: boolean;
+    options: Array<{ label: string; description?: string }>;
+  }>;
+};
+
 type PlanHost = ToolStreamHost & {
   planStatus?: PlanStatus | null;
+  requestUpdate?: () => void;
+};
+
+type QuestionHost = ToolStreamHost & {
+  questionStatus?: QuestionStatus | null;
   requestUpdate?: () => void;
 };
 
@@ -745,6 +765,71 @@ function handlePlanEvent(host: PlanHost, payload: AgentEventPayload) {
   host.requestUpdate?.();
 }
 
+function parseQuestionStatus(
+  data: Record<string, unknown>,
+  runId: string | null,
+): QuestionStatus | null {
+  const itemId = toTrimmedString(data.itemId);
+  const actionToken = toTrimmedString(data.actionToken);
+  if (!itemId || !actionToken?.match(/^[0-9a-f-]{36}$/u) || !Array.isArray(data.questions)) {
+    return null;
+  }
+  // Sensitive answers cannot use the chat-send seam without becoming transcript content.
+  // Keep the existing warned text prompt until the dedicated question RPC exists.
+  if (data.questions.some((value) => readRecord(value)?.isSecret === true)) {
+    return null;
+  }
+  const questions = data.questions.flatMap((value) => {
+    const question = readRecord(value);
+    const id = toTrimmedString(question?.id);
+    const header = toTrimmedString(question?.header);
+    const prompt = toTrimmedString(question?.question);
+    if (!id || !header || !prompt) {
+      return [];
+    }
+    const options = Array.isArray(question?.options)
+      ? question.options.flatMap((rawOption) => {
+          const option = readRecord(rawOption);
+          const label = toTrimmedString(option?.label);
+          const description = toTrimmedString(option?.description);
+          return label ? [{ label, ...(description ? { description } : {}) }] : [];
+        })
+      : [];
+    return [
+      {
+        id,
+        header,
+        question: prompt,
+        isOther: question?.isOther === true,
+        options,
+      },
+    ];
+  });
+  return questions.length > 0
+    ? { ...(runId ? { runId } : {}), itemId, actionToken, questions }
+    : null;
+}
+
+function handleQuestionEvent(host: QuestionHost, payload: AgentEventPayload) {
+  if (!resolveAcceptedSession(host, payload, { allowSessionScopedWhenIdle: true }).accepted) {
+    return;
+  }
+  const data = payload.data ?? {};
+  const itemId = toTrimmedString(data.itemId);
+  if (data.phase === "resolved") {
+    if (!itemId || host.questionStatus?.itemId === itemId) {
+      host.questionStatus = null;
+      host.requestUpdate?.();
+    }
+    return;
+  }
+  if (data.phase !== "requested") {
+    return;
+  }
+  host.questionStatus = parseQuestionStatus(data, toTrimmedString(payload.runId));
+  host.requestUpdate?.();
+}
+
 export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload) {
   if (!payload) {
     return;
@@ -781,6 +866,11 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
 
   if (payload.stream === "plan") {
     handlePlanEvent(host as PlanHost, payload);
+    return;
+  }
+
+  if (payload.stream === "question") {
+    handleQuestionEvent(host as QuestionHost, payload);
     return;
   }
 

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -4,5 +4,6 @@
 @import "./chat/grouped.css";
 @import "./chat/tool-cards.css";
 @import "./chat/plan-checklist.css";
+@import "./chat/question-card.css";
 @import "./chat/sidebar.css";
 @import "./chat/split-view.css";

--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -1,0 +1,59 @@
+.chat-question {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-elevated);
+}
+
+.chat-question__title {
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chat-question__field {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.chat-question__field legend {
+  padding: 0;
+  color: var(--text-strong);
+  font-weight: 650;
+}
+
+.chat-question__prompt {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.chat-question__option {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.chat-question__option small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-muted);
+}
+
+.chat-question__other {
+  width: 100%;
+}
+
+.chat-question__submit {
+  justify-self: end;
+}


### PR DESCRIPTION
Related: #102261
Related: #102260

## What Problem This Solves

Codex app-server runs could request structured user input or expose a native thread goal, but OpenClaw only surfaced a flattened text prompt and had no native goal command path. Control UI users could not answer the structured request in place, and operators could not read or update the upstream goal without a second state system.

## Why This Change Was Made

This is the first, bounded slice of the approved Codex-parity split. It carries native `request_user_input` questions through the existing typed presentation seam into channels and the Control UI, then routes request-scoped answers back to the waiting app-server request. Secret questions stay on the warned text path and never receive an action token.

It also maps `/codex goal` read/write commands directly to upstream `thread/goal/get`, `thread/goal/set`, and `thread/goal/clear`. There is no parallel goal store. Per-thread `features.goals` remains disabled because upstream couples the feature to automatic idle continuation; the app-server RPC gate remains available from its stable process default.

The existing `turn/plan/updated` projector and Activity/UI display already landed on `main`, so this PR does not duplicate that implementation.

Upstream contract checked directly at `openai/codex@315195492c80fdade38e917c18f9584efd599304`:

- [`request_user_input` method and response path](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server-protocol/src/protocol/common.rs#L1486-L1490), [question/answer wire shapes](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1585-L1637), and [response submission](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server/src/bespoke_event_handling.rs#L1602-L1680)
- [native goal methods](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server-protocol/src/protocol/common.rs#L539-L552), [partial set/get/clear shapes](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L759-L856), and [processor behavior](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server/src/request_processors/thread_goal_processor.rs#L117-L236)
- [`turn/plan/updated` shape](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L411-L435) and [event projection](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server/src/bespoke_event_handling.rs#L1192-L1246)
- [goals feature explicitly includes automatic continuation](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/features/src/lib.rs#L217-L222) and [idle hook launches continuation](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/ext/goal/src/extension.rs#L154-L165)

Thanks @100yenadmin for the original UI/protocol work in #102261. Contributor credit is preserved in the commit history and squash metadata.

## User Impact

Control UI users see native Codex questions as structured option/free-form cards and can submit an answer without leaving chat. Supported channels receive typed choice actions. Codex operators can inspect, set, pause, resume, block, complete, or clear the native upstream thread goal through `/codex goal`.

Automatic goal-driven follow-on turns are deliberately out of scope. Provider-neutral question RPC and autonomous continuation design remain later slices.

## Evidence

- Focused local proof: 35 Control UI tests and 325 Codex extension tests passed.
- Full changed-surface Testbox gate: [run 29559093843](https://github.com/openclaw/openclaw/actions/runs/29559093843), Testbox `tbx_01kxqax7egbxg325a8vvqv3jqy`, exit 0 after 21m04s. Typecheck, lint, format, API baseline, plugin boundaries, i18n, DB/state guards, and import-cycle checks passed.
- Source-blind Control UI behavior proof passed: no initial card; native plan shown; structured question shown; scoped exact-label answer emitted; resolved card cleared; secret question produced no card.
- Sanitized before/question/resolved screenshots and a video were captured from the real Control UI E2E harness. Visual artifacts will be attached to this PR.
- Fresh full-branch autoreview: no accepted/actionable findings; correctness `0.84`.
