### PR TITLE
fix(coding-agent): isolate Codex CLI CODEX_HOME from OpenClaw OAuth in skill launch forms

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -50,6 +50,7 @@ Use for background feature builds, PR reviews, large refactors, and issue-to-PR 
 - Never checkout branches or run background coding agents in `~/Projects/openclaw`; use an isolated checkout.
 - Classify the source ref as trusted or untrusted before any checkout or worktree creation. Never materialize a contributor-controlled ref outside the repository's approved untrusted-PR sandbox/review workflow, and never launch a permission-bypassed worker in it.
 - For tasks that modify a Git-backed project, prepare and verify the Git worktree before launch, then include the exact Git preparation block below in the worker prompt.
+- When the same ChatGPT account is authenticated for both OpenClaw OAuth and Codex CLI (`~/.codex`), the two clients can invalidate each other's refresh tokens (`refresh_token_reused`). Isolate the Codex credential home: create a dedicated `CODEX_HOME` outside every Git worktree (`mkdir -p <safe-path> && chmod 700 <safe-path>`), run `CODEX_HOME=<safe-path> codex login` once, and prepend `CODEX_HOME=<safe-path>` to every `codex exec` launch below. Codex scopes CLI auth to `CODEX_HOME`, but the configured credential store may persist it in `$CODEX_HOME/auth.json`, the OS keyring, or a keyring-with-file-fallback mode; treat the home path and matching keyring entry as credentials and never stage or commit them. The runtime's bounded-turn path already isolates `CODEX_HOME`; this rule applies to the manual launch forms.
 
 ## Mandatory Git preparation
 
@@ -123,7 +124,7 @@ Use `$PROMPT` when launching from the same shell/session. If using a separate to
 Codex:
 
 ```bash
-bash pty:true background:true workdir:/path/isolated-worktree command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:/path/isolated-worktree command:"CODEX_HOME=/safe/path/.codex-isolated codex exec - < \"$PROMPT\""
 ```
 
 Claude Code:
@@ -153,13 +154,25 @@ Codex needs a trusted git repo. This throwaway scaffold is not project work and 
 ```bash
 SCRATCH=$(mktemp -d)
 git -C "$SCRATCH" init
+CODEX_HOME=$(mktemp -d)
+chmod 700 "$CODEX_HOME"
+CODEX_HOME=$CODEX_HOME codex login
 PROMPT=$(mktemp -t openclaw-worker-prompt.XXXXXX)
 cat >"$PROMPT" <<'EOF'
 Build X.
 <notification block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
-bash pty:true background:true workdir:$SCRATCH command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:$SCRATCH command:"CODEX_HOME=$CODEX_HOME codex exec - < \"$PROMPT\""
+```
+
+The scratch worker uses a dedicated, authenticated `CODEX_HOME` outside `$SCRATCH` (mode 700) so it never discovers the ambient `~/.codex` credential or places auth state inside a Git checkout. For repeated scratch workers, reuse a previously authenticated external home instead of creating a fresh empty one each time:
+
+```bash
+CODEX_HOME=/safe/path/.codex-isolated
+mkdir -p "$CODEX_HOME"
+chmod 700 "$CODEX_HOME"
+CODEX_HOME=$CODEX_HOME codex login
 ```
 
 ## Process actions


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users launching Codex workers from the bundled
`coding-agent` skill could reuse the ambient `~/.codex` ChatGPT OAuth state
that OpenClaw also depends on, which can leave one client failing with
`refresh_token_reused`.

Fixes #109704

## Why This Change Was Made

The manual Codex launch forms now require an authenticated `CODEX_HOME` outside
every Git worktree, and the scratch recipe logs in the isolated home before
running `codex exec`. The credential warning now matches Codex's supported
storage modes instead of implying that OAuth state is always in `auth.json`.

## User Impact

Users can run Codex background workers without placing Codex credentials in a
checkout or accidentally launching scratch workers from an empty auth store.

## Evidence

- Codex source inspection at `openai/codex@f2bee854a736`: `CODEX_HOME` is
  canonicalized as the configuration directory
  (`codex-rs/utils/home-dir/src/lib.rs:13-50`); file mode uses
  `$CODEX_HOME/auth.json`, while keyring and auto modes derive their key from
  the canonical Codex home and auto falls back to that file
  (`codex-rs/config/src/types.rs:104-117`,
  `codex-rs/login/src/auth/storage.rs:150-215,231-244,291-303,405-446`).
- Negative control: a fresh empty `CODEX_HOME` reports `Not logged in`, so the
  old scratch shape cannot complete an authenticated turn without login.
- Real production CLI call chain: a temporary Git repo plus an authenticated
  external `CODEX_HOME` completed `codex exec` and returned the requested
  message; the empty-home login-status run is the negative control.
- `pnpm docs:list`
- `git diff --check 521d05f290c2f86d3237db7b219de231a9975c10...HEAD`

```text
$ TMP_CODEX_HOME=$(mktemp -d); chmod 700 "$TMP_CODEX_HOME"; CODEX_HOME="$TMP_CODEX_HOME" codex login status
Not logged in

$ SCRATCH=$(mktemp -d); git -C "$SCRATCH" init
$ CODEX_HOME=<authenticated-external-home> codex login status
Logged in using ChatGPT
$ CODEX_HOME=<authenticated-external-home> codex exec --skip-git-repo-check -C <tmp-git-repo> --output-last-message <proof-output> 'Reply exactly: isolated-codex-home-ok'
workdir: <tmp-git-repo>
last_message:
isolated-codex-home-ok
```

AI-assisted: built with Codex
