### PR TITLE
fix: restore postpublish verifier typecheck

### DIFF
--- a/scripts/lib/error-format.d.mts
+++ b/scripts/lib/error-format.d.mts
@@ -1,0 +1,1 @@
+export declare function formatErrorMessage(error: unknown): string;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the scripts typecheck fails after the npm postpublish verifier moved to the isolated `error-format.mjs` helper. TypeScript cannot infer that JavaScript module's exported signature without its matching declaration.

## Why This Change Was Made

Adds the standard adjacent `.d.mts` declaration for the existing helper. This preserves the release-tooling isolation introduced by `8858944a81c5` without routing the verifier back through production source.

## User Impact

No product behavior changes. Maintainer CI and postpublish-verifier validation can pass the scripts typecheck again.

## Evidence

- `node scripts/run-vitest.mjs test/openclaw-npm-postpublish-verify.test.ts` — 40 passed.
- `node scripts/check-changed.mjs -- scripts/lib/error-format.d.mts` — passed all script/tooling gates on Testbox: https://github.com/openclaw/openclaw/actions/runs/29566204572
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.

AI-assisted maintainer fix. I reviewed and understand the change.
