### PR TITLE
perf(ci): remove the anthropic-cli jiti stall and stripe the full-plan whales

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,7 +644,7 @@ jobs:
                 save_vitest_fs_cache: shard.saveVitestFsCache,
                 targets: shard.targets,
                 requires_go:
-                  shard.shardName === "core-tooling" ||
+                  shard.shardName.startsWith("core-tooling") ||
                   shard.groups?.some((group) => group.shard_name.startsWith("core-tooling")),
               }));
           const nodeTestNonDistShards = nodeTestShards.filter((shard) => !shard.requires_dist);

--- a/.github/workflows/vitest-cache-warm.yml
+++ b/.github/workflows/vitest-cache-warm.yml
@@ -48,15 +48,20 @@ jobs:
           import { appendFileSync } from "node:fs";
           import { createNodeTestShards } from "./scripts/lib/ci-node-test-plan.mjs";
 
-          const shard = createNodeTestShards().find((candidate) => candidate.shardName === "core-unit-fast");
-          if (!shard) {
-            throw new Error("core-unit-fast cache seed shard is missing");
+          // The unit-fast graph is striped across jobs; warm the union of its
+          // configs as whole suites so the seed covers every stripe's imports.
+          const shards = createNodeTestShards().filter((candidate) =>
+            candidate.shardName.startsWith("core-unit-fast"),
+          );
+          if (shards.length === 0) {
+            throw new Error("core-unit-fast cache seed shards are missing");
           }
+          const configs = [...new Set(shards.flatMap((shard) => shard.configs))];
           appendFileSync(
             process.env.GITHUB_ENV,
             [
-              `OPENCLAW_NODE_TEST_CONFIGS_JSON=${JSON.stringify(shard.configs)}`,
-              `OPENCLAW_VITEST_SHARD_NAME=${shard.shardName}`,
+              `OPENCLAW_NODE_TEST_CONFIGS_JSON=${JSON.stringify(configs)}`,
+              "OPENCLAW_VITEST_SHARD_NAME=core-unit-fast",
               "OPENCLAW_NODE_TEST_PLAN_CONCURRENCY=1",
             ].join("\n") + "\n",
           );

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -549,7 +549,10 @@ const config = {
     },
     [`${BUNDLED_PLUGIN_ROOT_DIR}/amazon-bedrock-mantle`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/amazon-bedrock`]: bundledPluginWorkspace(),
-    [`${BUNDLED_PLUGIN_ROOT_DIR}/anthropic`]: bundledPluginWorkspace(),
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/anthropic`]: bundledPluginWorkspace([
+      // The plugin-SDK anthropic-cli facade resolves this shipped artifact by basename.
+      "cli-api.ts!",
+    ]),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/anthropic-vertex`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/acpx`]: bundledPluginWorkspace([
       // Copied as executable runtime internals by the package artifact manifest.

--- a/extensions/anthropic/cli-api.ts
+++ b/extensions/anthropic/cli-api.ts
@@ -1,0 +1,5 @@
+// Lightweight Claude CLI identity artifact for core facades. The full api.js
+// barrel drags the whole plugin graph through jiti on source checkouts
+// (~130s per cold worker on CI); keep this surface to static facts only.
+export { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
+export { isClaudeCliProvider } from "./cli-shared.js";

--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -4,7 +4,12 @@ import { agentsCoreIsolatedTestFiles } from "../../test/vitest/vitest.agents-pat
 import { commandsLightTestFiles } from "../../test/vitest/vitest.commands-light-paths.mjs";
 import { fullSuiteVitestShards } from "../../test/vitest/vitest.test-shards.mjs";
 import { toolingIsolatedTestFiles } from "../../test/vitest/vitest.tooling-isolated-paths.mjs";
-import { getUnitFastTestFilesForIncludePatterns } from "../../test/vitest/vitest.unit-fast-paths.mjs";
+import {
+  getUnitFastIsolatedTestFiles,
+  getUnitFastTestFiles,
+  getUnitFastTestFilesForIncludePatterns,
+  getUnitFastTimerTestFiles,
+} from "../../test/vitest/vitest.unit-fast-paths.mjs";
 import { boundaryTestFiles } from "../../test/vitest/vitest.unit-paths.mjs";
 import { listTrackedTestFiles } from "./list-test-files.mjs";
 
@@ -36,6 +41,7 @@ const COMPACT_TOOLING_NODE_TEST_GROUPS = 4;
 const COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES = 120;
 const AUTO_REPLY_COMMANDS_STRIPES = 3;
 const AGENTS_CORE_RUNNER_CLI_STRIPES = 3;
+const UNIT_FAST_NODE_TEST_STRIPES = 2;
 // Advisory runtime estimates (seconds) per split shard: mean [shard:*]
 // begin->end wall clock across five green Blacksmith compact PR runs
 // (29557851276, 29558164241, 29558528472, 29558634980, 29558677406).
@@ -46,8 +52,8 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
   ["agentic-agents-core-isolated", 8],
   ["agentic-agents-core-models", 60],
   // Reliability's runtime-free provider check dropped its wall time from
-  // ~245s to ~5s. LPT now puts spawn in stripe 1 and balances the small files
-  // across the remaining stripes.
+  // ~245s to ~5s; the narrow anthropic cli-api artifact removes the same
+  // full-barrel evaluation for the remaining facade importers (spawn).
   ["agentic-agents-core-runner-cli-1", 18],
   ["agentic-agents-core-runner-cli-2", 11],
   ["agentic-agents-core-runner-cli-3", 12],
@@ -123,9 +129,10 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
   ["core-tooling-2", 112],
   ["core-tooling-3", 106],
   ["core-tooling-4", 105],
-  ["core-tooling-docker", 6],
-  ["core-tooling-isolated", 52],
-  ["core-unit-fast", 142],
+  ["core-tooling-isolated", 58],
+  ["core-unit-fast-1", 60],
+  ["core-unit-fast-2", 60],
+  ["core-unit-fast-isolated", 25],
   ["core-unit-src-security", 108],
   ["core-unit-support", 15],
 ]);
@@ -171,8 +178,7 @@ const DEFAULT_SECONDS_PER_TEST_FILE = 0.5;
 // Spawn/signal-timing suites (process-group waits, PTY smoke) flake when a
 // concurrent sibling Vitest run competes for the 4 vCPU runner. Pack them
 // into bins the shard runner executes at concurrency 1.
-const EXCLUSIVE_COMPACT_GROUP_RE =
-  /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$/u;
+const EXCLUSIVE_COMPACT_GROUP_RE = /^core-tooling(?:-\d+|-isolated)$|^core-runtime-tui-pty$/u;
 // Exclusive bins run serially, so their packed estimate is their wall clock.
 const COMPACT_EXCLUSIVE_JOB_SECONDS = 150;
 
@@ -185,7 +191,7 @@ function isExclusiveCompactGroup(group) {
 // scales with the runner class. infra-process spawns child processes per test
 // and hit worker-startup timeouts under contention before serialization.
 const PINNED_WORKER_COMPACT_GROUP_RE =
-  /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-media-ui$|^agentic-gateway-(?:core|methods)$/u;
+  /^core-tooling(?:-\d+|-isolated)$|^core-runtime-tui-pty$|^core-runtime-infra-process$|^core-runtime-media-ui$|^agentic-gateway-(?:core|methods)$/u;
 const PINNED_COMPACT_GROUP_ENV = { OPENCLAW_VITEST_MAX_WORKERS: "2" };
 
 function applyCompactGroupWorkerPins(group) {
@@ -211,13 +217,14 @@ const TOOLING_ISOLATED_CONFIG = "test/vitest/vitest.tooling-isolated.config.ts";
 // The full matrix is capped at 28 jobs. Admit the consistently slow serial
 // shards first so short alphabetical groups cannot leave them on the tail.
 const FULL_NODE_TEST_ADMISSION_PRIORITY = new Map([
-  ["core-tooling", 0],
-  ["auto-reply-reply-commands-1", 1],
-  ["auto-reply-reply-commands-2", 1],
-  ["auto-reply-reply-commands-3", 1],
   // Start the broad cache writer in the first admission wave so later jobs
   // can reuse its protected transform snapshot on the next run.
-  ["core-unit-fast", 1],
+  ["core-unit-fast-1", 0],
+  ["core-unit-fast-2", 0],
+  ["core-tooling-1", 1],
+  ["core-tooling-2", 1],
+  ["core-tooling-3", 1],
+  ["core-tooling-4", 1],
 ]);
 // Commands and cron run non-isolated, so keep their split shards as separate
 // processes. Combining their include lists can retain test state across groups.
@@ -247,7 +254,8 @@ const KEEP_LARGE_NODE_TEST_RUNNER = new Set([
   "auto-reply-reply-commands-2",
   "auto-reply-reply-commands-3",
   "core-runtime-media-ui",
-  "core-unit-fast",
+  "core-unit-fast-1",
+  "core-unit-fast-2",
   "core-unit-src-security",
 ]);
 const RELEASE_ONLY_PLUGIN_SHARDS = new Set(["agentic-plugins"]);
@@ -989,21 +997,60 @@ function createInfraSplitShards() {
     .filter((shard) => shard.includePatterns.length > 0);
 }
 
-const SPLIT_NODE_SHARDS = new Map([
-  [
-    "core-unit-fast",
-    [
-      {
-        shardName: "core-unit-fast",
-        configs: [
-          "test/vitest/vitest.unit-fast.config.ts",
-          "test/vitest/vitest.unit-fast-isolated.config.ts",
-          "test/vitest/vitest.unit-fast-fake-timers.config.ts",
-        ],
+// The broad unit-fast graph is import-bound (~180s of module evaluation on an
+// 8 vCPU runner as one job); striping the file list halves the wall clock.
+// Isolated and fake-timer projects stay whole: they are small and own
+// worker-isolation semantics that include lists must not slice.
+function createUnitFastSplitShards() {
+  const timerTestFiles = new Set(getUnitFastTimerTestFiles());
+  const isolatedTestFiles = new Set(getUnitFastIsolatedTestFiles());
+  const stripeFiles = getUnitFastTestFiles().filter(
+    (file) => !timerTestFiles.has(file) && !isolatedTestFiles.has(file),
+  );
+  return [
+    ...createStripedBatches(stripeFiles, UNIT_FAST_NODE_TEST_STRIPES).map(
+      (includePatterns, index) => ({
+        shardName: `core-unit-fast-${index + 1}`,
+        configs: ["test/vitest/vitest.unit-fast.config.ts"],
+        includePatterns,
         requiresDist: false,
-      },
-    ],
-  ],
+      }),
+    ),
+    {
+      shardName: "core-unit-fast-isolated",
+      configs: [
+        "test/vitest/vitest.unit-fast-isolated.config.ts",
+        "test/vitest/vitest.unit-fast-fake-timers.config.ts",
+      ],
+      requiresDist: false,
+    },
+  ];
+}
+
+// Tooling is test-time bound (~170s of spawned-process tests as one serial
+// job). Both the full and compact plans consume these stripes; the compact
+// packer keeps them in exclusive bins via EXCLUSIVE_COMPACT_GROUP_RE.
+function createToolingSplitShards() {
+  return [
+    ...createStripedBatches(listCompactToolingTestFiles(), COMPACT_TOOLING_NODE_TEST_GROUPS).map(
+      (includePatterns, index) => ({
+        shardName: `core-tooling-${index + 1}`,
+        configs: [TOOLING_CONFIG],
+        includePatterns,
+        requiresDist: false,
+      }),
+    ),
+    {
+      shardName: "core-tooling-isolated",
+      configs: ["test/vitest/vitest.tooling-docker.config.ts", TOOLING_ISOLATED_CONFIG],
+      requiresDist: false,
+    },
+  ];
+}
+
+const SPLIT_NODE_SHARDS = new Map([
+  ["core-unit-fast", createUnitFastSplitShards()],
+  ["core-tooling", createToolingSplitShards()],
   [
     "core-unit-src",
     [
@@ -1019,24 +1066,6 @@ const SPLIT_NODE_SHARDS = new Map([
     ],
   ],
   ["core-unit-security", []],
-  [
-    "core-tooling",
-    [
-      {
-        shardName: "core-tooling",
-        configs: [
-          "test/vitest/vitest.tooling.config.ts",
-          "test/vitest/vitest.tooling-isolated.config.ts",
-        ],
-        requiresDist: false,
-      },
-      {
-        shardName: "core-tooling-docker",
-        configs: ["test/vitest/vitest.tooling-docker.config.ts"],
-        requiresDist: false,
-      },
-    ],
-  ],
   [
     "core-unit-support",
     [
@@ -1326,33 +1355,6 @@ function listCompactToolingTestFiles() {
   );
 }
 
-function expandCompactNodeTestGroup(group) {
-  if (group.shard_name !== "core-tooling") {
-    return [group];
-  }
-
-  // Tooling is hundreds of serial files. Split only the compact PR plan so
-  // one runner cannot dominate admission while release/main topology stays stable.
-  const toolingGroups = createStripedBatches(
-    listCompactToolingTestFiles(),
-    COMPACT_TOOLING_NODE_TEST_GROUPS,
-  ).map((includePatterns, index) =>
-    Object.assign({}, group, {
-      configs: [TOOLING_CONFIG],
-      includePatterns,
-      shard_name: `core-tooling-${index + 1}`,
-    }),
-  );
-  return [
-    ...toolingGroups,
-    {
-      ...group,
-      configs: [TOOLING_ISOLATED_CONFIG],
-      shard_name: "core-tooling-isolated",
-    },
-  ];
-}
-
 /**
  * Collapse split include-pattern shards into bounded jobs for normal CI.
  * The base plan remains unchanged for release and coverage consumers.
@@ -1440,8 +1442,8 @@ export function createNodeTestShardBundles(options = {}) {
 export function assignVitestFsCacheWriter(shards) {
   const preferredIndex = shards.findIndex(
     (shard) =>
-      shard.shardName === "core-unit-fast" ||
-      shard.groups?.some((group) => group.shard_name === "core-unit-fast"),
+      shard.shardName.startsWith("core-unit-fast") ||
+      shard.groups?.some((group) => group.shard_name.startsWith("core-unit-fast")),
   );
   const writerIndex = preferredIndex >= 0 ? preferredIndex : shards.length > 0 ? 0 : -1;
   return shards.map((shard, index) => ({
@@ -1466,7 +1468,7 @@ function createCompactNodeTestShardBundles(options = {}) {
       runner,
       shard_name: shard.shardName,
     };
-    groups.push(...expandCompactNodeTestGroup(group).map(applyCompactGroupWorkerPins));
+    groups.push(applyCompactGroupWorkerPins(group));
     groupsByRunner.set(key, groups);
   }
 

--- a/src/plugin-sdk/anthropic-cli.ts
+++ b/src/plugin-sdk/anthropic-cli.ts
@@ -7,9 +7,11 @@ type FacadeModule = {
 };
 
 function loadFacadeModule(): FacadeModule {
+  // cli-api.js, not api.js: this facade evaluates at module scope, and the
+  // full barrel costs ~130s per cold jiti worker on source checkouts.
   return loadBundledPluginPublicSurfaceModuleSync<FacadeModule>({
     dirName: "anthropic",
-    artifactBasename: "api.js",
+    artifactBasename: "cli-api.js",
   });
 }
 /** Anthropic plugin backend id for Claude CLI provider detection. */

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -577,8 +577,16 @@ export function ensureOpenClawAgentDatabasePermissions(
     chmodSync(dir, OPENCLAW_AGENT_DB_DIR_MODE);
   }
   for (const candidate of resolveSqliteDatabaseFilePaths(pathname)) {
-    if (existsSync(candidate)) {
+    try {
       chmodSync(candidate, OPENCLAW_AGENT_DB_FILE_MODE);
+    } catch (error) {
+      // WAL/SHM/journal sidecars are transient: SQLite removes them at
+      // checkpoint/close, so a concurrent worker can race this sweep. A
+      // vanished sidecar needs no tightening; an existsSync guard would just
+      // reintroduce the TOCTOU window.
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
     }
   }
 }

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -121,10 +121,10 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
       expect(marked.map((shard) => shard.shardName)).toEqual(plan.map((shard) => shard.shardName));
       expect(marked.filter((shard) => shard.saveVitestFsCache)).toHaveLength(1);
       expect(
-        marked.find((shard) => shard.saveVitestFsCache)?.shardName === "core-unit-fast" ||
+        marked.find((shard) => shard.saveVitestFsCache)?.shardName.startsWith("core-unit-fast") ||
           marked
             .find((shard) => shard.saveVitestFsCache)
-            ?.groups?.some((group) => group.shard_name === "core-unit-fast"),
+            ?.groups?.some((group) => group.shard_name.startsWith("core-unit-fast")),
       ).toBe(true);
     };
     expectWriter(full);
@@ -181,14 +181,18 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     ).toBe(true);
     expect(bundled.every((shard) => shard.runner?.startsWith("blacksmith-"))).toBe(true);
     expect(bundled).toEqual(createNodeTestShardBundles({ includeReleaseOnlyPluginShards: false }));
-    expect(bundled.slice(0, 5).map((shard) => shard.shardName)).toEqual([
-      "core-tooling",
-      "auto-reply-reply-commands-1",
-      "auto-reply-reply-commands-2",
-      "auto-reply-reply-commands-3",
-      "core-unit-fast",
+    expect(bundled.slice(0, 6).map((shard) => shard.shardName)).toEqual([
+      "core-unit-fast-1",
+      "core-unit-fast-2",
+      "core-tooling-1",
+      "core-tooling-2",
+      "core-tooling-3",
+      "core-tooling-4",
     ]);
-    expect(bundled.find((shard) => shard.shardName === "core-unit-fast")?.runner).toBe(
+    expect(bundled.find((shard) => shard.shardName === "core-unit-fast-1")?.runner).toBe(
+      DEFAULT_NODE_TEST_RUNNER,
+    );
+    expect(bundled.find((shard) => shard.shardName === "core-unit-fast-2")?.runner).toBe(
       DEFAULT_NODE_TEST_RUNNER,
     );
     expect(
@@ -238,12 +242,14 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     const jobOf = (name: string) =>
       compact.findIndex((shard) => shard.groups.some((group) => group.shard_name === name));
     expect(jobOf("agentic-agents-core-runner-embedded")).toBeGreaterThanOrEqual(0);
-    expect(jobOf("core-unit-fast")).toBeGreaterThanOrEqual(0);
-    expect(jobOf("agentic-agents-core-runner-embedded")).not.toBe(jobOf("core-unit-fast"));
+    expect(jobOf("core-unit-fast-1")).toBeGreaterThanOrEqual(0);
+    expect(jobOf("core-unit-fast-2")).toBeGreaterThanOrEqual(0);
+    expect(jobOf("core-unit-fast-1")).not.toBe(jobOf("core-unit-fast-2"));
+    expect(jobOf("agentic-agents-core-runner-embedded")).not.toBe(jobOf("core-unit-fast-1"));
     // Spawn/signal-timing suites never mix with regular groups, and every
     // compact bin runs serially: overlapping Vitest runs flake timing-
     // sensitive tests on both runner classes.
-    const exclusiveGroupRe = /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$/u;
+    const exclusiveGroupRe = /^core-tooling(?:-\d+|-isolated)$|^core-runtime-tui-pty$/u;
     for (const shard of compact) {
       const exclusiveCount = shard.groups.filter((group) =>
         exclusiveGroupRe.test(group.shard_name),
@@ -258,13 +264,11 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
         shard.groups.some((group) => exclusiveGroupRe.test(group.shard_name)),
       ).length,
     ).toBeGreaterThan(0);
+    // Both plans carry the same split stripes now; compact bundling must
+    // preserve base include coverage exactly.
     expect(
       compact
-        .flatMap((shard) =>
-          shard.groups.flatMap((group) =>
-            group.shard_name.startsWith("core-tooling-") ? [] : (group.includePatterns ?? []),
-          ),
-        )
+        .flatMap((shard) => shard.groups.flatMap((group) => group.includePatterns ?? []))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
       base.flatMap((shard) => shard.includePatterns ?? []).toSorted((a, b) => a.localeCompare(b)),
@@ -313,18 +317,19 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
         .find((group) => group.shard_name === "core-tooling-isolated"),
     ).toEqual(
       expect.objectContaining({
-        configs: ["test/vitest/vitest.tooling-isolated.config.ts"],
+        configs: [
+          "test/vitest/vitest.tooling-docker.config.ts",
+          "test/vitest/vitest.tooling-isolated.config.ts",
+        ],
       }),
     );
+    // The docker helper config rides with the isolated shard on both plans;
+    // no standalone core-tooling-docker group remains.
     expect(
       compact
         .flatMap((shard) => shard.groups)
-        .find((group) => group.shard_name === "core-tooling-docker"),
-    ).toEqual(
-      expect.objectContaining({
-        configs: ["test/vitest/vitest.tooling-docker.config.ts"],
-      }),
-    );
+        .some((group) => group.shard_name === "core-tooling-docker"),
+    ).toBe(false);
     const toolingGroups = compact
       .flatMap((shard) => shard.groups)
       .filter((group) => /^core-tooling-\d+$/u.test(group.shard_name));
@@ -350,13 +355,22 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
 
     expect(coreUnitShards).toEqual([
       {
+        configs: ["test/vitest/vitest.unit-fast.config.ts"],
+        requiresDist: false,
+        shardName: "core-unit-fast-1",
+      },
+      {
+        configs: ["test/vitest/vitest.unit-fast.config.ts"],
+        requiresDist: false,
+        shardName: "core-unit-fast-2",
+      },
+      {
         configs: [
-          "test/vitest/vitest.unit-fast.config.ts",
           "test/vitest/vitest.unit-fast-isolated.config.ts",
           "test/vitest/vitest.unit-fast-fake-timers.config.ts",
         ],
         requiresDist: false,
-        shardName: "core-unit-fast",
+        shardName: "core-unit-fast-isolated",
       },
       {
         configs: [
@@ -410,25 +424,25 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
       shard.shardName.startsWith("core-tooling"),
     );
 
-    expect(toolingShards).toEqual([
-      {
-        checkName: "checks-node-core-tooling",
-        configs: [
-          "test/vitest/vitest.tooling.config.ts",
-          "test/vitest/vitest.tooling-isolated.config.ts",
-        ],
-        requiresDist: false,
-        runner: "blacksmith-8vcpu-ubuntu-2404",
-        shardName: "core-tooling",
-      },
-      {
-        checkName: "checks-node-core-tooling-docker",
-        configs: ["test/vitest/vitest.tooling-docker.config.ts"],
-        requiresDist: false,
-        runner: "blacksmith-8vcpu-ubuntu-2404",
-        shardName: "core-tooling-docker",
-      },
-    ]);
+    const stripes = toolingShards.filter((shard) => /^core-tooling-\d+$/u.test(shard.shardName));
+    expect(stripes).toHaveLength(4);
+    for (const stripe of stripes) {
+      expect(stripe.configs).toEqual(["test/vitest/vitest.tooling.config.ts"]);
+      expect(stripe.requiresDist).toBe(false);
+      expect(stripe.includePatterns?.length ?? 0).toBeGreaterThan(0);
+    }
+    // Stripes partition the tooling files: no overlap, nothing dropped.
+    const stripeFiles = stripes.flatMap((stripe) => stripe.includePatterns ?? []);
+    expect(new Set(stripeFiles).size).toBe(stripeFiles.length);
+    expect(
+      toolingShards.find((shard) => shard.shardName === "core-tooling-isolated"),
+    ).toMatchObject({
+      configs: [
+        "test/vitest/vitest.tooling-docker.config.ts",
+        "test/vitest/vitest.tooling-isolated.config.ts",
+      ],
+      requiresDist: false,
+    });
   });
 
   it("assigns Blacksmith runners to every core node shard", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2286,7 +2286,7 @@ describe("ci workflow guards", () => {
     expect(warmer.on.repository_dispatch.types).toEqual(["vitest-cache-warm"]);
     expect(warmer.jobs.warm.if).toBe("github.repository == 'openclaw/openclaw'");
     expect(warmerSource).toContain('cron: "17 8 * * *"');
-    expect(warmerSource).toContain('candidate.shardName === "core-unit-fast"');
+    expect(warmerSource).toContain('candidate.shardName.startsWith("core-unit-fast")');
     expect(warmerSetup.with).toMatchObject({
       "node-compile-cache-scope": "test",
       "save-node-compile-cache": "true",


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #109332, attacking the two ~250s serial CI bins that now own main-run wall time, plus a profiled 130s module-evaluation stall:

1. **`src/plugin-sdk/anthropic-cli.ts` stalled ~131s per cold worker on CI.** It snapshots `CLAUDE_CLI_BACKEND_ID` at module scope through the sync facade loader, which on source checkouts jiti-evaluates the anthropic plugin's **full `api.js` barrel** (Testbox import profile: `anthropic-cli.ts` self-time 130.86s). Every graph that reaches `src/agents/cli-runner/prepare.ts` paid it — this is why `agentic-agents-core-runner-cli` stripes ran 157–245s for two files whose tests finish in 1s, and why yesterday's timing census concluded the file "cannot be split further".
2. **`core-fast` (268s) and `core-tooling` (265s) ran as single jobs on the full/main plan.** core-fast is import-bound (247s vitest: 181s module evaluation vs 49s tests); core-tooling is test-time bound (173s of spawned-process tests). The compact PR plan already stripes tooling; the full plan did not.

## Why This Change Was Made

Maintainer-requested bundled follow-up ("do all of it, one larger PR"). After #109332 and the caching waves (#109330/#109425/#109593), these were the measured critical-path items.

## User Impact

- CI main-run wall time: the two ~265s bins become ~5 jobs of ~60–110s each; the cli stripes drop from a 245s tail to ordinary ~15s bins.
- Contributors on source checkouts stop paying a silent 130s jiti stall in any test whose graph touches `cli-runner/prepare.ts`.
- Compact PR plans gain the docker tooling helper coverage they previously dropped (the docker config now rides with the isolated shard on both plans), and the compact-only tooling expansion is deleted (one striping path).

## Evidence

- **Testbox proof of the stall fix**: `vitest.agents-core` on `cli-runner.reliability + helpers`: **157.6s → 14.25s** (import 155.7s → 12.8s); import profile before/after names `src/plugin-sdk/anthropic-cli.ts` (130.86s self) as the sole whale. New narrow artifact `extensions/anthropic/cli-api.ts` follows the documented lightweight-artifact pattern (`extensions/CLAUDE.md`), knip models it like the browser artifacts, and `pnpm plugin-sdk:surface:check` is clean (facade exports unchanged).
- **Full-plan striping**: `core-unit-fast` → 2 include-list stripes (8 vCPU, admission wave 0, stripe 1 is the vitest fs-cache writer) + a whole `core-unit-fast-isolated` shard (isolated + fake-timer projects stay unsliced); `core-tooling` → 4 stripes + combined docker+isolated shard, shared by full and compact plans. Planner invariants tested: stripes partition files with no overlap, bundled include coverage equals base coverage, cache-warm workflow warms the union of unit-fast configs.
- **Hints**: rebased onto the fresh 5-run census (#109717) and corrected only the entries the stall fix invalidates (cli stripes 245/18/8 → 15/15/8, with the measured Testbox rationale in the comment).
- Tests: `ci-node-test-plan`, `ci-workflow-guards`, `ci-changed-node-test-plan`, `ci-run-node-test-shard`, `plugin-sdk-subpaths` contract, `extensions/anthropic/cli-shared`, `cli-runner/prepare` — all green post-rebase (300+ assertions). Remote `pnpm build` green (facade/lazy-boundary rule). Codex autoreview (gpt-5.6-sol, xhigh): clean.
- Not addressed here (measured, needs its own session): `check-prompt-snapshots` stays ~196s — still ~304s on a 16 vCPU Testbox **with** the facade fix, so its cost is broad graph execution under tsx, not the stall.
