### PR TITLE
fix: keep session thinking through transcript recovery

### DIFF
--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -113,4 +113,90 @@ describe("command resolveSession provider-owned daily reset", () => {
     expect(result.isNewSession).toBe(false);
     expect(result.sessionId).toBe("locked-session-id");
   });
+
+  it("carries stored thinking and verbose preferences during terminal transcript recovery", () => {
+    const sessionKey = "agent:main:cli";
+    const now = Date.now();
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "recovering-session-id",
+        updatedAt: now,
+        sessionStartedAt: now,
+        lastInteractionAt: now,
+        thinkingLevel: "high",
+        verboseLevel: "full",
+      },
+    };
+    hoisted.terminalTranscriptNewer = true;
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("recovering-session-id");
+    expect(result.persistedThinking).toBe("high");
+    expect(result.persistedVerbose).toBe("full");
+  });
+
+  it("does not carry preferences when terminal recovery overlaps a daily reset", () => {
+    const sessionKey = "agent:main:cli";
+    const startedAt = Date.now() - 2 * DAY_MS;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "daily-expired-session-id",
+        updatedAt: startedAt,
+        sessionStartedAt: startedAt,
+        lastInteractionAt: startedAt,
+        thinkingLevel: "high",
+        verboseLevel: "full",
+      },
+    };
+    hoisted.terminalTranscriptNewer = true;
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("daily-expired-session-id");
+    expect(result.persistedThinking).toBeUndefined();
+    expect(result.persistedVerbose).toBeUndefined();
+  });
+
+  it("does not carry preferences when terminal recovery overlaps an idle reset", () => {
+    const sessionKey = "agent:main:cli";
+    const now = Date.now();
+    const lastInteractionAt = now - 60 * 60 * 1000;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "idle-expired-session-id",
+        updatedAt: lastInteractionAt,
+        sessionStartedAt: now,
+        lastInteractionAt,
+        thinkingLevel: "high",
+        verboseLevel: "on",
+      },
+    };
+    hoisted.terminalTranscriptNewer = true;
+
+    const result = resolveSession({
+      cfg: {
+        session: {
+          reset: { mode: "idle", idleMinutes: 30 },
+        },
+      } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("idle-expired-session-id");
+    expect(result.persistedThinking).toBeUndefined();
+    expect(result.persistedVerbose).toBeUndefined();
+  });
 });

--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -141,7 +141,7 @@ describe("command resolveSession provider-owned daily reset", () => {
     expect(result.persistedVerbose).toBe("full");
   });
 
-  it("does not carry preferences when terminal recovery overlaps a daily reset", () => {
+  it("carries preferences when terminal recovery overlaps a daily reset", () => {
     const sessionKey = "agent:main:cli";
     const startedAt = Date.now() - 2 * DAY_MS;
     hoisted.store = {
@@ -157,18 +157,18 @@ describe("command resolveSession provider-owned daily reset", () => {
     hoisted.terminalTranscriptNewer = true;
 
     const result = resolveSession({
-      cfg: { session: {} } as OpenClawConfig,
+      cfg: { session: { reset: { mode: "daily" } } } as OpenClawConfig,
       sessionKey,
       agentId: "main",
     });
 
     expect(result.isNewSession).toBe(true);
     expect(result.sessionId).not.toBe("daily-expired-session-id");
-    expect(result.persistedThinking).toBeUndefined();
-    expect(result.persistedVerbose).toBeUndefined();
+    expect(result.persistedThinking).toBe("high");
+    expect(result.persistedVerbose).toBe("full");
   });
 
-  it("does not carry preferences when terminal recovery overlaps an idle reset", () => {
+  it("carries preferences when terminal recovery overlaps an idle reset", () => {
     const sessionKey = "agent:main:cli";
     const now = Date.now();
     const lastInteractionAt = now - 60 * 60 * 1000;
@@ -196,7 +196,7 @@ describe("command resolveSession provider-owned daily reset", () => {
 
     expect(result.isNewSession).toBe(true);
     expect(result.sessionId).not.toBe("idle-expired-session-id");
-    expect(result.persistedThinking).toBeUndefined();
-    expect(result.persistedVerbose).toBeUndefined();
+    expect(result.persistedThinking).toBe("high");
+    expect(result.persistedVerbose).toBe("on");
   });
 });

--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -141,7 +141,7 @@ describe("command resolveSession provider-owned daily reset", () => {
     expect(result.persistedVerbose).toBe("full");
   });
 
-  it("carries preferences when terminal recovery overlaps a daily reset", () => {
+  it("carries preferences across a daily reset", () => {
     const sessionKey = "agent:main:cli";
     const startedAt = Date.now() - 2 * DAY_MS;
     hoisted.store = {
@@ -154,8 +154,6 @@ describe("command resolveSession provider-owned daily reset", () => {
         verboseLevel: "full",
       },
     };
-    hoisted.terminalTranscriptNewer = true;
-
     const result = resolveSession({
       cfg: { session: { reset: { mode: "daily" } } } as OpenClawConfig,
       sessionKey,

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -433,22 +433,20 @@ export function resolveSession(opts: {
   const lockedModelSelection = isModelSelectionLocked(sessionEntry);
   const skipImplicitExpiry =
     resetPolicy.configured !== true && hasProviderOwnedSession(sessionEntry);
-  const lifecycleFreshness =
-    sessionEntry && !skipImplicitExpiry
-      ? evaluateSessionFreshness({
-          updatedAt: sessionEntry.updatedAt,
-          ...resolveSessionLifecycleTimestamps({
-            entry: sessionEntry,
-            agentId: sessionAgentId,
-            storePath,
-          }),
-          now,
-          policy: resetPolicy,
-        })
-      : undefined;
-  const freshUnderResetPolicy = skipImplicitExpiry || lifecycleFreshness?.fresh === true;
   const fresh = sessionEntry
-    ? lockedModelSelection || (!terminalMainTranscriptNewerThanRegistry && freshUnderResetPolicy)
+    ? lockedModelSelection ||
+      (!terminalMainTranscriptNewerThanRegistry &&
+        (skipImplicitExpiry ||
+          evaluateSessionFreshness({
+            updatedAt: sessionEntry.updatedAt,
+            ...resolveSessionLifecycleTimestamps({
+              entry: sessionEntry,
+              agentId: sessionAgentId,
+              storePath,
+            }),
+            now,
+            policy: resetPolicy,
+          }).fresh))
     : false;
   const sessionId =
     requestedSessionId || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
@@ -461,19 +459,12 @@ export function resolveSession(opts: {
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,
   });
 
-  // Terminal transcript recovery may rotate the session id without crossing a
-  // configured reset boundary; carry prefs only for that recovery case.
-  const carryPersistedPreferences =
-    Boolean(sessionEntry) &&
-    (fresh || (terminalMainTranscriptNewerThanRegistry && freshUnderResetPolicy));
-  const persistedThinking =
-    carryPersistedPreferences && sessionEntry?.thinkingLevel
-      ? normalizeThinkLevel(sessionEntry.thinkingLevel)
-      : undefined;
-  const persistedVerbose =
-    carryPersistedPreferences && sessionEntry?.verboseLevel
-      ? normalizeVerboseLevel(sessionEntry.verboseLevel)
-      : undefined;
+  const persistedThinking = sessionEntry?.thinkingLevel
+    ? normalizeThinkLevel(sessionEntry.thinkingLevel)
+    : undefined;
+  const persistedVerbose = sessionEntry?.verboseLevel
+    ? normalizeVerboseLevel(sessionEntry.verboseLevel)
+    : undefined;
 
   return {
     sessionId,

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -459,6 +459,8 @@ export function resolveSession(opts: {
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,
   });
 
+  // Behavior overrides belong to the logical session, not one transcript id.
+  // Carry them across every rollover; explicit `default` directives clear them.
   const persistedThinking = sessionEntry?.thinkingLevel
     ? normalizeThinkLevel(sessionEntry.thinkingLevel)
     : undefined;

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -433,20 +433,22 @@ export function resolveSession(opts: {
   const lockedModelSelection = isModelSelectionLocked(sessionEntry);
   const skipImplicitExpiry =
     resetPolicy.configured !== true && hasProviderOwnedSession(sessionEntry);
+  const lifecycleFreshness =
+    sessionEntry && !skipImplicitExpiry
+      ? evaluateSessionFreshness({
+          updatedAt: sessionEntry.updatedAt,
+          ...resolveSessionLifecycleTimestamps({
+            entry: sessionEntry,
+            agentId: sessionAgentId,
+            storePath,
+          }),
+          now,
+          policy: resetPolicy,
+        })
+      : undefined;
+  const freshUnderResetPolicy = skipImplicitExpiry || lifecycleFreshness?.fresh === true;
   const fresh = sessionEntry
-    ? lockedModelSelection ||
-      (!terminalMainTranscriptNewerThanRegistry &&
-        (skipImplicitExpiry ||
-          evaluateSessionFreshness({
-            updatedAt: sessionEntry.updatedAt,
-            ...resolveSessionLifecycleTimestamps({
-              entry: sessionEntry,
-              agentId: sessionAgentId,
-              storePath,
-            }),
-            now,
-            policy: resetPolicy,
-          }).fresh))
+    ? lockedModelSelection || (!terminalMainTranscriptNewerThanRegistry && freshUnderResetPolicy)
     : false;
   const sessionId =
     requestedSessionId || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
@@ -459,12 +461,17 @@ export function resolveSession(opts: {
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,
   });
 
+  // Terminal transcript recovery may rotate the session id without crossing a
+  // configured reset boundary; carry prefs only for that recovery case.
+  const carryPersistedPreferences =
+    Boolean(sessionEntry) &&
+    (fresh || (terminalMainTranscriptNewerThanRegistry && freshUnderResetPolicy));
   const persistedThinking =
-    fresh && sessionEntry?.thinkingLevel
+    carryPersistedPreferences && sessionEntry?.thinkingLevel
       ? normalizeThinkLevel(sessionEntry.thinkingLevel)
       : undefined;
   const persistedVerbose =
-    fresh && sessionEntry?.verboseLevel
+    carryPersistedPreferences && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)
       : undefined;
 


### PR DESCRIPTION
Closes #109275

## What Problem This Solves

Stored `/think` and `/verbose` session preferences were hidden whenever command-session resolution rotated the transcript ID. That made terminal transcript recovery, daily rollover, and idle rollover silently run one turn with defaults even though the logical session still retained the overrides.

## Why This Change Was Made

Session freshness decides whether OpenClaw reuses a transcript ID; it does not own logical-session behavior overrides. This aligns command-session resolution with the existing reply-session contract: thinking and verbose preferences survive every session-ID rollover, while explicit `default` directives clear them.

The contributor's recovery regression coverage is retained and expanded to prove ordinary configured daily rollover plus recovery overlapping configured idle expiry.

## User Impact

Users who set `/think high` or `/verbose on` keep those session preferences through transcript recovery and automatic session rollover instead of silently falling back for the first turn of the replacement transcript.

## Evidence

- `node scripts/run-vitest.mjs src/agents/command/session.provider-owned-reset.test.ts` — 6 passed.
- `node scripts/run-vitest.mjs src/commands/agent.session.test.ts` — 7 passed.
- `node scripts/check-changed.mjs -- src/agents/command/session.ts src/agents/command/session.provider-owned-reset.test.ts` — passed on Blacksmith Testbox `tbx_01ky1hkc0j9tj4sxcpbrx5aj59`, run 29803480978.
- AutoReview full branch — clean, no accepted/actionable findings.
- `git diff --check` — passed.

Contributor credit is preserved in the original commit by 0668001420 (`TianT1209`).
