### PR TITLE
perf(test): poll Telegram webhook state faster

### DIFF
--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -61,6 +61,13 @@ const TELEGRAM_WEBHOOK_PATH = "/hook";
 const WEBHOOK_DRAIN_GUARD_MS = 5;
 const TELEGRAM_WEBHOOK_RATE_LIMIT_BURST = WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests + 10;
 
+async function waitForWebhookState<T>(
+  assertion: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+): Promise<T> {
+  return await vi.waitFor(assertion, { interval: 1, ...options });
+}
+
 async function yieldWebhookTask(): Promise<void> {
   await new Promise<void>((resolve) => {
     setImmediate(resolve);
@@ -529,7 +536,7 @@ async function runNearLimitPayloadTestAndExpectUpdate(
       });
 
       expect(response.statusCode).toBe(200);
-      await vi.waitFor(() => expectSingleNearLimitUpdate({ seenUpdates, expected }));
+      await waitForWebhookState(() => expectSingleNearLimitUpdate({ seenUpdates, expected }));
     },
   );
 }
@@ -647,7 +654,7 @@ describe("startTelegramWebhook", () => {
         expect(health.status).toBe(200);
         expect(stopSpy).not.toHaveBeenCalled();
         expectMockMessageContains(runtimeError, "telegram setWebhook failed: fetch failed");
-        await vi.waitFor(() => expect(setWebhookSpy).toHaveBeenCalledTimes(2));
+        await waitForWebhookState(() => expect(setWebhookSpy).toHaveBeenCalledTimes(2));
         expect(runtimeLog).toHaveBeenCalledWith("telegram setWebhook retry 1 scheduled in 0ms");
         expectMockMessageContains(runtimeLog, "webhook advertised to telegram on http://");
         expect(setStatus).toHaveBeenCalledWith({
@@ -705,7 +712,7 @@ describe("startTelegramWebhook", () => {
     });
 
     try {
-      await vi.waitFor(() => {
+      await waitForWebhookState(() => {
         expect(started.server.listening).toBe(false);
         expect(stopSpy).toHaveBeenCalledTimes(1);
         expect(transportCloseSpies[0]).toHaveBeenCalledTimes(1);
@@ -863,11 +870,11 @@ describe("startTelegramWebhook", () => {
         expect(response.status).toBe(200);
         expect(response.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
         expect(await response.text()).toBe("");
-        await vi.waitFor(() => expect(workStarted).toBe(true));
+        await waitForWebhookState(() => expect(workStarted).toBe(true));
         expect(workFinished).toBe(false);
 
         finishWork?.();
-        await vi.waitFor(() => expect(workFinished).toBe(true));
+        await waitForWebhookState(() => expect(workFinished).toBe(true));
       },
     );
   });
@@ -961,8 +968,8 @@ describe("startTelegramWebhook", () => {
 
           expect(response.status).toBe(200);
           expect(await response.text()).toBe("");
-          await vi.waitFor(() => expect(seenUpdates).toEqual([JSON.parse(payload)]));
-          await vi.waitFor(async () =>
+          await waitForWebhookState(() => expect(seenUpdates).toEqual([JSON.parse(payload)]));
+          await waitForWebhookState(async () =>
             expect(
               (await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).length,
             ).toBe(1),
@@ -973,10 +980,10 @@ describe("startTelegramWebhook", () => {
           );
           vi.setSystemTime(Date.now() + 1_100);
           await vi.advanceTimersByTimeAsync(500);
-          await vi.waitFor(() =>
+          await waitForWebhookState(() =>
             expect(seenUpdates).toEqual([JSON.parse(payload), JSON.parse(payload)]),
           );
-          await vi.waitFor(async () =>
+          await waitForWebhookState(async () =>
             expect(
               await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() }),
             ).toEqual([]),
@@ -1022,13 +1029,13 @@ describe("startTelegramWebhook", () => {
         runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       });
       try {
-        await vi.waitFor(() => expect(seenUpdateIds).toEqual([40]));
+        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40]));
         await vi.advanceTimersByTimeAsync(25 * 60_000 + 10_000);
         await yieldWebhookTask();
         expect(seenUpdateIds).toEqual([40]);
 
         finishFirstUpdate?.();
-        await vi.waitFor(() => expect(seenUpdateIds).toEqual([40, 41]));
+        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40, 41]));
       } finally {
         await started.stop();
       }
@@ -1062,7 +1069,7 @@ describe("startTelegramWebhook", () => {
         runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       });
       try {
-        await vi.waitFor(() => expect(participant).toBeDefined());
+        await waitForWebhookState(() => expect(participant).toBeDefined());
         await vi.advanceTimersByTimeAsync(25 * 60_000 + 10_000);
         await yieldWebhookTask();
 
@@ -1075,7 +1082,7 @@ describe("startTelegramWebhook", () => {
 
         settlementHold?.release("discard-pending");
         participant?.settle({ kind: "completed" });
-        await vi.waitFor(async () =>
+        await waitForWebhookState(async () =>
           expect(
             await listTelegramSpooledUpdateClaims({ spoolDir: requireWebhookSpoolDir() }),
           ).toEqual([]),
@@ -1103,8 +1110,8 @@ describe("startTelegramWebhook", () => {
         path: TELEGRAM_WEBHOOK_PATH,
       },
       async () => {
-        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledWith(update));
-        await vi.waitFor(async () =>
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalledWith(update));
+        await waitForWebhookState(async () =>
           expect(await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).toEqual(
             [],
           ),
@@ -1178,7 +1185,7 @@ describe("startTelegramWebhook", () => {
     try {
       await completionRetryStarted;
       const claimNextCallsBeforeLaterDrain = claimNextCalls;
-      await vi.waitFor(
+      await waitForWebhookState(
         () => {
           expect(claimNextCalls).toBeGreaterThan(claimNextCallsBeforeLaterDrain);
         },
@@ -1197,8 +1204,8 @@ describe("startTelegramWebhook", () => {
       ).toEqual([51]);
 
       releaseCompletion?.();
-      await vi.waitFor(() => expect(seenUpdateIds).toEqual([50, 51]));
-      await vi.waitFor(async () =>
+      await waitForWebhookState(() => expect(seenUpdateIds).toEqual([50, 51]));
+      await waitForWebhookState(async () =>
         expect(
           await listTelegramSpooledUpdateClaims({ spoolDir: requireWebhookSpoolDir() }),
         ).toEqual([]),
@@ -1250,7 +1257,7 @@ describe("startTelegramWebhook", () => {
       runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
     });
 
-    await vi.waitFor(() =>
+    await waitForWebhookState(() =>
       expect(mockMessages(runtimeLog).join("\n")).toMatch(
         /completion retry 1 scheduled|tombstone retry 1\//,
       ),
@@ -1285,9 +1292,9 @@ describe("startTelegramWebhook", () => {
         runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
       });
       try {
-        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalled());
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalled());
         await vi.advanceTimersByTimeAsync(130_000);
-        await vi.waitFor(async () =>
+        await waitForWebhookState(async () =>
           expect(
             (await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).map(
               (spooled) => spooled.updateId,
@@ -1325,9 +1332,9 @@ describe("startTelegramWebhook", () => {
         runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
       });
       try {
-        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalled());
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalled());
         await vi.advanceTimersByTimeAsync(130_000);
-        await vi.waitFor(async () =>
+        await waitForWebhookState(async () =>
           expect(await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).toEqual(
             [],
           ),
@@ -1426,7 +1433,7 @@ describe("startTelegramWebhook", () => {
         expect(validResponse.status).toBe(200);
         expect(validResponse.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
         expect(await validResponse.text()).toBe("");
-        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
       },
     );
   });
@@ -1447,7 +1454,7 @@ describe("startTelegramWebhook", () => {
           });
           expect(response.status).toBe(200);
         }
-        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalled());
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalled());
       },
     );
   });
@@ -1500,7 +1507,7 @@ describe("startTelegramWebhook", () => {
         );
 
         expect(isolatedClient.status).toBe(200);
-        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
+        await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
       },
     );
   });
@@ -1548,7 +1555,7 @@ describe("startTelegramWebhook", () => {
       });
 
       expect(secondResponse.status).toBe(200);
-      await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
+      await waitForWebhookState(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
     } finally {
       await first.stop();
       await second.stop();
@@ -1610,7 +1617,7 @@ describe("startTelegramWebhook", () => {
         });
         expect(res.status).toBe(200);
         expect(await res.text()).toBe("");
-        await vi.waitFor(() => expect(seenUpdate).toEqual(JSON.parse(payload)));
+        await waitForWebhookState(() => expect(seenUpdate).toEqual(JSON.parse(payload)));
       },
     );
   });
@@ -1643,7 +1650,7 @@ describe("startTelegramWebhook", () => {
           expect(res.status).toBe(200);
         }
 
-        await vi.waitFor(() =>
+        await waitForWebhookState(() =>
           expect(seenPayloads.map((x) => JSON.parse(x))).toEqual(
             payloads.map((x) => JSON.parse(x)),
           ),
@@ -1686,7 +1693,7 @@ describe("startTelegramWebhook", () => {
 
         expect(firstResponse.statusCode).toBe(200);
         expect(secondResponse.statusCode).toBe(200);
-        await vi.waitFor(() =>
+        await waitForWebhookState(() =>
           expect(seenUpdates).toEqual([JSON.parse(firstPayload), JSON.parse(secondPayload)]),
         );
       },


### PR DESCRIPTION
## What Problem This Solves

The Telegram webhook suite used Vitest's 50 ms default polling interval in 29 asynchronous state assertions. The repeated latency accumulated across the 35-test file.

## Why This Change Was Made

Route those assertions through a test-local helper with a 1 ms default interval. Preserve every assertion, Vitest's default timeout, and explicit caller timeout or interval options.

## User Impact

No user-visible or production behavior changes. Controlled same-Testbox median test-body time drops from 5.46 seconds to 4.51 seconds.

## Evidence

- Before: 5.51/5.46/5.09 seconds; median 5.46 seconds.
- After: 4.65/3.89/4.51 seconds; median 4.51 seconds (about 17% faster). Final exact-patch run: 4.35 seconds.
- Testbox `tbx_01kxqdrs6gn00njjzqtycey2cv`: 35/35 tests passed across all comparison runs and the final exact-patch run.
- Same Testbox: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed.
- Autoreview: clean, 0.98 confidence.
