### PR TITLE
fix: ensure browser.headless config falls through to resolved value (#109673)

### DIFF
--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -720,7 +720,10 @@ export function resolveManagedBrowserHeadlessMode(
 
   const profileHeadlessSource = profile.headlessSource ?? "default";
   if (profileHeadlessSource !== "default") {
-    return { headless: profile.headless, source: profileHeadlessSource };
+    return {
+      headless: profile.headless ?? resolved.headless,
+      source: profileHeadlessSource,
+    };
   }
 
   if (platform === "linux" && !hasLinuxDisplay(env)) {


### PR DESCRIPTION
## What Problem This Solves

When browser.headless: true is set in openclaw.json, the profile-level headlessSource is correctly set to "config", but if profile.headless itself is undefined (not explicitly set at the profile level), resolveManagedBrowserHeadlessMode returns { headless: undefined, source: "config" } at the profile-headless-source check — skipping the fallback to resolved.headless on the last line of the function.

## Why This Change Was Made

The bug causes the configured browser.headless value to be silently ignored when the profile does not carry an explicit headless value of its own. The user set headless: true in their config, but the browser starts in headed mode anyway.

## User Impact

- Before: setting  in openclaw.json has no effect if the active profile doesn't also set headless — browser starts in headed mode
- After: the config value falls through correctly via nullish coalescing ()

## Evidence

Verified with inline test covering 8 scenarios:
| Scenario | Expected | Result |
|---|---|---|
| profile.headless=true, source=config | headless=true | ✅ |
| profile.headless=undefined, source=config (the bug) | headless=true (from resolved) | ✅ |
| profile.headless=false, source=profile | headless=false (profile override) | ✅ |
| profile.headless=true, source=profile | headless=true | ✅ |
| No source, resolved.headless=true | headless=true | ✅ |
| No source, resolved.headless=false | headless=false | ✅ |
| source=env | headless=true | ✅ |
| source=request | headless=true | ✅ |

8/8 passed. The fix is a one-line change:  in extensions/browser/src/browser/config.ts.