### PR TITLE
fix(line): inbound messages are lost when dispatch failures outlast two minutes of retries

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -46,8 +46,9 @@ The Gateway answers LINE's webhook verification (GET). For signed inbound events
 (POST), it writes each event to the durable ingress queue before returning `200`;
 agent processing continues asynchronously. Failed delivery is retried from the
 queue, including after a Gateway restart, and poison events become failed queue
-records after bounded retries. If durable persistence fails, the request returns
-`500` instead of acknowledging an event that could be lost.
+records after bounded retries (an attempt floor plus a minimum event age,
+matching Telegram's retry policy). If durable persistence fails, the request
+returns `500` instead of acknowledging an event that could be lost.
 If you need a custom path, set `channels.line.webhookPath` or
 `channels.line.accounts.<id>.webhookPath` and update the URL accordingly.
 

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -5,6 +5,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { webhook } from "@line/bot-sdk";
+import { DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS } from "openclaw/plugin-sdk/channel-outbound";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests as createChannelIngressQueue,
@@ -102,6 +103,7 @@ describe("LINE webhook spool", () => {
         runtime: runtime(),
         queue,
         maxAttempts: 1,
+        deadLetterMinAgeMs: 0,
         retryBaseMs: 0,
         deliver: async () => {
           throw new Error("dispatch failed");
@@ -212,6 +214,7 @@ describe("LINE webhook spool", () => {
         runtime: runtime(),
         queue,
         maxAttempts: 3,
+        deadLetterMinAgeMs: 0,
         retryBaseMs: 0,
         retryMaxMs: 0,
         deliver,
@@ -234,6 +237,74 @@ describe("LINE webhook spool", () => {
       if (duplicate.kind === "failed") {
         expect(duplicate.record.reason).toBe("retry-limit-exceeded");
       }
+      await spool.stop();
+    });
+  });
+
+  it("keeps retry-limit events pending until they are old enough to dead-letter", async () => {
+    await withQueue(async (queue) => {
+      const deliver = vi.fn(async () => {
+        throw new Error("young poison");
+      });
+      const outcomes: LineWebhookDeliveryOutcome[] = [];
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        maxAttempts: 2,
+        retryBaseMs: 0,
+        retryMaxMs: 0,
+        deliver,
+        onOutcome: (outcome) => outcomes.push(outcome),
+      });
+      spool.start();
+      await spool.accept(callback(createEvent("event-young-poison")));
+
+      await vi.waitFor(() => {
+        expect(
+          outcomes.some((outcome) => outcome.kind === "retry-scheduled" && outcome.attempt > 2),
+        ).toBe(true);
+      });
+      expect(outcomes.some((outcome) => outcome.kind === "dead-lettered")).toBe(false);
+      await spool.stop();
+      expect(await queue.listPending()).toHaveLength(1);
+    });
+  });
+
+  it("dead-letters retry-limit events once they reach the minimum age", async () => {
+    await withQueue(async (queue) => {
+      const event = createEvent("event-old-poison");
+      await queue.enqueue(
+        "event-old-poison",
+        { version: 1, destination: "destination-1", event },
+        {
+          laneKey: "user:user-1",
+          receivedAt: Date.now() - DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+        },
+      );
+      const deliver = vi.fn(async () => {
+        throw new Error("old poison");
+      });
+      const outcomes: LineWebhookDeliveryOutcome[] = [];
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        maxAttempts: 2,
+        retryBaseMs: 0,
+        retryMaxMs: 0,
+        deliver,
+        onOutcome: (outcome) => outcomes.push(outcome),
+      });
+      spool.start();
+
+      const outcome = await waitForOutcome(outcomes, "dead-lettered");
+      expect(outcome).toMatchObject({
+        eventId: "event-old-poison",
+        attempt: 2,
+        reason: "retry-limit-exceeded",
+      });
+      expect(deliver).toHaveBeenCalledTimes(2);
       await spool.stop();
     });
   });

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -1,10 +1,11 @@
 // Line plugin module owns durable webhook admission and replay.
 import { createHash, randomUUID } from "node:crypto";
 import type { webhook } from "@line/bot-sdk";
-import type {
-  ChannelIngressQueue,
-  ChannelIngressQueueClaim,
-  ChannelIngressQueueRecord,
+import {
+  type ChannelIngressQueue,
+  type ChannelIngressQueueClaim,
+  type ChannelIngressQueueRecord,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { danger, sleepWithAbort, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
@@ -52,6 +53,7 @@ type LineWebhookSpoolOptions = {
   ) => Promise<void>;
   queue?: ChannelIngressQueue<LineWebhookSpoolPayload>;
   maxAttempts?: number;
+  deadLetterMinAgeMs?: number;
   retryBaseMs?: number;
   retryMaxMs?: number;
   claimStaleMs?: number;
@@ -146,6 +148,10 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     });
   const ownerId = `${process.pid}:${randomUUID()}`;
   const maxAttempts = Math.max(1, options.maxAttempts ?? LINE_WEBHOOK_MAX_ATTEMPTS);
+  const deadLetterMinAgeMs = Math.max(
+    0,
+    options.deadLetterMinAgeMs ?? DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  );
   const retryBaseMs = Math.max(0, options.retryBaseMs ?? LINE_WEBHOOK_RETRY_BASE_MS);
   const retryMaxMs = Math.max(retryBaseMs, options.retryMaxMs ?? LINE_WEBHOOK_RETRY_MAX_MS);
   const claimStaleMs = Math.max(0, options.claimStaleMs ?? LINE_WEBHOOK_CLAIM_STALE_MS);
@@ -334,7 +340,9 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
           });
           throw error;
         }
-        if (attempt >= maxAttempts) {
+        // Dead-letter needs BOTH the attempt floor and event age; a too-young
+        // over-limit event keeps retrying at the capped delay until age is met.
+        if (attempt >= maxAttempts && Date.now() - claim.receivedAt >= deadLetterMinAgeMs) {
           await persistClaimTransition({
             claim,
             label: "retry-limit dead-letter",


### PR DESCRIPTION
Closes #109795

## What Problem This Solves

Fixes an issue where LINE users lose inbound messages permanently when event dispatch keeps failing for longer than about two minutes. The webhook spool acknowledges the event to LINE, retries eight times within ~127 seconds, then dead-letters it with the payload erased, so a session-initialization conflict spell or a crash-looping gateway silently destroys every message received in the window. LINE redelivery cannot compensate: the failed tombstone swallows redelivered copies of the same event.

## Why This Change Was Made

The spool's dead-letter decision checked the attempt cap alone, while the core ingress retry policy it mirrors requires both an attempt floor and a minimum event age (`shouldDeadLetterRetryableIngressEvent`, `src/channels/message/ingress-retry-policy.ts`), which is what Telegram ships through the core drain. This change applies the same dual condition using `DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS`, which #108924 already exports through the plugin SDK, so over-limit events keep retrying at the existing capped delay until they are old enough; the spool's existing backoff needed no changes. Rewiring LINE onto the core ingress drain (which would also bring the pre-adoption stall watchdog) was considered and left out as a larger architectural move for maintainers to schedule. Non-retryable dead-letters (`invalid-event`, `delivery-side-effects-committed`) intentionally keep failing immediately, matching core semantics, and `CHANGELOG.md` is untouched.

## User Impact

LINE messages caught in a transient failure window are delivered once the failure clears instead of disappearing. The trade-off is the one Telegram already ships: a genuinely poisoned event now retries in its own conversation lane for up to 24 hours (every few minutes at the capped delay) instead of dying after two, while terminal classification via `LineWebhookTerminalDeliveryError` still short-circuits immediately. This also stops restart-inflated attempt counts (claim-refresh releases and stale-claim recovery both record attempts) from dead-lettering an event that never saw a genuine delivery failure.

## Evidence

Behavior addressed: retryable LINE webhook events dead-letter at the attempt cap ~127s after receipt instead of retrying until the dead-letter age floor.

### Live LINE platform proof (outage and recovery, real webhook flow)

Real environment tested: gateway built from this branch (Windows 11, Node 24.15.0), a real LINE Messaging API channel, webhook delivered by the LINE platform over HTTPS to the local gateway. The outage is a genuine pre-adoption dispatch failure (legacy agent-workspace state requiring migration, so every dispatch fails before turn adoption); recovery is the operator fixing the workspace configuration and restarting the gateway.

A single "ping" sent from the LINE app during the outage (gateway error log, verbatim, local username redacted):

```
16:39:54 [line] webhook event 01KXQKPTBX8G10S0FFXJKDRSTV delivery failed on attempt 1: Legacy workspace setup state requires migration ...
16:39:55 attempt 2   16:39:57 attempt 3   16:40:01 attempt 4   16:40:09 attempt 5
16:40:25 attempt 6   16:40:57 attempt 7
16:42:01 [line] webhook event 01KXQKPTBX8G10S0FFXJKDRSTV delivery failed on attempt 8   <- t+127s: current main dead-letters here; this branch keeps the event queued
16:44:09 [line] webhook event 01KXQKPTBX8G10S0FFXJKDRSTV delivery failed on attempt 9   <- beyond the attempt floor
16:44:39 operator recovery: workspace config fixed, gateway restarted
16:45:03 [gateway] ready; the stale claim is recovered by the drain lease
16:47:12 turn adopted and completed; reply delivered by push (the reply token had expired during the outage)
```

Final ingress-queue row after delivery (read-only SQLite query):

```
event_id                     status     attempts  received             completed
01KXQKPTBX8G10S0FFXJKDRSTV   completed  9         2026-07-17 16:39:53  2026-07-17 16:47:12
```

One row, nine attempts, exactly one completion. On current main this row would read `failed | retry-limit-exceeded` with the payload erased. Delivery without duplication: exactly one reply visible in the LINE client (screenshot), and a synthetic sibling event queued in the same outage window followed the same retry path to a single completion (11 attempts).

<img src="https://raw.githubusercontent.com/edenfunf/moltbot/evidence/line-spool-age-floor/evidence/line-spool-outage-recovery.png" width="360">

### Controlled wall-clock harness (single variable)

Before evidence (current main, real SQLite ingress queue driven through the exported `createLineWebhookSpool` factory, default retry constants, real timers; deliver throws "reply session initialization conflicted" on every attempt):

```
[t+0.0s]   webhook accepted (event persisted, 200 returned)
[t+0.0s]   attempt 1 -> retry-scheduled
[t+1.0s]   attempt 2 -> retry-scheduled
[t+3.1s]   attempt 3 -> retry-scheduled
[t+7.1s]   attempt 4 -> retry-scheduled
[t+15.1s]  attempt 5 -> retry-scheduled
[t+31.1s]  attempt 6 -> retry-scheduled
[t+63.1s]  attempt 7 -> retry-scheduled
[t+127.1s] attempt 8 -> {"kind":"dead-lettered","reason":"retry-limit-exceeded"}
```

Evidence after fix (same harness, same input, only the dead-letter condition changed):

```
[t+0.0s]   ... attempts 1-7 identical to the run above ...
[t+127.1s] attempt 8 -> {"kind":"retry-scheduled","attempt":8}
[t+200.8s] no dead-letter; row still pending (attempts=8, lastError="reply session initialization conflicted")
```

Observed result after fix: the event survives the outage window and keeps retrying at the capped delay; a backdated event older than the age floor still dead-letters as `retry-limit-exceeded` on the same attempt floor.

Exact steps or command run after this patch:

```
pnpm exec vitest run --config test/vitest/vitest.extension-line.config.ts extensions/line/src/webhook-spool.test.ts
Test Files  1 passed (1) / Tests  18 passed (18)
```

Control-red: reverting the source change makes the new test "keeps retry-limit events pending until they are old enough to dead-letter" fail (the event dead-letters at the attempt cap) while "dead-letters retry-limit events once they reach the minimum age" still passes, so the old attempts-only behavior can no longer satisfy the suite. Both new tests mirror Telegram's age-floor regression tests; the two existing bounded-retry tests pin the attempts-only semantics explicitly via `deadLetterMinAgeMs: 0`.

Additional review: extension source typecheck (`tsconfig.extensions.json`), extension test-types typecheck (`test/tsconfig/tsconfig.extensions.test.json`), `pnpm lint:extensions`, `oxfmt --check` on touched files, and docs MDX check on `docs/channels/line.md` all pass; the branch is rebased onto current main and the focused suite re-ran green on the rebased head.

What was not tested: the 24-hour age floor is asserted by backdating `receivedAt` (the same technique as Telegram's minimum-age test) and the live outage lasted ~7.5 minutes, so a wall-clock 24-hour dead-letter run was not performed.

Proof limitations or environment constraints: Windows 11 local runs; harness timeline timestamps vary by ±0.1s; the live-proof screenshot and evidence image are hosted on the contributor fork's `evidence/line-spool-age-floor` branch.
