### PR TITLE
fix(build): bound UI i18n taskkill cleanup

### DIFF
--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -629,7 +629,10 @@ export async function runProcess(
       if (force) {
         taskkillArgs.push("/F");
       }
-      const result = spawnSync(resolveWindowsTaskkillPath(), taskkillArgs, { stdio: "ignore" });
+      const result = spawnSync(resolveWindowsTaskkillPath(), taskkillArgs, {
+        stdio: "ignore",
+        timeout: 5_000,
+      });
       return result.status === 0;
     };
     const signalChild = (signal: NodeJS.Signals) => {


### PR DESCRIPTION
## What Problem This Solves

The UI i18n extraction script calls `taskkill.exe` via `spawnSync` without a timeout. A stuck process during i18n build can hang indefinitely.

## Why This Change Was Made

Adds a 5-second timeout to the `taskkill` spawnSync call.

## Evidence

- Single-line change, same pattern applied across QA and build scripts