### PR TITLE
fix(coding-agent): prevent workers from invalidating OpenClaw OAuth

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -47,6 +47,7 @@ Use for background feature builds, PR reviews, large refactors, and issue-to-PR 
 - Monitor with `process`; do not kill slow workers without cause.
 - If user asked for a specific agent, use that agent.
 - If worker fails/hangs, respawn or ask; do not silently hand-code instead.
+- Codex: use the worker-only `$HOME/.codex-coding-agent` home. Authorize it separately, scope `CODEX_HOME` to each `codex` command, and never export it into the OpenClaw Gateway environment.
 - Never checkout branches or run background coding agents in `~/Projects/openclaw`; use an isolated checkout.
 - Classify the source ref as trusted or untrusted before any checkout or worktree creation. Never materialize a contributor-controlled ref outside the repository's approved untrusted-PR sandbox/review workflow, and never launch a permission-bypassed worker in it.
 - For tasks that modify a Git-backed project, prepare and verify the Git worktree before launch, then include the exact Git preparation block below in the worker prompt.
@@ -120,10 +121,18 @@ printf 'prompt file: %s\n' "$PROMPT"
 
 Use `$PROMPT` when launching from the same shell/session. If using a separate tool call, substitute the printed path. The launch forms below are for trusted checkouts only; untrusted contributor refs require the repository's approved sandbox/review workflow.
 
+Before the first Codex launch on a host, create and authorize its worker-only home. Re-run the status check before later launches; only start login when it is not already authorized:
+
+```bash
+mkdir -p "$HOME/.codex-coding-agent"
+CODEX_HOME="$HOME/.codex-coding-agent" codex login status || \
+  CODEX_HOME="$HOME/.codex-coding-agent" codex login
+```
+
 Codex:
 
 ```bash
-bash pty:true background:true workdir:/path/isolated-worktree command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:/path/isolated-worktree command:"CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
 ```
 
 Claude Code:
@@ -159,7 +168,7 @@ Build X.
 <notification block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
-bash pty:true background:true workdir:$SCRATCH command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:$SCRATCH command:"CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
 ```
 
 ## Process actions


### PR DESCRIPTION
Closes #109704

## What Problem This Solves

Fixes an issue where users who authorize both OpenClaw and the bundled coding-agent through ChatGPT OAuth can lose OpenClaw model access after a Codex worker uses the ambient Codex credential home.

## Why This Change Was Made

The coding-agent now uses a stable worker-only Codex home, authorizes that home separately, checks its login before launch, and scopes `CODEX_HOME` to each Codex command. This covers both isolated-worktree and scratch launches without changing OpenClaw provider authentication or exporting worker credentials into the Gateway environment.

Upstream Codex resolves config and credentials from `CODEX_HOME`, requires an explicit home to exist, stores file credentials beneath that home, and derives keyring entries from the canonical home path. This makes a dedicated home the native isolation boundary rather than an OpenClaw-specific credential workaround.

## User Impact

Codex workers launched through the bundled coding-agent no longer reuse the operator's ambient Codex credential home. Users authorize the worker home once, while OpenClaw keeps ownership of its own OAuth profile.

## Evidence

- `git diff --check upstream/main...HEAD`
- Static launch audit: 2 Codex worker commands scoped with `CODEX_HOME`; 2 total Codex worker commands
- Fresh structured autoreview after rebasing onto `main@5c86a224c0af9f299c3f5a25ac5056d677688575`: clean, no actionable findings
- Upstream Codex contract checked at `315195492c80fdade38e917c18f9584efd599304`: `codex-rs/utils/home-dir/src/lib.rs`, `codex-rs/login/src/auth/storage.rs`, `codex-rs/cli/src/login.rs`, and `codex-rs/exec/src/lib.rs`
- The issue includes redacted live evidence that both an isolated Codex worker and OpenClaw OAuth remained usable after real requests
- `pnpm docs:list` could not run locally because the available Node 22.22.0 is below the repository minimum 22.22.3; `node scripts/docs-list.js` completed and identified the relevant OAuth/OpenAI/skills docs for source review
