### PR TITLE
fix(skills): filter NaN from Date.parse in history scan session cursors

### DIFF
--- a/src/skills/workshop/history-scan-transcript.ts
+++ b/src/skills/workshop/history-scan-transcript.ts
@@ -8,6 +8,10 @@ import {
   prepareSkillHistoryScanReviewMessages,
 } from "./history-scan-transcript-content.js";
 
+export type SkillHistoryScanBatchSession = SkillHistoryScanPromptSession & {
+  updatedAtMs: number;
+};
+
 const HISTORY_SCAN_MAX_CANDIDATES = 60;
 const HISTORY_SCAN_MAX_SESSIONS = 20;
 const HISTORY_SCAN_MAX_TRANSCRIPT_CHARS = 80_000;
@@ -82,10 +86,10 @@ export async function collectSkillHistoryScanBatch(params: {
 }): Promise<{
   blockedByActive: boolean;
   considered: SkillHistoryScanCandidate[];
-  sessions: SkillHistoryScanPromptSession[];
+  sessions: SkillHistoryScanBatchSession[];
 }> {
   const considered: SkillHistoryScanCandidate[] = [];
-  const sessions: SkillHistoryScanPromptSession[] = [];
+  const sessions: SkillHistoryScanBatchSession[] = [];
   const maxTranscriptChars = params.maxTranscriptChars ?? HISTORY_SCAN_MAX_TRANSCRIPT_CHARS;
   let blockedByActive = false;
   let transcriptChars = 0;
@@ -113,7 +117,13 @@ export async function collectSkillHistoryScanBatch(params: {
     if (!session) {
       continue;
     }
-    sessions.push(session);
+    const updatedAtMs = Date.parse(session.updatedAt);
+    // Pending cursors must identify every reviewed session for exact replay.
+    // Drop malformed sessions before they become canonical batch members.
+    if (!Number.isFinite(updatedAtMs)) {
+      continue;
+    }
+    sessions.push({ ...session, updatedAtMs });
     transcriptChars += session.transcript.length + HISTORY_SCAN_SESSION_OVERHEAD_CHARS;
     if (sessions.length >= HISTORY_SCAN_MAX_SESSIONS) {
       break;

--- a/src/skills/workshop/history-scan.resume.test.ts
+++ b/src/skills/workshop/history-scan.resume.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { SkillHistoryScanCandidate } from "./history-scan-candidates.js";
+import type { SkillHistoryScanPromptSession } from "./history-scan-prompt.js";
+
+type ReadHistoryScanSession = (
+  params: Parameters<typeof import("./history-scan-transcript.js").readHistoryScanSession>[0],
+) => Promise<SkillHistoryScanPromptSession | undefined>;
+type RunSkillHistoryScanReview =
+  typeof import("./history-scan-review.js").runSkillHistoryScanReview;
+
+const mocks = vi.hoisted(() => ({
+  candidates: [] as SkillHistoryScanCandidate[],
+  getProgress: vi.fn(async () => ({ mutationCount: 0, proposalIds: [] as string[] })),
+  readSession: vi.fn<ReadHistoryScanSession>(),
+  review: vi.fn<RunSkillHistoryScanReview>(),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentConfig: vi.fn(() => undefined),
+  resolveAgentDir: vi.fn(() => "/tmp/openclaw-history-scan-agent"),
+}));
+
+vi.mock("../../agents/embedded-agent-runner/model.js", () => ({
+  resolveModel: vi.fn(() => ({
+    model: { contextTokens: 8_192, contextWindow: 8_192 },
+  })),
+}));
+
+vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
+  isEmbeddedAgentRunActive: vi.fn(() => false),
+}));
+
+vi.mock("../../agents/model-selection-config.js", () => ({
+  resolveDefaultModelForAgent: vi.fn(() => ({ model: "gpt-5.5", provider: "openai" })),
+}));
+
+vi.mock("./history-scan-candidates.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./history-scan-candidates.js")>()),
+  listHistoryScanCandidates: vi.fn(() => mocks.candidates),
+  selectSkillHistoryScanCandidates: vi.fn(
+    (params: { candidates: readonly SkillHistoryScanCandidate[] }) => [...params.candidates],
+  ),
+}));
+
+vi.mock("./history-scan-review.js", () => ({
+  HISTORY_SCAN_SESSION_SEGMENT: "skill-workshop-history-scan",
+  runSkillHistoryScanReview: (...args: Parameters<RunSkillHistoryScanReview>) =>
+    mocks.review(...args),
+}));
+
+vi.mock("./history-scan-transcript.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./history-scan-transcript.js")>()),
+  readHistoryScanSession: (...args: Parameters<ReadHistoryScanSession>) =>
+    mocks.readSession(...args),
+}));
+
+vi.mock("./service.js", () => ({
+  getSkillProposalRunProgress: mocks.getProgress,
+}));
+
+import {
+  historyScanStateKey,
+  historyScanStore,
+  type SkillHistoryScanScope,
+} from "./history-scan-state.js";
+import { runSkillHistoryScan } from "./history-scan.js";
+
+function candidate(instanceId: string, updatedAtMs: number): SkillHistoryScanCandidate {
+  return {
+    instanceId,
+    sessionKey: `agent:main:${instanceId}`,
+    updatedAtMs,
+    entry: {
+      sessionId: instanceId,
+      updatedAt: updatedAtMs,
+    },
+  };
+}
+
+describe("Skill Workshop history scan resume", () => {
+  it("excludes malformed sessions before checkpointing and replays the same batch", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-history-scan-resume-"));
+    const workspaceDir = path.join(tempDir, "workspace");
+    const storePath = path.join(tempDir, "sessions.json");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempDir, "state") };
+    const validUpdatedAtMs = Date.parse("2026-07-16T12:00:00.000Z");
+    const invalid = candidate("invalid", validUpdatedAtMs + 1_000);
+    const valid = candidate("valid", validUpdatedAtMs);
+    const reviewedBatches: string[][] = [];
+    mocks.candidates = [invalid, valid];
+    mocks.readSession.mockImplementation(async ({ candidate: selected }) => ({
+      instanceId: selected.instanceId,
+      sessionKey: selected.sessionKey,
+      updatedAt:
+        selected.instanceId === invalid.instanceId
+          ? "not-a-date"
+          : new Date(selected.updatedAtMs).toISOString(),
+      modelIterations: 6,
+      transcript: `completed transcript for ${selected.instanceId}`,
+    }));
+    mocks.review
+      .mockImplementationOnce(async ({ sessions }) => {
+        reviewedBatches.push(sessions.map((session) => session.instanceId));
+        throw new Error("simulated interrupted history scan");
+      })
+      .mockImplementationOnce(async ({ onComplete, sessions }) => {
+        reviewedBatches.push(sessions.map((session) => session.instanceId));
+        await onComplete?.(0);
+        return 0;
+      });
+    const params = {
+      agentId: "main",
+      config: { session: { store: storePath } },
+      env,
+      workspaceDir,
+    } satisfies SkillHistoryScanScope;
+
+    await fs.mkdir(workspaceDir, { recursive: true });
+    try {
+      await expect(runSkillHistoryScan(params)).rejects.toThrow(
+        "simulated interrupted history scan",
+      );
+      const stateKey = historyScanStateKey(params.agentId, workspaceDir, storePath);
+      expect(historyScanStore(env).lookup(stateKey)?.pending?.sessionCursors).toEqual([
+        { instanceId: valid.instanceId, updatedAtMs: validUpdatedAtMs },
+      ]);
+
+      await expect(runSkillHistoryScan(params)).resolves.toMatchObject({
+        lastScanReviewed: 1,
+      });
+      expect(reviewedBatches).toEqual([["valid"], ["valid"]]);
+      expect(mocks.getProgress).toHaveBeenCalledTimes(1);
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(tempDir, { recursive: true, force: true });
+      vi.clearAllMocks();
+      mocks.candidates = [];
+    }
+  });
+});

--- a/src/skills/workshop/history-scan.test.ts
+++ b/src/skills/workshop/history-scan.test.ts
@@ -16,11 +16,13 @@ import {
   resolveSkillHistoryScanHasMore,
 } from "./history-scan-progress.js";
 import { buildSkillHistoryScanPrompt } from "./history-scan-prompt.js";
+import type { SkillHistoryScanPromptSession } from "./history-scan-prompt.js";
 import {
   resolveSkillHistoryScanReviewOutcome,
   resolveSkillHistoryScanRunFailure,
 } from "./history-scan-review-outcome.js";
 import { getSkillHistoryScanStatus, type SkillHistoryScanResult } from "./history-scan-state.js";
+import type { StoredSkillHistoryScanState } from "./history-scan-state.js";
 import {
   formatSkillHistoryScanTranscript,
   isSkillHistoryScanLocalTranscriptSizeEligible,
@@ -30,7 +32,7 @@ import {
   collectSkillHistoryScanBatch,
   resolveSkillHistoryScanTranscriptBudget,
 } from "./history-scan-transcript.js";
-import { runSkillHistoryScan } from "./history-scan.js";
+import { runSkillHistoryScan, __testing } from "./history-scan.js";
 
 function summary(sessionKey: string, overrides: Partial<SessionEntrySummary["entry"]> = {}) {
   return {
@@ -587,5 +589,75 @@ describe("Skill Workshop history scan", () => {
 
     expect(JSON.stringify(result)).not.toContain("transcript");
     expect(result.hasMore).toBe(true);
+  });
+});
+
+describe("toStoredState date bounds", () => {
+  const sessionHelper = (
+    overrides: Partial<SkillHistoryScanPromptSession>,
+  ): SkillHistoryScanPromptSession => ({
+    instanceId: "inst-1",
+    sessionKey: "session-1",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    modelIterations: 1,
+    transcript: "",
+    ...overrides,
+  });
+
+  it("filters invalid updatedAt timestamps instead of corrupting bounds with NaN", () => {
+    const result = __testing.toStoredState({
+      previous: undefined,
+      direction: "older",
+      considered: [],
+      sessions: [
+        sessionHelper({ instanceId: "a", updatedAt: "2026-01-01T00:00:00.000Z" }),
+        sessionHelper({ instanceId: "b", updatedAt: "not-a-date" }),
+        sessionHelper({ instanceId: "c", updatedAt: "2026-01-03T00:00:00.000Z" }),
+      ],
+      candidates: [],
+      ideasFound: 0,
+      now: 1_767_220_800_000,
+    });
+    expect(result.oldestReviewedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(result.newestReviewedAt).toBe("2026-01-03T00:00:00.000Z");
+  });
+
+  it("omits reviewed timestamps when all sessions have invalid dates", () => {
+    const result = __testing.toStoredState({
+      previous: undefined,
+      direction: "older",
+      considered: [],
+      sessions: [sessionHelper({ instanceId: "a", updatedAt: "not-a-date" })],
+      candidates: [],
+      ideasFound: 0,
+      now: 1_767_220_800_000,
+    });
+    expect(result.oldestReviewedAt).toBeUndefined();
+    expect(result.newestReviewedAt).toBeUndefined();
+  });
+
+  it("ignores invalid previous bounds without corrupting current bounds", () => {
+    const previous: StoredSkillHistoryScanState = {
+      schema: "openclaw.skill-workshop.history-scan.v1",
+      hasScanned: true,
+      reviewedSessions: 5,
+      ideasFound: 2,
+      hasMore: false,
+      lastScanReviewed: 5,
+      lastScanIdeas: 2,
+      oldestReviewedAt: "not-a-date",
+      newestReviewedAt: "also-not-a-date",
+    };
+    const result = __testing.toStoredState({
+      previous,
+      direction: "older",
+      considered: [],
+      sessions: [sessionHelper({ instanceId: "a", updatedAt: "2026-01-02T00:00:00.000Z" })],
+      candidates: [],
+      ideasFound: 1,
+      now: 1_767_220_800_000,
+    });
+    expect(result.oldestReviewedAt).toBe("2026-01-02T00:00:00.000Z");
+    expect(result.newestReviewedAt).toBe("2026-01-02T00:00:00.000Z");
   });
 });

--- a/src/skills/workshop/history-scan.test.ts
+++ b/src/skills/workshop/history-scan.test.ts
@@ -32,7 +32,7 @@ import {
   collectSkillHistoryScanBatch,
   resolveSkillHistoryScanTranscriptBudget,
 } from "./history-scan-transcript.js";
-import { runSkillHistoryScan, __testing } from "./history-scan.js";
+import { runSkillHistoryScan, toStoredState } from "./history-scan.js";
 
 function summary(sessionKey: string, overrides: Partial<SessionEntrySummary["entry"]> = {}) {
   return {
@@ -605,7 +605,7 @@ describe("toStoredState date bounds", () => {
   });
 
   it("filters invalid updatedAt timestamps instead of corrupting bounds with NaN", () => {
-    const result = __testing.toStoredState({
+    const result = toStoredState({
       previous: undefined,
       direction: "older",
       considered: [],
@@ -623,7 +623,7 @@ describe("toStoredState date bounds", () => {
   });
 
   it("omits reviewed timestamps when all sessions have invalid dates", () => {
-    const result = __testing.toStoredState({
+    const result = toStoredState({
       previous: undefined,
       direction: "older",
       considered: [],
@@ -648,7 +648,7 @@ describe("toStoredState date bounds", () => {
       oldestReviewedAt: "not-a-date",
       newestReviewedAt: "also-not-a-date",
     };
-    const result = __testing.toStoredState({
+    const result = toStoredState({
       previous,
       direction: "older",
       considered: [],

--- a/src/skills/workshop/history-scan.test.ts
+++ b/src/skills/workshop/history-scan.test.ts
@@ -22,7 +22,6 @@ import {
   resolveSkillHistoryScanRunFailure,
 } from "./history-scan-review-outcome.js";
 import { getSkillHistoryScanStatus, type SkillHistoryScanResult } from "./history-scan-state.js";
-import type { StoredSkillHistoryScanState } from "./history-scan-state.js";
 import {
   formatSkillHistoryScanTranscript,
   isSkillHistoryScanLocalTranscriptSizeEligible,
@@ -32,7 +31,7 @@ import {
   collectSkillHistoryScanBatch,
   resolveSkillHistoryScanTranscriptBudget,
 } from "./history-scan-transcript.js";
-import { runSkillHistoryScan, toStoredState } from "./history-scan.js";
+import { runSkillHistoryScan } from "./history-scan.js";
 
 function summary(sessionKey: string, overrides: Partial<SessionEntrySummary["entry"]> = {}) {
   return {
@@ -589,75 +588,5 @@ describe("Skill Workshop history scan", () => {
 
     expect(JSON.stringify(result)).not.toContain("transcript");
     expect(result.hasMore).toBe(true);
-  });
-});
-
-describe("toStoredState date bounds", () => {
-  const sessionHelper = (
-    overrides: Partial<SkillHistoryScanPromptSession>,
-  ): SkillHistoryScanPromptSession => ({
-    instanceId: "inst-1",
-    sessionKey: "session-1",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    modelIterations: 1,
-    transcript: "",
-    ...overrides,
-  });
-
-  it("filters invalid updatedAt timestamps instead of corrupting bounds with NaN", () => {
-    const result = toStoredState({
-      previous: undefined,
-      direction: "older",
-      considered: [],
-      sessions: [
-        sessionHelper({ instanceId: "a", updatedAt: "2026-01-01T00:00:00.000Z" }),
-        sessionHelper({ instanceId: "b", updatedAt: "not-a-date" }),
-        sessionHelper({ instanceId: "c", updatedAt: "2026-01-03T00:00:00.000Z" }),
-      ],
-      candidates: [],
-      ideasFound: 0,
-      now: 1_767_220_800_000,
-    });
-    expect(result.oldestReviewedAt).toBe("2026-01-01T00:00:00.000Z");
-    expect(result.newestReviewedAt).toBe("2026-01-03T00:00:00.000Z");
-  });
-
-  it("omits reviewed timestamps when all sessions have invalid dates", () => {
-    const result = toStoredState({
-      previous: undefined,
-      direction: "older",
-      considered: [],
-      sessions: [sessionHelper({ instanceId: "a", updatedAt: "not-a-date" })],
-      candidates: [],
-      ideasFound: 0,
-      now: 1_767_220_800_000,
-    });
-    expect(result.oldestReviewedAt).toBeUndefined();
-    expect(result.newestReviewedAt).toBeUndefined();
-  });
-
-  it("ignores invalid previous bounds without corrupting current bounds", () => {
-    const previous: StoredSkillHistoryScanState = {
-      schema: "openclaw.skill-workshop.history-scan.v1",
-      hasScanned: true,
-      reviewedSessions: 5,
-      ideasFound: 2,
-      hasMore: false,
-      lastScanReviewed: 5,
-      lastScanIdeas: 2,
-      oldestReviewedAt: "not-a-date",
-      newestReviewedAt: "also-not-a-date",
-    };
-    const result = toStoredState({
-      previous,
-      direction: "older",
-      considered: [],
-      sessions: [sessionHelper({ instanceId: "a", updatedAt: "2026-01-02T00:00:00.000Z" })],
-      candidates: [],
-      ideasFound: 1,
-      now: 1_767_220_800_000,
-    });
-    expect(result.oldestReviewedAt).toBe("2026-01-02T00:00:00.000Z");
-    expect(result.newestReviewedAt).toBe("2026-01-02T00:00:00.000Z");
   });
 });

--- a/src/skills/workshop/history-scan.test.ts
+++ b/src/skills/workshop/history-scan.test.ts
@@ -16,7 +16,6 @@ import {
   resolveSkillHistoryScanHasMore,
 } from "./history-scan-progress.js";
 import { buildSkillHistoryScanPrompt } from "./history-scan-prompt.js";
-import type { SkillHistoryScanPromptSession } from "./history-scan-prompt.js";
 import {
   resolveSkillHistoryScanReviewOutcome,
   resolveSkillHistoryScanRunFailure,

--- a/src/skills/workshop/history-scan.ts
+++ b/src/skills/workshop/history-scan.ts
@@ -61,7 +61,7 @@ function finalizeUnreplayableSkillHistoryScan(
   });
 }
 
-function toStoredState(params: {
+export function toStoredState(params: {
   previous: StoredSkillHistoryScanState | undefined;
   direction: SkillHistoryScanDirection;
   considered: readonly SkillHistoryScanCandidate[];
@@ -405,6 +405,3 @@ export function runSkillHistoryScan(
     .catch(() => undefined);
   return run;
 }
-
-const testing = { toStoredState };
-export { testing as __testing };

--- a/src/skills/workshop/history-scan.ts
+++ b/src/skills/workshop/history-scan.ts
@@ -61,7 +61,7 @@ function finalizeUnreplayableSkillHistoryScan(
   });
 }
 
-export function toStoredState(params: {
+function toStoredState(params: {
   previous: StoredSkillHistoryScanState | undefined;
   direction: SkillHistoryScanDirection;
   considered: readonly SkillHistoryScanCandidate[];

--- a/src/skills/workshop/history-scan.ts
+++ b/src/skills/workshop/history-scan.ts
@@ -15,7 +15,6 @@ import {
   reconcileSkillHistoryScanProgress,
   resolveSkillHistoryScanHasMore,
 } from "./history-scan-progress.js";
-import type { SkillHistoryScanPromptSession } from "./history-scan-prompt.js";
 import { HISTORY_SCAN_MAX_PROPOSAL_MUTATIONS } from "./history-scan-review-outcome.js";
 import { HISTORY_SCAN_SESSION_SEGMENT, runSkillHistoryScanReview } from "./history-scan-review.js";
 import {
@@ -38,6 +37,7 @@ import {
   HISTORY_SCAN_SESSION_OVERHEAD_CHARS,
   readHistoryScanSession,
   resolveSkillHistoryScanTranscriptBudget,
+  type SkillHistoryScanBatchSession,
 } from "./history-scan-transcript.js";
 import { getSkillProposalRunProgress } from "./service.js";
 
@@ -65,15 +65,13 @@ function toStoredState(params: {
   previous: StoredSkillHistoryScanState | undefined;
   direction: SkillHistoryScanDirection;
   considered: readonly SkillHistoryScanCandidate[];
-  sessions: readonly SkillHistoryScanPromptSession[];
+  sessions: readonly SkillHistoryScanBatchSession[];
   candidates: readonly SkillHistoryScanCandidate[];
   ideasFound: number;
   now: number;
 }): StoredSkillHistoryScanState {
   const previous = params.previous;
-  const reviewedTimes = params.sessions
-    .map((session) => Date.parse(session.updatedAt))
-    .filter((ms): ms is number => Number.isFinite(ms));
+  const reviewedTimes = params.sessions.map((session) => session.updatedAtMs);
   const previousOldest = previous?.oldestReviewedAt
     ? Date.parse(previous.oldestReviewedAt)
     : undefined;
@@ -303,14 +301,10 @@ async function runSkillHistoryScanCore(
       progress,
       sessionCursors:
         resumedPending?.sessionCursors ??
-        batch.sessions
-          .map((session) => ({
-            instanceId: session.instanceId,
-            updatedAtMs: Date.parse(session.updatedAt),
-          }))
-          .filter((cursor): cursor is { instanceId: string; updatedAtMs: number } =>
-            Number.isFinite(cursor.updatedAtMs),
-          ),
+        batch.sessions.map((session) => ({
+          instanceId: session.instanceId,
+          updatedAtMs: session.updatedAtMs,
+        })),
     },
   });
   let reviewError: unknown;

--- a/src/skills/workshop/history-scan.ts
+++ b/src/skills/workshop/history-scan.ts
@@ -71,7 +71,9 @@ function toStoredState(params: {
   now: number;
 }): StoredSkillHistoryScanState {
   const previous = params.previous;
-  const reviewedTimes = params.sessions.map((session) => Date.parse(session.updatedAt));
+  const reviewedTimes = params.sessions
+    .map((session) => Date.parse(session.updatedAt))
+    .filter((ms): ms is number => Number.isFinite(ms));
   const previousOldest = previous?.oldestReviewedAt
     ? Date.parse(previous.oldestReviewedAt)
     : undefined;
@@ -399,3 +401,6 @@ export function runSkillHistoryScan(
     .catch(() => undefined);
   return run;
 }
+
+const testing = { toStoredState };
+export { testing as __testing };

--- a/src/skills/workshop/history-scan.ts
+++ b/src/skills/workshop/history-scan.ts
@@ -303,10 +303,14 @@ async function runSkillHistoryScanCore(
       progress,
       sessionCursors:
         resumedPending?.sessionCursors ??
-        batch.sessions.map((session) => ({
-          instanceId: session.instanceId,
-          updatedAtMs: Date.parse(session.updatedAt),
-        })),
+        batch.sessions
+          .map((session) => ({
+            instanceId: session.instanceId,
+            updatedAtMs: Date.parse(session.updatedAt),
+          }))
+          .filter((cursor): cursor is { instanceId: string; updatedAtMs: number } =>
+            Number.isFinite(cursor.updatedAtMs),
+          ),
     },
   });
   let reviewError: unknown;


### PR DESCRIPTION
## What Problem This Solves

Skill Workshop history scans persisted `Date.parse(session.updatedAt)` into pending resume cursors. A malformed timestamp produced `NaN`, which could make a checkpoint impossible to reconstruct consistently after interruption.

## Why This Change Was Made

Filtering only the derived timestamp aggregate or cursor array was too late: the malformed session remained in `batch.sessions`, so the review batch and its persisted cursor set no longer had matching membership.

The maintainer fix validates each session timestamp during canonical batch assembly. Invalid sessions are excluded before review, progress, and pending state are built. Valid timestamps are parsed once and carried forward for stored review bounds and resume cursors.

## User Impact

Interrupted history scans can now resume the exact batch that was checkpointed, even when a session reader returns a malformed timestamp. Valid sessions retain the existing behavior.

## Evidence

- Local focused Vitest: 27/27 passed across `history-scan.test.ts` and `history-scan.resume.test.ts`.
- Blacksmith Testbox `tbx_01kxrqs8t58r3pn0xarhg2bhga`: 27/27 focused tests passed in Actions run `29606550747`.
- Testbox `check:changed`: formatting, core and core-test typechecks, changed-file lint, dependency checks, and architecture guards passed.
- Interrupted-resume regression: the first run checkpoints only the valid session cursor; the second run reconstructs and completes the same valid-only batch.
- Final autoreview: clean, no accepted or actionable findings.
