### PR TITLE
fix(agents): strip trailing assistant messages after sessions_yield artifact removal

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -195,6 +195,14 @@ export function stripSessionsYieldArtifacts(activeSession: {
     }
     break;
   }
+  while (strippedMessages.length > 0) {
+    const last = strippedMessages.at(-1) as AgentMessage | { role?: string };
+    if (last?.role === "assistant") {
+      strippedMessages.pop();
+      continue;
+    }
+    break;
+  }
   if (strippedMessages.length !== activeSession.messages.length) {
     activeSession.agent.state.messages = strippedMessages;
   }
@@ -238,7 +246,8 @@ export function stripSessionsYieldArtifacts(activeSession: {
       const isYieldInterruptMessage =
         entry.type === "custom_message" &&
         entry.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
-      return isYieldAbortAssistant || isYieldInterruptMessage;
+      const isTrailingAssistant = entry.type === "message" && entry.message?.role === "assistant";
+      return isYieldAbortAssistant || isYieldInterruptMessage || isTrailingAssistant;
     },
     {
       preserveTrailing: (entry) =>

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -184,7 +184,7 @@ describe("stripSessionsYieldArtifacts — trailing assistant stripping (#109638)
     stripSessionsYieldArtifacts(activeSession);
 
     expect(removeTrailingEntries).toHaveBeenCalledOnce();
-    const [predicate, options] = removeTrailingEntries.mock.calls[0];
+    const [predicate, options] = removeTrailingEntries.mock.calls[0]!;
 
     expect(
       predicate({ type: "message", message: { role: "assistant", stopReason: "aborted" } }),

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -161,7 +161,7 @@ describe("stripSessionsYieldArtifacts — trailing assistant stripping (#109638)
     // First loop removes yield interrupt + aborted assistant
     // Second loop removes the two trailing regular assistants
     expect(activeSession.agent.state.messages).toHaveLength(3);
-    const last = activeSession.agent.state.messages.at(-1) as any;
+    const last = activeSession.agent.state.messages.at(-1);
     expect(last.role).toBe("tool_result");
     expect(last.tool_use_id).toBe("t1");
   });

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -14,6 +14,7 @@ import {
   overflowBaseRunParams,
   warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
+import { stripSessionsYieldArtifacts } from "./run/attempt.sessions-yield.js";
 import { isEmbeddedAgentRunActive, queueEmbeddedAgentMessageWithOutcome } from "./runs.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
@@ -133,5 +134,30 @@ describe("sessions_yield orchestration", () => {
     // Neither clientToolCall nor yieldDetected → stopReason is undefined
     expect(result.meta.stopReason).toBeUndefined();
     expect(result.meta.pendingToolCalls).toBeUndefined();
+  });
+});
+
+describe("stripSessionsYieldArtifacts — trailing assistant stripping (#109638)", () => {
+  it("strips trailing regular assistant messages after aborted + yield interrupt", () => {
+    const messages: any[] = [
+      { role: "user", content: "do something" },
+      { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "fn", input: {} }] },
+      { role: "tool_result", tool_use_id: "t1", content: "ok" },
+      { role: "assistant", content: [{ type: "tool_use", id: "t2", name: "fn2", input: {} }] },
+      { role: "tool_result", tool_use_id: "t2", content: "done" },
+      { role: "assistant", stopReason: "aborted", content: [] },
+      { role: "custom", customType: "openclaw.sessions_yield_interrupt" },
+    ];
+
+    const activeSession = {
+      messages: messages.slice(),
+      agent: { state: { messages: messages.slice() } },
+    };
+
+    stripSessionsYieldArtifacts(activeSession);
+
+    const last = activeSession.agent.state.messages.at(-1) as any;
+    expect(last.role).toBe("tool_result");
+    expect(last.tool_use_id).toBe("t2");
   });
 });

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -143,8 +143,10 @@ describe("stripSessionsYieldArtifacts — trailing assistant stripping (#109638)
       { role: "user", content: "do something" },
       { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "fn", input: {} }] },
       { role: "tool_result", tool_use_id: "t1", content: "ok" },
-      { role: "assistant", content: [{ type: "tool_use", id: "t2", name: "fn2", input: {} }] },
-      { role: "tool_result", tool_use_id: "t2", content: "done" },
+      // Regular assistant messages that the second while loop should strip
+      { role: "assistant", content: [{ type: "text", text: "Let me wait for results" }] },
+      { role: "assistant", content: [{ type: "text", text: "Still processing" }] },
+      // Aborted + yield interrupt that the first while loop strips
       { role: "assistant", stopReason: "aborted", content: [] },
       { role: "custom", customType: "openclaw.sessions_yield_interrupt" },
     ];
@@ -156,8 +158,49 @@ describe("stripSessionsYieldArtifacts — trailing assistant stripping (#109638)
 
     stripSessionsYieldArtifacts(activeSession);
 
+    // First loop removes yield interrupt + aborted assistant
+    // Second loop removes the two trailing regular assistants
+    expect(activeSession.agent.state.messages).toHaveLength(3);
     const last = activeSession.agent.state.messages.at(-1) as any;
     expect(last.role).toBe("tool_result");
-    expect(last.tool_use_id).toBe("t2");
+    expect(last.tool_use_id).toBe("t1");
+  });
+
+  it("calls sessionManager.removeTrailingEntries with the correct predicate", () => {
+    const messages: any[] = [
+      { role: "user", content: "do something" },
+      { role: "assistant", content: [{ type: "text", text: "thinking" }] },
+      { role: "assistant", stopReason: "aborted", content: [] },
+      { role: "custom", customType: "openclaw.sessions_yield_interrupt" },
+    ];
+
+    const removeTrailingEntries = vi.fn().mockReturnValue(3);
+    const activeSession = {
+      messages: messages.slice(),
+      agent: { state: { messages: messages.slice() } },
+      sessionManager: { removeTrailingEntries },
+    };
+
+    stripSessionsYieldArtifacts(activeSession);
+
+    expect(removeTrailingEntries).toHaveBeenCalledOnce();
+    const [predicate, options] = removeTrailingEntries.mock.calls[0];
+
+    expect(
+      predicate({ type: "message", message: { role: "assistant", stopReason: "aborted" } }),
+    ).toBe(true);
+    expect(
+      predicate({ type: "custom_message", customType: "openclaw.sessions_yield_interrupt" }),
+    ).toBe(true);
+    expect(predicate({ type: "message", message: { role: "assistant" } })).toBe(true);
+    expect(predicate({ type: "message", message: { role: "user" } })).toBe(false);
+    expect(predicate({ type: "tool_result" })).toBe(false);
+
+    expect(options.preserveTrailing({ type: "custom" })).toBe(true);
+    expect(options.preserveTrailing({ type: "label" })).toBe(true);
+    expect(options.preserveTrailing({ type: "session_info" })).toBe(true);
+    expect(options.preserveTrailing({ type: "message", message: { role: "assistant" } })).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #109638.

After `sessions_yield`, `stripSessionsYieldArtifacts()` removes aborted assistant messages and yield interrupt custom messages, but leaves trailing regular assistant messages (from pre-yield tool work) intact. When a sub-agent completes and auto-announce tries to inject a continuation message, it fails because the last visible message is an assistant — causing a deadlock.

## Changes

- **`src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts`**: Added a second while-loop pass in `stripSessionsYieldArtifacts()` that strips any trailing regular assistant messages remaining after the yield-specific artifacts are removed. Updated `removeTrailingEntries` predicate to match.
- **`src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts`**: Added regression test verifying that after stripping a transcript with pre-yield tool work, the last message is a `tool_result` (not an assistant).

## Why this is safe

`stripSessionsYieldArtifacts` is only called inside the yield abort handler (after `waitForSessionsYieldAbortSettle`). It never runs on non-yield sessions. Trailing assistant messages in the yield context are always intermediate tool-calling work — not meaningful final responses.

## Real behavior proof

**Behavior or issue addressed**: After sessions_yield, auto-announce continuation delivery fails with role-continuity error because trailing assistant messages block injection.

**Real environment tested**: Linux x64, Node v24.18.0, vitest

**Exact steps or command run after this patch**: `npx vitest run src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts -t "trailing assistant" --reporter=verbose`

**Evidence after fix**: Test passes in both shards (agents-core 55ms, agents-embedded-agent 43ms). Last message after stripping is confirmed to be tool_result role.

**Observed result after fix**: 2 test files passed, 2 tests passed, 8 skipped (non-matching filter).

**What was not tested**: Full end-to-end yield→announce flow (requires live sub-agent spawn + completion cycle, covered by integration environment).