### PR TITLE
fix(scripts): bound gh CLI helper subprocess calls

### DIFF
--- a/scripts/lib/plain-gh.mjs
+++ b/scripts/lib/plain-gh.mjs
@@ -3,6 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 
 const PLAIN_GH_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+// Every gh CLI call reaches the GitHub API over the network. Bound every
+// invocation so a stalled TCP connection, unresponsive API endpoint, or
+// proxy timeout does not hang the calling script indefinitely.
+const PLAIN_GH_DEFAULT_TIMEOUT_MS = 30_000;
 export const PLAIN_GH_SYSTEM_CANDIDATES = [
   // Prefer package-manager opt paths: bin/gh may intentionally be an Octopool shim.
   "/opt/homebrew/opt/gh/bin/gh",
@@ -85,6 +89,7 @@ export function execPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+    timeout: options.timeout ?? PLAIN_GH_DEFAULT_TIMEOUT_MS,
   });
 }
 
@@ -96,6 +101,7 @@ export function execGhApiRead(endpoint, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+    timeout: options.timeout ?? PLAIN_GH_DEFAULT_TIMEOUT_MS,
   });
 }
 
@@ -106,5 +112,6 @@ export function spawnPlainGh(args, options = {}) {
     ...options,
     env,
     maxBuffer: options.maxBuffer ?? PLAIN_GH_MAX_BUFFER_BYTES,
+    timeout: options.timeout ?? PLAIN_GH_DEFAULT_TIMEOUT_MS,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

`scripts/lib/plain-gh.mjs` is the central helper for invoking the `gh` CLI across many repo scripts. All three functions (`execPlainGh`, `execGhApiRead`, `spawnPlainGh`) call `execFileSync`/`spawnSync` without a timeout. Every `gh` CLI invocation reaches the GitHub API over the network — a stalled TCP connection, unresponsive API endpoint, or proxy timeout can hang the calling script indefinitely.

## Why This Change Was Made

Adds a 30-second default timeout (`PLAIN_GH_DEFAULT_TIMEOUT_MS`) to all three helper functions. Callers can override via `options.timeout` when a longer deadline is needed.

This follows the same pattern as other network-operation bound PRs:
- `fix(ci): bound release evidence dispatch` (#108898)
- `fix(ci): bound plugin npm artifact connection` (#108897)

## User Impact

All scripts that use `plain-gh.mjs` (PR creation, release evidence, CI checks, etc.) are now protected from network hangs.

## Evidence

- 3 functions updated, all following the same `options.timeout ?? DEFAULT` pattern
- Callers can override when needed
- No test changes needed (these are script helpers)