### PR TITLE
fix(secrets): surface degradation in logs and doctor

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -10,7 +10,7 @@ title: "Doctor"
 
 Health checks and quick fixes for the gateway, channels, plugins, skills, model routing, local state, and config migrations. Use it whenever something is not behaving as expected and you want one command to explain what is wrong.
 
-When Gateway status reports SecretRef owners isolated during cold startup, doctor prints a **Secret owners unavailable** warning with every owner and affected config path.
+When Gateway status reports SecretRef owners isolated during cold startup, doctor prints a **Secret runtime degradation** warning with every cold owner, affected config path, redacted reason, and the `openclaw secrets reload` retry command.
 
 Related:
 

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -21,7 +21,7 @@ Plaintext credentials remain agent-readable if they sit in files the agent can i
 ## Runtime model
 
 - Secrets resolve into an in-memory runtime snapshot, eagerly during activation, not lazily on request paths.
-- Cold Gateway startup isolates unavailable SecretRefs to a known non-Gateway owner when that owner supports isolation. Today this covers model providers and the built-in TTS capability. The Gateway starts, records that owner as configured-unavailable, and emits a redacted `SECRETS_OWNER_UNAVAILABLE` warning. Gateway ingress auth, structurally invalid refs or resolved values, and refs whose runtime owner is not yet mapped still fail startup.
+- Cold Gateway startup isolates unavailable SecretRefs to a known non-Gateway owner when that owner supports isolation. Today this covers model providers, the built-in TTS capability, web search and fetch providers, and webhook routes. The Gateway starts, records that owner as configured-unavailable, and emits a redacted `SECRETS_OWNER_UNAVAILABLE` warning. Gateway ingress auth, structurally invalid refs or resolved values, and refs whose runtime owner is not yet mapped still fail startup.
 - Reload is an atomic swap: full success, or keep the last-known-good snapshot.
 - Policy violations (for example an OAuth-mode auth profile combined with SecretRef input) fail activation before the runtime swap.
 - Runtime requests read only the active in-memory snapshot. Model-provider SecretRef credentials pass through auth storage and stream options as process-local sentinels until egress. Outbound delivery paths (Discord reply/thread delivery, Telegram action sends) also read that snapshot and do not re-resolve refs per send.
@@ -29,7 +29,7 @@ Plaintext credentials remain agent-readable if they sit in files the agent can i
 This keeps secret-provider outages off hot request paths.
 
 <Note>
-Target policy for the SecretRef ownership-isolation migration: failures isolate to the smallest known owner. Only unavailable Gateway ingress protection, structurally invalid config, or unknown ownership will block startup; other affected capabilities, accounts, or routes will become configured-unavailable with typed redacted diagnostics and no implicit credential fallback. Reload will retain last-known-good only for an unchanged ref and provider, while a changed unresolved ref will make that owner cold. Doctor and status will list every degraded owner. This migration is not fully implemented; the current activation rules on this page remain in effect.
+Target policy for the SecretRef ownership-isolation migration: failures isolate to the smallest known owner. Only unavailable Gateway ingress protection, structurally invalid config, or unknown ownership will block startup; other affected capabilities, accounts, or routes will become configured-unavailable with typed redacted diagnostics and no implicit credential fallback. Reload will retain last-known-good only for an unchanged ref and provider, while a changed unresolved ref will make that owner cold. Doctor and structured Gateway warnings will identify degraded owners. This migration is not fully implemented; the current activation rules on this page remain in effect.
 </Note>
 
 ## Egress-time injection (sentinels)
@@ -617,6 +617,8 @@ Behavior:
 - Recovered: emitted once after the next successful activation.
 - Repeated failures while already degraded log warnings but do not re-emit the event.
 - Startup fail-fast never emits a degraded event, because runtime never became active.
+- Startup and reload failures emit a structured `SECRETS_DEGRADED` warning for each affected owner. The warning includes the owner kind and id, a redacted reason, `cold` or `stale` state, and the `openclaw secrets reload` retry hint. It never includes resolved values or SecretRef ids.
+- `openclaw doctor` lists owners isolated during cold startup with their affected config paths, redacted reason, and retry guidance.
 
 ## Command-path resolution
 

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -127,7 +127,14 @@ describe("checkGatewayHealth", () => {
             ownerId: "tts",
             state: "unavailable",
             paths: ["messages.tts.providers.elevenlabs.apiKey"],
-            reason: "secret provider failed",
+            reason: "secret provider policy denied resolution",
+          },
+          {
+            ownerKind: "capability",
+            ownerId: "web-fetch:firecrawl",
+            state: "unavailable",
+            paths: ["plugins.entries.firecrawl.config.webFetch.apiKey"],
+            reason: "resolved secret value was invalid",
           },
         ],
       })
@@ -138,10 +145,14 @@ describe("checkGatewayHealth", () => {
 
     expect(note).toHaveBeenCalledWith(
       [
-        "- account:discord:ops (channels.discord.accounts.ops.token): secret reference was not found",
-        "- capability:tts (messages.tts.providers.elevenlabs.apiKey): secret provider failed",
+        "- cold account:discord:ops (channels.discord.accounts.ops.token): secret reference was not found",
+        "  Retry: openclaw secrets reload",
+        "- cold capability:tts (messages.tts.providers.elevenlabs.apiKey): secret provider policy denied resolution",
+        "  Retry: openclaw secrets reload",
+        "- cold capability:web-fetch:firecrawl (plugins.entries.firecrawl.config.webFetch.apiKey): resolved secret value was invalid",
+        "  Retry: openclaw secrets reload",
       ].join("\n"),
-      "Secret owners unavailable",
+      "Secret runtime degradation",
     );
   });
 

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -120,7 +120,7 @@ describe("checkGatewayHealth", () => {
             ownerId: "discord:ops",
             state: "unavailable",
             paths: ["channels.discord.accounts.ops.token"],
-            reason: "secret reference was not found",
+            reason: "secret reference was not found (env:default:PRIVATE_REF_ID)",
           },
           {
             ownerKind: "capability",
@@ -145,7 +145,7 @@ describe("checkGatewayHealth", () => {
 
     expect(note).toHaveBeenCalledWith(
       [
-        "- cold account:discord:ops (channels.discord.accounts.ops.token): secret reference was not found",
+        "- cold account:discord:ops (channels.discord.accounts.ops.token): secret resolution failed",
         "  Retry: openclaw secrets reload",
         "- cold capability:tts (messages.tts.providers.elevenlabs.apiKey): secret provider policy denied resolution",
         "  Retry: openclaw secrets reload",

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -91,10 +91,11 @@ export async function checkGatewayHealth(params: {
         status.degradedSecretOwners
           .map(
             (owner) =>
-              `- ${owner.ownerKind}:${owner.ownerId} (${owner.paths.join(", ")}): ${owner.reason}`,
+              `- cold ${owner.ownerKind}:${owner.ownerId} (${owner.paths.join(", ")}): ${owner.reason}` +
+              "\n  Retry: openclaw secrets reload",
           )
           .join("\n"),
-        "Secret owners unavailable",
+        "Secret runtime degradation",
       );
     }
     if (status.degradedPlugins && status.degradedPlugins.length > 0) {

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -16,6 +16,7 @@ import type {
 import { collectChannelStatusIssues } from "../infra/channels-status-issues.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { redactSecretDegradationReason } from "../secrets/runtime-degraded-state.js";
 import { VERSION } from "../version.js";
 import {
   GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
@@ -91,7 +92,7 @@ export async function checkGatewayHealth(params: {
         status.degradedSecretOwners
           .map(
             (owner) =>
-              `- cold ${owner.ownerKind}:${owner.ownerId} (${owner.paths.join(", ")}): ${owner.reason}` +
+              `- cold ${owner.ownerKind}:${owner.ownerId} (${owner.paths.join(", ")}): ${redactSecretDegradationReason(owner.reason)}` +
               "\n  Retry: openclaw secrets reload",
           )
           .join("\n"),

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -286,7 +286,7 @@ describe("getStatusSummary", () => {
         state: "unavailable",
         paths: ["channels.discord.accounts.ops.token"],
         refKeys: ["env:default:PRIVATE_REF_ID"],
-        reason: "secret reference was not found",
+        reason: "provider SecretRef is unresolved (env:default:PRIVATE_REF_ID)",
       },
     ]);
 
@@ -298,7 +298,7 @@ describe("getStatusSummary", () => {
         ownerId: "discord:ops",
         state: "unavailable",
         paths: ["channels.discord.accounts.ops.token"],
-        reason: "secret reference was not found",
+        reason: "secret resolution failed",
       },
     ]);
     expect(JSON.stringify(summary.degradedSecretOwners)).not.toContain("PRIVATE_REF_ID");

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -21,7 +21,10 @@ import {
   toPublicPluginVerificationDiagnostic,
 } from "../plugins/runtime-degraded-state.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
-import { listActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
+import {
+  listActiveDegradedSecretOwners,
+  redactSecretDegradationReason,
+} from "../secrets/runtime-degraded-state.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import {
@@ -570,13 +573,16 @@ export async function getStatusSummary(
     channelSummary,
     queuedSystemEvents,
     degradedSecretOwners: listActiveDegradedSecretOwners().map(
-      ({ ownerKind, ownerId, state, paths: ownerPaths, reason }) => ({
-        ownerKind,
-        ownerId,
-        state,
-        paths: ownerPaths,
-        reason,
-      }),
+      ({ ownerKind, ownerId, state, paths: ownerPaths, reason }) => {
+        const redactedReason: string = redactSecretDegradationReason(reason);
+        return {
+          ownerKind,
+          ownerId,
+          state,
+          paths: ownerPaths,
+          reason: redactedReason,
+        };
+      },
     ),
     degradedPlugins: listActiveDegradedPlugins().map(({ pluginId, state, diagnostic }) => ({
       pluginId,

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -178,22 +178,6 @@ export function setAppliedRuntimeConfigSnapshot(
   runtimeConfigAppliedHash = hashRuntimeConfigValue(sourceConfig);
 }
 
-/** Publish a newer canonical source without changing the active runtime object. */
-export function setRuntimeConfigSourceSnapshotIfCurrent(params: {
-  expectedRevision: number;
-  sourceConfig: OpenClawConfig;
-}): boolean {
-  if (
-    !runtimeConfigSnapshot ||
-    !runtimeConfigSnapshotMetadata ||
-    runtimeConfigSnapshotMetadata.revision !== params.expectedRevision
-  ) {
-    return false;
-  }
-  setRuntimeConfigSnapshot(runtimeConfigSnapshot, params.sourceConfig);
-  return true;
-}
-
 export function resetConfigRuntimeState(): void {
   runtimeConfigSnapshot = null;
   runtimeConfigSourceSnapshot = null;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -667,7 +667,7 @@ function createReloaderHarness(
       nextConfig: OpenClawConfig,
       ownership: GatewayConfigReloadTransactionOwnership,
       sourceConfig: OpenClawConfig,
-    ) => Promise<() => Promise<void>>;
+    ) => Promise<{ rollback: () => Promise<void>; commit?: () => void }>;
     onConfigApplied?: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
     onConfigRevisionApplied?: (hash: string) => void;
     onConfigChange?: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
@@ -703,7 +703,7 @@ function createReloaderHarness(
   const onConfigAccepted = vi.fn(options.onConfigAccepted ?? (async () => {}));
   const onConfigRevisionApplied = vi.fn(options.onConfigRevisionApplied ?? (() => {}));
   const onEffectiveConfigUnchanged = vi.fn(
-    options.onEffectiveConfigUnchanged ?? (async () => async () => {}),
+    options.onEffectiveConfigUnchanged ?? (async () => ({ rollback: async () => {} })),
   );
   const onNoopConfigCommit = vi.fn(
     options.onNoopConfigCommit ??
@@ -3021,6 +3021,8 @@ describe("startGatewayConfigReloader", () => {
       ...initialConfig,
       logging: { level: "debug" as const },
     } satisfies OpenClawConfig;
+    const publicationEvents: string[] = [];
+    let publicationId = 0;
     const rollbackSource = vi.fn(async () => {});
     let emitSupersedingChange = () => {};
     const harness = createReloaderHarness(
@@ -3032,7 +3034,18 @@ describe("startGatewayConfigReloader", () => {
           queueMicrotask(emitSupersedingChange);
           return rollback;
         },
-        onEffectiveConfigUnchanged: async () => rollbackSource,
+        onEffectiveConfigUnchanged: async () => {
+          const id = publicationId++;
+          return {
+            rollback: async () => {
+              publicationEvents.push(`rollback:${id}`);
+              await rollbackSource();
+            },
+            commit: () => {
+              publicationEvents.push(`commit:${id}`);
+            },
+          };
+        },
       },
     );
     emitSupersedingChange = () => {
@@ -3063,6 +3076,7 @@ describe("startGatewayConfigReloader", () => {
       initialConfig,
     ]);
     expect(rollbackSource).toHaveBeenCalledOnce();
+    expect(publicationEvents).toEqual(["rollback:0", "commit:1"]);
 
     await harness.reloader.stop();
   });

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -175,7 +175,11 @@ export function startGatewayConfigReloader(opts: {
     nextConfig: OpenClawConfig,
     ownership: GatewayConfigReloadTransactionOwnership,
     sourceConfig: OpenClawConfig,
-  ) => Promise<() => Promise<void>>;
+  ) => Promise<{
+    rollback: () => Promise<void>;
+    /** Runs only when this exact source publication can no longer roll back. */
+    commit?: () => void;
+  }>;
   onNoopConfigCommit: (
     plan: GatewayReloadPlan,
     nextConfig: OpenClawConfig,
@@ -497,16 +501,27 @@ export function startGatewayConfigReloader(opts: {
       }
     };
     if (changedPaths.length === 0) {
+      let publishedSource: { rollback: () => Promise<void>; commit?: () => void } | undefined;
       let publishedSourceRollback: (() => Promise<void>) | undefined;
+      let publishedSourceRolledBack = false;
       const publishSource = opts.onEffectiveConfigUnchanged
-        ? async () =>
-            (publishedSourceRollback ??= await opts.onEffectiveConfigUnchanged!(
+        ? async () => {
+            publishedSource ??= await opts.onEffectiveConfigUnchanged!(
               nextConfig,
               ownership,
               nextSourceConfig,
-            ))
+            );
+            publishedSourceRollback ??= async () => {
+              publishedSourceRolledBack = true;
+              await publishedSource?.rollback();
+            };
+            return publishedSourceRollback;
+          }
         : undefined;
       await commitReloadBaseline(publishSource ? { publishSource } : {});
+      if (!publishedSourceRolledBack) {
+        publishedSource?.commit?.();
+      }
       opts.onConfigRevisionApplied?.(nextConfigRevisionHash);
       return;
     }

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -413,8 +413,18 @@ describe("gateway aux handlers", () => {
       canonicalConfig,
     ]);
     expect(activateRuntimeSecrets.mock.calls.map(([, activation]) => activation)).toEqual([
-      { reason: "reload", activate: false },
-      { reason: "reload", activate: false },
+      {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
+      },
+      {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
+      },
     ]);
     expect(activatePreparedSnapshotIfCurrent).toHaveBeenCalledTimes(2);
     expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(canonicalConfig);

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -264,6 +264,9 @@ export function createGatewayAuxHandlers(params: {
                     {
                       reason: "reload",
                       activate: false,
+                      publishFailureAsDegraded: true,
+                      canPublishFailureAsDegraded: () =>
+                        getActiveSecretsRuntimeSnapshotRevision() === previousSnapshotRevision,
                     },
                   );
                   const plan = buildReloadPlan(

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -423,6 +423,14 @@ function createManagedRestartSequenceHarness(
     },
   } as OpenClawConfig;
   setRuntimeConfigSnapshot(initialConfig, initialConfig);
+  activateSecretsRuntimeSnapshot({
+    sourceConfig: initialConfig,
+    config: initialConfig,
+    authStores: [],
+    authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+    warnings: [],
+    webTools: createEmptyRuntimeWebToolsMetadata(),
+  });
   const deferredConfig = {
     gateway: {
       port: 18790,
@@ -893,7 +901,7 @@ describe("managed reload transaction ownership", () => {
     async (kind) => {
       const result = await runManagedOwnershipScenario({ kind, queueRevert: true });
 
-      expect(result.activateRuntimeSecrets).toHaveBeenCalledTimes(2);
+      expect(result.activateRuntimeSecrets).toHaveBeenCalledOnce();
       expect(result.commitTerminalConfig).not.toHaveBeenCalled();
       expect(result.acceptTerminalConfig).toHaveBeenCalledOnce();
       expect(result.prepareTerminalConfig).toHaveBeenCalledOnce();

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -40,7 +40,10 @@ import {
   tryBeginGatewaySuspendAdmission,
 } from "../process/gateway-work-admission.js";
 import { CommandLane } from "../process/lanes.js";
+import { resolveAuthProfileSecretOwnerId } from "../secrets/runtime-auth-profile-owner.js";
+import { listActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import { createEmptyRuntimeWebToolsMetadata } from "../secrets/runtime-fast-path.js";
+import { classifySecretOwnerDegradationState } from "../secrets/runtime-owner-assignments.js";
 import {
   activateSecretsRuntimeSnapshot,
   clearSecretsRuntimeSnapshot,
@@ -890,7 +893,7 @@ describe("managed reload transaction ownership", () => {
     async (kind) => {
       const result = await runManagedOwnershipScenario({ kind, queueRevert: true });
 
-      expect(result.activateRuntimeSecrets).toHaveBeenCalledOnce();
+      expect(result.activateRuntimeSecrets).toHaveBeenCalledTimes(2);
       expect(result.commitTerminalConfig).not.toHaveBeenCalled();
       expect(result.acceptTerminalConfig).toHaveBeenCalledOnce();
       expect(result.prepareTerminalConfig).toHaveBeenCalledOnce();
@@ -3880,7 +3883,7 @@ describe("gateway Gmail hot reload handlers", () => {
       gateway: { reload: { debounceMs: 0 } },
       messages: { visibleReplies: "message_tool" },
     };
-    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig) => ({
+    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig, _params: unknown) => ({
       sourceConfig: config,
       config,
       authStores: [],
@@ -3977,6 +3980,9 @@ describe("gateway Gmail hot reload handlers", () => {
     expect(activateRuntimeSecrets).toHaveBeenCalledWith(nextConfig, {
       reason: "reload",
       activate: false,
+      publishFailureAsDegraded: true,
+      canPublishFailureAsDegraded: expect.any(Function),
+      includeAuthStoreRefs: undefined,
     });
     expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(nextConfig);
     expect(acceptTerminalConfig).toHaveBeenCalledWith({
@@ -3985,6 +3991,380 @@ describe("gateway Gmail hot reload handlers", () => {
     expect(heartbeatRunner.updateConfig).not.toHaveBeenCalled();
     expect(commitTerminalConfig).toHaveBeenCalledWith(nextConfig);
     await reloader.stop();
+  });
+
+  it("refreshes owner refs when only the resolved source snapshot changes", async () => {
+    vi.useFakeTimers();
+    const authAgentDir = "/tmp/openclaw-source-only-auth-owner";
+    const authProfileId = "openai:source-only";
+    const authOwnerId = resolveAuthProfileSecretOwnerId({
+      agentDir: authAgentDir,
+      profileId: authProfileId,
+    });
+    const firstRef = { source: "env" as const, provider: "default", id: "TTS_FIRST" };
+    const secondRef = { source: "env" as const, provider: "default", id: "TTS_SECOND" };
+    const thirdRef = { source: "env" as const, provider: "default", id: "TTS_THIRD" };
+    const fourthRef = { source: "env" as const, provider: "default", id: "TTS_FOURTH" };
+    const sourceConfig = (ref: typeof firstRef): OpenClawConfig => ({
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { tts: { providers: { elevenlabs: { apiKey: ref } } } },
+    });
+    const runtimeConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { tts: { providers: { elevenlabs: { apiKey: String(42) } } } },
+    };
+    const initialSourceConfig = sourceConfig(firstRef);
+    const nextSourceConfig = sourceConfig(secondRef);
+    activateSecretsRuntimeSnapshot({
+      sourceConfig: initialSourceConfig,
+      config: runtimeConfig,
+      authStores: [
+        {
+          agentDir: authAgentDir,
+          store: {
+            version: 1,
+            profiles: {
+              [authProfileId]: {
+                type: "api_key",
+                provider: "openai",
+                key: String(42),
+                keyRef: { source: "env", provider: "default", id: "AUTH_FIRST" },
+              },
+            },
+          },
+        },
+      ],
+      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      warnings: [],
+      degradedOwners: [
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          state: "unavailable",
+          paths: ["messages.tts.providers.elevenlabs.apiKey"],
+          refKeys: ["env:default:TTS_FIRST"],
+          reason: "secret reference was not found",
+        },
+        {
+          ownerKind: "account",
+          ownerId: authOwnerId,
+          state: "unavailable",
+          paths: [`${authAgentDir}.auth-profiles.${authProfileId}.key`],
+          refKeys: ["env:default:AUTH_FIRST"],
+          reason: "secret provider failed",
+        },
+      ],
+      secretOwners: [
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          refKeys: ["env:default:TTS_FIRST"],
+        },
+        {
+          ownerKind: "account",
+          ownerId: authOwnerId,
+          refKeys: ["env:default:AUTH_FIRST"],
+        },
+      ],
+      webTools: createEmptyRuntimeWebToolsMetadata(),
+    });
+    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
+      current: null,
+    };
+    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig, _params: unknown) => ({
+      sourceConfig: config,
+      config: runtimeConfig,
+      authStores: [
+        {
+          agentDir: authAgentDir,
+          store: {
+            version: 1,
+            profiles: {
+              [authProfileId]: {
+                type: "api_key" as const,
+                provider: "openai",
+                key: String(42),
+                keyRef: { source: "env" as const, provider: "default", id: "AUTH_SECOND" },
+              },
+            },
+          },
+        },
+      ],
+      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      warnings: [],
+      secretOwners: [
+        {
+          ownerKind: "capability" as const,
+          ownerId: "tts",
+          refKeys: ["env:default:TTS_SECOND"],
+        },
+        {
+          ownerKind: "account" as const,
+          ownerId: authOwnerId,
+          refKeys: ["env:default:AUTH_SECOND"],
+        },
+      ],
+      webTools: createEmptyRuntimeWebToolsMetadata(),
+    }));
+    const reloader = startManagedGatewayConfigReloader({
+      minimalTestGateway: false,
+      initialConfig: runtimeConfig,
+      initialCompareConfig: runtimeConfig,
+      initialInternalWriteHash: null,
+      watchPath: "/tmp/openclaw.json",
+      readSnapshot: vi.fn(async () => ({
+        path: "/tmp/openclaw.json",
+        exists: true,
+        raw: "{}",
+        parsed: nextSourceConfig,
+        sourceConfig: nextSourceConfig,
+        resolved: runtimeConfig,
+        valid: true,
+        runtimeConfig,
+        config: runtimeConfig,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+        hash: "same-runtime-next-source",
+      })) as never,
+      promoteSnapshot: vi.fn(async () => true) as never,
+      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
+        writeListenerRef.current = listener;
+        return () => {
+          if (writeListenerRef.current === listener) {
+            writeListenerRef.current = null;
+          }
+        };
+      }) as never,
+      prepareConfigCandidate: ({ runtimeConfig: candidateRuntime }) => ({
+        runtimeConfig: candidateRuntime,
+        compareConfig: candidateRuntime,
+      }),
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      reloadPlugins: vi.fn(async () => ({
+        restartChannels: new Set<ChannelKind>(),
+        activeChannels: new Set<ChannelKind>(),
+      })),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      channelManager: {} as never,
+      activateRuntimeSecrets: activateRuntimeSecrets as never,
+      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+      sharedGatewaySessionGenerationState: { current: undefined, required: null },
+      clients: [],
+      reconcileTerminalSessions: vi.fn(),
+      commitTerminalConfig: vi.fn(),
+      acceptTerminalConfig: vi.fn(),
+    });
+
+    try {
+      const listener = writeListenerRef.current;
+      if (!listener) {
+        throw new Error("Expected config write listener to be registered");
+      }
+      const unrelatedSourceConfig = {
+        ...initialSourceConfig,
+        logging: { level: "info" as const },
+      };
+      listener({
+        configPath: "/tmp/openclaw.json",
+        sourceConfig: unrelatedSourceConfig,
+        runtimeConfig,
+        persistedHash: "same-secrets-new-source",
+        revision: 1,
+        fingerprint: "same-runtime",
+        sourceFingerprint: "same-secrets-new-source",
+        writtenAtMs: Date.now(),
+      });
+      await vi.runAllTimersAsync();
+
+      expect(activateRuntimeSecrets).not.toHaveBeenCalled();
+      expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(unrelatedSourceConfig);
+      expect(getActiveSecretsRuntimeSnapshot()?.secretOwners).toEqual([
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          refKeys: ["env:default:TTS_FIRST"],
+        },
+        {
+          ownerKind: "account",
+          ownerId: authOwnerId,
+          refKeys: ["env:default:AUTH_FIRST"],
+        },
+      ]);
+
+      listener({
+        configPath: "/tmp/openclaw.json",
+        sourceConfig: nextSourceConfig,
+        runtimeConfig,
+        persistedHash: "same-runtime-next-source",
+        revision: 2,
+        fingerprint: "same-runtime",
+        sourceFingerprint: "next-source",
+        writtenAtMs: Date.now(),
+      });
+      await vi.runAllTimersAsync();
+
+      expect(activateRuntimeSecrets.mock.calls[0]?.[1]).toMatchObject({
+        activate: false,
+        includeAuthStoreRefs: true,
+        publishFailureAsDegraded: true,
+      });
+      expect(listActiveDegradedSecretOwners()).toEqual([]);
+      expect(getActiveSecretsRuntimeSnapshot()?.secretOwners).toEqual([
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          refKeys: ["env:default:TTS_SECOND"],
+        },
+        {
+          ownerKind: "account",
+          ownerId: authOwnerId,
+          refKeys: ["env:default:AUTH_SECOND"],
+        },
+      ]);
+      expect(
+        getActiveSecretsRuntimeSnapshot()?.authStores[0]?.store.profiles[authProfileId],
+      ).toMatchObject({
+        key: String(42),
+        keyRef: { source: "env", provider: "default", id: "AUTH_SECOND" },
+      });
+      expect(
+        classifySecretOwnerDegradationState({
+          ownerKind: "capability",
+          ownerId: "tts",
+          refs: [secondRef],
+          config: nextSourceConfig,
+        }),
+      ).toBe("stale");
+
+      activateRuntimeSecrets.mockImplementationOnce(async (config: OpenClawConfig) => ({
+        sourceConfig: config,
+        config: { ...runtimeConfig, logging: { level: "debug" } },
+        authStores: [],
+        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+        warnings: [],
+        secretOwners: [
+          {
+            ownerKind: "capability" as const,
+            ownerId: "tts",
+            refKeys: ["env:default:TTS_THIRD"],
+          },
+        ],
+        webTools: createEmptyRuntimeWebToolsMetadata(),
+      }));
+      listener({
+        configPath: "/tmp/openclaw.json",
+        sourceConfig: sourceConfig(thirdRef),
+        runtimeConfig,
+        persistedHash: "changed-second-resolution",
+        revision: 2,
+        fingerprint: "same-runtime",
+        sourceFingerprint: "changed-second-resolution",
+        writtenAtMs: Date.now(),
+      });
+      await vi.runAllTimersAsync();
+
+      expect(getActiveSecretsRuntimeSnapshot()?.secretOwners).toEqual([
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          refKeys: ["env:default:TTS_SECOND"],
+        },
+        {
+          ownerKind: "account",
+          ownerId: authOwnerId,
+          refKeys: ["env:default:AUTH_SECOND"],
+        },
+      ]);
+
+      let releasePreparation = () => {};
+      let markPreparationStarted: (() => void) | undefined;
+      const preparationStarted = new Promise<void>((resolve) => {
+        markPreparationStarted = resolve;
+      });
+      const preparationGate = new Promise<void>((resolve) => {
+        releasePreparation = resolve;
+      });
+      activateRuntimeSecrets.mockImplementationOnce(async (config: OpenClawConfig) => {
+        markPreparationStarted?.();
+        await preparationGate;
+        return {
+          sourceConfig: config,
+          config: runtimeConfig,
+          authStores: [],
+          authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+          warnings: [],
+          secretOwners: [
+            {
+              ownerKind: "capability" as const,
+              ownerId: "tts",
+              refKeys: ["env:default:TTS_THIRD"],
+            },
+          ],
+          webTools: createEmptyRuntimeWebToolsMetadata(),
+        };
+      });
+      listener({
+        configPath: "/tmp/openclaw.json",
+        sourceConfig: sourceConfig(thirdRef),
+        runtimeConfig,
+        persistedHash: "superseded-source-owner",
+        revision: 3,
+        fingerprint: "same-runtime",
+        sourceFingerprint: "superseded-source-owner",
+        writtenAtMs: Date.now(),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await preparationStarted;
+
+      const concurrentSourceConfig = sourceConfig(fourthRef);
+      activateSecretsRuntimeSnapshot({
+        sourceConfig: concurrentSourceConfig,
+        config: runtimeConfig,
+        authStores: [],
+        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+        warnings: [],
+        secretOwners: [
+          {
+            ownerKind: "capability",
+            ownerId: "tts",
+            refKeys: ["env:default:TTS_FOURTH"],
+          },
+        ],
+        webTools: createEmptyRuntimeWebToolsMetadata(),
+      });
+      releasePreparation();
+      await vi.runAllTimersAsync();
+
+      expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(concurrentSourceConfig);
+      expect(getActiveSecretsRuntimeSnapshot()?.secretOwners).toEqual([
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          refKeys: ["env:default:TTS_FOURTH"],
+        },
+      ]);
+    } finally {
+      await reloader.stop();
+    }
   });
 
   it("rejects ownerless irreversible plans but applies safe hot plans", async () => {
@@ -4408,10 +4788,14 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(harness.activateRuntimeSecrets).toHaveBeenNthCalledWith(1, harness.deferredConfig, {
         reason: "restart-check",
         activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
       });
       expect(harness.activateRuntimeSecrets).toHaveBeenNthCalledWith(2, harness.invalidConfig, {
         reason: "restart-check",
         activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
       });
       expect(harness.terminalPolicy.isEnabled()).toBe(false);
       expect(harness.promoteSnapshot.mock.calls.map(([snapshot]) => snapshot.hash)).not.toContain(
@@ -4435,11 +4819,15 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(harness.activateRuntimeSecrets).toHaveBeenNthCalledWith(3, acceptedWithLogging, {
         reason: "reload",
         activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
         includeAuthStoreRefs: undefined,
       });
       expect(harness.activateRuntimeSecrets).toHaveBeenNthCalledWith(4, acceptedWithLogging, {
         reason: "restart-check",
         activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
       });
       const deferredPlan = buildGatewayReloadPlan(
         diffConfigPaths(harness.initialConfig, harness.deferredConfig),
@@ -4588,6 +4976,8 @@ describe("gateway Gmail hot reload handlers", () => {
         {
           reason: "restart-check",
           activate: false,
+          publishFailureAsDegraded: true,
+          canPublishFailureAsDegraded: expect.any(Function),
         },
       );
       expect(harness.requestRecoveryRestart).not.toHaveBeenCalled();
@@ -4692,6 +5082,8 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(harness.activateRuntimeSecrets).toHaveBeenCalledWith(harness.deferredConfig, {
         reason: "restart-check",
         activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
       });
       await vi.advanceTimersByTimeAsync(500);
       expect(harness.requestRecoveryRestart.mock.calls).toEqual([
@@ -4739,6 +5131,8 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(harness.activateRuntimeSecrets).toHaveBeenNthCalledWith(3, harness.deferredConfig, {
         reason: "restart-check",
         activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
       });
       expect(harness.requestRecoveryRestart).not.toHaveBeenCalled();
       expect(harness.promoteSnapshot.mock.calls.map(([snapshot]) => snapshot.hash)).not.toContain(
@@ -4773,6 +5167,8 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(harness.activateRuntimeSecrets).toHaveBeenNthCalledWith(2, harness.replacementConfig, {
         reason: "restart-check",
         activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: expect.any(Function),
       });
       expect(harness.requestRecoveryRestart).not.toHaveBeenCalled();
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -2016,7 +2016,7 @@ export function startManagedGatewayConfigReloader(
             !(await restoreSecretsRuntimeSnapshotIfCurrent(
               previousSecretsSnapshot,
               committedSecretsRevision,
-              sourceOnlySnapshot,
+              activated,
               { runtimeSourceConfig: previousRuntimeSourceConfig },
             ))
           ) {
@@ -2030,7 +2030,7 @@ export function startManagedGatewayConfigReloader(
         return {
           rollback: rollbackPublishedSource,
           commit: () =>
-            publishRuntimeSecretsRecovery(params.activateRuntimeSecrets, sourceOnlySnapshot, {
+            publishRuntimeSecretsRecovery(params.activateRuntimeSecrets, activated, {
               sourceOnly: true,
             }),
         };
@@ -2081,7 +2081,7 @@ export function startManagedGatewayConfigReloader(
           !(await restoreSecretsRuntimeSnapshotIfCurrent(
             previousSecretsSnapshot,
             committedSecretsRevision,
-            preparedSecrets,
+            activated,
             { runtimeSourceConfig: previousRuntimeSourceConfig },
           ))
         ) {
@@ -2094,7 +2094,7 @@ export function startManagedGatewayConfigReloader(
       }
       return {
         rollback: rollbackPublishedSource,
-        commit: () => publishRuntimeSecretsRecovery(params.activateRuntimeSecrets, preparedSecrets),
+        commit: () => publishRuntimeSecretsRecovery(params.activateRuntimeSecrets, activated),
       };
     },
     onNoopConfigCommit: async (plan, nextConfig, transactionOwnership, sourceConfig) => {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -14,11 +14,7 @@ import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
 import { getConfigValueAtPath } from "../config/config-paths.js";
-import {
-  getRuntimeConfigSnapshotMetadata,
-  getRuntimeConfigSourceSnapshot,
-  setRuntimeConfigAppliedHash,
-} from "../config/config.js";
+import { getRuntimeConfigSourceSnapshot, setRuntimeConfigAppliedHash } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef } from "../config/types.secrets.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -43,7 +39,7 @@ import {
   clearSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshotRevision,
-  setSecretsRuntimeSourceSnapshotIfCurrent,
+  hasSameSecretReloadContract,
   type PreparedSecretsRuntimeSnapshot,
 } from "../secrets/runtime-state.js";
 import { getInspectableActiveTaskRestartBlockers } from "../tasks/task-registry.maintenance.js";
@@ -84,7 +80,10 @@ import {
   type SharedGatewaySessionGenerationOwnership,
   type SharedGatewaySessionGenerationState,
 } from "./server-shared-auth-generation.js";
-import type { ActivateRuntimeSecrets } from "./server-startup-config.js";
+import {
+  publishRuntimeSecretsRecovery,
+  type ActivateRuntimeSecrets,
+} from "./server-startup-config.js";
 import { resolveHookClientIpConfig } from "./server/hook-client-ip-config.js";
 import type { HookClientIpConfig } from "./server/hooks-request-handler.js";
 
@@ -117,13 +116,18 @@ async function activateSecretsRuntimeSnapshotIfCurrent(
   options?: {
     canActivate?: () => boolean;
     onActivated?: () => void;
+    runtimeSourceConfig?: OpenClawConfig;
   },
 ): Promise<boolean> {
   const runtime = await import("../secrets/runtime.js");
   if (options?.canActivate && !options.canActivate()) {
     return false;
   }
-  if (!runtime.activateSecretsRuntimeSnapshotIfCurrent(snapshot, expectedRevision)) {
+  if (
+    !runtime.activateSecretsRuntimeSnapshotIfCurrent(snapshot, expectedRevision, {
+      runtimeSourceConfig: options?.runtimeSourceConfig,
+    })
+  ) {
     return false;
   }
   options?.onActivated?.();
@@ -134,10 +138,14 @@ async function restoreSecretsRuntimeSnapshotIfCurrent(
   snapshot: PreparedSecretsRuntimeSnapshot,
   expectedRevision: number,
   ownedSnapshot: PreparedSecretsRuntimeSnapshot,
-  options?: { onActivated?: () => void },
+  options?: { onActivated?: () => void; runtimeSourceConfig?: OpenClawConfig },
 ): Promise<boolean> {
   const runtime = await import("../secrets/runtime.js");
-  if (!runtime.restoreSecretsRuntimeSnapshotIfCurrent(snapshot, expectedRevision, ownedSnapshot)) {
+  if (
+    !runtime.restoreSecretsRuntimeSnapshotIfCurrent(snapshot, expectedRevision, ownedSnapshot, {
+      runtimeSourceConfig: options?.runtimeSourceConfig,
+    })
+  ) {
     return false;
   }
   options?.onActivated?.();
@@ -1732,6 +1740,8 @@ export function startManagedGatewayConfigReloader(
           {
             reason: "restart-check",
             activate: false,
+            publishFailureAsDegraded: true,
+            canPublishFailureAsDegraded: transactionOwnership.isCurrent,
             ...(transactionOwnership.runtimeEnv
               ? { env: transactionOwnership.runtimeEnv.env }
               : {}),
@@ -1799,6 +1809,8 @@ export function startManagedGatewayConfigReloader(
             {
               reason: "restart-check",
               activate: false,
+              publishFailureAsDegraded: true,
+              canPublishFailureAsDegraded: transactionOwnership.isCurrent,
               ...(transactionOwnership.runtimeEnv
                 ? { env: transactionOwnership.runtimeEnv.env }
                 : {}),
@@ -1866,6 +1878,8 @@ export function startManagedGatewayConfigReloader(
             {
               reason: "restart-check",
               activate: false,
+              publishFailureAsDegraded: true,
+              canPublishFailureAsDegraded: transactionOwnership.isCurrent,
               ...(transactionOwnership.runtimeEnv
                 ? { env: transactionOwnership.runtimeEnv.env }
                 : {}),
@@ -1948,41 +1962,139 @@ export function startManagedGatewayConfigReloader(
       if (!transactionOwnership.isCurrent()) {
         throw new GatewayConfigReloadSupersededError();
       }
-      const metadata = getRuntimeConfigSnapshotMetadata();
       const previousRuntimeSourceConfig = getRuntimeConfigSourceSnapshot();
-      const previousSecretsSourceConfig = getActiveSecretsRuntimeSnapshot()?.sourceConfig;
+      const previousSecretsSnapshot = getActiveSecretsRuntimeSnapshot();
       const previousSecretsRevision = getActiveSecretsRuntimeSnapshotRevision();
+      const nextSecretsSourceConfig = prepareRuntimeCandidate(
+        nextConfig,
+        sourceConfig,
+        transactionOwnership,
+      );
       if (
-        !metadata ||
-        !previousRuntimeSourceConfig ||
-        !setSecretsRuntimeSourceSnapshotIfCurrent({
-          expectedSecretsRevision: previousSecretsRevision,
-          expectedRuntimeConfigRevision: metadata.revision,
-          runtimeSourceConfig: sourceConfig,
-          secretsSourceConfig: prepareRuntimeCandidate(
-            nextConfig,
-            sourceConfig,
-            transactionOwnership,
-          ),
-        }) ||
-        !transactionOwnership.isCurrent()
+        previousRuntimeSourceConfig &&
+        previousSecretsSnapshot &&
+        hasSameSecretReloadContract(previousSecretsSnapshot.sourceConfig, nextSecretsSourceConfig)
       ) {
+        const sourceOnlySnapshot = {
+          ...previousSecretsSnapshot,
+          sourceConfig: nextSecretsSourceConfig,
+          warnings: [],
+        };
+        if (!isDeepStrictEqual(sourceOnlySnapshot.config, nextConfig)) {
+          throw new GatewayConfigReloadSupersededError();
+        }
+        const activateIfCurrent = params.activateRuntimeSecrets.activatePreparedSnapshotIfCurrent;
+        const activated = activateIfCurrent
+          ? await activateIfCurrent(
+              sourceOnlySnapshot,
+              previousSecretsRevision,
+              {
+                reason: "reload",
+                activate: true,
+                publishRecovery: false,
+                runtimeSourceConfig: sourceConfig,
+              },
+              undefined,
+              transactionOwnership.isCurrent,
+            )
+          : (await activateSecretsRuntimeSnapshotIfCurrent(
+                sourceOnlySnapshot,
+                previousSecretsRevision,
+                {
+                  canActivate: transactionOwnership.isCurrent,
+                  runtimeSourceConfig: sourceConfig,
+                },
+              ))
+            ? sourceOnlySnapshot
+            : null;
+        if (!activated) {
+          throw new GatewayConfigReloadSupersededError();
+        }
+        const committedSecretsRevision = getActiveSecretsRuntimeSnapshotRevision();
+        const rollbackPublishedSource = async () => {
+          if (
+            !(await restoreSecretsRuntimeSnapshotIfCurrent(
+              previousSecretsSnapshot,
+              committedSecretsRevision,
+              sourceOnlySnapshot,
+              { runtimeSourceConfig: previousRuntimeSourceConfig },
+            ))
+          ) {
+            throw new GatewayConfigReloadSupersededError();
+          }
+        };
+        if (!transactionOwnership.isCurrent()) {
+          await rollbackPublishedSource();
+          throw new GatewayConfigReloadSupersededError();
+        }
+        return {
+          rollback: rollbackPublishedSource,
+          commit: () =>
+            publishRuntimeSecretsRecovery(params.activateRuntimeSecrets, sourceOnlySnapshot, {
+              sourceOnly: true,
+            }),
+        };
+      }
+      const preparedSecrets = await params.activateRuntimeSecrets(nextSecretsSourceConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: transactionOwnership.isCurrent,
+        ...(transactionOwnership.runtimeEnv ? { env: transactionOwnership.runtimeEnv.env } : {}),
+        includeAuthStoreRefs: true,
+      });
+      if (!transactionOwnership.isCurrent()) {
         throw new GatewayConfigReloadSupersededError();
       }
-      const committedMetadata = getRuntimeConfigSnapshotMetadata();
+      if (!isDeepStrictEqual(preparedSecrets.config, nextConfig)) {
+        throw new GatewayConfigReloadSupersededError();
+      }
+      if (!previousRuntimeSourceConfig || !previousSecretsSnapshot) {
+        throw new GatewayConfigReloadSupersededError();
+      }
+      const activateIfCurrent = params.activateRuntimeSecrets.activatePreparedSnapshotIfCurrent;
+      const activated = activateIfCurrent
+        ? await activateIfCurrent(
+            preparedSecrets,
+            previousSecretsRevision,
+            {
+              reason: "reload",
+              activate: true,
+              publishRecovery: false,
+              runtimeSourceConfig: sourceConfig,
+            },
+            undefined,
+            transactionOwnership.isCurrent,
+          )
+        : (await activateSecretsRuntimeSnapshotIfCurrent(preparedSecrets, previousSecretsRevision, {
+              canActivate: transactionOwnership.isCurrent,
+              runtimeSourceConfig: sourceConfig,
+            }))
+          ? preparedSecrets
+          : null;
+      if (!activated) {
+        throw new GatewayConfigReloadSupersededError();
+      }
       const committedSecretsRevision = getActiveSecretsRuntimeSnapshotRevision();
-      return async () => {
+      const rollbackPublishedSource = async () => {
         if (
-          !committedMetadata ||
-          !setSecretsRuntimeSourceSnapshotIfCurrent({
-            expectedSecretsRevision: committedSecretsRevision,
-            expectedRuntimeConfigRevision: committedMetadata.revision,
-            runtimeSourceConfig: previousRuntimeSourceConfig,
-            secretsSourceConfig: previousSecretsSourceConfig ?? previousRuntimeSourceConfig,
-          })
+          !(await restoreSecretsRuntimeSnapshotIfCurrent(
+            previousSecretsSnapshot,
+            committedSecretsRevision,
+            preparedSecrets,
+            { runtimeSourceConfig: previousRuntimeSourceConfig },
+          ))
         ) {
           throw new GatewayConfigReloadSupersededError();
         }
+      };
+      if (!transactionOwnership.isCurrent()) {
+        await rollbackPublishedSource();
+        throw new GatewayConfigReloadSupersededError();
+      }
+      return {
+        rollback: rollbackPublishedSource,
+        commit: () => publishRuntimeSecretsRecovery(params.activateRuntimeSecrets, preparedSecrets),
       };
     },
     onNoopConfigCommit: async (plan, nextConfig, transactionOwnership, sourceConfig) => {
@@ -1996,6 +2108,8 @@ export function startManagedGatewayConfigReloader(
           {
             reason: "reload",
             activate: false,
+            publishFailureAsDegraded: true,
+            canPublishFailureAsDegraded: transactionOwnership.isCurrent,
             ...(transactionOwnership.runtimeEnv
               ? { env: transactionOwnership.runtimeEnv.env }
               : {}),
@@ -2048,6 +2162,8 @@ export function startManagedGatewayConfigReloader(
           {
             reason: "reload",
             activate: false,
+            publishFailureAsDegraded: true,
+            canPublishFailureAsDegraded: transactionOwnership.isCurrent,
             ...(transactionOwnership.runtimeEnv
               ? { env: transactionOwnership.runtimeEnv.env }
               : {}),
@@ -2083,6 +2199,8 @@ export function startManagedGatewayConfigReloader(
                 {
                   reason: "restart-check",
                   activate: false,
+                  publishFailureAsDegraded: true,
+                  canPublishFailureAsDegraded: transactionOwnership.isCurrent,
                   ...(transactionOwnership.runtimeEnv
                     ? { env: transactionOwnership.runtimeEnv.env }
                     : {}),

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
+import { refResolutionError } from "../secrets/resolve-errors.js";
+import { associateSecretResolutionErrorOwners } from "../secrets/runtime-degraded-state.js";
 import {
   activateSecretsRuntimeSnapshotState,
   clearSecretsRuntimeSnapshot,
@@ -23,6 +25,7 @@ import type { PreparedSecretsRuntimeSnapshot, SecretResolverWarning } from "../s
 import {
   createRuntimeSecretsActivator,
   prepareGatewayStartupConfig,
+  publishRuntimeSecretsRecovery,
 } from "./server-startup-config.js";
 import { buildTestConfigSnapshot } from "./test-helpers.config-snapshots.js";
 
@@ -44,7 +47,7 @@ type GatewayStartupSecretsRuntimeMock = {
 
 type GatewayStartupLogMock = {
   info: ReturnType<typeof vi.fn<(message: string) => void>>;
-  warn: ReturnType<typeof vi.fn<(message: string) => void>>;
+  warn: ReturnType<typeof vi.fn<(message: string, meta?: Record<string, unknown>) => void>>;
   error: ReturnType<typeof vi.fn<(message: string) => void>>;
 };
 
@@ -184,7 +187,7 @@ function runtimeSecretsActivatorOptionsForTest() {
 function mockLogSecretsForTest(): GatewayStartupLogMock {
   return {
     info: vi.fn<(message: string) => void>(),
-    warn: vi.fn<(message: string) => void>(),
+    warn: vi.fn<(message: string, meta?: Record<string, unknown>) => void>(),
     error: vi.fn<(message: string) => void>(),
   };
 }
@@ -643,25 +646,86 @@ describe("gateway startup config secret preflight", () => {
   });
 
   it("wraps startup secret activation failures without emitting reload state events", async () => {
-    const error = new Error('Environment variable "OPENAI_API_KEY" is missing or empty.');
+    const error = refResolutionError({
+      code: "SECRET_REF_NOT_FOUND",
+      source: "env",
+      provider: "default",
+      refId: "PRIVATE_STARTUP_AUTH_REF",
+      message: 'Environment variable "PRIVATE_STARTUP_AUTH_REF" is missing or empty.',
+    });
+    associateSecretResolutionErrorOwners(error, [
+      {
+        ownerKind: "gateway",
+        ownerId: "auth",
+        state: "unavailable",
+        paths: ["gateway.auth.token"],
+        refKeys: ["env:default:PRIVATE_STARTUP_AUTH_REF"],
+        reason: "secret reference was not found",
+        degradationState: "cold",
+        failureMatched: true,
+      },
+    ]);
     const prepareRuntimeSecretsSnapshot = vi.fn(async () => {
       throw error;
     });
     const emitStateEvent = vi.fn();
+    const logSecrets = mockLogSecretsForTest();
     const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
       emitStateEvent,
+      logSecrets,
       prepareRuntimeSecretsSnapshot,
     });
 
-    await expect(
-      activateRuntimeSecrets(gatewayTokenConfig({}), {
-        reason: "startup",
-        activate: false,
-      }),
-    ).rejects.toThrow(
-      'Startup failed: required secrets are unavailable. Error: Environment variable "OPENAI_API_KEY" is missing or empty.',
+    const startupFailure = await activateRuntimeSecrets(gatewayTokenConfig({}), {
+      reason: "startup",
+      activate: false,
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
     );
+    expect(startupFailure).toBeInstanceOf(Error);
+    expect(String(startupFailure)).toBe("Error: Startup failed: required secrets are unavailable.");
+    expect((startupFailure as Error).cause).toBeUndefined();
+    expect(String(startupFailure)).not.toContain("PRIVATE_STARTUP_AUTH_REF");
+    expect(logSecrets.warn).toHaveBeenCalledWith(
+      "[SECRETS_DEGRADED] cold gateway:auth: secret reference was not found. " +
+        "Retry: openclaw secrets reload.",
+      {
+        event: "secrets.degraded",
+        ownerKind: "gateway",
+        ownerId: "auth",
+        reason: "secret reference was not found",
+        state: "cold",
+        retryHint: "openclaw secrets reload",
+      },
+    );
+    expect(JSON.stringify(logSecrets.warn.mock.calls)).not.toContain("PRIVATE_STARTUP_AUTH_REF");
     expect(emitStateEvent).not.toHaveBeenCalled();
+  });
+
+  it("preserves diagnostics for unclassified startup activation failures", async () => {
+    const error = new Error("secret provider transport failed");
+    const logSecrets = mockLogSecretsForTest();
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      logSecrets,
+      prepareRuntimeSecretsSnapshot: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    const startupFailure = await activateRuntimeSecrets(gatewayTokenConfig({}), {
+      reason: "startup",
+      activate: false,
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(String(startupFailure)).toContain("secret provider transport failed");
+    expect((startupFailure as Error).cause).toBe(error);
+    expect(logSecrets.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("SECRETS_DEGRADED"),
+      expect.anything(),
+    );
   });
 
   it("allows cold startup snapshots with isolated SecretRef owners", async () => {
@@ -680,12 +744,22 @@ describe("gateway startup config secret preflight", () => {
       code: "SECRETS_OWNER_UNAVAILABLE",
       path: "messages.tts.providers.elevenlabs.apiKey",
       message:
-        "Secret owner capability:tts is configured-unavailable; paths: messages.tts.providers.elevenlabs.apiKey; reason: secret reference was not found.",
+        "Secret owner capability:tts is configured-unavailable; paths: messages.tts.providers.elevenlabs.apiKey; reason: secret provider policy denied resolution.",
     };
     const prepareRuntimeSecretsSnapshot = vi.fn(async () => ({
       ...preparedSnapshot(sourceConfig),
       config: structuredClone(sourceConfig),
       warnings: [warning],
+      degradedOwners: [
+        {
+          ownerKind: "capability" as const,
+          ownerId: "tts",
+          state: "unavailable" as const,
+          paths: ["messages.tts.providers.elevenlabs.apiKey"],
+          refKeys: ["env:default:ELEVENLABS_API_KEY"],
+          reason: "secret provider policy denied resolution",
+        },
+      ],
     }));
     const emitStateEvent = vi.fn();
     const logSecrets = mockLogSecretsForTest();
@@ -707,12 +781,26 @@ describe("gateway startup config secret preflight", () => {
       expect.objectContaining({ allowUnavailableSecretOwners: true }),
     );
     expect(logSecrets.warn).toHaveBeenCalledWith(`[${warning.code}] ${warning.message}`);
+    expect(logSecrets.warn).toHaveBeenCalledWith(
+      "[SECRETS_DEGRADED] cold capability:tts: secret provider policy denied resolution. " +
+        "Retry: openclaw secrets reload.",
+      {
+        event: "secrets.degraded",
+        ownerKind: "capability",
+        ownerId: "tts",
+        reason: "secret provider policy denied resolution",
+        state: "cold",
+        retryHint: "openclaw secrets reload",
+      },
+    );
+    expect(JSON.stringify(logSecrets.warn.mock.calls)).not.toContain("ELEVENLABS_API_KEY");
     expect(emitStateEvent).not.toHaveBeenCalled();
   });
 
   it.each(["reload", "restart-check"] as const)(
-    "keeps unavailable SecretRef owners fail-closed during %s",
+    "does not classify untyped %s errors as secret degradation",
     async (reason) => {
+      activateSecretsRuntimeSnapshotForTest(preparedSnapshot(gatewayTokenConfig({})));
       const missingSecretError = new Error(
         'Environment variable "ELEVENLABS_API_KEY" is missing or empty.',
       );
@@ -720,15 +808,20 @@ describe("gateway startup config secret preflight", () => {
         throw missingSecretError;
       });
       const activateRuntimeSecretsSnapshot = vi.fn();
+      const emitStateEvent = vi.fn();
+      const logSecrets = mockLogSecretsForTest();
       const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
         prepareRuntimeSecretsSnapshot,
         activateRuntimeSecretsSnapshot,
+        emitStateEvent,
+        logSecrets,
       });
 
       await expect(
         activateRuntimeSecrets(gatewayTokenConfig({}), {
           reason,
-          activate: true,
+          activate: false,
+          publishFailureAsDegraded: true,
         }),
       ).rejects.toThrow(missingSecretError.message);
 
@@ -736,15 +829,256 @@ describe("gateway startup config secret preflight", () => {
         expect.objectContaining({ allowUnavailableSecretOwners: false }),
       );
       expect(activateRuntimeSecretsSnapshot).not.toHaveBeenCalled();
+      expect(logSecrets.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("SECRETS_DEGRADED"),
+        expect.anything(),
+      );
+      expect(emitStateEvent).not.toHaveBeenCalled();
     },
   );
 
+  it.each(["reload", "restart-check"] as const)(
+    "publishes the owner when a resolved secret value is invalid during %s",
+    async (reason) => {
+      activateSecretsRuntimeSnapshotForTest(preparedSnapshot(gatewayTokenConfig({})));
+      const invalidSecretError = new Error(
+        "messages.tts.providers.elevenlabs.apiKey resolved to a non-string or empty value.",
+      );
+      associateSecretResolutionErrorOwners(invalidSecretError, [
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          state: "unavailable",
+          paths: ["messages.tts.providers.elevenlabs.apiKey"],
+          refKeys: ["file:ttsfile:/private/value"],
+          reason: "resolved secret value was invalid",
+          degradationState: "stale",
+          failureMatched: true,
+        },
+      ]);
+      const prepareRuntimeSecretsSnapshot = vi.fn(async () => {
+        throw invalidSecretError;
+      });
+      const emitStateEvent = vi.fn();
+      const logSecrets = mockLogSecretsForTest();
+      const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+        prepareRuntimeSecretsSnapshot,
+        emitStateEvent,
+        logSecrets,
+      });
+
+      await expect(
+        activateRuntimeSecrets(gatewayTokenConfig({}), {
+          reason,
+          activate: false,
+          publishFailureAsDegraded: true,
+        }),
+      ).rejects.toThrow(invalidSecretError.message);
+
+      expect(logSecrets.warn).toHaveBeenCalledWith(
+        "[SECRETS_DEGRADED] stale capability:tts: resolved secret value was invalid. " +
+          "Retry: openclaw secrets reload.",
+        {
+          event: "secrets.degraded",
+          ownerKind: "capability",
+          ownerId: "tts",
+          reason: "resolved secret value was invalid",
+          state: "stale",
+          retryHint: "openclaw secrets reload",
+        },
+      );
+      expect(JSON.stringify(logSecrets.warn.mock.calls)).not.toContain("/private/value");
+      expect(emitStateEvent).toHaveBeenCalledWith(
+        "SECRETS_RELOADER_DEGRADED",
+        "Secret resolution failed; runtime remains on the last-known-good snapshot.",
+        expect.anything(),
+      );
+    },
+  );
+
+  it("does not publish typed degradation after reload ownership expires", async () => {
+    activateSecretsRuntimeSnapshotForTest(preparedSnapshot(gatewayTokenConfig({})));
+    const failure = refResolutionError({
+      code: "SECRET_REF_NOT_FOUND",
+      source: "env",
+      provider: "default",
+      refId: "EXPIRED_RELOAD_REF",
+      message: "expired reload fixture",
+    });
+    associateSecretResolutionErrorOwners(failure, [
+      {
+        ownerKind: "capability",
+        ownerId: "tts",
+        state: "unavailable",
+        paths: ["messages.tts.providers.elevenlabs.apiKey"],
+        refKeys: ["env:default:EXPIRED_RELOAD_REF"],
+        reason: "secret reference was not found",
+        degradationState: "stale",
+        failureMatched: true,
+      },
+    ]);
+    const emitStateEvent = vi.fn();
+    const logSecrets = mockLogSecretsForTest();
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      prepareRuntimeSecretsSnapshot: vi.fn(async () => {
+        throw failure;
+      }),
+      emitStateEvent,
+      logSecrets,
+    });
+
+    await expect(
+      activateRuntimeSecrets(gatewayTokenConfig({}), {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+        canPublishFailureAsDegraded: () => false,
+      }),
+    ).rejects.toThrow(failure.message);
+
+    expect(logSecrets.warn).not.toHaveBeenCalled();
+    expect(emitStateEvent).not.toHaveBeenCalled();
+  });
+
+  it("publishes a redacted unknown-owner warning for an unmapped typed reload failure", async () => {
+    activateSecretsRuntimeSnapshotForTest(preparedSnapshot(gatewayTokenConfig({})));
+    const missingSecretError = refResolutionError({
+      code: "SECRET_REF_NOT_FOUND",
+      source: "env",
+      provider: "default",
+      refId: "PRIVATE_UNMAPPED_REF",
+      message: 'Environment variable "PRIVATE_UNMAPPED_REF" is missing or empty.',
+    });
+    const prepareRuntimeSecretsSnapshot = vi.fn(async () => {
+      throw missingSecretError;
+    });
+    const emitStateEvent = vi.fn();
+    const logSecrets = mockLogSecretsForTest();
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      prepareRuntimeSecretsSnapshot,
+      emitStateEvent,
+      logSecrets,
+    });
+
+    await expect(
+      activateRuntimeSecrets(gatewayTokenConfig({}), {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toThrow(missingSecretError.message);
+
+    expect(logSecrets.warn).toHaveBeenCalledWith(
+      "[SECRETS_DEGRADED] cold unknown:unmapped: secret reference was not found. " +
+        "Retry: openclaw secrets reload.",
+      {
+        event: "secrets.degraded",
+        ownerKind: "unknown",
+        ownerId: "unmapped",
+        reason: "secret reference was not found",
+        state: "cold",
+        retryHint: "openclaw secrets reload",
+      },
+    );
+    expect(JSON.stringify(logSecrets.warn.mock.calls)).not.toContain("PRIVATE_UNMAPPED_REF");
+    expect(emitStateEvent).toHaveBeenCalledWith(
+      "SECRETS_RELOADER_DEGRADED",
+      "Secret resolution failed; runtime remains on the last-known-good snapshot.",
+      expect.anything(),
+    );
+  });
+
+  it("preserves invalid provider diagnostics instead of reporting runtime degradation", async () => {
+    const invalidProviderError = refResolutionError({
+      code: "SECRET_PROVIDER_INVALID",
+      source: "env",
+      provider: "missing",
+      refId: "INVALID_PROVIDER_REF",
+      message: 'Secret provider "missing" is not configured.',
+    });
+    const emitStateEvent = vi.fn();
+    const logSecrets = mockLogSecretsForTest();
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      prepareRuntimeSecretsSnapshot: vi.fn(async () => {
+        throw invalidProviderError;
+      }),
+      emitStateEvent,
+      logSecrets,
+    });
+
+    await expect(
+      activateRuntimeSecrets(gatewayTokenConfig({}), {
+        reason: "startup",
+        activate: false,
+      }),
+    ).rejects.toThrow('Secret provider "missing" is not configured.');
+
+    expect(logSecrets.warn).not.toHaveBeenCalled();
+    expect(emitStateEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not publish a rejected candidate-only preflight as active degradation", async () => {
+    let shouldFail = true;
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => {
+      if (shouldFail) {
+        throw new Error("candidate secret resolution failed");
+      }
+      return preparedSnapshot(config);
+    });
+    const emitStateEvent = vi.fn();
+    const logSecrets = mockLogSecretsForTest();
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      prepareRuntimeSecretsSnapshot,
+      emitStateEvent,
+      logSecrets,
+    });
+
+    await expect(
+      activateRuntimeSecrets(gatewayTokenConfig({}), {
+        reason: "reload",
+        activate: false,
+      }),
+    ).rejects.toThrow("candidate secret resolution failed");
+
+    expect(emitStateEvent).not.toHaveBeenCalled();
+    expect(logSecrets.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("SECRETS_DEGRADED"),
+      expect.anything(),
+    );
+
+    shouldFail = false;
+    await expect(
+      activateRuntimeSecrets(gatewayTokenConfig({}), {
+        reason: "reload",
+        activate: false,
+      }),
+    ).resolves.toBeDefined();
+    expect(emitStateEvent).not.toHaveBeenCalled();
+    expect(logSecrets.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("SECRETS_RELOADER_RECOVERED"),
+    );
+  });
+
   it("enables cold-start owner isolation during non-activating startup preparation", async () => {
-    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => ({
+      ...preparedSnapshot(config),
+      degradedOwners: [
+        {
+          ownerKind: "capability" as const,
+          ownerId: "tts",
+          state: "unavailable" as const,
+          paths: ["messages.tts.providers.elevenlabs.apiKey"],
+          refKeys: ["env:default:ELEVENLABS_API_KEY"],
+          reason: "secret reference was not found",
+        },
+      ],
+    }));
     const activateRuntimeSecretsSnapshot = vi.fn();
+    const logSecrets = mockLogSecretsForTest();
     const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
       prepareRuntimeSecretsSnapshot,
       activateRuntimeSecretsSnapshot,
+      logSecrets,
     });
 
     await activateRuntimeSecrets(gatewayTokenConfig({}), {
@@ -756,6 +1090,10 @@ describe("gateway startup config secret preflight", () => {
       expect.objectContaining({ allowUnavailableSecretOwners: true }),
     );
     expect(activateRuntimeSecretsSnapshot).not.toHaveBeenCalled();
+    expect(logSecrets.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("SECRETS_DEGRADED"),
+      expect.anything(),
+    );
   });
 
   it("does not enable cold-start degradation while a runtime snapshot is active", async () => {
@@ -867,6 +1205,21 @@ describe("gateway startup config secret preflight", () => {
         },
       },
     });
+    const activeSnapshot = preparedSnapshot(sourceConfig);
+    activeSnapshot.config.models!.providers!.openai!.apiKey = "test-api-key";
+    activateSecretsRuntimeSnapshotForTest(activeSnapshot);
+    associateSecretResolutionErrorOwners(missingSecretError, [
+      {
+        ownerKind: "provider",
+        ownerId: "openai",
+        state: "unavailable",
+        paths: ["models.providers.openai.apiKey"],
+        refKeys: ["env:default:OPENAI_API_KEY"],
+        reason: "secret reference was not found",
+        degradationState: "stale",
+        failureMatched: true,
+      },
+    ]);
     const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => {
       if (!shouldResolve) {
         throw missingSecretError;
@@ -879,39 +1232,181 @@ describe("gateway startup config secret preflight", () => {
       logSecrets,
       emitStateEvent,
       prepareRuntimeSecretsSnapshot,
+      activateRuntimeSecretsSnapshot: activateSecretsRuntimeSnapshotForTest,
     });
 
     await expect(
       activateRuntimeSecrets(sourceConfig, {
         reason: "reload",
-        activate: true,
+        activate: false,
+        publishFailureAsDegraded: true,
       }),
     ).rejects.toThrow(missingSecretError.message);
     await expect(
       activateRuntimeSecrets(sourceConfig, {
         reason: "reload",
-        activate: true,
+        activate: false,
+        publishFailureAsDegraded: true,
       }),
     ).rejects.toThrow(missingSecretError.message);
     shouldResolve = true;
+    const activeRevision = getActiveSecretsRuntimeSnapshotRevision();
+    const prepared = await activateRuntimeSecrets(sourceConfig, {
+      reason: "restart-check",
+      activate: false,
+    });
+    expect(emitStateEvent).toHaveBeenCalledTimes(1);
+
     await expect(
-      activateRuntimeSecrets(sourceConfig, {
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(prepared, activeRevision, {
         reason: "reload",
         activate: true,
       }),
     ).resolves.toMatchObject({ config: sourceConfig });
-
     expect(emitStateEvent.mock.calls.map((call) => call[0])).toEqual([
       "SECRETS_RELOADER_DEGRADED",
       "SECRETS_RELOADER_RECOVERED",
     ]);
-    expect(logSecrets.error).toHaveBeenCalledTimes(1);
-    expect(logSecrets.warn).toHaveBeenCalledWith(
-      `[SECRETS_RELOADER_DEGRADED] Error: ${missingSecretError.message}`,
+    expect(emitStateEvent.mock.calls[0]?.[1]).toBe(
+      "Secret resolution failed; runtime remains on the last-known-good snapshot.",
     );
+    expect(logSecrets.error).not.toHaveBeenCalled();
+    expect(logSecrets.warn).toHaveBeenCalledTimes(2);
+    expect(logSecrets.warn).toHaveBeenCalledWith(
+      "[SECRETS_DEGRADED] stale provider:openai: secret reference was not found. " +
+        "Retry: openclaw secrets reload.",
+      {
+        event: "secrets.degraded",
+        ownerKind: "provider",
+        ownerId: "openai",
+        reason: "secret reference was not found",
+        state: "stale",
+        retryHint: "openclaw secrets reload",
+      },
+    );
+    expect(JSON.stringify(logSecrets.warn.mock.calls)).not.toContain("OPENAI_API_KEY");
     expect(logSecrets.info).toHaveBeenCalledWith(
       "[SECRETS_RELOADER_RECOVERED] Secret resolution recovered; runtime remained on last-known-good during the outage.",
     );
+
+    shouldResolve = false;
+    await expect(
+      activateRuntimeSecrets(sourceConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toThrow(missingSecretError.message);
+    shouldResolve = true;
+    const sourceOnlyRevision = getActiveSecretsRuntimeSnapshotRevision();
+    const sourceOnly = await activateRuntimeSecrets(sourceConfig, {
+      reason: "reload",
+      activate: false,
+      publishFailureAsDegraded: true,
+    });
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(sourceOnly, sourceOnlyRevision, {
+        reason: "reload",
+        activate: true,
+        publishRecovery: false,
+      }),
+    ).resolves.toMatchObject({ config: sourceConfig });
+    expect(emitStateEvent.mock.calls.map((call) => call[0])).toEqual([
+      "SECRETS_RELOADER_DEGRADED",
+      "SECRETS_RELOADER_RECOVERED",
+      "SECRETS_RELOADER_DEGRADED",
+    ]);
+    shouldResolve = false;
+    await expect(
+      activateRuntimeSecrets(sourceConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toThrow(missingSecretError.message);
+    publishRuntimeSecretsRecovery(activateRuntimeSecrets, sourceOnly);
+    expect(emitStateEvent.mock.calls.map((call) => call[0])).toEqual([
+      "SECRETS_RELOADER_DEGRADED",
+      "SECRETS_RELOADER_RECOVERED",
+      "SECRETS_RELOADER_DEGRADED",
+    ]);
+    shouldResolve = true;
+    const newerRevision = getActiveSecretsRuntimeSnapshotRevision();
+    const newerPrepared = await activateRuntimeSecrets(sourceConfig, {
+      reason: "reload",
+      activate: false,
+    });
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(newerPrepared, newerRevision, {
+        reason: "reload",
+        activate: true,
+      }),
+    ).resolves.toMatchObject({ config: sourceConfig });
+    expect(emitStateEvent.mock.calls.map((call) => call[0])).toEqual([
+      "SECRETS_RELOADER_DEGRADED",
+      "SECRETS_RELOADER_RECOVERED",
+      "SECRETS_RELOADER_DEGRADED",
+      "SECRETS_RELOADER_RECOVERED",
+    ]);
+
+    const changedSourceConfig: OpenClawConfig = structuredClone(sourceConfig);
+    changedSourceConfig.models!.providers!.openai!.apiKey = {
+      source: "env",
+      provider: "default",
+      id: "OPENAI_API_KEY_NEXT",
+    };
+    shouldResolve = false;
+    await expect(
+      activateRuntimeSecrets(changedSourceConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toThrow(missingSecretError.message);
+    const revertedSnapshot = getActiveSecretsRuntimeSnapshot()!;
+    const revertedRevision = getActiveSecretsRuntimeSnapshotRevision();
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(
+        revertedSnapshot,
+        revertedRevision,
+        {
+          reason: "reload",
+          activate: true,
+          publishRecovery: false,
+        },
+      ),
+    ).resolves.toMatchObject({ sourceConfig });
+    publishRuntimeSecretsRecovery(activateRuntimeSecrets, revertedSnapshot, { sourceOnly: true });
+    expect(emitStateEvent.mock.calls.map((call) => call[0]).slice(-2)).toEqual([
+      "SECRETS_RELOADER_DEGRADED",
+      "SECRETS_RELOADER_RECOVERED",
+    ]);
+
+    await expect(
+      activateRuntimeSecrets(sourceConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toThrow(missingSecretError.message);
+    const unchangedSnapshot = getActiveSecretsRuntimeSnapshot()!;
+    const unchangedRevision = getActiveSecretsRuntimeSnapshotRevision();
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(
+        unchangedSnapshot,
+        unchangedRevision,
+        {
+          reason: "reload",
+          activate: true,
+          publishRecovery: false,
+        },
+      ),
+    ).resolves.toMatchObject({ sourceConfig });
+    publishRuntimeSecretsRecovery(activateRuntimeSecrets, unchangedSnapshot, { sourceOnly: true });
+    expect(emitStateEvent.mock.calls.map((call) => call[0]).slice(-2)).toEqual([
+      "SECRETS_RELOADER_RECOVERED",
+      "SECRETS_RELOADER_DEGRADED",
+    ]);
   });
 
   it.each(KNOWN_WEAK_GATEWAY_TOKEN_PLACEHOLDERS)(

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
-import { refResolutionError } from "../secrets/resolve-errors.js";
+import { providerResolutionError, refResolutionError } from "../secrets/resolve-errors.js";
 import { associateSecretResolutionErrorOwners } from "../secrets/runtime-degraded-state.js";
 import {
   activateSecretsRuntimeSnapshotState,
@@ -992,11 +992,10 @@ describe("gateway startup config secret preflight", () => {
   });
 
   it("preserves invalid provider diagnostics instead of reporting runtime degradation", async () => {
-    const invalidProviderError = refResolutionError({
+    const invalidProviderError = providerResolutionError({
       code: "SECRET_PROVIDER_INVALID",
       source: "env",
       provider: "missing",
-      refId: "INVALID_PROVIDER_REF",
       message: 'Secret provider "missing" is not configured.',
     });
     const emitStateEvent = vi.fn();

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -1359,6 +1359,19 @@ describe("gateway startup config secret preflight", () => {
       provider: "default",
       id: "OPENAI_API_KEY_NEXT",
     };
+    associateSecretResolutionErrorOwners(missingSecretError, [
+      {
+        ownerKind: "provider",
+        ownerId: "openai",
+        state: "unavailable",
+        paths: ["models.providers.openai.apiKey"],
+        refKeys: ["env:default:OPENAI_API_KEY_NEXT"],
+        reason: "secret reference was not found",
+        degradationState: "cold",
+        failureMatched: true,
+        source: "config",
+      },
+    ]);
     shouldResolve = false;
     await expect(
       activateRuntimeSecrets(changedSourceConfig, {
@@ -1384,6 +1397,52 @@ describe("gateway startup config secret preflight", () => {
     expect(emitStateEvent.mock.calls.map((call) => call[0]).slice(-2)).toEqual([
       "SECRETS_RELOADER_DEGRADED",
       "SECRETS_RELOADER_RECOVERED",
+    ]);
+
+    const unrelatedChangedSourceConfig = structuredClone(sourceConfig);
+    unrelatedChangedSourceConfig.messages = {
+      tts: {
+        providers: {
+          elevenlabs: {
+            apiKey: { source: "env", provider: "default", id: "UNRELATED_TTS_KEY" },
+          },
+        },
+      },
+    };
+    associateSecretResolutionErrorOwners(missingSecretError, [
+      {
+        ownerKind: "provider",
+        ownerId: "openai",
+        state: "unavailable",
+        paths: ["models.providers.openai.apiKey"],
+        refKeys: ["env:default:OPENAI_API_KEY"],
+        reason: "secret reference was not found",
+        degradationState: "stale",
+        failureMatched: true,
+        source: "config",
+      },
+    ]);
+    await expect(
+      activateRuntimeSecrets(unrelatedChangedSourceConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toThrow(missingSecretError.message);
+    const unrelatedRevertedSnapshot = getActiveSecretsRuntimeSnapshot()!;
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(
+        unrelatedRevertedSnapshot,
+        getActiveSecretsRuntimeSnapshotRevision(),
+        { reason: "reload", activate: true, publishRecovery: false },
+      ),
+    ).resolves.toMatchObject({ sourceConfig });
+    publishRuntimeSecretsRecovery(activateRuntimeSecrets, unrelatedRevertedSnapshot, {
+      sourceOnly: true,
+    });
+    expect(emitStateEvent.mock.calls.map((call) => call[0]).slice(-2)).toEqual([
+      "SECRETS_RELOADER_RECOVERED",
+      "SECRETS_RELOADER_DEGRADED",
     ]);
 
     await expect(

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -663,6 +663,7 @@ describe("gateway startup config secret preflight", () => {
         reason: "secret reference was not found",
         degradationState: "cold",
         failureMatched: true,
+        source: "config",
       },
     ]);
     const prepareRuntimeSecretsSnapshot = vi.fn(async () => {
@@ -854,6 +855,7 @@ describe("gateway startup config secret preflight", () => {
           reason: "resolved secret value was invalid",
           degradationState: "stale",
           failureMatched: true,
+          source: "config",
         },
       ]);
       const prepareRuntimeSecretsSnapshot = vi.fn(async () => {
@@ -915,6 +917,7 @@ describe("gateway startup config secret preflight", () => {
         reason: "secret reference was not found",
         degradationState: "stale",
         failureMatched: true,
+        source: "config",
       },
     ]);
     const emitStateEvent = vi.fn();
@@ -1218,6 +1221,7 @@ describe("gateway startup config secret preflight", () => {
         reason: "secret reference was not found",
         degradationState: "stale",
         failureMatched: true,
+        source: "config",
       },
     ]);
     const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => {
@@ -1404,6 +1408,139 @@ describe("gateway startup config secret preflight", () => {
     ).resolves.toMatchObject({ sourceConfig });
     publishRuntimeSecretsRecovery(activateRuntimeSecrets, unchangedSnapshot, { sourceOnly: true });
     expect(emitStateEvent.mock.calls.map((call) => call[0]).slice(-2)).toEqual([
+      "SECRETS_RELOADER_RECOVERED",
+      "SECRETS_RELOADER_DEGRADED",
+    ]);
+  });
+
+  it("does not recover auth-store degradation from a config-only source reversion", async () => {
+    const stableConfig = gatewayTokenConfig({
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: { source: "env", provider: "default", id: "OPENAI_STABLE" },
+            models: [],
+          },
+        },
+      },
+    });
+    const changedConfig = structuredClone(stableConfig);
+    changedConfig.models!.providers!.openai!.apiKey = {
+      source: "env",
+      provider: "default",
+      id: "OPENAI_CHANGED",
+    };
+    const configFailure = new Error("config secret failed");
+    associateSecretResolutionErrorOwners(configFailure, [
+      {
+        ownerKind: "provider",
+        ownerId: "openai",
+        state: "unavailable",
+        paths: ["models.providers.openai.apiKey"],
+        refKeys: ["env:default:OPENAI_CHANGED"],
+        reason: "secret reference was not found",
+        degradationState: "cold",
+        failureMatched: true,
+        source: "config",
+      },
+    ]);
+    const authStoreFailure = new Error("auth store secret failed");
+    associateSecretResolutionErrorOwners(authStoreFailure, [
+      {
+        ownerKind: "account",
+        ownerId: "auth-profile-owner",
+        state: "unavailable",
+        paths: ["/tmp/agent.auth-profiles.openai:default.key"],
+        refKeys: ["env:default:AUTH_PROFILE_KEY"],
+        reason: "secret reference was not found",
+        degradationState: "stale",
+        failureMatched: true,
+        source: "auth-store",
+      },
+    ]);
+    const emitStateEvent = vi.fn();
+    let nextFailure = configFailure;
+    const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
+      emitStateEvent,
+      prepareRuntimeSecretsSnapshot: vi.fn(async () => {
+        throw nextFailure;
+      }),
+      activateRuntimeSecretsSnapshot: activateSecretsRuntimeSnapshotForTest,
+    });
+    activateSecretsRuntimeSnapshotForTest(preparedSnapshot(stableConfig));
+
+    await expect(
+      activateRuntimeSecrets(changedConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toBe(configFailure);
+    nextFailure = authStoreFailure;
+    await expect(
+      activateRuntimeSecrets(changedConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toBe(authStoreFailure);
+
+    const revertedSnapshot = preparedSnapshot(stableConfig);
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(
+        revertedSnapshot,
+        getActiveSecretsRuntimeSnapshotRevision(),
+        { reason: "reload", activate: true, publishRecovery: false },
+      ),
+    ).resolves.toBe(revertedSnapshot);
+    publishRuntimeSecretsRecovery(activateRuntimeSecrets, revertedSnapshot, { sourceOnly: true });
+    expect(emitStateEvent.mock.calls.map((call) => call[0])).toEqual(["SECRETS_RELOADER_DEGRADED"]);
+
+    const fullyResolvedSnapshot = preparedSnapshot(stableConfig);
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(
+        fullyResolvedSnapshot,
+        getActiveSecretsRuntimeSnapshotRevision(),
+        { reason: "reload", activate: true, publishRecovery: false },
+      ),
+    ).resolves.toBe(fullyResolvedSnapshot);
+    publishRuntimeSecretsRecovery(activateRuntimeSecrets, fullyResolvedSnapshot);
+    expect(emitStateEvent.mock.calls.map((call) => call[0])).toEqual([
+      "SECRETS_RELOADER_DEGRADED",
+      "SECRETS_RELOADER_RECOVERED",
+    ]);
+
+    nextFailure = authStoreFailure;
+    await expect(
+      activateRuntimeSecrets(changedConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toBe(authStoreFailure);
+    nextFailure = configFailure;
+    await expect(
+      activateRuntimeSecrets(changedConfig, {
+        reason: "reload",
+        activate: false,
+        publishFailureAsDegraded: true,
+      }),
+    ).rejects.toBe(configFailure);
+
+    const secondRevertedSnapshot = preparedSnapshot(stableConfig);
+    await expect(
+      activateRuntimeSecrets.activatePreparedSnapshotIfCurrent?.(
+        secondRevertedSnapshot,
+        getActiveSecretsRuntimeSnapshotRevision(),
+        { reason: "reload", activate: true, publishRecovery: false },
+      ),
+    ).resolves.toBe(secondRevertedSnapshot);
+    publishRuntimeSecretsRecovery(activateRuntimeSecrets, secondRevertedSnapshot, {
+      sourceOnly: true,
+    });
+    expect(emitStateEvent.mock.calls.map((call) => call[0])).toEqual([
+      "SECRETS_RELOADER_DEGRADED",
       "SECRETS_RELOADER_RECOVERED",
       "SECRETS_RELOADER_DEGRADED",
     ]);

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -22,6 +22,7 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
   classifySecretResolutionErrorDegradations,
+  listSecretResolutionErrorOwners,
   redactSecretDegradationReason,
   SECRET_DEGRADATION_RETRY_HINT,
   type SecretDegradation,
@@ -234,6 +235,7 @@ export function createRuntimeSecretsActivator(params: {
   let degradationGeneration = 0;
   let activeDegradationGeneration: number | null = null;
   let activeDegradationConfig: OpenClawConfig | null = null;
+  let activeDegradationSupportsSourceOnlyRecovery = false;
   const deferredRecoveryGenerations = new WeakMap<object, number>();
   let secretsActivationTail: Promise<void> = Promise.resolve();
   const loadSecretsRuntime = createLazyPromise(() => import("../secrets/runtime.js"), {
@@ -276,6 +278,7 @@ export function createRuntimeSecretsActivator(params: {
     secretsDegraded = false;
     activeDegradationGeneration = null;
     activeDegradationConfig = null;
+    activeDegradationSupportsSourceOnlyRecovery = false;
   };
 
   const finishPreparedSnapshot = async (
@@ -350,6 +353,14 @@ export function createRuntimeSecretsActivator(params: {
             eventConfig,
           );
         }
+        const failedOwners = listSecretResolutionErrorOwners(err).filter(
+          (owner) => owner.failureMatched,
+        );
+        const currentFailureSupportsSourceOnlyRecovery =
+          failedOwners.length > 0 && failedOwners.every((owner) => owner.source === "config");
+        activeDegradationSupportsSourceOnlyRecovery = secretsDegraded
+          ? activeDegradationSupportsSourceOnlyRecovery && currentFailureSupportsSourceOnlyRecovery
+          : currentFailureSupportsSourceOnlyRecovery;
         secretsDegraded = true;
         activeDegradationGeneration = ++degradationGeneration;
         activeDegradationConfig = structuredClone(eventConfig);
@@ -529,7 +540,8 @@ export function createRuntimeSecretsActivator(params: {
     deferredRecoveryGenerations.delete(snapshot);
     const sourceOnlyContractRecovered =
       options?.sourceOnly !== true ||
-      (activeDegradationConfig !== null &&
+      (activeDegradationSupportsSourceOnlyRecovery &&
+        activeDegradationConfig !== null &&
         !hasSameSecretReloadContract(activeDegradationConfig, snapshot.sourceConfig));
     if (expectedGeneration !== undefined && sourceOnlyContractRecovered) {
       publishRecovery(snapshot.config, expectedGeneration);

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -357,7 +357,10 @@ export function createRuntimeSecretsActivator(params: {
           (owner) => owner.failureMatched,
         );
         const currentFailureSupportsSourceOnlyRecovery =
-          failedOwners.length > 0 && failedOwners.every((owner) => owner.source === "config");
+          failedOwners.length > 0 &&
+          failedOwners.every(
+            (owner) => owner.source === "config" && owner.degradationState === "cold",
+          );
         activeDegradationSupportsSourceOnlyRecovery = secretsDegraded
           ? activeDegradationSupportsSourceOnlyRecovery && currentFailureSupportsSourceOnlyRecovery
           : currentFailureSupportsSourceOnlyRecovery;

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -20,6 +20,12 @@ import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.opencla
 import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  classifySecretResolutionErrorDegradations,
+  redactSecretDegradationReason,
+  SECRET_DEGRADATION_RETRY_HINT,
+  type SecretDegradation,
+} from "../secrets/runtime-degraded-state.js";
 import { prepareSecretsRuntimeFastPathSnapshot } from "../secrets/runtime-fast-path.js";
 import {
   GATEWAY_AUTH_SURFACE_PATHS,
@@ -30,6 +36,7 @@ import {
   graftActiveSecretsRuntimeAuthState,
   getActiveSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshotRevision,
+  hasSameSecretReloadContract,
   hasCurrentAuthStoreCredentialsRevision,
 } from "../secrets/runtime-state.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
@@ -48,7 +55,7 @@ import {
 
 type GatewayStartupLog = {
   info: (message: string) => void;
-  warn: (message: string) => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
   error?: (message: string) => void;
 };
 
@@ -63,8 +70,16 @@ type PreparedRuntimeSecretsSnapshot = Awaited<ReturnType<PrepareRuntimeSecretsSn
 type RuntimeSecretsActivationParams = {
   reason: "startup" | "reload" | "restart-check";
   activate: boolean;
+  /** This preparation belongs to a live reload; publish failure against the active snapshot. */
+  publishFailureAsDegraded?: boolean;
+  /** Reject warning publication after a speculative reload loses transaction ownership. */
+  canPublishFailureAsDegraded?: () => boolean;
   env?: NodeJS.ProcessEnv;
   includeAuthStoreRefs?: boolean;
+  /** Raw config source paired with an otherwise fully activated prepared snapshot. */
+  runtimeSourceConfig?: OpenClawConfig;
+  /** Defer recovery until a larger transaction can no longer roll activation back. */
+  publishRecovery?: boolean;
 };
 
 /** Gateway startup hook that prepares secrets and optionally activates the prepared snapshot. */
@@ -85,6 +100,20 @@ export type ActivateRuntimeSecrets = ((
   ) => Promise<PreparedRuntimeSecretsSnapshot | null>;
 };
 
+const runtimeSecretsRecoveryPublishers = new WeakMap<
+  ActivateRuntimeSecrets,
+  (snapshot: PreparedRuntimeSecretsSnapshot, options?: { sourceOnly?: boolean }) => void
+>();
+
+/** Publishes recovery after a prepared source-only snapshot wins its commit CAS. */
+export function publishRuntimeSecretsRecovery(
+  activateRuntimeSecrets: ActivateRuntimeSecrets,
+  snapshot: PreparedRuntimeSecretsSnapshot,
+  options?: { sourceOnly?: boolean },
+): void {
+  runtimeSecretsRecoveryPublishers.get(activateRuntimeSecrets)?.(snapshot, options);
+}
+
 type GatewayStartupConfigOverrides = {
   auth?: GatewayAuthConfig;
   tailscale?: GatewayTailscaleConfig;
@@ -95,6 +124,22 @@ type GatewayStartupConfigMeasure = <T>(
   run: () => T | Promise<T>,
   options?: { omitErrorMessage?: boolean },
 ) => Promise<T>;
+
+function logSecretDegradation(log: GatewayStartupLog, degradation: SecretDegradation): void {
+  const reason = redactSecretDegradationReason(degradation.reason);
+  log.warn(
+    `[SECRETS_DEGRADED] ${degradation.state} ${degradation.kind}:${degradation.id}: ` +
+      `${reason}. Retry: ${degradation.retryHint}.`,
+    {
+      event: "secrets.degraded",
+      ownerKind: degradation.kind,
+      ownerId: degradation.id,
+      reason,
+      state: degradation.state,
+      retryHint: degradation.retryHint,
+    },
+  );
+}
 
 /** Config snapshot plus optional plugin metadata loaded before Gateway startup auth. */
 export type GatewayStartupConfigSnapshotLoadResult = {
@@ -186,6 +231,10 @@ export function createRuntimeSecretsActivator(params: {
   channelAutostartSuppression?: ChannelAutostartSuppression | null;
 }): ActivateRuntimeSecrets {
   let secretsDegraded = false;
+  let degradationGeneration = 0;
+  let activeDegradationGeneration: number | null = null;
+  let activeDegradationConfig: OpenClawConfig | null = null;
+  const deferredRecoveryGenerations = new WeakMap<object, number>();
   let secretsActivationTail: Promise<void> = Promise.resolve();
   const loadSecretsRuntime = createLazyPromise(() => import("../secrets/runtime.js"), {
     cacheRejections: true,
@@ -213,6 +262,22 @@ export function createRuntimeSecretsActivator(params: {
     return (await loadSecretsRuntime()).activateSecretsRuntimeSnapshot;
   };
 
+  const publishRecovery = (config: OpenClawConfig, expectedGeneration?: number) => {
+    if (
+      !secretsDegraded ||
+      (expectedGeneration !== undefined && activeDegradationGeneration !== expectedGeneration)
+    ) {
+      return;
+    }
+    const recoveredMessage =
+      "Secret resolution recovered; runtime remained on last-known-good during the outage.";
+    params.logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
+    params.emitStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, config);
+    secretsDegraded = false;
+    activeDegradationGeneration = null;
+    activeDegradationConfig = null;
+  };
+
   const finishPreparedSnapshot = async (
     prepared: PreparedRuntimeSecretsSnapshot,
     activationParams: RuntimeSecretsActivationParams,
@@ -234,13 +299,30 @@ export function createRuntimeSecretsActivator(params: {
     for (const warning of prepared.warnings) {
       params.logSecrets.warn(`[${warning.code}] ${warning.message}`);
     }
-    if (secretsDegraded) {
-      const recoveredMessage =
-        "Secret resolution recovered; runtime remained on last-known-good during the outage.";
-      params.logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
-      params.emitStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, prepared.config);
+    if (
+      activationParams.reason === "startup" &&
+      activationParams.activate &&
+      (prepared.degradedOwners?.length ?? 0) > 0
+    ) {
+      for (const owner of prepared.degradedOwners ?? []) {
+        logSecretDegradation(params.logSecrets, {
+          kind: owner.ownerKind,
+          id: owner.ownerId,
+          reason: owner.reason,
+          state: "cold",
+          retryHint: SECRET_DEGRADATION_RETRY_HINT,
+        });
+      }
     }
-    secretsDegraded = false;
+    if (activationParams.activate && secretsDegraded) {
+      if (activationParams.publishRecovery === false) {
+        if (activeDegradationGeneration !== null) {
+          deferredRecoveryGenerations.set(prepared, activeDegradationGeneration);
+        }
+      } else {
+        publishRecovery(prepared.config);
+      }
+    }
     return prepared;
   };
 
@@ -249,22 +331,35 @@ export function createRuntimeSecretsActivator(params: {
     activationParams: RuntimeSecretsActivationParams,
     eventConfig: OpenClawConfig,
   ): never => {
-    const details = String(err);
-    if (!secretsDegraded) {
-      params.logSecrets.error?.(`[SECRETS_RELOADER_DEGRADED] ${details}`);
-      if (activationParams.reason !== "startup") {
-        params.emitStateEvent(
-          "SECRETS_RELOADER_DEGRADED",
-          `Secret resolution failed; runtime remains on last-known-good snapshot. ${details}`,
-          eventConfig,
-        );
+    const mayPublishReloadDegradation =
+      (activationParams.activate || activationParams.publishFailureAsDegraded === true) &&
+      (activationParams.canPublishFailureAsDegraded?.() ?? true);
+    const degradations = classifySecretResolutionErrorDegradations(err);
+    if (
+      degradations.length > 0 &&
+      (activationParams.reason === "startup" || mayPublishReloadDegradation)
+    ) {
+      for (const degradation of degradations) {
+        logSecretDegradation(params.logSecrets, degradation);
       }
-    } else {
-      params.logSecrets.warn(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+      if (activationParams.reason !== "startup") {
+        if (!secretsDegraded) {
+          params.emitStateEvent(
+            "SECRETS_RELOADER_DEGRADED",
+            "Secret resolution failed; runtime remains on the last-known-good snapshot.",
+            eventConfig,
+          );
+        }
+        secretsDegraded = true;
+        activeDegradationGeneration = ++degradationGeneration;
+        activeDegradationConfig = structuredClone(eventConfig);
+      }
     }
-    secretsDegraded = true;
     if (activationParams.reason === "startup") {
-      throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
+      if (degradations.length > 0) {
+        throw new Error("Startup failed: required secrets are unavailable.");
+      }
+      throw new Error(`Startup failed: required secrets are unavailable. ${String(err)}`, {
         cause: err,
       });
     }
@@ -273,6 +368,7 @@ export function createRuntimeSecretsActivator(params: {
 
   const activateRuntimeSecrets = (async (config, activationParams) =>
     await runWithSecretsActivationLock(async () => {
+      let activationSourceConfig = config;
       try {
         const { sourceConfig, assignmentConfig } = resolveGatewayStartupSecretProjection({
           config,
@@ -280,6 +376,7 @@ export function createRuntimeSecretsActivator(params: {
           channelAutostartSuppression: params.channelAutostartSuppression,
           ...(activationParams.env ? { env: activationParams.env } : {}),
         });
+        activationSourceConfig = sourceConfig;
         const startupPreflight =
           activationParams.reason === "startup" || activationParams.reason === "restart-check";
         if (
@@ -358,7 +455,7 @@ export function createRuntimeSecretsActivator(params: {
         }
         return await finishPreparedSnapshot(prepared, activationParams);
       } catch (err) {
-        return handleSecretsActivationError(err, activationParams, config);
+        return handleSecretsActivationError(err, activationParams, activationSourceConfig);
       }
     })) as ActivateRuntimeSecrets;
 
@@ -380,8 +477,17 @@ export function createRuntimeSecretsActivator(params: {
   ) => {
     // Resolve the lazy activator before entering the compare-and-activate
     // section so no await separates revision ownership from state publication.
+    const runtimeSourceConfig = activationParams.runtimeSourceConfig;
     const activateRuntimeSecretsSnapshot = activationParams.activate
-      ? await loadActivateRuntimeSecretsSnapshot()
+      ? runtimeSourceConfig
+        ? (
+            (runtime) => (preparedSnapshot: PreparedRuntimeSecretsSnapshot) =>
+              runtime.activateSecretsRuntimeSnapshotWithSource(
+                preparedSnapshot,
+                runtimeSourceConfig,
+              )
+          )(await loadSecretsRuntime())
+        : await loadActivateRuntimeSecretsSnapshot()
       : undefined;
     return await runWithSecretsActivationLock(async () => {
       if (
@@ -417,6 +523,18 @@ export function createRuntimeSecretsActivator(params: {
       return activated;
     });
   };
+
+  runtimeSecretsRecoveryPublishers.set(activateRuntimeSecrets, (snapshot, options) => {
+    const expectedGeneration = deferredRecoveryGenerations.get(snapshot);
+    deferredRecoveryGenerations.delete(snapshot);
+    const sourceOnlyContractRecovered =
+      options?.sourceOnly !== true ||
+      (activeDegradationConfig !== null &&
+        !hasSameSecretReloadContract(activeDegradationConfig, snapshot.sourceConfig));
+    if (expectedGeneration !== undefined && sourceOnlyContractRecovered) {
+      publishRecovery(snapshot.config, expectedGeneration);
+    }
+  });
 
   return activateRuntimeSecrets;
 }

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -231,7 +231,6 @@ export function createRuntimeSecretsActivator(params: {
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins" | "manifestRegistry">;
   channelAutostartSuppression?: ChannelAutostartSuppression | null;
 }): ActivateRuntimeSecrets {
-  let secretsDegraded = false;
   let degradationGeneration = 0;
   let activeDegradationGeneration: number | null = null;
   let activeDegradationConfig: OpenClawConfig | null = null;
@@ -266,7 +265,7 @@ export function createRuntimeSecretsActivator(params: {
 
   const publishRecovery = (config: OpenClawConfig, expectedGeneration?: number) => {
     if (
-      !secretsDegraded ||
+      activeDegradationGeneration === null ||
       (expectedGeneration !== undefined && activeDegradationGeneration !== expectedGeneration)
     ) {
       return;
@@ -275,7 +274,6 @@ export function createRuntimeSecretsActivator(params: {
       "Secret resolution recovered; runtime remained on last-known-good during the outage.";
     params.logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
     params.emitStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, config);
-    secretsDegraded = false;
     activeDegradationGeneration = null;
     activeDegradationConfig = null;
     activeDegradationSupportsSourceOnlyRecovery = false;
@@ -317,11 +315,9 @@ export function createRuntimeSecretsActivator(params: {
         });
       }
     }
-    if (activationParams.activate && secretsDegraded) {
+    if (activationParams.activate && activeDegradationGeneration !== null) {
       if (activationParams.publishRecovery === false) {
-        if (activeDegradationGeneration !== null) {
-          deferredRecoveryGenerations.set(prepared, activeDegradationGeneration);
-        }
+        deferredRecoveryGenerations.set(prepared, activeDegradationGeneration);
       } else {
         publishRecovery(prepared.config);
       }
@@ -346,7 +342,8 @@ export function createRuntimeSecretsActivator(params: {
         logSecretDegradation(params.logSecrets, degradation);
       }
       if (activationParams.reason !== "startup") {
-        if (!secretsDegraded) {
+        const wasDegraded = activeDegradationGeneration !== null;
+        if (!wasDegraded) {
           params.emitStateEvent(
             "SECRETS_RELOADER_DEGRADED",
             "Secret resolution failed; runtime remains on the last-known-good snapshot.",
@@ -361,10 +358,9 @@ export function createRuntimeSecretsActivator(params: {
           failedOwners.every(
             (owner) => owner.source === "config" && owner.degradationState === "cold",
           );
-        activeDegradationSupportsSourceOnlyRecovery = secretsDegraded
+        activeDegradationSupportsSourceOnlyRecovery = wasDegraded
           ? activeDegradationSupportsSourceOnlyRecovery && currentFailureSupportsSourceOnlyRecovery
           : currentFailureSupportsSourceOnlyRecovery;
-        secretsDegraded = true;
         activeDegradationGeneration = ++degradationGeneration;
         activeDegradationConfig = structuredClone(eventConfig);
       }

--- a/src/secrets/resolve-errors.ts
+++ b/src/secrets/resolve-errors.ts
@@ -10,6 +10,12 @@ type SecretRefResolutionCode =
 
 type SecretProviderResolutionCode = "SECRET_PROVIDER_INVALID" | "SECRET_PROVIDER_UNAVAILABLE";
 
+export type SecretResolutionFailureReason =
+  | "secret provider failed"
+  | "secret provider policy denied resolution"
+  | "secret provider response violated its contract"
+  | "secret reference was not found";
+
 /** Error for failures that affect an entire configured secret provider. */
 class SecretProviderResolutionError extends Error {
   readonly scope = "provider" as const;
@@ -73,7 +79,9 @@ export function isSecretResolutionError(
 }
 
 /** Redacted reason suitable for warnings and status output. */
-export function describeSecretResolutionError(value: unknown): string | undefined {
+export function describeSecretResolutionError(
+  value: unknown,
+): SecretResolutionFailureReason | undefined {
   if (value instanceof SecretProviderResolutionError) {
     return value.code === "SECRET_PROVIDER_UNAVAILABLE" ? "secret provider failed" : undefined;
   }

--- a/src/secrets/runtime-assignment-provenance.ts
+++ b/src/secrets/runtime-assignment-provenance.ts
@@ -1,7 +1,7 @@
 /** Internal provenance for assignments collected outside openclaw.json. */
 import type { SecretAssignment } from "./runtime-shared.js";
 
-export type SecretAssignmentSource = "auth-store" | "config";
+type SecretAssignmentSource = "auth-store" | "config";
 
 const assignmentSources = new WeakMap<SecretAssignment, SecretAssignmentSource>();
 

--- a/src/secrets/runtime-assignment-provenance.ts
+++ b/src/secrets/runtime-assignment-provenance.ts
@@ -1,0 +1,17 @@
+/** Internal provenance for assignments collected outside openclaw.json. */
+import type { SecretAssignment } from "./runtime-shared.js";
+
+export type SecretAssignmentSource = "auth-store" | "config";
+
+const assignmentSources = new WeakMap<SecretAssignment, SecretAssignmentSource>();
+
+export function setSecretAssignmentSource(
+  assignment: SecretAssignment,
+  source: SecretAssignmentSource,
+): void {
+  assignmentSources.set(assignment, source);
+}
+
+export function getSecretAssignmentSource(assignment: SecretAssignment): SecretAssignmentSource {
+  return assignmentSources.get(assignment) ?? "config";
+}

--- a/src/secrets/runtime-auth-collectors.ts
+++ b/src/secrets/runtime-auth-collectors.ts
@@ -4,6 +4,7 @@ import { assertNoOAuthSecretRefPolicyViolations } from "../agents/auth-profiles/
 import type { AuthProfileCredential, AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { ProviderAuthAliasLookupParams } from "../agents/provider-auth-aliases.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { setSecretAssignmentSource } from "./runtime-assignment-provenance.js";
 import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import {
   collectRuntimeSecretInputAssignment,
@@ -24,6 +25,16 @@ type TokenCredentialLike = AuthProfileCredential & {
   token?: string;
   tokenRef?: unknown;
 };
+
+function collectAuthStoreSecretInputAssignment(
+  params: Parameters<typeof collectRuntimeSecretInputAssignment>[0],
+): void {
+  const previousCount = params.context.assignments.length;
+  collectRuntimeSecretInputAssignment(params);
+  for (const assignment of params.context.assignments.slice(previousCount)) {
+    setSecretAssignmentSource(assignment, "auth-store");
+  }
+}
 
 function collectApiKeyProfileAssignment(params: {
   profile: ApiKeyCredentialLike;
@@ -67,10 +78,9 @@ function collectApiKeyProfileAssignment(params: {
     provider: params.profile.provider,
     profileId: params.profileId,
   });
-  collectRuntimeSecretInputAssignment({
+  collectAuthStoreSecretInputAssignment({
     value: resolvedKeyRef,
     path: `${params.agentDir}.auth-profiles.${params.profileId}.key`,
-    source: "auth-store",
     expected: "string",
     defaults: params.defaults,
     context: params.context,
@@ -130,10 +140,9 @@ function collectTokenProfileAssignment(params: {
     provider: params.profile.provider,
     profileId: params.profileId,
   });
-  collectRuntimeSecretInputAssignment({
+  collectAuthStoreSecretInputAssignment({
     value: resolvedTokenRef,
     path: `${params.agentDir}.auth-profiles.${params.profileId}.token`,
-    source: "auth-store",
     expected: "string",
     defaults: params.defaults,
     context: params.context,

--- a/src/secrets/runtime-auth-collectors.ts
+++ b/src/secrets/runtime-auth-collectors.ts
@@ -70,6 +70,7 @@ function collectApiKeyProfileAssignment(params: {
   collectRuntimeSecretInputAssignment({
     value: resolvedKeyRef,
     path: `${params.agentDir}.auth-profiles.${params.profileId}.key`,
+    source: "auth-store",
     expected: "string",
     defaults: params.defaults,
     context: params.context,
@@ -132,6 +133,7 @@ function collectTokenProfileAssignment(params: {
   collectRuntimeSecretInputAssignment({
     value: resolvedTokenRef,
     path: `${params.agentDir}.auth-profiles.${params.profileId}.token`,
+    source: "auth-store",
     expected: "string",
     defaults: params.defaults,
     context: params.context,

--- a/src/secrets/runtime-auth-refresh-failure.test.ts
+++ b/src/secrets/runtime-auth-refresh-failure.test.ts
@@ -1,7 +1,9 @@
-/** Tests secrets runtime refresh failure handling for auth-profile stores. */
+/** Tests secrets runtime refresh handling for auth-profile stores. */
+import fs from "node:fs/promises";
 import os from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempHome } from "../config/home-env.test-harness.js";
+import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import {
   beginSecretsRuntimeIsolationForTest,
   createOpenAIFileRuntimeConfig,
@@ -13,10 +15,12 @@ import {
   OPENAI_FILE_KEY_REF,
   type SecretsRuntimeEnvSnapshot,
 } from "./runtime-auth.integration.test-helpers.js";
+import { listSecretResolutionErrorOwners } from "./runtime-degraded-state.js";
 import {
   activateSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
   prepareSecretsRuntimeSnapshot,
+  refreshActiveProviderAuthRuntimeSnapshot,
 } from "./runtime.js";
 
 vi.unmock("../version.js");
@@ -90,6 +94,77 @@ describe("secrets runtime snapshot auth refresh failure", () => {
       expectResolvedOpenAIRuntime(agentDir);
       expect(activeAfterFailure.sourceConfig.models?.providers?.openai?.apiKey).toEqual(
         OPENAI_FILE_KEY_REF,
+      );
+    });
+  });
+
+  it("classifies a changed auth-profile ref as stale after a successful refresh", async () => {
+    if (os.platform() === "win32") {
+      return;
+    }
+    await withTempHome("openclaw-secrets-runtime-refresh-owner-", async (home) => {
+      const { secretFile, agentDir } = await createOpenAIFileRuntimeFixture(home);
+      const firstRef = { source: "file" as const, provider: "default", id: "/accounts/first" };
+      const secondRef = { source: "file" as const, provider: "default", id: "/accounts/second" };
+      let activeRef = firstRef;
+      const loadAuthStore = () =>
+        loadAuthStoreWithProfiles({
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: activeRef,
+          },
+        });
+      const writeSecrets = async (includeSecond: boolean) => {
+        await fs.writeFile(
+          secretFile,
+          `${JSON.stringify({
+            providers: { openai: { apiKey: "test-api-key" } },
+            accounts: {
+              first: "first-fixture",
+              ...(includeSecond ? { second: "second-fixture" } : {}),
+            },
+          })}\n`,
+          { encoding: "utf8", mode: 0o600 },
+        );
+      };
+
+      await writeSecrets(true);
+      const prepared = await prepareSecretsRuntimeSnapshot({
+        config: createOpenAIFileRuntimeConfig(secretFile),
+        agentDirs: [agentDir],
+        loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+        loadAuthStore,
+      });
+      prepared.secretOwners = [
+        ...(prepared.secretOwners ?? []),
+        {
+          ownerKind: "account",
+          ownerId: "discord:ops",
+          refKeys: ["env:default:DISCORD_BOT_TOKEN"],
+        },
+      ];
+      activateSecretsRuntimeSnapshot(prepared);
+
+      activeRef = secondRef;
+      await expect(refreshActiveProviderAuthRuntimeSnapshot()).resolves.toBe(true);
+      expect(expectActiveSecretsRuntimeSnapshot().secretOwners).toContainEqual({
+        ownerKind: "account",
+        ownerId: "discord:ops",
+        refKeys: ["env:default:DISCORD_BOT_TOKEN"],
+      });
+      await writeSecrets(false);
+
+      const error = await refreshActiveProviderAuthRuntimeSnapshot().catch(
+        (cause: unknown) => cause,
+      );
+      expect(listSecretResolutionErrorOwners(error)).toContainEqual(
+        expect.objectContaining({
+          ownerKind: "account",
+          ownerId: resolveAuthProfileSecretOwnerId({ agentDir, profileId: "openai:default" }),
+          degradationState: "stale",
+          failureMatched: true,
+        }),
       );
     });
   });

--- a/src/secrets/runtime-auth-refresh-failure.test.ts
+++ b/src/secrets/runtime-auth-refresh-failure.test.ts
@@ -164,6 +164,7 @@ describe("secrets runtime snapshot auth refresh failure", () => {
           ownerId: resolveAuthProfileSecretOwnerId({ agentDir, profileId: "openai:default" }),
           degradationState: "stale",
           failureMatched: true,
+          source: "auth-store",
         }),
       );
     });

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -1,0 +1,386 @@
+/** Tests degraded-owner attribution during runtime SecretRef preparation. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.ts";
+import type { SecretRef } from "../config/types.secrets.js";
+import { listSecretResolutionErrorOwners } from "./runtime-degraded-state.js";
+import { activateSecretsRuntimeSnapshotState } from "./runtime-state.js";
+import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-support.ts";
+
+const EMPTY_LOADABLE_PLUGIN_ORIGINS = new Map();
+const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const TTS_REF = {
+  source: "env",
+  provider: "default",
+  id: "ELEVENLABS_API_KEY",
+} as const;
+
+describe("secrets runtime degraded-owner attribution", () => {
+  it("fails closed for missing TTS SecretRefs outside cold-start isolation", async () => {
+    const error = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        models: {
+          providers: {
+            example: {
+              apiKey: { source: "env", provider: "default", id: "CURRENT_PROVIDER_REF" },
+              baseUrl: "https://example.invalid/v1",
+              models: [],
+            },
+          },
+        },
+        messages: {
+          tts: {
+            providers: {
+              elevenlabs: { apiKey: TTS_REF },
+            },
+          },
+        },
+      }),
+      env: { CURRENT_PROVIDER_REF: "resolved" },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).then(
+      () => undefined,
+      (failure: unknown) => failure,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain(
+      'Environment variable "ELEVENLABS_API_KEY" is missing or empty.',
+    );
+    expect(listSecretResolutionErrorOwners(error)).toEqual([
+      expect.objectContaining({
+        ownerKind: "capability",
+        ownerId: "tts",
+        paths: ["messages.tts.providers.elevenlabs.apiKey"],
+        reason: "secret reference was not found",
+        degradationState: "cold",
+        failureMatched: true,
+      }),
+    ]);
+  });
+
+  it.each([
+    ["CURRENT_REF", "stale"],
+    ["CHANGED_REF", "cold"],
+  ] as const)("classifies unresolved reload ref %s", async (candidateId, expectedState) => {
+    const config = (ref: SecretRef) =>
+      asConfig({ messages: { tts: { providers: { elevenlabs: { apiKey: ref } } } } });
+    const ref = (id: string): SecretRef => ({ source: "env", provider: "default", id });
+    const active = await prepareSecretsRuntimeSnapshot({
+      config: config(ref("CURRENT_REF")),
+      env: { CURRENT_REF: "resolved" },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+
+    const error = await prepareSecretsRuntimeSnapshot({
+      config: config(ref(candidateId)),
+      env: {},
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(listSecretResolutionErrorOwners(error)).toEqual([
+      expect.objectContaining({
+        ownerKind: "capability",
+        ownerId: "tts",
+        degradationState: expectedState,
+      }),
+    ]);
+  });
+
+  it.each([
+    ["explicit", "WEB_TOOL_REF", "stale"],
+    ["explicit", "CHANGED_WEB_TOOL_REF", "cold"],
+    ["auto", "WEB_TOOL_REF", "stale"],
+  ] as const)("classifies %s web tool ref %s", async (mode, candidateId, expectedState) => {
+    const config = (id: string) =>
+      asConfig({
+        tools: {
+          web: { search: mode === "explicit" ? { provider: "gemini" } : { enabled: true } },
+        },
+        plugins: {
+          entries: {
+            ...(mode === "auto"
+              ? {
+                  brave: {
+                    config: {
+                      webSearch: {
+                        apiKey: { source: "env", provider: "default", id: "EARLIER_REF" },
+                      },
+                    },
+                  },
+                }
+              : {}),
+            google: {
+              config: {
+                webSearch: { apiKey: { source: "env", provider: "default", id } },
+              },
+            },
+          },
+        },
+      });
+    const active = await prepareSecretsRuntimeSnapshot({
+      config: config("WEB_TOOL_REF"),
+      env: { WEB_TOOL_REF: "resolved" },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+
+    const error = await prepareSecretsRuntimeSnapshot({
+      config: config(candidateId),
+      env: {},
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    const owners = listSecretResolutionErrorOwners(error);
+    expect(owners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "web-search:gemini",
+          degradationState: expectedState,
+          failureMatched: true,
+        }),
+      ]),
+    );
+    if (mode === "auto") {
+      expect(owners).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            ownerId: "web-search:brave",
+            degradationState: "cold",
+          }),
+        ]),
+      );
+    }
+  });
+
+  it("attributes provider failures by source and provider before matching ref ids", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = tempDirs.make("openclaw-secret-provider-owner-match-");
+    const healthyPath = path.join(root, "healthy.json");
+    await fs.writeFile(healthyPath, JSON.stringify({ shared: "healthy" }), "utf8");
+    await fs.chmod(healthyPath, 0o600);
+    const sharedId = "/shared";
+    const error = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        secrets: {
+          providers: {
+            missing: {
+              source: "file",
+              path: path.join(root, "missing.json"),
+              mode: "json",
+            },
+            healthy: { source: "file", path: healthyPath, mode: "json" },
+          },
+        },
+        models: {
+          providers: {
+            example: {
+              apiKey: { source: "file", provider: "missing", id: sharedId },
+              baseUrl: "https://example.invalid/v1",
+              models: [],
+            },
+          },
+        },
+        messages: {
+          tts: {
+            providers: {
+              elevenlabs: {
+                apiKey: { source: "file", provider: "healthy", id: sharedId },
+              },
+            },
+          },
+        },
+      }),
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(listSecretResolutionErrorOwners(error)).toEqual([
+      expect.objectContaining({ ownerKind: "provider", ownerId: "example" }),
+    ]);
+  });
+
+  it("keeps TTS SecretRefs that resolve to non-strings fail-closed", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = tempDirs.make("openclaw-tts-secretref-object-");
+    const secretsPath = path.join(root, "secrets.json");
+    await fs.writeFile(
+      secretsPath,
+      JSON.stringify(
+        {
+          providers: {
+            elevenlabs: {
+              apiKey: { value: "not-a-string" },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    await fs.chmod(secretsPath, 0o600);
+
+    const error = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        secrets: {
+          providers: {
+            ttsfile: {
+              source: "file",
+              path: secretsPath,
+              mode: "json",
+            },
+          },
+        },
+        messages: {
+          tts: {
+            providers: {
+              elevenlabs: {
+                apiKey: {
+                  source: "file",
+                  provider: "ttsfile",
+                  id: "/providers/elevenlabs/apiKey",
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: {},
+      includeAuthStoreRefs: false,
+      allowUnavailableSecretOwners: true,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain(
+      "messages.tts.providers.elevenlabs.apiKey resolved to a non-string or empty value.",
+    );
+    expect(listSecretResolutionErrorOwners(error)).toEqual([
+      expect.objectContaining({
+        ownerKind: "capability",
+        ownerId: "tts",
+        paths: ["messages.tts.providers.elevenlabs.apiKey"],
+        reason: "resolved secret value was invalid",
+        degradationState: "cold",
+        failureMatched: true,
+      }),
+    ]);
+  });
+
+  it("reports every cold-start owner sharing an invalid resolved value", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = tempDirs.make("openclaw-shared-invalid-secretref-");
+    const secretsPath = path.join(root, "secrets.json");
+    await fs.writeFile(secretsPath, JSON.stringify({ shared: { invalid: true } }), "utf8");
+    await fs.chmod(secretsPath, 0o600);
+    const sharedRef = { source: "file" as const, provider: "shared", id: "/shared" };
+    const error = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        secrets: {
+          providers: {
+            shared: { source: "file", path: secretsPath, mode: "json" },
+          },
+        },
+        models: {
+          providers: {
+            example: {
+              apiKey: sharedRef,
+              baseUrl: "https://example.invalid/v1",
+              models: [],
+            },
+          },
+        },
+        messages: {
+          tts: { providers: { elevenlabs: { apiKey: sharedRef } } },
+        },
+        skills: {
+          entries: {
+            healthy: {
+              apiKey: { source: "env", provider: "default", id: "HEALTHY_SKILL_KEY" },
+            },
+          },
+        },
+      }),
+      env: { HEALTHY_SKILL_KEY: "healthy-skill-key" },
+      includeAuthStoreRefs: false,
+      allowUnavailableSecretOwners: true,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(error).toBeInstanceOf(Error);
+    const owners = listSecretResolutionErrorOwners(error);
+    expect(owners).toHaveLength(2);
+    expect(owners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ownerKind: "provider",
+          ownerId: "example",
+          reason: "resolved secret value was invalid",
+          failureMatched: true,
+        }),
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "tts",
+          reason: "resolved secret value was invalid",
+          failureMatched: true,
+        }),
+      ]),
+    );
+    expect(owners).not.toContainEqual(expect.objectContaining({ ownerId: "skill:healthy" }));
+  });
+
+  it("still fails required gateway auth SecretRefs when env is missing", async () => {
+    const error = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        gateway: {
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "GATEWAY_TOKEN_REF" },
+          },
+        },
+      }),
+      env: {},
+      includeAuthStoreRefs: false,
+      allowUnavailableSecretOwners: true,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(String(error)).toContain(
+      'Environment variable "GATEWAY_TOKEN_REF" is missing or empty.',
+    );
+    expect(listSecretResolutionErrorOwners(error)).toEqual([
+      expect.objectContaining({
+        ownerKind: "gateway",
+        ownerId: "ingress-auth",
+        degradationState: "cold",
+        failureMatched: true,
+      }),
+    ]);
+  });
+});

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -228,7 +228,7 @@ describe("secrets runtime degraded-owner attribution", () => {
     }
     const root = tempDirs.make("openclaw-secret-provider-active-co-owner-");
     const provider = "missing";
-    const candidateRef = { source: "file" as const, provider, id: "/candidate" };
+    const apiKeyRef = { source: "file" as const, provider, id: "/candidate" };
     const activeRef = { source: "file" as const, provider, id: "/active" };
     const config = asConfig({
       secrets: {
@@ -243,7 +243,7 @@ describe("secrets runtime degraded-owner attribution", () => {
       models: {
         providers: {
           example: {
-            apiKey: candidateRef,
+            apiKey: apiKeyRef,
             baseUrl: "https://example.invalid/v1",
             models: [],
           },

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -396,6 +396,70 @@ describe("secrets runtime degraded-owner attribution", () => {
     );
   });
 
+  it("includes active web-tool co-owners when a shared resolved value is invalid", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = tempDirs.make("openclaw-invalid-web-co-owner-");
+    const secretsPath = path.join(root, "secrets.json");
+    await fs.writeFile(secretsPath, JSON.stringify({ shared: "dummy" }), "utf8");
+    await fs.chmod(secretsPath, 0o600);
+    const sharedRef = { source: "file" as const, provider: "shared", id: "/shared" };
+    const config = asConfig({
+      secrets: {
+        providers: {
+          shared: { source: "file", path: secretsPath, mode: "json" },
+        },
+      },
+      models: {
+        providers: {
+          example: {
+            apiKey: sharedRef,
+            baseUrl: "https://example.invalid/v1",
+            models: [],
+          },
+        },
+      },
+      tools: { web: { search: { provider: "gemini" } } },
+      plugins: {
+        entries: {
+          google: { config: { webSearch: { apiKey: sharedRef } } },
+        },
+      },
+    });
+    const active = await prepareSecretsRuntimeSnapshot({
+      config,
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+    await fs.writeFile(secretsPath, JSON.stringify({ shared: { invalid: true } }), "utf8");
+
+    const error = await prepareSecretsRuntimeSnapshot({
+      config,
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(listSecretResolutionErrorOwners(error)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ownerKind: "provider", ownerId: "example" }),
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "web-search:gemini",
+          reason: "resolved secret value was invalid",
+          degradationState: "stale",
+          failureMatched: true,
+          source: "config",
+        }),
+      ]),
+    );
+  });
+
   it("keeps TTS SecretRefs that resolve to non-strings fail-closed", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -460,6 +460,72 @@ describe("secrets runtime degraded-owner attribution", () => {
     );
   });
 
+  it("includes later active web-tool co-owners when web resolution fails first", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = tempDirs.make("openclaw-invalid-web-sibling-");
+    const secretsPath = path.join(root, "secrets.json");
+    await fs.writeFile(secretsPath, JSON.stringify({ shared: "dummy" }), "utf8");
+    await fs.chmod(secretsPath, 0o600);
+    const sharedRef = { source: "file" as const, provider: "shared", id: "/shared" };
+    const config = asConfig({
+      secrets: {
+        providers: {
+          shared: { source: "file", path: secretsPath, mode: "json" },
+        },
+      },
+      tools: {
+        web: {
+          search: { provider: "gemini" },
+          fetch: { provider: "firecrawl" },
+        },
+      },
+      plugins: {
+        entries: {
+          google: { config: { webSearch: { apiKey: sharedRef } } },
+          firecrawl: { config: { webFetch: { apiKey: sharedRef } } },
+        },
+      },
+    });
+    const active = await prepareSecretsRuntimeSnapshot({
+      config,
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+    await fs.writeFile(secretsPath, JSON.stringify({ shared: { invalid: true } }), "utf8");
+
+    const error = await prepareSecretsRuntimeSnapshot({
+      config,
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(listSecretResolutionErrorOwners(error)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "web-search:gemini",
+          reason: "resolved secret value was invalid",
+          degradationState: "stale",
+          failureMatched: true,
+        }),
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "web-fetch:firecrawl",
+          reason: "resolved secret value was invalid",
+          degradationState: "stale",
+          failureMatched: true,
+        }),
+      ]),
+    );
+  });
+
   it("keeps TTS SecretRefs that resolve to non-strings fail-closed", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -222,6 +222,96 @@ describe("secrets runtime degraded-owner attribution", () => {
     ]);
   });
 
+  it("includes active co-owners using another ref from a failed provider", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = tempDirs.make("openclaw-secret-provider-active-co-owner-");
+    const provider = "missing";
+    const candidateRef = { source: "file" as const, provider, id: "/candidate" };
+    const activeRef = { source: "file" as const, provider, id: "/active" };
+    const config = asConfig({
+      secrets: {
+        providers: {
+          [provider]: {
+            source: "file",
+            path: path.join(root, "missing.json"),
+            mode: "json",
+          },
+        },
+      },
+      models: {
+        providers: {
+          example: {
+            apiKey: candidateRef,
+            baseUrl: "https://example.invalid/v1",
+            models: [],
+          },
+        },
+      },
+    });
+    const agentDir = path.join(root, "agent");
+    const profileId = "openai:provider-failure";
+    const accountOwnerId = resolveAuthProfileSecretOwnerId({
+      agentDir,
+      profileId,
+    });
+    const active = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({}),
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+    active.sourceConfig = config;
+    active.config = config;
+    active.authStores = [
+      {
+        agentDir,
+        store: {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "api_key",
+              provider: "openai",
+              key: "dummy",
+              keyRef: activeRef,
+            },
+          },
+        },
+      },
+    ];
+    active.secretOwners = [
+      {
+        ownerKind: "account",
+        ownerId: accountOwnerId,
+        refKeys: ["file:missing:/active"],
+      },
+    ];
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+
+    const error = await prepareSecretsRuntimeSnapshot({
+      config,
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(listSecretResolutionErrorOwners(error)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ownerKind: "provider", ownerId: "example" }),
+        expect.objectContaining({
+          ownerKind: "account",
+          ownerId: accountOwnerId,
+          degradationState: "stale",
+          source: "auth-store",
+          failureMatched: true,
+        }),
+      ]),
+    );
+  });
+
   it("includes active web-tool co-owners when strict resolution fails first", async () => {
     const sharedRef = { source: "env" as const, provider: "default", id: "SHARED_API_KEY" };
     const authAgentDir = "/tmp/shared-secret-co-owner";

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.ts";
 import type { SecretRef } from "../config/types.secrets.js";
+import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import { listSecretResolutionErrorOwners } from "./runtime-degraded-state.js";
 import { activateSecretsRuntimeSnapshotState } from "./runtime-state.js";
 import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-support.ts";
@@ -221,6 +222,90 @@ describe("secrets runtime degraded-owner attribution", () => {
     ]);
   });
 
+  it("includes active web-tool co-owners when strict resolution fails first", async () => {
+    const sharedRef = { source: "env" as const, provider: "default", id: "SHARED_API_KEY" };
+    const authAgentDir = "/tmp/shared-secret-co-owner";
+    const authProfileId = "openai:shared";
+    const authOwnerId = resolveAuthProfileSecretOwnerId({
+      agentDir: authAgentDir,
+      profileId: authProfileId,
+    });
+    const config = asConfig({
+      models: {
+        providers: {
+          example: {
+            apiKey: sharedRef,
+            baseUrl: "https://example.invalid/v1",
+            models: [],
+          },
+        },
+      },
+      tools: { web: { search: { provider: "gemini" } } },
+      plugins: {
+        entries: {
+          google: { config: { webSearch: { apiKey: sharedRef } } },
+        },
+      },
+    });
+    const active = await prepareSecretsRuntimeSnapshot({
+      config,
+      env: { SHARED_API_KEY: "dummy" },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+    active.authStores = [
+      {
+        agentDir: authAgentDir,
+        store: {
+          version: 1,
+          profiles: {
+            [authProfileId]: {
+              type: "api_key",
+              provider: "openai",
+              key: "dummy",
+              keyRef: sharedRef,
+            },
+          },
+        },
+      },
+    ];
+    active.secretOwners?.push({
+      ownerKind: "account",
+      ownerId: authOwnerId,
+      refKeys: ["env:default:SHARED_API_KEY"],
+    });
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+
+    const error = await prepareSecretsRuntimeSnapshot({
+      config,
+      env: {},
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    }).catch((failure: unknown) => failure);
+
+    expect(listSecretResolutionErrorOwners(error)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ownerKind: "provider", ownerId: "example" }),
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "web-search:gemini",
+          degradationState: "stale",
+          failureMatched: true,
+        }),
+        expect.objectContaining({
+          ownerKind: "account",
+          ownerId: authOwnerId,
+          source: "auth-store",
+          failureMatched: true,
+        }),
+      ]),
+    );
+  });
+
   it("keeps TTS SecretRefs that resolve to non-strings fail-closed", async () => {
     if (process.platform === "win32") {
       return;
@@ -243,32 +328,69 @@ describe("secrets runtime degraded-owner attribution", () => {
       "utf8",
     );
     await fs.chmod(secretsPath, 0o600);
+    const ref = {
+      source: "file" as const,
+      provider: "ttsfile",
+      id: "/providers/elevenlabs/apiKey",
+    };
+    const config = asConfig({
+      secrets: {
+        providers: {
+          ttsfile: {
+            source: "file",
+            path: secretsPath,
+            mode: "json",
+          },
+        },
+      },
+      messages: {
+        tts: { providers: { elevenlabs: { apiKey: ref } } },
+      },
+    });
+    const authAgentDir = "/tmp/invalid-value-auth-co-owner";
+    const authProfileId = "openai:invalid-value";
+    const authOwnerId = resolveAuthProfileSecretOwnerId({
+      agentDir: authAgentDir,
+      profileId: authProfileId,
+    });
+    const active = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({}),
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+    active.sourceConfig = config;
+    active.config = config;
+    active.authStores = [
+      {
+        agentDir: authAgentDir,
+        store: {
+          version: 1,
+          profiles: {
+            [authProfileId]: {
+              type: "api_key",
+              provider: "openai",
+              key: "dummy",
+              keyRef: ref,
+            },
+          },
+        },
+      },
+    ];
+    active.secretOwners = [
+      {
+        ownerKind: "account",
+        ownerId: authOwnerId,
+        refKeys: ["file:ttsfile:/providers/elevenlabs/apiKey"],
+      },
+    ];
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
 
     const error = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({
-        secrets: {
-          providers: {
-            ttsfile: {
-              source: "file",
-              path: secretsPath,
-              mode: "json",
-            },
-          },
-        },
-        messages: {
-          tts: {
-            providers: {
-              elevenlabs: {
-                apiKey: {
-                  source: "file",
-                  provider: "ttsfile",
-                  id: "/providers/elevenlabs/apiKey",
-                },
-              },
-            },
-          },
-        },
-      }),
+      config,
       env: {},
       includeAuthStoreRefs: false,
       allowUnavailableSecretOwners: true,
@@ -279,16 +401,25 @@ describe("secrets runtime degraded-owner attribution", () => {
     expect(String(error)).toContain(
       "messages.tts.providers.elevenlabs.apiKey resolved to a non-string or empty value.",
     );
-    expect(listSecretResolutionErrorOwners(error)).toEqual([
-      expect.objectContaining({
-        ownerKind: "capability",
-        ownerId: "tts",
-        paths: ["messages.tts.providers.elevenlabs.apiKey"],
-        reason: "resolved secret value was invalid",
-        degradationState: "cold",
-        failureMatched: true,
-      }),
-    ]);
+    expect(listSecretResolutionErrorOwners(error)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ownerKind: "capability",
+          ownerId: "tts",
+          paths: ["messages.tts.providers.elevenlabs.apiKey"],
+          reason: "resolved secret value was invalid",
+          degradationState: "cold",
+          failureMatched: true,
+        }),
+        expect.objectContaining({
+          ownerKind: "account",
+          ownerId: authOwnerId,
+          reason: "resolved secret value was invalid",
+          source: "auth-store",
+          failureMatched: true,
+        }),
+      ]),
+    );
   });
 
   it("reports every cold-start owner sharing an invalid resolved value", async () => {

--- a/src/secrets/runtime-degraded-state.test.ts
+++ b/src/secrets/runtime-degraded-state.test.ts
@@ -1,9 +1,11 @@
 /** Tests for process-local SecretRef degraded-owner state. */
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  associateSecretResolutionErrorOwners,
   assertSecretOwnerAvailable,
   clearActiveCredentialDegradedOwner,
   listActiveDegradedSecretOwners,
+  listSecretResolutionErrorOwners,
   SecretSurfaceUnavailableError,
   setActiveCredentialDegradedOwner,
   setActiveDegradedSecretOwners,
@@ -36,6 +38,26 @@ describe("runtime degraded SecretRef owners", () => {
       "Secret owner provider:openai is configured but unavailable",
     );
     expect(() => assertSecretOwnerAvailable("provider", "anthropic")).not.toThrow();
+  });
+  it("records strict resolution owner metadata without exposing mutable state", () => {
+    const error = new Error("private provider details");
+    const owner = {
+      ownerKind: "provider" as const,
+      ownerId: "openai",
+      state: "unavailable" as const,
+      paths: ["models.providers.openai.apiKey"],
+      refKeys: ["env:default:OPENAI_API_KEY"],
+      reason: "secret provider failed",
+      degradationState: "stale" as const,
+      failureMatched: true,
+    };
+    associateSecretResolutionErrorOwners(error, [owner]);
+
+    const recorded = listSecretResolutionErrorOwners(error);
+    recorded[0]?.paths.push("mutated");
+    expect(listSecretResolutionErrorOwners(error)[0]?.paths).toEqual([
+      "models.providers.openai.apiKey",
+    ]);
   });
 
   it("merges runtime-discovered credential owners and clears them independently", () => {

--- a/src/secrets/runtime-degraded-state.test.ts
+++ b/src/secrets/runtime-degraded-state.test.ts
@@ -50,6 +50,7 @@ describe("runtime degraded SecretRef owners", () => {
       reason: "secret provider failed",
       degradationState: "stale" as const,
       failureMatched: true,
+      source: "config" as const,
     };
     associateSecretResolutionErrorOwners(error, [owner]);
 

--- a/src/secrets/runtime-degraded-state.ts
+++ b/src/secrets/runtime-degraded-state.ts
@@ -1,4 +1,16 @@
 /** Process-local registry for SecretRef owners isolated during cold startup. */
+import {
+  describeSecretResolutionError,
+  isSecretResolutionError,
+  type SecretResolutionFailureReason,
+} from "./resolve-errors.js";
+
+export type SecretDegradationReason =
+  | SecretResolutionFailureReason
+  | "resolved secret value was invalid"
+  | "secret reference is not allowed for this provider"
+  | "secret reference was not materialized by the active runtime"
+  | "secret resolution failed";
 
 export type SecretOwnerKind =
   | "account"
@@ -18,6 +30,75 @@ export type DegradedSecretOwner = {
   refKeys: string[];
   reason: string;
 };
+
+/** SecretRef identities resolved for one owner in an active runtime snapshot. */
+export type SecretOwnerRefState = Pick<DegradedSecretOwner, "ownerKind" | "ownerId" | "refKeys">;
+
+/** One owner from an atomic resolution attempt, including whether it caused the failure. */
+type SecretResolutionErrorOwner = DegradedSecretOwner & {
+  degradationState: "cold" | "stale";
+  failureMatched: boolean;
+};
+
+export const SECRET_DEGRADATION_RETRY_HINT = "openclaw secrets reload" as const;
+
+/** Redacted owner details for one structured degradation warning. */
+export type SecretDegradation = {
+  kind: SecretOwnerKind;
+  id: string;
+  reason: string;
+  state: "cold" | "stale";
+  retryHint: typeof SECRET_DEGRADATION_RETRY_HINT;
+};
+
+/** Maps a typed resolution failure to redacted owner warnings when attribution is safe. */
+export function classifySecretResolutionErrorDegradations(error: unknown): SecretDegradation[] {
+  const degradations = listSecretResolutionErrorOwners(error).flatMap((owner) =>
+    owner.failureMatched
+      ? [
+          {
+            kind: owner.ownerKind,
+            id: owner.ownerId,
+            reason: owner.reason,
+            state: owner.degradationState,
+            retryHint: SECRET_DEGRADATION_RETRY_HINT,
+          },
+        ]
+      : [],
+  );
+  if (degradations.length > 0 || !isSecretResolutionError(error)) {
+    return degradations;
+  }
+  const reason = describeSecretResolutionError(error);
+  return reason
+    ? [
+        {
+          kind: "unknown",
+          id: "unmapped",
+          reason,
+          state: "cold",
+          retryHint: SECRET_DEGRADATION_RETRY_HINT,
+        },
+      ]
+    : [];
+}
+
+/** Preserves known failure classes while dropping any embedded SecretRef identity. */
+export function redactSecretDegradationReason(reason: string): SecretDegradationReason {
+  switch (reason) {
+    case "secret provider failed":
+    case "secret provider policy denied resolution":
+    case "secret provider response violated its contract":
+    case "secret reference is not allowed for this provider":
+    case "secret reference was not found":
+    case "secret reference was not materialized by the active runtime":
+    case "resolved secret value was invalid":
+    case "secret resolution failed":
+      return reason;
+    default:
+      return "secret resolution failed";
+  }
+}
 
 const SECRET_SURFACE_UNAVAILABLE_ERROR_CODE = "SECRET_SURFACE_UNAVAILABLE";
 
@@ -40,6 +121,7 @@ export class SecretSurfaceUnavailableError extends Error {
 }
 
 let activeDegradedOwners: DegradedSecretOwner[] = [];
+const resolutionErrorOwners = new WeakMap<object, SecretResolutionErrorOwner[]>();
 const activeCredentialDegradedOwners = new Map<string, DegradedSecretOwner>();
 
 function ownerKey(ownerKind: DegradedSecretOwner["ownerKind"], ownerId: string): string {
@@ -51,6 +133,14 @@ function cloneOwner(owner: DegradedSecretOwner): DegradedSecretOwner {
     ...owner,
     paths: [...owner.paths],
     refKeys: [...owner.refKeys],
+  };
+}
+
+function cloneResolutionErrorOwner(owner: SecretResolutionErrorOwner): SecretResolutionErrorOwner {
+  return {
+    ...cloneOwner(owner),
+    degradationState: owner.degradationState,
+    failureMatched: owner.failureMatched,
   };
 }
 
@@ -79,6 +169,25 @@ export function listActiveDegradedSecretOwners(): DegradedSecretOwner[] {
     ...activeDegradedOwners.map(cloneOwner),
     ...Array.from(activeCredentialDegradedOwners.values(), cloneOwner),
   ];
+}
+
+/** Associates a strict activation failure with the owners it prevented from refreshing. */
+export function associateSecretResolutionErrorOwners(
+  error: unknown,
+  owners: readonly SecretResolutionErrorOwner[],
+): void {
+  if ((typeof error !== "object" && typeof error !== "function") || error === null) {
+    return;
+  }
+  resolutionErrorOwners.set(error, owners.map(cloneResolutionErrorOwner));
+}
+
+/** Returns owner metadata recorded for a strict activation failure. */
+export function listSecretResolutionErrorOwners(error: unknown): SecretResolutionErrorOwner[] {
+  if ((typeof error !== "object" && typeof error !== "function") || error === null) {
+    return [];
+  }
+  return (resolutionErrorOwners.get(error) ?? []).map(cloneResolutionErrorOwner);
 }
 
 /** Returns one active degraded owner, if present. */

--- a/src/secrets/runtime-degraded-state.ts
+++ b/src/secrets/runtime-degraded-state.ts
@@ -38,6 +38,7 @@ export type SecretOwnerRefState = Pick<DegradedSecretOwner, "ownerKind" | "owner
 type SecretResolutionErrorOwner = DegradedSecretOwner & {
   degradationState: "cold" | "stale";
   failureMatched: boolean;
+  source: "auth-store" | "config";
 };
 
 export const SECRET_DEGRADATION_RETRY_HINT = "openclaw secrets reload" as const;
@@ -141,6 +142,7 @@ function cloneResolutionErrorOwner(owner: SecretResolutionErrorOwner): SecretRes
     ...cloneOwner(owner),
     degradationState: owner.degradationState,
     failureMatched: owner.failureMatched,
+    source: owner.source,
   };
 }
 

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -276,6 +276,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
     authStoreCredentialsRevision,
     warnings: [],
     degradedOwners: [],
+    secretOwners: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
   };
   return {

--- a/src/secrets/runtime-owner-assignments.ts
+++ b/src/secrets/runtime-owner-assignments.ts
@@ -1,4 +1,7 @@
 /** Resolves SecretRef assignments atomically by owning runtime surface. */
+import { isDeepStrictEqual } from "node:util";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
 import { toErrorObject } from "../infra/errors.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { secretRefKey } from "./ref-contract.js";
@@ -8,15 +11,55 @@ import {
   isSecretResolutionError,
 } from "./resolve-errors.js";
 import { resolveSecretRefValues, resolveSecretRefValuesSettledByProvider } from "./resolve.js";
-import type { DegradedSecretOwner } from "./runtime-degraded-state.js";
+import type {
+  DegradedSecretOwner,
+  SecretDegradationReason,
+  SecretOwnerRefState,
+} from "./runtime-degraded-state.js";
+import { associateSecretResolutionErrorOwners } from "./runtime-degraded-state.js";
 import {
   applyResolvedAssignments,
+  getSecretAssignmentValidationFailures,
   pushWarning,
   type ResolverContext,
   type SecretAssignment,
 } from "./runtime-shared.js";
+import {
+  getActiveSecretsRuntimeSnapshot,
+  hasSameSecretProviderDefinition,
+} from "./runtime-state.js";
 
 type SecretResolutionOptions = Parameters<typeof resolveSecretRefValues>[1];
+
+/** Classifies whether an unresolved owner has an unchanged active SecretRef snapshot. */
+export function classifySecretOwnerDegradationState(params: {
+  ownerKind: DegradedSecretOwner["ownerKind"];
+  ownerId: string;
+  refs: SecretRef[];
+  config: OpenClawConfig;
+}): "cold" | "stale" {
+  const active = getActiveSecretsRuntimeSnapshot();
+  if (
+    !active ||
+    active.degradedOwners?.some(
+      (entry) => entry.ownerKind === params.ownerKind && entry.ownerId === params.ownerId,
+    )
+  ) {
+    return "cold";
+  }
+  const activeOwner = active.secretOwners?.find(
+    (entry) => entry.ownerKind === params.ownerKind && entry.ownerId === params.ownerId,
+  );
+  const refKeys = params.refs.map(secretRefKey).toSorted();
+  const providerDefinitionsMatch = params.refs.every((ref) =>
+    hasSameSecretProviderDefinition(ref, [active.sourceConfig, params.config]),
+  );
+  return activeOwner &&
+    isDeepStrictEqual(activeOwner.refKeys.toSorted(), refKeys) &&
+    providerDefinitionsMatch
+    ? "stale"
+    : "cold";
+}
 
 function registerResolvedValuesForRedaction(resolved: ReadonlyMap<string, unknown>): void {
   for (const value of resolved.values()) {
@@ -53,7 +96,26 @@ function groupAssignmentsByOwner(assignments: SecretAssignment[]): SecretAssignm
   return [...groups.values()];
 }
 
-function createDegradedOwner(assignments: SecretAssignment[], reason: string): DegradedSecretOwner {
+/** Captures every typed owner/ref relationship for later reload classification. */
+export function listSecretAssignmentOwners(assignments: SecretAssignment[]): SecretOwnerRefState[] {
+  return groupAssignmentsByOwner(assignments).flatMap((ownerAssignments) => {
+    const owner = ownerAssignments[0];
+    return !owner || owner.ownerKind === "unknown"
+      ? []
+      : [
+          {
+            ownerKind: owner.ownerKind,
+            ownerId: owner.ownerId,
+            refKeys: ownerAssignments.map((assignment) => secretRefKey(assignment.ref)).toSorted(),
+          },
+        ];
+  });
+}
+
+function createDegradedOwner(
+  assignments: SecretAssignment[],
+  reason: SecretDegradationReason,
+): DegradedSecretOwner {
   const owner = assignments[0]!;
   if (owner.ownerKind === "unknown") {
     throw new Error(`Secret assignment ${owner.path} has no runtime owner.`);
@@ -66,6 +128,51 @@ function createDegradedOwner(assignments: SecretAssignment[], reason: string): D
     refKeys: assignments.map((assignment) => secretRefKey(assignment.ref)),
     reason,
   };
+}
+
+function associateAssignmentFailureOwners(params: {
+  assignments: SecretAssignment[];
+  error: unknown;
+  config: OpenClawConfig;
+}): void {
+  const validationFailures = getSecretAssignmentValidationFailures(params.error);
+  const validationFailureOwnerKeys = new Set(
+    validationFailures.map((failure) => `${failure.ownerKind}\0${failure.ownerId}`),
+  );
+  const reason =
+    validationFailures.length > 0
+      ? "resolved secret value was invalid"
+      : describeSecretResolutionError(params.error);
+  if (!reason) {
+    return;
+  }
+  const owners = groupAssignmentsByOwner(params.assignments).flatMap((assignments) => {
+    if (assignments[0]?.ownerKind === "unknown") {
+      return [];
+    }
+    const failureMatched = assignments.some((assignment) =>
+      validationFailures.length > 0
+        ? validationFailureOwnerKeys.has(assignmentOwnerKey(assignment))
+        : assignmentMatchesResolutionFailure(assignment, params.error),
+    );
+    if (!failureMatched) {
+      return [];
+    }
+    const degradedOwner = createDegradedOwner(assignments, reason);
+    return [
+      {
+        ...degradedOwner,
+        degradationState: classifySecretOwnerDegradationState({
+          ownerKind: degradedOwner.ownerKind,
+          ownerId: degradedOwner.ownerId,
+          refs: assignments.map((assignment) => assignment.ref),
+          config: params.config,
+        }),
+        failureMatched,
+      },
+    ];
+  });
+  associateSecretResolutionErrorOwners(params.error, owners);
 }
 
 /** Emits the canonical warning for one isolated runtime secret owner. */
@@ -86,25 +193,39 @@ async function resolveStrictAssignments(params: {
   assignments: SecretAssignment[];
   options: SecretResolutionOptions;
 }): Promise<void> {
-  const resolved = await resolveSecretRefValues(
-    params.assignments.map((assignment) => assignment.ref),
-    params.options,
-  );
-  registerResolvedValuesForRedaction(resolved);
-  applyResolvedAssignments({ assignments: params.assignments, resolved });
+  try {
+    const resolved = await resolveSecretRefValues(
+      params.assignments.map((assignment) => assignment.ref),
+      params.options,
+    );
+    registerResolvedValuesForRedaction(resolved);
+    applyResolvedAssignments({ assignments: params.assignments, resolved });
+  } catch (error) {
+    associateAssignmentFailureOwners({
+      assignments: params.assignments,
+      error,
+      config: params.options.config,
+    });
+    throw error;
+  }
 }
 
 function assignmentMatchesResolutionFailure(assignment: SecretAssignment, error: unknown): boolean {
   if (!isSecretResolutionError(error)) {
     return false;
   }
+  // Provider failures affect every ref under that exact source/provider pair. Ref failures
+  // additionally require the id, so equal ids under sibling providers never share attribution.
   if (assignment.ref.source !== error.source || assignment.ref.provider !== error.provider) {
     return false;
   }
   return isProviderScopedSecretResolutionError(error) || assignment.ref.id.trim() === error.refId;
 }
 
-function assertOwnerCanBeIsolated(assignments: SecretAssignment[], error: unknown): string {
+function assertOwnerCanBeIsolated(
+  assignments: SecretAssignment[],
+  error: unknown,
+): SecretDegradationReason {
   const owner = assignments[0]!;
   const reason = describeSecretResolutionError(error);
   if (
@@ -138,8 +259,13 @@ export async function resolveAndApplySecretAssignments(params: {
     );
     registerResolvedValuesForRedaction(resolution.resolved);
 
-    const failedOwners = new Map<SecretAssignment[], string>();
+    const failedOwners = new Map<SecretAssignment[], SecretDegradationReason>();
     for (const failure of resolution.failures) {
+      associateAssignmentFailureOwners({
+        assignments: pendingOwners.flat(),
+        error: failure.error,
+        config: params.options.config,
+      });
       const matchingOwners = pendingOwners.filter((assignments) =>
         assignments.some((assignment) =>
           assignmentMatchesResolutionFailure(assignment, failure.error),
@@ -152,6 +278,28 @@ export async function resolveAndApplySecretAssignments(params: {
         if (!failedOwners.has(assignments)) {
           failedOwners.set(assignments, assertOwnerCanBeIsolated(assignments, failure.error));
         }
+      }
+    }
+
+    const readyAssignments = pendingOwners
+      .filter(
+        (assignments) =>
+          !failedOwners.has(assignments) &&
+          assignments.every((assignment) => resolution.resolved.has(secretRefKey(assignment.ref))),
+      )
+      .flat();
+    if (readyAssignments.length > 0) {
+      // Validate the whole ready set so owners sharing one invalid ref are all reported.
+      // Failure association filters by validated owner keys; unrelated owners stay healthy.
+      try {
+        applyResolvedAssignments({ assignments: readyAssignments, resolved: resolution.resolved });
+      } catch (error) {
+        associateAssignmentFailureOwners({
+          assignments: readyAssignments,
+          error,
+          config: params.options.config,
+        });
+        throw error;
       }
     }
 
@@ -172,7 +320,6 @@ export async function resolveAndApplySecretAssignments(params: {
       if (
         assignments.every((assignment) => resolution.resolved.has(secretRefKey(assignment.ref)))
       ) {
-        applyResolvedAssignments({ assignments, resolved: resolution.resolved });
         continue;
       }
       nextPendingOwners.push(assignments);

--- a/src/secrets/runtime-owner-assignments.ts
+++ b/src/secrets/runtime-owner-assignments.ts
@@ -195,6 +195,13 @@ function associateAssignmentFailureOwners(params: {
           .filter((assignment) => assignmentMatchesResolutionFailure(assignment, params.error))
           .map((assignment) => [secretRefKey(assignment.ref), assignment.ref] as const),
   );
+  const providerFailure =
+    validationFailures.length === 0 && isProviderScopedSecretResolutionError(params.error)
+      ? params.error
+      : null;
+  const providerRefPrefix = providerFailure
+    ? `${providerFailure.source}:${providerFailure.provider}:`
+    : null;
   const ownerKeys = new Set(
     owners.map((owner) => `${owner.source}\0${owner.ownerKind}\0${owner.ownerId}`),
   );
@@ -223,7 +230,19 @@ function associateAssignmentFailureOwners(params: {
     }
     const refs = owner.refKeys.flatMap((refKey) => {
       const ref = failureRefs.get(refKey);
-      return ref ? [ref] : [];
+      if (ref) {
+        return [ref];
+      }
+      if (!providerFailure || !providerRefPrefix || !refKey.startsWith(providerRefPrefix)) {
+        return [];
+      }
+      return [
+        {
+          source: providerFailure.source,
+          provider: providerFailure.provider,
+          id: refKey.slice(providerRefPrefix.length),
+        },
+      ];
     });
     if (refs.length === 0) {
       return [];

--- a/src/secrets/runtime-owner-assignments.ts
+++ b/src/secrets/runtime-owner-assignments.ts
@@ -219,13 +219,10 @@ function associateAssignmentFailureOwners(params: {
       owner.ownerKind === "account" && activeAuthOwnerIds.has(owner.ownerId)
         ? ("auth-store" as const)
         : ("config" as const);
-    if (validationFailures.length > 0 && source !== "auth-store") {
-      return [];
-    }
     const ownerKey = `${source}\0${owner.ownerKind}\0${owner.ownerId}`;
-    // Collected auth assignments are authoritative for the intended store. Retain the active
-    // fallback only when this preparation excluded that store and cannot supersede its owner.
-    if (ownerKeys.has(ownerKey) || (source === "auth-store" && collectedOwnerKeys.has(ownerKey))) {
+    // Current assignments are authoritative. Retain active co-owners only for runtime surfaces
+    // that strict assignment validation prevented this preparation from reaching.
+    if (ownerKeys.has(ownerKey) || collectedOwnerKeys.has(ownerKey)) {
       return [];
     }
     const refs = owner.refKeys.flatMap((refKey) => {

--- a/src/secrets/runtime-owner-assignments.ts
+++ b/src/secrets/runtime-owner-assignments.ts
@@ -11,6 +11,7 @@ import {
   isSecretResolutionError,
 } from "./resolve-errors.js";
 import { resolveSecretRefValues, resolveSecretRefValuesSettledByProvider } from "./resolve.js";
+import { getSecretAssignmentSource } from "./runtime-assignment-provenance.js";
 import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import type {
   DegradedSecretOwner,
@@ -71,7 +72,7 @@ function registerResolvedValuesForRedaction(resolved: ReadonlyMap<string, unknow
 }
 
 function assignmentOwnerKey(assignment: SecretAssignment): string {
-  return `${assignment.source ?? "config"}\0${assignment.ownerKind}\0${assignment.ownerId}`;
+  return `${getSecretAssignmentSource(assignment)}\0${assignment.ownerKind}\0${assignment.ownerId}`;
 }
 
 function groupAssignmentsByOwner(assignments: SecretAssignment[]): SecretAssignment[][] {
@@ -139,8 +140,16 @@ function associateAssignmentFailureOwners(params: {
   const validationFailures = getSecretAssignmentValidationFailures(params.error);
   const validationFailureRefKeys = new Set(validationFailures.map((failure) => failure.refKey));
   const validationFailureOwnerKeys = new Set(
-    validationFailures.map(
-      (failure) => `${failure.source ?? "config"}\0${failure.ownerKind}\0${failure.ownerId}`,
+    validationFailures.flatMap((failure) =>
+      params.assignments
+        .filter(
+          (assignment) =>
+            assignment.ownerKind === failure.ownerKind &&
+            assignment.ownerId === failure.ownerId &&
+            assignment.expected === failure.expected &&
+            secretRefKey(assignment.ref) === failure.refKey,
+        )
+        .map(assignmentOwnerKey),
     ),
   );
   const reason =
@@ -173,7 +182,7 @@ function associateAssignmentFailureOwners(params: {
           config: params.config,
         }),
         failureMatched,
-        source: assignments[0]?.source ?? "config",
+        source: getSecretAssignmentSource(assignments[0]!),
       },
     ];
   });

--- a/src/secrets/runtime-owner-assignments.ts
+++ b/src/secrets/runtime-owner-assignments.ts
@@ -11,6 +11,7 @@ import {
   isSecretResolutionError,
 } from "./resolve-errors.js";
 import { resolveSecretRefValues, resolveSecretRefValuesSettledByProvider } from "./resolve.js";
+import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import type {
   DegradedSecretOwner,
   SecretDegradationReason,
@@ -70,7 +71,7 @@ function registerResolvedValuesForRedaction(resolved: ReadonlyMap<string, unknow
 }
 
 function assignmentOwnerKey(assignment: SecretAssignment): string {
-  return `${assignment.ownerKind}\0${assignment.ownerId}`;
+  return `${assignment.source ?? "config"}\0${assignment.ownerKind}\0${assignment.ownerId}`;
 }
 
 function groupAssignmentsByOwner(assignments: SecretAssignment[]): SecretAssignment[][] {
@@ -136,8 +137,11 @@ function associateAssignmentFailureOwners(params: {
   config: OpenClawConfig;
 }): void {
   const validationFailures = getSecretAssignmentValidationFailures(params.error);
+  const validationFailureRefKeys = new Set(validationFailures.map((failure) => failure.refKey));
   const validationFailureOwnerKeys = new Set(
-    validationFailures.map((failure) => `${failure.ownerKind}\0${failure.ownerId}`),
+    validationFailures.map(
+      (failure) => `${failure.source ?? "config"}\0${failure.ownerKind}\0${failure.ownerId}`,
+    ),
   );
   const reason =
     validationFailures.length > 0
@@ -169,10 +173,72 @@ function associateAssignmentFailureOwners(params: {
           config: params.config,
         }),
         failureMatched,
+        source: assignments[0]?.source ?? "config",
       },
     ];
   });
-  associateSecretResolutionErrorOwners(params.error, owners);
+  const failureRefs = new Map(
+    validationFailures.length > 0
+      ? params.assignments
+          .filter((assignment) => validationFailureRefKeys.has(secretRefKey(assignment.ref)))
+          .map((assignment) => [secretRefKey(assignment.ref), assignment.ref] as const)
+      : params.assignments
+          .filter((assignment) => assignmentMatchesResolutionFailure(assignment, params.error))
+          .map((assignment) => [secretRefKey(assignment.ref), assignment.ref] as const),
+  );
+  const ownerKeys = new Set(
+    owners.map((owner) => `${owner.source}\0${owner.ownerKind}\0${owner.ownerId}`),
+  );
+  const collectedOwnerKeys = new Set(params.assignments.map(assignmentOwnerKey));
+  const activeSnapshot = getActiveSecretsRuntimeSnapshot();
+  const activeAuthOwnerIds = new Set(
+    (activeSnapshot?.authStores ?? []).flatMap(({ agentDir, store }) =>
+      Object.keys(store.profiles).map((profileId) =>
+        resolveAuthProfileSecretOwnerId({ agentDir, profileId }),
+      ),
+    ),
+  );
+  const activeCoOwners = (activeSnapshot?.secretOwners ?? []).flatMap((owner) => {
+    const source =
+      owner.ownerKind === "account" && activeAuthOwnerIds.has(owner.ownerId)
+        ? ("auth-store" as const)
+        : ("config" as const);
+    if (validationFailures.length > 0 && source !== "auth-store") {
+      return [];
+    }
+    const ownerKey = `${source}\0${owner.ownerKind}\0${owner.ownerId}`;
+    // Collected auth assignments are authoritative for the intended store. Retain the active
+    // fallback only when this preparation excluded that store and cannot supersede its owner.
+    if (ownerKeys.has(ownerKey) || (source === "auth-store" && collectedOwnerKeys.has(ownerKey))) {
+      return [];
+    }
+    const refs = owner.refKeys.flatMap((refKey) => {
+      const ref = failureRefs.get(refKey);
+      return ref ? [ref] : [];
+    });
+    if (refs.length === 0) {
+      return [];
+    }
+    return [
+      {
+        ownerKind: owner.ownerKind,
+        ownerId: owner.ownerId,
+        state: "unavailable" as const,
+        paths: [],
+        refKeys: [...owner.refKeys],
+        reason,
+        degradationState: classifySecretOwnerDegradationState({
+          ownerKind: owner.ownerKind,
+          ownerId: owner.ownerId,
+          refs,
+          config: params.config,
+        }),
+        failureMatched: true,
+        source,
+      },
+    ];
+  });
+  associateSecretResolutionErrorOwners(params.error, [...owners, ...activeCoOwners]);
 }
 
 /** Emits the canonical warning for one isolated runtime secret owner. */

--- a/src/secrets/runtime-shared.ts
+++ b/src/secrets/runtime-shared.ts
@@ -38,6 +38,33 @@ export type SecretAssignment = {
   apply: (value: unknown) => void;
 };
 
+type SecretAssignmentValidationFailure = Pick<
+  SecretAssignment,
+  "ownerKind" | "ownerId" | "expected"
+> & {
+  refKey: string;
+};
+
+class SecretAssignmentValidationError extends Error {
+  readonly failures: SecretAssignmentValidationFailure[];
+
+  constructor(params: { failures: SecretAssignmentValidationFailure[]; error: Error }) {
+    super(params.error.message, { cause: params.error });
+    this.name = "SecretAssignmentValidationError";
+    this.failures = params.failures.map((failure) => ({ ...failure }));
+  }
+}
+
+/** Returns every assignment whose resolved value failed its target shape contract. */
+export function getSecretAssignmentValidationFailures(
+  error: unknown,
+): SecretAssignmentValidationFailure[] {
+  if (!(error instanceof SecretAssignmentValidationError)) {
+    return [];
+  }
+  return error.failures.map((failure) => ({ ...failure }));
+}
+
 export type SecretAssignmentOwner = Pick<
   SecretAssignment,
   "ownerKind" | "ownerId" | "requiredForGateway" | "disposition"
@@ -172,21 +199,37 @@ export function applyResolvedAssignments(params: {
   resolved: Map<string, unknown>;
 }): void {
   const values: unknown[] = [];
+  const failures: SecretAssignmentValidationFailure[] = [];
+  let firstValidationError: Error | undefined;
   for (const assignment of params.assignments) {
     const key = secretRefKey(assignment.ref);
     if (!params.resolved.has(key)) {
       throw new Error(`Secret reference "${key}" resolved to no value.`);
     }
     const value = params.resolved.get(key);
-    assertExpectedResolvedSecretValue({
-      value,
-      expected: assignment.expected,
-      errorMessage:
-        assignment.expected === "string"
-          ? `${assignment.path} resolved to a non-string or empty value.`
-          : `${assignment.path} resolved to an unsupported value type.`,
-    });
+    try {
+      assertExpectedResolvedSecretValue({
+        value,
+        expected: assignment.expected,
+        errorMessage:
+          assignment.expected === "string"
+            ? `${assignment.path} resolved to a non-string or empty value.`
+            : `${assignment.path} resolved to an unsupported value type.`,
+      });
+    } catch (error) {
+      const validationError = error instanceof Error ? error : new Error(String(error));
+      firstValidationError ??= validationError;
+      failures.push({
+        ownerKind: assignment.ownerKind,
+        ownerId: assignment.ownerId,
+        expected: assignment.expected,
+        refKey: key,
+      });
+    }
     values.push(value);
+  }
+  if (firstValidationError) {
+    throw new SecretAssignmentValidationError({ error: firstValidationError, failures });
   }
   for (const [index, assignment] of params.assignments.entries()) {
     assignment.apply(values[index]);

--- a/src/secrets/runtime-shared.ts
+++ b/src/secrets/runtime-shared.ts
@@ -30,6 +30,7 @@ export type SecretResolverWarning = {
 export type SecretAssignment = {
   ref: SecretRef;
   path: string;
+  source?: "auth-store" | "config";
   expected: "string" | "string-or-object";
   ownerKind: SecretOwnerKind;
   ownerId: string;
@@ -40,7 +41,7 @@ export type SecretAssignment = {
 
 type SecretAssignmentValidationFailure = Pick<
   SecretAssignment,
-  "ownerKind" | "ownerId" | "expected"
+  "ownerKind" | "ownerId" | "expected" | "source"
 > & {
   refKey: string;
 };
@@ -105,7 +106,7 @@ export function createResolverContext(params: {
  * Records a SecretRef assignment that should be resolved and applied later.
  */
 export function pushAssignment(context: ResolverContext, assignment: SecretAssignment): void {
-  context.assignments.push(assignment);
+  context.assignments.push({ ...assignment, source: assignment.source ?? "config" });
 }
 
 /**
@@ -149,6 +150,7 @@ export function collectSecretInputAssignment(params: {
   context: ResolverContext;
   active?: boolean;
   inactiveReason?: string;
+  source?: SecretAssignment["source"];
   owner?: SecretAssignmentOwner;
   apply: (value: unknown) => void;
 }): void {
@@ -182,6 +184,7 @@ export function collectRuntimeSecretInputAssignment(params: {
   pushAssignment(params.context, {
     ref,
     path: params.path,
+    source: params.source ?? "config",
     expected: params.expected,
     ownerKind: params.owner?.ownerKind ?? "unknown",
     ownerId: params.owner?.ownerId ?? params.path,
@@ -223,6 +226,7 @@ export function applyResolvedAssignments(params: {
         ownerKind: assignment.ownerKind,
         ownerId: assignment.ownerId,
         expected: assignment.expected,
+        source: assignment.source,
         refKey: key,
       });
     }

--- a/src/secrets/runtime-shared.ts
+++ b/src/secrets/runtime-shared.ts
@@ -30,7 +30,6 @@ export type SecretResolverWarning = {
 export type SecretAssignment = {
   ref: SecretRef;
   path: string;
-  source?: "auth-store" | "config";
   expected: "string" | "string-or-object";
   ownerKind: SecretOwnerKind;
   ownerId: string;
@@ -41,7 +40,7 @@ export type SecretAssignment = {
 
 type SecretAssignmentValidationFailure = Pick<
   SecretAssignment,
-  "ownerKind" | "ownerId" | "expected" | "source"
+  "ownerKind" | "ownerId" | "expected"
 > & {
   refKey: string;
 };
@@ -106,7 +105,7 @@ export function createResolverContext(params: {
  * Records a SecretRef assignment that should be resolved and applied later.
  */
 export function pushAssignment(context: ResolverContext, assignment: SecretAssignment): void {
-  context.assignments.push({ ...assignment, source: assignment.source ?? "config" });
+  context.assignments.push(assignment);
 }
 
 /**
@@ -150,7 +149,6 @@ export function collectSecretInputAssignment(params: {
   context: ResolverContext;
   active?: boolean;
   inactiveReason?: string;
-  source?: SecretAssignment["source"];
   owner?: SecretAssignmentOwner;
   apply: (value: unknown) => void;
 }): void {
@@ -184,7 +182,6 @@ export function collectRuntimeSecretInputAssignment(params: {
   pushAssignment(params.context, {
     ref,
     path: params.path,
-    source: params.source ?? "config",
     expected: params.expected,
     ownerKind: params.owner?.ownerKind ?? "unknown",
     ownerId: params.owner?.ownerId ?? params.path,
@@ -226,7 +223,6 @@ export function applyResolvedAssignments(params: {
         ownerKind: assignment.ownerKind,
         ownerId: assignment.ownerId,
         expected: assignment.expected,
-        source: assignment.source,
         refKey: key,
       });
     }

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -16,6 +16,7 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import { getRuntimeConfigSourceSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -72,6 +73,50 @@ describe("secrets runtime state", () => {
     expect(configSnapshot?.sourceConfig).not.toBe(fullSnapshot?.sourceConfig);
     expect(configSnapshot?.config).toEqual(snapshot.config);
     expect(configSnapshot?.sourceConfig).toEqual(snapshot.sourceConfig);
+  });
+
+  it("publishes distinct raw and overlay source snapshots without changing runtime auth", () => {
+    const secretRef = {
+      source: "env" as const,
+      provider: "default",
+      id: "OPENCLAW_DEBUG_AUTH_TOKEN",
+    };
+    const snapshot: PreparedSecretsRuntimeSnapshot = {
+      sourceConfig: { gateway: { auth: { mode: "token", token: secretRef } } },
+      config: { gateway: { auth: { mode: "token", token: "resolved-debug-token" } } },
+      authStores: [],
+      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      warnings: [],
+      webTools: {
+        search: { providerSource: "none", diagnostics: [] },
+        fetch: { providerSource: "none", diagnostics: [] },
+        diagnostics: [],
+      },
+    };
+    activateSecretsRuntimeSnapshotState({
+      snapshot,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+    const rawSourceConfig = { gateway: { port: 19_030 } } satisfies OpenClawConfig;
+    const secretsSourceConfig = {
+      ...rawSourceConfig,
+      gateway: { ...rawSourceConfig.gateway, auth: { mode: "token" as const, token: secretRef } },
+    } satisfies OpenClawConfig;
+
+    expect(
+      activateSecretsRuntimeSnapshotStateIfCurrent({
+        snapshot: { ...snapshot, sourceConfig: secretsSourceConfig },
+        expectedRevision: getActiveSecretsRuntimeSnapshotRevision(),
+        refreshContext: null,
+        refreshHandler: null,
+        runtimeSourceConfig: rawSourceConfig,
+      }),
+    ).toBe(true);
+
+    expect(getRuntimeConfigSourceSnapshot()).toEqual(rawSourceConfig);
+    expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(secretsSourceConfig);
+    expect(getActiveSecretsRuntimeSnapshot()?.config).toEqual(snapshot.config);
   });
 
   it("preserves live auth bookkeeping when prepared credentials activate", () => {

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -16,10 +16,6 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import {
-  getRuntimeConfigSnapshotMetadata,
-  getRuntimeConfigSourceSnapshot,
-} from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -32,7 +28,6 @@ import {
   getActiveSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshotRevision,
   restoreSecretsRuntimeSnapshotStateIfCurrent,
-  setSecretsRuntimeSourceSnapshotIfCurrent,
   type PreparedSecretsRuntimeSnapshot,
 } from "./runtime-state.js";
 
@@ -77,53 +72,6 @@ describe("secrets runtime state", () => {
     expect(configSnapshot?.sourceConfig).not.toBe(fullSnapshot?.sourceConfig);
     expect(configSnapshot?.config).toEqual(snapshot.config);
     expect(configSnapshot?.sourceConfig).toEqual(snapshot.sourceConfig);
-  });
-
-  it("publishes distinct raw and overlay source snapshots without changing runtime auth", () => {
-    const secretRef = {
-      source: "env" as const,
-      provider: "default",
-      id: "OPENCLAW_DEBUG_AUTH_TOKEN",
-    };
-    const snapshot: PreparedSecretsRuntimeSnapshot = {
-      sourceConfig: { gateway: { auth: { mode: "token", token: secretRef } } },
-      config: { gateway: { auth: { mode: "token", token: "resolved-debug-token" } } },
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: {
-        search: { providerSource: "none", diagnostics: [] },
-        fetch: { providerSource: "none", diagnostics: [] },
-        diagnostics: [],
-      },
-    };
-    activateSecretsRuntimeSnapshotState({
-      snapshot,
-      refreshContext: null,
-      refreshHandler: null,
-    });
-    const metadata = getRuntimeConfigSnapshotMetadata();
-    if (!metadata) {
-      throw new Error("expected runtime config metadata");
-    }
-    const rawSourceConfig = { gateway: { port: 19_030 } } satisfies OpenClawConfig;
-    const secretsSourceConfig = {
-      ...rawSourceConfig,
-      gateway: { ...rawSourceConfig.gateway, auth: { mode: "token" as const, token: secretRef } },
-    } satisfies OpenClawConfig;
-
-    expect(
-      setSecretsRuntimeSourceSnapshotIfCurrent({
-        expectedSecretsRevision: getActiveSecretsRuntimeSnapshotRevision(),
-        expectedRuntimeConfigRevision: metadata.revision,
-        runtimeSourceConfig: rawSourceConfig,
-        secretsSourceConfig,
-      }),
-    ).toBe(true);
-
-    expect(getRuntimeConfigSourceSnapshot()).toEqual(rawSourceConfig);
-    expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(secretsSourceConfig);
-    expect(getActiveSecretsRuntimeSnapshot()?.config).toEqual(snapshot.config);
   });
 
   it("preserves live auth bookkeeping when prepared credentials activate", () => {

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -31,6 +31,7 @@ import { isRecord } from "../utils.js";
 import {
   setActiveDegradedSecretOwners,
   type DegradedSecretOwner,
+  type SecretOwnerRefState,
 } from "./runtime-degraded-state.js";
 import type { SecretResolverWarning } from "./runtime-shared.js";
 import {
@@ -47,8 +48,53 @@ export type PreparedSecretsRuntimeSnapshot = {
   authStoreCredentialsRevision: number;
   warnings: SecretResolverWarning[];
   degradedOwners?: DegradedSecretOwner[];
+  secretOwners?: SecretOwnerRefState[];
   webTools: RuntimeWebToolsMetadata;
 };
+
+type LocatedSecretRef = {
+  path: Array<string | number>;
+  ref: SecretRef;
+};
+
+function listLocatedSecretRefs(
+  value: unknown,
+  path: Array<string | number> = [],
+  refs: LocatedSecretRef[] = [],
+): LocatedSecretRef[] {
+  if (isSecretRef(value)) {
+    refs.push({ path, ref: value });
+    return refs;
+  }
+  if (Array.isArray(value)) {
+    for (const [index, entry] of value.entries()) {
+      listLocatedSecretRefs(entry, [...path, index], refs);
+    }
+    return refs;
+  }
+  if (isRecord(value)) {
+    for (const key of Object.keys(value).toSorted()) {
+      listLocatedSecretRefs(value[key], [...path, key], refs);
+    }
+  }
+  return refs;
+}
+
+/** Whether two configs resolve the same SecretRefs through the same provider contracts. */
+export function hasSameSecretReloadContract(left: OpenClawConfig, right: OpenClawConfig): boolean {
+  return isDeepStrictEqual(
+    {
+      refs: listLocatedSecretRefs(left),
+      defaults: left.secrets?.defaults,
+      providers: left.secrets?.providers,
+    },
+    {
+      refs: listLocatedSecretRefs(right),
+      defaults: right.secrets?.defaults,
+      providers: right.secrets?.providers,
+    },
+  );
+}
 
 /** Context needed to refresh active secrets runtime snapshots without losing plugin origin data. */
 export type SecretsRuntimeRefreshContext = {
@@ -140,6 +186,11 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
       paths: [...owner.paths],
       refKeys: [...owner.refKeys],
       reason: owner.reason,
+    })),
+    secretOwners: (snapshot.secretOwners ?? []).map((owner) => ({
+      ownerKind: owner.ownerKind,
+      ownerId: owner.ownerId,
+      refKeys: [...owner.refKeys],
     })),
     webTools: structuredClone(snapshot.webTools),
   };
@@ -281,7 +332,10 @@ function mergeRollbackValue(previous: unknown, candidate: unknown, current: unkn
   return merged;
 }
 
-function hasSameSecretProviderDefinition(ref: SecretRef, configs: OpenClawConfig[]): boolean {
+export function hasSameSecretProviderDefinition(
+  ref: SecretRef,
+  configs: OpenClawConfig[],
+): boolean {
   const definition = configs[0]?.secrets?.providers?.[ref.provider];
   if (
     !configs.every((config) =>
@@ -790,6 +844,7 @@ export function activateSecretsRuntimeSnapshotState(params: {
   snapshot: PreparedSecretsRuntimeSnapshot;
   refreshContext: SecretsRuntimeRefreshContext | null;
   refreshHandler: RuntimeConfigSnapshotRefreshHandler | null;
+  runtimeSourceConfig?: OpenClawConfig;
   mergeLiveAuthBookkeeping?: boolean;
   preserveActivationLineage?: boolean;
 }): void {
@@ -812,7 +867,7 @@ export function activateSecretsRuntimeSnapshotState(params: {
   const nextRefreshContext = params.refreshContext
     ? cloneSecretsRuntimeRefreshContext(params.refreshContext)
     : null;
-  setRuntimeConfigSnapshot(next.config, next.sourceConfig);
+  setRuntimeConfigSnapshot(next.config, params.runtimeSourceConfig ?? next.sourceConfig);
   replaceRuntimeAuthProfileStoreSnapshots(next.authStores);
   next.authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
   const previousLineageStartRevision = activeSnapshotLineageStartRevision;

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -18,7 +18,6 @@ import type {
 } from "../agents/auth-profiles/types.js";
 import {
   clearRuntimeConfigSnapshot,
-  setRuntimeConfigSourceSnapshotIfCurrent,
   setRuntimeConfigSnapshot,
   setRuntimeConfigSnapshotRefreshHandler,
   type RuntimeConfigSnapshotRefreshHandler,
@@ -1009,38 +1008,6 @@ export function getActiveSecretsRuntimeSnapshot(): PreparedSecretsRuntimeSnapsho
 /** Stable token for compare-and-activate ownership across cloned snapshot reads. */
 export function getActiveSecretsRuntimeSnapshotRevision(): number {
   return activeSnapshotRevision;
-}
-
-/** Advance canonical source ownership without replacing resolved runtime or auth bytes. */
-export function setSecretsRuntimeSourceSnapshotIfCurrent(params: {
-  expectedSecretsRevision: number;
-  expectedRuntimeConfigRevision: number;
-  runtimeSourceConfig: OpenClawConfig;
-  secretsSourceConfig: OpenClawConfig;
-}): boolean {
-  if (activeSnapshotRevision !== params.expectedSecretsRevision) {
-    return false;
-  }
-  const nextRuntimeSourceConfig = structuredClone(params.runtimeSourceConfig);
-  const nextSecretsSourceConfig = structuredClone(params.secretsSourceConfig);
-  const currentAuthStores = structuredClone(listRuntimeAuthProfileStoreSnapshots());
-  const nextAuthMutations = captureAuthStoreMutationLineage(currentAuthStores, currentAuthStores);
-  if (
-    !setRuntimeConfigSourceSnapshotIfCurrent({
-      expectedRevision: params.expectedRuntimeConfigRevision,
-      sourceConfig: nextRuntimeSourceConfig,
-    })
-  ) {
-    return false;
-  }
-  if (activeSnapshot) {
-    activeSnapshot.sourceConfig = nextSecretsSourceConfig;
-    activeSnapshotRevision += 1;
-    activeSnapshotLineageStartRevision = activeSnapshotRevision;
-    activeSnapshotLineageAuthStores = currentAuthStores;
-    activeSnapshotLineageAuthMutations = nextAuthMutations;
-  }
-  return true;
 }
 
 // Hot-path readers only need the config pair for availability decisions.

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -1,9 +1,10 @@
 /** Shared helpers for web-tool secret metadata resolution. */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { createLazyRuntimeNamedExport } from "../shared/lazy-runtime.js";
 import { setPathExistingStrict } from "./path-utils.js";
+import type { SecretDegradationReason } from "./runtime-degraded-state.js";
 import type {
   ResolverContext,
   SecretDefaults,
@@ -28,19 +29,43 @@ export type SecretResolutionResult<TSource extends string> = {
   value?: string;
   source: TSource;
   secretRefConfigured: boolean;
+  secretRef?: SecretRef;
   secretRefKey?: string;
-  unresolvedRefReason?: string;
+  unresolvedRefReason?: SecretDegradationReason;
   fallbackEnvVar?: string;
 };
 
-export type RuntimeWebProviderSelectionResult = {
-  unavailableProvider?: {
-    providerId: string;
-    path: string;
-    refKey: string;
-    reason: string;
-  };
+export type RuntimeWebSecretOwner = {
+  providerId: string;
+  path: string;
+  ref: SecretRef;
+  refKey: string;
+  reason?: SecretDegradationReason;
 };
+
+export type RuntimeWebUnavailableProvider = RuntimeWebSecretOwner & {
+  reason: SecretDegradationReason;
+};
+
+export type RuntimeWebProviderSelectionResult = {
+  secretOwners: RuntimeWebSecretOwner[];
+  unavailableProviders: RuntimeWebUnavailableProvider[];
+};
+
+/** Carries typed web-provider ownership through strict reload failures. */
+export class RuntimeWebProviderUnavailableError extends Error {
+  readonly unavailableProviders: RuntimeWebUnavailableProvider[];
+
+  constructor(
+    code: RuntimeWebWarningCode,
+    reason: SecretDegradationReason,
+    unavailableProviders: RuntimeWebUnavailableProvider[],
+  ) {
+    super(`[${code}] ${reason}`);
+    this.name = "RuntimeWebProviderUnavailableError";
+    this.unavailableProviders = unavailableProviders;
+  }
+}
 
 /**
  * Metadata fields shared by runtime web search and fetch provider selection.
@@ -80,8 +105,9 @@ type RuntimeWebProviderSelectionParams<
   allowKeylessAutoSelect: boolean;
   /** Defer keyless providers until credential-bearing auto-detect candidates are exhausted. */
   deferKeylessFallback: boolean;
-  /** Keep cold-start preparation alive when an explicit provider ref cannot resolve. */
-  allowUnavailableExplicitProvider?: boolean;
+  /** Keep cold-start preparation alive when no configured provider ref can resolve. */
+  allowUnavailableProviders?: boolean;
+  onUnavailableProviders?: (error: RuntimeWebProviderUnavailableError) => void;
   noFallbackCode: RuntimeWebWarningCode;
   autoDetectSelectedCode: RuntimeWebWarningCode;
   /** Reads the primary credential location for a provider from source config. */
@@ -404,20 +430,23 @@ export async function resolveRuntimeWebProviderSelection<
     params.metadata.providerSource = "configured";
   }
 
-  let unavailableProvider: RuntimeWebProviderSelectionResult["unavailableProvider"];
+  const unavailableProviders: RuntimeWebUnavailableProvider[] = [];
+  let selectedProvider: string | undefined;
+  let selectedPath: string | undefined;
+  let selectedResolution: SecretResolutionResult<TSource> | undefined;
   if (params.enabled) {
     const candidates = params.configuredProvider
       ? params.providers.filter((provider) => provider.id === params.configuredProvider)
       : params.providers;
-    const unresolvedWithoutFallback: Array<{
+    type UnresolvedProvider = {
       provider: string;
       path: string;
+      ref?: SecretRef;
       refKey?: string;
-      reason: string;
-    }> = [];
+      reason: SecretDegradationReason;
+    };
+    const unresolvedWithoutFallback: UnresolvedProvider[] = [];
 
-    let selectedProvider: string | undefined;
-    let selectedResolution: SecretResolutionResult<TSource> | undefined;
     let keylessFallbackProvider: TProvider | undefined;
 
     for (const provider of candidates) {
@@ -494,6 +523,7 @@ export async function resolveRuntimeWebProviderSelection<
         unresolvedWithoutFallback.push({
           provider: provider.id,
           path: selectedCandidatePath,
+          ref: selectedCandidateResolution.secretRef,
           refKey: selectedCandidateResolution.secretRefKey,
           reason: selectedCandidateResolution.unresolvedRefReason,
         });
@@ -513,6 +543,7 @@ export async function resolveRuntimeWebProviderSelection<
 
       if (params.configuredProvider) {
         selectedProvider = provider.id;
+        selectedPath = selectedCandidatePath;
         selectedResolution = selectedCandidateResolution;
         if (selectedCandidateResolution.value) {
           setResolvedCredentialPath({
@@ -531,6 +562,7 @@ export async function resolveRuntimeWebProviderSelection<
 
       if (isKeyless) {
         selectedProvider = provider.id;
+        selectedPath = selectedCandidatePath;
         selectedResolution = selectedCandidateResolution;
         if (selectedCandidateResolution.value) {
           setResolvedCredentialPath({
@@ -549,6 +581,7 @@ export async function resolveRuntimeWebProviderSelection<
 
       if (selectedCandidateResolution.value) {
         selectedProvider = provider.id;
+        selectedPath = selectedCandidatePath;
         selectedResolution = selectedCandidateResolution;
         setResolvedCredentialPath({
           resolvedConfig: params.resolvedConfig,
@@ -572,7 +605,10 @@ export async function resolveRuntimeWebProviderSelection<
       };
     }
 
-    const failUnresolvedNoFallback = (unresolved: { path: string; reason: string }) => {
+    const recordUnresolvedNoFallback = (unresolved: {
+      path: string;
+      reason: SecretDegradationReason;
+    }) => {
       const diagnostic: RuntimeWebDiagnostic = {
         code: params.noFallbackCode,
         message: unresolved.reason,
@@ -585,6 +621,34 @@ export async function resolveRuntimeWebProviderSelection<
         path: unresolved.path,
         message: unresolved.reason,
       });
+    };
+    const failUnresolvedNoFallback = (
+      unresolved: UnresolvedProvider,
+      related: UnresolvedProvider[] = [unresolved],
+    ): never => {
+      recordUnresolvedNoFallback(unresolved);
+      const relatedUnavailableProviders = related.flatMap((entry) =>
+        entry.ref && entry.refKey
+          ? [
+              {
+                providerId: entry.provider,
+                path: entry.path,
+                ref: entry.ref,
+                refKey: entry.refKey,
+                reason: entry.reason,
+              },
+            ]
+          : [],
+      );
+      if (relatedUnavailableProviders.length > 0) {
+        const error = new RuntimeWebProviderUnavailableError(
+          params.noFallbackCode,
+          unresolved.reason,
+          relatedUnavailableProviders,
+        );
+        params.onUnavailableProviders?.(error);
+        throw error;
+      }
       throw new Error(`[${params.noFallbackCode}] ${unresolved.reason}`);
     };
 
@@ -592,22 +656,50 @@ export async function resolveRuntimeWebProviderSelection<
       const unresolved = unresolvedWithoutFallback[0];
       if (unresolved) {
         const refKey = unresolved.refKey;
-        if (params.allowUnavailableExplicitProvider && refKey) {
-          unavailableProvider = {
+        const ref = unresolved.ref;
+        if (refKey && ref) {
+          const unavailable = {
             providerId: params.configuredProvider,
             path: unresolved.path,
+            ref,
             refKey,
             reason: unresolved.reason,
           };
+          if (params.allowUnavailableProviders) {
+            unavailableProviders.push(unavailable);
+          } else {
+            failUnresolvedNoFallback(unresolved);
+          }
         } else {
           failUnresolvedNoFallback(unresolved);
         }
       }
     } else {
       if (!selectedProvider && unresolvedWithoutFallback.length > 0) {
-        failUnresolvedNoFallback(
-          expectDefined(unresolvedWithoutFallback[0], "unresolved without fallback entry at 0"),
+        const firstUnresolved = expectDefined(
+          unresolvedWithoutFallback[0],
+          "unresolved without fallback entry at 0",
         );
+        if (!params.allowUnavailableProviders) {
+          failUnresolvedNoFallback(firstUnresolved, unresolvedWithoutFallback);
+        }
+        const unavailable = unresolvedWithoutFallback.flatMap((entry) =>
+          entry.ref && entry.refKey
+            ? [
+                {
+                  providerId: entry.provider,
+                  path: entry.path,
+                  ref: entry.ref,
+                  refKey: entry.refKey,
+                  reason: entry.reason,
+                },
+              ]
+            : [],
+        );
+        if (unavailable.length !== unresolvedWithoutFallback.length) {
+          failUnresolvedNoFallback(firstUnresolved, unresolvedWithoutFallback);
+        }
+        unavailableProviders.push(...unavailable);
       }
 
       if (selectedProvider) {
@@ -628,14 +720,14 @@ export async function resolveRuntimeWebProviderSelection<
       }
     }
 
-    if (selectedProvider && !unavailableProvider) {
+    if (selectedProvider && unavailableProviders.length === 0) {
       params.metadata.selectedProvider = selectedProvider;
       params.metadata.selectedProviderKeySource = selectedResolution?.source;
       if (!params.configuredProvider) {
         params.metadata.providerSource = "auto-detect";
       }
       const provider = params.providers.find((entry) => entry.id === selectedProvider);
-      if (provider && params.mergeRuntimeMetadata && !unavailableProvider) {
+      if (provider && params.mergeRuntimeMetadata) {
         await params.mergeRuntimeMetadata({
           provider,
           metadata: params.metadata,
@@ -667,5 +759,20 @@ export async function resolveRuntimeWebProviderSelection<
     });
   }
 
-  return unavailableProvider ? { unavailableProvider } : {};
+  const selectedSecretOwner =
+    selectedProvider &&
+    selectedPath &&
+    selectedResolution?.secretRef &&
+    selectedResolution.secretRefKey
+      ? {
+          providerId: selectedProvider,
+          path: selectedPath,
+          ref: selectedResolution.secretRef,
+          refKey: selectedResolution.secretRefKey,
+        }
+      : undefined;
+  return {
+    secretOwners: selectedSecretOwner ? [selectedSecretOwner] : unavailableProviders,
+    unavailableProviders,
+  };
 }

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -53,7 +53,7 @@ export type RuntimeWebProviderSelectionResult = {
 };
 
 /** Carries typed web-provider ownership through strict reload failures. */
-export class RuntimeWebProviderUnavailableError extends Error {
+class RuntimeWebProviderUnavailableError extends Error {
   readonly unavailableProviders: RuntimeWebUnavailableProvider[];
 
   constructor(

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -110,7 +110,6 @@ type RuntimeWebProviderSelectionParams<
   onUnavailableProviders?: (error: RuntimeWebProviderUnavailableError) => void;
   noFallbackCode: RuntimeWebWarningCode;
   autoDetectSelectedCode: RuntimeWebWarningCode;
-  /** Reads the primary credential location for a provider from source config. */
   readConfiguredCredential: (params: {
     provider: TProvider;
     config: OpenClawConfig;
@@ -121,13 +120,12 @@ type RuntimeWebProviderSelectionParams<
     config: OpenClawConfig;
     toolConfig: TToolConfig;
   }) => { path: string; value: unknown } | undefined;
-  /** Resolves inline/env/SecretRef credentials and reports the winning source. */
   resolveSecretInput: (params: {
+    providerId: string;
     value: unknown;
     path: string;
     envVars: string[];
   }) => Promise<SecretResolutionResult<TSource>>;
-  /** Writes the selected credential into the resolved runtime config snapshot. */
   setResolvedCredential: (params: {
     resolvedConfig: OpenClawConfig;
     provider: TProvider;
@@ -446,7 +444,6 @@ export async function resolveRuntimeWebProviderSelection<
       reason: SecretDegradationReason;
     };
     const unresolvedWithoutFallback: UnresolvedProvider[] = [];
-
     let keylessFallbackProvider: TProvider | undefined;
 
     for (const provider of candidates) {
@@ -467,11 +464,14 @@ export async function resolveRuntimeWebProviderSelection<
         config: params.sourceConfig,
         toolConfig: params.toolConfig,
       });
-      const resolution = await params.resolveSecretInput({
-        value,
-        path,
-        envVars: getProviderEnvVars(provider),
-      });
+      const resolveSecretInput = (input: unknown, inputPath: string) =>
+        params.resolveSecretInput({
+          providerId: provider.id,
+          value: input,
+          path: inputPath,
+          envVars: getProviderEnvVars(provider),
+        });
+      const resolution = await resolveSecretInput(value, path);
       let selectedCandidatePath = path;
       let selectedCandidateResolution = resolution;
 
@@ -483,11 +483,7 @@ export async function resolveRuntimeWebProviderSelection<
         });
         if (fallback?.value !== undefined) {
           selectedCandidatePath = fallback.path;
-          selectedCandidateResolution = await params.resolveSecretInput({
-            value: fallback.value,
-            path: fallback.path,
-            envVars: getProviderEnvVars(provider),
-          });
+          selectedCandidateResolution = await resolveSecretInput(fallback.value, fallback.path);
         }
       } else if (resolution.source === "env" && !resolution.secretRefConfigured) {
         const fallback = params.readConfiguredCredentialFallback?.({
@@ -499,11 +495,7 @@ export async function resolveRuntimeWebProviderSelection<
           fallback?.value !== undefined &&
           params.hasConfiguredSecretRef(fallback.value, params.defaults)
         ) {
-          const fallbackResolution = await params.resolveSecretInput({
-            value: fallback.value,
-            path: fallback.path,
-            envVars: getProviderEnvVars(provider),
-          });
+          const fallbackResolution = await resolveSecretInput(fallback.value, fallback.path);
           if (fallbackResolution.source === "secretRef" && fallbackResolution.value) {
             // Preserve transcript/config bytes for env-selected providers while materializing refs.
             setResolvedCredentialPath({

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -899,37 +899,44 @@ describe("runtime web tools resolution", () => {
     );
   });
 
-  it("keeps unresolved auto-detected providers strict during cold-start isolation", async () => {
-    await expect(
-      runRuntimeWebTools({
-        config: asConfig({
-          tools: {
-            web: {
-              search: {
-                enabled: true,
-              },
+  it("isolates unresolved auto-detected providers during cold start", async () => {
+    const { metadata, degradedOwners } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            search: {
+              enabled: true,
             },
           },
-          plugins: {
-            entries: {
-              google: {
-                enabled: true,
-                config: {
-                  webSearch: {
-                    apiKey: {
-                      source: "env",
-                      provider: "default",
-                      id: "MISSING_GEMINI_API_KEY_REF",
-                    },
+        },
+        plugins: {
+          entries: {
+            google: {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "MISSING_GEMINI_API_KEY_REF",
                   },
                 },
               },
             },
           },
-        }),
-        allowUnavailableSecretOwners: true,
+        },
       }),
-    ).rejects.toThrow("[WEB_SEARCH_KEY_UNRESOLVED_NO_FALLBACK]");
+      allowUnavailableSecretOwners: true,
+    });
+
+    expect(metadata.search.selectedProvider).toBeUndefined();
+    expect(degradedOwners).toMatchObject([
+      {
+        ownerKind: "capability",
+        ownerId: "web-search:gemini",
+        reason: "secret reference was not found",
+      },
+    ]);
   });
 
   it("auto-detects Gemini from the Google model provider key after env fallbacks", async () => {
@@ -1513,15 +1520,20 @@ describe("runtime web tools resolution", () => {
     expect(firstMockArg(resolvePluginWebFetchProvidersMock).sandboxed).toBe(true);
   });
 
-  it("isolates an explicit web fetch provider instead of using env after its ref fails", async () => {
+  it("isolates an explicit web fetch provider when its ref is unavailable", async () => {
     const { metadata, resolvedConfig, context, degradedOwners } = await runRuntimeWebTools({
       config: asConfig({
+        secrets: {
+          providers: {
+            default: { source: "file", path: "/missing/firecrawl-secrets.json" },
+          },
+        },
         plugins: {
           entries: {
             firecrawl: {
               config: {
                 webFetch: {
-                  apiKey: { source: "env", provider: "default", id: "MISSING_FIRECRAWL_REF" },
+                  apiKey: { source: "file", provider: "default", id: "/firecrawl/apiKey" },
                 },
               },
             },
@@ -1550,21 +1562,96 @@ describe("runtime web tools resolution", () => {
           | { webFetch?: { apiKey?: unknown } }
           | undefined
       )?.webFetch?.apiKey,
-    ).toEqual({ source: "env", provider: "default", id: "MISSING_FIRECRAWL_REF" });
+    ).toEqual({ source: "file", provider: "default", id: "/firecrawl/apiKey" });
     expect(degradedOwners).toContainEqual(
       expect.objectContaining({
         ownerKind: "capability",
         ownerId: "web-fetch:firecrawl",
         state: "unavailable",
         paths: ["plugins.entries.firecrawl.config.webFetch.apiKey"],
-        reason: expect.stringContaining("MISSING_FIRECRAWL_REF"),
+        reason: "secret provider failed",
       }),
     );
-    expect(degradedOwners[0]?.refKeys).toEqual(["env:default:MISSING_FIRECRAWL_REF"]);
+    expect(degradedOwners[0]?.refKeys).toEqual(["file:default:/firecrawl/apiKey"]);
+    expect(degradedOwners[0]?.reason).not.toContain("/missing/firecrawl-secrets.json");
     expectDiagnostic(context.warnings, {
       code: "SECRETS_OWNER_UNAVAILABLE",
       path: "plugins.entries.firecrawl.config.webFetch.apiKey",
     });
+  });
+
+  it("fails fast on an invalid resolved value without exposing its ref", async () => {
+    const refId = "FIRECRAWL_API_KEY";
+    const resolveSpy = vi
+      .spyOn(secretResolve, "resolveSecretRefValues")
+      .mockResolvedValue(new Map([[`env:default:${refId}`, { value: "fixture-api-key" }]]));
+    restoreResolveSecretRefValuesSpy = () => resolveSpy.mockRestore();
+
+    const error = await runRuntimeWebTools({
+      config: asConfig({
+        plugins: {
+          entries: {
+            firecrawl: {
+              config: {
+                webFetch: {
+                  apiKey: { source: "env", provider: "default", id: refId },
+                },
+              },
+            },
+          },
+        },
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+      }),
+      allowUnavailableSecretOwners: true,
+    }).then(
+      () => undefined,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    const message = error instanceof Error ? error.message : String(error);
+    expect(message).toBe(
+      "plugins.entries.firecrawl.config.webFetch.apiKey resolved to a non-string or empty value.",
+    );
+    expect(message).not.toContain(refId);
+    expect(message).not.toContain("fixture-api-key");
+  });
+
+  it("preserves a denied-provider reason without exposing its ref", async () => {
+    const refId = "FIRECRAWL_API_KEY";
+    const { degradedOwners } = await runRuntimeWebTools({
+      config: asConfig({
+        secrets: {
+          providers: {
+            default: { source: "env", allowlist: ["OTHER_API_KEY"] },
+          },
+        },
+        plugins: {
+          entries: {
+            firecrawl: {
+              config: {
+                webFetch: {
+                  apiKey: { source: "env", provider: "default", id: refId },
+                },
+              },
+            },
+          },
+        },
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+      }),
+      env: { [refId]: "fixture-api-key" },
+      allowUnavailableSecretOwners: true,
+    });
+
+    expect(degradedOwners).toMatchObject([
+      {
+        ownerKind: "capability",
+        ownerId: "web-fetch:firecrawl",
+        reason: "secret provider policy denied resolution",
+      },
+    ]);
+    expect(degradedOwners[0]?.reason).not.toContain(refId);
+    expect(degradedOwners[0]?.reason).not.toContain("fixture-api-key");
   });
 
   it("resolves web fetch fallback SecretRefs with provider env var allowlist", async () => {
@@ -1674,7 +1761,7 @@ describe("runtime web tools resolution", () => {
           firecrawl: {
             config: {
               webFetch: {
-                apiKey: { source: "env", provider: "default", id: "MISSING_FIRECRAWL_REF" },
+                apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
               },
             },
           },
@@ -1741,13 +1828,12 @@ describe("runtime web tools resolution", () => {
         sourceConfig,
         resolvedConfig,
         context,
+        allowUnavailableSecretOwners: true,
       }),
-    ).rejects.toThrow("[WEB_FETCH_PROVIDER_KEY_UNRESOLVED_NO_FALLBACK]");
-    expectDiagnostic(context.warnings, {
-      code: "WEB_FETCH_PROVIDER_KEY_UNRESOLVED_NO_FALLBACK",
-      path: "plugins.entries.firecrawl.config.webFetch.apiKey",
-      messageIncludes: 'SecretRef env var "AWS_SECRET_ACCESS_KEY" is not allowed.',
-    });
+    ).rejects.toThrow(
+      "plugins.entries.firecrawl.config.webFetch.apiKey SecretRef is not allowed for this provider.",
+    );
+    expect(context.warnings).toEqual([]);
   });
 
   it("keeps web fetch provider discovery bundled-only during runtime secret resolution", async () => {

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -5,6 +5,7 @@ import type {
   PluginWebFetchProviderEntry,
   PluginWebSearchProviderEntry,
 } from "../plugins/types.js";
+import { listSecretResolutionErrorOwners } from "./runtime-degraded-state.js";
 
 type ProviderUnderTest = "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "duckduckgo";
 
@@ -1615,6 +1616,45 @@ describe("runtime web tools resolution", () => {
     );
     expect(message).not.toContain(refId);
     expect(message).not.toContain("fixture-api-key");
+    expect(listSecretResolutionErrorOwners(error)).toEqual([
+      expect.objectContaining({
+        ownerKind: "capability",
+        ownerId: "web-fetch:firecrawl",
+        reason: "resolved secret value was invalid",
+        degradationState: "cold",
+        failureMatched: true,
+        source: "config",
+      }),
+    ]);
+  });
+
+  it("attributes an invalid legacy x_search value to the Grok capability", async () => {
+    const refId = "X_SEARCH_KEY_REF";
+    const resolveSpy = vi
+      .spyOn(secretResolve, "resolveSecretRefValues")
+      .mockResolvedValue(new Map([[`env:default:${refId}`, { value: "fixture-api-key" }]]));
+    restoreResolveSecretRefValuesSpy = () => resolveSpy.mockRestore();
+
+    const error = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            x_search: {
+              apiKey: { source: "env", provider: "default", id: refId },
+            },
+          },
+        },
+      }),
+    }).catch((caught: unknown) => caught);
+
+    expect(listSecretResolutionErrorOwners(error)).toEqual([
+      expect.objectContaining({
+        ownerKind: "capability",
+        ownerId: "web-search:grok",
+        reason: "resolved secret value was invalid",
+        failureMatched: true,
+      }),
+    ]);
   });
 
   it("preserves a denied-provider reason without exposing its ref", async () => {

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -19,9 +19,17 @@ import { sortWebSearchProvidersForAutoDetect } from "../plugins/web-search-provi
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import { secretRefKey } from "./ref-contract.js";
+import { describeSecretResolutionError } from "./resolve-errors.js";
 import { resolveSecretRefValues } from "./resolve.js";
-import type { DegradedSecretOwner } from "./runtime-degraded-state.js";
-import { warnDegradedSecretOwner } from "./runtime-owner-assignments.js";
+import {
+  associateSecretResolutionErrorOwners,
+  type DegradedSecretOwner,
+  type SecretOwnerRefState,
+} from "./runtime-degraded-state.js";
+import {
+  classifySecretOwnerDegradationState,
+  warnDegradedSecretOwner,
+} from "./runtime-owner-assignments.js";
 import { hasCredentialBearingObjectValue } from "./runtime-secret-scan.js";
 import type { ResolverContext, SecretDefaults } from "./runtime-shared.js";
 import { runtimeWebSecretOwnerId } from "./runtime-web-secret-owner.js";
@@ -31,7 +39,10 @@ import {
   isRecord,
   resolveRuntimeWebProviderSurface,
   resolveRuntimeWebProviderSelection,
+  RuntimeWebProviderUnavailableError,
   type RuntimeWebProviderSelectionResult,
+  type RuntimeWebSecretOwner,
+  type RuntimeWebUnavailableProvider,
   type SecretResolutionResult,
 } from "./runtime-web-tools.shared.js";
 import type {
@@ -40,6 +51,7 @@ import type {
   RuntimeWebSearchMetadata,
   RuntimeWebToolsMetadata,
 } from "./runtime-web-tools.types.js";
+import { assertExpectedResolvedSecretValue } from "./secret-value.js";
 
 const loadRuntimeWebToolsFallbackProviders = createLazyRuntimeSurface(
   () => import("./runtime-web-tools-fallback.runtime.js"),
@@ -67,28 +79,68 @@ type SecretResolutionSource =
 type ResolvedRuntimeWebTools = {
   metadata: RuntimeWebToolsMetadata;
   degradedOwners: DegradedSecretOwner[];
+  secretOwners: SecretOwnerRefState[];
 };
 
-function collectUnavailableWebProvider(params: {
+function createUnavailableWebProviderOwner(params: {
+  kind: "search" | "fetch";
+  unavailable: RuntimeWebUnavailableProvider;
+}): DegradedSecretOwner {
+  return {
+    ownerKind: "capability",
+    ownerId: runtimeWebSecretOwnerId(params.kind, params.unavailable.providerId),
+    state: "unavailable",
+    paths: [params.unavailable.path],
+    refKeys: [params.unavailable.refKey],
+    reason: params.unavailable.reason,
+  };
+}
+
+function collectUnavailableWebProviders(params: {
   kind: "search" | "fetch";
   result: RuntimeWebProviderSelectionResult;
   context: ResolverContext;
   degradedOwners: DegradedSecretOwner[];
 }): void {
-  const unavailable = params.result.unavailableProvider;
-  if (!unavailable) {
-    return;
+  for (const unavailable of params.result.unavailableProviders) {
+    const owner = createUnavailableWebProviderOwner({ kind: params.kind, unavailable });
+    params.degradedOwners.push(owner);
+    warnDegradedSecretOwner(params.context, owner);
   }
-  const owner: DegradedSecretOwner = {
+}
+
+function toWebSecretOwnerRefState(
+  kind: "search" | "fetch",
+  owner: RuntimeWebSecretOwner,
+): SecretOwnerRefState {
+  return {
     ownerKind: "capability",
-    ownerId: runtimeWebSecretOwnerId(params.kind, unavailable.providerId),
-    state: "unavailable",
-    paths: [unavailable.path],
-    refKeys: [unavailable.refKey],
-    reason: unavailable.reason,
+    ownerId: runtimeWebSecretOwnerId(kind, owner.providerId),
+    refKeys: [owner.refKey],
   };
-  params.degradedOwners.push(owner);
-  warnDegradedSecretOwner(params.context, owner);
+}
+
+function associateWebProviderResolutionError(params: {
+  kind: "search" | "fetch";
+  config: OpenClawConfig;
+  error: RuntimeWebProviderUnavailableError;
+}): void {
+  associateSecretResolutionErrorOwners(
+    params.error,
+    params.error.unavailableProviders.map((unavailable) => {
+      const owner = createUnavailableWebProviderOwner({ kind: params.kind, unavailable });
+      return {
+        ...owner,
+        degradationState: classifySecretOwnerDegradationState({
+          ownerKind: owner.ownerKind,
+          ownerId: owner.ownerId,
+          refs: [unavailable.ref],
+          config: params.config,
+        }),
+        failureMatched: true,
+      };
+    }),
+  );
 }
 
 function needsRuntimeWebFetchProviderDiscovery(params: {
@@ -226,20 +278,6 @@ function readNonEmptyEnvValue(
   return {};
 }
 
-function buildUnresolvedReason(params: {
-  path: string;
-  kind: "unresolved" | "non-string" | "empty";
-  refLabel: string;
-}): string {
-  if (params.kind === "non-string") {
-    return `${params.path} SecretRef resolved to a non-string value.`;
-  }
-  if (params.kind === "empty") {
-    return `${params.path} SecretRef resolved to an empty value.`;
-  }
-  return `${params.path} SecretRef is unresolved (${params.refLabel}).`;
-}
-
 async function resolveSecretInputWithEnvFallback(params: {
   sourceConfig: OpenClawConfig;
   context: ResolverContext;
@@ -278,16 +316,15 @@ async function resolveSecretInputWithEnvFallback(params: {
     };
   }
 
-  const refLabel = `${ref.source}:${ref.provider}:${ref.id}`;
   let resolvedFromRef: string | undefined;
-  let unresolvedRefReason: string | undefined;
+  let unresolvedRefReason: SecretResolutionResult<SecretResolutionSource>["unresolvedRefReason"];
 
   if (
     params.restrictEnvRefsToEnvVars === true &&
     ref.source === "env" &&
     !params.envVars.includes(ref.id)
   ) {
-    unresolvedRefReason = `${params.path} SecretRef env var "${ref.id}" is not allowed.`;
+    throw new Error(`${params.path} SecretRef is not allowed for this provider.`);
   } else {
     try {
       const resolved = await resolveSecretRefValues([ref], {
@@ -297,28 +334,20 @@ async function resolveSecretInputWithEnvFallback(params: {
         manifestRegistry: params.context.manifestRegistry,
       });
       const resolvedValue = resolved.get(secretRefKey(ref));
-      if (typeof resolvedValue !== "string") {
-        unresolvedRefReason = buildUnresolvedReason({
-          path: params.path,
-          kind: "non-string",
-          refLabel,
-        });
-      } else {
-        resolvedFromRef = normalizeSecretInput(resolvedValue);
-        if (!resolvedFromRef) {
-          unresolvedRefReason = buildUnresolvedReason({
-            path: params.path,
-            kind: "empty",
-            refLabel,
-          });
-        }
-      }
-    } catch {
-      unresolvedRefReason = buildUnresolvedReason({
-        path: params.path,
-        kind: "unresolved",
-        refLabel,
+      assertExpectedResolvedSecretValue({
+        value: resolvedValue,
+        expected: "string",
+        errorMessage: `${params.path} resolved to a non-string or empty value.`,
       });
+      resolvedFromRef = normalizeSecretInput(resolvedValue);
+    } catch (error) {
+      const reason = describeSecretResolutionError(error);
+      if (!reason) {
+        // Invalid provider config or resolved values are structural failures. They must fail
+        // activation before publishing an owner degradation that could imply retryability.
+        throw error;
+      }
+      unresolvedRefReason = reason;
     }
   }
 
@@ -327,12 +356,14 @@ async function resolveSecretInputWithEnvFallback(params: {
       value: resolvedFromRef,
       source: "secretRef",
       secretRefConfigured: true,
+      secretRef: ref,
       secretRefKey: secretRefKey(ref),
     };
   }
 
   return {
     source: "missing",
+    secretRef: ref,
     secretRefKey: secretRefKey(ref),
     unresolvedRefReason,
     secretRefConfigured: true,
@@ -540,9 +571,11 @@ export async function resolveRuntimeWebTools(params: {
   const defaults = params.sourceConfig.secrets?.defaults;
   const diagnostics: RuntimeWebDiagnostic[] = [];
   const degradedOwners: DegradedSecretOwner[] = [];
+  const secretOwners: SecretOwnerRefState[] = [];
   const finish = (metadata: RuntimeWebToolsMetadata): ResolvedRuntimeWebTools => ({
     metadata,
     degradedOwners,
+    secretOwners,
   });
   const env = { ...process.env, ...params.context.env };
 
@@ -695,7 +728,13 @@ export async function resolveRuntimeWebTools(params: {
       defaults,
       allowKeylessAutoSelect: false,
       deferKeylessFallback: true,
-      allowUnavailableExplicitProvider: params.allowUnavailableSecretOwners,
+      allowUnavailableProviders: params.allowUnavailableSecretOwners,
+      onUnavailableProviders: (error) =>
+        associateWebProviderResolutionError({
+          kind: "search",
+          config: params.sourceConfig,
+          error,
+        }),
       noFallbackCode: "WEB_SEARCH_KEY_UNRESOLVED_NO_FALLBACK",
       autoDetectSelectedCode: "WEB_SEARCH_AUTODETECT_SELECTED",
       readConfiguredCredential: ({ provider, config, toolConfig }) =>
@@ -748,7 +787,10 @@ export async function resolveRuntimeWebTools(params: {
         );
       },
     });
-    collectUnavailableWebProvider({
+    for (const owner of searchSelection.secretOwners) {
+      secretOwners.push(toWebSecretOwnerRefState("search", owner));
+    }
+    collectUnavailableWebProviders({
       kind: "search",
       result: searchSelection,
       context: params.context,
@@ -814,7 +856,13 @@ export async function resolveRuntimeWebTools(params: {
       defaults,
       allowKeylessAutoSelect: true,
       deferKeylessFallback: false,
-      allowUnavailableExplicitProvider: params.allowUnavailableSecretOwners,
+      allowUnavailableProviders: params.allowUnavailableSecretOwners,
+      onUnavailableProviders: (error) =>
+        associateWebProviderResolutionError({
+          kind: "fetch",
+          config: params.sourceConfig,
+          error,
+        }),
       noFallbackCode: "WEB_FETCH_PROVIDER_KEY_UNRESOLVED_NO_FALLBACK",
       autoDetectSelectedCode: "WEB_FETCH_AUTODETECT_SELECTED",
       readConfiguredCredential: ({ provider, config, toolConfig }) =>
@@ -868,7 +916,10 @@ export async function resolveRuntimeWebTools(params: {
         );
       },
     });
-    collectUnavailableWebProvider({
+    for (const owner of fetchSelection.secretOwners) {
+      secretOwners.push(toWebSecretOwnerRefState("fetch", owner));
+    }
+    collectUnavailableWebProviders({
       kind: "fetch",
       result: fetchSelection,
       context: params.context,

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -32,6 +32,7 @@ import {
 } from "./runtime-owner-assignments.js";
 import { hasCredentialBearingObjectValue } from "./runtime-secret-scan.js";
 import type { ResolverContext, SecretDefaults } from "./runtime-shared.js";
+import { getActiveSecretsRuntimeSnapshot } from "./runtime-state.js";
 import { runtimeWebSecretOwnerId } from "./runtime-web-secret-owner.js";
 import {
   ensureObject,
@@ -125,23 +126,62 @@ function associateWebProviderResolutionError(params: {
   error: unknown;
   unavailableProviders: RuntimeWebUnavailableProvider[];
 }): void {
-  associateSecretResolutionErrorOwners(
-    params.error,
-    params.unavailableProviders.map((unavailable) => {
-      const owner = createUnavailableWebProviderOwner({ kind: params.kind, unavailable });
-      return {
-        ...owner,
-        degradationState: classifySecretOwnerDegradationState({
+  const failureByRefKey = new Map(
+    params.unavailableProviders.map((unavailable) => [unavailable.refKey, unavailable] as const),
+  );
+  const owners = params.unavailableProviders.map((unavailable) => {
+    const owner = createUnavailableWebProviderOwner({ kind: params.kind, unavailable });
+    return {
+      ...owner,
+      degradationState: classifySecretOwnerDegradationState({
+        ownerKind: owner.ownerKind,
+        ownerId: owner.ownerId,
+        refs: [unavailable.ref],
+        config: params.config,
+      }),
+      failureMatched: true,
+      source: "config" as const,
+    };
+  });
+  const ownerIds = new Set(owners.map((owner) => owner.ownerId));
+  const activeCoOwners = (getActiveSecretsRuntimeSnapshot()?.secretOwners ?? []).flatMap(
+    (owner) => {
+      if (
+        owner.ownerKind !== "capability" ||
+        ownerIds.has(owner.ownerId) ||
+        (!owner.ownerId.startsWith("web-search:") && !owner.ownerId.startsWith("web-fetch:"))
+      ) {
+        return [];
+      }
+      const matches = owner.refKeys.flatMap((refKey) => {
+        const unavailable = failureByRefKey.get(refKey);
+        return unavailable ? [unavailable] : [];
+      });
+      const firstMatch = matches[0];
+      if (!firstMatch) {
+        return [];
+      }
+      return [
+        {
           ownerKind: owner.ownerKind,
           ownerId: owner.ownerId,
-          refs: [unavailable.ref],
-          config: params.config,
-        }),
-        failureMatched: true,
-        source: "config" as const,
-      };
-    }),
+          state: "unavailable" as const,
+          paths: [],
+          refKeys: [...owner.refKeys],
+          reason: firstMatch.reason,
+          degradationState: classifySecretOwnerDegradationState({
+            ownerKind: owner.ownerKind,
+            ownerId: owner.ownerId,
+            refs: matches.map((match) => match.ref),
+            config: params.config,
+          }),
+          failureMatched: true,
+          source: "config" as const,
+        },
+      ];
+    },
   );
+  associateSecretResolutionErrorOwners(params.error, [...owners, ...activeCoOwners]);
 }
 
 function needsRuntimeWebFetchProviderDiscovery(params: {

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -138,6 +138,7 @@ function associateWebProviderResolutionError(params: {
           config: params.config,
         }),
         failureMatched: true,
+        source: "config" as const,
       };
     }),
   );

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -39,7 +39,6 @@ import {
   isRecord,
   resolveRuntimeWebProviderSurface,
   resolveRuntimeWebProviderSelection,
-  RuntimeWebProviderUnavailableError,
   type RuntimeWebProviderSelectionResult,
   type RuntimeWebSecretOwner,
   type RuntimeWebUnavailableProvider,
@@ -51,7 +50,7 @@ import type {
   RuntimeWebSearchMetadata,
   RuntimeWebToolsMetadata,
 } from "./runtime-web-tools.types.js";
-import { assertExpectedResolvedSecretValue } from "./secret-value.js";
+import { isExpectedResolvedSecretValue } from "./secret-value.js";
 
 const loadRuntimeWebToolsFallbackProviders = createLazyRuntimeSurface(
   () => import("./runtime-web-tools-fallback.runtime.js"),
@@ -123,11 +122,12 @@ function toWebSecretOwnerRefState(
 function associateWebProviderResolutionError(params: {
   kind: "search" | "fetch";
   config: OpenClawConfig;
-  error: RuntimeWebProviderUnavailableError;
+  error: unknown;
+  unavailableProviders: RuntimeWebUnavailableProvider[];
 }): void {
   associateSecretResolutionErrorOwners(
     params.error,
-    params.error.unavailableProviders.map((unavailable) => {
+    params.unavailableProviders.map((unavailable) => {
       const owner = createUnavailableWebProviderOwner({ kind: params.kind, unavailable });
       return {
         ...owner,
@@ -280,6 +280,8 @@ function readNonEmptyEnvValue(
 }
 
 async function resolveSecretInputWithEnvFallback(params: {
+  kind: "search" | "fetch";
+  providerId: string;
   sourceConfig: OpenClawConfig;
   context: ResolverContext;
   defaults: SecretDefaults | undefined;
@@ -335,11 +337,24 @@ async function resolveSecretInputWithEnvFallback(params: {
         manifestRegistry: params.context.manifestRegistry,
       });
       const resolvedValue = resolved.get(secretRefKey(ref));
-      assertExpectedResolvedSecretValue({
-        value: resolvedValue,
-        expected: "string",
-        errorMessage: `${params.path} resolved to a non-string or empty value.`,
-      });
+      if (!isExpectedResolvedSecretValue(resolvedValue, "string")) {
+        const error = new Error(`${params.path} resolved to a non-string or empty value.`);
+        associateWebProviderResolutionError({
+          kind: params.kind,
+          config: params.sourceConfig,
+          error,
+          unavailableProviders: [
+            {
+              providerId: params.providerId,
+              path: params.path,
+              ref,
+              refKey: secretRefKey(ref),
+              reason: "resolved secret value was invalid",
+            },
+          ],
+        });
+        throw error;
+      }
       resolvedFromRef = normalizeSecretInput(resolvedValue);
     } catch (error) {
       const reason = describeSecretResolutionError(error);
@@ -617,6 +632,8 @@ export async function resolveRuntimeWebTools(params: {
     const legacyXSearchSourceRecord = legacyXSearchSource as Record<string, unknown>;
     const legacyXSearchResolvedRecord = legacyXSearchResolved as Record<string, unknown>;
     const resolution = await resolveSecretInputWithEnvFallback({
+      kind: "search",
+      providerId: "grok",
       sourceConfig: params.sourceConfig,
       context: params.context,
       defaults,
@@ -735,6 +752,7 @@ export async function resolveRuntimeWebTools(params: {
           kind: "search",
           config: params.sourceConfig,
           error,
+          unavailableProviders: error.unavailableProviders,
         }),
       noFallbackCode: "WEB_SEARCH_KEY_UNRESOLVED_NO_FALLBACK",
       autoDetectSelectedCode: "WEB_SEARCH_AUTODETECT_SELECTED",
@@ -750,8 +768,10 @@ export async function resolveRuntimeWebTools(params: {
           config,
           search: toolConfig,
         }),
-      resolveSecretInput: ({ value, path, envVars }) =>
+      resolveSecretInput: ({ providerId, value, path, envVars }) =>
         resolveSecretInputWithEnvFallback({
+          kind: "search",
+          providerId,
           sourceConfig: params.sourceConfig,
           context: params.context,
           defaults,
@@ -863,6 +883,7 @@ export async function resolveRuntimeWebTools(params: {
           kind: "fetch",
           config: params.sourceConfig,
           error,
+          unavailableProviders: error.unavailableProviders,
         }),
       noFallbackCode: "WEB_FETCH_PROVIDER_KEY_UNRESOLVED_NO_FALLBACK",
       autoDetectSelectedCode: "WEB_FETCH_AUTODETECT_SELECTED",
@@ -878,8 +899,10 @@ export async function resolveRuntimeWebTools(params: {
           config,
           fetch: toolConfig,
         }),
-      resolveSecretInput: ({ value, path, envVars }) =>
+      resolveSecretInput: ({ providerId, value, path, envVars }) =>
         resolveSecretInputWithEnvFallback({
+          kind: "fetch",
+          providerId,
           sourceConfig: params.sourceConfig,
           context: params.context,
           defaults,

--- a/src/secrets/runtime.auth.integration.test.ts
+++ b/src/secrets/runtime.auth.integration.test.ts
@@ -64,10 +64,12 @@ vi.mock("./runtime-prepare.runtime.js", () => ({
       diagnostics: [],
     },
     degradedOwners: [],
+    secretOwners: [],
   }),
 }));
 
 vi.mock("./runtime-owner-assignments.js", () => ({
+  listSecretAssignmentOwners: () => [],
   resolveAndApplySecretAssignments: async () => [],
 }));
 

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -22,6 +22,7 @@ const { resolveRuntimeWebToolsMock, runtimePrepareImportMock } = vi.hoisted(() =
       diagnostics: [],
     },
     degradedOwners: [],
+    secretOwners: [],
   })),
   runtimePrepareImportMock: vi.fn(),
 }));
@@ -44,6 +45,7 @@ vi.mock("./runtime-prepare.runtime.js", () => {
 });
 
 vi.mock("./runtime-owner-assignments.js", () => ({
+  listSecretAssignmentOwners: () => [],
   resolveAndApplySecretAssignments: async () => [],
 }));
 

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -390,6 +390,7 @@ describe("secrets runtime snapshot", () => {
       }),
       env: {},
       includeAuthStoreRefs: false,
+      allowUnavailableSecretOwners: true,
       loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
     });
 
@@ -474,27 +475,6 @@ describe("secrets runtime snapshot", () => {
         loadablePluginOrigins: BUNDLED_CODEX_PLUGIN_ORIGINS,
       }),
     ).rejects.toThrow('Environment variable "CODEX_APP_SERVER_TOKEN" is missing or empty.');
-  });
-
-  it("fails closed for missing TTS SecretRefs outside cold-start isolation", async () => {
-    await expect(
-      prepareSecretsRuntimeSnapshot({
-        config: asConfig({
-          messages: {
-            tts: {
-              providers: {
-                elevenlabs: {
-                  apiKey: TTS_REF,
-                },
-              },
-            },
-          },
-        }),
-        env: {},
-        includeAuthStoreRefs: false,
-        loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-      }),
-    ).rejects.toThrow('Environment variable "ELEVENLABS_API_KEY" is missing or empty.');
   });
 
   it("isolates the TTS owner when its SecretRef is missing during cold startup", async () => {
@@ -753,84 +733,6 @@ describe("secrets runtime snapshot", () => {
         loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
       }),
     ).rejects.toThrow('Secret provider "missing" is not configured');
-  });
-
-  it("keeps TTS SecretRefs that resolve to non-strings fail-closed", async () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const root = tempDirs.make("openclaw-tts-secretref-object-");
-    const secretsPath = path.join(root, "secrets.json");
-    await fs.writeFile(
-      secretsPath,
-      JSON.stringify(
-        {
-          providers: {
-            elevenlabs: {
-              apiKey: { value: "not-a-string" },
-            },
-          },
-        },
-        null,
-        2,
-      ),
-      "utf8",
-    );
-    await fs.chmod(secretsPath, 0o600);
-
-    await expect(
-      prepareSecretsRuntimeSnapshot({
-        config: asConfig({
-          secrets: {
-            providers: {
-              ttsfile: {
-                source: "file",
-                path: secretsPath,
-                mode: "json",
-              },
-            },
-          },
-          messages: {
-            tts: {
-              providers: {
-                elevenlabs: {
-                  apiKey: {
-                    source: "file",
-                    provider: "ttsfile",
-                    id: "/providers/elevenlabs/apiKey",
-                  },
-                },
-              },
-            },
-          },
-        }),
-        env: {},
-        includeAuthStoreRefs: false,
-        allowUnavailableSecretOwners: true,
-        loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-      }),
-    ).rejects.toThrow(
-      "messages.tts.providers.elevenlabs.apiKey resolved to a non-string or empty value.",
-    );
-  });
-
-  it("still fails required gateway auth SecretRefs when env is missing", async () => {
-    await expect(
-      prepareSecretsRuntimeSnapshot({
-        config: asConfig({
-          gateway: {
-            auth: {
-              mode: "token",
-              token: { source: "env", provider: "default", id: "GATEWAY_TOKEN_REF" },
-            },
-          },
-        }),
-        env: {},
-        includeAuthStoreRefs: false,
-        allowUnavailableSecretOwners: true,
-        loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-      }),
-    ).rejects.toThrow('Environment variable "GATEWAY_TOKEN_REF" is missing or empty.');
   });
 
   it("isolates an unavailable model provider without applying another credential source", async () => {

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -20,6 +20,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { isRecord, resolveUserPath } from "../utils.js";
+import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import {
   canUseSecretsRuntimeFastPath,
   collectCandidateAgentDirs,
@@ -178,6 +179,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       authStoreCredentialsRevision,
       warnings: [],
       degradedOwners: [],
+      secretOwners: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
     };
     setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
@@ -198,7 +200,8 @@ export async function prepareSecretsRuntimeSnapshot(params: {
     createResolverContext,
     resolveRuntimeWebTools,
   } = await loadRuntimePrepareHelpers();
-  const { resolveAndApplySecretAssignments } = await loadRuntimeOwnerAssignmentHelpers();
+  const { listSecretAssignmentOwners, resolveAndApplySecretAssignments } =
+    await loadRuntimeOwnerAssignmentHelpers();
   const manifestRegistry =
     params.manifestRegistry ?? params.pluginMetadataSnapshot?.manifestRegistry;
   const loadablePluginOrigins =
@@ -257,6 +260,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
           },
         })
       : [];
+  const assignmentSecretOwners = listSecretAssignmentOwners(context.assignments);
 
   const webTools = includeConfigRefs
     ? await resolveRuntimeWebTools({
@@ -268,6 +272,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
     : {
         metadata: createEmptyRuntimeWebToolsMetadata(),
         degradedOwners: [],
+        secretOwners: [],
       };
   const snapshot = {
     sourceConfig,
@@ -276,6 +281,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
     authStoreCredentialsRevision,
     warnings: context.warnings,
     degradedOwners: [...degradedOwners, ...webTools.degradedOwners],
+    secretOwners: [...assignmentSecretOwners, ...webTools.secretOwners],
     webTools: webTools.metadata,
   };
   setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
@@ -295,16 +301,28 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
   activateSecretsRuntimeSnapshotState(createSecretsRuntimeSnapshotActivation(snapshot));
 }
 
+/** Activates resolved runtime bytes while retaining the distinct raw config source. */
+export function activateSecretsRuntimeSnapshotWithSource(
+  snapshot: PreparedSecretsRuntimeSnapshot,
+  runtimeSourceConfig: OpenClawConfig,
+): void {
+  activateSecretsRuntimeSnapshotState({
+    ...createSecretsRuntimeSnapshotActivation(snapshot),
+    runtimeSourceConfig,
+  });
+}
+
 /** Compare-and-activate boundary for snapshots prepared from process-wide runtime state. */
 export function activateSecretsRuntimeSnapshotIfCurrent(
   snapshot: PreparedSecretsRuntimeSnapshot,
   expectedRevision: number,
-  options?: { preserveActivationLineage?: boolean },
+  options?: { preserveActivationLineage?: boolean; runtimeSourceConfig?: OpenClawConfig },
 ): boolean {
   return activateSecretsRuntimeSnapshotStateIfCurrent({
     ...createSecretsRuntimeSnapshotActivation(snapshot),
     expectedRevision,
     preserveActivationLineage: options?.preserveActivationLineage,
+    runtimeSourceConfig: options?.runtimeSourceConfig,
   });
 }
 
@@ -313,11 +331,13 @@ export function restoreSecretsRuntimeSnapshotIfCurrent(
   snapshot: PreparedSecretsRuntimeSnapshot,
   expectedRevision: number,
   ownedSnapshot: PreparedSecretsRuntimeSnapshot,
+  options?: { runtimeSourceConfig?: OpenClawConfig },
 ): boolean {
   return restoreSecretsRuntimeSnapshotStateIfCurrent({
     ...createSecretsRuntimeSnapshotActivation(snapshot),
     expectedRevision,
     ownedSnapshot,
+    runtimeSourceConfig: options?.runtimeSourceConfig,
   });
 }
 
@@ -474,6 +494,37 @@ function selectProviderAuthConfig(config: OpenClawConfig): OpenClawConfig {
   };
 }
 
+function listAuthProfileSecretOwnerIds(
+  authStores: PreparedSecretsRuntimeSnapshot["authStores"],
+): Set<string> {
+  return new Set(
+    authStores.flatMap(({ agentDir, store }) =>
+      Object.keys(store.profiles).map((profileId) =>
+        resolveAuthProfileSecretOwnerId({ agentDir, profileId }),
+      ),
+    ),
+  );
+}
+
+function mergeProviderAuthSecretOwners(
+  active: PreparedSecretsRuntimeSnapshot,
+  candidate: PreparedSecretsRuntimeSnapshot,
+): PreparedSecretsRuntimeSnapshot["secretOwners"] {
+  const activeAuthProfileOwnerIds = listAuthProfileSecretOwnerIds(active.authStores);
+  const isActiveProviderAuthOwner = (owner: NonNullable<typeof active.secretOwners>[number]) =>
+    owner.ownerKind === "provider" ||
+    (owner.ownerKind === "account" && activeAuthProfileOwnerIds.has(owner.ownerId));
+  const isCandidateProviderAuthOwner = (
+    owner: NonNullable<typeof candidate.secretOwners>[number],
+  ) => owner.ownerKind === "provider" || owner.ownerKind === "account";
+  // This refresh publishes provider and account state only. Keep transport-owned refs pinned
+  // to their active snapshot so later failures compare against the values actually in use.
+  return [
+    ...(active.secretOwners ?? []).filter((owner) => !isActiveProviderAuthOwner(owner)),
+    ...(candidate.secretOwners ?? []).filter(isCandidateProviderAuthOwner),
+  ];
+}
+
 function createSecretsRuntimeSnapshotActivation(snapshot: PreparedSecretsRuntimeSnapshot) {
   const refreshContext =
     getPreparedSecretsRuntimeSnapshotRefreshContext(snapshot) ??
@@ -531,6 +582,7 @@ export async function refreshActiveProviderAuthRuntimeSnapshot(): Promise<boolea
       config,
       authStores: candidate.snapshot.authStores,
       authStoreCredentialsRevision: candidate.snapshot.authStoreCredentialsRevision,
+      secretOwners: mergeProviderAuthSecretOwners(activeSnapshot, candidate.snapshot),
     };
     // The pinned config read and revision claim are synchronous: preserve gateway-owned
     // runtime mutations while preventing a concurrently prepared secrets snapshot from winning.


### PR DESCRIPTION
Related: #101265

## What Problem This Solves

SecretRef degradation can leave one owner cold at startup or keep a stale last-known-good value after reload, but the primary operator signal was easy to miss and could expose low-level resolution text.

## Why This Change Was Made

- Emits a warning-level structured `secrets.degraded` log at startup and reload with redacted owner kind, owner id, reason, cold/stale state, and the `openclaw secrets reload` retry hint.
- Keeps exact owner isolation: a failed webhook route stays cold while unrelated routes remain available.
- Makes doctor list degraded owners with the same redacted reason and retry guidance.
- Attributes typed reload failures to the actual failed owner; an unmapped typed failure reports conservative `unknown:unmapped` / cold metadata without leaking the SecretRef id.

Per maintainer decision, this PR adds no `secrets.degraded[]` gateway protocol/status field, schema, generated Swift model, protocol version bump, config option, parameter, environment variable, UI, or new capability.

## User Impact

Operators get a loud signal in the existing web UI log view and a human-readable doctor section. Public webhook requests remain generic `401 unauthorized`; secret values and SecretRef ids are not logged.

## Evidence

- Exact rebased head: `49d0bc99355d163c8d2c677cd65c44ddac4e9af1`
- Final focused behavior suite: 290 tests passed across gateway startup/reload, runtime config, secrets attribution/state/web tools, and doctor.
- Plugin SDK API manifest check passed on the repaired main baseline.
- Full changed gate: formatting, max-lines, SDK baseline, dependency/boundary guards, production and test typechecks, complete core lint, database/import-cycle/webhook/pairing guards: https://github.com/openclaw/openclaw/actions/runs/29640908452
- Real built-Gateway proof: health `200`; cold webhook route `401 unauthorized`; structured warning and doctor output complete and redacted: https://github.com/openclaw/openclaw/actions/runs/29627775967
- Fresh full-branch autoreview: clean after owner attribution, redaction, typed-unmapped fallback, conservative cold-state, recovery-order, and stale-publication fixes.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29640878015
- Final GitHub diff: 34 files, +3395 / -429.
