### PR TITLE
fix: order ambient transcript watermarks by decimal ids

### DIFF
--- a/extensions/telegram/src/group-history-window.ts
+++ b/extensions/telegram/src/group-history-window.ts
@@ -50,12 +50,23 @@ function telegramHistoryEntryKey(entry: HistoryEntry): string | undefined {
   return undefined;
 }
 
-function numericMessageId(value: string | undefined): number | undefined {
-  if (!value?.trim()) {
+function numericMessageId(value: string | undefined): bigint | undefined {
+  if (!value || !/^(?:0|[1-9]\d*)$/.test(value)) {
     return undefined;
   }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  return BigInt(value);
+}
+
+function compareMessageIds(left: string | undefined, right: string | undefined): number {
+  if (left === undefined || right === undefined) {
+    return left === right ? 0 : left === undefined ? -1 : 1;
+  }
+  const leftMessageId = numericMessageId(left);
+  const rightMessageId = numericMessageId(right);
+  if (leftMessageId !== undefined && rightMessageId !== undefined) {
+    return leftMessageId === rightMessageId ? 0 : leftMessageId > rightMessageId ? 1 : -1;
+  }
+  return left === right ? 0 : left > right ? 1 : -1;
 }
 
 export function isTelegramHistoryEntryAfterAmbientWatermark(
@@ -70,20 +81,9 @@ export function isTelegramHistoryEntryAfterAmbientWatermark(
     if (entry.timestamp !== watermark.timestampMs) {
       return entry.timestamp > watermark.timestampMs;
     }
-    const entryMessageId = numericMessageId(entry.messageId);
-    const watermarkMessageId = numericMessageId(watermark.messageId);
-    return (
-      entryMessageId !== undefined &&
-      watermarkMessageId !== undefined &&
-      entryMessageId > watermarkMessageId
-    );
+    return compareMessageIds(entry.messageId, watermark.messageId) > 0;
   }
-  const entryMessageId = numericMessageId(entry.messageId);
-  const watermarkMessageId = numericMessageId(watermark.messageId);
-  if (entryMessageId !== undefined && watermarkMessageId !== undefined) {
-    return entryMessageId > watermarkMessageId;
-  }
-  return entry.messageId !== watermark.messageId;
+  return compareMessageIds(entry.messageId, watermark.messageId) > 0;
 }
 
 function telegramChatWindowPayload(

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -1264,6 +1264,46 @@ describe("telegram message cache", () => {
     expect(context.map((entry) => entry.node.body)).toContain("unpersisted gap");
   });
 
+  it("uses a stable same-timestamp boundary for non-decimal ambient watermark ids", () => {
+    const watermark = {
+      messageId: "b",
+      timestampMs: 1_700_000_001_000,
+      sessionId: "session-current",
+      updatedAt: 1_700_000_002_000,
+    };
+
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "a", timestamp: 1_700_000_001_000 },
+        watermark,
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "b", timestamp: 1_700_000_001_000 },
+        watermark,
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "c", timestamp: 1_700_000_001_000 },
+        watermark,
+      ),
+    ).toBe(true);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "1000", timestamp: 1_700_000_001_000 },
+        { ...watermark, messageId: "999" },
+      ),
+    ).toBe(true);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "1e3", timestamp: 1_700_000_001_000 },
+        { ...watermark, messageId: "999" },
+      ),
+    ).toBe(false);
+  });
+
   it("does not select messages before the latest session reset command", async () => {
     const cache = createTelegramMessageCache();
     const beforeSession = Date.parse("2026-05-10T12:40:00.000Z");

--- a/src/config/sessions/ambient-transcript-watermark.test.ts
+++ b/src/config/sessions/ambient-transcript-watermark.test.ts
@@ -148,5 +148,10 @@ describe("ambient transcript watermark", () => {
     await expect(updateMessageId("18")).resolves.toBe("18");
     await expect(updateMessageId("1e3")).resolves.toBe("1e3");
     await expect(updateMessageId("999")).resolves.toBe("999");
+    await expect(updateMessageId("1e3")).resolves.toBe("999");
+    await expect(updateMessageId("0999")).resolves.toBe("999");
+    await expect(updateMessageId("a")).resolves.toBe("a");
+    await expect(updateMessageId("b")).resolves.toBe("b");
+    await expect(updateMessageId("a")).resolves.toBe("b");
   });
 });

--- a/src/config/sessions/ambient-transcript-watermark.test.ts
+++ b/src/config/sessions/ambient-transcript-watermark.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   readAmbientTranscriptWatermark,
   resolveAmbientTranscriptWatermarkKey,
@@ -25,7 +26,8 @@ describe("ambient transcript watermark", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    closeOpenClawAgentDatabasesForTest();
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
   });
 
   it("stamps and resolves the watermark for the current session id only", async () => {
@@ -120,5 +122,31 @@ describe("ambient transcript watermark", () => {
     expect(
       readAmbientTranscriptWatermark(loadSessionEntry({ sessionKey, storePath }), key),
     ).toBeUndefined();
+  });
+
+  it("orders only canonical decimal message ids numerically within a timestamp", async () => {
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      { sessionId: "current-session", updatedAt: 1_700_000_000_000 },
+    );
+
+    const updateMessageId = async (messageId: string) => {
+      await updateAmbientTranscriptWatermark({
+        storePath,
+        sessionKey,
+        key,
+        messageId,
+        timestampMs: 1_700_000_001_000,
+      });
+      return loadSessionEntry({ sessionKey, storePath })?.ambientTranscriptWatermarks?.[key]
+        ?.messageId;
+    };
+
+    await expect(updateMessageId("0x12")).resolves.toBe("0x12");
+    await expect(updateMessageId("17")).resolves.toBe("17");
+    await expect(updateMessageId("16")).resolves.toBe("17");
+    await expect(updateMessageId("18")).resolves.toBe("18");
+    await expect(updateMessageId("1e3")).resolves.toBe("1e3");
+    await expect(updateMessageId("999")).resolves.toBe("999");
   });
 });

--- a/src/config/sessions/ambient-transcript-watermark.ts
+++ b/src/config/sessions/ambient-transcript-watermark.ts
@@ -26,6 +26,15 @@ function numericMessageId(value: string): bigint | undefined {
   return BigInt(value);
 }
 
+function compareMessageIds(left: string, right: string): number {
+  const leftMessageId = numericMessageId(left);
+  const rightMessageId = numericMessageId(right);
+  if (leftMessageId !== undefined && rightMessageId !== undefined) {
+    return leftMessageId === rightMessageId ? 0 : leftMessageId > rightMessageId ? 1 : -1;
+  }
+  return left === right ? 0 : left > right ? 1 : -1;
+}
+
 function isAmbientTranscriptWatermarkAfter(
   next: Pick<AmbientTranscriptWatermark, "messageId" | "timestampMs">,
   current: AmbientTranscriptWatermark | undefined,
@@ -37,19 +46,9 @@ function isAmbientTranscriptWatermarkAfter(
     if (next.timestampMs !== current.timestampMs) {
       return next.timestampMs > current.timestampMs;
     }
-    const nextMessageId = numericMessageId(next.messageId);
-    const currentMessageId = numericMessageId(current.messageId);
-    if (nextMessageId !== undefined && currentMessageId !== undefined) {
-      return nextMessageId > currentMessageId;
-    }
-    return next.messageId !== current.messageId;
+    return compareMessageIds(next.messageId, current.messageId) > 0;
   }
-  const nextMessageId = numericMessageId(next.messageId);
-  const currentMessageId = numericMessageId(current.messageId);
-  if (nextMessageId !== undefined && currentMessageId !== undefined) {
-    return nextMessageId > currentMessageId;
-  }
-  return next.messageId !== current.messageId;
+  return compareMessageIds(next.messageId, current.messageId) > 0;
 }
 
 export function readAmbientTranscriptWatermark(

--- a/src/config/sessions/ambient-transcript-watermark.ts
+++ b/src/config/sessions/ambient-transcript-watermark.ts
@@ -19,9 +19,11 @@ export function resolveAmbientTranscriptWatermarkKey(
   ]);
 }
 
-function numericMessageId(value: string): number | undefined {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+function numericMessageId(value: string): bigint | undefined {
+  if (!/^(?:0|[1-9]\d*)$/.test(value)) {
+    return undefined;
+  }
+  return BigInt(value);
 }
 
 function isAmbientTranscriptWatermarkAfter(
@@ -37,11 +39,10 @@ function isAmbientTranscriptWatermarkAfter(
     }
     const nextMessageId = numericMessageId(next.messageId);
     const currentMessageId = numericMessageId(current.messageId);
-    return (
-      nextMessageId !== undefined &&
-      currentMessageId !== undefined &&
-      nextMessageId > currentMessageId
-    );
+    if (nextMessageId !== undefined && currentMessageId !== undefined) {
+      return nextMessageId > currentMessageId;
+    }
+    return next.messageId !== current.messageId;
   }
   const nextMessageId = numericMessageId(next.messageId);
   const currentMessageId = numericMessageId(current.messageId);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ambient transcript watermarks could treat non-decimal message ids such as `0x12` or `1e3` as ordered numbers when multiple messages share the same timestamp. That could advance or suppress the watermark using a numeric interpretation the channel did not actually provide.

## Why This Change Was Made

Watermark comparison now uses numeric ordering only for canonical non-negative decimal integer message ids. Other ids use a stable string boundary in both watermark persistence and Telegram history filtering, so equal-timestamp replay cannot move the stored boundary backward just because a different non-decimal id appears.

## User Impact

Users and operators get more reliable ambient transcript replay boundaries for channels that emit message ids that look numeric but are not canonical decimal integers.

## Evidence

Current head: `2860f40f5dfb4b918393cc4a7949a19dce6a6333`

- GitHub `Real behavior proof` passed on the current head: https://github.com/openclaw/openclaw/actions/runs/29612810770/job/87991156445
- Focused regression suite: `node scripts/run-vitest.mjs src/config/sessions/ambient-transcript-watermark.test.ts extensions/telegram/src/message-cache.test.ts` passed 31 tests across the session watermark and Telegram history-filter surfaces.
- Whitespace check: `git diff --check` passed.