### PR TITLE
fix(line): prevent profile cache growth across users

### DIFF
--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -515,6 +515,19 @@ describe("LINE send helpers", () => {
     expect(getProfileMock).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds profile cache entries across distinct users", async () => {
+    getProfileMock.mockImplementation(async (userId: string) => ({
+      displayName: userId,
+    }));
+
+    for (let index = 0; index <= 1000; index += 1) {
+      await sendModule.getUserProfile(`U-profile-${index}`, { cfg: LINE_TEST_CFG });
+    }
+    await sendModule.getUserProfile("U-profile-0", { cfg: LINE_TEST_CFG });
+
+    expect(getProfileMock).toHaveBeenCalledTimes(1002);
+  });
+
   it("continues when loading animation is unsupported", async () => {
     showLoadingAnimationMock.mockRejectedValueOnce(new Error("unsupported"));
 

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -1,6 +1,7 @@
 // Line plugin module implements send behavior.
 import { messagingApi } from "@line/bot-sdk";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -29,6 +30,24 @@ const userProfileCache = new Map<
   { displayName: string; pictureUrl?: string; fetchedAt: number }
 >();
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
+const PROFILE_CACHE_MAX_ENTRIES = 1000;
+
+function cacheUserProfile(
+  userId: string,
+  profile: { displayName: string; pictureUrl?: string; fetchedAt: number },
+): void {
+  userProfileCache.delete(userId);
+  userProfileCache.set(userId, profile);
+  if (userProfileCache.size <= PROFILE_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  for (const [key, cached] of userProfileCache) {
+    if (profile.fetchedAt - cached.fetchedAt >= PROFILE_CACHE_TTL_MS) {
+      userProfileCache.delete(key);
+    }
+  }
+  pruneMapToMaxSize(userProfileCache, PROFILE_CACHE_MAX_ENTRIES);
+}
 
 interface LineSendOpts {
   cfg: OpenClawConfig;
@@ -511,7 +530,7 @@ export async function getUserProfile(
       pictureUrl: profile.pictureUrl,
     };
 
-    userProfileCache.set(userId, {
+    cacheUserProfile(userId, {
       ...result,
       fetchedAt: Date.now(),
     });

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -36,6 +36,7 @@ function cacheUserProfile(
   userId: string,
   profile: { displayName: string; pictureUrl?: string; fetchedAt: number },
 ): void {
+  // Refresh insertion order so overflow evicts expired entries first, then the oldest live fetch.
   userProfileCache.delete(userId);
   userProfileCache.set(userId, profile);
   if (userProfileCache.size <= PROFILE_CACHE_MAX_ENTRIES) {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where long-running LINE accounts that receive messages from many distinct users would retain every successful sender profile in memory, even after entries aged beyond the existing five-minute reuse window.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The LINE profile-cache owner now keeps at most 1,000 entries. When the cache crosses that boundary it removes expired profiles first, then evicts the oldest remaining entries; the existing five-minute cache hits, provider request behavior, and failure fallback remain unchanged. This is an internal retention change with no config, schema, or public API changes.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

LINE gateways serving high-cardinality accounts no longer retain an ever-growing set of old sender profiles. Recently resolved users keep the same fast cache path, while an evicted user is fetched again if they return later.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- On latest main `d8dd59bf8f60`, the production-function regression resolved 1,001 distinct users and then repeated the oldest user. The provider client was called only 1,001 times, proving the oldest profile was still retained.
- After this change, a standalone Node process imported the production `getUserProfile` owner and ran the same sequence. It observed 1,002 provider calls, proving the oldest profile was evicted and fetched again. The external LINE SDK client was replaced with an in-process deterministic client; no live LINE account was used.
- `node scripts/run-vitest.mjs extensions/line/src/send.test.ts` — 22 tests passed.
- Local `check:changed` child mode passed extension production/test typechecks, targeted lint, formatting, plugin boundaries, dependency guards, and runtime import-cycle checks.
