### PR TITLE
chore(channels): mark the legacy plan-step wire branch for removal

### DIFF
--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -193,8 +193,10 @@ function isAgentPlanStepStatus(value: unknown): value is AgentPlanStepStatus {
 }
 
 /**
- * Older installed @openclaw/codex releases emit plan steps as strings.
- * Normalize that external-plugin version skew to pending typed steps.
+ * TODO(remove): normalizes the pre-2026.7.2 string plan-step wire shape to
+ * pending typed steps. Bundled producers all emit typed steps, and
+ * @openclaw/codex is force-updated with core, so this only covers a plugin
+ * pinned against an update. Delete once that cannot happen.
  */
 export function normalizeAgentPlanSteps(value: unknown): AgentPlanStep[] | undefined {
   if (!Array.isArray(value)) {


### PR DESCRIPTION
## What Problem This Solves

`normalizeAgentPlanSteps` keeps a branch that maps legacy string plan steps (`"step (status)"`, the pre-2026.7.2 wire shape) to typed pending steps. Its comment justified this as permanent tolerance for `@openclaw/codex` version skew — but that plugin is force-updated together with core, so that rationale is wrong and would have quietly turned a temporary shim into standing architecture.

## Why This Change Was Made

Comment-only correction. The branch stays for now — it still covers a plugin deliberately pinned against an update — but it is now recorded as a `TODO(remove)` naming the real (narrow) condition, so the next person deletes it instead of preserving it as a contract.

## User Impact

None. No behavior, API, or config change.

## Evidence

- `node scripts/run-vitest.mjs src/channels/streaming.test.ts` — 19 passed (legacy-string normalization coverage unchanged).
- Comment-only diff; `pnpm format` clean.
