### PR TITLE
fix(skills): keep healthy skills available when one secret fails

### DIFF
--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -269,4 +269,40 @@ describe("Gateway startup SecretRef owner isolation", () => {
       );
     });
   });
+
+  it("reaches /readyz with one skill secret isolated", async () => {
+    await withEnvAsync({ MISSING_SKILL_KEY: undefined }, async () => {
+      await writeConfig({
+        ...baseConfig(),
+        skills: {
+          entries: {
+            cold: {
+              apiKey: {
+                source: "env",
+                provider: "default",
+                id: "MISSING_SKILL_KEY",
+              },
+            },
+          },
+        },
+      });
+
+      const port = await getFreePort();
+      server = await startGatewayServer(port, { auth: { mode: "none" } });
+      const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+
+      expect(ready.status).toBe(200);
+      expect(getActiveSecretsRuntimeSnapshot()?.degradedOwners).toMatchObject([
+        { ownerKind: "capability", ownerId: "skill:cold", state: "unavailable" },
+      ]);
+      expect(getActiveSecretsRuntimeSnapshot()?.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "SECRETS_OWNER_UNAVAILABLE",
+            path: "skills.entries.cold.apiKey",
+          }),
+        ]),
+      );
+    });
+  });
 });

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -104,7 +104,7 @@ function collectSkillAssignments(params: {
   context: ResolverContext;
 }): void {
   for (const [skillKey, entry] of Object.entries(params.entries)) {
-    collectSecretInputAssignment({
+    collectRuntimeSecretInputAssignment({
       value: entry.apiKey,
       path: `skills.entries.${skillKey}.apiKey`,
       expected: "string",
@@ -112,6 +112,14 @@ function collectSkillAssignments(params: {
       context: params.context,
       active: entry.enabled !== false,
       inactiveReason: "skill entry is disabled.",
+      // Keep this id aligned with isSkillSecretOwnerUnavailable so a failed key
+      // removes only its owning skill from prompts and runtime env injection.
+      owner: {
+        ownerKind: "capability",
+        ownerId: `skill:${skillKey}`,
+        requiredForGateway: false,
+        disposition: "isolate",
+      },
       apply: (value) => {
         entry.apiKey = value;
       },

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -42,6 +42,45 @@ function expectWarning(
 }
 
 describe("secrets runtime snapshot", () => {
+  it("isolates only the skill whose API key cannot resolve", async () => {
+    const missingRef = {
+      source: "env",
+      provider: "default",
+      id: "MISSING_SKILL_KEY",
+    } as const;
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        skills: {
+          entries: {
+            cold: { apiKey: missingRef },
+            healthy: {
+              apiKey: { source: "env", provider: "default", id: "HEALTHY_SKILL_KEY" },
+            },
+          },
+        },
+      }),
+      env: { HEALTHY_SKILL_KEY: "healthy" },
+      includeAuthStoreRefs: false,
+      allowUnavailableSecretOwners: true,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+
+    expect(snapshot.config.skills?.entries?.cold?.apiKey).toEqual(missingRef);
+    expect(snapshot.config.skills?.entries?.healthy?.apiKey).toBe("healthy");
+    expect(snapshot.degradedOwners).toMatchObject([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold",
+        state: "unavailable",
+        paths: ["skills.entries.cold.apiKey"],
+      },
+    ]);
+    expectWarning(snapshot, {
+      code: "SECRETS_OWNER_UNAVAILABLE",
+      path: "skills.entries.cold.apiKey",
+    });
+  });
+
   it("isolates one webhooks route while resolving its sibling snapshot", async () => {
     const missingRef = {
       source: "env",

--- a/src/skills/loading/config.ts
+++ b/src/skills/loading/config.ts
@@ -8,6 +8,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import type { SkillConfig } from "../../config/types.skills.js";
 import {
+  findActiveDegradedSecretOwner,
+  listActiveDegradedSecretOwners,
+} from "../../secrets/runtime-degraded-state.js";
+import {
   evaluateRuntimeEligibility,
   hasBinary,
   isConfigPathTruthyWithDefaults,
@@ -55,6 +59,18 @@ export function resolveSkillConfig(
     return undefined;
   }
   return entry;
+}
+
+/** Returns whether cold startup isolated this exact skill's configured secret. */
+export function isSkillSecretOwnerUnavailable(skillKey: string): boolean {
+  return Boolean(findActiveDegradedSecretOwner("capability", `skill:${skillKey}`));
+}
+
+/** Returns whether cold startup isolated any configured skill secret. */
+export function hasUnavailableSkillSecretOwners(): boolean {
+  return listActiveDegradedSecretOwners().some(
+    (owner) => owner.ownerKind === "capability" && owner.ownerId.startsWith("skill:"),
+  );
 }
 
 export function isSkillEnvRequirementSatisfied(params: {
@@ -113,6 +129,9 @@ export function shouldIncludeSkill(params: {
   const skillConfig = resolveSkillConfig(config, skillKey);
 
   if (skillConfig?.enabled === false) {
+    return false;
+  }
+  if (isSkillSecretOwnerUnavailable(skillKey)) {
     return false;
   }
   if (!isBundledSkillAllowed(entry, bundledAllowlist)) {

--- a/src/skills/loading/prompt-resolution.test.ts
+++ b/src/skills/loading/prompt-resolution.test.ts
@@ -146,6 +146,86 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("/app/skills/healthy-skill/SKILL.md");
   });
 
+  it("does not add supplied skills outside the saved snapshot during a degraded rebuild", () => {
+    const createEntry = (name: string): SkillEntry => ({
+      skill: createCanonicalFixtureSkill({
+        name,
+        description: name,
+        filePath: `/app/skills/${name}/SKILL.md`,
+        baseDir: `/app/skills/${name}`,
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-skill",
+        state: "unavailable",
+        paths: ["skills.entries.cold-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "STALE COLD SKILL PROMPT",
+        skills: [
+          { name: "cold-skill", skillKey: "cold-skill" },
+          { name: "healthy-skill", skillKey: "healthy-skill" },
+        ],
+      },
+      entries: [createEntry("cold-skill"), createEntry("healthy-skill"), createEntry("new-skill")],
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).not.toContain("STALE COLD SKILL PROMPT");
+    expect(prompt).not.toContain("/app/skills/cold-skill/SKILL.md");
+    expect(prompt).toContain("/app/skills/healthy-skill/SKILL.md");
+    expect(prompt).not.toContain("/app/skills/new-skill/SKILL.md");
+  });
+
+  it("does not load newly installed skills into a degraded snapshot-only prompt", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-prompt-"));
+    for (const name of ["cold-skill", "healthy-skill", "new-skill"]) {
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", name),
+        name,
+        description: name,
+      });
+    }
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-skill",
+        state: "unavailable",
+        paths: ["skills.entries.cold-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    try {
+      const prompt = resolveSkillsPromptForRun({
+        skillsSnapshot: {
+          prompt: "STALE COLD SKILL PROMPT",
+          skills: [
+            { name: "cold-skill", skillKey: "cold-skill" },
+            { name: "healthy-skill", skillKey: "healthy-skill" },
+          ],
+        },
+        workspaceDir,
+      });
+
+      expect(prompt).not.toContain("cold-skill/SKILL.md");
+      expect(prompt).toContain("healthy-skill/SKILL.md");
+      expect(prompt).not.toContain("new-skill/SKILL.md");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps legacy entries with disableModelInvocation hidden when exposure metadata is absent", () => {
     const hidden: SkillEntry = {
       skill: createCanonicalFixtureSkill({

--- a/src/skills/loading/prompt-resolution.test.ts
+++ b/src/skills/loading/prompt-resolution.test.ts
@@ -1,8 +1,17 @@
 // Prompt resolution tests cover skill prompt lookup and active skill selection.
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
+import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
 import { resolveSkillsPromptForRun } from "./workspace.js";
+
+afterEach(() => {
+  setActiveDegradedSecretOwners([]);
+});
 
 describe("resolveSkillsPromptForRun", () => {
   it("prefers snapshot prompt when available", () => {
@@ -29,6 +38,112 @@ describe("resolveSkillsPromptForRun", () => {
     });
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
+  });
+
+  it("rebuilds a snapshot-only legacy prompt without its unavailable skill", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-prompt-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "cold-skill"),
+      name: "cold-skill",
+      description: "Cold",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "healthy-skill"),
+      name: "healthy-skill",
+      description: "Healthy",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "outside-skill"),
+      name: "outside-skill",
+      description: "Outside the saved filter",
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-skill",
+        state: "unavailable",
+        paths: ["skills.entries.cold-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    try {
+      const prompt = resolveSkillsPromptForRun({
+        skillsSnapshot: {
+          prompt: "STALE COLD SKILL PROMPT",
+          skills: [{ name: "cold-skill" }, { name: "healthy-skill" }],
+          skillFilter: ["cold-skill", "healthy-skill"],
+        },
+        config: {
+          skills: {
+            entries: {
+              "cold-skill": {
+                apiKey: { source: "env", provider: "default", id: "MISSING_SKILL_KEY" },
+              },
+            },
+          },
+        },
+        workspaceDir,
+      });
+
+      expect(prompt).not.toContain("STALE COLD SKILL PROMPT");
+      expect(prompt).not.toContain("cold-skill/SKILL.md");
+      expect(prompt).toContain("healthy-skill/SKILL.md");
+      expect(prompt).not.toContain("outside-skill/SKILL.md");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches unavailable owners against a snapshot skill's config key", () => {
+    const cold: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "cold-skill",
+        description: "Cold",
+        filePath: "/app/skills/cold-skill/SKILL.md",
+        baseDir: "/app/skills/cold-skill",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+      metadata: { skillKey: "cold-alias" },
+    };
+    const healthy: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "healthy-skill",
+        description: "Healthy",
+        filePath: "/app/skills/healthy-skill/SKILL.md",
+        baseDir: "/app/skills/healthy-skill",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-alias",
+        state: "unavailable",
+        paths: ["skills.entries.cold-alias.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "STALE COLD SKILL PROMPT",
+        skills: [
+          { name: "cold-skill", skillKey: "cold-alias" },
+          { name: "healthy-skill", skillKey: "healthy-skill" },
+        ],
+      },
+      entries: [cold, healthy],
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).not.toContain("STALE COLD SKILL PROMPT");
+    expect(prompt).not.toContain("/app/skills/cold-skill/SKILL.md");
+    expect(prompt).toContain("/app/skills/healthy-skill/SKILL.md");
   });
 
   it("keeps legacy entries with disableModelInvocation hidden when exposure metadata is absent", () => {

--- a/src/skills/loading/prompt-resolution.test.ts
+++ b/src/skills/loading/prompt-resolution.test.ts
@@ -6,8 +6,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
-import type { SkillEntry } from "../types.js";
-import { resolveSkillsPromptForRun } from "./workspace.js";
+import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION, type SkillEntry } from "../types.js";
+import { buildWorkspaceSkillSnapshot, resolveSkillsPromptForRun } from "./workspace.js";
 
 afterEach(() => {
   setActiveDegradedSecretOwners([]);
@@ -40,23 +40,28 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
   });
 
-  it("rebuilds a snapshot-only legacy prompt without its unavailable skill", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-prompt-"));
-    await writeSkill({
-      dir: path.join(workspaceDir, "skills", "cold-skill"),
-      name: "cold-skill",
-      description: "Cold",
-    });
-    await writeSkill({
-      dir: path.join(workspaceDir, "skills", "healthy-skill"),
-      name: "healthy-skill",
-      description: "Healthy",
-    });
-    await writeSkill({
-      dir: path.join(workspaceDir, "skills", "outside-skill"),
-      name: "outside-skill",
-      description: "Outside the saved filter",
-    });
+  it("keeps an empty snapshot authoritative over current entries", () => {
+    const entry: SkillEntry = {
+      skill: createCanonicalFixtureSkill({
+        name: "new-skill",
+        description: "New",
+        filePath: "/app/skills/new-skill/SKILL.md",
+        baseDir: "/app/skills/new-skill",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+
+    expect(
+      resolveSkillsPromptForRun({
+        skillsSnapshot: { prompt: "", skills: [] },
+        entries: [entry],
+        workspaceDir: "/tmp/openclaw",
+      }),
+    ).toBe("");
+  });
+
+  it("fails closed before filtering an unsupported degraded prompt format", () => {
     setActiveDegradedSecretOwners([
       {
         ownerKind: "capability",
@@ -68,32 +73,40 @@ describe("resolveSkillsPromptForRun", () => {
       },
     ]);
 
-    try {
-      const prompt = resolveSkillsPromptForRun({
+    expect(
+      resolveSkillsPromptForRun({
         skillsSnapshot: {
-          prompt: "STALE COLD SKILL PROMPT",
-          skills: [{ name: "cold-skill" }, { name: "healthy-skill" }],
-          skillFilter: ["cold-skill", "healthy-skill"],
+          prompt:
+            "LEAKED COLD INSTRUCTIONS\n<available_skills>\n  <skill>\n    <name>cold-skill</name>\n  </skill>\n</available_skills>",
+          skills: [{ name: "cold-skill", skillKey: "cold-skill" }],
+          promptFormatVersion: WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION - 1,
         },
-        config: {
-          skills: {
-            entries: {
-              "cold-skill": {
-                apiKey: { source: "env", provider: "default", id: "MISSING_SKILL_KEY" },
-              },
-            },
-          },
-        },
-        workspaceDir,
-      });
+        workspaceDir: "/tmp/openclaw",
+      }),
+    ).toBe("");
+  });
 
-      expect(prompt).not.toContain("STALE COLD SKILL PROMPT");
-      expect(prompt).not.toContain("cold-skill/SKILL.md");
-      expect(prompt).toContain("healthy-skill/SKILL.md");
-      expect(prompt).not.toContain("outside-skill/SKILL.md");
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
+  it("fails closed for a legacy snapshot whose owner identity is ambiguous", () => {
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-skill",
+        state: "unavailable",
+        paths: ["skills.entries.cold-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "LEGACY SKILL PROMPT",
+        skills: [{ name: "cold-skill" }, { name: "healthy-skill" }],
+      },
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toBe("");
   });
 
   it("matches unavailable owners against a snapshot skill's config key", () => {
@@ -118,6 +131,9 @@ describe("resolveSkillsPromptForRun", () => {
       }),
       frontmatter: {},
     };
+    const snapshot = buildWorkspaceSkillSnapshot("/tmp/openclaw", {
+      entries: [cold, healthy],
+    });
     setActiveDegradedSecretOwners([
       {
         ownerKind: "capability",
@@ -130,18 +146,11 @@ describe("resolveSkillsPromptForRun", () => {
     ]);
 
     const prompt = resolveSkillsPromptForRun({
-      skillsSnapshot: {
-        prompt: "STALE COLD SKILL PROMPT",
-        skills: [
-          { name: "cold-skill", skillKey: "cold-alias" },
-          { name: "healthy-skill", skillKey: "healthy-skill" },
-        ],
-      },
+      skillsSnapshot: snapshot,
       entries: [cold, healthy],
       workspaceDir: "/tmp/openclaw",
     });
 
-    expect(prompt).not.toContain("STALE COLD SKILL PROMPT");
     expect(prompt).not.toContain("/app/skills/cold-skill/SKILL.md");
     expect(prompt).toContain("/app/skills/healthy-skill/SKILL.md");
   });
@@ -157,6 +166,10 @@ describe("resolveSkillsPromptForRun", () => {
       }),
       frontmatter: {},
     });
+    const capturedEntries = [createEntry("cold-skill"), createEntry("healthy-skill")];
+    const snapshot = buildWorkspaceSkillSnapshot("/tmp/openclaw", {
+      entries: capturedEntries,
+    });
     setActiveDegradedSecretOwners([
       {
         ownerKind: "capability",
@@ -169,29 +182,38 @@ describe("resolveSkillsPromptForRun", () => {
     ]);
 
     const prompt = resolveSkillsPromptForRun({
-      skillsSnapshot: {
-        prompt: "STALE COLD SKILL PROMPT",
-        skills: [
-          { name: "cold-skill", skillKey: "cold-skill" },
-          { name: "healthy-skill", skillKey: "healthy-skill" },
-        ],
-      },
-      entries: [createEntry("cold-skill"), createEntry("healthy-skill"), createEntry("new-skill")],
+      skillsSnapshot: snapshot,
+      entries: [...capturedEntries, createEntry("new-skill")],
       workspaceDir: "/tmp/openclaw",
     });
 
-    expect(prompt).not.toContain("STALE COLD SKILL PROMPT");
     expect(prompt).not.toContain("/app/skills/cold-skill/SKILL.md");
     expect(prompt).toContain("/app/skills/healthy-skill/SKILL.md");
     expect(prompt).not.toContain("/app/skills/new-skill/SKILL.md");
   });
 
-  it("preserves an explicitly empty supplied catalog during a degraded rebuild", async () => {
+  it("preserves captured skill content during degraded prompt filtering", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-prompt-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "cold-skill"),
+      name: "cold-skill",
+      description: "Captured cold",
+    });
     await writeSkill({
       dir: path.join(workspaceDir, "skills", "healthy-skill"),
       name: "healthy-skill",
-      description: "Healthy",
+      description: "Captured healthy",
+    });
+    const snapshot = buildWorkspaceSkillSnapshot(workspaceDir);
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "healthy-skill"),
+      name: "healthy-skill",
+      description: "Replacement healthy",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "new-skill"),
+      name: "new-skill",
+      description: "New skill",
     });
     setActiveDegradedSecretOwners([
       {
@@ -206,57 +228,14 @@ describe("resolveSkillsPromptForRun", () => {
 
     try {
       const prompt = resolveSkillsPromptForRun({
-        skillsSnapshot: {
-          prompt: "STALE COLD SKILL PROMPT",
-          skills: [
-            { name: "cold-skill", skillKey: "cold-skill" },
-            { name: "healthy-skill", skillKey: "healthy-skill" },
-          ],
-        },
-        entries: [],
-        workspaceDir,
-      });
-
-      expect(prompt).toBe("");
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
-  });
-
-  it("does not load newly installed skills into a degraded snapshot-only prompt", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-prompt-"));
-    for (const name of ["cold-skill", "healthy-skill", "new-skill"]) {
-      await writeSkill({
-        dir: path.join(workspaceDir, "skills", name),
-        name,
-        description: name,
-      });
-    }
-    setActiveDegradedSecretOwners([
-      {
-        ownerKind: "capability",
-        ownerId: "skill:cold-skill",
-        state: "unavailable",
-        paths: ["skills.entries.cold-skill.apiKey"],
-        refKeys: ["env:default:MISSING_SKILL_KEY"],
-        reason: "secret provider failed",
-      },
-    ]);
-
-    try {
-      const prompt = resolveSkillsPromptForRun({
-        skillsSnapshot: {
-          prompt: "STALE COLD SKILL PROMPT",
-          skills: [
-            { name: "cold-skill", skillKey: "cold-skill" },
-            { name: "healthy-skill", skillKey: "healthy-skill" },
-          ],
-        },
+        skillsSnapshot: snapshot,
         workspaceDir,
       });
 
       expect(prompt).not.toContain("cold-skill/SKILL.md");
       expect(prompt).toContain("healthy-skill/SKILL.md");
+      expect(prompt).toContain("Captured healthy");
+      expect(prompt).not.toContain("Replacement healthy");
       expect(prompt).not.toContain("new-skill/SKILL.md");
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });

--- a/src/skills/loading/prompt-resolution.test.ts
+++ b/src/skills/loading/prompt-resolution.test.ts
@@ -186,6 +186,43 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).not.toContain("/app/skills/new-skill/SKILL.md");
   });
 
+  it("preserves an explicitly empty supplied catalog during a degraded rebuild", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-prompt-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "healthy-skill"),
+      name: "healthy-skill",
+      description: "Healthy",
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-skill",
+        state: "unavailable",
+        paths: ["skills.entries.cold-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    try {
+      const prompt = resolveSkillsPromptForRun({
+        skillsSnapshot: {
+          prompt: "STALE COLD SKILL PROMPT",
+          skills: [
+            { name: "cold-skill", skillKey: "cold-skill" },
+            { name: "healthy-skill", skillKey: "healthy-skill" },
+          ],
+        },
+        entries: [],
+        workspaceDir,
+      });
+
+      expect(prompt).toBe("");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not load newly installed skills into a degraded snapshot-only prompt", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-prompt-"));
     for (const name of ["cold-skill", "healthy-skill", "new-skill"]) {

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { captureEnv, withPathResolutionEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
@@ -175,6 +176,7 @@ afterAll(async () => {
 afterEach(() => {
   clearRuntimeConfigSnapshot();
   clearPluginMetadataLifecycleCaches();
+  setActiveDegradedSecretOwners([]);
 });
 
 describe("buildWorkspaceSkillCommandSpecs", () => {
@@ -557,9 +559,74 @@ describe("shouldIncludeSkill", () => {
       ).toBe(true);
     });
   });
+
+  it("excludes only the skill whose configured secret is unavailable", () => {
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:env-skill",
+        state: "unavailable",
+        paths: ["skills.entries.env-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    expect(shouldInclude(rawSkillApiKeyRefConfig("env-skill"))).toBe(false);
+    expect(
+      shouldIncludeSkill({
+        entry: makeSkillEntry("healthy-skill", { always: true }),
+        bundledAllowlist: undefined,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("applySkillEnvOverrides", () => {
+  it("skips only the skill whose configured secret is unavailable", () => {
+    const unavailable = envSkillEntries("cold-skill", {
+      primaryEnv: "COLD_SKILL_KEY",
+      requires: { env: ["COLD_SKILL_KEY"] },
+    });
+    const healthy = envSkillEntries("healthy-skill", {
+      primaryEnv: "HEALTHY_SKILL_KEY",
+      requires: { env: ["HEALTHY_SKILL_KEY"] },
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-skill",
+        state: "unavailable",
+        paths: ["skills.entries.cold-skill.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+
+    withClearedEnv(["COLD_SKILL_KEY", "HEALTHY_SKILL_KEY"], () => {
+      const restore = applySkillEnvOverrides({
+        skills: [...unavailable, ...healthy],
+        config: {
+          skills: {
+            entries: {
+              "cold-skill": {
+                apiKey: { source: "env", provider: "default", id: "MISSING_SKILL_KEY" },
+              },
+              "healthy-skill": { apiKey: "healthy" }, // pragma: allowlist secret
+            },
+          },
+        },
+      });
+
+      try {
+        expect(process.env.COLD_SKILL_KEY).toBeUndefined();
+        expect(process.env.HEALTHY_SKILL_KEY).toBe("healthy");
+      } finally {
+        restore();
+      }
+    });
+  });
+
   it("sets and restores env vars", () => {
     const entries = envSkillEntries("env-skill", {
       primaryEnv: "ENV_KEY",

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -697,47 +697,6 @@ describe("applySkillEnvOverrides", () => {
     });
   });
 
-  it("does not guess degraded owner aliases for legacy snapshot overrides", () => {
-    setActiveDegradedSecretOwners([
-      {
-        ownerKind: "capability",
-        ownerId: "skill:cold-alias",
-        state: "unavailable",
-        paths: ["skills.entries.cold-alias.apiKey"],
-        refKeys: ["env:default:MISSING_SKILL_KEY"],
-        reason: "secret provider failed",
-      },
-    ]);
-    const snapshot: SkillSnapshot = {
-      prompt: "",
-      skills: [
-        { name: "cold-skill", primaryEnv: "COLD_SKILL_KEY" },
-        { name: "healthy-skill", skillKey: "healthy-skill", primaryEnv: "HEALTHY_SKILL_KEY" },
-      ],
-    };
-
-    withClearedEnv(["COLD_SKILL_KEY", "HEALTHY_SKILL_KEY"], () => {
-      const restore = applySkillEnvOverridesFromSnapshot({
-        snapshot,
-        config: {
-          skills: {
-            entries: {
-              "cold-skill": { [apiKeyField]: "test-token" }, // pragma: allowlist secret
-              "healthy-skill": { [apiKeyField]: "healthy" }, // pragma: allowlist secret
-            },
-          },
-        },
-      });
-
-      try {
-        expect(process.env.COLD_SKILL_KEY).toBeUndefined();
-        expect(process.env.HEALTHY_SKILL_KEY).toBe("healthy");
-      } finally {
-        restore();
-      }
-    });
-  });
-
   it("skips disabled snapshot skills before resolving raw apiKey SecretRefs", () => {
     const skillName = "env-skill";
     const snapshot = envSkillSnapshot(skillName, {

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -697,6 +697,47 @@ describe("applySkillEnvOverrides", () => {
     });
   });
 
+  it("does not guess degraded owner aliases for legacy snapshot overrides", () => {
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "skill:cold-alias",
+        state: "unavailable",
+        paths: ["skills.entries.cold-alias.apiKey"],
+        refKeys: ["env:default:MISSING_SKILL_KEY"],
+        reason: "secret provider failed",
+      },
+    ]);
+    const snapshot: SkillSnapshot = {
+      prompt: "",
+      skills: [
+        { name: "cold-skill", primaryEnv: "COLD_SKILL_KEY" },
+        { name: "healthy-skill", skillKey: "healthy-skill", primaryEnv: "HEALTHY_SKILL_KEY" },
+      ],
+    };
+
+    withClearedEnv(["COLD_SKILL_KEY", "HEALTHY_SKILL_KEY"], () => {
+      const restore = applySkillEnvOverridesFromSnapshot({
+        snapshot,
+        config: {
+          skills: {
+            entries: {
+              "cold-skill": { [apiKeyField]: "test-token" }, // pragma: allowlist secret
+              "healthy-skill": { [apiKeyField]: "healthy" }, // pragma: allowlist secret
+            },
+          },
+        },
+      });
+
+      try {
+        expect(process.env.COLD_SKILL_KEY).toBeUndefined();
+        expect(process.env.HEALTHY_SKILL_KEY).toBe("healthy");
+      } finally {
+        restore();
+      }
+    });
+  });
+
   it("skips disabled snapshot skills before resolving raw apiKey SecretRefs", () => {
     const skillName = "env-skill";
     const snapshot = envSkillSnapshot(skillName, {

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -34,8 +34,17 @@ import type {
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
-import { resolveBundledAllowlist, shouldIncludeSkill } from "./config.js";
-import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontmatter.js";
+import {
+  hasUnavailableSkillSecretOwners,
+  isSkillSecretOwnerUnavailable,
+  resolveBundledAllowlist,
+  shouldIncludeSkill,
+} from "./config.js";
+import {
+  resolveOpenClawMetadata,
+  resolveSkillInvocationPolicy,
+  resolveSkillKey,
+} from "./frontmatter.js";
 import {
   loadSkillsFromDirSafe,
   readSkillFrontmatterSafe,
@@ -1502,6 +1511,7 @@ export function buildWorkspaceSkillSnapshot(
     prompt,
     skills: eligible.map((entry) => ({
       name: entry.skill.name,
+      skillKey: resolveSkillKey(entry.skill, entry),
       primaryEnv: entry.metadata?.primaryEnv,
       requiredEnv: entry.metadata?.requires?.env?.slice(),
     })),
@@ -1607,15 +1617,35 @@ export function resolveSkillsPromptForRun(params: {
   eligibility?: SkillEligibilityContext;
 }): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
-  if (snapshotPrompt) {
+  const snapshotHasLegacySkillIdentity = params.skillsSnapshot?.skills.some(
+    (skill) => !skill.skillKey,
+  );
+  const snapshotHasUnavailableSkill =
+    params.skillsSnapshot?.skills.some((skill) =>
+      isSkillSecretOwnerUnavailable(skill.skillKey ?? skill.name),
+    ) ||
+    (snapshotHasLegacySkillIdentity && hasUnavailableSkillSecretOwners());
+  if (snapshotPrompt && !snapshotHasUnavailableSkill) {
     return snapshotPrompt;
   }
-  if (params.entries && params.entries.length > 0) {
+  const entries =
+    params.entries && params.entries.length > 0
+      ? params.entries
+      : snapshotHasUnavailableSkill
+        ? loadVisibleWorkspaceSkillEntries(params.workspaceDir, {
+            config: params.config,
+            agentId: params.agentId,
+            eligibility: params.eligibility,
+            skillFilter: params.skillsSnapshot?.skillFilter,
+          })
+        : undefined;
+  if (entries && entries.length > 0) {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
-      entries: params.entries,
+      entries,
       config: params.config,
       agentId: params.agentId,
       eligibility: params.eligibility,
+      skillFilter: params.skillsSnapshot?.skillFilter,
     });
     return prompt.trim() ? prompt : "";
   }

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1628,7 +1628,7 @@ export function resolveSkillsPromptForRun(params: {
   if (snapshotPrompt && !snapshotHasUnavailableSkill) {
     return snapshotPrompt;
   }
-  const entries =
+  const loadedEntries =
     params.entries && params.entries.length > 0
       ? params.entries
       : snapshotHasUnavailableSkill
@@ -1639,6 +1639,23 @@ export function resolveSkillsPromptForRun(params: {
             skillFilter: params.skillsSnapshot?.skillFilter,
           })
         : undefined;
+  const snapshotSkillKeys = new Set(
+    params.skillsSnapshot?.skills.flatMap((skill) => (skill.skillKey ? [skill.skillKey] : [])) ??
+      [],
+  );
+  const legacySnapshotSkillNames = new Set(
+    params.skillsSnapshot?.skills.filter((skill) => !skill.skillKey).map((skill) => skill.name) ??
+      [],
+  );
+  // Rebuild only the catalog captured for this session. A degraded owner must
+  // not make newly installed or newly eligible skills appear mid-session.
+  const entries = params.skillsSnapshot
+    ? loadedEntries?.filter(
+        (entry) =>
+          snapshotSkillKeys.has(resolveSkillKey(entry.skill, entry)) ||
+          legacySnapshotSkillNames.has(entry.skill.name),
+      )
+    : loadedEntries;
   if (entries && entries.length > 0) {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
       entries,

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1641,8 +1641,7 @@ export function resolveSkillsPromptForRun(params: {
     const unavailableNames = new Set(
       params.skillsSnapshot?.skills
         .filter(
-          (skill): skill is typeof skill & { skillKey: string } =>
-            Boolean(skill.skillKey) && isSkillSecretOwnerUnavailable(skill.skillKey),
+          (skill) => skill.skillKey !== undefined && isSkillSecretOwnerUnavailable(skill.skillKey),
         )
         .map((skill) => escapeXml(skill.name)),
     );

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1617,52 +1617,80 @@ export function resolveSkillsPromptForRun(params: {
   eligibility?: SkillEligibilityContext;
 }): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
+  if (params.skillsSnapshot && !snapshotPrompt) {
+    return "";
+  }
   const snapshotHasLegacySkillIdentity = params.skillsSnapshot?.skills.some(
     (skill) => !skill.skillKey,
   );
-  const snapshotHasUnavailableSkill =
-    params.skillsSnapshot?.skills.some((skill) =>
-      isSkillSecretOwnerUnavailable(skill.skillKey ?? skill.name),
-    ) ||
-    (snapshotHasLegacySkillIdentity && hasUnavailableSkillSecretOwners());
-  if (snapshotPrompt && !snapshotHasUnavailableSkill) {
-    return snapshotPrompt;
+  if (snapshotPrompt) {
+    const snapshotHasUnavailableSkill =
+      params.skillsSnapshot?.skills.some((skill) =>
+        isSkillSecretOwnerUnavailable(skill.skillKey ?? skill.name),
+      ) ||
+      (snapshotHasLegacySkillIdentity && hasUnavailableSkillSecretOwners());
+    if (
+      snapshotHasUnavailableSkill &&
+      params.skillsSnapshot?.promptFormatVersion !== WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION
+    ) {
+      return "";
+    }
+    if (snapshotHasLegacySkillIdentity && hasUnavailableSkillSecretOwners()) {
+      return "";
+    }
+    const unavailableNames = new Set(
+      params.skillsSnapshot?.skills
+        .filter(
+          (skill): skill is typeof skill & { skillKey: string } =>
+            Boolean(skill.skillKey) && isSkillSecretOwnerUnavailable(skill.skillKey),
+        )
+        .map((skill) => escapeXml(skill.name)),
+    );
+    if (unavailableNames.size === 0) {
+      return snapshotPrompt;
+    }
+    const catalogOpen = "<available_skills>";
+    const catalogClose = "</available_skills>";
+    const catalogStart = snapshotPrompt.indexOf(catalogOpen);
+    const catalogEnd = snapshotPrompt.indexOf(catalogClose, catalogStart + catalogOpen.length);
+    if (
+      catalogStart < 0 ||
+      catalogEnd < 0 ||
+      snapshotPrompt.indexOf(catalogOpen, catalogStart + catalogOpen.length) >= 0 ||
+      snapshotPrompt.indexOf(catalogClose, catalogEnd + catalogClose.length) >= 0
+    ) {
+      return "";
+    }
+    const bodyStart = catalogStart + catalogOpen.length;
+    const catalogBody = snapshotPrompt.slice(bodyStart, catalogEnd);
+    const blockPattern = /\n  <skill>\n[\s\S]*?\n  <\/skill>/g;
+    let cursor = 0;
+    let filteredBody = "";
+    for (const match of catalogBody.matchAll(blockPattern)) {
+      const gap = catalogBody.slice(cursor, match.index);
+      const block = match[0];
+      const name = /^    <name>(.*)<\/name>$/m.exec(block)?.[1];
+      if (gap.trim() || !name) {
+        return "";
+      }
+      filteredBody += gap;
+      if (!unavailableNames.has(name)) {
+        filteredBody += block;
+      }
+      cursor = (match.index ?? 0) + block.length;
+    }
+    const tail = catalogBody.slice(cursor);
+    if (tail.trim()) {
+      return "";
+    }
+    return `${snapshotPrompt.slice(0, bodyStart)}${filteredBody}${tail}${snapshotPrompt.slice(catalogEnd)}`.trim();
   }
-  const loadedEntries =
-    params.entries !== undefined
-      ? params.entries
-      : snapshotHasUnavailableSkill
-        ? loadVisibleWorkspaceSkillEntries(params.workspaceDir, {
-            config: params.config,
-            agentId: params.agentId,
-            eligibility: params.eligibility,
-            skillFilter: params.skillsSnapshot?.skillFilter,
-          })
-        : undefined;
-  const snapshotSkillKeys = new Set(
-    params.skillsSnapshot?.skills.flatMap((skill) => (skill.skillKey ? [skill.skillKey] : [])) ??
-      [],
-  );
-  const legacySnapshotSkillNames = new Set(
-    params.skillsSnapshot?.skills.filter((skill) => !skill.skillKey).map((skill) => skill.name) ??
-      [],
-  );
-  // Rebuild only the catalog captured for this session. A degraded owner must
-  // not make newly installed or newly eligible skills appear mid-session.
-  const entries = params.skillsSnapshot
-    ? loadedEntries?.filter(
-        (entry) =>
-          snapshotSkillKeys.has(resolveSkillKey(entry.skill, entry)) ||
-          legacySnapshotSkillNames.has(entry.skill.name),
-      )
-    : loadedEntries;
-  if (entries && entries.length > 0) {
+  if (params.entries && params.entries.length > 0) {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
-      entries,
+      entries: params.entries,
       config: params.config,
       agentId: params.agentId,
       eligibility: params.eligibility,
-      skillFilter: params.skillsSnapshot?.skillFilter,
     });
     return prompt.trim() ? prompt : "";
   }

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1629,7 +1629,7 @@ export function resolveSkillsPromptForRun(params: {
     return snapshotPrompt;
   }
   const loadedEntries =
-    params.entries && params.entries.length > 0
+    params.entries !== undefined
       ? params.entries
       : snapshotHasUnavailableSkill
         ? loadVisibleWorkspaceSkillEntries(params.workspaceDir, {

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1655,20 +1655,20 @@ export function resolveSkillsPromptForRun(params: {
     if (
       catalogStart < 0 ||
       catalogEnd < 0 ||
-      snapshotPrompt.indexOf(catalogOpen, catalogStart + catalogOpen.length) >= 0 ||
-      snapshotPrompt.indexOf(catalogClose, catalogEnd + catalogClose.length) >= 0
+      snapshotPrompt.includes(catalogOpen, catalogStart + catalogOpen.length) ||
+      snapshotPrompt.includes(catalogClose, catalogEnd + catalogClose.length)
     ) {
       return "";
     }
     const bodyStart = catalogStart + catalogOpen.length;
     const catalogBody = snapshotPrompt.slice(bodyStart, catalogEnd);
-    const blockPattern = /\n  <skill>\n[\s\S]*?\n  <\/skill>/g;
+    const blockPattern = /\n[ ]{2}<skill>\n[\s\S]*?\n[ ]{2}<\/skill>/g;
     let cursor = 0;
     let filteredBody = "";
     for (const match of catalogBody.matchAll(blockPattern)) {
       const gap = catalogBody.slice(cursor, match.index);
       const block = match[0];
-      const name = /^    <name>(.*)<\/name>$/m.exec(block)?.[1];
+      const name = /^[ ]{4}<name>(.*)<\/name>$/m.exec(block)?.[1];
       if (gap.trim() || !name) {
         return "";
       }

--- a/src/skills/runtime/env-overrides.ts
+++ b/src/skills/runtime/env-overrides.ts
@@ -7,7 +7,7 @@ import {
   isDangerousHostEnvVarName,
 } from "../../infra/host-env-security.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { resolveSkillConfig } from "../loading/config.js";
+import { isSkillSecretOwnerUnavailable, resolveSkillConfig } from "../loading/config.js";
 import { resolveSkillKey } from "../loading/frontmatter.js";
 import { resolveSkillRuntimeConfig } from "../loading/runtime-config.js";
 import type { SkillEntry, SkillSnapshot } from "../types.js";
@@ -228,6 +228,9 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
 
   for (const entry of skills) {
     const skillKey = resolveSkillKey(entry.skill, entry);
+    if (isSkillSecretOwnerUnavailable(skillKey)) {
+      continue;
+    }
     const skillConfig = resolveSkillConfig(config, skillKey);
     if (!skillConfig) {
       continue;
@@ -260,7 +263,11 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   const updates: EnvUpdate[] = [];
 
   for (const skill of snapshot.skills) {
-    const skillConfig = resolveSkillConfig(config, skill.name);
+    const skillKey = skill.skillKey ?? skill.name;
+    if (isSkillSecretOwnerUnavailable(skillKey)) {
+      continue;
+    }
+    const skillConfig = resolveSkillConfig(config, skillKey);
     if (!skillConfig) {
       continue;
     }
@@ -273,7 +280,7 @@ export function applySkillEnvOverridesFromSnapshot(params: {
       skillConfig,
       primaryEnv: skill.primaryEnv,
       requiredEnv: skill.requiredEnv,
-      skillKey: skill.name,
+      skillKey,
     });
   }
 

--- a/src/skills/runtime/env-overrides.ts
+++ b/src/skills/runtime/env-overrides.ts
@@ -7,7 +7,11 @@ import {
   isDangerousHostEnvVarName,
 } from "../../infra/host-env-security.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { isSkillSecretOwnerUnavailable, resolveSkillConfig } from "../loading/config.js";
+import {
+  hasUnavailableSkillSecretOwners,
+  isSkillSecretOwnerUnavailable,
+  resolveSkillConfig,
+} from "../loading/config.js";
 import { resolveSkillKey } from "../loading/frontmatter.js";
 import { resolveSkillRuntimeConfig } from "../loading/runtime-config.js";
 import type { SkillEntry, SkillSnapshot } from "../types.js";
@@ -263,6 +267,11 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   const updates: EnvUpdate[] = [];
 
   for (const skill of snapshot.skills) {
+    // Legacy snapshots lack the config key, so aliases cannot be matched to an
+    // unavailable owner. Skip their overrides instead of guessing by display name.
+    if (!skill.skillKey && hasUnavailableSkillSecretOwners()) {
+      continue;
+    }
     const skillKey = skill.skillKey ?? skill.name;
     if (isSkillSecretOwnerUnavailable(skillKey)) {
       continue;

--- a/src/skills/runtime/env-overrides.ts
+++ b/src/skills/runtime/env-overrides.ts
@@ -7,11 +7,7 @@ import {
   isDangerousHostEnvVarName,
 } from "../../infra/host-env-security.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import {
-  hasUnavailableSkillSecretOwners,
-  isSkillSecretOwnerUnavailable,
-  resolveSkillConfig,
-} from "../loading/config.js";
+import { isSkillSecretOwnerUnavailable, resolveSkillConfig } from "../loading/config.js";
 import { resolveSkillKey } from "../loading/frontmatter.js";
 import { resolveSkillRuntimeConfig } from "../loading/runtime-config.js";
 import type { SkillEntry, SkillSnapshot } from "../types.js";
@@ -267,11 +263,6 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   const updates: EnvUpdate[] = [];
 
   for (const skill of snapshot.skills) {
-    // Legacy snapshots lack the config key, so aliases cannot be matched to an
-    // unavailable owner. Skip their overrides instead of guessing by display name.
-    if (!skill.skillKey && hasUnavailableSkillSecretOwners()) {
-      continue;
-    }
     const skillKey = skill.skillKey ?? skill.name;
     if (isSkillSecretOwnerUnavailable(skillKey)) {
       continue;

--- a/src/skills/runtime/session-snapshot.test.ts
+++ b/src/skills/runtime/session-snapshot.test.ts
@@ -270,4 +270,19 @@ describe("resolveReusableWorkspaceSkillSnapshot", () => {
     );
     expect(snapshotParams.snapshotVersion).toBe(0);
   });
+
+  it("refreshes snapshots from before config-key skill identities", () => {
+    shouldRefreshSnapshotForVersionMock.mockReturnValue(false);
+    const result = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: TEST_WORKSPACE_DIR,
+      config: {},
+      existingSnapshot: {
+        ...strippedSnapshot(),
+        promptFormatVersion: WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION - 1,
+      },
+    });
+
+    expect(result.shouldRefresh).toBe(true);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -119,7 +119,13 @@ export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 2;
 
 export type SkillSnapshot = {
   prompt: string;
-  skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
+  skills: Array<{
+    name: string;
+    /** Config key can differ from the prompt-facing skill name. */
+    skillKey?: string;
+    primaryEnv?: string;
+    requiredEnv?: string[];
+  }>;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
   /** Effective node-exec eligibility used to select connected node-hosted skills. */

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -115,7 +115,7 @@ export type SkillEligibilityContext = {
   };
 };
 
-export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 2;
+export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 3;
 
 export type SkillSnapshot = {
   prompt: string;


### PR DESCRIPTION
Related: #101265

## What Problem This Solves

Fixes an issue where one unavailable `skills.entries.*.apiKey` SecretRef could prevent the Gateway from starting instead of disabling only its owning skill.

## Why This Change Was Made

Each skill API key now has an isolatable per-skill owner. Live discovery, persisted prompt reconstruction, and both live and snapshot environment injection honor the same owner identity, including custom config keys and saved skill filters.

## User Impact

The Gateway and healthy skills stay available when one configured skill secret cannot resolve. Existing session snapshots are rebuilt without the cold skill, while preserving healthy skills and the saved agent filter. Existing degraded-secret diagnostics expose the exact skill owner.

## Evidence

- Focused runtime, Gateway, skill loading, persisted prompt, and snapshot tests: 69 passed.
- Four autoreview iterations; final result clean. Earlier findings drove persisted-session invalidation, custom config-key identity, snapshot-only reconstruction, and filter preservation.
- `node scripts/check-changed.mjs -- <9 touched files>` on Blacksmith Testbox: full changed gate green in 19m07s. Action: https://github.com/openclaw/openclaw/actions/runs/29563823676
