### PR TITLE
fix(ai): preserve Unicode in provider error bodies

### DIFF
--- a/packages/ai/src/utils/provider-error.test.ts
+++ b/packages/ai/src/utils/provider-error.test.ts
@@ -34,4 +34,11 @@ describe("formatProviderError", () => {
 
     expect(formatProviderError(error)).toBe(body);
   });
+
+  it("does not split surrogate pairs when truncating response bodies", () => {
+    const body = `${"x".repeat(3999)}😀tail`;
+    const error = Object.assign(new Error("502 status code (no body)"), { status: 502, body });
+
+    expect(formatProviderError(error)).toBe(`502: ${"x".repeat(3999)}... [truncated]`);
+  });
 });

--- a/packages/ai/src/utils/provider-error.ts
+++ b/packages/ai/src/utils/provider-error.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 const MAX_ERROR_BODY_LENGTH = 4000;
 
 type HttpErrorShape = Error & {
@@ -47,7 +49,7 @@ function readBody(error: HttpErrorShape): string | undefined {
     if (body.length > 0) {
       return body.length <= MAX_ERROR_BODY_LENGTH
         ? body
-        : `${body.slice(0, MAX_ERROR_BODY_LENGTH)}... [truncated]`;
+        : `${truncateUtf16Safe(body, MAX_ERROR_BODY_LENGTH)}... [truncated]`;
     }
   }
   return undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could receive malformed provider error text when an external API response body placed an emoji or another non-BMP character at the truncation boundary.

## Why This Change Was Made

The shared provider-error formatter now uses the existing UTF-16-safe truncation helper instead of splitting the string at an arbitrary code unit. This keeps the existing 4,000-code-unit cap and output format unchanged while preventing lone surrogates.

## User Impact

Provider failures continue to include a bounded response-body excerpt, but the excerpt is now valid Unicode even when the boundary falls inside an emoji.

## Evidence

- Added a focused regression case with 3,999 ASCII code units followed by an emoji, reproducing the exact split boundary.
- Node 24 Docker proof: `node scripts/run-vitest.mjs packages/ai/src/utils/provider-error.test.ts` passed 1 file / 5 tests.
- `git diff --check` and targeted `oxfmt` passed.
- Fresh branch autoreview against current `upstream/main` completed with no actionable findings.

### Exact-head installed-package and provider-adapter proof

- Secretless fork CI [run 29718185603](https://github.com/Leon-SK668/openclaw/actions/runs/29718185603/job/88275446466) checked out and asserted the immutable PR head `0032b79886ea9915e28d177d412bddd0719be677` before executing repository code.
- Under Node `v24.15.0` and the repository-pinned pnpm `11.2.2`, it built `packages/ai/dist`, packed `@openclaw/ai`, and installed the tarball with scripts disabled into an empty consumer.
- The build emitted 63 files and the tarball SHA-256 is `3cb82cf5b893e31964471a9fa34567f943e8ff08518b7c5d2391d3fe77bd5b4f`.
- Neither the built nor installed package retained an `@openclaw/normalization-core` import, and the empty consumer did not contain that workspace package.
- The installed public `@openclaw/ai/internal/openai` entry then ran `streamSimpleOpenAICompletions` against a deterministic loopback OpenAI-compatible HTTP endpoint. The adapter sent `/v1/chat/completions`; the endpoint returned a 502 JSON error with the emoji's high surrogate at serialized code-unit index 3,999.

Redacted exact-head output:

```text
PACKAGED_PROVIDER_PROOF_109786 {"head":"0032b79886ea9915e28d177d412bddd0719be677","node":"v24.15.0","packageEntry":"@openclaw/ai/internal/openai","requestPath":"/v1/chat/completions","serializedErrorBoundary":3999,"stopReason":"error","errorMessageLength":4019,"endsWithTruncationMarker":true,"hasLoneSurrogate":false,"boundarySuffix":"xxxxxxxxxxxxxxxxx... [truncated]"}
PACKAGED_PROVIDER_ARTIFACT_109786 {"head":"0032b79886ea9915e28d177d412bddd0719be677","distFiles":"63","tarballSha256":"3cb82cf5b893e31964471a9fa34567f943e8ff08518b7c5d2391d3fe77bd5b4f"}
```

This is an installed-package and real provider-adapter HTTP-path probe using a local deterministic error endpoint. It does not claim an external provider credential run.

This PR was prepared with AI assistance; the behavior, dependency boundary, diff, and test evidence were reviewed before submission.
