### PR TITLE
fix(signal): add handshakeTimeout to probe WebSocket

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -386,7 +386,7 @@ describe("containerCheck", () => {
 
     expect(result).toEqual({ ok: true, status: 101, error: null });
     expect(wsMockState.urls).toEqual(["ws://localhost:8080/v1/receive/%2B14259798283"]);
-    expect(wsMockState.options).toEqual([{ maxPayload: 1024 * 1024 }]);
+    expect(wsMockState.options).toEqual([{ maxPayload: 1024 * 1024, handshakeTimeout: 30_000 }]);
   });
 
   it("rejects container receive endpoints that do not upgrade to WebSocket", async () => {

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -217,7 +217,10 @@ function containerReceiveCheck(
       resolve(result);
     };
     try {
-      ws = new WebSocket(wsUrl, { maxPayload: WS_MAX_PAYLOAD });
+      ws = new WebSocket(wsUrl, {
+        maxPayload: WS_MAX_PAYLOAD,
+        handshakeTimeout: WS_HANDSHAKE_MS,
+      });
     } catch (err) {
       settle({
         ok: false,


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

The Signal container REST probe WebSocket creates `new WebSocket()` without `handshakeTimeout`. The production receiver socket at line 380 already uses `handshakeTimeout: WS_HANDSHAKE_MS` (30 s) — only the probe socket was missed.

## Why This Change Was Made

`handshakeTimeout: WS_HANDSHAKE_MS` (30 s) — the same constant already defined and already used by the receiver socket. One line, reusing existing infrastructure.

## User Impact

Signal container health probes now fail within 30 s on a stalled WebSocket upgrade instead of hanging indefinitely.

## Evidence

### Before vs After (controlled stalled WebSocket upgrade)

A TCP server accepts but stalls the upgrade (partial HTTP 101, no terminating `\r\n`):

```json
{"label":"BEFORE (default=0, unlimited)","handshakeTimeoutMs":0,"outcome":"REJECTED","error":"aborted after 5000ms","elapsed_ms":5016}
{"label":"AFTER Signal probe (30 s) — still waiting at 4 s","handshakeTimeoutMs":30000,"outcome":"REJECTED","error":"aborted after 4000ms","elapsed_ms":4012}
```

- **BEFORE**: `handshakeTimeout=0` → still hanging at 5 s (aborted externally). This IS the pre-fix behavior — ws waits forever.
- **AFTER** (30 s): still waiting at 4 s — the deadline is NOT firing prematurely. A 30 s timeout correctly allows slow but healthy upgrades to complete.

### Focused tests (parameter plumbing verified)

```
node scripts/run-vitest.mjs extensions/signal/src/client-container.test.ts --run
Test Files  1 passed (1)  Tests  65 passed (65)
```

- `expect(wsMockState.options).toEqual([{ maxPayload: 1048576, handshakeTimeout: 30_000 }])` — `WS_HANDSHAKE_MS` reaches ws constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)