### PR TITLE
fix(plugins): handle NaN from Date.parse in catalog rollback detection

### DIFF
--- a/src/plugins/official-external-plugin-catalog-envelope.test.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.test.ts
@@ -190,7 +190,11 @@ describe("official external plugin catalog signed envelopes", () => {
         signedEnvelope({ keys: [key], feed: { entries: [] } }),
         { trustedKeys },
       ),
-    ).toMatchObject({ ok: false, error: "invalid-payload" });
+    ).toMatchObject({
+      ok: false,
+      error: "invalid-payload",
+      authenticatedPayload: { entries: [] },
+    });
   });
 
   it("rejects malformed envelopes before verification", () => {

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -40,6 +40,7 @@ type OfficialExternalPluginCatalogEnvelopeVerificationResult =
         | "missing-trust-key"
         | "invalid-signature";
       message: string;
+      authenticatedPayload?: unknown;
     };
 function createOfficialExternalPluginCatalogEnvelopeSigningInput(params: {
   payloadType: string;
@@ -110,17 +111,18 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     }
   }
   if (trustedSignaturePublicKeys.size >= threshold) {
-    const feed = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
-    if (!feed) {
+    const decoded = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
+    if (!decoded?.feed) {
       return {
         ok: false,
         error: "invalid-payload",
         message: "hosted catalog signed envelope payload is invalid",
+        ...(decoded ? { authenticatedPayload: decoded.raw } : {}),
       };
     }
     return {
       ok: true,
-      feed,
+      feed: decoded.feed,
       signedBy: trustedSignatureKeyIds[0] ?? "",
       ...(threshold > 1
         ? {
@@ -218,10 +220,13 @@ function decodeOfficialExternalPluginCatalogEnvelopePayloadBytes(payload: string
 
 function decodeOfficialExternalPluginCatalogEnvelopePayload(
   payloadBytes: Buffer,
-): OfficialExternalPluginCatalogFeed | null {
+): { raw: unknown; feed: OfficialExternalPluginCatalogFeed | null } | null {
   try {
     const raw = JSON.parse(payloadBytes.toString("utf8")) as unknown;
-    return isOfficialExternalPluginCatalogFeed(raw) ? raw : null;
+    return {
+      raw,
+      feed: isOfficialExternalPluginCatalogFeed(raw) ? raw : null,
+    };
   } catch {
     return null;
   }

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -142,7 +142,15 @@ function isMonotonicRollback(params: {
   if (params.candidate.sequence > params.current.sequence) {
     return false;
   }
-  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
+  const candidateTime = Date.parse(params.candidate.generatedAt);
+  const currentTime = Date.parse(params.current.generatedAt);
+  if (Number.isNaN(candidateTime)) {
+    return true;
+  }
+  if (Number.isNaN(currentTime)) {
+    return false;
+  }
+  return candidateTime < currentTime;
 }
 
 function assertSignedSnapshotWriteIsMonotonic(params: {
@@ -285,3 +293,6 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
     },
   };
 }
+
+const testing = { isMonotonicRollback };
+export { testing as __testing };

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -18,6 +18,7 @@ import {
   type HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
   type HostedOfficialExternalPluginCatalogSnapshotStore,
   type HostedOfficialExternalPluginCatalogTrustState,
+  isOfficialExternalPluginCatalogSequence,
   parseOfficialExternalPluginCatalogTimestamp,
 } from "./official-external-plugin-catalog.js";
 
@@ -123,7 +124,7 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
             generatedAt?: unknown;
           })
         : document;
-    if (typeof feed.sequence !== "number") {
+    if (!isOfficialExternalPluginCatalogSequence(feed.sequence)) {
       return undefined;
     }
     if (

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -12,12 +12,13 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import type {
-  HostedOfficialExternalPluginCatalogMetadata,
-  HostedOfficialExternalPluginCatalogSnapshot,
-  HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
-  HostedOfficialExternalPluginCatalogSnapshotStore,
-  HostedOfficialExternalPluginCatalogTrustState,
+import {
+  type HostedOfficialExternalPluginCatalogMetadata,
+  type HostedOfficialExternalPluginCatalogSnapshot,
+  type HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
+  type HostedOfficialExternalPluginCatalogSnapshotStore,
+  type HostedOfficialExternalPluginCatalogTrustState,
+  parseOfficialExternalPluginCatalogTimestamp,
 } from "./official-external-plugin-catalog.js";
 
 type HostedOfficialExternalPluginCatalogSnapshotStoreOptions = {
@@ -45,6 +46,11 @@ type HostedCatalogSnapshotDatabase = Pick<
   OpenClawStateKyselyDatabase,
   "official_external_plugin_catalog_snapshots"
 >;
+
+type StoredHostedCatalogMonotonicState = {
+  sequence: number;
+  generatedAt?: string;
+};
 
 function resolveStoreEnv(
   options: HostedOfficialExternalPluginCatalogSnapshotStoreOptions,
@@ -103,9 +109,7 @@ function decodeBase64Payload(payload: string): string {
   return Buffer.from(normalized, "base64").toString("utf8");
 }
 
-function readMonotonicStateFromBody(
-  body: string,
-): HostedOfficialExternalPluginCatalogSnapshotMonotonicState | undefined {
+function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicState | undefined {
   try {
     const document = JSON.parse(body) as {
       payload?: unknown;
@@ -119,11 +123,16 @@ function readMonotonicStateFromBody(
             generatedAt?: unknown;
           })
         : document;
-    if (typeof feed.sequence !== "number" || typeof feed.generatedAt !== "string") {
+    if (typeof feed.sequence !== "number") {
       return undefined;
     }
+    if (
+      typeof feed.generatedAt !== "string" ||
+      parseOfficialExternalPluginCatalogTimestamp(feed.generatedAt) === undefined
+    ) {
+      return { sequence: feed.sequence };
+    }
     return {
-      mode: "signed-feed",
       sequence: feed.sequence,
       generatedAt: feed.generatedAt,
     };
@@ -134,7 +143,7 @@ function readMonotonicStateFromBody(
 
 function isMonotonicRollback(params: {
   candidate: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
-  current: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
+  current: StoredHostedCatalogMonotonicState;
 }): boolean {
   if (params.candidate.sequence < params.current.sequence) {
     return true;
@@ -142,15 +151,10 @@ function isMonotonicRollback(params: {
   if (params.candidate.sequence > params.current.sequence) {
     return false;
   }
-  const candidateTime = Date.parse(params.candidate.generatedAt);
-  const currentTime = Date.parse(params.current.generatedAt);
-  if (Number.isNaN(candidateTime)) {
-    return true;
-  }
-  if (Number.isNaN(currentTime)) {
+  if (params.current.generatedAt === undefined) {
     return false;
   }
-  return candidateTime < currentTime;
+  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
 }
 
 function assertSignedSnapshotWriteIsMonotonic(params: {

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -132,7 +132,7 @@ function readMonotonicStateFromBody(
   }
 }
 
-function isMonotonicRollback(params: {
+export function isMonotonicRollback(params: {
   candidate: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
   current: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
 }): boolean {
@@ -293,6 +293,3 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
     },
   };
 }
-
-const testing = { isMonotonicRollback };
-export { testing as __testing };

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -132,7 +132,7 @@ function readMonotonicStateFromBody(
   }
 }
 
-export function isMonotonicRollback(params: {
+function isMonotonicRollback(params: {
   candidate: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
   current: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
 }): boolean {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -159,6 +159,38 @@ function signedCatalogConfig(publicKeyPem: string): HostedCatalogConfig {
   };
 }
 
+function signedHostedCatalogSnapshot(params: {
+  body: string;
+  savedAt?: string;
+  monotonic?: { sequence: number; generatedAt: string };
+}): HostedOfficialExternalPluginCatalogSnapshot {
+  const savedAt = params.savedAt ?? "2026-06-22T00:00:10.000Z";
+  return {
+    body: params.body,
+    metadata: {
+      url: "https://packages.acme.example/openclaw/feed",
+      status: 200,
+      checksum: `sha256:${crypto.createHash("sha256").update(params.body).digest("hex")}`,
+    },
+    savedAt,
+    trust: {
+      mode: "signed",
+      signedBy: "acme-root",
+      signatureCount: 1,
+      threshold: 1,
+      verifiedAt: savedAt,
+    },
+    ...(params.monotonic
+      ? {
+          monotonic: {
+            mode: "signed-feed",
+            ...params.monotonic,
+          },
+        }
+      : {}),
+  };
+}
+
 describe("official external plugin catalog", () => {
   it("keeps hosted fetch guard loading lazy for bundled catalog import paths", () => {
     const source = readFileSync(
@@ -242,6 +274,39 @@ describe("official external plugin catalog", () => {
         entries: [],
       }),
     ).toBe(false);
+    for (const generatedAt of [
+      "not-a-date",
+      "2026-02-30T00:00:00.000Z",
+      "2026-02-30 00:00:00.000Z",
+    ]) {
+      expect(
+        isOfficialExternalPluginCatalogFeed({
+          schemaVersion: 1,
+          id: "openclaw-official-external-plugins",
+          generatedAt,
+          sequence: 2,
+          entries: [],
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("accepts valid timestamp serializations supported by shipped releases", () => {
+    for (const generatedAt of [
+      "2026-06-22T00:00:10Z",
+      "2026-06-22T01:00:10+01:00",
+      " 2026-06-22 00:00:10Z ",
+    ]) {
+      expect(
+        isOfficialExternalPluginCatalogFeed({
+          schemaVersion: 1,
+          id: "openclaw-official-external-plugins",
+          generatedAt,
+          sequence: 2,
+          entries: [],
+        }),
+      ).toBe(true);
+    }
   });
 
   it("accepts the live ClawHub feed schema version", () => {
@@ -457,6 +522,70 @@ describe("official external plugin catalog", () => {
     }
   });
 
+  it("replaces malformed signed SQLite snapshot metadata with a valid snapshot", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-snapshot-repair-"));
+    const url = "https://packages.acme.example/openclaw/feed";
+    const malformed = signedHostedCatalogFeed({
+      feed: {
+        ...hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/malformed-current" }),
+        generatedAt: "2026-02-30T00:00:00.000Z",
+      },
+    });
+    const validFeed = hostedCatalogFeed({
+      sequence: 10,
+      pluginName: "@openclaw/repaired-current",
+    });
+    const valid = signedHostedCatalogFeed({
+      feed: validFeed,
+      privateKeyPem: malformed.privateKeyPem,
+    });
+    const lowerFeed = hostedCatalogFeed({
+      sequence: 9,
+      pluginName: "@openclaw/lower-current",
+    });
+    const lower = signedHostedCatalogFeed({
+      feed: lowerFeed,
+      privateKeyPem: malformed.privateKeyPem,
+    });
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: malformed.body,
+          monotonic: { sequence: 10, generatedAt: "2026-02-30T00:00:00.000Z" },
+        }),
+      );
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: lower.body,
+            monotonic: {
+              sequence: lowerFeed.sequence,
+              generatedAt: lowerFeed.generatedAt,
+            },
+          }),
+        ),
+      ).rejects.toThrow("sequence is older");
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: valid.body,
+          monotonic: {
+            sequence: validFeed.sequence,
+            generatedAt: validFeed.generatedAt,
+          },
+        }),
+      );
+
+      await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: valid.body });
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("verifies signed hosted feeds and rejects rollback before replacing snapshots", async () => {
     const newer = signedHostedCatalogFeed({
       feed: hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/signed-v10" }),
@@ -504,6 +633,97 @@ describe("official external plugin catalog", () => {
     expect(writeSpy).not.toHaveBeenCalled();
   });
 
+  it("rejects malformed feed timestamps before rollback handling", async () => {
+    const malformed = signedHostedCatalogFeed({
+      feed: {
+        ...hostedCatalogFeed({ sequence: 11, pluginName: "@openclaw/malformed-date" }),
+        generatedAt: "not-a-date",
+      },
+    });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(malformed.publicKeyPem),
+      fetchImpl: vi.fn(async () => new Response(malformed.body, { status: 200 })),
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("signed envelope payload is invalid");
+    }
+  });
+
+  it("replaces a signed snapshot with an invalid timestamp using a valid feed", async () => {
+    const malformed = signedHostedCatalogFeed({
+      feed: {
+        ...hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/malformed-current" }),
+        generatedAt: "not-a-date",
+      },
+    });
+    const valid = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/repaired-current" }),
+      privateKeyPem: malformed.privateKeyPem,
+    });
+    const lower = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 9, pluginName: "@openclaw/lower-current" }),
+      privateKeyPem: malformed.privateKeyPem,
+    });
+    const url = "https://packages.acme.example/openclaw/feed";
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore([
+      signedHostedCatalogSnapshot({ body: malformed.body }),
+    ]);
+
+    const rejected = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(lower.publicKeyPem),
+      fetchImpl: vi.fn(async () => new Response(lower.body, { status: 200 })),
+      snapshotStore,
+    });
+
+    expect(rejected.source).toBe("bundled-fallback");
+    await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: malformed.body });
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(valid.publicKeyPem),
+      fetchImpl: vi.fn(async () => new Response(valid.body, { status: 200 })),
+      snapshotStore,
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/repaired-current"]);
+    await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: valid.body });
+  });
+
+  it("does not replace a signed snapshot that fails current trust verification", async () => {
+    const current = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/current-key" }),
+    });
+    const candidate = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 9, pluginName: "@openclaw/new-key" }),
+    });
+    const url = "https://packages.acme.example/openclaw/feed";
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore([
+      signedHostedCatalogSnapshot({ body: current.body }),
+    ]);
+    const writeSpy = vi.spyOn(snapshotStore, "write");
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(candidate.publicKeyPem),
+      fetchImpl: vi.fn(async () => new Response(candidate.body, { status: 200 })),
+      snapshotStore,
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("signature is invalid");
+    }
+    expect(writeSpy).not.toHaveBeenCalled();
+    await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: current.body });
+  });
+
   it("fails closed for unsigned signed-profile responses and re-verifies offline snapshots", async () => {
     const signed = signedHostedCatalogFeed({
       feed: hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/signed-offline" }),
@@ -527,22 +747,10 @@ describe("official external plugin catalog", () => {
     }
 
     const signedSnapshot = createInMemoryHostedCatalogSnapshotStore([
-      {
+      signedHostedCatalogSnapshot({
         body: signed.body,
-        metadata: {
-          url: "https://packages.acme.example/openclaw/feed",
-          status: 200,
-          checksum: `sha256:${crypto.createHash("sha256").update(signed.body).digest("hex")}`,
-        },
         savedAt: "2026-06-22T00:00:08.000Z",
-        trust: {
-          mode: "signed",
-          signedBy: "acme-root",
-          signatureCount: 1,
-          threshold: 1,
-          verifiedAt: "2026-06-22T00:00:08.000Z",
-        },
-      },
+      }),
     ]);
     const offline = await loadHostedCatalog({
       feedProfile: "acme",

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -5,8 +5,10 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
-import { __testing as snapshotTesting } from "./official-external-plugin-catalog-snapshot-store.js";
+import {
+  createSqliteHostedOfficialExternalPluginCatalogSnapshotStore,
+  isMonotonicRollback,
+} from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type HostedOfficialExternalPluginCatalogSnapshot,
   type HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
@@ -25,7 +27,7 @@ import {
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
-import { __testing } from "./official-external-plugin-catalog.js";
+import { isHostedCatalogSignedFeedRollback } from "./official-external-plugin-catalog.js";
 
 function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
   const entry = getOfficialExternalPluginCatalogEntry(id);
@@ -1229,8 +1231,6 @@ describe("official external plugin catalog", () => {
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
 
 describe("isHostedCatalogSignedFeedRollback", () => {
-  const { isHostedCatalogSignedFeedRollback } = __testing;
-
   function feed(
     overrides: Partial<OfficialExternalPluginCatalogFeed>,
   ): OfficialExternalPluginCatalogFeed {
@@ -1291,8 +1291,6 @@ describe("isHostedCatalogSignedFeedRollback", () => {
 });
 
 describe("isMonotonicRollback", () => {
-  const { isMonotonicRollback } = snapshotTesting;
-
   function state(
     overrides: Partial<HostedOfficialExternalPluginCatalogSnapshotMonotonicState>,
   ): HostedOfficialExternalPluginCatalogSnapshotMonotonicState {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -5,13 +5,9 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import {
-  createSqliteHostedOfficialExternalPluginCatalogSnapshotStore,
-  isMonotonicRollback,
-} from "./official-external-plugin-catalog-snapshot-store.js";
+import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type HostedOfficialExternalPluginCatalogSnapshot,
-  type HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
   type HostedOfficialExternalPluginCatalogSnapshotStore,
   type OfficialExternalPluginCatalogEntry,
   type OfficialExternalPluginCatalogFeed,
@@ -27,7 +23,6 @@ import {
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
-import { isHostedCatalogSignedFeedRollback } from "./official-external-plugin-catalog.js";
 
 function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
   const entry = getOfficialExternalPluginCatalogEntry(id);
@@ -1229,121 +1224,3 @@ describe("official external plugin catalog", () => {
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
-
-describe("isHostedCatalogSignedFeedRollback", () => {
-  function feed(
-    overrides: Partial<OfficialExternalPluginCatalogFeed>,
-  ): OfficialExternalPluginCatalogFeed {
-    return {
-      schemaVersion: 1,
-      id: "test-feed",
-      generatedAt: "2026-01-01T00:00:00.000Z",
-      sequence: 10,
-      entries: [],
-      ...overrides,
-    };
-  }
-
-  it("returns false when candidate is newer by sequence", () => {
-    expect(
-      isHostedCatalogSignedFeedRollback({
-        candidate: feed({ sequence: 11, generatedAt: "2026-01-01T00:00:00.000Z" }),
-        current: feed({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true when candidate is older by sequence", () => {
-    expect(
-      isHostedCatalogSignedFeedRollback({
-        candidate: feed({ sequence: 9, generatedAt: "2026-01-02T00:00:00.000Z" }),
-        current: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-      }),
-    ).toBe(true);
-  });
-
-  it("compares generatedAt when sequences are equal", () => {
-    expect(
-      isHostedCatalogSignedFeedRollback({
-        candidate: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-        current: feed({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
-      }),
-    ).toBe(true);
-  });
-
-  it("treats candidate with invalid generatedAt as a rollback", () => {
-    expect(
-      isHostedCatalogSignedFeedRollback({
-        candidate: feed({ sequence: 10, generatedAt: "not-a-date" }),
-        current: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-      }),
-    ).toBe(true);
-  });
-
-  it("does not treat current with invalid generatedAt as a rollback", () => {
-    expect(
-      isHostedCatalogSignedFeedRollback({
-        candidate: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-        current: feed({ sequence: 10, generatedAt: "not-a-date" }),
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("isMonotonicRollback", () => {
-  function state(
-    overrides: Partial<HostedOfficialExternalPluginCatalogSnapshotMonotonicState>,
-  ): HostedOfficialExternalPluginCatalogSnapshotMonotonicState {
-    return {
-      mode: "signed-feed",
-      sequence: 10,
-      generatedAt: "2026-01-01T00:00:00.000Z",
-      ...overrides,
-    };
-  }
-
-  it("returns false when candidate is newer by sequence", () => {
-    expect(
-      isMonotonicRollback({
-        candidate: state({ sequence: 11, generatedAt: "2026-01-01T00:00:00.000Z" }),
-        current: state({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true when candidate is older by sequence", () => {
-    expect(
-      isMonotonicRollback({
-        candidate: state({ sequence: 9, generatedAt: "2026-01-02T00:00:00.000Z" }),
-        current: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-      }),
-    ).toBe(true);
-  });
-
-  it("compares generatedAt when sequences are equal", () => {
-    expect(
-      isMonotonicRollback({
-        candidate: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-        current: state({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
-      }),
-    ).toBe(true);
-  });
-
-  it("treats candidate with invalid generatedAt as a rollback", () => {
-    expect(
-      isMonotonicRollback({
-        candidate: state({ sequence: 10, generatedAt: "not-a-date" }),
-        current: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-      }),
-    ).toBe(true);
-  });
-
-  it("does not treat current with invalid generatedAt as a rollback", () => {
-    expect(
-      isMonotonicRollback({
-        candidate: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
-        current: state({ sequence: 10, generatedAt: "not-a-date" }),
-      }),
-    ).toBe(false);
-  });
-});

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -23,6 +23,7 @@ import {
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
+import { __testing } from "./official-external-plugin-catalog.js";
 
 function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
   const entry = getOfficialExternalPluginCatalogEntry(id);
@@ -1224,3 +1225,65 @@ describe("official external plugin catalog", () => {
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+
+describe("isHostedCatalogSignedFeedRollback", () => {
+  const { isHostedCatalogSignedFeedRollback } = __testing;
+
+  function feed(
+    overrides: Partial<OfficialExternalPluginCatalogFeed>,
+  ): OfficialExternalPluginCatalogFeed {
+    return {
+      schemaVersion: 1,
+      id: "test-feed",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      sequence: 10,
+      entries: [],
+      ...overrides,
+    };
+  }
+
+  it("returns false when candidate is newer by sequence", () => {
+    expect(
+      isHostedCatalogSignedFeedRollback({
+        candidate: feed({ sequence: 11, generatedAt: "2026-01-01T00:00:00.000Z" }),
+        current: feed({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when candidate is older by sequence", () => {
+    expect(
+      isHostedCatalogSignedFeedRollback({
+        candidate: feed({ sequence: 9, generatedAt: "2026-01-02T00:00:00.000Z" }),
+        current: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("compares generatedAt when sequences are equal", () => {
+    expect(
+      isHostedCatalogSignedFeedRollback({
+        candidate: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+        current: feed({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("treats candidate with invalid generatedAt as a rollback", () => {
+    expect(
+      isHostedCatalogSignedFeedRollback({
+        candidate: feed({ sequence: 10, generatedAt: "not-a-date" }),
+        current: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat current with invalid generatedAt as a rollback", () => {
+    expect(
+      isHostedCatalogSignedFeedRollback({
+        candidate: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+        current: feed({ sequence: 10, generatedAt: "not-a-date" }),
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -289,6 +289,17 @@ describe("official external plugin catalog", () => {
         }),
       ).toBe(false);
     }
+    for (const sequence of [Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(
+        isOfficialExternalPluginCatalogFeed({
+          schemaVersion: 1,
+          id: "openclaw-official-external-plugins",
+          generatedAt: "2026-06-22T00:00:00.000Z",
+          sequence,
+          entries: [],
+        }),
+      ).toBe(false);
+    }
   });
 
   it("accepts valid timestamp serializations supported by shipped releases", () => {
@@ -569,6 +580,44 @@ describe("official external plugin catalog", () => {
           }),
         ),
       ).rejects.toThrow("sequence is older");
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: valid.body,
+          monotonic: {
+            sequence: validFeed.sequence,
+            generatedAt: validFeed.generatedAt,
+          },
+        }),
+      );
+
+      await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: valid.body });
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores an invalid recovered sequence when repairing a signed SQLite snapshot", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-snapshot-sequence-"));
+    const url = "https://packages.acme.example/openclaw/feed";
+    const malformedBody =
+      '{"schemaVersion":1,"id":"openclaw-official-external-plugins","generatedAt":"not-a-date","sequence":1e999,"entries":[]}';
+    const validFeed = hostedCatalogFeed({
+      sequence: 10,
+      pluginName: "@openclaw/repaired-sequence",
+    });
+    const valid = signedHostedCatalogFeed({ feed: validFeed });
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: malformedBody,
+          monotonic: { sequence: 10, generatedAt: "not-a-date" },
+        }),
+      );
       await snapshotStore.write(
         signedHostedCatalogSnapshot({
           body: valid.body,

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -6,8 +6,10 @@ import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
+import { __testing as snapshotTesting } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type HostedOfficialExternalPluginCatalogSnapshot,
+  type HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
   type HostedOfficialExternalPluginCatalogSnapshotStore,
   type OfficialExternalPluginCatalogEntry,
   type OfficialExternalPluginCatalogFeed,
@@ -1283,6 +1285,66 @@ describe("isHostedCatalogSignedFeedRollback", () => {
       isHostedCatalogSignedFeedRollback({
         candidate: feed({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
         current: feed({ sequence: 10, generatedAt: "not-a-date" }),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isMonotonicRollback", () => {
+  const { isMonotonicRollback } = snapshotTesting;
+
+  function state(
+    overrides: Partial<HostedOfficialExternalPluginCatalogSnapshotMonotonicState>,
+  ): HostedOfficialExternalPluginCatalogSnapshotMonotonicState {
+    return {
+      mode: "signed-feed",
+      sequence: 10,
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  it("returns false when candidate is newer by sequence", () => {
+    expect(
+      isMonotonicRollback({
+        candidate: state({ sequence: 11, generatedAt: "2026-01-01T00:00:00.000Z" }),
+        current: state({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when candidate is older by sequence", () => {
+    expect(
+      isMonotonicRollback({
+        candidate: state({ sequence: 9, generatedAt: "2026-01-02T00:00:00.000Z" }),
+        current: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("compares generatedAt when sequences are equal", () => {
+    expect(
+      isMonotonicRollback({
+        candidate: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+        current: state({ sequence: 10, generatedAt: "2026-01-02T00:00:00.000Z" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("treats candidate with invalid generatedAt as a rollback", () => {
+    expect(
+      isMonotonicRollback({
+        candidate: state({ sequence: 10, generatedAt: "not-a-date" }),
+        current: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat current with invalid generatedAt as a rollback", () => {
+    expect(
+      isMonotonicRollback({
+        candidate: state({ sequence: 10, generatedAt: "2026-01-01T00:00:00.000Z" }),
+        current: state({ sequence: 10, generatedAt: "not-a-date" }),
       }),
     ).toBe(false);
   });

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -718,7 +718,7 @@ async function loadHostedCatalogSnapshotResult(params: {
   };
 }
 
-export function isHostedCatalogSignedFeedRollback(params: {
+function isHostedCatalogSignedFeedRollback(params: {
   candidate: OfficialExternalPluginCatalogFeed;
   current: OfficialExternalPluginCatalogFeed;
 }): boolean {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -728,7 +728,16 @@ function isHostedCatalogSignedFeedRollback(params: {
   if (params.candidate.sequence > params.current.sequence) {
     return false;
   }
-  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
+  const candidateAt = Date.parse(params.candidate.generatedAt);
+  const currentAt = Date.parse(params.current.generatedAt);
+  // If either date is invalid, treat the candidate as older (conservative rollback).
+  if (!Number.isFinite(candidateAt)) {
+    return true;
+  }
+  if (!Number.isFinite(currentAt)) {
+    return false;
+  }
+  return candidateAt < currentAt;
 }
 
 function assertSnapshotMatchesRequestValidators(params: {
@@ -1447,4 +1456,7 @@ export function getOfficialExternalPluginCatalogEntryForPackage(
     (entry) => normalizeOptionalString(entry.name) === normalized,
   );
 }
+
+const testing = { isHostedCatalogSignedFeedRollback };
+export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -297,6 +297,10 @@ export function parseOfficialExternalPluginCatalogTimestamp(value: string): numb
     : undefined;
 }
 
+export function isOfficialExternalPluginCatalogSequence(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
 export function isOfficialExternalPluginCatalogFeed(
   raw: unknown,
 ): raw is OfficialExternalPluginCatalogFeed {
@@ -318,9 +322,7 @@ export function isOfficialExternalPluginCatalogFeed(
     typeof generatedAt === "string" &&
     generatedAt.trim().length > 0 &&
     generatedAtMs !== undefined &&
-    typeof sequence === "number" &&
-    Number.isInteger(sequence) &&
-    sequence >= 0 &&
+    isOfficialExternalPluginCatalogSequence(sequence) &&
     Array.isArray(entries)
   );
 }

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1456,5 +1456,4 @@ export function getOfficialExternalPluginCatalogEntryForPackage(
     (entry) => normalizeOptionalString(entry.name) === normalized,
   );
 }
-
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -718,7 +718,7 @@ async function loadHostedCatalogSnapshotResult(params: {
   };
 }
 
-function isHostedCatalogSignedFeedRollback(params: {
+export function isHostedCatalogSignedFeedRollback(params: {
   candidate: OfficialExternalPluginCatalogFeed;
   current: OfficialExternalPluginCatalogFeed;
 }): boolean {
@@ -1457,6 +1457,4 @@ export function getOfficialExternalPluginCatalogEntryForPackage(
   );
 }
 
-const testing = { isHostedCatalogSignedFeedRollback };
-export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -272,6 +272,30 @@ const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
+const ISO_CALENDAR_DATE_PREFIX_RE = /^(\d{4})-(\d{2})-(\d{2})/u;
+
+export function parseOfficialExternalPluginCatalogTimestamp(value: string): number | undefined {
+  const timestamp = value.trim();
+  const parsed = Date.parse(timestamp);
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+  const calendarDate = ISO_CALENDAR_DATE_PREFIX_RE.exec(timestamp);
+  if (!calendarDate) {
+    return parsed;
+  }
+  const year = Number(calendarDate[1]);
+  const month = Number(calendarDate[2]);
+  const day = Number(calendarDate[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+  // Shipped releases accepted every Date.parse-compatible serialization. Keep those
+  // formats, but reject ISO-shaped impossible dates that Date.parse normalizes.
+  return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth[month - 1]!
+    ? parsed
+    : undefined;
+}
 
 export function isOfficialExternalPluginCatalogFeed(
   raw: unknown,
@@ -280,14 +304,20 @@ export function isOfficialExternalPluginCatalogFeed(
     return false;
   }
   const sequence = raw.sequence;
+  const generatedAt = raw.generatedAt;
+  const generatedAtMs =
+    typeof generatedAt === "string"
+      ? parseOfficialExternalPluginCatalogTimestamp(generatedAt)
+      : undefined;
   const entries = raw.entries;
   return (
     typeof raw.schemaVersion === "number" &&
     SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS.has(raw.schemaVersion) &&
     typeof raw.id === "string" &&
     raw.id.trim().length > 0 &&
-    typeof raw.generatedAt === "string" &&
-    raw.generatedAt.trim().length > 0 &&
+    typeof generatedAt === "string" &&
+    generatedAt.trim().length > 0 &&
+    generatedAtMs !== undefined &&
     typeof sequence === "number" &&
     Number.isInteger(sequence) &&
     sequence >= 0 &&
@@ -653,6 +683,15 @@ async function parseHostedCatalogFeedBody(params: {
       threshold,
     });
     if (!verification.ok) {
+      const invalidTimestampSequence =
+        verification.error === "invalid-payload" && "authenticatedPayload" in verification
+          ? readOfficialExternalPluginCatalogInvalidTimestampSequence(
+              verification.authenticatedPayload,
+            )
+          : undefined;
+      if (invalidTimestampSequence !== undefined) {
+        throw new HostedCatalogFeedTimestampError(verification.message, invalidTimestampSequence);
+      }
       throw new Error(verification.message);
     }
     return {
@@ -670,6 +709,34 @@ async function parseHostedCatalogFeedBody(params: {
     throw new Error("hosted catalog feed did not match a supported schema version");
   }
   return { feed: raw };
+}
+
+class HostedCatalogFeedTimestampError extends Error {
+  constructor(
+    message: string,
+    readonly sequence: number,
+  ) {
+    super(message);
+  }
+}
+
+function readOfficialExternalPluginCatalogInvalidTimestampSequence(
+  raw: unknown,
+): number | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  if (
+    typeof raw.generatedAt === "string" &&
+    parseOfficialExternalPluginCatalogTimestamp(raw.generatedAt) !== undefined
+  ) {
+    return undefined;
+  }
+  const normalized = {
+    ...raw,
+    generatedAt: "1970-01-01T00:00:00.000Z",
+  };
+  return isOfficialExternalPluginCatalogFeed(normalized) ? normalized.sequence : undefined;
 }
 
 async function loadHostedCatalogSnapshotResult(params: {
@@ -720,7 +787,7 @@ async function loadHostedCatalogSnapshotResult(params: {
 
 function isHostedCatalogSignedFeedRollback(params: {
   candidate: OfficialExternalPluginCatalogFeed;
-  current: OfficialExternalPluginCatalogFeed;
+  current: Pick<OfficialExternalPluginCatalogFeed, "sequence"> & { generatedAt?: string };
 }): boolean {
   if (params.candidate.sequence < params.current.sequence) {
     return true;
@@ -728,16 +795,10 @@ function isHostedCatalogSignedFeedRollback(params: {
   if (params.candidate.sequence > params.current.sequence) {
     return false;
   }
-  const candidateAt = Date.parse(params.candidate.generatedAt);
-  const currentAt = Date.parse(params.current.generatedAt);
-  // If either date is invalid, treat the candidate as older (conservative rollback).
-  if (!Number.isFinite(candidateAt)) {
-    return true;
-  }
-  if (!Number.isFinite(currentAt)) {
+  if (params.current.generatedAt === undefined) {
     return false;
   }
-  return candidateAt < currentAt;
+  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
 }
 
 function assertSnapshotMatchesRequestValidators(params: {
@@ -987,17 +1048,19 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     if (snapshotStore && parsed.trust?.mode === "signed") {
       const currentSnapshot = await snapshotStore.read(url.href);
       if (currentSnapshot?.trust?.mode === "signed") {
+        // Only an authenticated invalid-timestamp payload is repairable. Signature
+        // and trust failures must remain fail-closed so rollback checks cannot be bypassed.
         const current = await parseHostedCatalogFeedBody({
           body: currentSnapshot.body,
           verification: source.verification,
           verifiedAt: currentSnapshot.trust.verifiedAt,
+        }).catch((err: unknown) => {
+          if (err instanceof HostedCatalogFeedTimestampError) {
+            return { feed: { sequence: err.sequence } };
+          }
+          throw err;
         });
-        if (
-          isHostedCatalogSignedFeedRollback({
-            candidate: parsed.feed,
-            current: current.feed,
-          })
-        ) {
+        if (isHostedCatalogSignedFeedRollback({ candidate: parsed.feed, current: current.feed })) {
           throw new Error("hosted catalog signed feed sequence is older than current snapshot");
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Signed plugin catalog rollback checks used `Date.parse()` results without first ensuring `generatedAt` was a real calendar timestamp. Malformed or calendar-invalid values could therefore reach rollback comparison as `NaN`, where ordering comparisons silently return `false`.

Persisted signed snapshots also need a recovery path: a corrupt timestamp must not let lower-sequence feeds overwrite the snapshot, but it must not permanently block a valid same-sequence replacement.

## Why This Change Was Made

- Validate `generatedAt` at the shared catalog-feed boundary, including ISO-shaped dates that `Date.parse()` normalizes despite impossible calendar components.
- Preserve valid timestamp serializations accepted by shipped releases.
- Expose an authenticated decoded payload only after signed-envelope verification succeeds, so timestamp-corrupt snapshots can retain their sequence during repair without weakening signature or trust failures.
- Keep rollback helpers private and prove behavior through the public loader and SQLite snapshot-store paths.

## User Impact

Malformed hosted catalog feeds are rejected before they can replace trusted snapshots. Lower-sequence candidates remain blocked when the stored timestamp is corrupt, while a valid same-sequence feed can repair that stored state. Valid existing timestamp formats continue to work.

## Evidence

- Exact maintainer head: `a632f17bbcf4a0a44a4923974b953b6221c28e2e`
- Focused tests: 53 passed across `official-external-plugin-catalog.test.ts` and `official-external-plugin-catalog-envelope.test.ts`
- Public-path coverage includes malformed candidate rejection, impossible calendar dates, invalid/unsafe sequence rejection, signed snapshot repair, lower-sequence rejection, and trust-failure fail-closed behavior.
- Real SQLite snapshot-store proof: Blacksmith Testbox `tbx_01kxrw9f98hmq0n56ps64mv1xj`, run `29611363957`. The production store rejected sequence 9 against a timestamp-corrupt sequence 10 snapshot, accepted a valid same-sequence replacement, and repaired a stored `1e999` sequence without weakening rollback protection.
- Fresh autoreview: clean, no actionable findings.
- Repo-native review artifacts: validated, `READY FOR /prepare-pr`, findings=0.
- Repo-native `prepare-run`: passed and verified the remote PR tree matches the prepared head.
- Exact-head hosted CI: run `29611308972`.
