### PR TITLE
fix(anthropic): surface HTTP response body in stream error messages

### DIFF
--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -2776,5 +2776,30 @@ describe("Anthropic provider", () => {
       expect(capturedPayload).not.toHaveProperty("output_config");
     }
   });
+
+  it("surfaces HTTP response body text from Anthropic-compatible errors", async () => {
+    // The SDK throws an APIError carrying status + body on 429/5xx; the stream
+    // must surface the body, not just the bare status message.
+    const error = Object.assign(new Error("529 status code (no body)"), {
+      status: 529,
+      body: "overloaded",
+    });
+    const client = {
+      messages: {
+        create: vi.fn(() => ({
+          asResponse: () => Promise.reject(error),
+        })),
+      },
+    };
+
+    const result = await streamAnthropic(
+      makeAnthropicModel(),
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+      { apiKey: "sk-ant-provider", client: client as never },
+    ).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("529: overloaded");
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -36,6 +36,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
+import { formatProviderError } from "../utils/provider-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   splitSystemPromptCacheBoundary,
@@ -800,7 +801,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         output.content = [];
       }
       output.stopReason = requestOptions?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      output.errorMessage = formatProviderError(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     }


### PR DESCRIPTION
## What Problem This Solves

`streamAnthropic` (in `packages/ai/src/providers/anthropic.ts`) builds `output.errorMessage` in its catch block from the bare error message. For an SDK HTTP error this collapses to a status-only string like "529 status code (no body)" and drops the response body that carries the real failure reason, so Anthropic 429/overloaded/5xx failures are hard to diagnose from the surfaced error.

PR #109556 introduced `formatProviderError` and applied it to `google-shared.ts` and `openai-completions.ts` to surface HTTP status + body as "<status>: <body>". The anthropic provider's catch block is the same shape but was missed in that pass. This adopts the helper there so Anthropic matches the other OpenAI-compatible providers; non-HTTP errors keep their existing message via the helper's fallback path.

## Evidence

- The fix replaces `error instanceof Error ? error.message : JSON.stringify(error)` with `formatProviderError(error)` in the `streamAnthropic` catch block, mirroring the one-line change #109556 made in google-shared.ts:472 and openai-completions.ts:564.
- Local vitest run of `packages/ai/src/providers/anthropic.test.ts` is green: 70 passed (70), including a new regression case.
- New regression test throws a 529 error carrying a body and asserts the stream error message is `"529: overloaded"` (previously it would have been `"529 status code (no body)"`).

```ts
output.errorMessage = formatProviderError(error);
```

```
 Test Files  1 passed (1)
      Tests  70 passed (70)
```

Sibling of #109556 (same formatProviderError helper, same catch-block shape); applies it to the anthropic provider that the original pass missed.
