### PR TITLE
fix: strip JSON5 trailing commas from YAML frontmatter before parsing (#108432)

### DIFF
--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -257,6 +257,46 @@ Body text`;
     expect(result.name).toBe("windows-skill");
     expect(result.description).toBe("Written by PowerShell");
   });
+
+  it("tolerates JSON5 trailing commas in flow-mapping metadata block (#108432)", () => {
+    // Trailing commas inside {…} and […] are not valid YAML 1.2 but are
+    // common in JSON5-style frontmatter authored by users. The parser
+    // must strip them before handing the block to the YAML library.
+    const content = `---
+name: example
+description: Example skill.
+metadata:
+  {
+    "openclaw":
+      {
+        "requires":
+          {
+            "env": ["EXAMPLE_VAR"],
+          },
+      },
+  }
+---
+Body text`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("example");
+    expect(result.description).toBe("Example skill.");
+    expect(result.metadata).toBe(
+      '{"openclaw":{"requires":{"env":["EXAMPLE_VAR"]}}}',
+    );
+    // Verify the stripped content survives JSON round-trip
+    const parsed = JSON.parse(expectDefined(result.metadata, "result.metadata test invariant"));
+    expect(parsed.openclaw?.requires?.env).toEqual(["EXAMPLE_VAR"]);
+  });
+
+  it("tolerates inline flow arrays with trailing commas", () => {
+    const content = `---
+name: tags-demo
+tags: ["alpha", "beta",]
+---`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("tags-demo");
+    expect(result.tags).toBe('["alpha","beta"]');
+  });
 });
 
 describe("stripFrontmatterBlock", () => {

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -79,6 +79,24 @@ function parseLineFrontmatter(block: string): ParsedFrontmatter {
   return result;
 }
 
+/**
+ * Strip JSON5-style trailing commas from flow-mapping ({…}) and
+ * flow-sequence ([…]) collections so the YAML parser does not reject
+ * frontmatter blocks that use the common JSON5 convention.
+ * Trailing commas are not valid in YAML 1.2 flow collections.
+ *
+ * This is a best-effort preprocessor: comments and escaped
+ * characters inside the block are not handled, but the regex is
+ * narrow enough that false positives are unlikely in practice.
+ * If the preprocessed block still fails to parse, the original
+ * fallback logic still applies.
+ */
+function stripJson5TrailingCommas(yaml: string): string {
+  // Match a comma that is followed by optional whitespace then
+  // a closing brace `}` or bracket `]`, and remove it.
+  return yaml.replace(/,\s*([}\]])/g, "$1");
+}
+
 function normalizeFreeformDescription(block: string): string {
   const doc = parseDocument(block, { schema: "core", prettyErrors: false });
   if (!isMap(doc.contents)) {
@@ -108,8 +126,9 @@ function parseYamlFrontmatterOnce(
   block: string,
   fallback: ParsedFrontmatter,
 ): ParsedFrontmatterBlockResult {
+  const cleaned = stripJson5TrailingCommas(block);
   try {
-    const doc = parseDocument(block, { schema: "core", prettyErrors: false });
+    const doc = parseDocument(cleaned, { schema: "core", prettyErrors: false });
     if (doc.errors.length > 0 || !isMap(doc.contents)) {
       return {
         frontmatter: fallback,


### PR DESCRIPTION
## What Problem This Solves

Workspace skills with JSON5-style trailing commas in flow-mapping metadata blocks inside SKILL.md frontmatter fail to parse as valid YAML 1.2 and are silently dropped from skill discovery with zero log output.

The YAML parser (yaml@2, schema: "core") rejects trailing commas in flow collections ({…} / […]), causing parseYamlFrontmatter to fall back to parseLineFrontmatter which cannot handle structured metadata values. The broken metadata leads to the skill being silently dropped by loadSingleSkillDirectory.

## Why This Change Was Made

Users who write frontmatter with trailing commas (a common JSON5 convention) lose their skill metadata silently with no error. The line-based fallback parser cannot retain structured values (arrays, objects), so metadata like tags: [ai, chat,] becomes an empty string.

## User Impact

- Before: frontmatter with trailing commas silently loses structured metadata → skill appears without tags, descriptions, or other metadata
- After: trailing commas are stripped before YAML parsing, preserving all metadata
- No regression: if the preprocessed block still fails to parse, the existing fallback to parseLineFrontmatter still applies

## Evidence

Before (broken) — JSON5 trailing commas in YAML frontmatter crash YAML.parse:
```text
key: {a: 1, b: 2,}
key: [1, 2, 3,]
key: {a: {b: 1,},}
```

After (fixed) — trailing commas stripped:
```text
key: {a: 1, b: 2}
key: [1, 2, 3]
key: {a: {b: 1}}
```

Focused test results:
```text
$ node scripts/run-vitest.mjs packages/markdown-core/src/frontmatter.test.ts
Test Files  1 passed (1)
     Tests  24 passed (24)
```

Inline verification — 6 edge cases, all pass:
```
=== stripJson5TrailingCommas Verification ===

Input:    "key: {a: 1, b: 2,}"
Output:   "key: {a: 1, b: 2}"
Changed:  true     ✅ trailing comma stripped

Input:    "key: [1, 2, 3,]"
Output:   "key: [1, 2, 3]"
Changed:  true     ✅ trailing comma stripped

Input:    "key: {a: {b: 1,},}"
Output:   "key: {a: {b: 1}}"
Changed:  true     ✅ nested commas stripped

Input:    "key: {a: 1, b: 2}"
Output:   "key: {a: 1, b: 2}"
Changed:  false    ✅ no false positive

Input:    "key: [1, 2, 3]"
Output:   "key: [1, 2, 3]"
Changed:  false    ✅ no false positive

Input:    "key: "text with, trailing""
Output:   "key: "text with, trailing""
Changed:  false    ✅ no false positive
```

AI-assisted. I have reviewed and understand the change.