### PR TITLE
fix(ai): treat blank env API keys as unconfigured

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -212,7 +212,7 @@ export function findEnvKeys(provider: string): string[] | undefined {
     return undefined;
   }
 
-  const found = envVars.filter((envVar) => Boolean(getEnvValue(envVar)));
+  const found = envVars.filter((envVar) => Boolean(getEnvValue(envVar)?.trim()));
   return found.length > 0 ? found : undefined;
 }
 
@@ -232,9 +232,9 @@ export function getEnvApiKey(provider: string): string | undefined {
   if (provider === "google-vertex") {
     const hasCredentials = hasVertexAdcCredentials();
     const hasProject = Boolean(
-      getEnvValue("GOOGLE_CLOUD_PROJECT") || getEnvValue("GCLOUD_PROJECT"),
+      getEnvValue("GOOGLE_CLOUD_PROJECT")?.trim() || getEnvValue("GCLOUD_PROJECT")?.trim(),
     );
-    const hasLocation = Boolean(getEnvValue("GOOGLE_CLOUD_LOCATION"));
+    const hasLocation = Boolean(getEnvValue("GOOGLE_CLOUD_LOCATION")?.trim());
 
     if (hasCredentials && hasProject && hasLocation) {
       return "<authenticated>";
@@ -250,12 +250,12 @@ export function getEnvApiKey(provider: string): string | undefined {
     // 5. AWS_CONTAINER_CREDENTIALS_FULL_URI - ECS task roles (full URI)
     // 6. AWS_WEB_IDENTITY_TOKEN_FILE - IRSA (IAM Roles for Service Accounts)
     if (
-      getEnvValue("AWS_PROFILE") ||
-      (getEnvValue("AWS_ACCESS_KEY_ID") && getEnvValue("AWS_SECRET_ACCESS_KEY")) ||
-      getEnvValue("AWS_BEARER_TOKEN_BEDROCK") ||
-      getEnvValue("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") ||
-      getEnvValue("AWS_CONTAINER_CREDENTIALS_FULL_URI") ||
-      getEnvValue("AWS_WEB_IDENTITY_TOKEN_FILE")
+      getEnvValue("AWS_PROFILE")?.trim() ||
+      (getEnvValue("AWS_ACCESS_KEY_ID")?.trim() && getEnvValue("AWS_SECRET_ACCESS_KEY")?.trim()) ||
+      getEnvValue("AWS_BEARER_TOKEN_BEDROCK")?.trim() ||
+      getEnvValue("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")?.trim() ||
+      getEnvValue("AWS_CONTAINER_CREDENTIALS_FULL_URI")?.trim() ||
+      getEnvValue("AWS_WEB_IDENTITY_TOKEN_FILE")?.trim()
     ) {
       return "<authenticated>";
     }

--- a/src/llm/env-api-keys.test.ts
+++ b/src/llm/env-api-keys.test.ts
@@ -184,6 +184,45 @@ describe("getEnvApiKey", () => {
     );
   });
 
+  it("treats blank env API keys as unconfigured", async () => {
+    await withEnvAsync({ OPENAI_API_KEY: "  " }, async () => {
+      vi.resetModules();
+      const { findEnvKeys, getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+
+      expect(findEnvKeys("openai")).toBeUndefined();
+      expect(getEnvApiKey("openai")).toBeUndefined();
+    });
+  });
+
+  it("treats blank Google Vertex ADC env vars as unconfigured", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-vertex-adc-"));
+    tempDirs.push(dir);
+    const credentialsPath = join(dir, "application_default_credentials.json");
+    await writeFile(credentialsPath, "{}", "utf-8");
+    await withEnvAsync(
+      {
+        GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+        GOOGLE_CLOUD_LOCATION: "  ",
+        GOOGLE_CLOUD_PROJECT: "  ",
+      },
+      async () => {
+        vi.resetModules();
+        const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+
+        expect(getEnvApiKey("google-vertex")).toBeUndefined();
+      },
+    );
+  });
+
+  it("treats blank Amazon Bedrock env vars as unconfigured", async () => {
+    await withEnvAsync({ AWS_PROFILE: "  " }, async () => {
+      vi.resetModules();
+      const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+
+      expect(getEnvApiKey("amazon-bedrock")).toBeUndefined();
+    });
+  });
+
   it("trims the Google Vertex credentials path before checking it", async () => {
     const dir = await mkdtemp(join(tmpdir(), "openclaw-vertex-adc-"));
     tempDirs.push(dir);


### PR DESCRIPTION
## What Problem This Solves

Provider credential detection treats whitespace-only env vars (e.g., `OPENAI_API_KEY="  "`) as valid credentials, causing downstream API calls to fail with authentication errors instead of falling through to the next configured provider.

## Why This Change Was Made

The fix trims env var values before the "is configured" check in `packages/ai/src/env-api-keys.ts`. Previously only `undefined`/empty-string was treated as unconfigured; now whitespace-only values are treated the same way. This affects OpenAI, Google Vertex, and Amazon Bedrock credential paths.

## Evidence

```
$ npx vitest run src/llm/env-api-keys.test.ts --no-coverage

 RUN  v4.1.9 /home/0668001435/.openclaw/browser/openclaw

 ✓ src/llm/env-api-keys.test.ts (13 tests) 11ms
   ✓ treats blank env API keys as unconfigured
   ✓ treats blank Google Vertex ADC env vars as unconfigured
   ✓ treats blank Amazon Bedrock env vars as unconfigured

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  17:13:50
   Duration  2.64s
```

## Merge Risk

Low — trim is idempotent for already-valid keys. The only behavioral change: whitespace-only values that would previously cause downstream auth failures now correctly fall through to next provider.
