### PR TITLE
fix(build): bound Chromium executable version probes

### DIFF
--- a/scripts/ensure-playwright-chromium.mjs
+++ b/scripts/ensure-playwright-chromium.mjs
@@ -28,6 +28,7 @@ export const systemChromiumExecutableCandidates = [
 export function canRunChromiumExecutable(executablePath, spawnSync = spawnSyncImpl) {
   const result = spawnSync(executablePath, ["--version"], {
     stdio: "ignore",
+    timeout: 5_000,
   });
   return result.status === 0;
 }


### PR DESCRIPTION
## What Problem This Solves

`canRunChromiumExecutable()` in the Playwright Chromium setup script calls `spawnSync(executablePath, ["--version"])` without a timeout. A broken or hung Chromium binary can block indefinitely, hanging e2e/QA test setup.

## Why This Change Was Made

Adds a 5-second timeout to the Chromium version probe so it fails closed instead of blocking.

## Evidence

- Single-line change: `timeout: 5_000` added to spawn options
- Same pattern as the web-runtime fix in PR #109072