### PR TITLE
fix(plugin-sdk): guard assertHttpUrlTargetsPrivateNetwork against malformed URLs

### DIFF
--- a/src/plugin-sdk/ssrf-policy.test.ts
+++ b/src/plugin-sdk/ssrf-policy.test.ts
@@ -296,7 +296,7 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
       assertHttpUrlTargetsPrivateNetwork("not-a-url", {
         dangerouslyAllowPrivateNetwork: true,
       }),
-    ).rejects.toThrow(new Error("Invalid URL"));
+    ).rejects.toThrow(new TypeError("Invalid URL"));
   });
 
   it("does not reflect credential-bearing malformed URLs in errors", async () => {
@@ -313,7 +313,7 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
       (err: unknown) => err,
     );
 
-    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(TypeError);
 
     // Outer message must be stable and non-disclosing.
     const message = (error as Error).message;

--- a/src/plugin-sdk/ssrf-policy.test.ts
+++ b/src/plugin-sdk/ssrf-policy.test.ts
@@ -304,18 +304,35 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
     const secretPass = "matrix-fixture";
     const malformed = `http://${secretUser}:${secretPass}@${["invalid", "host"].join(" ")}`;
 
-    await expect(
-      assertHttpUrlTargetsPrivateNetwork(malformed, {
-        dangerouslyAllowPrivateNetwork: true,
-      }),
-    ).rejects.toSatisfy((error: unknown) => {
-      expect(error).toBeInstanceOf(Error);
-      const message = (error as Error).message;
-      expect(message).toBe("Invalid URL");
-      expect(message).not.toContain(secretUser);
-      expect(message).not.toContain(secretPass);
-      return true;
-    });
+    const error = await assertHttpUrlTargetsPrivateNetwork(malformed, {
+      dangerouslyAllowPrivateNetwork: true,
+    }).then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+
+    // Outer message must be stable and non-disclosing.
+    const message = (error as Error).message;
+    expect(message).toBe("Invalid URL");
+    expect(message).not.toContain(secretUser);
+    expect(message).not.toContain(secretPass);
+
+    // No native parser error cause that could retain the malformed input.
+    const err = error as Error & { cause?: unknown };
+    expect(err.cause).toBeUndefined();
+
+    // Complete error serialization must not expose credentials.
+    const serialized = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(Object.getOwnPropertyDescriptors(error)).map(([k, d]) => [k, d.value]),
+      ),
+    );
+    expect(serialized).not.toContain(secretUser);
+    expect(serialized).not.toContain(secretPass);
   });
 });
 

--- a/src/plugin-sdk/ssrf-policy.test.ts
+++ b/src/plugin-sdk/ssrf-policy.test.ts
@@ -290,6 +290,14 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
       }),
     ).rejects.toThrow("HTTP URL must target a trusted private/internal host");
   });
+
+  it("rejects malformed URLs with a typed error", async () => {
+    await expect(
+      assertHttpUrlTargetsPrivateNetwork("not-a-url", {
+        dangerouslyAllowPrivateNetwork: true,
+      }),
+    ).rejects.toThrow("Invalid URL: not-a-url");
+  });
 });
 
 describe("normalizeHostnameSuffixAllowlist", () => {

--- a/src/plugin-sdk/ssrf-policy.test.ts
+++ b/src/plugin-sdk/ssrf-policy.test.ts
@@ -291,12 +291,31 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
     ).rejects.toThrow("HTTP URL must target a trusted private/internal host");
   });
 
-  it("rejects malformed URLs with a typed error", async () => {
+  it("rejects malformed URLs with a stable error", async () => {
     await expect(
       assertHttpUrlTargetsPrivateNetwork("not-a-url", {
         dangerouslyAllowPrivateNetwork: true,
       }),
-    ).rejects.toThrow("Invalid URL: not-a-url");
+    ).rejects.toThrow(new Error("Invalid URL"));
+  });
+
+  it("does not reflect credential-bearing malformed URLs in errors", async () => {
+    const secretUser = "matrix-user";
+    const secretPass = "matrix-fixture";
+    const malformed = `http://${secretUser}:${secretPass}@${["invalid", "host"].join(" ")}`;
+
+    await expect(
+      assertHttpUrlTargetsPrivateNetwork(malformed, {
+        dangerouslyAllowPrivateNetwork: true,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toBe("Invalid URL");
+      expect(message).not.toContain(secretUser);
+      expect(message).not.toContain(secretPass);
+      return true;
+    });
   });
 });
 

--- a/src/plugin-sdk/ssrf-policy.test.ts
+++ b/src/plugin-sdk/ssrf-policy.test.ts
@@ -291,22 +291,7 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
     ).rejects.toThrow("HTTP URL must target a trusted private/internal host");
   });
 
-  it("rejects malformed URLs with a stable error", async () => {
-    const err = await assertHttpUrlTargetsPrivateNetwork("not-a-url", {
-      dangerouslyAllowPrivateNetwork: true,
-    }).then(
-      () => {
-        throw new Error("expected rejection");
-      },
-      (e: unknown) => e,
-    );
-
-    expect(err).toBeInstanceOf(TypeError);
-    expect((err as Error).message).toBe("Invalid URL");
-    expect((err as TypeError & { code?: string }).code).toBe("ERR_INVALID_URL");
-  });
-
-  it("does not reflect credential-bearing malformed URLs in errors", async () => {
+  it("rejects malformed URLs without retaining credential-bearing input", async () => {
     const secretUser = "matrix-user";
     const secretPass = "matrix-fixture";
     const malformed = `http://${secretUser}:${secretPass}@${["invalid", "host"].join(" ")}`;
@@ -321,26 +306,10 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
     );
 
     expect(error).toBeInstanceOf(TypeError);
+    expect(error).toMatchObject({ code: "ERR_INVALID_URL", message: "Invalid URL" });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
 
-    // Preserve the ERR_INVALID_URL code for caller classification.
-    expect((error as TypeError & { code?: unknown }).code).toBe("ERR_INVALID_URL");
-
-    // Outer message must be stable and non-disclosing.
-    const message = (error as Error).message;
-    expect(message).toBe("Invalid URL");
-    expect(message).not.toContain(secretUser);
-    expect(message).not.toContain(secretPass);
-
-    // No native parser error cause that could retain the malformed input.
-    const err = error as Error & { cause?: unknown };
-    expect(err.cause).toBeUndefined();
-
-    // Complete error serialization must not expose credentials.
-    const serialized = JSON.stringify(
-      Object.fromEntries(
-        Object.entries(Object.getOwnPropertyDescriptors(error)).map(([k, d]) => [k, d.value]),
-      ),
-    );
+    const serialized = JSON.stringify(error, Object.getOwnPropertyNames(error));
     expect(serialized).not.toContain(secretUser);
     expect(serialized).not.toContain(secretPass);
   });

--- a/src/plugin-sdk/ssrf-policy.test.ts
+++ b/src/plugin-sdk/ssrf-policy.test.ts
@@ -292,11 +292,18 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
   });
 
   it("rejects malformed URLs with a stable error", async () => {
-    await expect(
-      assertHttpUrlTargetsPrivateNetwork("not-a-url", {
-        dangerouslyAllowPrivateNetwork: true,
-      }),
-    ).rejects.toThrow(new TypeError("Invalid URL"));
+    const err = await assertHttpUrlTargetsPrivateNetwork("not-a-url", {
+      dangerouslyAllowPrivateNetwork: true,
+    }).then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as Error).message).toBe("Invalid URL");
+    expect((err as TypeError & { code?: string }).code).toBe("ERR_INVALID_URL");
   });
 
   it("does not reflect credential-bearing malformed URLs in errors", async () => {
@@ -314,6 +321,9 @@ describe("assertHttpUrlTargetsPrivateNetwork", () => {
     );
 
     expect(error).toBeInstanceOf(TypeError);
+
+    // Preserve the ERR_INVALID_URL code for caller classification.
+    expect((error as TypeError & { code?: unknown }).code).toBe("ERR_INVALID_URL");
 
     // Outer message must be stable and non-disclosing.
     const message = (error as Error).message;

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -228,7 +228,12 @@ export async function assertHttpUrlTargetsPrivateNetwork(
     errorMessage?: string;
   } = {},
 ): Promise<void> {
-  const parsed = new URL(url);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
   if (parsed.protocol !== "http:") {
     return;
   }

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -231,8 +231,12 @@ export async function assertHttpUrlTargetsPrivateNetwork(
   let parsed: URL;
   try {
     parsed = new URL(url);
-  } catch (cause) {
-    throw new Error("Invalid URL", { cause });
+  } catch {
+    // Do not attach the native ERR_INVALID_URL as cause — Node's URL parser
+    // retains the rejected URL in its structured input property, so callers
+    // that inspect or serialize the complete error graph could recover
+    // credential-bearing endpoint strings despite the safe outer message.
+    throw new Error("Invalid URL");
   }
   if (parsed.protocol !== "http:") {
     return;

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -232,11 +232,7 @@ export async function assertHttpUrlTargetsPrivateNetwork(
   try {
     parsed = new URL(url);
   } catch {
-    // Preserve the ERR_INVALID_URL code for caller classification while
-    // stripping the native error's input and cause — Node's URL parser
-    // retains the rejected URL in its structured input property, so callers
-    // that inspect or serialize the complete error graph could recover
-    // credential-bearing endpoint strings despite the safe outer message.
+    // URL parser errors retain rejected input. Keep only stable classification.
     const err = new TypeError("Invalid URL") as TypeError & { code: string };
     err.code = "ERR_INVALID_URL";
     throw err;

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -236,7 +236,7 @@ export async function assertHttpUrlTargetsPrivateNetwork(
     // retains the rejected URL in its structured input property, so callers
     // that inspect or serialize the complete error graph could recover
     // credential-bearing endpoint strings despite the safe outer message.
-    throw new Error("Invalid URL");
+    throw new TypeError("Invalid URL");
   }
   if (parsed.protocol !== "http:") {
     return;

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -232,11 +232,14 @@ export async function assertHttpUrlTargetsPrivateNetwork(
   try {
     parsed = new URL(url);
   } catch {
-    // Do not attach the native ERR_INVALID_URL as cause — Node's URL parser
+    // Preserve the ERR_INVALID_URL code for caller classification while
+    // stripping the native error's input and cause — Node's URL parser
     // retains the rejected URL in its structured input property, so callers
     // that inspect or serialize the complete error graph could recover
     // credential-bearing endpoint strings despite the safe outer message.
-    throw new TypeError("Invalid URL");
+    const err = new TypeError("Invalid URL") as TypeError & { code: string };
+    err.code = "ERR_INVALID_URL";
+    throw err;
   }
   if (parsed.protocol !== "http:") {
     return;

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -231,8 +231,8 @@ export async function assertHttpUrlTargetsPrivateNetwork(
   let parsed: URL;
   try {
     parsed = new URL(url);
-  } catch {
-    throw new Error(`Invalid URL: ${url}`);
+  } catch (cause) {
+    throw new Error("Invalid URL", { cause });
   }
   if (parsed.protocol !== "http:") {
     return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where callers of the public plugin-sdk SSRF helper `assertHttpUrlTargetsPrivateNetwork` would receive an uncaught `TypeError: Invalid URL` when given malformed input, instead of a controlled application error. Node's `ERR_INVALID_URL` retains the rejected URL in its structured `input` property, so attaching the native error as `cause` would leave credential-bearing endpoint strings reachable to callers that inspect or serialize the complete error graph.

## Why This Change Was Made

The helper now wraps `new URL(url)` in try/catch and throws a sanitized `TypeError("Invalid URL")` that preserves the `ERR_INVALID_URL` code for caller classification while stripping the native `input` and `cause` properties. This maintains the existing public plugin SDK error contract — callers using `instanceof TypeError` or `err.code === "ERR_INVALID_URL"` continue to work, and credential-bearing endpoint strings are never reflected into diagnostics, logs, or structured error inspection.

## User Impact

Plugin and channel code that validates self-hosted HTTP endpoints now gets a safe, predictable `TypeError` with `code: "ERR_INVALID_URL"` for malformed URLs, without echoing credential-bearing endpoint strings into setup diagnostics, logs, or structured error inspection. Existing `instanceof TypeError` and `err.code` guards continue to work.

## Evidence

**Before (upstream/main):**
`new URL(malformedInput)` throws `TypeError` with the rejected URL preserved in `error.input`.

**Premise (sibling pattern in the same file):**
`isHttpsUrlAllowedByHostnameSuffixAllowlist` already wraps `new URL(url)` in try/catch without reflecting the supplied URL.

**After (this branch):**
- `instanceof TypeError`: true
- `message`: `"Invalid URL"`
- `code`: `"ERR_INVALID_URL"`
- `cause`: `undefined`
- Serialized own properties contain no credential substrings

Harness (real exported function, no mocks):
```bash
node --import tsx -e "
import { assertHttpUrlTargetsPrivateNetwork } from './src/plugin-sdk/ssrf-policy.ts';
const malformed = 'http://matrix-user:matrix-fixture@invalid host';
try {
  await assertHttpUrlTargetsPrivateNetwork(malformed, { dangerouslyAllowPrivateNetwork: true });
} catch (err) {
  console.log('error name:', err?.constructor?.name);
  console.log('error message:', err instanceof Error ? err.message : String(err));
  const e = err as TypeError & { code?: unknown; cause?: unknown };
  console.log('error.cause:', e.cause);
  console.log('cause is undefined:', e.cause === undefined);
  const entries = Object.entries(Object.getOwnPropertyDescriptors(err));
  console.log('own property names:', entries.map(([k]) => k));
  const serialized = JSON.stringify(Object.fromEntries(entries.map(([k, d]) => [k, d.value])));
  console.log('JSON.stringify(own props):', serialized);
  console.log('serialized includes username:', serialized.includes('matrix-user'));
  console.log('serialized includes password:', serialized.includes('matrix-fixture'));
}
"
```

Focused tests (TypeError class + ERR_INVALID_URL code + no credential reflection):
```bash
node scripts/run-vitest.mjs run src/plugin-sdk/ssrf-policy.test.ts
# 63 passed
```

Formatting / lint clean:
```bash
./node_modules/.bin/oxfmt --check src/plugin-sdk/ssrf-policy.ts src/plugin-sdk/ssrf-policy.test.ts
# All matched files use the correct format.
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/ssrf-policy.ts src/plugin-sdk/ssrf-policy.test.ts
# (clean)
```

What was not tested: live Matrix/SearXNG/Brave channel setup flows with malformed homeserver URLs; the local harness proves the public SDK entry now fails closed with a sanitized `TypeError` preserving `ERR_INVALID_URL`, no native parser cause attached, and no credential-bearing input reachable through structured error inspection or serialization.

AI-assisted: Cursor Composer; proof run manually on this machine.