### PR TITLE
fix(google): anchor OAuth credential regex patterns with word boundaries

### DIFF
--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -235,10 +235,10 @@ function parseGeminiCliCredentials(
 ): { clientId: string; clientSecret: string } | null {
   const clientId =
     content.match(/OAUTH_CLIENT_ID\s*=\s*["']([^"']+)["']/)?.[1] ??
-    content.match(/(\d+-[a-z0-9]+\.apps\.googleusercontent\.com)/)?.[1];
+    content.match(/\b(\d+-[a-z0-9]+\.apps\.googleusercontent\.com)\b/)?.[1];
   const clientSecret =
     content.match(/OAUTH_CLIENT_SECRET\s*=\s*["']([^"']+)["']/)?.[1] ??
-    content.match(/(GOCSPX-[A-Za-z0-9_-]+)/)?.[1];
+    content.match(/\b(GOCSPX-[A-Za-z0-9_-]+)\b/)?.[1];
   if (!clientId || !clientSecret) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

The fallback regex patterns for parsing Gemini CLI credentials lacked anchors, allowing a crafted input string to embed a credential-like substring and pass the match.

## Why This Change Was Made

- Add `\b` word boundaries to the client-id pattern.
- Add `\b` word boundaries to the client-secret pattern.
- Prevents substring embedding bypass in credential extraction.

## Risk / Compatibility

Low. Word boundaries only restrict the match to complete tokens — valid credential strings are unaffected. The primary OAUTH_CLIENT_ID/OAUTH_CLIENT_SECRET env-var patterns are unchanged.

AI-assisted: contributor patch used coding agents.