### PR TITLE
perf(test): poll Chrome MCP state faster

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -43,6 +43,10 @@ type ToolCallMock = {
   };
 };
 
+function waitForChromeMcpState<T>(assertion: () => T | Promise<T>): Promise<T> {
+  return vi.waitFor(assertion, { interval: 1 });
+}
+
 function createSdkTimeoutCallTool() {
   return vi.fn(
     async (_call: ToolCall, _resultSchema?: unknown, options?: { timeout?: number }) =>
@@ -1929,12 +1933,12 @@ describe("chrome MCP page parsing", () => {
     });
     const tabsExpectation = expect(tabsPromise).rejects.toThrow(/caller cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
     releaseFactory();
 
     await tabsExpectation;
-    await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMock).toHaveBeenCalledTimes(1));
     expect(factoryCalls).toBe(1);
   });
 
@@ -1973,7 +1977,7 @@ describe("chrome MCP page parsing", () => {
     const ctrl = new AbortController();
     const tabsPromise = listChromeMcpTabs("chrome-live", undefined, { signal: ctrl.signal });
     const tabsExpectation = expect(tabsPromise).rejects.toThrow("caller cancelled");
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
@@ -2016,7 +2020,7 @@ describe("chrome MCP page parsing", () => {
     const ctrl = new AbortController();
     const aborted = listChromeMcpTabs("chrome-live", undefined, { signal: ctrl.signal });
     const abortedExpectation = expect(aborted).rejects.toThrow("pending cleanup failed");
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
 
     const blockedReplacement = listChromeMcpTabs("chrome-live");
@@ -2064,7 +2068,7 @@ describe("chrome MCP page parsing", () => {
     });
     const abortedTabsExpectation = expect(abortedTabsPromise).rejects.toThrow(/caller cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
 
     const tabsPromise = listChromeMcpTabs("chrome-live");
@@ -2074,8 +2078,8 @@ describe("chrome MCP page parsing", () => {
     expect(factoryCalls).toBe(1);
     releaseFactories[0]?.();
     await abortedTabsExpectation;
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
-    await vi.waitFor(() => expect(factoryCalls).toBe(2));
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(2));
     releaseFactories[1]?.();
 
     await expect(tabsPromise).resolves.toHaveLength(2);
@@ -2113,10 +2117,10 @@ describe("chrome MCP page parsing", () => {
     const ctrl = new AbortController();
     const cancelled = listChromeMcpTabs("chrome-live", undefined, { signal: ctrl.signal });
     const cancelledExpectation = expect(cancelled).rejects.toThrow("caller cancelled");
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
     releaseFactory();
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledOnce());
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalledOnce());
 
     const probe = ensureChromeMcpAvailable("chrome-live", undefined, { ephemeral: true });
     await new Promise<void>((resolve) => {
@@ -2157,12 +2161,12 @@ describe("chrome MCP page parsing", () => {
     });
     const tabsExpectation = expect(tabsPromise).rejects.toThrow(/caller cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
     releaseReady();
 
     await tabsExpectation;
-    await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMock).toHaveBeenCalledTimes(1));
   });
 
   it("waits for last-waiter cleanup before starting a replacement session", async () => {
@@ -2200,9 +2204,9 @@ describe("chrome MCP page parsing", () => {
     });
     const abortedTabsExpectation = expect(abortedTabsPromise).rejects.toThrow(/caller cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
 
     const tabsPromise = listChromeMcpTabs("chrome-live");
     await new Promise<void>((resolve) => {
@@ -2212,7 +2216,7 @@ describe("chrome MCP page parsing", () => {
 
     releaseFirstClose();
     await abortedTabsExpectation;
-    await vi.waitFor(() => expect(factoryCalls).toBe(2));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(2));
     await expect(tabsPromise).resolves.toHaveLength(2);
     expect(closeMocks[1]).not.toHaveBeenCalled();
   });
@@ -2245,13 +2249,13 @@ describe("chrome MCP page parsing", () => {
     const abortedTabsExpectation =
       expect(abortedTabsPromise).rejects.toThrow(/first caller cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
-    await vi.waitFor(() => expect(readyThen).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(readyThen).toHaveBeenCalledTimes(1));
     const keptCtrl = new AbortController();
     const tabsPromise = listChromeMcpTabs("chrome-live", undefined, {
       signal: keptCtrl.signal,
     });
-    await vi.waitFor(() => expect(readyThen).toHaveBeenCalledTimes(2));
+    await waitForChromeMcpState(() => expect(readyThen).toHaveBeenCalledTimes(2));
     ctrl.abort(new Error("first caller cancelled"));
     releaseReady();
 
@@ -2295,8 +2299,8 @@ describe("chrome MCP page parsing", () => {
     });
     const firstTabsExpectation = expect(firstTabsPromise).rejects.toThrow(/first waiter cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
-    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
     if (!firstSession) {
       throw new Error("Expected first Chrome MCP session to be created");
     }
@@ -2306,13 +2310,13 @@ describe("chrome MCP page parsing", () => {
     const siblingTabsPromise = listChromeMcpTabs("chrome-live");
     ctrl.abort(new Error("first waiter cancelled"));
     releaseFirstReady();
-    await vi.waitFor(() => expect(factoryCalls).toBe(2));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(2));
     const [tabs, siblingTabs] = await Promise.all([tabsPromise, siblingTabsPromise]);
     expect(tabs).toHaveLength(2);
     expect(siblingTabs).toHaveLength(2);
 
     await firstTabsExpectation;
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
     expect(closeMocks[1]).not.toHaveBeenCalled();
   });
 
@@ -2337,7 +2341,7 @@ describe("chrome MCP page parsing", () => {
     await expect(listChromeMcpTabs("chrome-live")).rejects.toThrow(/startup failed/);
 
     expect(factoryCalls).toBe(1);
-    await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMock).toHaveBeenCalledTimes(1));
   });
 
   it("bounds retries when ready sessions keep losing their transport", async () => {
@@ -2359,8 +2363,8 @@ describe("chrome MCP page parsing", () => {
     );
 
     expect(factoryCalls).toBe(2);
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalled());
-    await vi.waitFor(() => expect(closeMocks[1]).toHaveBeenCalled());
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalled());
+    await waitForChromeMcpState(() => expect(closeMocks[1]).toHaveBeenCalled());
   });
 
   it("does not reuse a stale ready-pending session for ephemeral probes", async () => {
@@ -2397,8 +2401,8 @@ describe("chrome MCP page parsing", () => {
     const firstAvailableExpectation =
       expect(firstAvailablePromise).rejects.toThrow(/first waiter cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
-    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
     if (!firstSession) {
       throw new Error("Expected first Chrome MCP session to be created");
     }
@@ -2411,10 +2415,10 @@ describe("chrome MCP page parsing", () => {
     releaseFirstReady();
     await expect(availablePromise).resolves.toBeUndefined();
     expect(factoryCalls).toBe(2);
-    await vi.waitFor(() => expect(closeMocks[1]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMocks[1]).toHaveBeenCalledTimes(1));
 
     await firstAvailableExpectation;
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
   });
 
   it("does not let ephemeral probes persist canceled pending attaches", async () => {
@@ -2449,8 +2453,8 @@ describe("chrome MCP page parsing", () => {
     const firstAvailableExpectation =
       expect(firstAvailablePromise).rejects.toThrow(/first waiter cancelled/);
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
-    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
 
     await expect(
       ensureChromeMcpAvailable("chrome-live", undefined, {
@@ -2459,12 +2463,12 @@ describe("chrome MCP page parsing", () => {
     ).resolves.toBeUndefined();
     expect(factoryCalls).toBe(2);
     expect(firstReadyThen).toHaveBeenCalledTimes(1);
-    await vi.waitFor(() => expect(closeMocks[1]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMocks[1]).toHaveBeenCalledTimes(1));
 
     ctrl.abort(new Error("first waiter cancelled"));
     releaseFirstReady();
     await firstAvailableExpectation;
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
 
     await expect(listChromeMcpTabs("chrome-live")).resolves.toHaveLength(2);
     expect(factoryCalls).toBe(3);
@@ -2504,8 +2508,8 @@ describe("chrome MCP page parsing", () => {
       signal: keptCtrl.signal,
     });
 
-    await vi.waitFor(() => expect(factoryCalls).toBe(1));
-    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(2));
+    await waitForChromeMcpState(() => expect(factoryCalls).toBe(1));
+    await waitForChromeMcpState(() => expect(firstReadyThen).toHaveBeenCalledTimes(2));
     await timedOutTabsExpectation;
 
     const laterTabsPromise = listChromeMcpTabs("chrome-live");
@@ -2539,7 +2543,7 @@ describe("chrome MCP page parsing", () => {
         timeoutMs: 1,
       }),
     ).rejects.toThrow(/timed out/);
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    await waitForChromeMcpState(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
 
     await expect(listChromeMcpTabs("chrome-live")).resolves.toHaveLength(2);
     expect(factoryCalls).toBe(2);
@@ -3032,7 +3036,7 @@ describe("chrome MCP page parsing", () => {
       ephemeral: true,
       signal: ctrl.signal,
     });
-    await vi.waitFor(() => expect(factory).toHaveBeenCalledOnce());
+    await waitForChromeMcpState(() => expect(factory).toHaveBeenCalledOnce());
     ctrl.abort(new Error("status budget exhausted"));
 
     await expect(promise).rejects.toThrow(/status budget exhausted/);


### PR DESCRIPTION
## What Problem This Solves

The Chrome MCP suite used Vitest's 50 ms default polling interval in 36 asynchronous state assertions. The repeated latency dominated the 81-test file.

## Why This Change Was Made

Route those assertions through a test-local helper with a 1 ms interval. Preserve every assertion, Vitest's default timeout, and production behavior.

## User Impact

No user-visible or production behavior changes. Controlled same-Testbox median test-body time drops from 1.173 seconds to 217 milliseconds.

## Evidence

- Before: 1.286/1.075/1.173 seconds; median 1.173 seconds.
- After: 198/217/219 milliseconds; median 217 milliseconds (about 82% faster).
- Testbox `tbx_01kxqfnkr2v2z15rnr7a3x83y7`: 81/81 tests passed across all comparison runs.
- Same Testbox: `pnpm check:changed` passed.
- Autoreview: clean, 0.96 confidence.
