### PR TITLE
fix: keep healthy channel accounts running when one credential fails

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-7e2ff4dedb7b220a133cb419ee91e67585b9b9f2799706f336cdea973be80bfb  plugin-sdk-api-baseline.json
-0a85effc98fb17a65d463956704bcb2dab31076cf0fa0d85b463a765ec9dc439  plugin-sdk-api-baseline.jsonl
+e06731c08fa6ad7c00fdd59807d0b99045de886afe65c482f8d46bd46e4b271d  plugin-sdk-api-baseline.json
+0ab4e245ac7d4cc68f0c888e58ebb6c4b404a620ce4d0087cdf3cfd9c31b1e62  plugin-sdk-api-baseline.jsonl

--- a/extensions/discord/src/secret-config-contract.ts
+++ b/extensions/discord/src/secret-config-contract.ts
@@ -131,6 +131,8 @@ export function collectRuntimeConfigAssignments(params: {
       isBaseFieldActiveForChannelSurface(surface, "pluralkit") &&
       isRecord(discord.pluralkit) &&
       isEnabledFlag(discord.pluralkit),
+    topLevelInheritedAccountActive: ({ account, enabled }) =>
+      enabled && !Object.hasOwn(account, "pluralkit") && isEnabledFlag(discord.pluralkit),
     topInactiveReason:
       "no enabled Discord surface inherits this top-level PluralKit config or PluralKit is disabled.",
     accountActive: ({ account, enabled }) =>

--- a/extensions/feishu/src/secret-contract.test.ts
+++ b/extensions/feishu/src/secret-contract.test.ts
@@ -1,0 +1,40 @@
+// Feishu tests cover secret contract plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createResolverContext } from "openclaw/plugin-sdk/secret-ref-runtime";
+import { describe, expect, it } from "vitest";
+import { collectRuntimeConfigAssignments } from "./secret-contract.js";
+
+describe("feishu secret contract", () => {
+  it("does not synthesize a second default owner for normalized account aliases", () => {
+    const sourceConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "top-app-id",
+          appSecret: {
+            source: "env",
+            provider: "default",
+            id: "FEISHU_UNUSED_VALUE",
+          },
+          accounts: {
+            " default ": {
+              enabled: true,
+              appId: "account-app-id",
+              appSecret: "fixture",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const context = createResolverContext({ sourceConfig, env: {} });
+
+    collectRuntimeConfigAssignments({
+      config: structuredClone(sourceConfig),
+      defaults: undefined,
+      context,
+    });
+
+    expect(context.assignments).toStrictEqual([]);
+    expect(context.warnings).toMatchObject([{ path: "channels.feishu.appSecret" }]);
+  });
+});

--- a/extensions/feishu/src/secret-contract.test.ts
+++ b/extensions/feishu/src/secret-contract.test.ts
@@ -5,6 +5,37 @@ import { describe, expect, it } from "vitest";
 import { collectRuntimeConfigAssignments } from "./secret-contract.js";
 
 describe("feishu secret contract", () => {
+  it("assigns an enabled accountless appSecret to the default owner without a configured appId", () => {
+    const sourceConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          appSecret: {
+            source: "env",
+            provider: "default",
+            id: "FEISHU_APP_SECRET",
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const context = createResolverContext({ sourceConfig, env: {} });
+
+    collectRuntimeConfigAssignments({
+      config: structuredClone(sourceConfig),
+      defaults: undefined,
+      context,
+    });
+
+    expect(context.assignments).toMatchObject([
+      {
+        path: "channels.feishu.appSecret",
+        ownerKind: "account",
+        ownerId: "feishu:default",
+      },
+    ]);
+    expect(context.warnings).toStrictEqual([]);
+  });
+
   it("does not synthesize a second default owner for normalized account aliases", () => {
     const sourceConfig = {
       channels: {

--- a/extensions/feishu/src/secret-contract.ts
+++ b/extensions/feishu/src/secret-contract.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements secret contract behavior.
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   collectConditionalChannelFieldAssignments,
   createChannelSecretTargetRegistryEntries,
@@ -38,7 +39,7 @@ export function collectRuntimeConfigAssignments(params: {
   if (
     hasImplicitDefaultAccount &&
     surface.hasExplicitAccounts &&
-    !surface.accounts.some(({ accountId }) => accountId === "default")
+    !surface.accounts.some(({ accountId }) => normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID)
   ) {
     surface.accounts.push({ accountId: "default", account: {}, enabled: true });
   }

--- a/extensions/feishu/src/secret-contract.ts
+++ b/extensions/feishu/src/secret-contract.ts
@@ -50,7 +50,7 @@ export function collectRuntimeConfigAssignments(params: {
     surface,
     defaults: params.defaults,
     context: params.context,
-    topLevelActiveWithoutAccounts: hasImplicitDefaultAccount,
+    topLevelActiveWithoutAccounts: surface.channelEnabled,
     topLevelInheritedAccountActive: ({ account, enabled }) =>
       enabled && !hasOwnProperty(account, "appSecret"),
     accountActive: ({ enabled }) => enabled,

--- a/extensions/feishu/src/secret-contract.ts
+++ b/extensions/feishu/src/secret-contract.ts
@@ -1,12 +1,10 @@
 // Feishu plugin module implements secret contract behavior.
 import {
   collectConditionalChannelFieldAssignments,
-  collectSecretInputAssignment,
   createChannelSecretTargetRegistryEntries,
   getChannelSurface,
   hasConfiguredSecretInputValue,
   hasOwnProperty,
-  isBaseFieldActiveForChannelSurface,
   normalizeSecretStringValue,
   type ResolverContext,
   type SecretDefaults,
@@ -37,39 +35,27 @@ export function collectRuntimeConfigAssignments(params: {
     surface.channelEnabled &&
     hasConfiguredSecretInputValue(feishu.appId, params.defaults) &&
     hasConfiguredSecretInputValue(feishu.appSecret, params.defaults);
-  const topLevelAppSecretActive =
-    hasImplicitDefaultAccount || isBaseFieldActiveForChannelSurface(surface, "appSecret");
-  collectSecretInputAssignment({
-    value: feishu.appSecret,
-    path: "channels.feishu.appSecret",
-    expected: "string",
+  if (
+    hasImplicitDefaultAccount &&
+    surface.hasExplicitAccounts &&
+    !surface.accounts.some(({ accountId }) => accountId === "default")
+  ) {
+    surface.accounts.push({ accountId: "default", account: {}, enabled: true });
+  }
+  collectConditionalChannelFieldAssignments({
+    channelKey: "feishu",
+    field: "appSecret",
+    channel: feishu,
+    surface,
     defaults: params.defaults,
     context: params.context,
-    active: topLevelAppSecretActive,
-    inactiveReason: "no enabled account inherits this top-level Feishu appSecret.",
-    apply: (value) => {
-      feishu.appSecret = value;
-    },
+    topLevelActiveWithoutAccounts: hasImplicitDefaultAccount,
+    topLevelInheritedAccountActive: ({ account, enabled }) =>
+      enabled && !hasOwnProperty(account, "appSecret"),
+    accountActive: ({ enabled }) => enabled,
+    topInactiveReason: "no enabled account inherits this top-level Feishu appSecret.",
+    accountInactiveReason: "Feishu account is disabled.",
   });
-  if (surface.hasExplicitAccounts) {
-    for (const { accountId, account, enabled } of surface.accounts) {
-      if (!hasOwnProperty(account, "appSecret")) {
-        continue;
-      }
-      collectSecretInputAssignment({
-        value: account.appSecret,
-        path: `channels.feishu.accounts.${accountId}.appSecret`,
-        expected: "string",
-        defaults: params.defaults,
-        context: params.context,
-        active: enabled,
-        inactiveReason: "Feishu account is disabled.",
-        apply: (value) => {
-          account.appSecret = value;
-        },
-      });
-    }
-  }
   const baseConnectionMode =
     normalizeSecretStringValue(feishu.connectionMode) === "webhook" ? "webhook" : "websocket";
   const resolveAccountMode = (account: Record<string, unknown>) =>

--- a/extensions/googlechat/src/secret-contract.test.ts
+++ b/extensions/googlechat/src/secret-contract.test.ts
@@ -43,10 +43,10 @@ describe("googlechat secret contract", () => {
 
     expect(context.assignments).toMatchObject([
       {
-        ownerKind: "unknown",
-        ownerId: "channels.googlechat.accounts.work.serviceAccount",
+        ownerKind: "account",
+        ownerId: "googlechat:work",
         requiredForGateway: false,
-        disposition: "fail-closed",
+        disposition: "isolate",
       },
     ]);
 

--- a/extensions/googlechat/src/secret-contract.ts
+++ b/extensions/googlechat/src/secret-contract.ts
@@ -1,4 +1,5 @@
 // Googlechat plugin module implements secret contract behavior.
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   createChannelSecretTargetRegistryEntries,
   getChannelSurface,
@@ -17,6 +18,15 @@ type GoogleChatAccountLike = {
   serviceAccountRef?: unknown;
   accounts?: Record<string, unknown>;
 };
+
+function accountSecretOwner(accountId: string) {
+  return {
+    ownerKind: "account" as const,
+    ownerId: `googlechat:${normalizeAccountId(accountId)}`,
+    requiredForGateway: false,
+    disposition: "isolate" as const,
+  };
+}
 
 export const secretTargetRegistryEntries = createChannelSecretTargetRegistryEntries({
   channelKey: "googlechat",
@@ -60,7 +70,7 @@ function collectGoogleChatAccountAssignment(params: {
   path: string;
   defaults?: SecretDefaults;
   context: ResolverContext;
-  active?: boolean;
+  ownerAccountIds: string[];
   inactiveReason?: string;
 }): void {
   const { explicitRef, ref } = resolveSecretInputRef({
@@ -71,7 +81,7 @@ function collectGoogleChatAccountAssignment(params: {
   if (!ref) {
     return;
   }
-  if (params.active === false) {
+  if (params.ownerAccountIds.length === 0) {
     pushInactiveSurfaceWarning({
       context: params.context,
       path: `${params.path}.serviceAccount`,
@@ -90,18 +100,17 @@ function collectGoogleChatAccountAssignment(params: {
       message: `${params.path}: serviceAccountRef is set; runtime will ignore plaintext serviceAccount.`,
     });
   }
-  pushAssignment(params.context, {
-    ref,
-    path: `${params.path}.serviceAccount`,
-    expected: "string-or-object",
-    ownerKind: "unknown",
-    ownerId: `${params.path}.serviceAccount`,
-    requiredForGateway: false,
-    disposition: "fail-closed",
-    apply: (value) => {
-      params.target.serviceAccount = value;
-    },
-  });
+  for (const accountId of params.ownerAccountIds) {
+    pushAssignment(params.context, {
+      ref,
+      path: `${params.path}.serviceAccount`,
+      expected: "string-or-object",
+      ...accountSecretOwner(accountId),
+      apply: (value) => {
+        params.target.serviceAccount = value;
+      },
+    });
+  }
 }
 
 export function collectRuntimeConfigAssignments(params: {
@@ -115,22 +124,24 @@ export function collectRuntimeConfigAssignments(params: {
   }
   const googleChat = resolved.channel as GoogleChatAccountLike;
   const surface = resolveChannelAccountSurface(googleChat as Record<string, unknown>);
-  const topLevelServiceAccountActive = !surface.channelEnabled
-    ? false
+  const topLevelServiceAccountOwners = !surface.channelEnabled
+    ? []
     : !surface.hasExplicitAccounts
-      ? true
-      : surface.accounts.some(
-          ({ account, enabled }) =>
-            enabled &&
-            !hasOwnProperty(account, "serviceAccount") &&
-            !hasOwnProperty(account, "serviceAccountRef"),
-        );
+      ? ["default"]
+      : surface.accounts
+          .filter(
+            ({ account, enabled }) =>
+              enabled &&
+              !hasOwnProperty(account, "serviceAccount") &&
+              !hasOwnProperty(account, "serviceAccountRef"),
+          )
+          .map(({ accountId }) => accountId);
   collectGoogleChatAccountAssignment({
     target: googleChat,
     path: "channels.googlechat",
     defaults: params.defaults,
     context: params.context,
-    active: topLevelServiceAccountActive,
+    ownerAccountIds: topLevelServiceAccountOwners,
     inactiveReason: "no enabled account inherits this top-level Google Chat serviceAccount.",
   });
   if (!surface.hasExplicitAccounts) {
@@ -148,7 +159,7 @@ export function collectRuntimeConfigAssignments(params: {
       path: `channels.googlechat.accounts.${accountId}`,
       defaults: params.defaults,
       context: params.context,
-      active: enabled,
+      ownerAccountIds: enabled ? [accountId] : [],
       inactiveReason: "Google Chat account is disabled.",
     });
   }

--- a/extensions/irc/src/secret-contract.ts
+++ b/extensions/irc/src/secret-contract.ts
@@ -49,6 +49,8 @@ export function collectRuntimeConfigAssignments(params: {
       isBaseFieldActiveForChannelSurface(surface, "nickserv") &&
       isRecord(irc.nickserv) &&
       isEnabledFlag(irc.nickserv),
+    topLevelInheritedAccountActive: ({ account, enabled }) =>
+      enabled && !Object.hasOwn(account, "nickserv") && isEnabledFlag(irc.nickserv),
     topInactiveReason:
       "no enabled account inherits this top-level IRC nickserv config or NickServ is disabled.",
     accountActive: ({ account, enabled }) =>

--- a/extensions/matrix/src/secret-contract.ts
+++ b/extensions/matrix/src/secret-contract.ts
@@ -12,6 +12,15 @@ import {
 } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { getMatrixScopedEnvVarNames } from "./env-vars.js";
 
+function accountSecretOwner(accountId: string) {
+  return {
+    ownerKind: "account" as const,
+    ownerId: `matrix:${normalizeAccountId(accountId)}`,
+    requiredForGateway: false,
+    disposition: "isolate" as const,
+  };
+}
+
 export const secretTargetRegistryEntries = createChannelSecretTargetRegistryEntries({
   channelKey: "matrix",
   account: ["accessToken", "password"],
@@ -34,10 +43,20 @@ export function collectRuntimeConfigAssignments(params: {
     normalizeSecretStringValue(
       params.context.env[getMatrixScopedEnvVarNames("default").accessToken],
     ).length > 0;
-  const defaultAccountAccessTokenConfigured = surface.accounts.some(
-    ({ accountId, account }) =>
-      normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID &&
-      hasConfiguredSecretInputValue(account.accessToken, params.defaults),
+  const defaultScopedPasswordConfigured =
+    normalizeSecretStringValue(params.context.env[getMatrixScopedEnvVarNames("default").password])
+      .length > 0;
+  const defaultAccount = surface.accounts.find(
+    ({ accountId }) => normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID,
+  );
+  const defaultAccountEnabled = surface.channelEnabled && (defaultAccount?.enabled ?? true);
+  const defaultAccountAccessTokenConfigured = hasConfiguredSecretInputValue(
+    defaultAccount?.account.accessToken,
+    params.defaults,
+  );
+  const defaultAccountPasswordConfigured = hasConfiguredSecretInputValue(
+    defaultAccount?.account.password,
+    params.defaults,
   );
   const baseAccessTokenConfigured = hasConfiguredSecretInputValue(
     matrix.accessToken,
@@ -49,8 +68,13 @@ export function collectRuntimeConfigAssignments(params: {
     expected: "string",
     defaults: params.defaults,
     context: params.context,
-    active: surface.channelEnabled,
-    inactiveReason: "Matrix channel is disabled.",
+    active:
+      defaultAccountEnabled &&
+      !defaultAccountAccessTokenConfigured &&
+      !defaultScopedAccessTokenConfigured,
+    inactiveReason:
+      "Matrix channel or default account is disabled, or default-account access-token auth overrides the top-level accessToken.",
+    owner: accountSecretOwner(DEFAULT_ACCOUNT_ID),
     apply: (value) => {
       matrix.accessToken = value;
     },
@@ -62,15 +86,18 @@ export function collectRuntimeConfigAssignments(params: {
     defaults: params.defaults,
     context: params.context,
     active:
-      surface.channelEnabled &&
+      defaultAccountEnabled &&
       !(
         baseAccessTokenConfigured ||
         envAccessTokenConfigured ||
         defaultScopedAccessTokenConfigured ||
-        defaultAccountAccessTokenConfigured
+        defaultAccountAccessTokenConfigured ||
+        defaultAccountPasswordConfigured ||
+        defaultScopedPasswordConfigured
       ),
     inactiveReason:
-      "Matrix channel is disabled or access-token auth is configured for the default Matrix account.",
+      "Matrix channel or default account is disabled, or higher-precedence default-account auth is configured.",
+    owner: accountSecretOwner(DEFAULT_ACCOUNT_ID),
     apply: (value) => {
       matrix.password = value;
     },
@@ -88,6 +115,7 @@ export function collectRuntimeConfigAssignments(params: {
         context: params.context,
         active: enabled,
         inactiveReason: "Matrix account is disabled.",
+        owner: accountSecretOwner(accountId),
         apply: (value) => {
           account.accessToken = value;
         },
@@ -121,6 +149,7 @@ export function collectRuntimeConfigAssignments(params: {
           inheritedDefaultAccountAccessTokenConfigured
         ),
       inactiveReason: "Matrix account is disabled or this account has an accessToken configured.",
+      owner: accountSecretOwner(accountId),
       apply: (value) => {
         account.password = value;
       },

--- a/extensions/matrix/src/secret-contract.ts
+++ b/extensions/matrix/src/secret-contract.ts
@@ -46,9 +46,9 @@ export function collectRuntimeConfigAssignments(params: {
   const defaultScopedPasswordConfigured =
     normalizeSecretStringValue(params.context.env[getMatrixScopedEnvVarNames("default").password])
       .length > 0;
-  const defaultAccount = surface.accounts.find(
-    ({ accountId }) => normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID,
-  );
+  const defaultAccount = surface.hasExplicitAccounts
+    ? surface.accounts.find(({ accountId }) => normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID)
+    : undefined;
   const defaultAccountEnabled = surface.channelEnabled && (defaultAccount?.enabled ?? true);
   const defaultAccountAccessTokenConfigured = hasConfiguredSecretInputValue(
     defaultAccount?.account.accessToken,

--- a/extensions/msteams/src/secret-contract.ts
+++ b/extensions/msteams/src/secret-contract.ts
@@ -29,6 +29,12 @@ export function collectRuntimeConfigAssignments(params: {
     context: params.context,
     active: msteams.enabled !== false,
     inactiveReason: "Microsoft Teams channel is disabled.",
+    owner: {
+      ownerKind: "account",
+      ownerId: "msteams:default",
+      requiredForGateway: false,
+      disposition: "isolate",
+    },
     apply: (value) => {
       msteams.appPassword = value;
     },

--- a/extensions/slack/src/secret-contract.ts
+++ b/extensions/slack/src/secret-contract.ts
@@ -100,6 +100,8 @@ export function collectRuntimeConfigAssignments(params: {
             resolveAccountMode(account) === "relay" &&
             !hasNestedAuthTokenOverride(account),
         )),
+    topLevelInheritedAccountActive: ({ account, enabled }) =>
+      enabled && resolveAccountMode(account) === "relay" && !hasNestedAuthTokenOverride(account),
     topInactiveReason:
       "no enabled Slack relay-mode surface inherits this top-level relay authToken.",
     accountActive: ({ account, enabled }) => enabled && resolveAccountMode(account) === "relay",

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -116,10 +116,10 @@ describe("checkGatewayHealth", () => {
       .mockResolvedValueOnce({
         degradedSecretOwners: [
           {
-            ownerKind: "provider",
-            ownerId: "openai",
+            ownerKind: "account",
+            ownerId: "discord:ops",
             state: "unavailable",
-            paths: ["models.providers.openai.apiKey"],
+            paths: ["channels.discord.accounts.ops.token"],
             reason: "secret reference was not found",
           },
           {
@@ -138,7 +138,7 @@ describe("checkGatewayHealth", () => {
 
     expect(note).toHaveBeenCalledWith(
       [
-        "- provider:openai (models.providers.openai.apiKey): secret reference was not found",
+        "- account:discord:ops (channels.discord.accounts.ops.token): secret reference was not found",
         "- capability:tts (messages.tts.providers.elevenlabs.apiKey): secret provider failed",
       ].join("\n"),
       "Secret owners unavailable",

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -279,10 +279,10 @@ describe("getStatusSummary", () => {
   it("reports degraded SecretRef owners without exposing ref identifiers", async () => {
     setActiveDegradedSecretOwners([
       {
-        ownerKind: "provider",
-        ownerId: "openai",
+        ownerKind: "account",
+        ownerId: "discord:ops",
         state: "unavailable",
-        paths: ["models.providers.openai.apiKey"],
+        paths: ["channels.discord.accounts.ops.token"],
         refKeys: ["env:default:PRIVATE_REF_ID"],
         reason: "secret reference was not found",
       },
@@ -292,10 +292,10 @@ describe("getStatusSummary", () => {
 
     expect(summary.degradedSecretOwners).toEqual([
       {
-        ownerKind: "provider",
-        ownerId: "openai",
+        ownerKind: "account",
+        ownerId: "discord:ops",
         state: "unavailable",
-        paths: ["models.providers.openai.apiKey"],
+        paths: ["channels.discord.accounts.ops.token"],
         reason: "secret reference was not found",
       },
     ]);

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -18,6 +18,7 @@ import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => {
@@ -255,6 +256,7 @@ describe("server-channels auto restart", () => {
     hoisted.sleepWithAbort.mockClear();
     hoisted.startChannelApprovalHandlerBootstrap.mockReset();
     hoisted.startChannelApprovalHandlerBootstrap.mockResolvedValue(async () => {});
+    setActiveDegradedSecretOwners([]);
   });
 
   afterEach(async () => {
@@ -268,6 +270,7 @@ describe("server-channels auto restart", () => {
     await flushMicrotasks();
     vi.clearAllTimers();
     vi.useRealTimers();
+    setActiveDegradedSecretOwners([]);
     setActivePluginRegistry(previousRegistry ?? createEmptyPluginRegistry());
   });
 
@@ -1272,6 +1275,45 @@ describe("server-channels auto restart", () => {
 
     expect(failingStart).toHaveBeenCalledTimes(1);
     expect(succeedingStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps only the degraded channel account cold", async () => {
+    const discordStart = vi.fn(async (_context: ChannelGatewayContext<TestAccount>) => {});
+    const slackStart = vi.fn(async () => {});
+    const discordResolve = vi.fn(() => ({ enabled: true, configured: true }));
+    installTestRegistry(
+      createTestPlugin({
+        id: "discord",
+        order: 1,
+        listAccountIds: () => ["broken", "healthy"],
+        resolveAccount: discordResolve,
+        startAccount: discordStart,
+      }),
+      createTestPlugin({ id: "slack", order: 2, startAccount: slackStart }),
+    );
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "account",
+        ownerId: "discord:broken",
+        state: "unavailable",
+        paths: ["channels.discord.accounts.broken.token"],
+        refKeys: ["env:default:BROKEN_TOKEN"],
+        reason: "secret reference was not found",
+      },
+    ]);
+    const manager = createManager({ channelIds: ["discord", "slack"] });
+
+    await expect(manager.startChannels()).resolves.toBeUndefined();
+
+    expect(discordStart.mock.calls.map(([context]) => context.accountId)).toEqual(["healthy"]);
+    expect(discordResolve).toHaveBeenCalledOnce();
+    expect(discordResolve).toHaveBeenCalledWith(expect.anything(), "healthy");
+    expect(slackStart).toHaveBeenCalledTimes(1);
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord?.broken).toMatchObject({
+      running: false,
+      lastError:
+        "Secret owner account:discord:broken is configured but unavailable (secret reference was not found).",
+    });
   });
 
   it("uses fallback logger and runtime when a channel is missing startup wiring", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -27,6 +27,7 @@ import {
   normalizeOptionalAccountId,
 } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js";
 import { isAccountEnabled } from "../shared/account-enabled.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import type {
@@ -550,6 +551,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         };
 
         try {
+          // Reject the account before plugin resolution so an explicit failed SecretRef cannot
+          // drift into a channel-specific environment or file fallback.
+          assertSecretOwnerAvailable("account", `${channelId}:${normalizeAccountId(id)}`);
           const account = plugin.config.resolveAccount(cfg, id);
           const enabled = plugin.config.isEnabled
             ? plugin.config.isEnabled(account, cfg)

--- a/src/plugin-sdk/channel-secret-basic-runtime.test.ts
+++ b/src/plugin-sdk/channel-secret-basic-runtime.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { createChannelSecretTargetRegistryEntries } from "./channel-secret-basic-runtime.js";
+import {
+  collectConditionalChannelFieldAssignments,
+  collectSimpleChannelFieldAssignments,
+  createChannelSecretTargetRegistryEntries,
+  resolveChannelAccountSurface,
+  type ResolverContext,
+} from "./channel-secret-basic-runtime.js";
+
+function createContext(): ResolverContext {
+  return {
+    sourceConfig: {},
+    env: {},
+    cache: {},
+    warnings: [],
+    warningKeys: new Set(),
+    assignments: [],
+  };
+}
 
 describe("createChannelSecretTargetRegistryEntries", () => {
   it("builds account and channel SecretInput targets with fixed registry metadata", () => {
@@ -61,5 +78,88 @@ describe("createChannelSecretTargetRegistryEntries", () => {
       expectedResolvedValue: "string-or-object",
       accountIdPathSegmentIndex: 3,
     });
+  });
+
+  it("partitions inherited and overridden credentials by channel account", () => {
+    const channel = {
+      token: { source: "env" as const, provider: "default", id: "FIXTURE_SHARED" },
+      accounts: {
+        alpha: {},
+        beta: {
+          token: { source: "env" as const, provider: "default", id: "FIXTURE_BETA" },
+        },
+        disabled: { enabled: false },
+      },
+    };
+    const context = createContext();
+
+    collectSimpleChannelFieldAssignments({
+      channelKey: "example",
+      field: "token",
+      channel,
+      surface: resolveChannelAccountSurface(channel),
+      defaults: undefined,
+      context,
+      topInactiveReason: "inactive",
+      accountInactiveReason: "inactive account",
+    });
+
+    expect(
+      context.assignments.map(({ path, ownerKind, ownerId }) => ({ path, ownerKind, ownerId })),
+    ).toEqual([
+      {
+        path: "channels.example.token",
+        ownerKind: "account",
+        ownerId: "example:alpha",
+      },
+      {
+        path: "channels.example.accounts.beta.token",
+        ownerKind: "account",
+        ownerId: "example:beta",
+      },
+    ]);
+  });
+
+  it("keeps inherited webhook credentials owned only by webhook-mode accounts", () => {
+    const channel = {
+      webhookSecret: { source: "env" as const, provider: "default", id: "FIXTURE_WEBHOOK" },
+      accounts: {
+        webhook: { mode: "webhook" },
+        polling: { mode: "polling" },
+        override: {
+          mode: "webhook",
+          webhookSecret: {
+            source: "env" as const,
+            provider: "default",
+            id: "FIXTURE_OVERRIDE",
+          },
+        },
+      },
+    };
+    const context = createContext();
+    const surface = resolveChannelAccountSurface(channel);
+
+    collectConditionalChannelFieldAssignments({
+      channelKey: "example",
+      field: "webhookSecret",
+      channel,
+      surface,
+      defaults: undefined,
+      context,
+      topLevelActiveWithoutAccounts: true,
+      topLevelInheritedAccountActive: ({ account, enabled }) =>
+        enabled && account.mode === "webhook" && !Object.hasOwn(account, "webhookSecret"),
+      accountActive: ({ account, enabled }) => enabled && account.mode === "webhook",
+      topInactiveReason: "webhook mode inactive",
+      accountInactiveReason: "account webhook mode inactive",
+    });
+
+    expect(context.assignments.map(({ path, ownerId }) => ({ path, ownerId }))).toEqual([
+      { path: "channels.example.webhookSecret", ownerId: "example:webhook" },
+      {
+        path: "channels.example.accounts.override.webhookSecret",
+        ownerId: "example:override",
+      },
+    ]);
   });
 });

--- a/src/secrets/channel-secret-basic-runtime.ts
+++ b/src/secrets/channel-secret-basic-runtime.ts
@@ -1,11 +1,13 @@
 /** Basic channel secret runtime helpers for account/root credential collection. */
 import { coerceSecretRef } from "../config/types.secrets.js";
+import { normalizeAccountId } from "../routing/account-id.js";
 import {
   collectSecretInputAssignment,
   hasOwnProperty,
   isChannelAccountEffectivelyEnabled,
   isEnabledFlag,
   type ResolverContext,
+  type SecretAssignmentOwner,
   type SecretDefaults,
 } from "./runtime-shared.js";
 import { isRecord } from "./shared.js";
@@ -93,6 +95,19 @@ export type ChannelAccountSurface = {
 
 /** Predicate used by channel helpers to decide whether an account-owned secret is active. */
 export type ChannelAccountPredicate = (entry: ChannelAccountEntry) => boolean;
+
+/** Stable owner identity shared by SecretRef collection and channel activation. */
+function createChannelAccountSecretOwner(
+  channelKey: string,
+  accountId: string,
+): SecretAssignmentOwner {
+  return {
+    ownerKind: "account",
+    ownerId: `${channelKey}:${normalizeAccountId(accountId)}`,
+    requiredForGateway: false,
+    disposition: "isolate",
+  };
+}
 
 /** Reads a channel config block when it exists as an object. */
 export function getChannelRecord(
@@ -182,7 +197,52 @@ export function hasConfiguredSecretInputValue(
   return normalizeSecretStringValue(value).length > 0 || coerceSecretRef(value, defaults) !== null;
 }
 
-/** Collects a simple channel field from the channel root and explicit account overrides. */
+function collectTopLevelChannelFieldAssignments(params: {
+  channelKey: string;
+  fieldPath: string;
+  value: unknown;
+  expected: "string" | "string-or-object";
+  surface: ChannelAccountSurface;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+  activeWithoutAccounts: boolean;
+  inheritedAccountActive: ChannelAccountPredicate;
+  inactiveReason: string;
+  apply: (value: unknown) => void;
+}): void {
+  const owners = params.surface.hasExplicitAccounts
+    ? params.surface.accounts.filter(params.inheritedAccountActive)
+    : params.activeWithoutAccounts
+      ? [{ accountId: "default", account: {}, enabled: true }]
+      : [];
+  if (owners.length === 0) {
+    collectSecretInputAssignment({
+      value: params.value,
+      path: params.fieldPath,
+      expected: params.expected,
+      defaults: params.defaults,
+      context: params.context,
+      active: false,
+      inactiveReason: params.inactiveReason,
+      apply: params.apply,
+    });
+    return;
+  }
+  // One inherited ref can own several accounts. Duplicate only the assignment metadata so a
+  // failed shared credential degrades every consumer without collapsing unrelated accounts.
+  for (const { accountId } of owners) {
+    collectSecretInputAssignment({
+      value: params.value,
+      path: params.fieldPath,
+      expected: params.expected,
+      defaults: params.defaults,
+      context: params.context,
+      owner: createChannelAccountSecretOwner(params.channelKey, accountId),
+      apply: params.apply,
+    });
+  }
+}
+
 /** Collects root/account channel field SecretRef assignments for one credential path. */
 export function collectSimpleChannelFieldAssignments(params: {
   channelKey: string;
@@ -194,13 +254,17 @@ export function collectSimpleChannelFieldAssignments(params: {
   topInactiveReason: string;
   accountInactiveReason: string;
 }): void {
-  collectSecretInputAssignment({
+  collectTopLevelChannelFieldAssignments({
+    channelKey: params.channelKey,
     value: params.channel[params.field],
-    path: `channels.${params.channelKey}.${params.field}`,
+    fieldPath: `channels.${params.channelKey}.${params.field}`,
     expected: "string",
+    surface: params.surface,
     defaults: params.defaults,
     context: params.context,
-    active: isBaseFieldActiveForChannelSurface(params.surface, params.field),
+    activeWithoutAccounts: params.surface.channelEnabled,
+    inheritedAccountActive: ({ account, enabled }) =>
+      enabled && !hasOwnProperty(account, params.field),
     inactiveReason: params.topInactiveReason,
     apply: (value) => {
       params.channel[params.field] = value;
@@ -221,25 +285,12 @@ export function collectSimpleChannelFieldAssignments(params: {
       context: params.context,
       active: enabled,
       inactiveReason: params.accountInactiveReason,
+      owner: createChannelAccountSecretOwner(params.channelKey, accountId),
       apply: (value) => {
         account[params.field] = value;
       },
     });
   }
-}
-
-function isConditionalTopLevelFieldActive(params: {
-  surface: ChannelAccountSurface;
-  activeWithoutAccounts: boolean;
-  inheritedAccountActive: ChannelAccountPredicate;
-}): boolean {
-  if (!params.surface.channelEnabled) {
-    return false;
-  }
-  if (!params.surface.hasExplicitAccounts) {
-    return params.activeWithoutAccounts;
-  }
-  return params.surface.accounts.some(params.inheritedAccountActive);
 }
 
 /** Collects a channel field whose active state depends on caller-provided account predicates. */
@@ -256,17 +307,16 @@ export function collectConditionalChannelFieldAssignments(params: {
   topInactiveReason: string;
   accountInactiveReason: string | ((entry: ChannelAccountEntry) => string);
 }): void {
-  collectSecretInputAssignment({
+  collectTopLevelChannelFieldAssignments({
+    channelKey: params.channelKey,
     value: params.channel[params.field],
-    path: `channels.${params.channelKey}.${params.field}`,
+    fieldPath: `channels.${params.channelKey}.${params.field}`,
     expected: "string",
+    surface: params.surface,
     defaults: params.defaults,
     context: params.context,
-    active: isConditionalTopLevelFieldActive({
-      surface: params.surface,
-      activeWithoutAccounts: params.topLevelActiveWithoutAccounts,
-      inheritedAccountActive: params.topLevelInheritedAccountActive,
-    }),
+    activeWithoutAccounts: params.surface.channelEnabled && params.topLevelActiveWithoutAccounts,
+    inheritedAccountActive: params.topLevelInheritedAccountActive,
     inactiveReason: params.topInactiveReason,
     apply: (value) => {
       params.channel[params.field] = value;
@@ -290,6 +340,7 @@ export function collectConditionalChannelFieldAssignments(params: {
         typeof params.accountInactiveReason === "function"
           ? params.accountInactiveReason(entry)
           : params.accountInactiveReason,
+      owner: createChannelAccountSecretOwner(params.channelKey, entry.accountId),
       apply: (value) => {
         entry.account[params.field] = value;
       },
@@ -307,19 +358,26 @@ export function collectNestedChannelFieldAssignments(params: {
   defaults: SecretDefaults | undefined;
   context: ResolverContext;
   topLevelActive: boolean;
+  topLevelInheritedAccountActive?: ChannelAccountPredicate;
   topInactiveReason: string;
   accountActive: ChannelAccountPredicate;
   accountInactiveReason: string | ((entry: ChannelAccountEntry) => string);
 }): void {
   const topLevelNested = params.channel[params.nestedKey];
   if (isRecord(topLevelNested)) {
-    collectSecretInputAssignment({
+    collectTopLevelChannelFieldAssignments({
+      channelKey: params.channelKey,
       value: topLevelNested[params.field],
-      path: `channels.${params.channelKey}.${params.nestedKey}.${params.field}`,
+      fieldPath: `channels.${params.channelKey}.${params.nestedKey}.${params.field}`,
       expected: "string",
+      surface: params.surface,
       defaults: params.defaults,
       context: params.context,
-      active: params.topLevelActive,
+      activeWithoutAccounts: params.topLevelActive,
+      inheritedAccountActive:
+        params.topLevelInheritedAccountActive ??
+        (({ account, enabled }) =>
+          params.topLevelActive && enabled && !hasOwnProperty(account, params.nestedKey)),
       inactiveReason: params.topInactiveReason,
       apply: (value) => {
         topLevelNested[params.field] = value;
@@ -345,6 +403,7 @@ export function collectNestedChannelFieldAssignments(params: {
         typeof params.accountInactiveReason === "function"
           ? params.accountInactiveReason(entry)
           : params.accountInactiveReason,
+      owner: createChannelAccountSecretOwner(params.channelKey, entry.accountId),
       apply: (value) => {
         nested[params.field] = value;
       },

--- a/src/secrets/runtime-discord-surface.test.ts
+++ b/src/secrets/runtime-discord-surface.test.ts
@@ -197,6 +197,56 @@ describe("secrets runtime snapshot discord surface", () => {
     ).rejects.toThrow('Environment variable "MISSING_DISCORD_BASE_TOKEN" is missing or empty.');
   });
 
+  it("isolates one unresolved Discord account token while resolving its sibling", async () => {
+    const env = Object.fromEntries([["DISCORD_HEALTHY_TOKEN", "fixture-value"]]);
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          discord: {
+            accounts: {
+              broken: {
+                enabled: true,
+                token: {
+                  source: "env",
+                  provider: "default",
+                  id: "MISSING_DISCORD_BROKEN_TOKEN",
+                },
+              },
+              healthy: {
+                enabled: true,
+                token: {
+                  source: "env",
+                  provider: "default",
+                  id: "DISCORD_HEALTHY_TOKEN",
+                },
+              },
+            },
+          },
+        },
+      }),
+      env,
+      allowUnavailableSecretOwners: true,
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => loadAuthStoreWithProfiles({}),
+    });
+
+    expect(snapshot.config.channels?.discord?.accounts?.broken?.token).toEqual({
+      source: "env",
+      provider: "default",
+      id: "MISSING_DISCORD_BROKEN_TOKEN",
+    });
+    expect(snapshot.config.channels?.discord?.accounts?.healthy?.token).toBe("fixture-value");
+    expect(snapshot.degradedOwners).toMatchObject([
+      {
+        ownerKind: "account",
+        ownerId: "discord:broken",
+        state: "unavailable",
+        paths: ["channels.discord.accounts.broken.token"],
+        reason: "secret reference was not found",
+      },
+    ]);
+  });
+
   it("treats top-level Discord token refs as inactive when account token is explicitly blank", async () => {
     const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({

--- a/src/secrets/runtime-matrix-shadowing.test.ts
+++ b/src/secrets/runtime-matrix-shadowing.test.ts
@@ -112,6 +112,26 @@ describe("secrets runtime snapshot matrix shadowing", () => {
       },
     },
     {
+      name: "channels.matrix.accounts.default.password config",
+      config: {
+        channels: {
+          matrix: {
+            password: {
+              source: "env",
+              provider: "default",
+              id: "MATRIX_PASSWORD",
+            },
+            accounts: {
+              default: {
+                password: "fixture",
+              },
+            },
+          },
+        },
+      },
+      env: {},
+    },
+    {
       name: "MATRIX_DEFAULT_ACCESS_TOKEN env auth",
       config: {
         channels: {
@@ -142,6 +162,39 @@ describe("secrets runtime snapshot matrix shadowing", () => {
       id: "MATRIX_PASSWORD",
     });
     expectInactiveSurfaceWarning(snapshot, "channels.matrix.password");
+  });
+
+  it("ignores a top-level accessToken ref shadowed by the default account", async () => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          matrix: {
+            accessToken: {
+              source: "env",
+              provider: "default",
+              id: "MISSING_MATRIX_ROOT_ACCESS_TOKEN",
+            },
+            accounts: {
+              default: {
+                accessToken: "fixture",
+              },
+            },
+          },
+        },
+      }),
+      env: {},
+      allowUnavailableSecretOwners: true,
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => loadAuthStoreWithProfiles({}),
+    });
+
+    expect(requireMatrixConfig(snapshot).accessToken).toEqual({
+      source: "env",
+      provider: "default",
+      id: "MISSING_MATRIX_ROOT_ACCESS_TOKEN",
+    });
+    expect(snapshot.degradedOwners).toStrictEqual([]);
+    expectInactiveSurfaceWarning(snapshot, "channels.matrix.accessToken");
   });
 
   it.each([

--- a/src/secrets/runtime-matrix-top-level.test.ts
+++ b/src/secrets/runtime-matrix-top-level.test.ts
@@ -6,6 +6,32 @@ import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-s
 const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
 
 describe("secrets runtime snapshot matrix access token", () => {
+  it.each([
+    { field: "accessToken", envId: "MATRIX_ACCOUNTLESS_ACCESS_TOKEN" },
+    { field: "password", envId: "MATRIX_ACCOUNTLESS_PASSWORD" },
+  ] as const)("resolves an accountless top-level Matrix $field ref", async ({ field, envId }) => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          matrix: {
+            [field]: {
+              source: "env",
+              provider: "default",
+              id: envId,
+            },
+          },
+        },
+      }),
+      env: {
+        [envId]: "resolved-credential",
+      },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: new Map(),
+    });
+
+    expect(snapshot.config.channels?.matrix?.[field]).toBe("resolved-credential");
+  });
+
   it("resolves top-level Matrix accessToken refs even when named accounts exist", async () => {
     const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({

--- a/src/secrets/runtime-shared.ts
+++ b/src/secrets/runtime-shared.ts
@@ -122,6 +122,7 @@ export function collectSecretInputAssignment(params: {
   context: ResolverContext;
   active?: boolean;
   inactiveReason?: string;
+  owner?: SecretAssignmentOwner;
   apply: (value: unknown) => void;
 }): void {
   collectRuntimeSecretInputAssignment(params);


### PR DESCRIPTION
Related: #101265

## What Problem This Solves

Fixes an issue where operators using channel-account SecretRefs could lose Gateway channel activation when one account referenced a missing credential. A broken account could prevent healthy sibling accounts and unrelated channels from starting.

## Why This Change Was Made

Channel collectors now assign every credential to its normalized account owner, including inherited top-level credentials used by multiple accounts. Gateway activation marks only the unavailable owner cold before resolving that account, while preserving strict failure for unknown ownership and each channel's existing mode-specific webhook ownership.

The change is limited to channel credential collection and channel activation. It adds no config, environment variable, UI, or capability surface.

## User Impact

A missing credential for one channel account no longer takes down the Gateway or healthy sibling channel accounts. Status and doctor retain the typed degraded-owner evidence needed to diagnose the cold account.

## Evidence

- Focused local proof after the final rebase: 8 test files, 110 tests passed across 6 repository Vitest shards.
- Fresh branch autoreview after the final rebase: clean, no actionable findings.
- Exact changed-surface Testbox gate: [GitHub Actions run 29561353107](https://github.com/openclaw/openclaw/actions/runs/29561353107), including formatting, SDK surface/baseline, boundaries, all tsgo lanes, core and plugin lint, DB-first, cycles, and guards.
- Real built-Gateway Testbox proof: a Discord account with a missing SecretRef stayed cold with `SecretSurfaceUnavailableError`; a healthy Discord sibling and Telegram started independently; doctor reported `account:discord:broken (channels.discord.accounts.broken.token)`; the secret reference identifier was absent from status output. The fixture credentials then failed external authentication as expected, after activation had been demonstrated.

AI-assisted: implementation and review used Codex; maintainer-directed tests, hosted gates, and live Gateway proof verified the result.
