### PR TITLE
fix(voice-call): validate ngrok hostname via URL parsing instead of substring match

### DIFF
--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -737,6 +737,38 @@ describe("verifyTwilioWebhook", () => {
     expect(result.isNgrokFreeTier).toBe(true);
   });
 
+  it("does not classify query-injected ngrok substrings as ngrok free tier", () => {
+    const result = verifyTwilioWebhook(
+      {
+        headers: { host: "evil.example", "x-twilio-signature": "invalid" },
+        rawBody: "CallSid=CS123&CallStatus=completed",
+        url: "http://evil.example/voice/webhook?x=.ngrok.io",
+        method: "POST",
+      },
+      "test-auth-token",
+    );
+
+    expect(result.ok).toBe(false);
+    // Query injection must not bypass the hostname-only ngrok check.
+    expect(result.isNgrokFreeTier).toBe(false);
+  });
+
+  it("does not classify path-injected ngrok substrings as ngrok free tier", () => {
+    const result = verifyTwilioWebhook(
+      {
+        headers: { host: "evil.example", "x-twilio-signature": "invalid" },
+        rawBody: "CallSid=CS123&CallStatus=completed",
+        url: "http://evil.example/x.ngrok-free.app/webhook",
+        method: "POST",
+      },
+      "test-auth-token",
+    );
+
+    expect(result.ok).toBe(false);
+    // Path injection must not bypass the hostname-only ngrok check.
+    expect(result.isNgrokFreeTier).toBe(false);
+  });
+
   it("ignores attacker X-Forwarded-Host without allowedHosts or trustForwardingHeaders", () => {
     const authToken = "test-auth-token";
     const postBody = "CallSid=CS123&CallStatus=completed&From=%2B15550000000";

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -629,9 +629,15 @@ export function verifyTwilioWebhook(
     return { ok: true, verificationUrl: candidateUrl, isReplay, verifiedRequestKey: replayKey };
   }
 
-  // Check if this is ngrok free tier - the URL might have different format
-  const isNgrokFreeTier =
-    verificationUrl.includes(".ngrok-free.app") || verificationUrl.includes(".ngrok.io");
+  // Check if this is ngrok free tier — validate via hostname to avoid
+  // substring-match bypass on the path, query, or fragment.
+  let isNgrokFreeTier = false;
+  try {
+    const hostname = new URL(verificationUrl).hostname;
+    isNgrokFreeTier = hostname.endsWith(".ngrok-free.app") || hostname.endsWith(".ngrok.io");
+  } catch {
+    // verificationUrl may not be parseable as a URL; leave isNgrokFreeTier false.
+  }
   const diagnosticVerificationUrl = redactTwilioVerificationUrlForDiagnostics(verificationUrl);
 
   return {


### PR DESCRIPTION
## Problem
ngrok free-tier detection uses a substring match (`verificationUrl.includes(.ngrok-free.app) || verificationUrl.includes(.ngrok.io)`) — a URL like `https://evil.example/?x=.ngrok.io` bypasses signature verification, mis-classifying the request as ngrok free tier even though the hostname is not an ngrok domain.

## Fix
Replace substring match with URL-parsed hostname validation (`new URL(verificationUrl).hostname.endsWith(...)`). Non-parseable URLs leave `isNgrokFreeTier=false` (safe default).

## Evidence

**Focused regression tests (31/31 passing):**
```
$ node scripts/run-vitest.mjs extensions/voice-call/src/webhook-security.test.ts
  Tests  31 passed — incl. query and path injection cases:
    ✓ does not classify query-injected ngrok substrings as ngrok free tier
    ✓ does not classify path-injected ngrok substrings as ngrok free tier
    ✓ accepts valid signatures for ngrok free tier (existing)
    ✓ does not allow invalid signatures for ngrok free tier (existing)
```

oxfmt, oxlint, tsgo extensions prod+test types all pass.

**Real behavior proof — production module, no mocks:**
```
$ node --import tsx proof.mts
== production verifyTwilioWebhook ngrok classification ==
legit ngrok-free host                  -> isNgrokFreeTier=true
legit ngrok.io host                    -> isNgrokFreeTier=true
query injection (?x=.ngrok.io)         -> isNgrokFreeTier=false
path injection (/x.ngrok-free.app/)    -> isNgrokFreeTier=false
query injection (?u=https://a.ngrok...) -> isNgrokFreeTier=false
```
