### PR TITLE
fix(matrix): guard transport new URL() against malformed input

### DIFF
--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -465,6 +465,68 @@ describe("performMatrixRequest", () => {
     expect(result.text).toBe(payload);
     expect(result.buffer.toString("utf8")).toBe(payload);
   });
+
+  it("rejects malformed homeserver URLs with a stable error", async () => {
+    await expect(
+      performMatrixRequest({
+        homeserver: "http://matrix-user:matrix-fixture@invalid host",
+        accessToken: "token",
+        method: "GET",
+        endpoint: "/_matrix/client/v3/account/whoami",
+        timeoutMs: 5000,
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    ).rejects.toThrow(new Error("Invalid URL"));
+  });
+
+  it("rejects malformed redirect Location headers with a stable error", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(302, { location: "http://invalid host/path" });
+      res.end();
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as { port: number };
+
+    try {
+      await expect(
+        performMatrixRequest({
+          homeserver: `http://127.0.0.1:${port}`,
+          accessToken: "token",
+          method: "GET",
+          endpoint: "/_matrix/client/v3/account/whoami",
+          timeoutMs: 5000,
+          ssrfPolicy: { allowPrivateNetwork: true },
+        }),
+      ).rejects.toThrow(new Error("Invalid URL"));
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("does not reflect credential-bearing malformed homeserver URLs in errors", async () => {
+    const secretPass = "matrix-fixture";
+    const malformed = `http://matrix-user:${secretPass}@${["invalid", "host"].join(" ")}`;
+
+    try {
+      await performMatrixRequest({
+        homeserver: malformed,
+        accessToken: "token",
+        method: "GET",
+        endpoint: "/_matrix/client/v3/account/whoami",
+        timeoutMs: 5000,
+        ssrfPolicy: { allowPrivateNetwork: true },
+      });
+      throw new Error("expected performMatrixRequest to reject malformed homeserver URL");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toBe("Invalid URL");
+      expect(message).not.toContain(secretPass);
+    }
+  });
 });
 
 describe("createMatrixGuardedFetch", () => {
@@ -549,6 +611,14 @@ describe("createMatrixGuardedFetch", () => {
 
     expect(runtimeFetch).toHaveBeenCalledTimes(1);
     expect(runtimeFetch.mock.calls.at(0)?.[0]).toBe(url);
+  });
+
+  it("rejects malformed request URLs with a stable error", async () => {
+    const guardedFetch = createMatrixGuardedFetch({
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    await expect(guardedFetch("not-a-url")).rejects.toThrow(new Error("Invalid URL"));
   });
 });
 

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -45,6 +45,14 @@ function normalizeEndpoint(endpoint: string): string {
   return endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
 }
 
+function parseMatrixUrl(input: string, base?: string | URL): URL {
+  try {
+    return base !== undefined ? new URL(input, base) : new URL(input);
+  } catch (cause) {
+    throw new Error("Invalid URL", { cause });
+  }
+}
+
 function applyQuery(url: URL, qs: QueryParams): void {
   if (!qs) {
     return;
@@ -164,7 +172,7 @@ async function fetchWithMatrixGuardedRedirects(params: {
   ssrfPolicy?: SsrFPolicy;
   dispatcherPolicy?: PinnedDispatcherPolicy;
 }): Promise<{ response: Response; release: () => Promise<void>; finalUrl: string }> {
-  let currentUrl = new URL(params.url);
+  let currentUrl = parseMatrixUrl(params.url);
   let method = (params.init?.method ?? "GET").toUpperCase();
   let body = params.init?.body;
   let headers = new Headers(params.init?.headers ?? {});
@@ -215,7 +223,7 @@ async function fetchWithMatrixGuardedRedirects(params: {
         throw new Error(`Matrix redirect missing location header (${currentUrl.toString()})`);
       }
 
-      const nextUrl = new URL(location, currentUrl);
+      const nextUrl = parseMatrixUrl(location, currentUrl);
       if (nextUrl.protocol !== currentUrl.protocol) {
         cleanup();
         await closeDispatcher(dispatcher);
@@ -327,8 +335,8 @@ export async function performMatrixRequest(params: {
   }
 
   const baseUrl = isAbsoluteEndpoint
-    ? new URL(params.endpoint)
-    : new URL(normalizeEndpoint(params.endpoint), params.homeserver);
+    ? parseMatrixUrl(params.endpoint)
+    : parseMatrixUrl(normalizeEndpoint(params.endpoint), params.homeserver);
   applyQuery(baseUrl, params.qs);
 
   const headers = new Headers();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix transport callers would receive an uncaught `TypeError: Invalid URL` when given malformed homeserver URLs, redirect `Location` headers, or absolute API endpoints, instead of a controlled application error.

## Why This Change Was Made

Matrix transport now parses user-controlled URLs through a shared `parseMatrixUrl` helper that wraps `new URL()` in try/catch and throws a stable `Error("Invalid URL")` with the native parse failure retained as `cause`, matching the defensive pattern already used in the same file by `withoutMatrixStateAfterSyncParam`. Valid homeserver, redirect, and endpoint handling is unchanged. Risk note: this only hardens URL parsing at transport entry points; it does not change SSRF policy decisions once a URL parses successfully.

## User Impact

Matrix channel setup and API calls now fail with a predictable typed error for malformed URLs, without echoing credential-bearing homeserver strings into diagnostics or logs.

## Evidence

**Before (upstream/main):**
```
malformed homeserver error name: TypeError
malformed homeserver error message: Invalid URL
malformed guarded fetch URL error name: TypeError
malformed guarded fetch URL error message: Invalid URL
```

**Premise (sibling pattern in the same file):**
`withoutMatrixStateAfterSyncParam` already wraps `new URL(rawUrl)` in try/catch without reflecting the supplied URL.

**After (this branch):**
```
malformed homeserver error name: Error
malformed homeserver error message: Invalid URL
malformed homeserver message includes secret: false
malformed guarded fetch URL error name: Error
malformed guarded fetch URL error message: Invalid URL
malformed redirect location error name: Error
malformed redirect location error message: Invalid URL
malformed redirect location message includes secret: false
```

Harness (real exported functions, no mocks; redirect case uses a real loopback HTTP server):
```bash
node --import tsx -e "
import http from 'node:http';
import { performMatrixRequest, createMatrixGuardedFetch } from './extensions/matrix/src/matrix/sdk/transport.ts';
# ... homeserver, guarded fetch, and redirect probes as run locally
"
```

Focused tests:
```bash
node scripts/run-vitest.mjs run extensions/matrix/src/matrix/sdk/transport.test.ts -t "malformed"
# 5 passed
```

What was not tested: live Matrix homeserver setup with a real Synapse/Dendrite instance; the local harness proves transport entry points now fail closed with a stable non-disclosing error instead of a URL constructor `TypeError`, including on redirect `Location` headers from a real HTTP server.

AI-assisted: Cursor Composer; proof run manually on this machine.
