### PR TITLE
perf(ci): keep prompt snapshot generation off the jiti loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2113,8 +2113,9 @@ jobs:
             group: boundaries
             boundary_shard: 2/4,3/4,4/4
             runner: blacksmith-8vcpu-ubuntu-2404
-          # Prompt snapshot regeneration runs real embedded-agent turns (~2min)
-          # and used to own the boundaries-a wall clock; keep it in its own lane.
+          # Prompt snapshot regeneration evaluates the full agent tool/prompt
+          # import graph and used to own the boundaries-a wall clock; keep it
+          # in its own lane.
           - check_name: check-prompt-snapshots
             group: prompt-snapshots
             runner: blacksmith-8vcpu-ubuntu-2404

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -23,7 +23,14 @@ import type {
 } from "../../../src/plugin-sdk/agent-harness-runtime.js";
 import { normalizeAgentRuntimeTools } from "../../../src/plugin-sdk/agent-harness-runtime.js";
 import { createOpenClawCodingTools } from "../../../src/plugin-sdk/agent-harness.js";
+import type { PluginRegistry } from "../../../src/plugins/registry.js";
+import {
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../../src/plugins/runtime.js";
 import { resolveRelativeBundledPluginPublicModuleId } from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import { createTestRegistry } from "../../../src/test-utils/channel-plugins.js";
 import {
   CODEX_MODEL_PROMPT_FIXTURE_DIR,
   CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR,
@@ -149,6 +156,81 @@ const CODEX_TEST_API_MODULE_ID = resolveRelativeBundledPluginPublicModuleId({
 /** Load the Codex public test API without hardcoding plugin-private paths. */
 async function loadCodexPromptSnapshotApi(): Promise<CodexPromptSnapshotApi> {
   return (await import(CODEX_TEST_API_MODULE_ID)) as CodexPromptSnapshotApi;
+}
+
+type ScenarioChannelPluginFixture = {
+  pluginId: string;
+  plugin: unknown;
+};
+
+const scenarioChannelPluginFixtures = new Map<string, Promise<ScenarioChannelPluginFixture>>();
+
+/**
+ * Tool construction resolves the scenario's channel plugin for message-tool
+ * schema data. Without a loaded channel registry that lookup falls back to the
+ * bundled-channel jiti loader, which re-transpiles the core source graph and
+ * stalls snapshot generation by minutes. Import the entry-declared channel
+ * plugin surface through the ambient (tsx/vitest) module graph instead so the
+ * already-evaluated core modules are reused.
+ */
+function scenarioChannelPluginFixture(pluginId: string): Promise<ScenarioChannelPluginFixture> {
+  const cached = scenarioChannelPluginFixtures.get(pluginId);
+  if (cached) {
+    return cached;
+  }
+  const loading = loadScenarioChannelPluginFixture(pluginId);
+  scenarioChannelPluginFixtures.set(pluginId, loading);
+  return loading;
+}
+
+async function loadScenarioChannelPluginFixture(
+  pluginId: string,
+): Promise<ScenarioChannelPluginFixture> {
+  const moduleId = resolveRelativeBundledPluginPublicModuleId({
+    fromModuleUrl: import.meta.url,
+    pluginId,
+    artifactBasename: "channel-plugin-api.js",
+  });
+  const moduleNamespace = (await import(moduleId)) as Record<string, unknown>;
+  // Bundled channel entries (extensions/<id>/index.ts) declare their channel
+  // plugin export from channel-plugin-api.js as `<id>Plugin`; the setup-only
+  // sibling export shares the channel id, so name selection stays exact.
+  const exportName = `${pluginId}Plugin`;
+  const plugin = moduleNamespace[exportName];
+  if (!plugin || typeof plugin !== "object") {
+    throw new Error(
+      `missing channel plugin export "${exportName}" in ${moduleId}; align the snapshot helper with the ${pluginId} plugin entry`,
+    );
+  }
+  return { pluginId, plugin };
+}
+
+/**
+ * Pins exactly the scenario channel while its tools are built. Cross-channel
+ * action discovery walks every loaded channel plugin, so registering more than
+ * the scenario channel would change the generated message-tool schema bytes.
+ */
+function withScenarioChannelRegistry<T>(fixture: ScenarioChannelPluginFixture, build: () => T): T {
+  const previousRegistry: PluginRegistry | null = getActivePluginRegistry();
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: fixture.pluginId,
+        plugin: fixture.plugin,
+        source: "prompt-snapshot-fixture",
+        origin: "bundled",
+      },
+    ]),
+  );
+  try {
+    return build();
+  } finally {
+    if (previousRegistry) {
+      setActivePluginRegistry(previousRegistry);
+    } else {
+      resetPluginRuntimeStateForTest();
+    }
+  }
 }
 
 const CODEX_WORKSPACE_BOOTSTRAP_CONTEXT_FILES = [
@@ -446,6 +528,11 @@ function createDynamicTools(params: {
     modelId: MODEL_ID,
     modelApi: "responses",
     model: happyPathModel,
+    // No provider runtime plugin owns tool-schema hooks for the `codex`
+    // harness provider, so a runtime plugin load can only rediscover that
+    // through the jiti source loader (minutes of core re-transpilation).
+    // Registry-only resolution keeps the same no-op outcome instantly.
+    allowProviderRuntimePluginLoad: false,
   });
   return params.codexApi.createCodexDynamicToolSpecsForPromptSnapshot({
     tools: normalized.filter((tool) => HAPPY_PATH_TOOL_NAMES.has(tool.name)),
@@ -453,7 +540,20 @@ function createDynamicTools(params: {
   });
 }
 
-function createScenarios(codexApi: CodexPromptSnapshotApi): PromptScenario[] {
+async function createScenarioDynamicTools(params: {
+  codexApi: CodexPromptSnapshotApi;
+  ctx: TemplateContext;
+  trigger: "user" | "heartbeat";
+}): Promise<CodexDynamicToolSpec[]> {
+  const provider = params.ctx.Provider;
+  if (!provider) {
+    throw new Error("prompt snapshot scenarios must set ctx.Provider for channel tool fixtures");
+  }
+  const fixture = await scenarioChannelPluginFixture(provider);
+  return withScenarioChannelRegistry(fixture, () => createDynamicTools(params));
+}
+
+async function createScenarios(codexApi: CodexPromptSnapshotApi): Promise<PromptScenario[]> {
   const telegramDirectCtx: TemplateContext = {
     Provider: "telegram",
     Surface: "telegram",
@@ -506,17 +606,21 @@ function createScenarios(codexApi: CodexPromptSnapshotApi): PromptScenario[] {
     Body: resolveHeartbeatPromptForResponseTool(),
     BodyStripped: resolveHeartbeatPromptForResponseTool(),
   };
-  const telegramDirectTools = createDynamicTools({
+  const telegramDirectTools = await createScenarioDynamicTools({
     codexApi,
     ctx: telegramDirectCtx,
     trigger: "user",
   });
-  const discordGroupTools = createDynamicTools({
+  const discordGroupTools = await createScenarioDynamicTools({
     codexApi,
     ctx: discordGroupCtx,
     trigger: "user",
   });
-  const heartbeatTools = createDynamicTools({ codexApi, ctx: heartbeatCtx, trigger: "heartbeat" });
+  const heartbeatTools = await createScenarioDynamicTools({
+    codexApi,
+    ctx: heartbeatCtx,
+    trigger: "heartbeat",
+  });
 
   return [
     {
@@ -927,7 +1031,7 @@ function renderReadme(scenarios: PromptScenario[]): string {
 /** Build all Codex happy-path prompt snapshot files without writing them. */
 export async function createHappyPathPromptSnapshotFiles(): Promise<PromptSnapshotFile[]> {
   const codexApi = await loadCodexPromptSnapshotApi();
-  const scenarios = createScenarios(codexApi);
+  const scenarios = await createScenarios(codexApi);
   const files = [
     {
       path: path.join(CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR, "README.md"),

--- a/test/scripts/prompt-snapshots.test.ts
+++ b/test/scripts/prompt-snapshots.test.ts
@@ -13,8 +13,10 @@ import {
   renderCodexModelInstructions,
   runCodexModelPromptFixtureSync,
 } from "../../scripts/sync-codex-model-prompt-fixture.js";
+import { getPluginModuleLoaderStats } from "../../src/plugins/plugin-module-loader-cache.js";
 import { expectNoReaddirSyncDuring } from "../../src/test-utils/fs-scan-assertions.js";
 import { toRepoRelativePath } from "../../src/test-utils/repo-files.js";
+import { createHappyPathPromptSnapshotFiles } from "../helpers/agents/happy-path-prompt-snapshots.js";
 import {
   CODEX_MODEL_PROMPT_FIXTURE_DIR,
   CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR,
@@ -129,6 +131,24 @@ describe("happy path prompt snapshots", () => {
       "telegram-direct-codex-message-tool.md",
       "telegram-heartbeat-codex-tool.md",
     ]);
+  });
+
+  it("generates snapshots without jiti plugin-loader fallbacks", async () => {
+    // Perf contract for the check-prompt-snapshots CI lane: scenario channel
+    // plugins are preloaded through the ambient module graph. A jiti
+    // plugin-loader call here means a scenario channel (or another plugin
+    // surface) fell back to source re-transpilation, which re-evaluates the
+    // core graph and stalls the lane by minutes.
+    const callsBefore = getPluginModuleLoaderStats().calls;
+    const files = await createHappyPathPromptSnapshotFiles();
+    expect(files.length).toBeGreaterThan(0);
+    const stats = getPluginModuleLoaderStats();
+    expect(
+      stats.calls - callsBefore,
+      `prompt snapshot generation hit the jiti plugin loader; targets: ${stats.topSourceTransformTargets
+        .map((entry) => entry.target)
+        .join(", ")}`,
+    ).toBe(0);
   });
 
   it("deletes stale generated snapshot artifacts", async () => {

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -110,9 +110,9 @@ async function waitForChildClose(
 
 describe("run-additional-boundary-checks", () => {
   it("keeps prompt snapshot drift checks in their dedicated CI lane", () => {
-    // The snapshot check regenerates prompts with real embedded-agent turns
-    // (~2min); packing it into a boundary shard makes that shard the PR wall
-    // clock, so it owns the check-prompt-snapshots lane instead.
+    // The snapshot check regenerates prompt fixtures over the full agent
+    // tool/prompt import graph; packing it into a boundary shard makes that
+    // shard the PR wall clock, so it owns the check-prompt-snapshots lane.
     expect(BOUNDARY_CHECKS.some((check) => check.label === "prompt:snapshots:check")).toBe(false);
     const workflow = fs.readFileSync(".github/workflows/ci.yml", "utf8");
     expect(workflow).toContain("check_name: check-prompt-snapshots");


### PR DESCRIPTION
## What Problem This Solves

check-prompt-snapshots is a 5.1min job when it fires (~40-60% of PR runs) — the longest pole of those runs. Measured breakdown (run 29557851276): <2s of actual rendering/compare; ~4min is one-time jiti re-transpilation of the core source graph, triggered because tool construction resolves the scenario channel plugin against an empty loaded registry and falls back to the bundled-channel jiti loader (136.6s jiti self time in --cpu-prof), plus a cold provider-plugin lookup that only rediscovers a no-op.

## Why This Change Was Made

The planned shard split cannot help — the cost is per-process transpile, so every shard repays the full ~4min (warm jiti fsCache rerun still took 200s). Fix the generator instead:

- Preload each scenario's channel plugin surface (channel-plugin-api.js via the bundled-plugin public-surface resolver) through the ambient tsx/vitest ESM graph, and pin exactly that channel in a scoped loaded registry while the scenario's tools build. Snapshot bytes are unchanged: the loaded plugin object is the same export the jiti fallback materializes, and cross-channel action discovery still sees no other loaded channels.
- Pass `allowProviderRuntimePluginLoad=false` to normalizeAgentRuntimeTools — no provider plugin owns tool-schema hooks for the `codex` harness provider, so registry-only resolution returns the same undefined instantly.
- Perf-contract guard: test/scripts/prompt-snapshots.test.ts generates the snapshots and asserts zero jiti plugin-loader calls, naming the offending transform targets on failure — a future scenario/channel that misses the preload fails the suite instead of silently restoring the 4-minute lane.

## User Impact

None at runtime — test-helper and CI-comment changes only. The lane drops ~5.1min → ~1.5-2min when it fires.

## Evidence

- `pnpm prompt:snapshots:check` byte-identical against committed fixtures: 54s wall / 35s CPU (was 354s/306s); independently re-verified on a second machine after cherry-pick onto current main ("Prompt snapshots are current (7 files)").
- `node scripts/run-vitest.mjs test/scripts/prompt-snapshots.test.ts` — 13 passed incl. the new zero-jiti guard.
- tsgo core-test + extensions-test lanes, scoped oxlint/oxfmt, `git diff --check` — green (worker run).
- Live pole timing lands with this PR's own CI (this PR touches snapshot-affecting paths, so the lane fires here).
