### PR TITLE
fix(models): reject oversized piped auth input

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -1473,6 +1473,21 @@ describe("modelsAuthLoginCommand", () => {
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
+  it("rejects oversized piped auth input before buffering it", async () => {
+    const runtime = createRuntime();
+    restoreStdin?.();
+    const oversized = "x".repeat(1024 * 1024 + 1);
+    restoreStdin = withPipedStdin(oversized);
+
+    await expect(modelsAuthPasteApiKeyCommand({ provider: "openai" }, runtime)).rejects.toThrow(
+      "Piped auth input exceeds 1048576 bytes.",
+    );
+
+    expect(mocks.clackPassword).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
   it("writes pasted API keys to the requested agent store", async () => {
     const runtime = createRuntime();
     useCoderAgentConfig();

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -130,13 +130,20 @@ const password = async (params: Parameters<typeof clackPassword>[0]) =>
 const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
   guardCancel(await clackSelect(styleSelectParams(params)));
 
+const MODELS_AUTH_STDIN_MAX_BYTES = 1024 * 1024;
+
 async function readPipedStdin(): Promise<string> {
-  process.stdin.setEncoding("utf8");
-  let input = "";
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
   for await (const chunk of process.stdin) {
-    input += String(chunk);
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MODELS_AUTH_STDIN_MAX_BYTES) {
+      throw new Error(`Piped auth input exceeds ${MODELS_AUTH_STDIN_MAX_BYTES} bytes.`);
+    }
+    chunks.push(buffer);
   }
-  return input;
+  return Buffer.concat(chunks, totalBytes).toString("utf8");
 }
 
 async function readPastedSecret(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw models auth paste-token` and `paste-api-key` accumulated piped stdin without any size limit, allowing arbitrarily large input to buffer in memory before reaching downstream validation.

## Why This Change Was Made

The `readPipedStdin()` helper now enforces a 1 MiB cap (matching the existing `MATRIX_CLI_RECOVERY_KEY_STDIN_MAX_BYTES` and `CONFIG_PATCH_STDIN_MAX_BYTES` limits). The rejection happens at the stream boundary — during the read loop, not after buffering — so oversized input never reaches auth processing.

The change follows the same buffer-chunk pattern used in the Matrix recovery-key stdin fix (PR #108120): collect `Buffer` chunks, track `totalBytes` per chunk, and throw before the cap is exceeded. Normal TTY and small piped input paths are unchanged.

Collision check: searched open PRs for `readPipedStdin`, `models auth stdin`, `paste-token unbounded` — no same-file or same-problem open PR found.

## User Impact

Piped auth commands now fail with an explicit size error for oversized input instead of buffering unbounded data. Normal interactive entry and direct arguments are unaffected.

## Evidence

Exact head: `12be34c454b75916fcf481916dec7998105820df`

### Format / diff check

```
$ ./node_modules/.bin/oxfmt --check src/commands/models/auth.ts src/commands/models/auth.test.ts
All matched files use the correct format.

$ git diff --check
# exit 0
```

### Real CLI proof (local, Node 24.18.0, `pnpm dev`)

Normal small piped API key reaches auth validation:

```
$ printf 'sk-test123456789\n' | OPENCLAW_STATE_DIR=/tmp/openclaw-test-proof     pnpm dev models auth paste-api-key --provider openai
...
Updated config: /tmp/openclaw-test-proof/openclaw.json
Auth profile: openai:manual (openai/api_key)
```

Oversized piped input (1 MiB + 1 byte) rejected at the stdin boundary:

```
$ node -e 'process.stdout.write("x".repeat(1048577))' |     OPENCLAW_STATE_DIR=/tmp/openclaw-test-proof     pnpm dev models auth paste-api-key --provider openai
Error: Piped auth input exceeds 1048576 bytes.
```

### Standalone proof (loopback stream, calls real production function)

```
$ node --import tsx proof-models-auth-stdin-limit.mts

  ok: small piped input does not trigger size rejection
  info: small_error=Failed to update auth profile store; ...
  ok: oversized piped input is rejected
  ok: rejection message is "Piped auth input exceeds 1048576 bytes."
  info: oversized_error=Piped auth input exceeds 1048576 bytes.

=== Summary ===
ALL PROOF ASSERTIONS: 3 passed, 0 failed
```

### Tests

```
$ node scripts/run-vitest.mjs src/commands/models/auth.test.ts
 Test Files  1 passed (1)
      Tests  40 passed (40)
```

New test "rejects oversized piped auth input before buffering it" verifies the exact error message and confirms no downstream auth mutation.

### Mutation check

Reverted the fix to bare `input += String(chunk)` loop with no cap:

```
$ git checkout HEAD~1 -- src/commands/models/auth.ts
$ node scripts/run-vitest.mjs src/commands/models/auth.test.ts
 Test Files  1 failed (1)
      Tests  1 failed | 39 passed (40)
```

Oversized input passes through to validate() which reports "That does not look like an OpenAI API key." instead of the size rejection. Restored fix → 40/40 pass.

### Not tested

- Full `pnpm build` with dist-based CLI (Node 22.22.0 does not meet the >=22.22.3 requirement)
- The `paste-token` oversized path (shares the same `readPipedStdin` helper as the tested `paste-api-key` path)

🤖 Generated with [co-mind](https://claude.com/claude-code)