### PR TITLE
fix(elevenlabs): treat blank env API keys as unconfigured

### DIFF
--- a/extensions/elevenlabs/media-understanding-provider.test.ts
+++ b/extensions/elevenlabs/media-understanding-provider.test.ts
@@ -22,6 +22,7 @@ describe("elevenLabsMediaUnderstandingProvider", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     ssrfMock?.mockRestore();
     ssrfMock = undefined;
   });
@@ -92,5 +93,50 @@ describe("elevenLabsMediaUnderstandingProvider", () => {
         fetchFn: fetchMock,
       }),
     ).rejects.toThrow("ElevenLabs audio transcription failed: malformed JSON response");
+  });
+
+  it.each([
+    { ELEVENLABS_API_KEY: "  ", XI_API_KEY: "" },
+    { ELEVENLABS_API_KEY: "", XI_API_KEY: "\t" },
+    { ELEVENLABS_API_KEY: " ", XI_API_KEY: " " },
+  ])(
+    "treats whitespace-only env API keys as missing (%#)",
+    async ({ ELEVENLABS_API_KEY, XI_API_KEY }) => {
+      vi.stubEnv("ELEVENLABS_API_KEY", ELEVENLABS_API_KEY);
+      vi.stubEnv("XI_API_KEY", XI_API_KEY);
+      const fetchMock = vi.fn<typeof fetch>();
+
+      await expect(
+        transcribeElevenLabsAudio({
+          buffer: Buffer.from("audio"),
+          fileName: "voice.mp3",
+          mime: "audio/mpeg",
+          apiKey: "",
+          timeoutMs: 1000,
+          fetchFn: fetchMock,
+        }),
+      ).rejects.toThrow("ElevenLabs API key missing");
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("trims the env API key fallback before sending", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "  env-key  ");
+    vi.stubEnv("XI_API_KEY", "");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify({ text: "hello" })));
+
+    await transcribeElevenLabsAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+      mime: "audio/mpeg",
+      apiKey: "",
+      timeoutMs: 1000,
+      fetchFn: fetchMock,
+    });
+
+    const [, init] = requireFirstFetchCall(fetchMock);
+    expect(new Headers(init.headers).get("xi-api-key")).toBe("env-key");
   });
 });

--- a/extensions/elevenlabs/media-understanding-provider.ts
+++ b/extensions/elevenlabs/media-understanding-provider.ts
@@ -12,6 +12,7 @@ import {
   resolveProviderHttpRequestConfig,
   requireTranscriptionText,
 } from "openclaw/plugin-sdk/provider-http";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { DEFAULT_ELEVENLABS_BASE_URL, normalizeElevenLabsBaseUrl } from "./shared.js";
 
 const DEFAULT_ELEVENLABS_STT_MODEL = "scribe_v2";
@@ -20,7 +21,10 @@ export async function transcribeElevenLabsAudio(
   req: AudioTranscriptionRequest,
 ): Promise<AudioTranscriptionResult> {
   const fetchFn = req.fetchFn ?? fetch;
-  const apiKey = req.apiKey || process.env.ELEVENLABS_API_KEY || process.env.XI_API_KEY;
+  const apiKey =
+    normalizeOptionalString(req.apiKey) ??
+    normalizeOptionalString(process.env.ELEVENLABS_API_KEY) ??
+    normalizeOptionalString(process.env.XI_API_KEY);
   if (!apiKey) {
     throw new Error("ElevenLabs API key missing");
   }

--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -2,10 +2,19 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
 import { buildElevenLabsRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
+
+// The profile fallback reads real home-dir files; keep env-key tests hermetic.
+vi.mock("./config-compat.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config-compat.js")>();
+  return {
+    ...actual,
+    resolveElevenLabsApiKeyWithProfileFallback: () => null,
+  };
+});
 
 let cleanup: (() => Promise<void>) | undefined;
 
@@ -46,6 +55,7 @@ async function createRealtimeServer(onRequest: (url: URL) => void) {
 
 describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await cleanup?.();
     cleanup = undefined;
   });
@@ -159,5 +169,17 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     expect(requests[0]?.searchParams.get("audio_format")).toBe("ulaw_8000");
     expect(requests[0]?.searchParams.get("commit_strategy")).toBe("vad");
     expect(requests[0]?.searchParams.get("language_code")).toBe("en");
+  });
+
+  it("reports whitespace-only XI_API_KEY as unconfigured and rejects session creation", () => {
+    vi.stubEnv("XI_API_KEY", " \t ");
+    const provider = buildElevenLabsRealtimeTranscriptionProvider();
+
+    expect(provider.isConfigured({ providerConfig: {} })).toBe(false);
+    expect(() =>
+      provider.createSession({
+        providerConfig: {},
+      }),
+    ).toThrow("ElevenLabs API key missing");
   });
 });

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -265,12 +265,14 @@ export function buildElevenLabsRealtimeTranscriptionProvider(): RealtimeTranscri
       Boolean(
         normalizeProviderConfig(providerConfig).apiKey ||
         resolveElevenLabsApiKeyWithProfileFallback() ||
-        process.env.XI_API_KEY,
+        normalizeOptionalString(process.env.XI_API_KEY),
       ),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
       const apiKey =
-        config.apiKey || resolveElevenLabsApiKeyWithProfileFallback() || process.env.XI_API_KEY;
+        config.apiKey ||
+        resolveElevenLabsApiKeyWithProfileFallback() ||
+        normalizeOptionalString(process.env.XI_API_KEY);
       if (!apiKey) {
         throw new Error("ElevenLabs API key missing");
       }

--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -77,33 +77,62 @@ describe("elevenlabs speech provider", () => {
     );
   });
 
-  it("rejects blank credentials across discovery and synthesis before requests", async () => {
-    vi.stubEnv("ELEVENLABS_API_KEY", "   ");
-    vi.stubEnv("XI_API_KEY", "   ");
+  it.each([{ XI_API_KEY: "   " }, { XI_API_KEY: "" }, { XI_API_KEY: undefined }])(
+    "rejects blank credentials across discovery and synthesis before requests (%#)",
+    async ({ XI_API_KEY }) => {
+      vi.stubEnv("ELEVENLABS_API_KEY", "   ");
+      vi.stubEnv("XI_API_KEY", XI_API_KEY);
+      const provider = buildElevenLabsSpeechProvider();
+      const providerConfig = { apiKey: "   " };
+
+      expect(provider.isConfigured({ providerConfig, timeoutMs: 1_000 })).toBe(false);
+      await expect(
+        provider.listVoices?.({ apiKey: "   ", providerConfig, timeoutMs: 1_000 }),
+      ).rejects.toThrow("ElevenLabs API key missing");
+
+      const request = {
+        text: "hello",
+        cfg: {} as never,
+        providerConfig,
+        target: "audio-file" as const,
+        timeoutMs: 1_000,
+      };
+      await expect(provider.synthesize(request)).rejects.toThrow("ElevenLabs API key missing");
+      await expect(provider.streamSynthesize?.(request)).rejects.toThrow(
+        "ElevenLabs API key missing",
+      );
+      await expect(provider.synthesizeTelephony?.(request)).rejects.toThrow(
+        "ElevenLabs API key missing",
+      );
+
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("resolves a trimmed XI_API_KEY fallback only after configured keys", async () => {
+    vi.stubEnv("XI_API_KEY", "  xi-env-key  ");
     const provider = buildElevenLabsSpeechProvider();
-    const providerConfig = { apiKey: "   " };
-
-    expect(provider.isConfigured({ providerConfig, timeoutMs: 1_000 })).toBe(false);
-    await expect(
-      provider.listVoices?.({ apiKey: "   ", providerConfig, timeoutMs: 1_000 }),
-    ).rejects.toThrow("ElevenLabs API key missing");
-
-    const request = {
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const request = (apiKey: string) => ({
       text: "hello",
       cfg: {} as never,
-      providerConfig,
+      providerConfig: { apiKey },
       target: "audio-file" as const,
       timeoutMs: 1_000,
-    };
-    await expect(provider.synthesize(request)).rejects.toThrow("ElevenLabs API key missing");
-    await expect(provider.streamSynthesize?.(request)).rejects.toThrow(
-      "ElevenLabs API key missing",
-    );
-    await expect(provider.synthesizeTelephony?.(request)).rejects.toThrow(
-      "ElevenLabs API key missing",
-    );
+    });
 
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 1_000 })).toBe(true);
+    await provider.synthesize(request(" config-key "));
+    await provider.synthesize(request("   "));
+
+    const sentKeys = fetchMock.mock.calls.map(([, init]) =>
+      new Headers(init?.headers).get("xi-api-key"),
+    );
+    expect(sentKeys).toEqual(["config-key", "xi-env-key"]);
   });
 
   it("keeps non-equivalent deprecated ElevenLabs TTS model IDs", async () => {

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -29,7 +29,10 @@ import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
 } from "openclaw/plugin-sdk/ssrf-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveElevenLabsApiKeyWithProfileFallback } from "./config-api.js";
 import { isValidElevenLabsVoiceId, normalizeElevenLabsBaseUrl } from "./shared.js";
 import { elevenLabsTTS, elevenLabsTTSStream } from "./tts.js";
@@ -192,7 +195,7 @@ function resolveElevenLabsApiKey(...candidates: Array<string | undefined>): stri
   return resolveSpeechProviderApiKey(
     ...candidates,
     resolveElevenLabsApiKeyWithProfileFallback() ?? undefined,
-    process.env.XI_API_KEY,
+    normalizeOptionalString(process.env.XI_API_KEY),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Whitespace-only `ELEVENLABS_API_KEY` / `XI_API_KEY` environment values are truthy strings, so the ElevenLabs providers treated them as real credentials:

- `buildElevenLabsRealtimeTranscriptionProvider().isConfigured` returned `true` when `XI_API_KEY="  "`, so auto-selection could pick the realtime provider and only fail later at connection time.
- `transcribeElevenLabsAudio` skipped its `ElevenLabs API key missing` guard and sent the speech-to-text request with an empty `xi-api-key` header, surfacing as a confusing upstream 401 instead of a clear local configuration error.

## Why This Change Was Made

The config-file key path already normalizes blanks (`normalizeResolvedSecretInputString`), and the profile fallback already trims (`resolveElevenLabsApiKeyWithProfileFallback`). Only the raw env fallbacks bypassed normalization. This routes them (plus the request-level key, matching the merged xAI handling in `realtime-transcription-provider.ts`) through the same shared `normalizeOptionalString` helper so blank values are treated as missing everywhere in this provider.

## Changes

- `extensions/elevenlabs/realtime-transcription-provider.ts`: `isConfigured` and `createSession` resolve the `XI_API_KEY` fallback via `normalizeOptionalString`, so whitespace-only values report unconfigured and session creation fails fast with `ElevenLabs API key missing`.
- `extensions/elevenlabs/media-understanding-provider.ts`: the speech-to-text key resolution normalizes `req.apiKey`, `ELEVENLABS_API_KEY`, and `XI_API_KEY` with the same helper, so blank values are skipped and env keys are trimmed before being sent.
- Regression tests: whitespace-only env keys are treated as missing in both providers (including asserting no request is sent), and a padded env key is trimmed before use.

## User Impact

Operators with a whitespace-only `ELEVENLABS_API_KEY`/`XI_API_KEY` (e.g., a placeholder left in an env file) now get a clear "ElevenLabs API key missing" error and the realtime provider correctly reports itself unconfigured, instead of a request sent with an empty credential that fails upstream. Real keys are unaffected (verified trimmed-to-same-value in tests). No config, migration, or API changes.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs extensions/elevenlabs/` — 38/38 passed on Node 22.22.0.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json` — no errors in changed files (only pre-existing `packages/net-policy` errors from a stale local dependency install).
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check` passed for the changed files.
- Real HTTP proof below: loopback server + production functions, before/after this patch.

## Real behavior proof

**Behavior addressed:** A whitespace-only `XI_API_KEY` made the realtime provider report configured, and the speech-to-text path sent a real request carrying an empty `xi-api-key` header instead of failing fast locally.

**Real environment tested:** Linux x86_64, Node v22.22.0, production functions imported directly from the changed sources, real `node:http` loopback server as the ElevenLabs API endpoint (`request.allowPrivateNetwork: true` to permit the loopback target). Current head: `190a77b2b5f47aa30bede7eb55e98e010d68ca81`.

**Exact steps or command run after this patch:** `node --import tsx /tmp/elk-proof/proof.mts` with `ELEVENLABS_API_KEY=""` and `XI_API_KEY="  "` in the environment. The driver starts a real HTTP server, calls `buildElevenLabsRealtimeTranscriptionProvider().isConfigured({ providerConfig: {} })`, then calls the production `transcribeElevenLabsAudio({ buffer, fileName, mime, baseUrl: <loopback>, request: { allowPrivateNetwork: true } })` and reads the server's received-request count and captured `xi-api-key` header back.

**Evidence after fix:** Before the patch (same driver, base revision): `isConfigured (whitespace XI_API_KEY): true`, `transcribeElevenLabsAudio outcome: resolved (request was sent)`, `server received requests: 1`, `captured xi-api-key header: ""`. After the patch: `isConfigured (whitespace XI_API_KEY): false`, `transcribeElevenLabsAudio outcome: threw: ElevenLabs API key missing`, `server received requests: 0`.

**Observed result after fix:** The whitespace-only env key no longer counts as configured, the missing-key error fires locally before any network I/O (the loopback server confirms zero requests), and regression tests confirm a padded real env key (`"  env-key  "`) is trimmed and sent as `env-key`.

**What was not tested:** No live ElevenLabs API calls (no real credential available); the loopback server stands in for the upstream endpoint. The realtime websocket session path was not connected end-to-end with a blank key; its `isConfigured`/`createSession` gates are covered by the new unit tests and the same normalization helper. No UI changes.

## Follow-up: remaining `XI_API_KEY` fallback normalized

`resolveElevenLabsApiKey` in `extensions/elevenlabs/speech-provider.ts` (the fallback feeding `resolveSpeechProviderApiKey`) still read `process.env.XI_API_KEY` raw; it now goes through the same `normalizeOptionalString` as the other candidates, so a blank/whitespace env key falls through consistently instead of registering as configured. Regression coverage was extended to an `it.each` over blank/whitespace/missing env states asserting configured-state, discovery, synthesis, streaming, telephony, precedence, trimming, and zero egress (`node scripts/run-vitest.mjs run extensions/elevenlabs` — 41/41 pass).

## Intentionally out of scope

- Other providers' env credential paths (bedrock was handled in #109680, `packages/ai` env keys in #109691, deepgram in #108565); this PR is scoped to ElevenLabs only.
- The config-file `apiKey` handling, which already normalizes blanks via `normalizeResolvedSecretInputString`.
- `resolveElevenLabsApiKeyWithProfileFallback`, which already trims its env read.