### PR TITLE
fix(cron): keep scheduler running when webhook secret is unavailable

### DIFF
--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -10,6 +10,7 @@ import {
   tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../process/gateway-work-admission.js";
+import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 
 const mocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(async (_request: unknown) => ({ release: vi.fn() })),
@@ -90,6 +91,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
   afterEach(() => {
     resetGatewayWorkAdmission();
+    setActiveDegradedSecretOwners([]);
   });
 
   it("independently admits detached completion webhook delivery", async () => {
@@ -127,6 +129,44 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
     expect(getActiveGatewayRootWorkCount()).toBe(1);
     deferred.resolve();
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+  });
+
+  it("keeps webhook delivery cold when its token owner is unavailable", async () => {
+    const logger = { warn: vi.fn() };
+    const job = createWebhookJob({
+      mode: "webhook",
+      to: "https://example.invalid/cron",
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "cron-webhook",
+        state: "unavailable",
+        paths: ["cron.webhookToken"],
+        refKeys: ["env:default:MISSING_WEBHOOK_TOKEN"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: { jobId: job.id, action: "finished", status: "ok", summary: "done" },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    await vi.waitFor(() =>
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: job.id,
+          err: expect.stringContaining("Secret owner capability:cron-webhook"),
+        }),
+        "cron: webhook delivery failed",
+      ),
+    );
+    expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -22,6 +22,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js";
 
 const CRON_WEBHOOK_TIMEOUT_MS = 10_000;
 
@@ -211,6 +212,7 @@ async function postCronWebhook(params: {
   }, CRON_WEBHOOK_TIMEOUT_MS);
 
   try {
+    assertSecretOwnerAvailable("capability", "cron-webhook");
     const result = await fetchWithSsrFGuard({
       url: params.webhookUrl,
       init: {

--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -158,7 +158,7 @@ describe("Gateway startup SecretRef owner isolation", () => {
     });
   });
 
-  it("still refuses startup when an unresolved SecretRef owner is unknown", async () => {
+  it("reaches /readyz with cron webhook delivery isolated", async () => {
     await withEnvAsync({ MISSING_WEBHOOK_TOKEN: undefined }, async () => {
       await writeConfig({
         ...baseConfig(),
@@ -171,9 +171,23 @@ describe("Gateway startup SecretRef owner isolation", () => {
         },
       });
 
-      await expect(
-        startGatewayServer(await getFreePort(), { auth: { mode: "none" } }),
-      ).rejects.toThrow(/Startup failed: required secrets are unavailable/);
+      const port = await getFreePort();
+      server = await startGatewayServer(port, { auth: { mode: "none" } });
+      const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+
+      expect(ready.status).toBe(200);
+      await expect(ready.json()).resolves.toMatchObject({ ready: true });
+      expect(getActiveSecretsRuntimeSnapshot()?.degradedOwners).toMatchObject([
+        { ownerKind: "capability", ownerId: "cron-webhook", state: "unavailable" },
+      ]);
+      expect(getActiveSecretsRuntimeSnapshot()?.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "SECRETS_OWNER_UNAVAILABLE",
+            path: "cron.webhookToken",
+          }),
+        ]),
+      );
     });
   });
 });

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -587,12 +587,18 @@ function collectCronAssignments(params: {
   if (!isRecord(cron)) {
     return;
   }
-  collectSecretInputAssignment({
+  collectRuntimeSecretInputAssignment({
     value: cron.webhookToken,
     path: "cron.webhookToken",
     expected: "string",
     defaults: params.defaults,
     context: params.context,
+    owner: {
+      ownerKind: "capability",
+      ownerId: "cron-webhook",
+      requiredForGateway: false,
+      disposition: "isolate",
+    },
     apply: (value) => {
       cron.webhookToken = value;
     },

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -677,20 +677,27 @@ describe("secrets runtime snapshot", () => {
     ]);
   });
 
-  it("refuses cold-start isolation when an assignment owner is unknown", async () => {
-    await expect(
-      prepareSecretsRuntimeSnapshot({
-        config: asConfig({
-          cron: {
-            webhookToken: { source: "env", provider: "default", id: "MISSING_WEBHOOK_TOKEN" },
-          },
-        }),
-        env: {},
-        includeAuthStoreRefs: false,
-        allowUnavailableSecretOwners: true,
-        loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+  it("isolates cron webhook delivery when its token cannot resolve", async () => {
+    const ref = { source: "env", provider: "default", id: "MISSING_WEBHOOK_TOKEN" } as const;
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        cron: { webhookToken: ref },
       }),
-    ).rejects.toThrow('Environment variable "MISSING_WEBHOOK_TOKEN" is missing or empty.');
+      env: {},
+      includeAuthStoreRefs: false,
+      allowUnavailableSecretOwners: true,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+
+    expect(snapshot.config.cron?.webhookToken).toEqual(ref);
+    expect(snapshot.degradedOwners).toMatchObject([
+      {
+        ownerKind: "capability",
+        ownerId: "cron-webhook",
+        state: "unavailable",
+        paths: ["cron.webhookToken"],
+      },
+    ]);
   });
 
   it("fails when an active exec ref id contains traversal segments", async () => {


### PR DESCRIPTION
Related: #101265

## What Problem This Solves

Fixes an issue where users with an unavailable `cron.webhookToken` SecretRef could not start the Gateway, even though only webhook delivery requires that token.

## Why This Change Was Made

Cron webhook authentication now has its own isolatable capability owner. Cold startup records that owner as unavailable, and the central webhook delivery path rejects it without affecting scheduler execution or announce delivery.

## User Impact

The Gateway and cron scheduler stay available when the webhook token cannot resolve. Cron webhook delivery stays cold until the configured secret becomes available, with the degraded owner exposed through existing secret-status diagnostics.

## Evidence

- `node scripts/run-vitest.mjs src/secrets/runtime.test.ts src/gateway/server-cron-notifications.test.ts src/gateway/server-startup-secret-owner-isolation.test.ts` — 34 tests passed across two shards.
- Fresh autoreview: clean, correctness confidence 0.94.
- Hosted changed gate: conflict, max-lines, changelog attribution, re-export, duplicate coverage, dependency pin, and formatting checks passed. The unrelated Plugin SDK API baseline check is already stale outside this patch; this branch changes no Plugin SDK or generated baseline files.
