### PR TITLE
fix(signal): reject non-decimal status reaction ids

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -10,6 +10,9 @@ vi.useRealTimers();
 let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
 let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
 let createSignalEventHandler: typeof import("./event-handler.js").createSignalEventHandler;
+let resolveSignalStatusReactionTimestamp: typeof import(
+  "./event-handler.js"
+).resolveSignalStatusReactionTimestamp;
 
 type DispatchInboundMessageMockParams = {
   ctx: MsgContext;
@@ -212,8 +215,10 @@ function nextTimerTick(): Promise<void> {
 
 describe("signal createSignalEventHandler inbound context", () => {
   beforeAll(async () => {
-    [{ createBaseSignalEventHandlerDeps, createSignalReceiveEvent }, { createSignalEventHandler }] =
-      await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
+    [
+      { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
+      { createSignalEventHandler, resolveSignalStatusReactionTimestamp },
+    ] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
   });
 
   beforeEach(() => {
@@ -941,6 +946,24 @@ describe("signal createSignalEventHandler inbound context", () => {
         baseUrl: "http://localhost",
       }),
     );
+  });
+
+  it("uses canonical decimal message ids for Signal status reaction timestamp fallback", () => {
+    expect(resolveSignalStatusReactionTimestamp({ messageId: "1700000000002" })).toBe(
+      1700000000002,
+    );
+  });
+
+  it("rejects non-decimal message ids for Signal status reaction timestamp fallback", () => {
+    for (const messageId of [
+      "0x10",
+      "1e3",
+      "01700000000002",
+      "1700000000002.5",
+      "9007199254740993",
+    ]) {
+      expect(resolveSignalStatusReactionTimestamp({ messageId })).toBeNull();
+    }
   });
 
   it("does not send Signal status reactions without an inbound timestamp", async () => {

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -10,9 +10,6 @@ vi.useRealTimers();
 let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
 let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
 let createSignalEventHandler: typeof import("./event-handler.js").createSignalEventHandler;
-let resolveSignalStatusReactionTimestamp: typeof import(
-  "./event-handler.js"
-).resolveSignalStatusReactionTimestamp;
 
 type DispatchInboundMessageMockParams = {
   ctx: MsgContext;
@@ -215,10 +212,8 @@ function nextTimerTick(): Promise<void> {
 
 describe("signal createSignalEventHandler inbound context", () => {
   beforeAll(async () => {
-    [
-      { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
-      { createSignalEventHandler, resolveSignalStatusReactionTimestamp },
-    ] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
+    [{ createBaseSignalEventHandlerDeps, createSignalReceiveEvent }, { createSignalEventHandler }] =
+      await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
   });
 
   beforeEach(() => {
@@ -946,24 +941,6 @@ describe("signal createSignalEventHandler inbound context", () => {
         baseUrl: "http://localhost",
       }),
     );
-  });
-
-  it("uses canonical decimal message ids for Signal status reaction timestamp fallback", () => {
-    expect(resolveSignalStatusReactionTimestamp({ messageId: "1700000000002" })).toBe(
-      1700000000002,
-    );
-  });
-
-  it("rejects non-decimal message ids for Signal status reaction timestamp fallback", () => {
-    for (const messageId of [
-      "0x10",
-      "1e3",
-      "01700000000002",
-      "1700000000002.5",
-      "9007199254740993",
-    ]) {
-      expect(resolveSignalStatusReactionTimestamp({ messageId })).toBeNull();
-    }
   });
 
   it("does not send Signal status reactions without an inbound timestamp", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -144,23 +144,11 @@ function resolveSignalInboundRoute(params: {
   });
 }
 
-const SIGNAL_CANONICAL_DECIMAL_TIMESTAMP_RE = /^[1-9]\d*$/u;
-
-export function resolveSignalStatusReactionTimestamp(params: {
-  timestamp?: number;
-  messageId?: string;
-}): number | null {
+function resolveSignalStatusReactionTimestamp(params: { timestamp?: number }): number | null {
   if (typeof params.timestamp === "number") {
     return Number.isFinite(params.timestamp) && params.timestamp > 0 ? params.timestamp : null;
   }
-  if (
-    typeof params.messageId !== "string" ||
-    !SIGNAL_CANONICAL_DECIMAL_TIMESTAMP_RE.test(params.messageId)
-  ) {
-    return null;
-  }
-  const parsed = Number(params.messageId);
-  return Number.isSafeInteger(parsed) ? parsed : null;
+  return null;
 }
 
 type SignalStatusDispatchResult = {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -144,15 +144,23 @@ function resolveSignalInboundRoute(params: {
   });
 }
 
-function resolveSignalStatusReactionTimestamp(params: {
+const SIGNAL_CANONICAL_DECIMAL_TIMESTAMP_RE = /^[1-9]\d*$/u;
+
+export function resolveSignalStatusReactionTimestamp(params: {
   timestamp?: number;
   messageId?: string;
 }): number | null {
   if (typeof params.timestamp === "number") {
     return Number.isFinite(params.timestamp) && params.timestamp > 0 ? params.timestamp : null;
   }
+  if (
+    typeof params.messageId !== "string" ||
+    !SIGNAL_CANONICAL_DECIMAL_TIMESTAMP_RE.test(params.messageId)
+  ) {
+    return null;
+  }
   const parsed = Number(params.messageId);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 type SignalStatusDispatchResult = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Signal status-reaction handling kept a secondary message-ID timestamp fallback that is not reachable from the current Signal receive path. The fallback made the status-reaction target look broader than the real runtime contract and could not be proven with a real Signal event.

## Why This Change Was Made

Signal status reactions now use only the native inbound numeric timestamp that the receive handler already derives from the envelope or dataMessage timestamp. The artificial message-ID fallback and its helper-only tests were removed, while the existing handler-level tests continue to cover dataMessage timestamp fallback and the no-timestamp no-reaction path.

Related independent bug-family PRs: this is part of strict numeric parser PRs and is independent/not stacked/no merge dependency.

## User Impact

Signal users keep the supported status-reaction behavior for real inbound timestamps, and the implementation no longer preserves an unproven alternate timestamp source.

## Evidence

Head: b5bc0d3c464

- `node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.inbound-context.test.ts` -> 1 file passed, 47 tests passed.
- `git diff --check` -> passed with no whitespace errors.