### PR TITLE
fix(ai): make normalizeOpenAIReasoningEffort case-insensitive

### DIFF
--- a/src/agents/openai-reasoning-effort.test.ts
+++ b/src/agents/openai-reasoning-effort.test.ts
@@ -1,6 +1,7 @@
 // Verifies model-specific OpenAI reasoning-effort normalization and disablement.
 import { describe, expect, it } from "vitest";
 import {
+  normalizeOpenAIReasoningEffort,
   resolveOpenAIReasoningEffortForModel,
   resolveOpenAISupportedReasoningEfforts,
 } from "./openai-reasoning-effort.js";
@@ -100,5 +101,41 @@ describe("OpenAI reasoning effort support", () => {
 
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBeUndefined();
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBe("high");
+  });
+
+  describe("normalizeOpenAIReasoningEffort", () => {
+    it("preserves lowercase effort values", () => {
+      expect(normalizeOpenAIReasoningEffort("low")).toBe("low");
+      expect(normalizeOpenAIReasoningEffort("medium")).toBe("medium");
+      expect(normalizeOpenAIReasoningEffort("high")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("xhigh")).toBe("xhigh");
+      expect(normalizeOpenAIReasoningEffort("none")).toBe("none");
+      expect(normalizeOpenAIReasoningEffort("minimal")).toBe("minimal");
+    });
+
+    it("lowercases mixed-case effort values", () => {
+      expect(normalizeOpenAIReasoningEffort("HIGH")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("High")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("Medium")).toBe("medium");
+      expect(normalizeOpenAIReasoningEffort("XHigh")).toBe("xhigh");
+      expect(normalizeOpenAIReasoningEffort("Minimal")).toBe("minimal");
+    });
+
+    it("trims whitespace from effort values", () => {
+      expect(normalizeOpenAIReasoningEffort("  high  ")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("\tmedium\n")).toBe("medium");
+    });
+
+    it("resolves mixed-case efforts through the model pipeline", () => {
+      const model = { provider: "openai", id: "gpt-5.1" };
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "HIGH" })).toBe("high");
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "LOW" })).toBe("low");
+    });
+
+    it("resolves uppercase none/off as disabled", () => {
+      const model = { provider: "openai", id: "gpt-5.1" };
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "NONE" })).toBe("none");
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "OFF" })).toBeUndefined();
+    });
   });
 });

--- a/src/agents/openai-reasoning-effort.ts
+++ b/src/agents/openai-reasoning-effort.ts
@@ -51,7 +51,7 @@ export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
 
 /** Normalize user-facing reasoning effort names to API effort names. */
 export function normalizeOpenAIReasoningEffort(effort: string): string {
-  return effort === "minimal" ? "minimal" : effort;
+  return normalizeLowercaseStringOrEmpty(effort);
 }
 
 function readCompatReasoningEfforts(compat: unknown): OpenAIApiReasoningEffort[] | undefined {


### PR DESCRIPTION
## Summary
- `normalizeOpenAIReasoningEffort` now uses `normalizeLowercaseStringOrEmpty` to handle mixed-case and whitespace-trimmed reasoning effort values
- Previously only the literal lowercase `minimal` string was handled; all other values passed through raw
- Adds test coverage for lowercase preservation, mixed-case normalization, whitespace trimming, and end-to-end pipeline with case-insensitive values

## Verification
- Local tests pass: `pnpm test src/agents/openai-reasoning-effort.test.ts`
