### PR TITLE
perf(test): advance Matrix draft timers

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -66,6 +66,13 @@ vi.mock("./replies.js", () => ({
   deliverMatrixReplies: deliverMatrixRepliesMock,
 }));
 
+function waitForMatrixState<T>(
+  assertion: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+): Promise<T> {
+  return vi.waitFor(assertion, { interval: 1, ...options });
+}
+
 async function writeMatrixSessionMeta(
   storePath: string,
   sessionKey: string,
@@ -1305,7 +1312,7 @@ describe("matrix monitor handler pairing account scope", () => {
         }),
       );
 
-      await vi.waitFor(() => {
+      await waitForMatrixState(() => {
         expect(sendNotice).toHaveBeenCalledTimes(1);
       });
       expect(dispatchReplyFromConfig).not.toHaveBeenCalled();
@@ -3076,7 +3083,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Single block" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3099,7 +3106,7 @@ describe("matrix monitor handler draft streaming", () => {
     expect(opts.suppressDefaultToolProgressMessages).toBe(true);
     await opts.onToolStart?.({ name: "read_file" });
 
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     expect(singleTextMessageBody()).toMatch(/\n`🧩 Read File`$/);
@@ -3113,43 +3120,49 @@ describe("matrix monitor handler draft streaming", () => {
   });
 
   it("replaces Matrix plan snapshots and keeps the explanation", async () => {
-    const { dispatch } = createStreamingHarness({
-      streaming: "progress",
-      previewToolProgressEnabled: true,
-      accountConfig: {
-        streaming: { mode: "progress", progress: { label: false } },
-      } as never,
-    });
-    const { opts, finish } = await dispatch();
+    vi.useFakeTimers();
+    let finish: (() => Promise<void>) | undefined;
+    try {
+      const { dispatch } = createStreamingHarness({
+        streaming: "progress",
+        previewToolProgressEnabled: true,
+        accountConfig: {
+          streaming: { mode: "progress", progress: { label: false } },
+        } as never,
+      });
+      const streaming = await dispatch();
+      const { opts } = streaming;
+      finish = streaming.finish;
 
-    await opts.onPlanUpdate?.({
-      phase: "update",
-      explanation: "Initial plan",
-      steps: [{ step: "Inspect", status: "in_progress" }],
-    });
-    await vi.waitFor(() => {
-      expect(singleTextMessageBody()).toBe("`Initial plan`\n\n`▸ Inspect`");
-    });
+      await opts.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Initial plan",
+        steps: [{ step: "Inspect", status: "in_progress" }],
+      });
+      await waitForMatrixState(() => {
+        expect(singleTextMessageBody()).toBe("`Initial plan`\n\n`▸ Inspect`");
+      });
 
-    await opts.onPlanUpdate?.({
-      phase: "update",
-      explanation: "Revised plan",
-      steps: [
-        { step: "Inspect", status: "completed" },
-        { step: "Patch", status: "in_progress" },
-      ],
-    });
-    await vi.waitFor(
-      () => {
-        expect(editMessageMatrixMock).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
-    expect(lastCallArg(editMessageMatrixMock, 2, "Matrix plan edit body")).toBe(
-      "`Revised plan`\n\n`✅ Inspect`\n`▸ Patch`",
-    );
-
-    await finish();
+      await opts.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Revised plan",
+        steps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "in_progress" },
+        ],
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(editMessageMatrixMock).toHaveBeenCalled();
+      expect(lastCallArg(editMessageMatrixMock, 2, "Matrix plan edit body")).toBe(
+        "`Revised plan`\n\n`✅ Inspect`\n`▸ Patch`",
+      );
+    } finally {
+      try {
+        await finish?.();
+      } finally {
+        vi.useRealTimers();
+      }
+    }
   });
 
   it("uses resolved Matrix account progress maxLines for draft text", async () => {
@@ -3387,7 +3400,7 @@ describe("matrix monitor handler draft streaming", () => {
       progressText: "@room ping @alice:example.org [label](https://example.org)",
     });
 
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     expect(singleTextMessageBody()).toMatch(
@@ -3447,7 +3460,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Single block" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3477,7 +3490,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "hello @alice:example.org" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3503,7 +3516,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "hello @alice:example.org" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3529,7 +3542,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Spoken answer" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3570,7 +3583,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Spoken answer" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3689,7 +3702,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Single" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3707,7 +3720,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Block one" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3724,7 +3737,7 @@ describe("matrix monitor handler draft streaming", () => {
       roomId: "!room",
     });
     opts.onPartialReply?.({ text: "Block two" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(2);
     });
 
@@ -3741,7 +3754,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Alpha" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3760,7 +3773,7 @@ describe("matrix monitor handler draft streaming", () => {
 
     await deliver({ text: "Alpha" }, { kind: "block" });
 
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(2);
     });
     expect(singleTextMessageBody(1)).toBe("Beta");
@@ -3774,7 +3787,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Alpha" });
-    await vi.waitFor(
+    await waitForMatrixState(
       () => {
         expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
       },
@@ -3782,7 +3795,7 @@ describe("matrix monitor handler draft streaming", () => {
     );
 
     opts.onPartialReply?.({ text: "AlphaBeta" });
-    await vi.waitFor(
+    await waitForMatrixState(
       () => {
         expectMatrixEdit("!room:example.org", "$draft1", "AlphaBeta");
       },
@@ -3799,7 +3812,7 @@ describe("matrix monitor handler draft streaming", () => {
     });
     await deliver({ text: "Alpha" }, { kind: "block" });
 
-    await vi.waitFor(
+    await waitForMatrixState(
       () => {
         expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
       },
@@ -3817,7 +3830,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Hello" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3836,7 +3849,7 @@ describe("matrix monitor handler draft streaming", () => {
       const { deliver, opts, finish } = await dispatch();
 
       opts.onPartialReply?.({ text: "Hello" });
-      await vi.waitFor(() => {
+      await waitForMatrixState(() => {
         expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
       });
 
@@ -3862,7 +3875,7 @@ describe("matrix monitor handler draft streaming", () => {
       const { deliver, opts, finish } = await dispatch();
 
       opts.onPartialReply?.({ text: "Primary answer" });
-      await vi.waitFor(() => {
+      await waitForMatrixState(() => {
         expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
       });
 
@@ -3921,7 +3934,7 @@ describe("matrix monitor handler draft streaming", () => {
 
     // Block 1: stream and deliver.
     opts.onPartialReply?.({ text: "Block one" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     await deliver({ text: "Block one" }, { kind: "block" });
@@ -3937,7 +3950,7 @@ describe("matrix monitor handler draft streaming", () => {
     sendSingleTextMessageMatrixMock.mockResolvedValue({ messageId: "$draft2", roomId: "!room" });
 
     opts.onPartialReply?.({ text: "Block two" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3952,7 +3965,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Alpha" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -3960,7 +3973,7 @@ describe("matrix monitor handler draft streaming", () => {
     opts.onAssistantMessageStart?.();
     opts.onPartialReply?.({ text: "Beta" });
 
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expectMatrixEdit("!room:example.org", "$draft1", "Beta");
     });
 
@@ -3975,7 +3988,7 @@ describe("matrix monitor handler draft streaming", () => {
     expectMatrixEdit("!room:example.org", "$draft1", "Alpha");
     expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
     expect(redactEventMock).not.toHaveBeenCalled();
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     expect(singleTextMessageBody()).toBe("Beta");
@@ -3993,7 +4006,7 @@ describe("matrix monitor handler draft streaming", () => {
 
     opts.onAssistantMessageStart?.();
     opts.onPartialReply?.({ text: "Alpha" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4001,7 +4014,7 @@ describe("matrix monitor handler draft streaming", () => {
     await opts.onBlockReplyQueued?.({ text: "Alpha" }, { assistantMessageIndex: 1 });
     opts.onPartialReply?.({ text: "Beta" });
 
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expectMatrixEdit("!room:example.org", "$draft1", "Beta");
     });
 
@@ -4016,7 +4029,7 @@ describe("matrix monitor handler draft streaming", () => {
     expectMatrixEdit("!room:example.org", "$draft1", "Alpha");
     expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
     expect(redactEventMock).not.toHaveBeenCalled();
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     expect(singleTextMessageBody()).toBe("Beta");
@@ -4033,7 +4046,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Alpha" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     expect(singleTextMessageBody()).toBe("Alpha");
@@ -4054,7 +4067,7 @@ describe("matrix monitor handler draft streaming", () => {
     });
     await deliver({ text: "Alpha" }, { kind: "block" });
 
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     expect(singleTextMessageBody()).toBe("Beta");
@@ -4068,7 +4081,7 @@ describe("matrix monitor handler draft streaming", () => {
     });
     await deliver({ text: "Beta" }, { kind: "block" });
 
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
     expect(singleTextMessageBody()).toBe("Gamma");
@@ -4102,7 +4115,7 @@ describe("matrix monitor handler draft streaming", () => {
           capturedReplyOpts = args?.replyOptions;
           // Simulate streaming then model error.
           capturedReplyOpts?.onPartialReply?.({ text: "partial" });
-          await vi.waitFor(() => {
+          await waitForMatrixState(() => {
             expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
           });
           throw new Error("model timeout");
@@ -4159,7 +4172,7 @@ describe("matrix monitor handler draft streaming", () => {
       dispatchReplyFromConfig: vi.fn(async (args: { replyOptions?: ReplyOpts }) => {
         capturedReplyOpts = args?.replyOptions;
         capturedReplyOpts?.onPartialReply?.({ text: "partial" });
-        await vi.waitFor(() => {
+        await waitForMatrixState(() => {
           expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
         });
         throw new Error("model timeout");
@@ -4188,7 +4201,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Partial reply" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4209,7 +4222,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Streaming" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4229,7 +4242,7 @@ describe("matrix monitor handler draft streaming", () => {
 
     // Simulate streaming: partial reply creates draft message.
     opts.onPartialReply?.({ text: "Partial reply" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4256,7 +4269,7 @@ describe("matrix monitor handler draft streaming", () => {
     opts.onAssistantMessageStart?.();
 
     opts.onPartialReply?.({ text: "Partial reply" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4274,7 +4287,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Partial reply" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4318,7 +4331,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "Partial reply" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4336,7 +4349,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "screenshot ready" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4361,7 +4374,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "screenshot ready" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4385,7 +4398,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "@room screenshot ready" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
@@ -4417,7 +4430,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { deliver, opts, finish } = await dispatch();
 
     opts.onPartialReply?.({ text: "1234" });
-    await vi.waitFor(() => {
+    await waitForMatrixState(() => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## What Problem This Solves

The Matrix handler suite accumulated Vitest's default polling delay across 45 asynchronous assertions, and one plan-preview test waited a real second for a known throttle.

## Why This Change Was Made

Use a test-local 1 ms polling helper while preserving explicit options. Drive the known 1,000 ms plan throttle with fake timers, assert directly at the bound, and guarantee handler/timer cleanup through nested `finally` blocks.

## User Impact

No user-visible or production behavior changes. Controlled same-Testbox median test-body time drops from 1.367 seconds to 339 milliseconds.

## Evidence

- Before: 1.489/1.367/1.363 seconds; median 1.367 seconds.
- After: 302/370/339 milliseconds; median 339 milliseconds (about 75% faster). Final exact-patch run: 419 milliseconds.
- Testbox `tbx_01kxqggqfq6c8jqa0155y05rqq`: 121/121 tests passed across comparison runs and final proof.
- Same Testbox: `pnpm check:changed` passed.
- Autoreview: two timing/cleanup findings fixed; final review clean, 0.96 confidence.
