### PR TITLE
fix(node-host): guard Claude CLI pipe errors

### DIFF
--- a/src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
+++ b/src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+import type { NodeHostClient } from "./client.js";
+import type { NodeInvokeRequestPayload } from "./invoke.js";
+
+function frame(params: unknown): NodeInvokeRequestPayload {
+  return {
+    id: "invoke-pipe-error",
+    nodeId: "node-pipe-error",
+    command: "agent.cli.claude.run.v1",
+    paramsJSON: JSON.stringify(params),
+  };
+}
+
+function client(): NodeHostClient {
+  return {
+    async request() {
+      return {};
+    },
+  };
+}
+
+describe("Claude CLI node command pipe errors", () => {
+  let realChild: import("node:child_process").ChildProcessWithoutNullStreams | undefined;
+
+  afterEach(() => {
+    if (realChild && !realChild.killed) {
+      realChild.kill("SIGKILL");
+    }
+    realChild = undefined;
+    spawnMock.mockReset();
+    vi.resetModules();
+  });
+
+  it("settles without uncaught pipe errors after real stdout/stderr stream failures", async () => {
+    const childProcess =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    realChild = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    spawnMock.mockReturnValueOnce(realChild as never);
+    const { runClaudeCliNodeCommand } = await import("./invoke-agent-cli-claude.js");
+
+    const uncaughtErrors: unknown[] = [];
+    const onUncaught = (error: unknown) => {
+      uncaughtErrors.push(error);
+    };
+    process.on("uncaughtException", onUncaught);
+    const request = { argv: ["-p"], idleTimeoutMs: 100, timeoutMs: 5_000 };
+
+    try {
+      const run = runClaudeCliNodeCommand({
+        client: client(),
+        frame: frame(request),
+        request,
+        argv: [process.execPath, ...request.argv],
+        cwd: undefined,
+        env: process.env as Record<string, string>,
+        timeoutMs: request.timeoutMs,
+      });
+      await vi.waitFor(() => typeof realChild?.pid === "number");
+      realChild.stdout.destroy(new Error("real stdout pipe failure"));
+      realChild.stderr.destroy(new Error("real stderr pipe failure"));
+      realChild.kill("SIGKILL");
+
+      await expect(run).resolves.toMatchObject({ success: false });
+      expect(uncaughtErrors).toEqual([]);
+      expect(spawnMock).toHaveBeenCalledOnce();
+    } finally {
+      process.off("uncaughtException", onUncaught);
+    }
+  });
+});

--- a/src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
+++ b/src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
@@ -20,8 +20,8 @@ function frame(params: unknown): NodeInvokeRequestPayload {
 
 function client(): NodeHostClient {
   return {
-    async request() {
-      return {};
+    async request<T = Record<string, unknown>>() {
+      return {} as T;
     },
   };
 }

--- a/src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
+++ b/src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
@@ -38,7 +38,7 @@ describe("Claude CLI node command pipe errors", () => {
     vi.resetModules();
   });
 
-  it("settles without uncaught pipe errors after real stdout/stderr stream failures", async () => {
+  it("guards real child stdout/stderr pipe error events", async () => {
     const childProcess =
       await vi.importActual<typeof import("node:child_process")>("node:child_process");
     realChild = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
@@ -47,33 +47,23 @@ describe("Claude CLI node command pipe errors", () => {
     spawnMock.mockReturnValueOnce(realChild as never);
     const { runClaudeCliNodeCommand } = await import("./invoke-agent-cli-claude.js");
 
-    const uncaughtErrors: unknown[] = [];
-    const onUncaught = (error: unknown) => {
-      uncaughtErrors.push(error);
-    };
-    process.on("uncaughtException", onUncaught);
     const request = { argv: ["-p"], idleTimeoutMs: 100, timeoutMs: 5_000 };
 
-    try {
-      const run = runClaudeCliNodeCommand({
-        client: client(),
-        frame: frame(request),
-        request,
-        argv: [process.execPath, ...request.argv],
-        cwd: undefined,
-        env: process.env as Record<string, string>,
-        timeoutMs: request.timeoutMs,
-      });
-      await vi.waitFor(() => typeof realChild?.pid === "number");
-      realChild.stdout.destroy(new Error("real stdout pipe failure"));
-      realChild.stderr.destroy(new Error("real stderr pipe failure"));
-      realChild.kill("SIGKILL");
+    const run = runClaudeCliNodeCommand({
+      client: client(),
+      frame: frame(request),
+      request,
+      argv: [process.execPath, ...request.argv],
+      cwd: undefined,
+      env: process.env as Record<string, string>,
+      timeoutMs: request.timeoutMs,
+    });
 
-      await expect(run).resolves.toMatchObject({ success: false });
-      expect(uncaughtErrors).toEqual([]);
-      expect(spawnMock).toHaveBeenCalledOnce();
-    } finally {
-      process.off("uncaughtException", onUncaught);
-    }
+    expect(() => realChild?.stdout.emit("error", new Error("stdout pipe failure"))).not.toThrow();
+    expect(() => realChild?.stderr.emit("error", new Error("stderr pipe failure"))).not.toThrow();
+    realChild.kill("SIGKILL");
+
+    await expect(run).resolves.toMatchObject({ success: false });
+    expect(spawnMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/node-host/invoke-agent-cli-claude.ts
+++ b/src/node-host/invoke-agent-cli-claude.ts
@@ -165,6 +165,8 @@ export async function runClaudeCliNodeCommand(params: {
           terminalLineTouchesTruncation = false;
         }
       };
+      child.stdout.on("error", () => {});
+      child.stderr.on("error", () => {});
       child.stdout.on("data", (raw: Buffer) => {
         const retained = retain(raw);
         if (retained.length > 0) {

--- a/src/node-host/invoke-agent-cli-claude.ts
+++ b/src/node-host/invoke-agent-cli-claude.ts
@@ -165,8 +165,10 @@ export async function runClaudeCliNodeCommand(params: {
           terminalLineTouchesTruncation = false;
         }
       };
-      child.stdout.on("error", () => {});
-      child.stderr.on("error", () => {});
+      // Output pipes can fail independently; child close/error remains authoritative.
+      const ignoreOutputStreamError = () => {};
+      child.stdout.on("error", ignoreOutputStreamError);
+      child.stderr.on("error", ignoreOutputStreamError);
       child.stdout.on("data", (raw: Buffer) => {
         const retained = retain(raw);
         if (retained.length > 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where headless node Claude CLI invocations could crash the node host with an uncaught `error` event when stdout or stderr pipes broke before or during streaming. stdin already had a pipe-error guard, but stdout and stderr did not.

## Why This Change Was Made

`runClaudeCliNodeCommand` now registers no-op `error` listeners on stdout and stderr before data handlers, matching the existing stdin guard and the same pattern used in `src/process/supervisor/adapters/child.ts`.

## User Impact

Approval-gated Claude CLI runs on nodes still fail or cancel the same way when the child exits or times out, but broken stdout/stderr pipes no longer risk taking down the node host process.

## Evidence

**Real-machine before / premise / after / negative control**

Environment: Linux 6.8.0-134-generic x86_64, Node v24.5.0.

Premise: on `upstream/main` at `6ac15970a74`, only stdin had a pipe-error guard:

```bash
git show upstream/main:src/node-host/invoke-agent-cli-claude.ts | rg 'stdout\.on\("error"|stderr\.on\("error"|stdin\.on\("error"'
```

```text
192:      child.stdin.on("error", () => {});
```

Pattern harness on real Node child pipes (same stdout/stderr destroy sequence):

```bash
node --import tsx /tmp/node-host-pipe-error-proof.mts
```

```text
{"before":{"guardStdout":false,"guardStderr":false,"uncaughtPipeError":true},"after":{"guardStdout":true,"guardStderr":true,"uncaughtPipeError":false}}
```

Negative control / before: destroying real stdout/stderr without guards surfaced an uncaught pipe error in the node process.

After: identical destroy sequence with guards present did not.

Production function validation on this branch (real spawned child, mocked only at the spawn seam so the production handler registration runs unchanged):

```bash
node scripts/run-vitest.mjs run src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
```

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

Focused lint:

```bash
./node_modules/.bin/oxlint src/node-host/invoke-agent-cli-claude.ts src/node-host/invoke-agent-cli-claude-pipe-error.test.ts
exit 0
```

Full build and broader suites were not run locally; fork GitHub Actions are expected to cover wider gates. Live Windows node-host deployments were not exercised in this checkout.

AI-assisted: Yes. Cursor agent reviewed the Claude CLI node runner, sibling pipe-error guards, tests, and real-machine evidence.
