### PR TITLE
fix(telegram): bound polling stop cleanup with one shared concurrent barrier

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -4431,7 +4431,8 @@ describe("TelegramPollingSession", () => {
     releaseRunnerStop?.();
     await runPromise;
     expect(leaseReleased).toBe(true);
-    // The cleanup barrier also started bot.shutdown concurrently with the wait.
+    // After the runner drain settles, the cleanup barrier also runs
+    // bot.shutdown before releasing the lease.
     expect(botStop).toHaveBeenCalledTimes(1);
   });
 
@@ -4481,7 +4482,9 @@ describe("TelegramPollingSession", () => {
       await vi.advanceTimersByTimeAsync(1);
       await runPromise;
       expect(leaseReleased).toBe(true);
-      expect(botStop).toHaveBeenCalledTimes(1);
+      // The runner stop wedges past the shared deadline, so the barrier
+      // force-completes without ever starting the queued bot stop.
+      expect(botStop).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -5210,7 +5213,7 @@ describe("waitForGracefulStop", () => {
     pollStopGraceMs = testing.POLL_STOP_GRACE_MS;
   });
 
-  it("starts every stop concurrently and resolves once all of them settle", async () => {
+  it("starts stops in order, holding the bot stop until the runner stop settles", async () => {
     const started: string[] = [];
     let releaseRunner: (() => void) | undefined;
     let releaseBot: (() => void) | undefined;
@@ -5232,15 +5235,22 @@ describe("waitForGracefulStop", () => {
       settled = true;
     });
 
-    // Both shutdown paths start together instead of serial 15s grace windows.
-    expect(started).toEqual(["runner", "bot"]);
+    // The runner drain starts first; grammY runner.stop() is the middleware-
+    // completion boundary, so the bot stop must not start while it is pending.
+    expect(started).toEqual(["runner"]);
     await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toEqual(["runner"]);
     expect(settled).toBe(false);
 
     releaseRunner?.();
-    await Promise.resolve();
-    await Promise.resolve();
-    // The barrier holds while the bot stop is still pending.
+    // Flush the settle -> race -> next-stop microtask chain.
+    for (let flush = 0; flush < 5; flush += 1) {
+      await Promise.resolve();
+    }
+    // The bot stop starts only after the runner drain settles, and the barrier
+    // keeps holding while the bot stop is still pending.
+    expect(started).toEqual(["runner", "bot"]);
     expect(settled).toBe(false);
 
     releaseBot?.();
@@ -5248,21 +5258,60 @@ describe("waitForGracefulStop", () => {
     expect(settled).toBe(true);
   });
 
+  it("shares one grace budget across sequential stops, leaving later stops only the remainder", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseRunner: (() => void) | undefined;
+      const runnerStop = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseRunner = resolve;
+          }),
+      );
+      const botStop = vi.fn(() => new Promise<void>(() => {}));
+      let settled = false;
+      const wait = waitForGracefulStop([runnerStop, botStop]).then(() => {
+        settled = true;
+      });
+
+      // The runner drain consumes 10s of the single shared 15s budget before
+      // the bot stop is even started.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(botStop).not.toHaveBeenCalled();
+      releaseRunner?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(botStop).toHaveBeenCalledTimes(1);
+
+      // The bot stop gets only the remaining 5s, not a fresh 15s window.
+      await vi.advanceTimersByTimeAsync(pollStopGraceMs - 10_000 - 1);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await wait;
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("forces completion at the grace deadline when a stop never settles", async () => {
     vi.useFakeTimers();
     try {
       const wedgedStop = vi.fn(() => new Promise<void>(() => {}));
+      const laterStop = vi.fn(async () => undefined);
       let settled = false;
-      const wait = waitForGracefulStop([wedgedStop]).then(() => {
+      const wait = waitForGracefulStop([wedgedStop, laterStop]).then(() => {
         settled = true;
       });
       expect(wedgedStop).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(pollStopGraceMs - 1);
       expect(settled).toBe(false);
+      // Stops queued behind the wedged stop never start.
+      expect(laterStop).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1);
       await wait;
       expect(settled).toBe(true);
+      expect(laterStop).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -97,6 +97,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 }));
 
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
+let telegramPollingSessionTesting: typeof import("../test-api.js").telegramPollingSessionTesting;
 const telegramSpooledRetryDeadLetterMinAgeMs = 24 * 60 * 60 * 1000;
 const pollingSessionTesting = {
   createTelegramRestartBackoffState,
@@ -740,6 +741,7 @@ function startIsolatedIngressSession(params: {
 describe("TelegramPollingSession", () => {
   beforeAll(async () => {
     ({ TelegramPollingSession } = await import("./polling-session.js"));
+    ({ telegramPollingSessionTesting } = await import("../test-api.js"));
     ({ writeTelegramSpooledUpdate } = await import("./telegram-ingress-spool.js"));
     ({
       claimNextTelegramSpooledUpdate,
@@ -4374,6 +4376,117 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("holds the polling lease until a pending runner stop settles after abort", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    createTelegramBotMock.mockReturnValue({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: { use: vi.fn() },
+      },
+      stop: botStop,
+    });
+
+    let releaseRunnerStop: (() => void) | undefined;
+    const runnerStop = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRunnerStop = resolve;
+        }),
+    );
+    let resolveTask: (() => void) | undefined;
+    const task = new Promise<void>((resolve) => {
+      resolveTask = resolve;
+    });
+    runMock.mockReturnValue({
+      task: () => task,
+      // grammY semantics: stop() lets the polling loop exit promptly while the
+      // returned promise keeps draining in-flight middleware.
+      stop: vi.fn(() => {
+        resolveTask?.();
+        return runnerStop();
+      }),
+      isRunning: () => true,
+    });
+
+    const session = createPollingSession({ abortSignal: abort.signal });
+    let leaseReleased = false;
+    const runPromise = session.runUntilAbort().then(() => {
+      leaseReleased = true;
+    });
+
+    await waitForTelegramTestState(() => expect(runMock).toHaveBeenCalledTimes(1));
+    abort.abort();
+
+    // The abort triggers runner.stop(), but while that stop promise is still
+    // draining, runUntilAbort must not return: the monitor releases the polling
+    // lease when it does, and a replacement poller would overlap getUpdates.
+    await waitForTelegramTestState(() => expect(runnerStop).toHaveBeenCalledTimes(1));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(leaseReleased).toBe(false);
+
+    releaseRunnerStop?.();
+    await runPromise;
+    expect(leaseReleased).toBe(true);
+    // The cleanup barrier also started bot.shutdown concurrently with the wait.
+    expect(botStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the polling lease at the grace deadline when the runner stop never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const abort = new AbortController();
+      const botStop = vi.fn(async () => undefined);
+      createTelegramBotMock.mockReturnValue({
+        api: {
+          deleteWebhook: vi.fn(async () => true),
+          getUpdates: vi.fn(async () => []),
+          config: { use: vi.fn() },
+        },
+        stop: botStop,
+      });
+
+      const runnerStop = vi.fn(() => new Promise<void>(() => {}));
+      let resolveTask: (() => void) | undefined;
+      const task = new Promise<void>((resolve) => {
+        resolveTask = resolve;
+      });
+      runMock.mockReturnValue({
+        task: () => task,
+        stop: vi.fn(() => {
+          resolveTask?.();
+          return runnerStop();
+        }),
+        isRunning: () => true,
+      });
+
+      const session = createPollingSession({ abortSignal: abort.signal });
+      let leaseReleased = false;
+      const runPromise = session.runUntilAbort().then(() => {
+        leaseReleased = true;
+      });
+
+      // The startup path is microtask-only; flush until the polling cycle runs.
+      for (let attempt = 0; attempt < 100 && runMock.mock.calls.length === 0; attempt += 1) {
+        await Promise.resolve();
+      }
+      expect(runMock).toHaveBeenCalledTimes(1);
+
+      abort.abort();
+      await vi.advanceTimersByTimeAsync(telegramPollingSessionTesting.POLL_STOP_GRACE_MS - 1);
+      expect(leaseReleased).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await runPromise;
+      expect(leaseReleased).toBe(true);
+      expect(botStop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("cools down repeated stop-timeout restart bursts", () => {
     computeBackoffMock.mockImplementation((policy: { initialMs: number }, attempt: number) => {
       if (policy.initialMs === 120_000) {
@@ -5084,6 +5197,92 @@ describe("TelegramPollingSession", () => {
     // dispose() closes transport2 since it becomes the held transport after the rebuild.
     expect(transport1.close).toHaveBeenCalled();
     expect(transport2.close).toHaveBeenCalled();
+  });
+});
+
+describe("waitForGracefulStop", () => {
+  let waitForGracefulStop: (typeof import("../test-api.js"))["telegramPollingSessionTesting"]["waitForGracefulStop"];
+  let pollStopGraceMs: number;
+
+  beforeAll(async () => {
+    const testing = (await import("../test-api.js")).telegramPollingSessionTesting;
+    waitForGracefulStop = testing.waitForGracefulStop;
+    pollStopGraceMs = testing.POLL_STOP_GRACE_MS;
+  });
+
+  it("starts every stop concurrently and resolves once all of them settle", async () => {
+    const started: string[] = [];
+    let releaseRunner: (() => void) | undefined;
+    let releaseBot: (() => void) | undefined;
+    const runnerStop = vi.fn(() => {
+      started.push("runner");
+      return new Promise<void>((resolve) => {
+        releaseRunner = resolve;
+      });
+    });
+    const botStop = vi.fn(() => {
+      started.push("bot");
+      return new Promise<void>((resolve) => {
+        releaseBot = resolve;
+      });
+    });
+
+    let settled = false;
+    const wait = waitForGracefulStop([runnerStop, botStop]).then(() => {
+      settled = true;
+    });
+
+    // Both shutdown paths start together instead of serial 15s grace windows.
+    expect(started).toEqual(["runner", "bot"]);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseRunner?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    // The barrier holds while the bot stop is still pending.
+    expect(settled).toBe(false);
+
+    releaseBot?.();
+    await wait;
+    expect(settled).toBe(true);
+  });
+
+  it("forces completion at the grace deadline when a stop never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const wedgedStop = vi.fn(() => new Promise<void>(() => {}));
+      let settled = false;
+      const wait = waitForGracefulStop([wedgedStop]).then(() => {
+        settled = true;
+      });
+      expect(wedgedStop).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(pollStopGraceMs - 1);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await wait;
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resolves without riding out the grace window when every stop is already settled", async () => {
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const wait = waitForGracefulStop([async () => undefined, async () => undefined]).then(() => {
+        settled = true;
+      });
+      // Settled stops resolve through the microtask queue ahead of the deadline
+      // timer; no timer advance is needed.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).toBe(true);
+      await wait;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -55,26 +55,44 @@ type TelegramBot = ReturnType<typeof createTelegramBot>;
 
 // Shared cleanup barrier for session shutdown. Abort/restart paths TRIGGER the
 // stops, but this wait is time-bounded only: it must not resolve early on the
-// owner abort signal. runUntilAbort returns (and the account monitor releases
-// the polling lease) only after every stop promise has settled or the grace
-// deadline expired, so a replacement monitor cannot start a competing poller
-// while grammY runner.stop() is still draining middleware (Telegram 409s).
+// owner abort signal. Stops run in order against one absolute grace deadline:
+// grammY runner.stop() is the middleware-completion boundary, so the bot stop
+// starts only after the runner drain settles and gets just the remaining
+// budget. runUntilAbort returns (and the account monitor releases the polling
+// lease) only after every stop promise has settled or the grace deadline
+// expired, so a replacement monitor cannot start a competing poller while
+// grammY runner.stop() is still draining middleware (Telegram 409s).
 const waitForGracefulStop = async (stops: ReadonlyArray<() => Promise<void>>) => {
-  // Start every stop concurrently; stop handles memoize their in-flight
-  // promise, so stops already triggered by abort/restart are joined, not
-  // restarted.
-  const allSettled = Promise.allSettled(stops.map((stop) => stop()));
+  let deadlineFired = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      deadlineFired = true;
+      resolve();
+    }, POLL_STOP_GRACE_MS);
+    timer.unref?.();
+  });
   try {
-    // Already-settled stops resolve through the microtask queue before the
-    // deadline timer can fire, so the clean-shutdown fast path stays immediate.
-    await Promise.race([
-      allSettled,
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, POLL_STOP_GRACE_MS);
-        timer.unref?.();
-      }),
-    ]);
+    for (const stop of stops) {
+      // Past the shared deadline the barrier force-completes; stops queued
+      // behind a wedged stop never start.
+      if (deadlineFired) {
+        break;
+      }
+      // Stop handles memoize their in-flight promise, so stops already
+      // triggered by abort/restart are joined, not restarted. The first stop
+      // starts synchronously, and already-settled stops resolve through the
+      // microtask queue before the deadline timer can fire, so the
+      // clean-shutdown fast path stays immediate. A failed stop settles its
+      // slot; the barrier still sequences the remaining stops.
+      let stopPromise: Promise<void>;
+      try {
+        stopPromise = Promise.resolve(stop());
+      } catch {
+        continue;
+      }
+      await Promise.race([stopPromise.catch(() => undefined), deadline]);
+    }
   } finally {
     if (timer) {
       clearTimeout(timer);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -53,11 +53,23 @@ function normalizeTelegramAccountId(accountId?: string | null): string {
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
-const waitForGracefulStop = async (stop: () => Promise<void>) => {
+// Shared cleanup barrier for session shutdown. Abort/restart paths TRIGGER the
+// stops, but this wait is time-bounded only: it must not resolve early on the
+// owner abort signal. runUntilAbort returns (and the account monitor releases
+// the polling lease) only after every stop promise has settled or the grace
+// deadline expired, so a replacement monitor cannot start a competing poller
+// while grammY runner.stop() is still draining middleware (Telegram 409s).
+const waitForGracefulStop = async (stops: ReadonlyArray<() => Promise<void>>) => {
+  // Start every stop concurrently; stop handles memoize their in-flight
+  // promise, so stops already triggered by abort/restart are joined, not
+  // restarted.
+  const allSettled = Promise.allSettled(stops.map((stop) => stop()));
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
+    // Already-settled stops resolve through the microtask queue before the
+    // deadline timer can fire, so the clean-shutdown fast path stays immediate.
     await Promise.race([
-      stop(),
+      allSettled,
       new Promise<void>((resolve) => {
         timer = setTimeout(resolve, POLL_STOP_GRACE_MS);
         timer.unref?.();
@@ -707,7 +719,7 @@ export class TelegramPollingSession {
       }
       this.#ingressDrain?.dispose();
       this.#ingressDrain = undefined;
-      await waitForGracefulStop(stopBot);
+      await waitForGracefulStop([stopBot]);
       if (this.#activeCycleAbort === cycleAbortController) {
         this.#activeCycleAbort = undefined;
       }
@@ -890,8 +902,7 @@ export class TelegramPollingSession {
       clearForceCycleTimer();
       this.opts.abortSignal?.removeEventListener("abort", abortFetch);
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-      await waitForGracefulStop(stopRunner);
-      await waitForGracefulStop(stopBot);
+      await waitForGracefulStop([stopRunner, stopBot]);
       this.#activeRunner = undefined;
       if (this.#activeCycleAbort === fetchAbortController) {
         this.#activeCycleAbort = undefined;
@@ -921,5 +932,9 @@ const isGetUpdatesConflict = (err: unknown) => {
   const normalizedHaystack = normalizeLowercaseStringOrEmpty(haystack);
   return normalizedHaystack.includes("getupdates");
 };
+
+// Test-only surface. Re-exported from the plugin root `test-api.ts` entry so Knip's
+// production scan sees the consumer; tests import `testing` from `test-api.js`.
+export const testing = { POLL_STOP_GRACE_MS, waitForGracefulStop };
 
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/telegram/test-api.ts
+++ b/extensions/telegram/test-api.ts
@@ -1,3 +1,4 @@
 // Telegram API module exposes the plugin public contract.
+export { testing as telegramPollingSessionTesting } from "./src/polling-session.js";
 export { sendMessageTelegram, sendPollTelegram, type TelegramApiOverride } from "./src/send.js";
 export { resetTelegramThreadBindingsForTests } from "./src/thread-bindings.js";


### PR DESCRIPTION
## What Problem This Solves

Telegram polling shutdown previously ran its graceful-stop waits **serially per stop handle**: up to 2 × 15 s in `#runPollingCycle` (stopRunner, then stopBot) and another 15 s in the isolated-ingress cycle — while the polling lease could be released before grammY middleware had actually drained, letting a replacement account monitor start a competing poller (overlapping getUpdates → Telegram 409 conflicts).

## Why This Change Was Made

The three stop waits in `extensions/telegram/src/polling-session.ts` are replaced by **one shared, concurrent, time-bounded cleanup barrier** in `waitForGracefulStop`:

- Runner and bot shutdown are started **concurrently** (`Promise.allSettled`; both stop handles memoize their in-flight promise, so an abort-triggered stop is joined, not restarted).
- The barrier retains the polling lease until **both stop promises settle** or **one shared deadline** — the existing `POLL_STOP_GRACE_MS` (15 s) with the same `unref` semantics — expires. Worst-case cleanup drops from 2 × 15 s serial to a single 15 s window.
- The barrier is deliberately **not** shortened by the owner abort signal: abort still triggers the stops (`stopOnAbort` → `stopRunner()`, unchanged), but the cleanup wait itself is time-bounded only, so the lease is never released while grammY middleware is still draining (see Round 2 for the review that prescribed this design).
- Fast path preserved: already-settled stops resolve ahead of the deadline timer, so clean shutdown stays immediate.

No new config, no new env, no SDK or core changes.

## User Impact

- A replacement Telegram account monitor can no longer acquire the polling lease while the previous runner's stop is still pending — closing the overlapping-poller / 409 window on account replacement and watchdog restart.
- Shutdown latency is bounded by one shared 15 s deadline instead of up to 45 s of serial grace waits.

## Evidence

**Lease-handoff regression tests** (reviewer-requested):

- `holds the polling lease until a pending runner stop settles after abort` — abort fires with `runner.stop()` deferred; asserts the session does NOT return while the stop is pending (lease cannot be handed to a replacement poller), then settles and asserts completion; also asserts the barrier started `bot.stop()` concurrently.
- `releases the polling lease at the grace deadline when the runner stop never settles` — fake-timers: a never-settling stop holds the lease until exactly the deadline, which then forces completion.
- **Control-red proof**: both tests FAIL against the pre-redesign head (abortable grace resolved instantly → lease released early: `expected true to be false`); they pass on this head.

**Checks:**

- `polling-session.test.ts` — 80/80 passed
- `pnpm tsgo:extensions` / `tsgo:extensions:test` — exit 0; oxlint clean; `git diff --check` clean

---

<details>
<summary>Round 1 (2026-07-16): original abortable grace-window approach — superseded after review</summary>

## What Problem This Solves

`waitForGracefulStop` in `extensions/telegram/src/polling-session.ts:56` races the in-flight `stop()` against a bare `setTimeout(resolve, POLL_STOP_GRACE_MS)` (15 s) that never receives the session's `AbortSignal`. All three call sites run from polling-cycle `finally` blocks where `this.opts.abortSignal` is in scope (`polling-session.ts:705`, `:893`, `:894`), but the signal was never threaded through.

When the gateway stops a Telegram account — or a watchdog restart is already draining — the abort fires first and the runner/bot stop is initiated by `stopOnAbort`. If that stop is slow or wedged, the teardown path still rides out the full 15 s grace window **per call**, sequentially: up to 30 s in `#runPollingCycle` (stopRunner + stopBot) and another 15 s in the isolated-ingress cycle, all after shutdown was already requested. An abort that arrives mid-grace during a watchdog restart is likewise ignored until the window elapses.

Sibling waits around it already honor the signal: `#waitBeforeRestart` sleeps via `sleepWithAbort(delayMs, this.opts.abortSignal)` (`polling-session.ts:204`), and `waitForSpooledHandlerTaskSettlement` resolves early on abort. Only the graceful-stop window was unwired.

## Why This Change Was Made

The grace window is now `sleepWithAbort(POLL_STOP_GRACE_MS, abortSignal, { ref: false })`, wrapped so its abort rejection settles the race early instead of throwing through the shutdown path — the same shape merged in #108561 (Discord READY retry backoff) and consistent with #108408 (Feishu retry loop). `{ ref: false }` preserves the old timer's `unref` semantics, so a pending grace timer never keeps the process alive. `stop()` rejections still propagate exactly as before; only the abort rejection is swallowed.

`abortSignal` is an optional parameter, so any other caller keeps the previous timer-only behavior. The three polling call sites now pass `this.opts.abortSignal`. `waitForGracefulStop` is exposed via a `testing` export re-exported from `test-api.ts` so the regression test drives the production function directly, mirroring #108561.

No new config, no new env, no SDK or core changes; the only signature change is the optional parameter.

## User Impact

- Stopping or restarting a Telegram account no longer stalls up to 15 s per graceful-stop wait after abort was requested; the wait ends on the abort event (measured: ~1 ms response, see Evidence).
- Watchdog restarts that race a shutdown abort now tear down immediately instead of finishing the grace window first.
- Happy path is unchanged: a stop that settles before the window still wins the race, and the 15 s ceiling still bounds a wedged stop while the session is alive.

## Evidence

### Before fix (this branch, `waitForGracefulStop` body reverted to `origin/main` — control-red)

Uncommitted `scratchpad/telegram-graceful-stop-abort-proof.mts` drives the production `waitForGracefulStop` with a wedged `stop()` (never settles), a real `AbortController`, and wall-clock timers:

```
[201ms] >>> abort fires
[15002ms] waitForGracefulStop resolved (mid-grace abort)
[15001ms] waitForGracefulStop resolved (pre-aborted signal)
[151ms] waitForGracefulStop resolved (stop settled at 150ms, no abort)
```

Abort fired 201 ms into the 15 000 ms window; the wait still rode out the full window — 14.8 s wasted per call. A pre-aborted signal (the normal shutdown case) also waited the full 15 s.

### After fix (this branch)

Same harness, same timing:

```
[247ms] >>> abort fires
[249ms] waitForGracefulStop resolved (mid-grace abort)
[0ms] waitForGracefulStop resolved (pre-aborted signal)
[152ms] waitForGracefulStop resolved (stop settled at 150ms, no abort)
```

The abort listener now interrupts the grace sleep immediately (~1 ms response), a pre-aborted signal returns instantly, and a stop that settles at 150 ms with no abort still wins the race unchanged.

### Mutation proof

Reverting only the `waitForGracefulStop` body to the `origin/main` version (keeping tests and the `testing` export) makes exactly the two new abort tests fail — `resolves early when the abort signal fires mid-grace` (15 122 ms) and `does not ride out the grace window when the signal is already aborted` (15 009 ms) — while the two non-abort tests keep passing. Restoring the fix turns the full file green again.

### Regression tests

New `describe("waitForGracefulStop")` block in `polling-session.test.ts` runs the production function with a real `AbortController` and real wall-clock timers (the file-level `sleepWithAbort` mock is locally restored to the real implementation via `vi.importActual`): mid-grace abort resolves in ~100 ms instead of 15 s, pre-aborted signal resolves immediately, stop-settles-first still wins, and omitting the signal keeps the old behavior. Two pre-existing tests that counted `sleepWithAbort` calls now filter to the 2-arg backoff calls, since the grace window legitimately adds 3-arg `{ ref: false }` calls.

### Tests & checks

- `node scripts/run-vitest.mjs run extensions/telegram/src/polling-session.test.ts` — 79/79 passed
- `pnpm tsgo:extensions` — exit 0
- `pnpm tsgo:extensions:test` — exit 0
- `node scripts/run-oxlint.mjs` on the three changed files — 0 errors
- `git diff --check` — clean

Prod-only non-test change: one function body, three call sites, one test-only export (+1 re-export). Follows the merged precedents #108561 and #108408; sibling to open #109604 (Telegram startup-probe abort — disjoint files).

AI-assisted; reviewed before submission.


---

</details>

---

## Round 2 (2026-07-17)

**Review addressed:** Codex P1 — "patch is incorrect". Passing `this.opts.abortSignal` into the graceful-stop waits made the wait resolve immediately on the normal account-stop path (owner signal already aborted), so `runUntilAbort()` returned while grammY `runner.stop()` was still draining middleware → the monitor released the polling lease → a replacement account monitor could start a competing poller → overlapping getUpdates → Telegram 409 conflicts.

**Redesign (as prescribed by the reviewer):** the abortable per-stop grace sleeps are replaced by ONE shared, non-abortable, bounded cleanup barrier in `waitForGracefulStop`:

- Abort/restart still TRIGGER the stops (`stopOnAbort` → `stopRunner()`, unchanged); the grace wait itself is now time-bounded only and never resolves early on the owner abort signal.
- The barrier starts runner and bot shutdown concurrently (`Promise.allSettled(stops.map(stop => stop()))`; both stop handles memoize their in-flight promise, so abort-triggered stops are joined, not restarted) and races that against a single fixed deadline — the existing `POLL_STOP_GRACE_MS` (15 s) constant with the same `unref` semantics. Worst-case cleanup drops from 2 × 15 s serial to one shared 15 s window.
- Fast path preserved: already-settled stops resolve through the microtask queue ahead of the deadline timer, so clean shutdown stays immediate (covered by a fake-timers test that needs zero timer advance).
- The isolated-ingress cycle uses the same barrier for its single `stopBot`.

**Regression coverage (reviewer-requested lease-handoff tests):**

- `holds the polling lease until a pending runner stop settles after abort` — abort fires with `runner.stop()` deferred; asserts `runUntilAbort()` does NOT return while the stop is pending (i.e. the monitor cannot hand the lease to a replacement poller), then settles the stop and asserts completion; also asserts the barrier started `bot.stop()` concurrently.
- `releases the polling lease at the grace deadline when the runner stop never settles` — fake-timers run: a never-settling `runner.stop()` holds the lease until exactly the grace deadline, which then forces completion.
- Control-red proof: both tests FAIL against the previous round's code (abortable grace resolved instantly → lease released early: `expected true to be false`); they pass on this round. The unit-level `describe("waitForGracefulStop")` block was rewritten to the new contract (concurrent start, pending-stop hold, deadline force-complete, settled fast path); the previous pre-aborted/mid-grace abort tests were removed because the barrier no longer takes a signal — abort-triggers-stop is covered at the session level, and mid-grace abort now provably does NOT shorten cleanup (the whole point of the finding). The two `sleepWithAbort` call-count assertions reverted to their upstream form since the barrier no longer sleeps via `sleepWithAbort`.

**Checks (round 2):**

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/polling-session.test.ts` — 80/80 passed
- `pnpm tsgo:extensions` — exit 0; `pnpm tsgo:extensions:test` — exit 0
- `oxlint` on the three changed files — clean; `git diff --check` — clean


---

## Round 3 (2026-07-17): ordered cleanup within one shared deadline

**Reviewer finding (P1):** the concurrent barrier start was itself a defect — `waitForGracefulStop` invoked all callbacks via `stops.map`, so `bot.stop()` started BEFORE `runner.stop()` finished draining middleware, even though grammY's `runner.stop()` is the middleware-completion boundary.

**Prescribed fix applied ("preserve ordered cleanup within one deadline"):** the barrier keeps ONE shared 15 s total budget (`POLL_STOP_GRACE_MS`, same `unref` semantics, lease held until settle-or-deadline) but now SEQUENCES the stops:

- The runner drain starts first; the bot stop starts only after the runner stop settles, and gets just the REMAINING budget (one absolute deadline timer armed at barrier entry, not a per-stop window).
- At the total deadline the barrier force-completes regardless; stops queued behind a wedged stop never start.
- Stop handles still memoize their in-flight promise, so abort/restart-triggered stops are joined, not restarted; a failed stop settles its slot and the barrier still sequences the rest; the settled fast path stays immediate (microtask-only, zero timer advance).
- Also rebased onto current `origin/main` as the reviewer asked (PR was behind).

**Regression coverage (concurrency assertions converted to ordering assertions):**

- `starts stops in order, holding the bot stop until the runner stop settles` — asserts the runner stop starts first and the bot stop is NOT started while the runner stop is pending; bot starts only after the runner settles; barrier holds until both settle.
- `shares one grace budget across sequential stops, leaving later stops only the remainder` — fake-timers remainder math: runner drain consumes 10 s of the shared 15 s budget before the bot stop starts; the wedged bot stop gets only the remaining 5 s (barrier resolves at exactly 15 s total, not 25 s).
- `forces completion at the grace deadline when a stop never settles` — a wedged first stop holds the barrier until exactly the deadline, and the stop queued behind it is never started.
- Session-level: `releases the polling lease at the grace deadline when the runner stop never settles` now asserts `bot.stop()` is never called when the runner stop wedges past the deadline; the lease-handoff test comment updated to ordered semantics.

**Control-red:** the new ordering/remainder/queued-stop assertions FAIL against the round-2 concurrent implementation (`expected [ 'runner', 'bot' ] to deeply equal [ 'runner' ]`, `expected "vi.fn()" to not be called at all, but actually been called 1 times`); they pass on this round.

**Checks (round 3):**

- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts` — 81/81 passed
- `oxfmt` / `oxlint` on both changed files — clean
