### PR TITLE
fix: require decimal numeric oc-path predicates

### DIFF
--- a/extensions/oc-path/src/oc-path/oc-path.ts
+++ b/extensions/oc-path/src/oc-path/oc-path.ts
@@ -495,7 +495,17 @@ export function parsePredicateSeg(seg: string): PredicateSpec | null {
   return null;
 }
 
-// Numeric ops require both sides to coerce to finite numbers.
+const STRICT_DECIMAL_NUMBER_RE = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+
+function parseStrictDecimalNumber(value: string): number | null {
+  if (!STRICT_DECIMAL_NUMBER_RE.test(value)) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+// Numeric ops require both sides to be explicit finite decimal numbers.
 export function evaluatePredicate(actual: string | null, pred: PredicateSpec): boolean {
   if (actual === null) {
     return false;
@@ -509,9 +519,9 @@ export function evaluatePredicate(actual: string | null, pred: PredicateSpec): b
     case "<=":
     case ">":
     case ">=": {
-      const a = Number(actual);
-      const b = Number(pred.value);
-      if (!Number.isFinite(a) || !Number.isFinite(b)) {
+      const a = parseStrictDecimalNumber(actual);
+      const b = parseStrictDecimalNumber(pred.value);
+      if (a === null || b === null) {
         return false;
       }
       if (pred.op === "<") {

--- a/extensions/oc-path/src/oc-path/tests/find.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/find.test.ts
@@ -375,11 +375,7 @@ describe("value predicates — numeric operators (v1.1)", () => {
   it("accepts finite decimal predicate values", () => {
     const out = findOcPaths(jsonc, parseOcPath(`${PREFIX}/[contextWindow>199999.5]/id`));
     const ids = out.map((m) => (m.match.kind === "leaf" ? m.match.valueText : ""));
-    expect(ids.toSorted()).toEqual([
-      "claude-opus-4-7",
-      "claude-sonnet-4-6",
-      "claude-sonnet-4-7",
-    ]);
+    expect(ids.toSorted()).toEqual(["claude-opus-4-7", "claude-sonnet-4-6", "claude-sonnet-4-7"]);
   });
 
   it("numeric operator rejects non-numeric leaves silently", () => {

--- a/extensions/oc-path/src/oc-path/tests/find.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/find.test.ts
@@ -372,6 +372,16 @@ describe("value predicates — numeric operators (v1.1)", () => {
     expect(ids).toEqual(["claude-sonnet-4-7"]);
   });
 
+  it("accepts finite decimal predicate values", () => {
+    const out = findOcPaths(jsonc, parseOcPath(`${PREFIX}/[contextWindow>199999.5]/id`));
+    const ids = out.map((m) => (m.match.kind === "leaf" ? m.match.valueText : ""));
+    expect(ids.toSorted()).toEqual([
+      "claude-opus-4-7",
+      "claude-sonnet-4-6",
+      "claude-sonnet-4-7",
+    ]);
+  });
+
   it("numeric operator rejects non-numeric leaves silently", () => {
     const out = findOcPaths(jsonc, parseOcPath(`${PREFIX}/[id>5]/id`));
     expect(out).toHaveLength(0);
@@ -380,6 +390,27 @@ describe("value predicates — numeric operators (v1.1)", () => {
   it("rejects numeric predicate value that is not a number", () => {
     const out = findOcPaths(jsonc, parseOcPath(`${PREFIX}/[maxTokens>foo]/id`));
     expect(out).toHaveLength(0);
+  });
+
+  it("rejects non-decimal numeric predicate values", () => {
+    for (const value of ["0x10", "1e5"]) {
+      const out = findOcPaths(jsonc, parseOcPath(`${PREFIX}/[contextWindow>${value}]/id`));
+      expect(out).toHaveLength(0);
+    }
+  });
+
+  it("rejects non-decimal numeric-looking actual values", () => {
+    const looseJsonc = parseJsonc(
+      '{"models":[' +
+        '{"id":"hex","contextWindow":"0x20"},' +
+        '{"id":"exponent","contextWindow":"1e6"},' +
+        '{"id":"blank","contextWindow":""},' +
+        '{"id":"decimal","contextWindow":"20"}' +
+        "]}",
+    ).ast;
+    const out = findOcPaths(looseJsonc, parseOcPath("oc://config/models/[contextWindow>10]/id"));
+    const ids = out.map((m) => (m.match.kind === "leaf" ? m.match.valueText : ""));
+    expect(ids).toEqual(["decimal"]);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users filtering oc-path results with numeric predicates could match non-decimal values when the predicate or source value used JavaScript-coercible forms such as hexadecimal, exponent notation, or blank strings.

## Why This Change Was Made

Numeric oc-path predicate comparisons now parse both sides as explicit finite decimal numbers before applying <, <=, >, or >=. Equality and inequality predicates remain string comparisons, and path segment/index parsing is unchanged.

## User Impact

Users can rely on numeric oc-path filters to compare only decimal numeric values, avoiding surprising matches from loosely coerced strings while preserving normal decimal comparisons.

## Evidence

Current head: `e8f05124c6856e275c721a2f2651c0e8492dc313`

- `Real behavior proof`: [`Real behavior proof`](https://github.com/openclaw/openclaw/actions/runs/29632232996/job/88048096320) passed on the current head.
- `openclaw/ci-gate`: [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/29632056976/job/88047981753) passed on the current head.
- Source-level runtime proof on the current head: a temporary `tsx` script imported `extensions/oc-path/src/oc-path/index.ts`, parsed this fixture, and evaluated `oc://fixture.json/items/[score>2]/id`:

```json
{
  "items": [
    { "id": "hex", "score": "0x10" },
    { "id": "exponent", "score": "1e2" },
    { "id": "blank", "score": "" },
    { "id": "decimal", "score": "2.5" },
    { "id": "integer", "score": 3 },
    { "id": "small", "score": "1.9" }
  ]
}
```

Observed output:

```json
{
  "head": "e8f05124c6856e275c721a2f2651c0e8492dc313",
  "pattern": "oc://fixture.json/items/[score>2]/id",
  "count": 2,
  "ids": ["decimal", "integer"],
  "paths": ["oc://fixture.json/items/3/id", "oc://fixture.json/items/4/id"]
}
```

- `git diff --check` passed in the current-head proof lane.