### PR TITLE
fix: isolate coding-agent Codex CLI with dedicated CODEX_HOME

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -44,6 +44,10 @@ OAuth providers commonly mint a new refresh token on every login/refresh.
 Some providers invalidate the previous refresh token when a new one is
 issued for the same user/app. Practical symptom: log in via OpenClaw _and_
 via Claude Code / Codex CLI, and one of them randomly gets logged out later.
+The bundled `coding-agent` skill can trigger the same class of failure when it
+launches external `codex exec` against the ambient Codex home (`$CODEX_HOME` or
+`~/.codex`) while OpenClaw holds ChatGPT OAuth for the same account — use a
+command-scoped worker `CODEX_HOME` as documented in the skill.
 
 To reduce that, OpenClaw treats the auth profile store as a **token sink**:
 

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -41,6 +41,7 @@ Use for background feature builds, PR reviews, large refactors, and issue-to-PR 
 - Always launch with `background:true`.
 - Codex and OpenCode: use `pty:true`.
 - Claude Code: no PTY; use `claude --permission-mode bypassPermissions --print`.
+- **Codex credential home:** never launch ambient `codex exec` against the default `~/.codex` (or an ambient process `$CODEX_HOME`) when OpenClaw also uses ChatGPT OAuth. Use a **dedicated worker `CODEX_HOME`**, authorize it once with `codex login`, preflight with `codex login status`, and scope `CODEX_HOME` only on the Codex worker command so OpenClaw keeps owning its OAuth profile. See [Codex credential isolation](#codex-credential-isolation).
 - Capture a real notification route before spawning.
 - Worker must send completion/failure via `openclaw message send`.
 - Do not rely on heartbeat, system events, or notify-on-exit.
@@ -104,6 +105,26 @@ Do not use openclaw system event or heartbeat.
 
 If no trustworthy route exists, say completion auto-notify is unavailable.
 
+## Codex credential isolation
+
+OpenClaw ChatGPT OAuth and the external Codex CLI both mint refresh tokens for the same provider app. Launching a coding-agent Codex worker against the ambient Codex home (`$CODEX_HOME` if already set in the process environment, otherwise `~/.codex`) can invalidate OpenClaw's stored refresh token (`refresh_token_reused` / login-expired guidance). OpenClaw remains the canonical owner of its own OAuth profile; the worker must use a **separate** Codex home. See also [OAuth](/concepts/oauth).
+
+One-time setup (worker home only; do **not** export this into the OpenClaw gateway process):
+
+```bash
+CODEX_HOME="${CODEX_HOME_CODING_AGENT:-$HOME/.codex-coding-agent}"
+mkdir -p "$CODEX_HOME"
+CODEX_HOME="$CODEX_HOME" codex login
+CODEX_HOME="$CODEX_HOME" codex login status   # preflight: must report logged in under this home
+```
+
+Rules:
+
+- Prefer a stable path such as `~/.codex-coding-agent` (or another dedicated directory you control).
+- Scope `CODEX_HOME` **only** on Codex worker commands (`codex login`, `codex login status`, `codex exec`). Do not set it on the OpenClaw gateway, agent runtime, or unrelated shells that should keep using OpenClaw's auth store.
+- If `codex login status` fails for the worker home, re-run `CODEX_HOME=… codex login` before spawning work. Do not fall back to ambient `~/.codex` to "just make it work."
+- Claude Code and OpenCode launches are unchanged by this section; apply the isolation only to Codex CLI workers.
+
 ## Launch forms
 
 Write the worker prompt to a temp file first. This avoids shell quoting bugs when the required notification block contains quotes or newlines.
@@ -120,10 +141,11 @@ printf 'prompt file: %s\n' "$PROMPT"
 
 Use `$PROMPT` when launching from the same shell/session. If using a separate tool call, substitute the printed path. The launch forms below are for trusted checkouts only; untrusted contributor refs require the repository's approved sandbox/review workflow.
 
-Codex:
+Codex (dedicated worker home — required):
 
 ```bash
-bash pty:true background:true workdir:/path/isolated-worktree command:"codex exec - < \"$PROMPT\""
+# Scope CODEX_HOME only on this command (default worker home shown).
+bash pty:true background:true workdir:/path/isolated-worktree command:"CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
 ```
 
 Claude Code:
@@ -148,7 +170,7 @@ bash pty:true background:true workdir:/path/isolated-worktree command:"opencode 
 
 ## Scratch Codex
 
-Codex needs a trusted git repo. This throwaway scaffold is not project work and has no canonical remote, so the Git preparation block does not apply:
+Codex needs a trusted git repo. This throwaway scaffold is not project work and has no canonical remote, so the Git preparation block does not apply. Still use a **dedicated worker `CODEX_HOME`** (never ambient `~/.codex`) when OpenClaw ChatGPT OAuth is also in use:
 
 ```bash
 SCRATCH=$(mktemp -d)
@@ -159,7 +181,7 @@ Build X.
 <notification block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
-bash pty:true background:true workdir:$SCRATCH command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:$SCRATCH command:"CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
 ```
 
 ## Process actions

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -118,6 +118,14 @@ CODEX_HOME="$CODEX_HOME" codex login
 CODEX_HOME="$CODEX_HOME" codex login status   # preflight: must report logged in under this home
 ```
 
+The dedicated home is a fully independent Codex profile, not only an authentication directory. It does not inherit the ambient profile's `config.toml`, profile overrides, MCP/plugin setup, skills or instructions, hooks, memories, logs, history, or sessions.
+
+When moving an existing worker off the ambient profile:
+
+1. Start with an empty dedicated home and run `codex login` there. Do not copy or symlink the ambient home, `auth.json`, `.credentials.json`, or platform-keyring credentials.
+2. Recreate only the settings the worker needs. Review and copy known non-secret configuration, instruction, or skill files individually; configure MCP servers under the dedicated home and authorize any credential-bearing integration separately.
+3. Leave logs, history, memories, and sessions behind. They are not required for the worker profile and may contain sensitive context.
+
 Rules:
 
 - Prefer a stable path such as `~/.codex-coding-agent` (or another dedicated directory you control).

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -121,6 +121,7 @@ CODEX_HOME="$CODEX_HOME" codex login status   # preflight: must report logged in
 Rules:
 
 - Prefer a stable path such as `~/.codex-coding-agent` (or another dedicated directory you control).
+- Set `CODEX_HOME_CODING_AGENT` when using a non-default worker home; the Codex launch forms below honor it.
 - Scope `CODEX_HOME` **only** on Codex worker commands (`codex login`, `codex login status`, `codex exec`). Do not set it on the OpenClaw gateway, agent runtime, or unrelated shells that should keep using OpenClaw's auth store.
 - If `codex login status` fails for the worker home, re-run `CODEX_HOME=… codex login` before spawning work. Do not fall back to ambient `~/.codex` to "just make it work."
 - Claude Code and OpenCode launches are unchanged by this section; apply the isolation only to Codex CLI workers.
@@ -144,8 +145,8 @@ Use `$PROMPT` when launching from the same shell/session. If using a separate to
 Codex (dedicated worker home — required):
 
 ```bash
-# Scope CODEX_HOME only on this command (default worker home shown).
-bash pty:true background:true workdir:/path/isolated-worktree command:"CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
+# Scope CODEX_HOME only on this command (override or default worker home).
+bash pty:true background:true workdir:/path/isolated-worktree command:"CODEX_HOME=\"${CODEX_HOME_CODING_AGENT:-$HOME/.codex-coding-agent}\" codex exec - < \"$PROMPT\""
 ```
 
 Claude Code:
@@ -181,7 +182,7 @@ Build X.
 <notification block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
-bash pty:true background:true workdir:$SCRATCH command:"CODEX_HOME=\"$HOME/.codex-coding-agent\" codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:$SCRATCH command:"CODEX_HOME=\"${CODEX_HOME_CODING_AGENT:-$HOME/.codex-coding-agent}\" codex exec - < \"$PROMPT\""
 ```
 
 ## Process actions


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who run the bundled `coding-agent` skill with Codex CLI against the ambient Codex home (`$CODEX_HOME` / `~/.codex`) while OpenClaw holds ChatGPT OAuth for the same account would hit persistent OpenClaw OAuth refresh failures (`refresh_token_reused` / login-expired guidance).

## Why This Change Was Made

The skill’s documented Codex launch form previously ran ambient `codex exec`, which can share and rotate ChatGPT refresh tokens with OpenClaw’s OAuth profile. This change makes a dedicated worker `CODEX_HOME` mandatory for Codex workers: one-time `codex login` into that home, `codex login status` preflight, and command-scoped `CODEX_HOME` only on Codex worker commands so OpenClaw remains the canonical OAuth owner. `CODEX_HOME_CODING_AGENT` selects a custom worker home consistently across setup, normal launches, and scratch launches; otherwise all three use `~/.codex-coding-agent`. No OpenClaw runtime auth APIs, provider plugins, or config knobs change.

The worker home is documented as a complete independent Codex profile, not only an auth directory. The upgrade guidance names the configuration/state that is not inherited and gives a safe migration path that never copies or links OAuth credentials.

Fix quality: compatibility — OpenClaw config/API remains unchanged, while the intentional Codex worker-profile reset and one-time setup are explicit; performance — none (static docs); usability — explicit setup + preflight instead of silent collision; security — keeps OpenClaw OAuth ownership separate from external worker credentials.

## User Impact

Operators who enable `coding-agent` and use Codex CLI get clear isolation instructions. Codex workers use `~/.codex-coding-agent` (or a dedicated path selected with `CODEX_HOME_CODING_AGENT`) so OpenClaw ChatGPT OAuth stays usable after worker launches. Existing users must complete one separate worker login once and selectively recreate any required non-secret Codex customization. Claude Code and OpenCode launch forms are unchanged.

## Compatibility and upgrade

A dedicated `CODEX_HOME` does not inherit the ambient Codex profile’s `config.toml`, profile overrides, MCP/plugin setup, skills or instructions, hooks, memories, logs, history, or sessions. The skill now tells users to:

1. start with an empty worker home and authenticate it separately;
2. never copy or symlink the ambient home, `auth.json`, `.credentials.json`, or keyring credentials;
3. recreate only required settings by reviewing and copying known non-secret files individually, configuring MCP servers under the worker home, and separately authorizing credential-bearing integrations;
4. leave logs, history, memories, and sessions behind because they are unnecessary and may contain sensitive context.

## Evidence

Verification host: local macOS. Docs/skill-only change.

```text
$ git diff --check
# clean

$ ./node_modules/.bin/oxfmt --check skills/coding-agent/SKILL.md docs/concepts/oauth.md
All matched files use the correct format.

$ pnpm docs:list
# completed successfully

$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.94)
```

Source inspection confirmed:

- both documented Codex launch forms scope `CODEX_HOME` to `${CODEX_HOME_CODING_AGENT:-$HOME/.codex-coding-agent}`;
- setup, login preflight, normal launches, and scratch launches resolve the same override/default;
- ambient `command:"codex exec ..."` guidance is gone;
- Claude Code and OpenCode forms remain unchanged;
- upstream Codex 0.144.4 resolves configuration and state from `CODEX_HOME`, stores file credentials at `$CODEX_HOME/auth.json`, and keys platform credential storage by the selected home ([Codex config contract](https://github.com/openai/codex/blob/rust-v0.144.4/codex-rs/core/src/config/mod.rs#L4339-L4348), [credential storage contract](https://github.com/openai/codex/blob/rust-v0.144.4/codex-rs/login/src/auth/storage.rs#L231-L244)).

## Real behavior proof

The linked issue contains a redacted live recovery run on macOS 15.7.7 with OpenClaw 2026.7.1 and Codex CLI 0.144.4. After removing the ambient Codex credential from discovery, re-authenticating OpenClaw, and authorizing a separate worker-only `CODEX_HOME`:

```text
OpenClaw real openai/gpt-5.6-sol request: AUTH_OK
Codex worker real gpt-5.6-sol request: CODING_AGENT_AUTH_OK
openclaw models status: OAuth profile usable
CODEX_HOME=~/.codex-coding-agent codex login status: Logged in using ChatGPT
isolated auth.json: absent (credential stored in macOS Keychain)
```

That run used the same command-scoped dedicated-home behavior now documented by this patch. Account identifiers, tokens, absolute local paths, and device codes were omitted. Full reproduction, failure logs, environment, and recovery sequence are in #109704.

Current-main control: both coding-agent Codex launch forms used ambient `codex exec`, with no worker login, dedicated home, or preflight. This patch changes both launch forms and adds the required setup and migration contract.

The live recovery was captured for the issue before this documentation commit rather than repeated after the text-only patch. ClawSweeper’s review of `0ed6b9f6b` marked this evidence `proof: sufficient` for the documentation-only workflow change.

Fixes #109704

## AI disclosure

This PR was authored with AI assistance (Grok and Codex).
