### PR TITLE
fix(apns): cancel redirect relay response body before returning

### DIFF
--- a/src/infra/push-apns.relay.test.ts
+++ b/src/infra/push-apns.relay.test.ts
@@ -285,6 +285,20 @@ describe("push-apns.relay", () => {
       expect(result.environment).toBeUndefined();
     });
 
+    it("cancels a redirect relay response body before returning", async () => {
+      const response = new Response("redirected", { status: 307 });
+      const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+      const fetchMock = vi.fn().mockResolvedValue(response);
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      const result = await sendApnsRelayPush(createRelayPushParams());
+
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(307);
+      expect(result.reason).toBe("RelayRedirectNotAllowed");
+      expect(cancel).toHaveBeenCalledOnce();
+    });
+
     it("falls back to fetch status when the relay body is not JSON", async () => {
       // Real Response body so the bounded reader runs end-to-end; non-JSON parse stays a soft null.
       const fetchMock = vi.fn().mockResolvedValue(new Response("not-json-at-all", { status: 202 }));

--- a/src/infra/push-apns.relay.test.ts
+++ b/src/infra/push-apns.relay.test.ts
@@ -267,11 +267,9 @@ describe("push-apns.relay", () => {
     });
 
     it("does not follow relay redirects", async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 302,
-        json: vi.fn().mockRejectedValue(new Error("no body")),
-      });
+      const response = new Response("redirected", { status: 302 });
+      const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+      const fetchMock = vi.fn().mockResolvedValue(response);
       vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
       const result = await sendApnsRelayPush(createRelayPushParams());
@@ -283,19 +281,6 @@ describe("push-apns.relay", () => {
       expect(result.status).toBe(302);
       expect(result.reason).toBe("RelayRedirectNotAllowed");
       expect(result.environment).toBeUndefined();
-    });
-
-    it("cancels a redirect relay response body before returning", async () => {
-      const response = new Response("redirected", { status: 307 });
-      const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
-      const fetchMock = vi.fn().mockResolvedValue(response);
-      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
-      const result = await sendApnsRelayPush(createRelayPushParams());
-
-      expect(result.ok).toBe(false);
-      expect(result.status).toBe(307);
-      expect(result.reason).toBe("RelayRedirectNotAllowed");
       expect(cancel).toHaveBeenCalledOnce();
     });
 

--- a/src/infra/push-apns.relay.ts
+++ b/src/infra/push-apns.relay.ts
@@ -295,6 +295,7 @@ async function sendApnsRelayRequest(params: {
   });
   // Do not follow relay redirects; grants and signatures are scoped to the configured relay origin.
   if (response.status >= 300 && response.status < 400) {
+    await response.body?.cancel().catch(() => undefined);
     return {
       ok: false,
       status: response.status,


### PR DESCRIPTION
## What Problem This Solves

`sendApnsRelayRequest` returns early when the relay responds with a 3xx redirect (relay redirects are not followed — grants and signatures are scoped to the configured relay origin). The response body was left unconsumed, keeping the underlying connection open until GC.

## Why This Change Was Made

Follows the same pattern as #109519 (Google Chat), #109508 (docs), #109525 (ClawRouter), and #109701 (MS Teams file consent) — cancel the response body before returning on non-OK paths.

## User Impact

No user-facing change. Prevents a minor resource leak when the APNs relay returns an unexpected redirect response.

## Evidence

```
$ npx vitest run src/infra/push-apns.relay.test.ts

 Test Files  1 passed (1)
      Tests  23 passed (23)
```

New test ("cancels a redirect relay response body before returning"):
- A real `Response` with status 307 is returned by the fetch stub
- `response.body.cancel()` is verified to be called exactly once before returning
- The result still carries the correct status and reason