### PR TITLE
fix(tui): submit slash-command on single Enter for exact arg completion

### DIFF
--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -206,6 +206,28 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
   return commands;
 }
 
+export function shouldSubmitExactArgumentCompletion(
+  input: string,
+  commands: SlashCommand[],
+): boolean {
+  const match = /^\/([^\s]+)\s+(.+)$/u.exec(input);
+  if (!match) {
+    return false;
+  }
+  const [, commandName, argumentText] = match;
+  if (argumentText === undefined) {
+    return false;
+  }
+  const command = commands.find((candidate) => candidate.name === commandName);
+  if (!command?.getArgumentCompletions) {
+    return false;
+  }
+  const completions = command.getArgumentCompletions(argumentText);
+  return (
+    Array.isArray(completions) && completions.length === 1 && completions[0]?.value === argumentText
+  );
+}
+
 export function helpText(options: SlashCommandOptions = {}): string {
   const thinkLevels = formatThinkingLevels(
     options.provider,

--- a/src/tui/components/custom-editor.test.ts
+++ b/src/tui/components/custom-editor.test.ts
@@ -1,8 +1,25 @@
 // Custom editor tests cover TUI editor key handling and cursor behavior.
-import { TUI } from "@earendil-works/pi-tui";
+import { CombinedAutocompleteProvider, TUI } from "@earendil-works/pi-tui";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getSlashCommands, shouldSubmitExactArgumentCompletion } from "../commands.js";
 import { editorTheme } from "../theme/theme.js";
 import { CustomEditor } from "./custom-editor.js";
+
+function createAutocompleteEditor() {
+  const tui = { requestRender: vi.fn() } as unknown as TUI;
+  const editor = new CustomEditor(tui, editorTheme);
+  const commands = getSlashCommands();
+  editor.setAutocompleteProvider(new CombinedAutocompleteProvider(commands, process.cwd()));
+  editor.shouldSubmitAutocomplete = (text) => shouldSubmitExactArgumentCompletion(text, commands);
+  return editor;
+}
+
+async function typeText(editor: CustomEditor, text: string) {
+  for (const character of text) {
+    editor.handleInput(character);
+  }
+  await vi.waitFor(() => expect(editor.isShowingAutocomplete()).toBe(true));
+}
 
 describe("CustomEditor", () => {
   afterEach(() => {
@@ -58,5 +75,40 @@ describe("CustomEditor", () => {
     editor.handleInput("\u001b[214;1:3u");
 
     expect(editor.getText()).toBe("Ö");
+  });
+
+  it("submits an exact sole argument completion with one Enter", async () => {
+    const editor = createAutocompleteEditor();
+    const onSubmit = vi.fn();
+    editor.onSubmit = onSubmit;
+    await typeText(editor, "/think high");
+
+    editor.handleInput("\r");
+
+    expect(onSubmit).toHaveBeenCalledWith("/think high");
+    expect(editor.getText()).toBe("");
+  });
+
+  it("keeps Enter as completion acceptance when multiple arguments match", async () => {
+    const editor = createAutocompleteEditor();
+    const onSubmit = vi.fn();
+    editor.onSubmit = onSubmit;
+    await typeText(editor, "/fast o");
+
+    editor.handleInput("\r");
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(editor.getText()).toBe("/fast on");
+  });
+
+  it("keeps commands without argument completions on one-Enter submit", async () => {
+    const editor = createAutocompleteEditor();
+    const onSubmit = vi.fn();
+    editor.onSubmit = onSubmit;
+    await typeText(editor, "/help");
+
+    editor.handleInput("\r");
+
+    expect(onSubmit).toHaveBeenCalledWith("/help");
   });
 });

--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -1,5 +1,5 @@
 // Custom editor component handles multiline TUI input and key bindings.
-import { Editor, isKeyRelease, Key, matchesKey } from "@earendil-works/pi-tui";
+import { Editor, getKeybindings, isKeyRelease, Key, matchesKey } from "@earendil-works/pi-tui";
 
 // Kitty keyboard protocol uses CSI-u sequences for AltGr on international layouts.
 const KITTY_CSI_U_SUFFIX_REGEX = /^(\d+)(?::(\d*))?(?::(\d+))?(?:;(\d+))?(?::(\d+))?u$/u;
@@ -55,6 +55,7 @@ export class CustomEditor extends Editor {
   onShiftTab?: () => void;
   onAltEnter?: () => void;
   onAltUp?: () => void;
+  shouldSubmitAutocomplete?: (text: string) => boolean;
 
   /** Dispatches TUI shortcuts before falling back to normal editor input handling. */
   override handleInput(data: string): void {
@@ -113,6 +114,22 @@ export class CustomEditor extends Editor {
     if (altGrPrintable !== undefined) {
       super.handleInput(altGrPrintable);
       return;
+    }
+
+    const keybindings = getKeybindings();
+    const cursor = this.getCursor();
+    const lines = this.getLines();
+    const cursorAtEnd =
+      cursor.line === lines.length - 1 && cursor.col === (lines[cursor.line]?.length ?? 0);
+    if (
+      cursorAtEnd &&
+      this.isShowingAutocomplete() &&
+      keybindings.matches(data, "tui.select.confirm") &&
+      keybindings.matches(data, "tui.input.submit") &&
+      this.shouldSubmitAutocomplete?.(this.getText())
+    ) {
+      // Exact argument already present: close the picker so this Enter reaches submit.
+      this.setText(this.getText());
     }
 
     super.handleInput(data);

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -793,9 +793,11 @@ describe.sequential("TUI PTY harness", () => {
   );
 
   it(
-    "shows fast mode status",
+    "submits an exact argument completion with one Enter",
     async () => {
-      await fixture.run.write("/fast status\r", { delay: false });
+      await fixture.run.write("/fast status", { delay: false });
+      await fixture.run.waitForOutput("→ status");
+      await fixture.run.write("\r", { delay: false });
       await fixture.run.waitForOutput("fast mode: off");
     },
     TEST_TIMEOUT_MS,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -34,7 +34,7 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { getSlashCommands } from "./commands.js";
+import { getSlashCommands, shouldSubmitExactArgumentCompletion } from "./commands.js";
 import { ChatLog } from "./components/chat-log.js";
 import { CustomEditor } from "./components/custom-editor.js";
 import { resolveLocalRunShutdownGraceMs } from "./local-run-shutdown.js";
@@ -805,19 +805,19 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
 
   const applyAutocompleteProvider = () => {
     const dynamicKey = resolveDynamicSlashCommandsKey();
+    const slashCommands = getSlashCommands({
+      cfg: config,
+      local: isLocalMode,
+      provider: sessionInfo.modelProvider,
+      model: sessionInfo.model,
+      agentRuntime: sessionInfo.agentRuntime?.id,
+      thinkingLevels: sessionInfo.thinkingLevels,
+      dynamicCommands: dynamicSlashCommandsKey === dynamicKey ? dynamicSlashCommands : [],
+    });
+    editor.shouldSubmitAutocomplete = (text) =>
+      shouldSubmitExactArgumentCompletion(text, slashCommands);
     editor.setAutocompleteProvider(
-      new CombinedAutocompleteProvider(
-        getSlashCommands({
-          cfg: config,
-          local: isLocalMode,
-          provider: sessionInfo.modelProvider,
-          model: sessionInfo.model,
-          agentRuntime: sessionInfo.agentRuntime?.id,
-          thinkingLevels: sessionInfo.thinkingLevels,
-          dynamicCommands: dynamicSlashCommandsKey === dynamicKey ? dynamicSlashCommands : [],
-        }),
-        resolveUsableCwd(),
-      ),
+      new CombinedAutocompleteProvider(slashCommands, resolveUsableCwd()),
     );
   };
 


### PR DESCRIPTION
## What Problem This Solves
In the terminal UI, slash-commands with argument completions (`/think /fast /verbose /trace /reasoning /usage /elevated /activation`) required TWO Enter presses — the first was eaten by the arg-completion picker. Fast typing could also concatenate leftover completion text into a misleading `invalid thinkingLevel` error for a valid value.

## Why This Change Was Made
Added shouldSubmitExactArgumentCompletion: when the typed argument equals the sole completion (e.g. `/think high`), a single Enter submits directly instead of being consumed by the picker. Multi-candidate pickers, completion-less commands, the /models and /agents overlays, the send-while-streaming guard, and ESC/Ctrl+C are unchanged.

## User Impact
`/think high⏎` (and the other arg-completion commands) now submit on one Enter, as expected.

## Evidence
25 focused unit tests + 21 real-PTY tests pass (single Enter → `fast mode: off` etc). git diff --check clean.
