### PR TITLE
test(gateway): stop background plugin reloads from wiping test task runtimes

### DIFF
--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -7,7 +7,6 @@ import { createAgentRunRestartAbortError } from "../../agents/run-termination.js
 import {
   getSubagentRunByChildSessionKey,
   resetSubagentRegistryForTests,
-  testing as subagentRegistryTesting,
 } from "../../agents/subagent-registry.test-helpers.js";
 import { getDetachedTaskLifecycleRuntime } from "../../tasks/detached-task-runtime.js";
 import {
@@ -21,6 +20,7 @@ import {
 } from "../../tasks/task-runtime.test-helpers.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import {
+  applyGatewaySubagentRegistryTestDeps,
   getAgentTestMocks,
   makeContext,
   type AgentHandlerArgs,
@@ -260,7 +260,9 @@ describe("gateway agent handler", () => {
         useTestStateDir(root);
         resetTaskRegistryForTests();
         resetSubagentRegistryForTests({ persist: false });
-        subagentRegistryTesting.setDepsForTest({
+        // Route through the harness helper so the ensureRuntimePluginsLoaded
+        // pin survives this wholesale deps override.
+        applyGatewaySubagentRegistryTestDeps({
           persistSubagentRunsToDiskOrThrow: () => {
             throw new Error("disk full");
           },

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -938,13 +938,34 @@ function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
   return error;
 }
 
+/**
+ * Pins subagent-registry deps for gateway handler tests, always keeping
+ * `ensureRuntimePluginsLoaded` a no-op. Real ended-run hooks reload the
+ * standalone plugin runtime in the background, and `loadOpenClawPlugins`
+ * starts by wiping process-wide plugin registrations — including the detached
+ * task lifecycle runtime a later test just installed via
+ * `setDetachedTaskLifecycleRuntime`. Without this pin, a prior test's async
+ * subagent completion can silently uninstall a later test's runtime seam
+ * between install and finalize, so the finalize spy is never called.
+ */
+export function applyGatewaySubagentRegistryTestDeps(
+  overrides?: Parameters<typeof subagentRegistryTesting.setDepsForTest>[0],
+) {
+  subagentRegistryTesting.setDepsForTest({
+    ensureRuntimePluginsLoaded: () => {},
+    ...overrides,
+  });
+}
+
+applyGatewaySubagentRegistryTestDeps();
+
 export const describe0AfterEach0 = () => {
   envSnapshot.restore();
   resetDetachedTaskLifecycleRuntimeForTests();
   resetDiagnosticEventsForTest();
   resetTaskRegistryForTests();
   resetSubagentRegistryForTests({ persist: false });
-  subagentRegistryTesting.setDepsForTest();
+  applyGatewaySubagentRegistryTestDeps();
   mocks.loadConfigReturn = {};
   mocks.emitGatewaySessionEndPluginHook.mockReset();
   mocks.emitGatewaySessionStartPluginHook.mockReset();


### PR DESCRIPTION
## What Problem This Solves

`gateway agent handler > logs a swallowed finalize error without blocking the background run` flaked twice with different symptoms — "expected 1 call, got 0" under the old 2s poll, then a full 120s timeout after #109653 made the wait event-driven. The second symptom proved the finalize spy is sometimes **never called**, not slow.

## Why This Change Was Made

Root cause, traced end to end: the ACP plugin-subagent test that runs just before leaks a background subagent completion. That chain (`completeSubagentRunAttempt` → `emitSubagentEndedHookForRun` → `ensureRuntimePluginsLoaded` → `loadOpenClawPlugins` → `clearActivatedPluginRuntimeState` → `clearDetachedTaskLifecycleRuntimeRegistration`) wipes the process-wide detached-task runtime registration. When it lands between the target test's `setDetachedTaskLifecycleRuntime(spy)` and its background finalize, `finalizeTaskRunByRunId` re-reads the registration at call time, falls back to the default executor, and finalizes *successfully* — the run completes with an ok frame while the spy structurally never fires. Instrumented traces caught the wipe landing 704ms/232ms before the target's window in green local runs; CI contention slides it inside.

Fix at the test-harness ownership boundary: `agent.test-harness.ts` pins subagent-registry deps with a no-op `ensureRuntimePluginsLoaded` (the same pattern `subagent-registry.test.ts` already uses) via a new `applyGatewaySubagentRegistryTestDeps()` — applied at harness setup, in the shared afterEach (which previously reset deps to real), and through the one wholesale deps override, so no leaked ended-run hook can reload the plugin runtime mid-test.

Prod note: prod has a narrower variant (registration absent from plugin-load start until re-registration, so a concurrent background finalize can misroute to the core executor); changing activation semantics is compat-sensitive, so it is filed as a separate follow-up rather than bundled here.

## User Impact

None at runtime — test-only (+26/−3). Kills a gateway-methods shard flake whose two prior fixes addressed the wrong hypothesis.

## Evidence

- Deterministic repro via a temporary env-gated interleaving patch (not committed): pre-fix reproduces the exact CI failure (120s timeout, registration observed ABSENT); post-fix under the identical interleaving, 238/238 pass with registration present. Flip verified both directions.
- Stress post-fix: 10× `agent.test.ts` + 5× full `src/gateway/server-methods` shard at `OPENCLAW_VITEST_MAX_WORKERS=6` — 0 failures (3765 tests per shard run).
- `git diff --check`, oxfmt, oxlint clean; autoreview (codex gpt-5.6-sol, xhigh): clean, "patch is correct (0.97)".
- Failing-run provenance: run 29559328261 attempt 1, job checks-node-compact-large-4.
