### PR TITLE
improve: cut CLI runner reliability import cost

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -45,12 +45,12 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
   ["agentic-agents-core-auth", 23],
   ["agentic-agents-core-isolated", 8],
   ["agentic-agents-core-models", 60],
-  // cli-runner.reliability.test.ts imports a ~245s module graph on its own
-  // (79 tests in <2s, import dominates); one file cannot be split further, so
-  // its stripe is a near-solo bin and the sibling stripes stay tiny.
-  ["agentic-agents-core-runner-cli-1", 245],
-  ["agentic-agents-core-runner-cli-2", 18],
-  ["agentic-agents-core-runner-cli-3", 8],
+  // Reliability's runtime-free provider check dropped its wall time from
+  // ~245s to ~5s. LPT now puts spawn in stripe 1 and balances the small files
+  // across the remaining stripes.
+  ["agentic-agents-core-runner-cli-1", 18],
+  ["agentic-agents-core-runner-cli-2", 11],
+  ["agentic-agents-core-runner-cli-3", 12],
   ["agentic-agents-core-runner-commands", 25],
   ["agentic-agents-core-runner-embedded", 9],
   ["agentic-agents-core-runner-sessions", 10],
@@ -136,10 +136,10 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
 // re-evaluation cost that dominates these serial suites.
 const STRIPE_FILE_SECONDS_HINTS = new Map([
   // cli-runner entries are CI wall clock (begin->checkmark deltas from the
-  // compact runs above); reliability's import graph alone runs ~245s, so LPT
-  // must isolate it or its stripe owns the PR tail.
+  // compact runs above), refreshed by focused Testbox profiling where noted.
   ["src/agents/cli-runner.context-engine.test.ts", 6],
-  ["src/agents/cli-runner.reliability.test.ts", 245],
+  // Fresh profile: 5.1s total, 3.8s import; retain a conservative packing hint.
+  ["src/agents/cli-runner.reliability.test.ts", 8],
   ["src/agents/cli-runner.spawn.test.ts", 18],
   ["src/auto-reply/reply/commands-export-session.test.ts", 8],
   ["src/auto-reply/reply/commands-gating.test.ts", 6],

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -55,7 +55,7 @@ const CLI_RUN_QUEUE = new KeyedAsyncQueue();
 const CLI_IMAGE_SWEEP_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
 const sweptCliImageRoots = new Set<string>();
 
-function isClaudeCliProvider(providerId: string): boolean {
+export function isClaudeCliProvider(providerId: string): boolean {
   return normalizeOptionalLowercaseString(providerId) === "claude-cli";
 }
 

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -70,11 +70,6 @@ vi.mock("../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => null),
 }));
 
-vi.mock("../../plugin-sdk/anthropic-cli.js", () => ({
-  CLAUDE_CLI_BACKEND_ID: "claude-cli",
-  isClaudeCliProvider: (providerId: string) => providerId === "claude-cli",
-}));
-
 vi.mock("../../tts/tts-settings.js", () => ({
   buildTtsSystemPromptHint: vi.fn(() => undefined),
 }));

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -25,7 +25,6 @@ import {
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import { resolveMcpLoopbackScopedTools } from "../../gateway/mcp-http.runtime.js";
 import { buildSystemAgentToolsMcpServerConfig } from "../../mcp/openclaw-tools-serve-config.js";
-import { isClaudeCliProvider } from "../../plugin-sdk/anthropic-cli.js";
 import type {
   CliBackendAuthEpochMode,
   CliBackendPreparedExecution,
@@ -101,7 +100,7 @@ import {
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { getClaudeLiveSessionGenerationForOwner } from "./claude-live-session.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
-import { buildCliAgentSystemPrompt, normalizeCliModel } from "./helpers.js";
+import { buildCliAgentSystemPrompt, isClaudeCliProvider, normalizeCliModel } from "./helpers.js";
 import { cliBackendLog } from "./log.js";
 import {
   buildCliMcpBashElevated,


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational CI bottleneck where `src/agents/cli-runner.reliability.test.ts` spent roughly 245 seconds importing modules while its 79 tests ran in under two seconds. The file set the floor for compact PR CI even after shard rebalancing isolated it.

## Why This Change Was Made

Vitest import profiling traced 185.93 seconds of self-time to `src/plugin-sdk/anthropic-cli.ts`, reached because CLI run preparation imported the public Anthropic facade for a pure provider-id predicate. Preparation now reuses the equivalent runtime-free predicate already owned by `cli-runner/helpers.ts`; the obsolete test facade mock is removed, and compact CI timing hints are refreshed for the new LPT stripe layout.

## User Impact

No product behavior changes. Pull requests touching the compact Node test matrix no longer wait roughly four minutes for this test file's import graph.

## Evidence

- Before, Blacksmith Testbox: 79/79 passed; duration 207.05s, import 205.07s, tests 1.20s. Import breakdown: `src/plugin-sdk/anthropic-cli.ts` 185.93s self-time.
- After, same Testbox: 79/79 passed; duration 5.09s, import 3.77s, tests 1.06s.
- Focused proof: `cli-runner.reliability.test.ts`, `cli-runner/prepare.test.ts`, and `ci-node-test-plan.test.ts`: 253/253 tests passed.
- `pnpm check:changed`: passed.
- `pnpm build`: passed.
- Autoreview: clean, no accepted/actionable findings.
- Testbox: https://github.com/openclaw/openclaw/actions/runs/29562418095

AI-assisted: Codex. Maintainer reviewed the implementation and evidence.
