### PR TITLE
fix(msteams): cancel non-OK Graph response body before throwing

### DIFF
--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -264,6 +264,19 @@ describe("msteams graph helpers", () => {
       "Graph /teams/team-1/channels failed (403): forbidden",
     );
 
+    const cancelBody = textResponse("forbidden", { status: 403 });
+    const cancelSpy = vi.spyOn(cancelBody.body!, "cancel").mockResolvedValue(undefined);
+    mockFetch(async () => cancelBody);
+
+    await expectRejectsToThrow(
+      fetchGraphJson({
+        token: graphToken,
+        path: "/teams/team-1/channels",
+      }),
+      "Graph /teams/team-1/channels failed (403): forbidden",
+    );
+    expect(cancelSpy).toHaveBeenCalledOnce();
+
     mockTextFetchResponse("{ nope", {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -322,6 +335,25 @@ describe("msteams graph helpers", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
       expect.objectContaining({ timeoutMs: 30_000 }),
     );
+  });
+
+  it("cancels non-OK absolute url response body before throwing", async () => {
+    const forbiddenBody = textResponse("forbidden", { status: 403 });
+    const cancelSpy = vi.spyOn(forbiddenBody.body!, "cancel").mockResolvedValue(undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: forbiddenBody,
+      finalUrl: "https://graph.microsoft.com/v1.0/groups",
+      release: async () => undefined,
+    });
+
+    await expectRejectsToThrow(
+      fetchGraphAbsoluteUrl({
+        token: graphToken,
+        url: "https://graph.microsoft.com/v1.0/groups",
+      }),
+      "Graph https://graph.microsoft.com/v1.0/groups failed (403): forbidden",
+    );
+    expect(cancelSpy).toHaveBeenCalledOnce();
   });
 
   it("posts Graph JSON to v1 and beta roots and treats empty mutation responses as undefined", async () => {

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -74,10 +74,12 @@ async function requestGraph(params: {
   let releaseInFinally = true;
   try {
     if (!response.ok) {
-      throw await createMSTeamsHttpError(
+      const error = await createMSTeamsHttpError(
         response,
         `${params.errorPrefix ?? "Graph"} ${params.path} failed`,
       );
+      await response.body?.cancel();
+      throw error;
     }
     releaseInFinally = false;
     return responseWithRelease(response, release);
@@ -142,7 +144,9 @@ export async function fetchGraphAbsoluteUrl<T>(params: {
   });
   try {
     if (!response.ok) {
-      throw await createMSTeamsHttpError(response, `Graph ${params.url} failed`);
+      const error = await createMSTeamsHttpError(response, `Graph ${params.url} failed`);
+      await response.body?.cancel();
+      throw error;
     }
     return await readProviderJsonResponse<T>(response, `Graph ${params.url} failed`);
   } finally {


### PR DESCRIPTION
AI-assisted: built with Codex

## What Problem This Solves

When `requestGraph` or `fetchGraphAbsoluteUrl` receives a non-OK response from
the Microsoft Graph API, the error code constructs an error from the response
text and throws — but the response stream is not explicitly cancelled. The
leaked stream body stays open until finalization, which can hold resources
(socket, memory) longer than necessary.

## Why This Change Was Made

Both sites now call `response.body?.cancel()` after the error message has been
read (so the error text is preserved) and before the throw. This matches the
pattern already used elsewhere in the msteams extension (e.g. `file-consent.ts`)
and in sibling extensions (e.g. `clawrouter`, `googlechat`, `docs`).

## User Impact

No user-visible change. Reduces resource churn on failed Graph API calls.

## Evidence

Both `requestGraph` (line ~76) and `fetchGraphAbsoluteUrl` (line ~143) now
cancel the response body after constructing the error:

```
extensions/msteams/src/graph.ts:77-82   requestGraph: cancel after createMSTeamsHttpError
extensions/msteams/src/graph.ts:149-152 fetchGraphAbsoluteUrl: same pattern
```

Test coverage — `graph.test.ts` verifies cancel is called once for each path:

```
npx vitest run --config test/vitest/vitest.extension-msteams.config.ts extensions/msteams/src/graph.test.ts
PASS (25)
```
