### PR TITLE
fix(openai): add handshakeTimeout to realtime voice WebSocket

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -334,7 +334,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
 
     const socket = FakeWebSocket.instances[0];
     const options = socket?.args[1] as
-      | { headers?: Record<string, string>; maxPayload?: number }
+      | { headers?: Record<string, string>; maxPayload?: number; handshakeTimeout?: number }
       | undefined;
     expectRecordFields(options?.headers, "websocket headers", {
       originator: "openclaw",
@@ -343,6 +343,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     });
     expect(options?.headers).not.toHaveProperty("OpenAI-Beta");
     expect(options?.maxPayload).toBe(16 * 1024 * 1024);
+    expect(options?.handshakeTimeout).toBe(10_000);
   });
 
   it("requires Platform auth for native realtime websocket bridges", async () => {

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -649,6 +649,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         const ws = new WebSocket(connection.url, {
           headers: connection.headers,
           maxPayload: OPENAI_VOICE_WS_MAX_PAYLOAD_BYTES,
+          handshakeTimeout: OpenAIRealtimeVoiceBridge.CONNECT_TIMEOUT_MS,
           ...(proxyAgent ? { agent: proxyAgent } : {}),
         });
         this.ws = ws;


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

The OpenAI realtime voice WebSocket creates `new WebSocket()` without `handshakeTimeout`. The `ws` library defaults this to 0 (unlimited).

The bridge watchdog (`setTimeout → ws.terminate()`) guards the post-open session-configuration phase, but does NOT protect the TCP→WS upgrade phase — if the peer stalls before `open` fires, `ws.terminate()` on a CONNECTING socket may not release underlying TCP resources.

## Why This Change Was Made

`handshakeTimeout: OpenAIRealtimeVoiceBridge.CONNECT_TIMEOUT_MS` (10 s). Matches Alix-007's pattern in Slack, Discord, Mattermost, xAI, and Signal WebSockets.

## User Impact

Stalled OpenAI realtime voice connections now fail within 10 s during the WebSocket upgrade phase. Healthy connections are unaffected.

## Evidence

### Before vs After (controlled stalled WebSocket upgrade)

A TCP server accepts but stalls the upgrade (partial HTTP 101, no terminating `\r\n`):

```json
{"label":"BEFORE (default=0, unlimited)","handshakeTimeoutMs":0,"outcome":"REJECTED","error":"aborted after 5000ms","elapsed_ms":5016}
{"label":"AFTER OpenAI bridge (10 s)","handshakeTimeoutMs":10000,"outcome":"REJECTED","error":"Opening handshake has timed out","elapsed_ms":10003}
```

- **BEFORE**: `handshakeTimeout=0` → still hanging at 5 s (aborted externally). This IS the pre-fix behavior.
- **AFTER** (10 s): `"Opening handshake has timed out"` at 10003 ms — matches `CONNECT_TIMEOUT_MS`.

### Focused tests (parameter plumbing verified)

```
node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts --run
Test Files  1 passed (1)  Tests  66 passed (66)
```

- `expect(options?.handshakeTimeout).toBe(10_000)` — constant reaches ws constructor.

### handshakeTimeout vs bridge watchdog (non-redundant)

| Layer | Guards | Failure mode |
|------|------|------|
| `handshakeTimeout` (ws) | TCP accept → HTTP upgrade | Stalled before `open` event |
| `connectTimeout` (bridge) | WS open → session configured | Stalled after `open` event |

🤖 Generated with [Claude Code](https://claude.com/claude-code)