### PR TITLE
fix(sandbox): cancel CDP probe response bodies

### DIFF
--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -774,6 +774,65 @@ describe("ensureSandboxBrowser create args", () => {
     );
   });
 
+  it("cancels the CDP probe response body after a non-ok startup probe", async () => {
+    let socketClosed = false;
+    let requestSocket: Socket | undefined;
+    let requestPath: string | undefined;
+    const server = createServer((req, res) => {
+      requestPath = req.url;
+      requestSocket = req.socket;
+      req.socket.once("close", () => {
+        socketClosed = true;
+      });
+      res.writeHead(503, { "content-type": "text/plain" });
+      res.write("not ready\n");
+      const interval = setInterval(() => res.write("still streaming\n"), 25);
+      req.socket.once("close", () => clearInterval(interval));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const cdpPort = (server.address() as AddressInfo).port;
+    dockerMocks.readDockerPort.mockImplementation(async (_containerName: string, port: number) => {
+      if (port === 9222) {
+        return cdpPort;
+      }
+      if (port === 6080) {
+        return 49101;
+      }
+      return null;
+    });
+    bridgeMocks.startBrowserBridgeServer.mockImplementationOnce(async (params) => {
+      await params.onEnsureAttachTarget?.({});
+      throw new Error("expected CDP startup to fail before bridge creation");
+    });
+
+    const cfg = buildConfig(false);
+    cfg.browser.autoStartTimeoutMs = 50;
+
+    try {
+      await expect(
+        ensureTestSandboxBrowser({
+          scopeKey: "session:test",
+          workspaceDir: "/tmp/workspace",
+          agentWorkspaceDir: "/tmp/workspace",
+          cfg,
+        }),
+      ).rejects.toThrow("hung container has been forcefully removed");
+      await new Promise((resolve) => {
+        setTimeout(resolve, 250);
+      });
+      expect(requestPath).toBe("/json/version");
+      expect(socketClosed).toBe(true);
+    } finally {
+      requestSocket?.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("keeps a stalled CDP request inside the browser startup deadline", async () => {
     const sockets = new Set<Socket>();
     let requestPath: string | undefined;

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -777,36 +777,15 @@ describe("ensureSandboxBrowser create args", () => {
   it.each([200, 503])(
     "cancels the CDP probe response body after a %i startup probe",
     async (status) => {
-      let socketClosed = false;
-      let requestSocket: Socket | undefined;
-      let requestPath: string | undefined;
-      const server = createServer((req, res) => {
-        requestPath = req.url;
-        requestSocket = req.socket;
-        req.socket.once("close", () => {
-          socketClosed = true;
-        });
-        res.writeHead(status, { "content-type": "text/plain" });
-        res.write("probe response\n");
-        const interval = setInterval(() => res.write("still streaming\n"), 25);
-        req.socket.once("close", () => clearInterval(interval));
+      const cancels: Array<ReturnType<typeof vi.fn>> = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        const cancel = vi.fn().mockResolvedValue(undefined);
+        cancels.push(cancel);
+        return {
+          ok: status === 200,
+          body: { cancel },
+        } as never;
       });
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", resolve);
-      });
-      const cdpPort = (server.address() as AddressInfo).port;
-      dockerMocks.readDockerPort.mockImplementation(
-        async (_containerName: string, port: number) => {
-          if (port === 9222) {
-            return cdpPort;
-          }
-          if (port === 6080) {
-            return 49101;
-          }
-          return null;
-        },
-      );
       bridgeMocks.startBrowserBridgeServer.mockImplementationOnce(async (params) => {
         await params.onEnsureAttachTarget?.({});
         throw new Error("probe completed before bridge creation");
@@ -815,28 +794,22 @@ describe("ensureSandboxBrowser create args", () => {
       const cfg = buildConfig(false);
       cfg.browser.autoStartTimeoutMs = 50;
 
-      try {
-        const startup = ensureTestSandboxBrowser({
+      await expect(
+        ensureTestSandboxBrowser({
           scopeKey: "session:test",
           workspaceDir: "/tmp/workspace",
           agentWorkspaceDir: "/tmp/workspace",
           cfg,
-        });
-        await expect(startup).rejects.toThrow(
-          status === 200
-            ? "probe completed before bridge creation"
-            : "hung container has been forcefully removed",
-        );
-        await new Promise((resolve) => {
-          setTimeout(resolve, 250);
-        });
-        expect(requestPath).toBe("/json/version");
-        expect(socketClosed).toBe(true);
-      } finally {
-        requestSocket?.destroy();
-        await new Promise<void>((resolve, reject) => {
-          server.close((error) => (error ? reject(error) : resolve()));
-        });
+        }),
+      ).rejects.toThrow(
+        status === 200
+          ? "probe completed before bridge creation"
+          : "hung container has been forcefully removed",
+      );
+
+      expect(cancels).not.toHaveLength(0);
+      for (const cancel of cancels) {
+        expect(cancel).toHaveBeenCalledOnce();
       }
     },
   );

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -774,64 +774,72 @@ describe("ensureSandboxBrowser create args", () => {
     );
   });
 
-  it("cancels the CDP probe response body after a non-ok startup probe", async () => {
-    let socketClosed = false;
-    let requestSocket: Socket | undefined;
-    let requestPath: string | undefined;
-    const server = createServer((req, res) => {
-      requestPath = req.url;
-      requestSocket = req.socket;
-      req.socket.once("close", () => {
-        socketClosed = true;
+  it.each([200, 503])(
+    "cancels the CDP probe response body after a %i startup probe",
+    async (status) => {
+      let socketClosed = false;
+      let requestSocket: Socket | undefined;
+      let requestPath: string | undefined;
+      const server = createServer((req, res) => {
+        requestPath = req.url;
+        requestSocket = req.socket;
+        req.socket.once("close", () => {
+          socketClosed = true;
+        });
+        res.writeHead(status, { "content-type": "text/plain" });
+        res.write("probe response\n");
+        const interval = setInterval(() => res.write("still streaming\n"), 25);
+        req.socket.once("close", () => clearInterval(interval));
       });
-      res.writeHead(503, { "content-type": "text/plain" });
-      res.write("not ready\n");
-      const interval = setInterval(() => res.write("still streaming\n"), 25);
-      req.socket.once("close", () => clearInterval(interval));
-    });
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const cdpPort = (server.address() as AddressInfo).port;
-    dockerMocks.readDockerPort.mockImplementation(async (_containerName: string, port: number) => {
-      if (port === 9222) {
-        return cdpPort;
-      }
-      if (port === 6080) {
-        return 49101;
-      }
-      return null;
-    });
-    bridgeMocks.startBrowserBridgeServer.mockImplementationOnce(async (params) => {
-      await params.onEnsureAttachTarget?.({});
-      throw new Error("expected CDP startup to fail before bridge creation");
-    });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const cdpPort = (server.address() as AddressInfo).port;
+      dockerMocks.readDockerPort.mockImplementation(
+        async (_containerName: string, port: number) => {
+          if (port === 9222) {
+            return cdpPort;
+          }
+          if (port === 6080) {
+            return 49101;
+          }
+          return null;
+        },
+      );
+      bridgeMocks.startBrowserBridgeServer.mockImplementationOnce(async (params) => {
+        await params.onEnsureAttachTarget?.({});
+        throw new Error("probe completed before bridge creation");
+      });
 
-    const cfg = buildConfig(false);
-    cfg.browser.autoStartTimeoutMs = 50;
+      const cfg = buildConfig(false);
+      cfg.browser.autoStartTimeoutMs = 50;
 
-    try {
-      await expect(
-        ensureTestSandboxBrowser({
+      try {
+        const startup = ensureTestSandboxBrowser({
           scopeKey: "session:test",
           workspaceDir: "/tmp/workspace",
           agentWorkspaceDir: "/tmp/workspace",
           cfg,
-        }),
-      ).rejects.toThrow("hung container has been forcefully removed");
-      await new Promise((resolve) => {
-        setTimeout(resolve, 250);
-      });
-      expect(requestPath).toBe("/json/version");
-      expect(socketClosed).toBe(true);
-    } finally {
-      requestSocket?.destroy();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  });
+        });
+        await expect(startup).rejects.toThrow(
+          status === 200
+            ? "probe completed before bridge creation"
+            : "hung container has been forcefully removed",
+        );
+        await new Promise((resolve) => {
+          setTimeout(resolve, 250);
+        });
+        expect(requestPath).toBe("/json/version");
+        expect(socketClosed).toBe(true);
+      } finally {
+        requestSocket?.destroy();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it("keeps a stalled CDP request inside the browser startup deadline", async () => {
     const sockets = new Set<Socket>();

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -99,10 +99,10 @@ async function waitForSandboxCdp(params: {
           headers: { Authorization: buildSandboxCdpAuthHeader(params.authToken) },
           signal: ctrl.signal,
         });
+        await res.body?.cancel().catch(() => undefined);
         if (res.ok) {
           return true;
         }
-        await res.body?.cancel().catch(() => undefined);
       } finally {
         clearTimeout(t);
       }

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -102,6 +102,7 @@ async function waitForSandboxCdp(params: {
         if (res.ok) {
           return true;
         }
+        await res.body?.cancel().catch(() => undefined);
       } finally {
         clearTimeout(t);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sandbox browser startup could leave HTTP response streams open after CDP readiness probes. Both unsuccessful probes that continued the retry loop and successful probes that returned early left unread response bodies for garbage collection, which could retain transport resources.

## Why This Change Was Made

`waitForSandboxCdp` now cancels every probe response body before branching on the HTTP status. Successful probes, retry timing, auth headers, and startup timeout behavior are unchanged.

## User Impact

Sandbox browser auto-start keeps the same readiness and failure semantics, while each completed CDP probe promptly releases its connection instead of leaving an unread stream open.

## Evidence

**Real-machine before / premise / after / negative control**

Environment: Linux 6.8.0-134-generic x86_64, Node v24.5.0.

I ran the same production-function harness from an `upstream/main` snapshot and this branch. The harness starts a real localhost `node:http` server, sends a streaming HTTP response through real Node fetch, calls the production `waitForSandboxCdp` loop, and observes the server-side TCP socket 250 ms after the function returns:

```bash
node --import tsx /tmp/sandbox-cdp-body-cancel-proof.mts /tmp/sandbox-cdp-before 200
node --import tsx /tmp/sandbox-cdp-body-cancel-proof.mts /tmp/sandbox-cdp-after 200
node --import tsx /tmp/sandbox-cdp-body-cancel-proof.mts /tmp/sandbox-cdp-after 503
```

The harness loads the probe loop from `src/agents/sandbox/browser.ts` (mirrored in `/tmp/sandbox-cdp-probe-*.ts` for import isolation). The server never ends its response body, making socket closure a direct observation of consumer cancellation rather than normal body completion.

Negative control / before (`upstream/main` at `e01027dd28a`), streaming HTTP 200:

```text
{"productionFunction":"waitForSandboxCdp","status":200,"cdpReachable":true,"serverObservedSocketClose":false}
```

After (`aac0533a40b`), streaming HTTP 200 and 503:

```text
{"productionFunction":"waitForSandboxCdp","status":200,"cdpReachable":true,"serverObservedSocketClose":true}
{"productionFunction":"waitForSandboxCdp","status":503,"cdpReachable":false,"serverObservedSocketClose":true}
```

The unchanged `cdpReachable` values are the behavioral controls: successful probes still succeed and unsuccessful probes still fail, while the real server observes prompt connection release in both paths.

Premise: Undici 8.5.0, installed by this repository, documents that every response body must be consumed or canceled because Node garbage collection does not release connection resources promptly. This probe only needs the response status, so cancellation is the bounded cleanup operation.

Focused validation:

```text
node scripts/run-vitest.mjs src/agents/sandbox/browser.create.test.ts -t "CDP probe response body"
Test Files  2 passed (2)
Tests       4 passed | 46 skipped (50)

./node_modules/.bin/oxfmt --check src/agents/sandbox/browser.ts src/agents/sandbox/browser.create.test.ts
All matched files use the correct format.

./node_modules/.bin/oxlint src/agents/sandbox/browser.ts src/agents/sandbox/browser.create.test.ts
exit 0

git diff --check
exit 0
```

Full build and broader suites were not run locally; fork GitHub Actions cover the wider gates. This is a non-visual transport cleanup, so no screenshot is applicable.

AI-assisted: Yes. Codex reviewed the probe loop, caller, adjacent tests, sibling response-body cleanup, the installed Undici contract, and real-machine evidence.
