### PR TITLE
fix(qa): bound matrix scenario taskkill cleanup

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli-process.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli-process.ts
@@ -23,7 +23,11 @@ export function killMatrixQaCliChild(
       if (signal === "SIGKILL") {
         args.push("/F");
       }
-      const result = runTaskkill(taskkillPath, args, { stdio: "ignore", windowsHide: true });
+      const result = runTaskkill(taskkillPath, args, {
+        stdio: "ignore",
+        windowsHide: true,
+        timeout: 5_000,
+      });
       if (!result.error && result.status === 0) {
         return;
       }
@@ -31,6 +35,7 @@ export function killMatrixQaCliChild(
         const forceResult = runTaskkill(taskkillPath, [...args, "/F"], {
           stdio: "ignore",
           windowsHide: true,
+          timeout: 5_000,
         });
         if (!forceResult.error && forceResult.status === 0) {
           return;


### PR DESCRIPTION
## What Problem This Solves

`killMatrixQaCliChild()` in the Matrix QA scenario runtime calls `taskkill.exe` via `spawnSync` (twice: graceful then forced) without a timeout. When the target process is stuck in a kernel wait state, `taskkill` can hang indefinitely, blocking QA scenario cleanup.

## Why This Change Was Made

Adds a 5-second timeout to both `taskkill.exe` spawnSync calls so stalled termination fails closed instead of hanging the test runner.

Same pattern as:
- `fix(qa): bound Windows taskkill process termination` (#109453)
- `fix(qa): bound gateway child taskkill termination` (#109454)

## User Impact

Matrix QA scenario cleanup no longer hangs when a spawned Windows process is unresponsive.

## Evidence

- Single-file change: 2 timeout additions
- Same proven pattern applied to sibling qa-lab modules