### PR TITLE
improve: let Code Mode use declared tool result shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Code Mode output contracts:** let core and plugin tools declare trusted structured-result schemas, surface bounded output hints in Code Mode and Tool Search, and validate catalog results before models transform them. (#109288)
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Code Mode output contracts:** let core and plugin tools declare trusted structured-result schemas, surface bounded output hints in Code Mode and Tool Search, and validate catalog results before models transform them. (#109288)
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-5bab8bc957d81266c1c8cb760ff989e03ca8ce9c4057c990137f0ec2de2f003e  plugin-sdk-api-baseline.json
-c5f6cd4cb5919af53c6d59765aa133740f00ab6002c65761bc3eedabc6c3ba70  plugin-sdk-api-baseline.jsonl
+dc2bf410e15972389b8e60d772f92731130148845dff24294fae4786d3b9f41a  plugin-sdk-api-baseline.json
+ce076f7e71bb1ffbd0eead42a178dd069e15693348c4fd69b2ed291d51a8fcd7  plugin-sdk-api-baseline.jsonl

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -165,6 +165,10 @@
       "destination": "/plugins/adding-capabilities"
     },
     {
+      "source": "/reference/code-mode",
+      "destination": "/tools/code-mode"
+    },
+    {
       "source": "/brave-search",
       "destination": "/tools/brave-search"
     },
@@ -1356,6 +1360,7 @@
                   "tools/apply-patch",
                   "tools/btw",
                   "tools/code-execution",
+                  "tools/code-mode",
                   "tools/diffs",
                   "tools/show-widget",
                   "tools/elevated",
@@ -1870,7 +1875,6 @@
                 "pages": [
                   "reference/rpc",
                   "gateway/external-apps",
-                  "reference/code-mode",
                   "reference/device-models"
                 ]
               },

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7541,6 +7541,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Write a tool
   - H2: Optional and factory tools
   - H2: Return values
+  - H2: Output contracts
   - H2: Configuration
   - H2: Generated metadata
   - H2: Package metadata
@@ -8623,48 +8624,6 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Skills (third-party APIs)
   - H2: Related
 
-## reference/code-mode.md
-
-- Route: /reference/code-mode
-- Headings:
-  - H2: What it does
-  - H2: Why use it
-  - H2: Enable it
-  - H2: Technical tour
-  - H2: Runtime status
-  - H2: Scope
-  - H2: Terms
-  - H2: Configuration
-  - H2: Activation
-  - H2: Model-visible tools
-  - H2: exec
-  - H2: wait
-  - H2: Guest runtime API
-  - H2: Internal namespaces
-  - H3: Registry lifecycle
-  - H3: Registration shape
-  - H3: Ownership and visibility
-  - H3: Scope serialization rules
-  - H3: Prompts
-  - H3: Cleanup
-  - H3: Test checklist
-  - H2: Output API
-  - H2: Tool catalog
-  - H2: Tool Search interaction
-  - H2: Tool names and collisions
-  - H2: Nested tool execution
-  - H2: Run and snapshot lifecycle
-  - H2: QuickJS-WASI runtime
-  - H2: TypeScript
-  - H2: Security boundary
-  - H2: Error codes
-  - H2: Telemetry
-  - H2: Debugging
-  - H2: Implementation layout
-  - H2: Validation checklist
-  - H2: E2E test plan
-  - H2: Related
-
 ## reference/credits.md
 
 - Route: /reference/credits
@@ -9672,6 +9631,52 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Setup
   - H2: How to use it
   - H2: Errors
+  - H2: Related
+
+## tools/code-mode.md
+
+- Route: /tools/code-mode
+- Headings:
+  - H2: What it does
+  - H2: Why use it
+  - H2: Quickstart
+  - H3: Enable Code Mode
+  - H3: What the model does
+  - H3: Verify the active surface
+  - H2: Technical tour
+  - H2: Runtime status
+  - H2: Scope
+  - H2: Terms
+  - H2: Configuration
+  - H2: Activation
+  - H2: Model-visible tools
+  - H2: exec
+  - H2: wait
+  - H2: Guest runtime API
+  - H2: Declared output contracts
+  - H2: Internal namespaces
+  - H3: Registry lifecycle
+  - H3: Registration shape
+  - H3: Ownership and visibility
+  - H3: Scope serialization rules
+  - H3: Prompts
+  - H3: Cleanup
+  - H3: Test checklist
+  - H2: Output API
+  - H2: Tool catalog
+  - H2: Tool Search interaction
+  - H2: Tool names and collisions
+  - H2: Nested tool execution
+  - H2: Run and snapshot lifecycle
+  - H2: QuickJS-WASI runtime
+  - H2: TypeScript
+  - H2: Security boundary
+  - H2: Error codes
+  - H2: Telemetry
+  - H2: Debugging
+  - H2: Implementation layout
+  - H2: Validation checklist
+  - H2: E2E test plan
   - H2: Related
 
 ## tools/creating-skills.md

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -111,7 +111,7 @@ The shorthand is also accepted:
 MCP declarations are exposed through the read-only virtual API file surface in
 code mode. Guest code can call `API.list("mcp")` and
 `API.read("mcp/<server>.d.ts")` to inspect TypeScript-style signatures before
-calling `MCP.<server>.<tool>()`. See [Code mode](/reference/code-mode) for the
+calling `MCP.<server>.<tool>()`. See [Code Mode](/tools/code-mode) for the
 runtime contract, limits, and debugging steps.
 
 ### `tools.allow` / `tools.deny`

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -107,7 +107,7 @@ approval), the session is not blindly re-run; the agent instead posts a short
 notice asking the user to resend the last request. For WebChat, that notice is
 written directly to the session history so it remains visible after reconnect.
 
-OpenClaw can also reconstruct interrupted read-only [Code Mode](/reference/code-mode)
+OpenClaw can also reconstruct interrupted read-only [Code Mode](/tools/code-mode)
 work. Code Mode marks these runs as restart-safe and rejects side-effecting
 catalog tools or plugin namespaces before they execute. If a restart lands on
 the `wait` control, the new gateway reconstructs the turn from its transcript

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -137,9 +137,15 @@ local proof.
           name: "my_tool",
           description: "Echo one input value",
           parameters: Type.Object({ input: Type.String() }),
+          outputSchema: Type.Object(
+            { input: Type.String() },
+            { additionalProperties: false },
+          ),
           async execute(_id, params) {
+            const details = { input: params.input };
             return {
               content: [{ type: "text", text: `Got: ${params.input}` }],
+              details,
             };
           },
         });
@@ -247,14 +253,27 @@ register(api) {
       name: "workflow_tool",
       description: "Run a workflow",
       parameters: Type.Object({ pipeline: Type.String() }),
+      outputSchema: Type.Object(
+        { pipeline: Type.String() },
+        { additionalProperties: false },
+      ),
       async execute(_id, params) {
-        return { content: [{ type: "text", text: params.pipeline }] };
+        return {
+          content: [{ type: "text", text: params.pipeline }],
+          details: { pipeline: params.pipeline },
+        };
       },
     },
     { optional: true },
   );
 }
 ```
+
+`outputSchema` is optional. It describes the structured `details` value used by
+[Code Mode](/tools/code-mode) and [Tool Search](/tools/tool-search). Catalog
+calls reject invalid schemas before execution and validate the final value after
+tool hooks. Omit it for tools without a stable JSON result. See
+[Tool plugins](/plugins/tool-plugins#output-contracts) for the full contract.
 
 Every tool registered with `api.registerTool(...)` must also be declared in the
 plugin manifest:

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -45,7 +45,7 @@ execution environment, OpenClaw keeps its policy-filtered `exec` and `process`
 tools available instead for direct, unsandboxed execution.
 
 This Codex-native feature is separate from
-[OpenClaw code mode](/reference/code-mode), an opt-in QuickJS-WASI runtime
+[OpenClaw Code Mode](/tools/code-mode), an opt-in QuickJS-WASI runtime
 for generic OpenClaw runs with a different `exec` input shape. For the
 broader model/provider/runtime split, start with
 [Agent runtimes](/concepts/agent-runtimes): `openai/gpt-5.6-sol` is the model

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -80,6 +80,13 @@ export default defineToolPlugin({
       parameters: Type.Object({
         symbol: Type.String({ description: "Ticker symbol." }),
       }),
+      outputSchema: Type.Object(
+        {
+          symbol: Type.String(),
+          hasKey: Type.Boolean(),
+        },
+        { additionalProperties: false },
+      ),
       execute: async ({ symbol }, config) => ({ symbol, hasKey: Boolean(config.apiKey) }),
     }),
   ],
@@ -91,6 +98,9 @@ export default defineToolPlugin({
 - `execute` returns a plain string or JSON-serializable value; the helper
   wraps it as a text tool result with `details` set to the original
   (unstringified) return value.
+- `outputSchema` optionally describes that original `details` value for Code
+  Mode and Tool Search. Catalog calls reject an invalid schema before execution
+  and validate the final value before returning it.
 - For custom tool results, `openclaw/plugin-sdk/tool-results` exports
   `textResult` and `jsonResult`.
 - Tool names are static, so `openclaw plugins build` derives

--- a/docs/plugins/tool-plugins.md
+++ b/docs/plugins/tool-plugins.md
@@ -94,6 +94,14 @@ export default defineToolPlugin({
       parameters: Type.Object({
         symbol: Type.String({ description: "Ticker symbol, for example OPEN." }),
       }),
+      outputSchema: Type.Object(
+        {
+          symbol: Type.String(),
+          configured: Type.Boolean(),
+          baseUrl: Type.String(),
+        },
+        { additionalProperties: false },
+      ),
       async execute({ symbol }, config, context) {
         context.signal?.throwIfAborted();
         return {
@@ -184,6 +192,54 @@ tool({
 
 Use a factory tool when you need a custom `AgentToolResult` or want to reuse an
 existing `api.registerTool` implementation.
+
+## Output contracts
+
+Add `outputSchema` when a tool returns stable JSON-compatible data. It describes
+the original value stored in `AgentToolResult.details`, not the formatted text
+in `content`:
+
+```typescript
+tool({
+  name: "shipment_list",
+  description: "List shipments.",
+  parameters: Type.Object({
+    buyer: Type.Optional(Type.String()),
+  }),
+  outputSchema: Type.Array(
+    Type.Object(
+      {
+        id: Type.String(),
+        buyer: Type.String(),
+        paid: Type.Boolean(),
+        tons: Type.Number(),
+      },
+      { additionalProperties: false },
+    ),
+  ),
+  execute: ({ buyer }) => listShipments(buyer),
+});
+```
+
+[Code Mode](/tools/code-mode) and [Tool Search](/tools/tool-search) turn this
+schema into a bounded TypeScript-style output hint. That lets a model call and
+transform a known result in one program instead of spending another model turn
+observing its shape.
+
+OpenClaw compiles the schema before executing a catalog call, then validates the
+final `details` value after tool hooks before returning it through the bridge.
+An invalid schema cannot run the tool; a result mismatch fails the completed
+call. Include every non-throwing result variant, including structured error
+variants, or omit the schema when the result is not stable. Do not put secrets
+or sensitive values in schema descriptions because trusted output metadata can
+become model-visible.
+Use `{ additionalProperties: false }` on object layers when you want a complete
+compact output hint; open or truncated schemas remain available through
+`tools.describe(...)` but are not advertised as complete quick-index contracts.
+
+Factory tools declare `outputSchema` on the concrete `AnyAgentTool` they
+return. The static `tool({ factory })` declaration does not accept a separate
+output schema because it could drift from the runtime tool.
 
 ## Configuration
 

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -1,10 +1,10 @@
 ---
-summary: "OpenClaw code mode: an opt-in compact tool surface backed by QuickJS-WASI and a hidden run-scoped tool catalog"
-title: "Code mode"
-sidebarTitle: "Code mode"
+summary: "Use OpenClaw Code Mode to discover, call, and combine large tool catalogs in compact JavaScript or TypeScript workflows"
+title: "Code Mode"
+sidebarTitle: "Code Mode"
 read_when:
   - You want to enable OpenClaw code mode for an agent run
-  - You need to explain why code mode is different from Codex Code mode
+  - You need to explain why Code Mode is different from Codex Code Mode
   - You are reviewing the compact tool contract, QuickJS-WASI sandbox, TypeScript transform, or hidden tool-catalog bridge
   - You are adding or reviewing an internal code-mode namespace registry integration
 ---
@@ -22,7 +22,8 @@ separate implementations:
 - Codex Code Mode runs inside the Codex coding harness. Its `exec` tool is a
   freeform-grammar tool: the model writes raw JavaScript source (optionally
   prefixed by a `// @exec: {...}` pragma line for execution options), executed
-  in a Deno/V8 runtime.
+  in Codex's V8 Code Mode runtime, either in-process or in a standalone host
+  depending on Codex configuration.
 - OpenClaw code mode runs in the generic OpenClaw agent runtime and is
   disabled unless `tools.codeMode.enabled: true` is configured. Its `exec`
   tool takes a JSON `{ code, language }` payload, executed in a QuickJS-WASI
@@ -43,8 +44,9 @@ identically-named `exec`/`wait` tools.
   standalone model tool and exposed inside the guest program through `ALL_TOOLS`
   and `tools`.
 - The `exec` description carries a bounded quick index of exact OpenClaw/plugin
-  catalog ids and compact input hints. It omits descriptions, full schemas, MCP
-  entries, and overflow entries; guest-side catalog lookup remains the fallback.
+  catalog ids, compact input hints, and compact declared output hints when a
+  trusted tool provides an output schema. It omits descriptions, full schemas,
+  MCP entries, and overflow entries; guest-side catalog lookup remains the fallback.
 - Guest code searches the hidden catalog, describes a tool's schema, and calls
   a tool through the same execution path used by normal agent turns (policy,
   approvals, hooks, telemetry all still apply).
@@ -64,6 +66,8 @@ behavior, or model selection.
   of full tool schemas.
 - Better orchestration: the model can use loops, joins, small transforms,
   conditional logic, and parallel nested tool calls inside one code cell.
+- Fewer model round trips: a declared output contract lets the model call and
+  transform a tool result in one `exec`; unknown outputs remain raw-first.
 - Provider neutral: works for OpenClaw, plugin, MCP, and client tools without
   depending on provider-native code execution.
 - Fails closed: if code mode is enabled but the QuickJS-WASI runtime is
@@ -73,7 +77,14 @@ behavior, or model selection.
 Most useful for agents with a large enabled tool catalog, or workflows where
 the model needs to search, combine, and call several tools before answering.
 
-## Enable it
+Keep direct tool exposure for a small catalog or a model that does not reliably
+write short programs. Use [Tool Search](/tools/tool-search) when you want a
+compact catalog but prefer structured search/describe/call controls instead of
+the QuickJS-WASI guest.
+
+## Quickstart
+
+### Enable Code Mode
 
 ```json5
 {
@@ -122,6 +133,25 @@ Set explicit limits for tighter bounds:
   },
 }
 ```
+
+### What the model does
+
+For a tool with a declared output such as
+`Array<{ id: string; paid: boolean; tons: number }>`, one guest program can
+select, call, and transform it:
+
+```javascript
+const [shipmentTool] = await tools.search("list shipments");
+const shipments = await tools.callValue(shipmentTool.id, {});
+return shipments.filter((shipment) => !shipment.paid && shipment.tons > 10);
+```
+
+When a quick-index line ends in `-> ?`, the output shape is unknown. The first
+`exec` must return `await tools.callValue(...)` unchanged. A later `exec` can
+transform the observed value. This costs an extra model turn, but prevents the
+model from guessing field names.
+
+### Verify the active surface
 
 To confirm the model payload shape while debugging, run the Gateway with
 targeted logging:
@@ -378,19 +408,17 @@ declare function json(value: unknown): void;
 declare function yield_control(reason?: string): Promise<void>;
 ```
 
-`ALL_TOOLS` is compact metadata for the run-scoped catalog; it does not
-contain full schemas by default. The model-visible `exec` description also
-includes a bounded, deterministic subset of exact OpenClaw/plugin ids and
-compact input hints so common calls can start without a separate catalog
-discovery turn. Descriptions remain deferred so adversarial catalog prose cannot
-steer the model. When that index omits a tool, read `ALL_TOOLS` or call
-`tools.search(...)` inside the guest program.
+`ALL_TOOLS` is compact metadata for the run-scoped catalog; it does not contain
+full schemas by default. The model-visible `exec` description also includes a
+bounded, deterministic subset of exact OpenClaw/plugin ids, compact input
+hints, and trusted declared output hints. Descriptions remain deferred so
+adversarial catalog prose cannot steer the model. When that index omits a tool,
+read `ALL_TOOLS` or call `tools.search(...)` inside the guest program.
 
-Compact entries describe tool inputs, not result schemas, so the index marks
-their result shape as `-> ?` (output unknown). When a workflow needs result
-fields, the first `exec` must return the raw
-`tools.callValue(...)` result unchanged. Filter or map the observed shape only
-in a later `exec` call instead of guessing field names.
+The arrow in each quick-index line describes the `tools.callValue(...)` value.
+`-> Array<{ id: string }>` is a declared output hint; `-> ?` is output unknown.
+Unknown outputs stay raw-first: return the value unchanged, observe it, then
+filter or map it in a later `exec` instead of guessing field names.
 
 ```typescript
 type ToolCatalogEntry = {
@@ -401,11 +429,15 @@ type ToolCatalogEntry = {
   source: "openclaw" | "mcp" | "client";
   sourceName?: string;
   input: string;
+  output?: string;
 };
 ```
 
 `input` is a bounded TypeScript-style signature for the common case. Use
-`tools.describe(...)` when the exact full schema is still needed.
+`tools.describe(...)` when the exact full schema is still needed. `output` is
+present only for a complete compact hint derived from a trusted OpenClaw core
+or plugin `outputSchema`. MCP and client output-schema claims are not promoted
+into this trusted catalog hint.
 
 Plugin tools use `source: "openclaw"` with `sourceName` set to the owning
 plugin id; there is no separate `"plugin"` source value. `source: "mcp"` is
@@ -417,6 +449,7 @@ Full schema is loaded only on demand:
 ```typescript
 type ToolCatalogEntryWithSchema = ToolCatalogEntry & {
   parameters: unknown;
+  outputSchema?: unknown;
 };
 ```
 
@@ -446,6 +479,69 @@ const hits = await tools.web_search({ query: "OpenClaw code mode" });
 `tools.callValue(...)` returns a normal tool's JSON `details` value directly.
 `tools.call(...)` preserves the raw `{ tool, result }` envelope for callers
 that need content blocks or other result metadata.
+
+## Declared output contracts
+
+OpenClaw tools can declare `outputSchema` for the structured value placed in
+`AgentToolResult.details`. This is useful for Code Mode and Tool Search; it is
+not a provider-native tool response schema and does not change direct tool
+exposure.
+
+For a tool made with `defineToolPlugin`, declare the schema beside
+`parameters`:
+
+```typescript
+import { Type } from "typebox";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+
+const Shipment = Type.Object(
+  {
+    id: Type.String(),
+    paid: Type.Boolean(),
+    tons: Type.Number(),
+  },
+  { additionalProperties: false },
+);
+
+export default defineToolPlugin({
+  id: "shipping",
+  name: "Shipping",
+  description: "Shipment tools.",
+  tools: (tool) => [
+    tool({
+      name: "shipping_list",
+      description: "List shipments.",
+      parameters: Type.Object({}),
+      outputSchema: Type.Array(Shipment),
+      execute: async () => loadShipments(),
+    }),
+  ],
+});
+```
+
+For `api.registerTool(...)` or a factory tool, put the same `outputSchema`
+property on the returned `AnyAgentTool` object.
+
+The contract rules are strict:
+
+- Describe the exact JSON-compatible `details` value, not rendered `content`
+  blocks or a provider envelope.
+- Include every non-throwing success or error variant. Omit `outputSchema` when
+  the tool has no stable structured result.
+- Close object layers with `{ additionalProperties: false }` for a complete
+  quick-index hint. Open, oversized, or otherwise partial schemas stay
+  available through `tools.describe(...)` but do not enable one-turn field use.
+- OpenClaw compiles the schema before running the tool, then validates final
+  `details` after normal tool hooks and before a catalog call returns. An
+  invalid schema cannot run the tool; a mismatch fails without printing the
+  value.
+- Compact hints are deterministic and bounded. `tools.describe(...)` exposes
+  the full trusted schema when the compact hint is insufficient.
+- Installed plugin code is already trusted local code. Remote MCP and client
+  metadata remains untrusted and cannot opt into these quick-index hints.
+
+See [Tool plugins](/plugins/tool-plugins#output-contracts) for plugin authoring
+details.
 
 MCP catalog entries are not callable through `tools.callValue(...)`,
 `tools.call(...)`, or convenience functions in code mode; they are exposed

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -434,7 +434,9 @@ type ToolCatalogEntry = {
 ```
 
 `input` is a bounded TypeScript-style signature for the common case. Use
-`tools.describe(...)` when the exact full schema is still needed. `output` is
+`tools.describe(...)` when the exact full schema is still needed. Remote MCP
+and client entries use `input: "unknown"` so their untrusted schemas stay
+deferred until `describe`. `output` is
 present only for a complete compact hint derived from a trusted OpenClaw core
 or plugin `outputSchema`. MCP and client output-schema claims are not promoted
 into this trusted catalog hint.

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -22,8 +22,7 @@ separate implementations:
 - Codex Code Mode runs inside the Codex coding harness. Its `exec` tool is a
   freeform-grammar tool: the model writes raw JavaScript source (optionally
   prefixed by a `// @exec: {...}` pragma line for execution options), executed
-  in Codex's V8 Code Mode runtime, either in-process or in a standalone host
-  depending on Codex configuration.
+  in Codex's in-process V8 Code Mode runtime.
 - OpenClaw code mode runs in the generic OpenClaw agent runtime and is
   disabled unless `tools.codeMode.enabled: true` is configured. Its `exec`
   tool takes a JSON `{ code, language }` payload, executed in a QuickJS-WASI

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -22,15 +22,16 @@ group membership, provider restrictions, and configuration fields, use
 For most agents, start with the built-in tool categories, then adjust policy
 only when the agent should see fewer tools or needs explicit host access.
 
-| If you need to...                           | Use this first                                 | Then read                                                                                                                                              |
-| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Let an agent act with existing capabilities | [Built-in tools](#built-in-tool-categories)    | [Tool categories](#built-in-tool-categories)                                                                                                           |
-| Control what an agent can call              | [Tool policy](#configure-access-and-approvals) | [Tools and custom providers](/gateway/config-tools)                                                                                                    |
-| Teach an agent a workflow                   | [Skills](#choose-tools-skills-or-plugins)      | [Skills](/tools/skills), [Creating skills](/tools/creating-skills), [Skill Workshop](/tools/skill-workshop), and [Self-learning](/tools/self-learning) |
-| Add a new integration or runtime surface    | [Plugins](#extend-capabilities)                | [Plugins](/tools/plugin) and [Build plugins](/plugins/building-plugins)                                                                                |
-| Run work later or in the background         | [Automation](/automation)                      | [Automation overview](/automation)                                                                                                                     |
-| Coordinate multiple agents or harnesses     | [Sub-agents](/tools/subagents)                 | [ACP agents](/tools/acp-agents) and [Agent send](/tools/agent-send)                                                                                    |
-| Search a large OpenClaw tool catalog        | [Tool Search](/tools/tool-search)              | [Tool Search](/tools/tool-search)                                                                                                                      |
+| If you need to...                            | Use this first                                 | Then read                                                                                                                                              |
+| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Let an agent act with existing capabilities  | [Built-in tools](#built-in-tool-categories)    | [Tool categories](#built-in-tool-categories)                                                                                                           |
+| Control what an agent can call               | [Tool policy](#configure-access-and-approvals) | [Tools and custom providers](/gateway/config-tools)                                                                                                    |
+| Teach an agent a workflow                    | [Skills](#choose-tools-skills-or-plugins)      | [Skills](/tools/skills), [Creating skills](/tools/creating-skills), [Skill Workshop](/tools/skill-workshop), and [Self-learning](/tools/self-learning) |
+| Add a new integration or runtime surface     | [Plugins](#extend-capabilities)                | [Plugins](/tools/plugin) and [Build plugins](/plugins/building-plugins)                                                                                |
+| Run work later or in the background          | [Automation](/automation)                      | [Automation overview](/automation)                                                                                                                     |
+| Coordinate multiple agents or harnesses      | [Sub-agents](/tools/subagents)                 | [ACP agents](/tools/acp-agents) and [Agent send](/tools/agent-send)                                                                                    |
+| Search a large OpenClaw tool catalog         | [Tool Search](/tools/tool-search)              | [Tool Search](/tools/tool-search)                                                                                                                      |
+| Combine several tools in one compact program | [Code Mode](/tools/code-mode)                  | [Code Mode](/tools/code-mode)                                                                                                                          |
 
 ## Choose tools, skills, or plugins
 
@@ -80,23 +81,23 @@ The table lists representative tools so you can recognize the surface. It is
 not the full policy reference. For exact groups, defaults, and allow/deny
 semantics, use [Tools and custom providers](/gateway/config-tools).
 
-| Category                | Use when the agent needs to...                                                | Representative tools                                                                                 | Read next                                                                                                              |
-| ----------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Runtime                 | Run commands, manage processes, or use provider-backed Python analysis        | `exec`, `process`, `terminal`, `code_execution`                                                      | [Exec](/tools/exec), [Control UI terminal](/web/control-ui#operator-terminal), [Code execution](/tools/code-execution) |
-| Files                   | Read and change workspace files                                               | `read`, `write`, `edit`, `apply_patch`                                                               | [Apply patch](/tools/apply-patch)                                                                                      |
-| Web                     | Search the web, search X posts, or fetch readable page content                | `web_search`, `x_search`, `web_fetch`                                                                | [Web tools](/tools/web), [Web fetch](/tools/web-fetch)                                                                 |
-| Browser                 | Operate a browser session                                                     | `browser`                                                                                            | [Browser](/tools/browser)                                                                                              |
-| Messaging and channels  | Send replies or channel actions                                               | `message`                                                                                            | [Agent send](/tools/agent-send)                                                                                        |
-| Sessions and agents     | Inspect sessions, delegate work, steer another run, or report status          | `sessions_*`, `subagents`, `agents_list`, `session_status`, `get_goal`, `create_goal`, `update_goal` | [Goal](/tools/goal), [Sub-agents](/tools/subagents), [Session tool](/concepts/session-tool)                            |
-| Automation              | Schedule work or respond to background events                                 | `cron`, `heartbeat_respond`                                                                          | [Automation](/automation)                                                                                              |
-| Gateway and nodes       | Inspect Gateway state or paired target devices                                | `gateway`, `nodes`                                                                                   | [Gateway configuration](/gateway/configuration), [Nodes](/nodes)                                                       |
-| Media                   | Analyze, generate, or speak media                                             | `image`, `image_generate`, `music_generate`, `video_generate`, `tts`                                 | [Media overview](/tools/media-overview)                                                                                |
-| Large OpenClaw catalogs | Search and call many eligible tools without sending every schema to the model | `tool_search_code`, `tool_search`, `tool_describe`                                                   | [Tool Search](/tools/tool-search)                                                                                      |
+| Category                | Use when the agent needs to...                                                          | Representative tools                                                                                 | Read next                                                                                                              |
+| ----------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Runtime                 | Run commands, manage processes, or use provider-backed Python analysis                  | `exec`, `process`, `terminal`, `code_execution`                                                      | [Exec](/tools/exec), [Control UI terminal](/web/control-ui#operator-terminal), [Code execution](/tools/code-execution) |
+| Files                   | Read and change workspace files                                                         | `read`, `write`, `edit`, `apply_patch`                                                               | [Apply patch](/tools/apply-patch)                                                                                      |
+| Web                     | Search the web, search X posts, or fetch readable page content                          | `web_search`, `x_search`, `web_fetch`                                                                | [Web tools](/tools/web), [Web fetch](/tools/web-fetch)                                                                 |
+| Browser                 | Operate a browser session                                                               | `browser`                                                                                            | [Browser](/tools/browser)                                                                                              |
+| Messaging and channels  | Send replies or channel actions                                                         | `message`                                                                                            | [Agent send](/tools/agent-send)                                                                                        |
+| Sessions and agents     | Inspect sessions, delegate work, steer another run, or report status                    | `sessions_*`, `subagents`, `agents_list`, `session_status`, `get_goal`, `create_goal`, `update_goal` | [Goal](/tools/goal), [Sub-agents](/tools/subagents), [Session tool](/concepts/session-tool)                            |
+| Automation              | Schedule work or respond to background events                                           | `cron`, `heartbeat_respond`                                                                          | [Automation](/automation)                                                                                              |
+| Gateway and nodes       | Inspect Gateway state or paired target devices                                          | `gateway`, `nodes`                                                                                   | [Gateway configuration](/gateway/configuration), [Nodes](/nodes)                                                       |
+| Media                   | Analyze, generate, or speak media                                                       | `image`, `image_generate`, `music_generate`, `video_generate`, `tts`                                 | [Media overview](/tools/media-overview)                                                                                |
+| Large OpenClaw catalogs | Search, call, and combine many eligible tools without sending every schema to the model | `exec`, `wait`, `tool_search_code`, `tool_search`, `tool_describe`                                   | [Code Mode](/tools/code-mode), [Tool Search](/tools/tool-search)                                                       |
 
 <Note>
-Tool Search is an experimental OpenClaw agent surface. Codex harness runs use
-Codex-native code mode, native tool search, deferred dynamic tools, and
-nested tool calls instead of `tools.toolSearch`.
+Code Mode and Tool Search are experimental OpenClaw agent surfaces. Codex
+harness runs use Codex-native code mode, native tool search, deferred dynamic
+tools, and nested tool calls instead of `tools.codeMode` or `tools.toolSearch`.
 </Note>
 
 ## Plugin-provided tools
@@ -170,7 +171,7 @@ the current turn:
 5. For delegated runs, check per-agent restrictions in
    [Per-agent sandbox and tool restrictions](/tools/multi-agent-sandbox-tools).
 6. For large OpenClaw catalogs, confirm whether the run uses direct tool
-   exposure or [Tool Search](/tools/tool-search).
+   exposure, [Code Mode](/tools/code-mode), or [Tool Search](/tools/tool-search).
 
 ## Related
 
@@ -187,3 +188,5 @@ the current turn:
   creation
 - [Tool Search](/tools/tool-search) for compact OpenClaw tool catalog
   discovery
+- [Code Mode](/tools/code-mode) for compact JavaScript or TypeScript workflows
+  over a hidden OpenClaw tool catalog

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -126,8 +126,10 @@ to put back into prompt context. Each hit includes a bounded TypeScript-style
 model can skip `describe` when that signature is sufficient. A trusted
 OpenClaw core or plugin tool may also include a compact `output` hint, such as
 `Array<{ id: string; paid: boolean }>`. MCP and client output-schema claims are
-not promoted into this trusted hint. Open, oversized, or otherwise partial
-output schemas omit the hint and remain available through `describe` instead.
+not promoted into this trusted hint. Their untrusted input schemas are also
+deferred as `input: "unknown"`; use `describe` before calling them. Open,
+oversized, or otherwise partial output schemas omit the hint and remain
+available through `describe` instead.
 
 ```js
 const hits = await openclaw.tools.search("calendar event", { limit: 5 });

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -16,6 +16,9 @@ search or dynamic-tools surface. Codex-native code mode, tool search, deferred
 dynamic tools, and nested tool calls are stable Codex harness surfaces and do
 not depend on `tools.toolSearch`.
 
+For the generic OpenClaw runtime that exposes a QuickJS-WASI `exec`/`wait`
+surface instead of Tool Search controls, see [Code Mode](/tools/code-mode).
+
 When enabled for OpenClaw runs, the model receives one `tool_search_code` tool
 by default, plus any direct-only tools whose structured results cannot cross
 the compact bridge. The code tool runs a short JavaScript body in an isolated
@@ -120,7 +123,11 @@ client-provided app tools.
 Searches the effective catalog for the current run. Results are compact and safe
 to put back into prompt context. Each hit includes a bounded TypeScript-style
 `input` signature, such as `{ id: string; mode?: "drip" | "flood" }`, so the
-model can skip `describe` when that signature is sufficient.
+model can skip `describe` when that signature is sufficient. A trusted
+OpenClaw core or plugin tool may also include a compact `output` hint, such as
+`Array<{ id: string; paid: boolean }>`. MCP and client output-schema claims are
+not promoted into this trusted hint. Open, oversized, or otherwise partial
+output schemas omit the hint and remain available through `describe` instead.
 
 ```js
 const hits = await openclaw.tools.search("calendar event", { limit: 5 });
@@ -128,7 +135,8 @@ const hits = await openclaw.tools.search("calendar event", { limit: 5 });
 
 `openclaw.tools.describe(id)`
 
-Loads full metadata for one search result, including the exact input schema.
+Loads full metadata for one search result, including the exact input schema and
+the trusted full `outputSchema` when the tool declares one.
 
 ```js
 const calendarCreate = await openclaw.tools.describe("mcp:calendar:create_event");
@@ -138,7 +146,9 @@ const calendarCreate = await openclaw.tools.describe("mcp:calendar:create_event"
 
 Calls a selected tool through OpenClaw and returns the raw `{ tool, result }`
 envelope. JSON-returning tools normally place their value in
-`result.details`.
+`result.details`. If a trusted tool declares `outputSchema`, OpenClaw compiles
+the schema before execution and validates final `details` after normal tool
+hooks before returning the catalog call.
 
 ```js
 await openclaw.tools.call(calendarCreate.id, {
@@ -146,6 +156,12 @@ await openclaw.tools.call(calendarCreate.id, {
   start: "2026-05-09T14:00:00Z",
 });
 ```
+
+Tool authors declare output contracts on the tool's `outputSchema` property.
+It describes `AgentToolResult.details`, not rendered content blocks. Include
+all non-throwing variants or omit it for unstable results. See
+[Code Mode output contracts](/tools/code-mode#declared-output-contracts) and
+[Tool plugins](/plugins/tool-plugins#output-contracts).
 
 The structured fallback mode exposes the same operations as tools:
 

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -462,6 +462,8 @@ export interface AgentTool<
 > extends Tool<TParameters> {
   /** Human-readable label for UI display. */
   label: string;
+  /** Optional schema for the structured `AgentToolResult.details` value. */
+  outputSchema?: TSchema;
   /** Preserve lifecycle telemetry without rendering transient channel progress. */
   hideFromChannelProgress?: boolean;
   /**

--- a/scripts/repro/tool-surface-live-bench.ts
+++ b/scripts/repro/tool-surface-live-bench.ts
@@ -3,7 +3,7 @@
 // Tool Search (code/tools), and Code Mode, over a decoy-heavy catalog.
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
-import { Type } from "typebox";
+import { Type, type TSchema } from "typebox";
 import type { Model } from "../../packages/agent-core/src/llm.js";
 import type { AgentEvent, AgentTool } from "../../packages/agent-core/src/types.js";
 import { applyCodeModeCatalog, createCodeModeTools } from "../../src/agents/code-mode.js";
@@ -53,6 +53,47 @@ const PROVIDERS: Record<
 type Plot = { id: string; crop: string; hectares: number; irrigation: string; yieldScore: number };
 type Sensor = { id: string; plotId: string; kind: string; battery: number; alert: boolean };
 type Shipment = { id: string; plotId: string; buyer: string; tons: number; paid: boolean };
+
+const PlotOutputSchema = Type.Object(
+  {
+    id: Type.String(),
+    crop: Type.String(),
+    hectares: Type.Number(),
+    irrigation: Type.String(),
+    yieldScore: Type.Number(),
+  },
+  { additionalProperties: false },
+);
+const SensorOutputSchema = Type.Object(
+  {
+    id: Type.String(),
+    plotId: Type.String(),
+    kind: Type.String(),
+    battery: Type.Number(),
+    alert: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+const ShipmentOutputSchema = Type.Object(
+  {
+    id: Type.String(),
+    plotId: Type.String(),
+    buyer: Type.String(),
+    tons: Type.Number(),
+    paid: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+const IrrigationUpdateOutputSchema = Type.Union([
+  Type.Object(
+    { ok: Type.Literal(true), id: Type.String(), mode: Type.String() },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    { ok: Type.Literal(false), error: Type.String(), id: Type.String() },
+    { additionalProperties: false },
+  ),
+]);
 
 function createOrchardService() {
   const plots: Plot[] = [
@@ -147,12 +188,14 @@ function makeTool(
   description: string,
   properties: Parameters<typeof Type.Object>[0],
   execute: (params: Record<string, unknown>) => unknown,
+  outputSchema?: TSchema,
 ): AnyAgentTool {
   const tool = {
     name,
     label: name,
     description,
     parameters: Type.Object(properties),
+    ...(outputSchema ? { outputSchema } : {}),
     execute: async (_toolCallId: string, params: unknown) =>
       jsonResult(
         await execute(
@@ -172,6 +215,7 @@ function createOrchardTools(service: OrchardService): AnyAgentTool[] {
       "List orchard plots with crop, hectares, irrigation mode, and yield score.",
       {},
       () => service.listPlots(),
+      Type.Array(PlotOutputSchema),
     ),
     makeTool(
       PLUGIN_ID,
@@ -179,6 +223,7 @@ function createOrchardTools(service: OrchardService): AnyAgentTool[] {
       "Get one orchard plot by id.",
       { id: Type.String() },
       (params) => service.getPlot(stringParam(params, "id")),
+      Type.Union([PlotOutputSchema, Type.Null()]),
     ),
     makeTool(
       PLUGIN_ID,
@@ -187,6 +232,7 @@ function createOrchardTools(service: OrchardService): AnyAgentTool[] {
       { plotId: Type.Optional(Type.String()) },
       (params) =>
         service.listSensors(typeof params.plotId === "string" ? params.plotId : undefined),
+      Type.Array(SensorOutputSchema),
     ),
     makeTool(
       PLUGIN_ID,
@@ -195,6 +241,7 @@ function createOrchardTools(service: OrchardService): AnyAgentTool[] {
       { buyer: Type.Optional(Type.String()) },
       (params) =>
         service.listShipments(typeof params.buyer === "string" ? params.buyer : undefined),
+      Type.Array(ShipmentOutputSchema),
     ),
     makeTool(
       PLUGIN_ID,
@@ -202,6 +249,7 @@ function createOrchardTools(service: OrchardService): AnyAgentTool[] {
       "Set the irrigation mode for one plot after its sensors have been read.",
       { id: Type.String(), mode: Type.String() },
       (params) => service.updateIrrigation(stringParam(params, "id"), stringParam(params, "mode")),
+      IrrigationUpdateOutputSchema,
     ),
   ];
 }

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -1288,6 +1288,16 @@ async function resolveSkillWorkshopApprovalForFinalParams(params: {
   });
 }
 
+// Success output schemas do not describe policy-layer terminal results. Track
+// identity instead of status shape so a tool cannot spoof a validation bypass.
+const preExecutionBlockedToolResults = new WeakSet<object>();
+
+export function isPreExecutionBlockedToolResult(result: unknown): boolean {
+  return (
+    result !== null && typeof result === "object" && preExecutionBlockedToolResults.has(result)
+  );
+}
+
 /** Build the standard terminal result for vetoed tool calls. */
 export function buildBlockedToolResult(params: {
   reason: string;
@@ -1296,7 +1306,7 @@ export function buildBlockedToolResult(params: {
   runId?: string;
 }) {
   recordPreExecutionBlockedToolCall(params.toolCallId, params.runId);
-  return {
+  const result = {
     content: [{ type: "text" as const, text: params.reason }],
     details: {
       status: "blocked",
@@ -1304,6 +1314,8 @@ export function buildBlockedToolResult(params: {
       reason: params.reason,
     },
   };
+  preExecutionBlockedToolResults.add(result);
+  return result;
 }
 
 // Build the private (trusted-listener-only) tool content payload for a tool

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -1289,7 +1289,7 @@ async function resolveSkillWorkshopApprovalForFinalParams(params: {
 }
 
 // Success output schemas do not describe policy-layer terminal results. Track
-// identity instead of status shape so a tool cannot spoof a validation bypass.
+// identity so catalog boundaries can reject them without trusting spoofable status fields.
 const preExecutionBlockedToolResults = new WeakSet<object>();
 
 export function isPreExecutionBlockedToolResult(result: unknown): boolean {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -1,6 +1,7 @@
 /** Tests Code Mode tool registration, namespace filtering, and run lifecycle. */
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
@@ -387,7 +388,10 @@ describe("Code Mode", () => {
 
     expect(execTool.description).toContain("Node.js modules");
     expect(execTool.description).toContain("`require`/`import` are NOT available");
-    expect(execTool.description).toContain("one exec invocation");
+    expect(execTool.description).toContain("process them in the first exec");
+    expect(execTool.description).toContain("do not spend another exec inspecting");
+    expect(execTool.description).toContain("dependent reads, checks, and follow-up calls in order");
+    expect(execTool.description).toContain("normal tool policy and approvals");
     expect(execTool.description).toContain("`ALL_TOOLS` is the complete compact catalog");
     expect(execTool.description).toContain("`tools.search(query: string, options?)`");
     expect(execTool.description).toContain("enabled catalog tools allowed by policy");
@@ -395,7 +399,8 @@ describe("Code Mode", () => {
     expect(execTool.description).toContain("`tools.callValue(id: string, args?)`");
     expect(execTool.description).toContain("`tools.call(id: string, args?)`");
     expect(execTool.description).toContain("Never invent or transform a tool id");
-    expect(execTool.description).toContain("Quick-index input hints are not output schemas");
+    expect(execTool.description).toContain("Quick-index arrows show trusted declared output hints");
+    expect(execTool.description).toContain("`-> ?` means never guess result field names");
     expect(execTool.description).toContain("never guess result field names");
     expect(execTool.description).toContain("return the raw tool value unchanged");
     expect(execTool.description).toContain("filter or map it only in a later exec");
@@ -422,14 +427,14 @@ describe("Code Mode", () => {
     );
   });
 
-  it("primes the exec schema with exact native tool ids and compact inputs", () => {
+  it("primes the exec schema with exact native tool ids and compact contracts", () => {
     const { config, catalogRef, tools } = createCodeModeHarness();
+    const alpha = pluginTool("alpha_tool", "Another deferred description.");
+    alpha.outputSchema = Type.Array(
+      Type.Object({ id: Type.String(), score: Type.Number() }, { additionalProperties: false }),
+    );
     const compacted = applyCodeModeCatalog({
-      tools: [
-        ...tools,
-        pluginTool("zeta_tool", "Description stays deferred."),
-        pluginTool("alpha_tool", "Another deferred description."),
-      ],
+      tools: [...tools, pluginTool("zeta_tool", "Description stays deferred."), alpha],
       config,
       sessionId: "session-code-mode",
       sessionKey: "agent:main:main",
@@ -439,7 +444,10 @@ describe("Code Mode", () => {
 
     const description = compacted.tools[0]?.description ?? "";
     expect(description).toContain("descriptions are intentionally deferred");
-    expect(description).toContain('- "openclaw:fake-code-mode:alpha_tool" { value?: string } -> ?');
+    expect(description).toContain("OUTPUT DECLARED RULE");
+    expect(description).toContain(
+      '- "openclaw:fake-code-mode:alpha_tool" { value?: string } -> Array<{ id: string; score: number }>',
+    );
     expect(description).toContain('- "openclaw:fake-code-mode:zeta_tool" { value?: string } -> ?');
     expect(description.indexOf("alpha_tool")).toBeLessThan(description.indexOf("zeta_tool"));
     expect(description).not.toContain("Description stays deferred.");

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -5,6 +5,7 @@ import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
+import { buildBlockedToolResult } from "./agent-tools.before-tool-call.js";
 import {
   clearCodeModeNamespacesForPlugin,
   createCodeModeNamespaceTool,
@@ -1181,6 +1182,41 @@ describe("Code Mode", () => {
     expect(details.value).toBe(
       "Unknown tool id: missing_tool. Use tools.search to find a tool, tools.describe to inspect it, then tools.call with the exact id or name.",
     );
+  });
+
+  it("surfaces policy blocks as guest call errors for declared outputs", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const target = pluginTool("fake_policy_block", "Return policy-controlled rows");
+    target.outputSchema = Type.Array(
+      Type.Object({ id: Type.String() }, { additionalProperties: false }),
+    );
+    target.execute = vi.fn(async () =>
+      buildBlockedToolResult({ reason: "blocked by orchard policy" }),
+    );
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, target],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = await runUntilCompleted({
+      execTool: expectDefined(codeModeTools[0], "codeModeTools[0] test invariant"),
+      waitTool: expectDefined(codeModeTools[1], "codeModeTools[1] test invariant"),
+      code: `
+        try {
+          const rows = await tools.callValue("fake_policy_block", {});
+          return rows.map((row) => row.id);
+        } catch (error) {
+          return error.message;
+        }
+      `,
+    });
+
+    expect(details.status).toBe("completed");
+    expect(details.value).toContain("was blocked before execution: blocked by orchard policy");
   });
 
   it("exposes MCP tools only through the MCP namespace", async () => {

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -1278,8 +1278,9 @@ function renderCodeModeCatalogIndex(lines: readonly string[], total: number): st
       ? `${omitted} additional OpenClaw/plugin tools omitted from this prompt index. Use ALL_TOOLS or tools.search inside exec to find them.`
       : "Use these exact ids with tools.callValue; use ALL_TOOLS or tools.search inside exec when lookup is ambiguous.";
   return [
-    "OpenClaw/plugin tool quick index (exact catalog ids and compact input hints; descriptions are intentionally deferred):",
-    "Each line contains an exact catalog id and compact input hint; `-> ?` means its output schema is unknown.",
+    "OpenClaw/plugin tool quick index (exact ids plus compact input and declared output hints; descriptions are intentionally deferred):",
+    "Each line is `id input -> output`; `-> ?` means the output shape is unknown.",
+    "OUTPUT DECLARED RULE: use the named fields in the first exec; keep dependent reads, checks, and follow-up calls in that exec instead of returning a raw value only to inspect an already-declared shape.",
     "OUTPUT UNKNOWN RULE: the first exec must return that tool's raw value unchanged; filter or map it only in a later exec after observing its shape.",
     ...lines,
     "",
@@ -1292,7 +1293,10 @@ function formatCodeModeCatalogIndex(catalog: readonly ToolSearchCatalogEntry[]):
     .filter((entry) => entry.source === "openclaw")
     .map((entry) => compactToolSearchCatalogEntry(entry))
     .toSorted((a, b) => a.id.localeCompare(b.id))
-    .map((entry) => `- ${JSON.stringify(entry.id)} ${entry.input ?? "unknown"} -> ?`);
+    .map(
+      (entry) =>
+        `- ${JSON.stringify(entry.id)} ${entry.input ?? "unknown"} -> ${entry.output ?? "?"}`,
+    );
   if (lines.length === 0) {
     return "";
   }
@@ -1340,7 +1344,7 @@ function createCodeModeExecDescription(
       : "";
   const catalogIndex = catalog ? formatCodeModeCatalogIndex(catalog) : "";
   return (
-    "Run JavaScript or TypeScript in OpenClaw code mode. Use `return` to pass the final value back to the agent; awaited calls without a returned value complete as `null`. Quick-index input hints are not output schemas: `output unknown` means never guess result field names. For an unknown output, the first exec must return the raw tool value unchanged with `return await tools.callValue(id, args);`; filter or map it only in a later exec after observing its shape. Prefer one exec invocation only when required result fields are documented: select tools, call them, and process their results in the same program. Await prerequisites before later calls; parallelize only independent work. `ALL_TOOLS` is the complete compact catalog with exact ids and input hints. Select from it directly when practical, use `tools.search(query: string, options?)` when lookup is ambiguous, and use `tools.describe(id: string)` only when the compact input hint is insufficient. Never invent or transform a tool id. `tools.callValue(id: string, args?)` executes a tool and returns its JSON value directly; `tools.call(id: string, args?)` preserves the raw `{ tool, result }` envelope. Example: `const hit = ALL_TOOLS.find((entry) => entry.description.includes('weather')) ?? (await tools.search('weather'))[0]; return await tools.callValue(hit.id, {});`. Node.js modules and `require`/`import` are NOT available; for any shell, file, network, or external action, use enabled catalog tools allowed by policy from inside your code." +
+    "Run JavaScript or TypeScript in OpenClaw code mode. Use `return` to pass the final value back to the agent; awaited calls without a returned value complete as `null`. Quick-index arrows show trusted declared output hints; `-> ?` means never guess result field names. For an unknown output, the first exec must return the raw tool value unchanged with `return await tools.callValue(id, args);`; filter or map it only in a later exec after observing its shape. When the arrow declares the fields you need, select, call, and process them in the first exec; do not spend another exec inspecting that declared shape. Within that exec, perform dependent reads, checks, and follow-up calls in order; nested calls still enforce normal tool policy and approvals. Parallelize only independent work. `ALL_TOOLS` is the complete compact catalog with exact ids, input hints, and declared output hints. Select from it directly when practical, use `tools.search(query: string, options?)` when lookup is ambiguous, and use `tools.describe(id: string)` only when the compact input hint is insufficient. Never invent or transform a tool id. `tools.callValue(id: string, args?)` executes a tool and returns its JSON value directly; `tools.call(id: string, args?)` preserves the raw `{ tool, result }` envelope. Example: `const hit = ALL_TOOLS.find((entry) => entry.description.includes('weather')) ?? (await tools.search('weather'))[0]; return await tools.callValue(hit.id, {});`. Node.js modules and `require`/`import` are NOT available; for any shell, file, network, or external action, use enabled catalog tools allowed by policy from inside your code." +
     mcpGuidance +
     namespaceGuidance +
     ' The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.' +

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  snapshotToolSearchTargetTranscriptResult,
-  type ToolSearchTargetTranscriptProjection,
-} from "../../tool-search.js";
+import type { ToolSearchTargetTranscriptProjection } from "../../tool-search.js";
 
 const mocks = vi.hoisted(() => ({
   buildSubscriptionParams: vi.fn(),
@@ -138,7 +135,11 @@ describe("prepareEmbeddedAttemptStream", () => {
       acceptResultBeforeProjection: async (candidate) => {
         expect(candidate).toBe(rawResult);
         expect(projections).toHaveLength(0);
-        return snapshotToolSearchTargetTranscriptResult(candidate);
+        const snapshot = structuredClone(candidate);
+        if (snapshot.details && typeof snapshot.details === "object") {
+          Object.freeze(snapshot.details);
+        }
+        return Object.freeze(snapshot);
       },
     });
 

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  snapshotToolSearchTargetTranscriptResult,
+  type ToolSearchTargetTranscriptProjection,
+} from "../../tool-search.js";
+
+const mocks = vi.hoisted(() => ({
+  buildSubscriptionParams: vi.fn(),
+  clearActiveRun: vi.fn(),
+  notifyToolActivity: vi.fn(),
+  setActiveRun: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
+vi.mock("../../embedded-agent-subscribe.js", () => ({
+  subscribeEmbeddedAgentSession: mocks.subscribe,
+}));
+vi.mock("../runs.js", () => ({
+  clearActiveEmbeddedRun: mocks.clearActiveRun,
+  setActiveEmbeddedRun: mocks.setActiveRun,
+}));
+vi.mock("./attempt.subscription-cleanup.js", () => ({
+  buildEmbeddedSubscriptionParams: mocks.buildSubscriptionParams,
+}));
+vi.mock("./tool-activity-heartbeat.js", () => ({
+  notifyToolActivity: mocks.notifyToolActivity,
+}));
+
+import { prepareEmbeddedAttemptStream } from "./attempt-stream-prepare.js";
+
+function prepareCatalogExecutor(projections: ToolSearchTargetTranscriptProjection[]) {
+  const runAbortController = new AbortController();
+  return prepareEmbeddedAttemptStream({
+    attempt: {
+      runId: "run-output-schema",
+      sessionId: "session-output-schema",
+      sessionKey: "agent:main:main",
+    } as never,
+    activeSession: { agent: {}, isStreaming: false } as never,
+    hookRunner: undefined as never,
+    hookAgentId: "main",
+    diagnosticTrace: {} as never,
+    clientToolCallSlots: [],
+    toolSearchTargetTranscriptProjections: projections,
+    isReplaySafeTool: () => false,
+    runAbortController,
+    abortRun: vi.fn(),
+    markExternalAbort: vi.fn(),
+    getRunState: () => ({
+      aborted: false,
+      promptError: undefined,
+      timedOut: false,
+      yieldDetected: false,
+    }),
+    hasDeliveredSourceReply: () => false,
+    markSourceReplyDelivered: vi.fn(),
+    onBlockReply: vi.fn(),
+    onBlockReplyFlush: vi.fn(),
+    sandboxSessionKey: "agent:main:main",
+    builtinToolNames: new Set(),
+    replaySafeToolNames: new Set(),
+  });
+}
+
+describe("prepareEmbeddedAttemptStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.buildSubscriptionParams.mockImplementation((params) => params);
+    mocks.subscribe.mockReturnValue({
+      toolMetas: [],
+      runToolLifecycle: vi.fn(async ({ execute }) => await execute()),
+      isCompacting: vi.fn(() => false),
+    });
+  });
+
+  it("validates hidden tool results before queuing transcript projections", async () => {
+    const projections: ToolSearchTargetTranscriptProjection[] = [];
+    const rawResult = {
+      content: [{ type: "text" as const, text: "rejected raw result" }],
+      details: { id: 42, unexpected: "must-not-enter-transcript" },
+    };
+    const prepared = prepareCatalogExecutor(projections);
+
+    await expect(
+      prepared.toolSearchCatalogExecutor({
+        tool: {
+          name: "orchard_bad_output",
+          description: "Return a rejected orchard result",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+          execute: vi.fn(async () => rawResult),
+        } as never,
+        toolName: "orchard_bad_output",
+        source: "openclaw",
+        sourceName: "fixture-plugin",
+        toolCallId: "call-output-schema",
+        parentToolCallId: "call-code-mode",
+        input: {},
+        acceptResultBeforeProjection: async (candidate) => {
+          expect(candidate).toBe(rawResult);
+          expect(projections).toHaveLength(0);
+          throw new Error("declared output mismatch");
+        },
+      }),
+    ).rejects.toThrow("declared output mismatch");
+
+    expect(projections).toEqual([
+      expect.objectContaining({
+        toolCallId: "call-output-schema",
+        toolName: "orchard_bad_output",
+        isError: true,
+      }),
+    ]);
+    expect(JSON.stringify(projections)).not.toContain("must-not-enter-transcript");
+    expect(mocks.notifyToolActivity).toHaveBeenCalledWith("run-output-schema");
+  });
+
+  it("snapshots accepted results before delayed transcript settlement", async () => {
+    const projections: ToolSearchTargetTranscriptProjection[] = [];
+    const rawResult = {
+      content: [{ type: "text" as const, text: "accepted result" }],
+      details: { id: 42 },
+    };
+    const prepared = prepareCatalogExecutor(projections);
+
+    const returned = await prepared.toolSearchCatalogExecutor({
+      tool: {
+        name: "orchard_output",
+        description: "Return an orchard result",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+        execute: vi.fn(async () => rawResult),
+      } as never,
+      toolName: "orchard_output",
+      source: "openclaw",
+      sourceName: "fixture-plugin",
+      toolCallId: "call-output-schema",
+      parentToolCallId: "call-code-mode",
+      input: {},
+      acceptResultBeforeProjection: async (candidate) => {
+        expect(candidate).toBe(rawResult);
+        expect(projections).toHaveLength(0);
+        return snapshotToolSearchTargetTranscriptResult(candidate);
+      },
+    });
+
+    rawResult.details.id = 99;
+    expect(returned).not.toBe(rawResult);
+    expect(projections[0]?.result).toBe(returned);
+    expect(returned).toMatchObject({ details: { id: 42 } });
+    expect(Object.isFrozen(returned)).toBe(true);
+    expect(Object.isFrozen(returned.details)).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -308,16 +308,19 @@ export function prepareEmbeddedAttemptStream(input: {
             undefined as never,
           ),
       });
+      // Settlement persists every queued projection. Validate the final result
+      // first so a rejected hidden-tool value never enters session history.
+      const acceptedResult = await toolParams.acceptResultBeforeProjection(result);
       input.toolSearchTargetTranscriptProjections.push({
         parentToolCallId: toolParams.parentToolCallId,
         toolCallId: toolParams.toolCallId,
         toolName: toolParams.toolName,
         input: toolParams.input,
-        result,
+        result: acceptedResult,
         timestamp: Date.now(),
       });
       notifyToolActivity(attempt.runId);
-      return result;
+      return acceptedResult;
     } catch (error) {
       const message = formatErrorMessage(error);
       input.toolSearchTargetTranscriptProjections.push({

--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -248,11 +248,11 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     const tool = {
       ...createParameterFreeTool("fixture_status"),
       outputSchema,
-    } as AgentTool;
+    } as unknown as AgentTool;
     const normalized = {
       ...createParameterFreeTool("fixture_status"),
       parameters: normalizedParameterFreeSchema(),
-    } as AgentTool;
+    } as unknown as AgentTool;
     mocks.normalizeProviderToolSchemas.mockReturnValueOnce([normalized]);
 
     const result = normalizeAgentRuntimeTools({

--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -8,6 +8,7 @@ import {
   createParameterFreeTool,
   normalizedParameterFreeSchema,
 } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
+import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tools.js";
 import {
@@ -237,6 +238,30 @@ describe("AgentRuntimePlan tool policy helpers", () => {
         toolName: "lookup_note",
       },
     });
+  });
+
+  it("preserves declared output schemas when runtime normalization clones tools", () => {
+    const outputSchema = Type.Object(
+      { id: Type.String(), ready: Type.Boolean() },
+      { additionalProperties: false },
+    );
+    const tool = {
+      ...createParameterFreeTool("fixture_status"),
+      outputSchema,
+    } as AgentTool;
+    const normalized = {
+      ...createParameterFreeTool("fixture_status"),
+      parameters: normalizedParameterFreeSchema(),
+    } as AgentTool;
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([normalized]);
+
+    const result = normalizeAgentRuntimeTools({
+      tools: [tool],
+      provider: "openai",
+    });
+
+    expect(result[0]).toBe(normalized);
+    expect(result[0]?.outputSchema).toBe(outputSchema);
   });
 
   it("preserves private execution metadata when provider normalization clones tools", () => {

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -68,6 +68,9 @@ function copyRuntimeToolMetadata(source: AgentTool, target: AgentTool): void {
   if (catalogMode) {
     (target as AnyAgentTool).catalogMode = catalogMode;
   }
+  if (source.outputSchema !== undefined) {
+    target.outputSchema = source.outputSchema;
+  }
   copyPluginToolMeta(source as never, target as never);
   copyChannelAgentToolMeta(source as never, target as never);
   copyBeforeToolCallHookMarker(source as never, target as never);

--- a/src/agents/tool-schema-hints.test.ts
+++ b/src/agents/tool-schema-hints.test.ts
@@ -1,0 +1,124 @@
+/** Tests bounded deterministic tool schema hints, including adversarial shapes. */
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { compactToolInputHint, compactToolOutputHint } from "./tool-schema-hints.js";
+
+describe("tool schema hints", () => {
+  it("renders nested declared outputs as compact TypeScript shapes", () => {
+    const outputSchema = Type.Array(
+      Type.Object(
+        {
+          id: Type.String(),
+          metrics: Type.Object(
+            {
+              paid: Type.Boolean(),
+              tons: Type.Number(),
+            },
+            { additionalProperties: false },
+          ),
+          state: Type.Union([Type.Literal("ready"), Type.Literal("held")]),
+        },
+        { additionalProperties: false },
+      ),
+    );
+
+    expect(compactToolOutputHint(outputSchema)).toBe(
+      'Array<{ id: string; metrics: { paid: boolean; tons: number }; state: "ready" | "held" }>',
+    );
+  });
+
+  it("orders required and optional fields deterministically", () => {
+    const first = {
+      type: "object",
+      properties: {
+        optional: { type: "boolean" },
+        beta: { type: "number" },
+        alpha: { type: "string" },
+      },
+      required: ["beta", "alpha"],
+    };
+    const second = {
+      type: "object",
+      properties: {
+        alpha: { type: "string" },
+        beta: { type: "number" },
+        optional: { type: "boolean" },
+      },
+      required: ["alpha", "beta"],
+    };
+
+    expect(compactToolInputHint(first)).toBe("{ alpha: string; beta: number; optional?: boolean }");
+    expect(compactToolInputHint(second)).toBe(compactToolInputHint(first));
+  });
+
+  it("omits incomplete output hints instead of inviting field guesses", () => {
+    const cyclic: Record<string, unknown> = { type: "object", properties: {} };
+    (cyclic.properties as Record<string, unknown>).self = cyclic;
+
+    expect(compactToolOutputHint(cyclic)).toBeUndefined();
+    expect(compactToolOutputHint({ $ref: "#/$defs/result" })).toBeUndefined();
+    expect(compactToolOutputHint({ anyOf: [] })).toBeUndefined();
+    expect(compactToolOutputHint(Type.Object({ id: Type.String() }))).toBeUndefined();
+    expect(
+      compactToolOutputHint({
+        type: "object",
+        properties: {},
+        patternProperties: { "^item_": { type: "number" } },
+        additionalProperties: false,
+      }),
+    ).toBeUndefined();
+
+    const oversized = Type.Object(
+      Object.fromEntries(
+        Array.from({ length: 32 }, (_unused, index) => [`field_${index}`, Type.String()]),
+      ),
+      { additionalProperties: false },
+    );
+    expect(compactToolOutputHint(oversized)).toBeUndefined();
+    expect(compactToolInputHint(oversized)).toContain("...");
+
+    const hugeName = Type.Object(
+      { ["x".repeat(10_000)]: Type.String() },
+      { additionalProperties: false },
+    );
+    expect(compactToolOutputHint(hugeName)).toBeUndefined();
+    expect(compactToolInputHint(hugeName)).toBe("{ ... }");
+  });
+
+  it('keeps complete fields and literals containing the word "unknown"', () => {
+    const outputSchema = Type.Object(
+      {
+        state: Type.Union([Type.Literal("known"), Type.Literal("unknown")]),
+        unknownReason: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    );
+
+    expect(compactToolOutputHint(outputSchema)).toBe(
+      '{ state: "known" | "unknown"; unknownReason?: string }',
+    );
+  });
+
+  it("bounds deterministic hints across a large adversarial catalog", () => {
+    const schemas = Array.from({ length: 1_000 }, (_, index) =>
+      Type.Array(
+        Type.Object(
+          Object.fromEntries(
+            Array.from({ length: 32 }, (_unused, propertyIndex) => [
+              `field_${index}_${propertyIndex}`,
+              Type.Optional(Type.String()),
+            ]),
+          ),
+          { additionalProperties: index % 2 === 0 },
+        ),
+      ),
+    );
+
+    const first = schemas.map(compactToolInputHint);
+    const second = schemas.map(compactToolInputHint);
+
+    expect(second).toEqual(first);
+    expect(first.every((hint) => hint.length <= 300)).toBe(true);
+    expect(schemas.every((schema) => compactToolOutputHint(schema) === undefined)).toBe(true);
+  });
+});

--- a/src/agents/tool-schema-hints.test.ts
+++ b/src/agents/tool-schema-hints.test.ts
@@ -75,6 +75,26 @@ describe("tool schema hints", () => {
     expect(compactToolOutputHint(cyclic)).toBeUndefined();
     expect(compactToolOutputHint({ $ref: "#/$defs/result" })).toBeUndefined();
     expect(compactToolOutputHint({ anyOf: [] })).toBeUndefined();
+    const closedBaseShape = {
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      additionalProperties: false,
+    };
+    expect(compactToolOutputHint({ ...closedBaseShape, oneOf: [] })).toBeUndefined();
+    expect(
+      compactToolOutputHint({
+        ...closedBaseShape,
+        anyOf: Array.from({ length: 5 }, (_unused, index) => ({ const: index })),
+      }),
+    ).toBeUndefined();
+    expect(
+      compactToolOutputHint({
+        ...closedBaseShape,
+        anyOf: [{ const: "a" }],
+        oneOf: [{ const: "b" }],
+      }),
+    ).toBeUndefined();
     expect(compactToolOutputHint(Type.Object({ id: Type.String() }))).toBeUndefined();
     expect(
       compactToolOutputHint({

--- a/src/agents/tool-schema-hints.test.ts
+++ b/src/agents/tool-schema-hints.test.ts
@@ -27,6 +27,23 @@ describe("tool schema hints", () => {
     );
   });
 
+  it("includes null in AJV-style nullable output hints", () => {
+    expect(compactToolOutputHint({ type: "string", nullable: true })).toBe("string | null");
+    expect(
+      compactToolOutputHint({
+        type: "object",
+        nullable: true,
+        properties: { id: { type: "string" } },
+        required: ["id"],
+        additionalProperties: false,
+      }),
+    ).toBe("{ id: string } | null");
+    expect(compactToolOutputHint({ type: "string", nullable: true, enum: ["ready"] })).toBe(
+      '"ready"',
+    );
+    expect(compactToolOutputHint({ type: "string", nullable: "yes" })).toBeUndefined();
+  });
+
   it("orders required and optional fields deterministically", () => {
     const first = {
       type: "object",

--- a/src/agents/tool-schema-hints.ts
+++ b/src/agents/tool-schema-hints.ts
@@ -1,0 +1,264 @@
+/** Bounded TypeScript-style hints for model-visible tool input and output schemas. */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+const MAX_COMPACT_SCHEMA_HINT_CHARS = 300;
+const MAX_COMPACT_SCHEMA_PROPERTIES = 16;
+const MAX_COMPACT_SCHEMA_PROPERTY_NAME_CHARS = 128;
+const MAX_COMPACT_SCHEMA_DEPTH = 4;
+const MAX_COMPACT_UNION_TYPES = 4;
+const MAX_COMPACT_ENUM_VALUES = 6;
+const MAX_COMPACT_ENUM_CHARS = 96;
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/u;
+const UNSUPPORTED_SHAPE_KEYWORDS = [
+  "$ref",
+  "$dynamicRef",
+  "$recursiveRef",
+  "allOf",
+  "patternProperties",
+  "unevaluatedProperties",
+  "dependentSchemas",
+  "dependencies",
+  "if",
+  "then",
+  "else",
+  "prefixItems",
+  "unevaluatedItems",
+] as const;
+
+type SchemaHint = {
+  text: string;
+  complete: boolean;
+};
+
+const UNKNOWN_HINT: SchemaHint = { text: "unknown", complete: false };
+
+function completeHint(text: string): SchemaHint {
+  return { text, complete: true };
+}
+
+function withSupportedShape(schema: Record<string, unknown>, hint: SchemaHint): SchemaHint {
+  return UNSUPPORTED_SHAPE_KEYWORDS.some((key) => Object.hasOwn(schema, key))
+    ? { ...hint, complete: false }
+    : hint;
+}
+
+function renderPrimitive(value: unknown): string | undefined {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return JSON.stringify(value);
+  }
+  return undefined;
+}
+
+function compactLiteralUnion(values: unknown): SchemaHint | undefined {
+  if (!Array.isArray(values) || values.length === 0 || values.length > MAX_COMPACT_ENUM_VALUES) {
+    return undefined;
+  }
+  const rendered = values.map(renderPrimitive);
+  if (rendered.some((value) => value === undefined)) {
+    return undefined;
+  }
+  const result = [...new Set(rendered as string[])].join(" | ");
+  return result.length <= MAX_COMPACT_ENUM_CHARS ? completeHint(result) : undefined;
+}
+
+function compactSchemaUnion(
+  schema: Record<string, unknown>,
+  depth: number,
+): SchemaHint | undefined {
+  const variants = Array.isArray(schema.anyOf)
+    ? schema.anyOf
+    : Array.isArray(schema.oneOf)
+      ? schema.oneOf
+      : undefined;
+  if (!variants || variants.length === 0 || variants.length > MAX_COMPACT_UNION_TYPES) {
+    return undefined;
+  }
+  const rendered = variants.map((variant) => compactSchemaType(variant, depth + 1));
+  if (rendered.some((hint) => !hint.complete)) {
+    return UNKNOWN_HINT;
+  }
+  return completeHint([...new Set(rendered.map((hint) => hint.text))].join(" | "));
+}
+
+function insertLexicallyBounded(values: string[], value: string, limit: number): void {
+  if (limit <= 0) {
+    return;
+  }
+  let low = 0;
+  let high = values.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if ((values[middle] ?? "").localeCompare(value) < 0) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  if (low >= limit) {
+    return;
+  }
+  values.splice(low, 0, value);
+  if (values.length > limit) {
+    values.pop();
+  }
+}
+
+function compactObjectHint(schema: Record<string, unknown>, depth: number): SchemaHint {
+  if (!isRecord(schema.properties)) {
+    const requiredValues = Array.isArray(schema.required) ? schema.required : [];
+    const required =
+      requiredValues.length > MAX_COMPACT_SCHEMA_PROPERTIES ||
+      requiredValues.some((value) => typeof value === "string");
+    return !required && schema.additionalProperties === false
+      ? completeHint("{}")
+      : { text: "{ ... }", complete: false };
+  }
+
+  const properties = schema.properties;
+  const requiredValues = Array.isArray(schema.required) ? schema.required : [];
+  const invalidRequired =
+    requiredValues.length <= MAX_COMPACT_SCHEMA_PROPERTIES &&
+    requiredValues.some((value) => typeof value !== "string");
+  const required = new Set(
+    requiredValues
+      .slice(0, MAX_COMPACT_SCHEMA_PROPERTIES)
+      .filter((value): value is string => typeof value === "string"),
+  );
+  const requiredKeys: string[] = [];
+  let missingRequired = false;
+  for (const key of required) {
+    if (key.length > MAX_COMPACT_SCHEMA_PROPERTY_NAME_CHARS) {
+      missingRequired = true;
+      continue;
+    }
+    if (!Object.hasOwn(properties, key)) {
+      missingRequired = true;
+      continue;
+    }
+    insertLexicallyBounded(requiredKeys, key, MAX_COMPACT_SCHEMA_PROPERTIES);
+  }
+
+  const optionalLimit = MAX_COMPACT_SCHEMA_PROPERTIES - requiredKeys.length;
+  const optionalKeys: string[] = [];
+  let optionalCount = 0;
+  let oversizedOptionalKey = false;
+  // Client tool schemas can be large and are not trusted metadata. Keep only a
+  // fixed-size sorted selection instead of materializing and sorting every key.
+  for (const key in properties) {
+    if (!Object.hasOwn(properties, key) || required.has(key)) {
+      continue;
+    }
+    optionalCount += 1;
+    if (key.length > MAX_COMPACT_SCHEMA_PROPERTY_NAME_CHARS) {
+      oversizedOptionalKey = true;
+      continue;
+    }
+    insertLexicallyBounded(optionalKeys, key, optionalLimit);
+  }
+
+  const keys = [...requiredKeys, ...optionalKeys];
+  const structurallyIncomplete =
+    requiredValues.length > MAX_COMPACT_SCHEMA_PROPERTIES ||
+    invalidRequired ||
+    missingRequired ||
+    oversizedOptionalKey ||
+    optionalCount > optionalLimit;
+  let omitted =
+    structurallyIncomplete ||
+    schema.additionalProperties === true ||
+    isRecord(schema.additionalProperties);
+  let complete = !structurallyIncomplete && schema.additionalProperties === false;
+  const parts: string[] = [];
+  for (const key of keys) {
+    const name = IDENTIFIER_RE.test(key) ? key : JSON.stringify(key);
+    const propertyHint = compactSchemaType(properties[key], depth);
+    complete &&= propertyHint.complete;
+    const part = `${name}${required.has(key) ? "" : "?"}: ${propertyHint.text}`;
+    const next = `{ ${[...parts, part].join("; ")} }`;
+    if (next.length > MAX_COMPACT_SCHEMA_HINT_CHARS) {
+      omitted = true;
+      complete = false;
+      break;
+    }
+    parts.push(part);
+  }
+  if (parts.length === 0) {
+    return keys.length === 0 && !omitted
+      ? { text: "{}", complete }
+      : { text: "{ ... }", complete: false };
+  }
+  return {
+    text: `{ ${parts.join("; ")}${omitted ? "; ..." : ""} }`,
+    complete,
+  };
+}
+
+function compactSchemaType(schema: unknown, depth = 0): SchemaHint {
+  if (!isRecord(schema) || depth >= MAX_COMPACT_SCHEMA_DEPTH) {
+    return UNKNOWN_HINT;
+  }
+  const finish = (hint: SchemaHint) => withSupportedShape(schema, hint);
+
+  const literal = renderPrimitive(schema.const);
+  if (literal !== undefined) {
+    return finish(completeHint(literal));
+  }
+  const enumUnion = compactLiteralUnion(schema.enum);
+  if (enumUnion) {
+    return finish(enumUnion);
+  }
+  const schemaUnion = compactSchemaUnion(schema, depth);
+  if (schemaUnion) {
+    return finish(schemaUnion);
+  }
+
+  const type = schema.type;
+  if (Array.isArray(type)) {
+    if (
+      type.length === 0 ||
+      type.length > MAX_COMPACT_UNION_TYPES ||
+      !type.every((value): value is string => typeof value === "string")
+    ) {
+      return UNKNOWN_HINT;
+    }
+    const rendered = type.map((value) => compactSchemaType({ ...schema, type: value }, depth + 1));
+    if (rendered.some((hint) => !hint.complete)) {
+      return UNKNOWN_HINT;
+    }
+    return finish(completeHint([...new Set(rendered.map((hint) => hint.text))].join(" | ")));
+  }
+  if (type === "integer" || type === "number") {
+    return finish(completeHint("number"));
+  }
+  if (type === "array") {
+    const itemHint = compactSchemaType(schema.items, depth + 1);
+    return finish({ text: `Array<${itemHint.text}>`, complete: itemHint.complete });
+  }
+  if (type === "object") {
+    return finish(compactObjectHint(schema, depth + 1));
+  }
+  if (type === "string" || type === "boolean" || type === "null") {
+    return finish(completeHint(type));
+  }
+  return UNKNOWN_HINT;
+}
+
+/** Compact one tool input schema. Unknown inputs remain explicit for safe describe fallback. */
+export function compactToolInputHint(schema: unknown): string {
+  if (!isRecord(schema)) {
+    return "unknown";
+  }
+  const hint = schema.type === "object" ? compactObjectHint(schema, 0) : compactSchemaType(schema);
+  return hint.text.length <= MAX_COMPACT_SCHEMA_HINT_CHARS ? hint.text : "unknown";
+}
+
+/** Compact one trusted output schema. Omit incomplete hints instead of inviting field guesses. */
+export function compactToolOutputHint(schema: unknown): string | undefined {
+  const hint = compactSchemaType(schema);
+  return hint.complete && hint.text.length <= MAX_COMPACT_SCHEMA_HINT_CHARS ? hint.text : undefined;
+}

--- a/src/agents/tool-schema-hints.ts
+++ b/src/agents/tool-schema-hints.ts
@@ -42,6 +42,36 @@ function withSupportedShape(schema: Record<string, unknown>, hint: SchemaHint): 
     : hint;
 }
 
+function normalizeNullableSchemaForHint(
+  schema: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!Object.hasOwn(schema, "nullable")) {
+    return schema;
+  }
+  if (typeof schema.nullable !== "boolean") {
+    return undefined;
+  }
+  const types =
+    typeof schema.type === "string"
+      ? [schema.type]
+      : Array.isArray(schema.type) && schema.type.every((value) => typeof value === "string")
+        ? schema.type
+        : undefined;
+  if (!types) {
+    return undefined;
+  }
+  if (!schema.nullable) {
+    return schema;
+  }
+  // Mirror the validator's AJV-style nullable normalization so promoted
+  // hints include every value that output validation can accept.
+  return {
+    ...schema,
+    nullable: false,
+    type: [...new Set([...types, "null"])],
+  };
+}
+
 function renderPrimitive(value: unknown): string | undefined {
   if (
     value === null ||
@@ -201,6 +231,13 @@ function compactObjectHint(schema: Record<string, unknown>, depth: number): Sche
 function compactSchemaType(schema: unknown, depth = 0): SchemaHint {
   if (!isRecord(schema) || depth >= MAX_COMPACT_SCHEMA_DEPTH) {
     return UNKNOWN_HINT;
+  }
+  const normalizedNullableSchema = normalizeNullableSchemaForHint(schema);
+  if (!normalizedNullableSchema) {
+    return UNKNOWN_HINT;
+  }
+  if (normalizedNullableSchema !== schema) {
+    return compactSchemaType(normalizedNullableSchema, depth);
   }
   const finish = (hint: SchemaHint) => withSupportedShape(schema, hint);
 

--- a/src/agents/tool-schema-hints.ts
+++ b/src/agents/tool-schema-hints.ts
@@ -100,13 +100,30 @@ function compactSchemaUnion(
   schema: Record<string, unknown>,
   depth: number,
 ): SchemaHint | undefined {
-  const variants = Array.isArray(schema.anyOf)
-    ? schema.anyOf
-    : Array.isArray(schema.oneOf)
-      ? schema.oneOf
-      : undefined;
-  if (!variants || variants.length === 0 || variants.length > MAX_COMPACT_UNION_TYPES) {
+  const hasAnyOf = Object.hasOwn(schema, "anyOf");
+  const hasOneOf = Object.hasOwn(schema, "oneOf");
+  if (!hasAnyOf && !hasOneOf) {
     return undefined;
+  }
+  if (hasAnyOf && hasOneOf) {
+    return UNKNOWN_HINT;
+  }
+  const variants = hasAnyOf ? schema.anyOf : schema.oneOf;
+  if (
+    !Array.isArray(variants) ||
+    variants.length === 0 ||
+    variants.length > MAX_COMPACT_UNION_TYPES
+  ) {
+    return UNKNOWN_HINT;
+  }
+  // A union plus a base structural shape is an intersection. This compact
+  // renderer cannot preserve that composition, so never promote it as complete.
+  if (
+    ["const", "enum", "type", "properties", "required", "additionalProperties", "items"].some(
+      (key) => Object.hasOwn(schema, key),
+    )
+  ) {
+    return UNKNOWN_HINT;
   }
   const rendered = variants.map((variant) => compactSchemaType(variant, depth + 1));
   if (rendered.some((hint) => !hint.complete)) {
@@ -241,6 +258,10 @@ function compactSchemaType(schema: unknown, depth = 0): SchemaHint {
   }
   const finish = (hint: SchemaHint) => withSupportedShape(schema, hint);
 
+  const schemaUnion = compactSchemaUnion(schema, depth);
+  if (schemaUnion) {
+    return finish(schemaUnion);
+  }
   const literal = renderPrimitive(schema.const);
   if (literal !== undefined) {
     return finish(completeHint(literal));
@@ -248,10 +269,6 @@ function compactSchemaType(schema: unknown, depth = 0): SchemaHint {
   const enumUnion = compactLiteralUnion(schema.enum);
   if (enumUnion) {
     return finish(enumUnion);
-  }
-  const schemaUnion = compactSchemaUnion(schema, depth);
-  if (schemaUnion) {
-    return finish(schemaUnion);
   }
 
   const type = schema.type;

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -303,8 +303,9 @@ describe("Tool Search", () => {
     const mcpResult = resultDetails(
       await search.execute("call-search-mcp", { query: "remote echo" }),
     );
-    expect(mcpResult).toContainEqual(expect.objectContaining({ name: "remote_echo" }));
-    expect(mcpResult).not.toContainEqual(expect.objectContaining({ input: expect.anything() }));
+    expect(mcpResult).toContainEqual(
+      expect.objectContaining({ name: "remote_echo", input: "unknown" }),
+    );
   });
 
   it("exposes and validates trusted OpenClaw output schemas", async () => {
@@ -1250,9 +1251,8 @@ describe("Tool Search", () => {
     );
 
     expect(result).toContainEqual(
-      expect.objectContaining({ name: "client_pick_file", source: "client" }),
+      expect.objectContaining({ name: "client_pick_file", source: "client", input: "unknown" }),
     );
-    expect(result).not.toContainEqual(expect.objectContaining({ input: expect.anything() }));
   });
 
   it("keeps client tools visible in directory mode", () => {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -4,12 +4,18 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-fixtures.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
   isToolWrappedWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
+import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
 import { SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import {
   addClientToolsToToolSearchCatalog,
@@ -170,6 +176,8 @@ describe("Tool Search", () => {
     expect(directory).not.toContain("\uD83D");
   });
   afterEach(() => {
+    resetGlobalHookRunner();
+    resetAdjustedParamsByToolCallIdForTests();
     testing.setToolSearchCodeModeSupportedForTest(undefined);
     testing.setToolSearchMinCodeTimeoutMsForTest(undefined);
   });
@@ -356,6 +364,56 @@ describe("Tool Search", () => {
     );
 
     await expect(runtime.callValue("orchard_bad_output")).rejects.toThrow(
+      "returned details that do not match its declared outputSchema",
+    );
+  });
+
+  it("preserves policy-blocked results outside a declared success output schema", async () => {
+    const execute = vi.fn(async () => jsonResult({ id: "should-not-run" }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_tool_call",
+          handler: vi.fn(async () => ({ block: true, blockReason: "blocked by orchard policy" })),
+        },
+      ]),
+    );
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_policy_block", "Return an orchard result");
+    target.outputSchema = Type.Object({ id: Type.String() }, { additionalProperties: false });
+    target.execute = execute;
+    registerHeadlessToolSearchCatalog({
+      catalogRef,
+      tools: [target],
+      hookContext: { runId: "run-policy-block" },
+    });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef, runId: "run-policy-block" },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.callValue("orchard_policy_block")).resolves.toEqual({
+      status: "blocked",
+      deniedReason: "plugin-before-tool-call",
+      reason: "blocked by orchard policy",
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tool-authored blocked lookalike that violates its output schema", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_fake_block", "Return an orchard result");
+    target.outputSchema = Type.Object({ id: Type.String() }, { additionalProperties: false });
+    target.execute = vi.fn(async () =>
+      jsonResult({ status: "blocked", reason: "tool-authored lookalike" }),
+    );
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.callValue("orchard_fake_block")).rejects.toThrow(
       "returned details that do not match its declared outputSchema",
     );
   });

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -2,6 +2,7 @@
 // tools, hooks, abort wrapping, and transcript projection.
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
@@ -27,6 +28,7 @@ import {
   TOOL_DESCRIBE_RAW_TOOL_NAME,
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
   TOOL_SEARCH_RAW_TOOL_NAME,
+  ToolSearchRuntime,
 } from "./tool-search.js";
 import { testing } from "./tool-search.test-support.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
@@ -302,6 +304,122 @@ describe("Tool Search", () => {
     );
     expect(mcpResult).toContainEqual(expect.objectContaining({ name: "remote_echo" }));
     expect(mcpResult).not.toContainEqual(expect.objectContaining({ input: expect.anything() }));
+  });
+
+  it("exposes and validates trusted OpenClaw output schemas", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_shipments", "List orchard shipments");
+    target.outputSchema = Type.Array(
+      Type.Object(
+        {
+          id: Type.String(),
+          paid: Type.Boolean(),
+          tons: Type.Number(),
+        },
+        { additionalProperties: false },
+      ),
+    );
+    target.execute = vi.fn(async () => jsonResult([{ id: "H-1", paid: false, tons: 14 }]));
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.search("orchard shipments")).resolves.toContainEqual(
+      expect.objectContaining({
+        name: "orchard_shipments",
+        output: "Array<{ id: string; paid: boolean; tons: number }>",
+      }),
+    );
+    await expect(runtime.describe("orchard_shipments")).resolves.toMatchObject({
+      outputSchema: { type: "array" },
+    });
+    await expect(runtime.callValue("orchard_shipments")).resolves.toEqual([
+      { id: "H-1", paid: false, tons: 14 },
+    ]);
+  });
+
+  it("rejects final catalog details that drift from a declared output schema", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_bad_output", "Return a bad orchard result");
+    target.outputSchema = Type.Object({ id: Type.String() }, { additionalProperties: false });
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      {
+        catalogRef,
+        executeTool: async () => jsonResult({ id: 42 }),
+      },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.callValue("orchard_bad_output")).rejects.toThrow(
+      "returned details that do not match its declared outputSchema",
+    );
+  });
+
+  it("rejects invalid trusted output schemas at the catalog call boundary", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_invalid_schema", "Return an orchard result");
+    target.outputSchema = { type: "sting" } as never;
+    const execute = vi.fn(async () => jsonResult({ id: "P-2" }));
+    target.execute = execute;
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.callValue("orchard_invalid_schema")).rejects.toThrow(
+      "has an invalid outputSchema",
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("recompiles validation when the same catalog id changes its output schema", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_schema_change", "Return a changing orchard result");
+    target.outputSchema = Type.String();
+    target.execute = vi.fn(async () => jsonResult("first"));
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.callValue("orchard_schema_change")).resolves.toBe("first");
+    target.outputSchema = Type.Number();
+    target.execute = vi.fn(async () => jsonResult(42));
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+
+    await expect(runtime.callValue("orchard_schema_change")).resolves.toBe(42);
+  });
+
+  it("ignores untrusted MCP and client output-schema claims", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const mcp = mcpPluginTool("remote_claim", "Remote schema claim");
+    mcp.outputSchema = Type.Object({ trusted: Type.Literal(true) });
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [mcp] });
+    const config = { tools: { toolSearch: { mode: "tools" } } } as never;
+    addClientToolsToToolSearchCatalog({
+      tools: [
+        {
+          name: "client_claim",
+          description: "Client schema claim",
+          parameters: Type.Object({}),
+          outputSchema: Type.Object({ trusted: Type.Literal(true) }),
+          execute: async () => jsonResult({ trusted: false }),
+        } as never,
+      ],
+      config,
+      catalogRef,
+    });
+    const runtime = new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig(config));
+
+    for (const id of ["remote_claim", "client_claim"]) {
+      expect(runtime.all().find((entry) => entry.name === id)).not.toHaveProperty("output");
+      await expect(runtime.describe(id)).resolves.not.toHaveProperty("outputSchema");
+    }
   });
 
   it("compacts plugin tools behind the code surface and can search, describe, and call them", async () => {
@@ -1980,6 +2098,20 @@ describe("Tool Search", () => {
       config,
       sessionId,
     });
+    expect(second.catalogReused).toBe(false);
+  });
+
+  it("does not reuse when a same-named tool changes its output schema", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const tool = pluginTool("fake_output_schema_swap", "Stable description");
+    tool.outputSchema = Type.Object({ value: Type.String() }, { additionalProperties: false });
+    const config = { tools: { toolSearch: true } } as never;
+    const sessionId = "session-tool-output-schema-change";
+
+    applyToolSearchCatalog({ tools: [codeTool, tool], config, sessionId });
+    tool.outputSchema = Type.Object({ value: Type.Number() }, { additionalProperties: false });
+
+    const second = applyToolSearchCatalog({ tools: [codeTool, tool], config, sessionId });
     expect(second.catalogReused).toBe(false);
   });
 

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -17,6 +17,7 @@ import {
   applyToolSchemaDirectoryCatalog,
   buildToolSchemaDirectoryPrompt,
   clearToolSearchCatalog,
+  compactToolSearchCatalogEntry,
   createToolSearchCatalogRef,
   createToolSearchTools,
   estimateToolSchemaDirectoryToolNames,
@@ -1187,6 +1188,73 @@ describe("Tool Search", () => {
     });
   });
 
+  it("defers untrusted client schemas without traversing their properties", async () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const config = { tools: { toolSearch: true } } as never;
+    applyToolSearchCatalog({
+      tools: [codeTool],
+      config,
+      sessionId: "session-client-schema",
+    });
+
+    const clientTool = fakeTool("client_pick_file", "Ask the client to pick a file");
+    clientTool.parameters = {
+      type: "object",
+      properties: new Proxy(
+        {},
+        {
+          ownKeys: () => {
+            throw new Error("client properties must remain deferred");
+          },
+        },
+      ),
+    };
+    const untrustedOutputSchema = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error("client output schema must remain deferred");
+        },
+        ownKeys: () => {
+          throw new Error("client output schema must remain deferred");
+        },
+      },
+    );
+    clientTool.outputSchema = untrustedOutputSchema;
+    expect(
+      compactToolSearchCatalogEntry({
+        id: "client:client:client_pick_file",
+        source: "client",
+        sourceName: "client",
+        name: clientTool.name,
+        description: clientTool.description,
+        parameters: clientTool.parameters,
+        outputSchema: untrustedOutputSchema as never,
+        tool: clientTool,
+      }),
+    ).not.toHaveProperty("output");
+    addClientToolsToToolSearchCatalog({
+      tools: [clientTool],
+      config,
+      sessionId: "session-client-schema",
+    });
+
+    const search = expectDefined(
+      createToolSearchTools({ config, sessionId: "session-client-schema" }).find(
+        (tool) => tool.name === TOOL_SEARCH_RAW_TOOL_NAME,
+      ),
+      "search tool",
+    );
+    const result = resultDetails(
+      await search.execute("call-search-client", { query: "pick file" }),
+    );
+
+    expect(result).toContainEqual(
+      expect.objectContaining({ name: "client_pick_file", source: "client" }),
+    );
+    expect(result).not.toContainEqual(expect.objectContaining({ input: expect.anything() }));
+  });
+
   it("keeps client tools visible in directory mode", () => {
     const describeTool = fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe");
     const callTool = fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call");
@@ -2098,6 +2166,26 @@ describe("Tool Search", () => {
       config,
       sessionId,
     });
+    expect(second.catalogReused).toBe(false);
+  });
+
+  it("does not traverse remote schemas but detects a replacement schema object", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const tool = mcpPluginTool("remote_schema_swap", "Stable remote description");
+    const config = { tools: { toolSearch: true } } as never;
+    const sessionId = "session-remote-schema-change";
+
+    applyToolSearchCatalog({ tools: [codeTool, tool], config, sessionId });
+    tool.parameters = new Proxy(
+      { type: "object", properties: {} },
+      {
+        ownKeys: () => {
+          throw new Error("remote schema must not be traversed");
+        },
+      },
+    );
+
+    const second = applyToolSearchCatalog({ tools: [codeTool, tool], config, sessionId });
     expect(second.catalogReused).toBe(false);
   });
 

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -394,7 +394,7 @@ describe("Tool Search", () => {
     );
   });
 
-  it("preserves policy-blocked results outside a declared success output schema", async () => {
+  it("rejects policy blocks outside a declared success output schema", async () => {
     const execute = vi.fn(async () => jsonResult({ id: "should-not-run" }));
     initializeGlobalHookRunner(
       createMockPluginRegistry([
@@ -418,11 +418,9 @@ describe("Tool Search", () => {
       resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
     );
 
-    await expect(runtime.callValue("orchard_policy_block")).resolves.toEqual({
-      status: "blocked",
-      deniedReason: "plugin-before-tool-call",
-      reason: "blocked by orchard policy",
-    });
+    await expect(runtime.callValue("orchard_policy_block")).rejects.toThrow(
+      "was blocked before execution: blocked by orchard policy",
+    );
     expect(execute).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -417,7 +417,7 @@ describe("Tool Search", () => {
     const catalogRef = createToolSearchCatalogRef();
     const target = pluginTool("orchard_empty_details", "Return an empty orchard result");
     target.execute = vi.fn(async () => ({
-      content: [{ type: "text", text: "No orchard result" }],
+      content: [{ type: "text" as const, text: "No orchard result" }],
       details: undefined,
     }));
     registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -416,16 +416,46 @@ describe("Tool Search", () => {
     const catalogRef = createToolSearchCatalogRef();
     const target = pluginTool("orchard_bad_output", "Return a bad orchard result");
     target.outputSchema = Type.Object({ id: Type.String() }, { additionalProperties: false });
+    const projected: unknown[] = [];
     registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
     const runtime = new ToolSearchRuntime(
       {
         catalogRef,
-        executeTool: async () => jsonResult({ id: 42 }),
+        executeTool: async (params) => {
+          const result = jsonResult({ id: 42 });
+          const acceptedResult = await params.acceptResultBeforeProjection(result);
+          projected.push(acceptedResult);
+          return acceptedResult;
+        },
       },
       resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
     );
 
     await expect(runtime.callValue("orchard_bad_output")).rejects.toThrow(
+      "returned details that do not match its declared outputSchema",
+    );
+    expect(projected).toEqual([]);
+  });
+
+  it("revalidates mutable results after executor-side acceptance", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_mutated_output", "Return a mutable orchard result");
+    target.outputSchema = Type.Object({ id: Type.String() }, { additionalProperties: false });
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      {
+        catalogRef,
+        executeTool: async (params) => {
+          const result = jsonResult({ id: "P-1" });
+          await params.acceptResultBeforeProjection(result);
+          (result.details as { id: unknown }).id = 42;
+          return result;
+        },
+      },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.callValue("orchard_mutated_output")).rejects.toThrow(
       "returned details that do not match its declared outputSchema",
     );
   });

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -427,7 +427,7 @@ describe("Tool Search", () => {
     );
 
     const call = await runtime.call("orchard_empty_details");
-    expect(Object.prototype.hasOwnProperty.call(call.result, "details")).toBe(true);
+    expect(Object.hasOwn(call.result, "details")).toBe(true);
     await expect(runtime.callValue("orchard_empty_details")).resolves.toBeUndefined();
   });
 

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -361,8 +361,10 @@ describe("Tool Search", () => {
       provider: "openai",
       runtimePlan: {
         tools: {
-          normalize: (tools) =>
-            tools.map(({ outputSchema: _outputSchema, ...tool }) => tool as AnyAgentTool),
+          normalize: (tools: AnyAgentTool[]) =>
+            tools.map(
+              ({ outputSchema: _outputSchema, ...tool }: AnyAgentTool) => tool as AnyAgentTool,
+            ),
           logDiagnostics: vi.fn(),
         },
       } as never,

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -16,6 +16,7 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
+import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import { SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import {
   addClientToolsToToolSearchCatalog,
@@ -348,6 +349,39 @@ describe("Tool Search", () => {
     await expect(runtime.callValue("orchard_shipments")).resolves.toEqual([
       { id: "H-1", paid: false, tons: 14 },
     ]);
+  });
+
+  it("keeps output hints and validation after runtime normalization clones tools", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_normalized_output", "Read a normalized orchard row");
+    target.outputSchema = Type.Object({ id: Type.String() }, { additionalProperties: false });
+    target.execute = vi.fn(async () => jsonResult({ id: 42 }));
+    const [normalized] = normalizeAgentRuntimeTools({
+      tools: [target],
+      provider: "openai",
+      runtimePlan: {
+        tools: {
+          normalize: (tools) =>
+            tools.map(({ outputSchema: _outputSchema, ...tool }) => tool as AnyAgentTool),
+          logDiagnostics: vi.fn(),
+        },
+      } as never,
+    });
+    registerHeadlessToolSearchCatalog({
+      catalogRef,
+      tools: [expectDefined(normalized, "normalized tool")],
+    });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.search("normalized orchard row")).resolves.toContainEqual(
+      expect.objectContaining({ name: "orchard_normalized_output", output: "{ id: string }" }),
+    );
+    await expect(runtime.callValue("orchard_normalized_output")).rejects.toThrow(
+      "returned details that do not match its declared outputSchema",
+    );
   });
 
   it("exposes nullable trusted output schemas without hiding null", async () => {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -346,9 +346,10 @@ describe("Tool Search", () => {
     await expect(runtime.describe("orchard_shipments")).resolves.toMatchObject({
       outputSchema: { type: "array" },
     });
-    await expect(runtime.callValue("orchard_shipments")).resolves.toEqual([
-      { id: "H-1", paid: false, tons: 14 },
-    ]);
+    const result = await runtime.callValue("orchard_shipments");
+    expect(result).toEqual([{ id: "H-1", paid: false, tons: 14 }]);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen((result as unknown[])[0])).toBe(true);
   });
 
   it("keeps output hints and validation after runtime normalization clones tools", async () => {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -350,6 +350,32 @@ describe("Tool Search", () => {
     ]);
   });
 
+  it("exposes nullable trusted output schemas without hiding null", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_optional_shipment", "Read an optional orchard shipment");
+    target.outputSchema = {
+      type: "object",
+      nullable: true,
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      additionalProperties: false,
+    } as never;
+    target.execute = vi.fn(async () => jsonResult(null));
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.search("optional orchard shipment")).resolves.toContainEqual(
+      expect.objectContaining({
+        name: "orchard_optional_shipment",
+        output: "{ id: string } | null",
+      }),
+    );
+    await expect(runtime.callValue("orchard_optional_shipment")).resolves.toBeNull();
+  });
+
   it("rejects final catalog details that drift from a declared output schema", async () => {
     const catalogRef = createToolSearchCatalogRef();
     const target = pluginTool("orchard_bad_output", "Return a bad orchard result");

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -413,6 +413,24 @@ describe("Tool Search", () => {
     await expect(runtime.callValue("orchard_optional_shipment")).resolves.toBeNull();
   });
 
+  it("preserves an explicit undefined details marker through result snapshots", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_empty_details", "Return an empty orchard result");
+    target.execute = vi.fn(async () => ({
+      content: [{ type: "text", text: "No orchard result" }],
+      details: undefined,
+    }));
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      { catalogRef },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    const call = await runtime.call("orchard_empty_details");
+    expect(Object.prototype.hasOwnProperty.call(call.result, "details")).toBe(true);
+    await expect(runtime.callValue("orchard_empty_details")).resolves.toBeUndefined();
+  });
+
   it("rejects final catalog details that drift from a declared output schema", async () => {
     const catalogRef = createToolSearchCatalogRef();
     const target = pluginTool("orchard_bad_output", "Return a bad orchard result");

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -431,7 +431,9 @@ const sessionCatalogs =
 const reusableCatalogSnapshots = new Map<string, ReusableCatalogSnapshot>();
 const catalogFingerprints = new WeakMap<ToolSearchCatalogSession, string>();
 const catalogToolIdentities = new WeakMap<object, number>();
+const untrustedSchemaIdentities = new WeakMap<object, number>();
 let nextCatalogToolIdentity = 1;
+let nextUntrustedSchemaIdentity = 1;
 
 function readToolSearchConfig(config?: OpenClawConfig): Record<string, unknown> {
   const tools = isRecord(config?.tools) ? config.tools : undefined;
@@ -567,6 +569,20 @@ function catalogToolIdentity(tool: CatalogTool): number {
   return next;
 }
 
+function untrustedSchemaFingerprint(schema: unknown): string {
+  if (schema === null || typeof schema !== "object") {
+    return stableJsonFingerprint(schema);
+  }
+  const existing = untrustedSchemaIdentities.get(schema);
+  if (existing !== undefined) {
+    return `object:${existing}`;
+  }
+  const next = nextUntrustedSchemaIdentity;
+  nextUntrustedSchemaIdentity += 1;
+  untrustedSchemaIdentities.set(schema, next);
+  return `object:${next}`;
+}
+
 function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): string {
   // Fingerprints include object identity for executable tools because function
   // bodies are not JSON-stable but catalog reuse must not bind stale executors.
@@ -580,8 +596,14 @@ function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): 
         entry.name,
         entry.label ?? "",
         entry.description,
-        stableJsonFingerprint(entry.parameters),
-        stableJsonFingerprint(entry.outputSchema),
+        // Remote/client schemas may be attacker-sized. Object identity still
+        // invalidates reuse when a schema object is replaced without walking it.
+        entry.source === "openclaw"
+          ? stableJsonFingerprint(entry.parameters)
+          : untrustedSchemaFingerprint(entry.parameters),
+        entry.source === "openclaw"
+          ? stableJsonFingerprint(entry.outputSchema)
+          : untrustedSchemaFingerprint(entry.outputSchema),
         String(catalogToolIdentity(entry.tool)),
       ]
         .map((part) => JSON.stringify(part))
@@ -1166,9 +1188,9 @@ export function compactToolSearchCatalogEntry(entry: ToolSearchCatalogEntry) {
     name: entry.name,
     label: entry.label,
     description: entry.description,
-    // MCP schemas are server-provided, untrusted metadata. Keep them deferred
-    // until the model explicitly describes or calls the selected tool.
-    ...(entry.source === "mcp" ? {} : { input: compactToolInputHint(entry.parameters) }),
+    // Remote MCP and client schemas are untrusted metadata. Keep them deferred
+    // rather than repeatedly traversing attacker-sized property maps on search.
+    ...(entry.source === "openclaw" ? { input: compactToolInputHint(entry.parameters) } : {}),
     ...(output ? { output } : {}),
   };
 }

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -13,7 +13,7 @@ import {
   uniqueValues,
 } from "@openclaw/normalization-core/string-normalization";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { Type } from "typebox";
+import { Type, type TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
 import {
@@ -27,6 +27,7 @@ import type { AgentMessage, AgentToolResult, AgentToolUpdateCallback } from "./r
 import type { ToolDefinition } from "./sessions/index.js";
 import { appendBoundedTextTail, SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import { isAgentToolReplaySafe } from "./tool-replay-safety.js";
+import { compactToolInputHint, compactToolOutputHint } from "./tool-schema-hints.js";
 import { asToolParamsRecord, jsonResult, ToolInputError } from "./tools/common.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -53,10 +54,6 @@ const DEFAULT_SEARCH_LIMIT = 8;
 const DEFAULT_MAX_SEARCH_LIMIT = 20;
 const MAX_REUSABLE_CATALOG_SNAPSHOTS = 256;
 const MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS = 18_000;
-const MAX_COMPACT_INPUT_HINT_CHARS = 300;
-const MAX_COMPACT_INPUT_PROPERTIES = 16;
-const MAX_COMPACT_SCHEMA_DEPTH = 4;
-const MAX_COMPACT_UNION_TYPES = 4;
 const TOOL_DIRECTORY_IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/u;
 
 type ToolSearchMode = "code" | "tools" | "directory";
@@ -138,6 +135,7 @@ export type ToolSearchCatalogEntry = {
   label?: string;
   description: string;
   parameters?: unknown;
+  outputSchema?: TSchema;
   tool: CatalogTool;
 };
 
@@ -583,6 +581,7 @@ function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): 
         entry.label ?? "",
         entry.description,
         stableJsonFingerprint(entry.parameters),
+        stableJsonFingerprint(entry.outputSchema),
         String(catalogToolIdentity(entry.tool)),
       ]
         .map((part) => JSON.stringify(part))
@@ -713,6 +712,11 @@ function toCatalogEntry(
     label: tool.label,
     description: tool.description ?? "",
     parameters: tool.parameters,
+    // Only locally loaded OpenClaw/core tools may declare model-visible output
+    // contracts. MCP and client metadata remains untrusted and deferred.
+    ...(source === "openclaw" && (tool as AnyAgentTool).outputSchema
+      ? { outputSchema: (tool as AnyAgentTool).outputSchema }
+      : {}),
     tool: catalogTool,
   };
 }
@@ -1151,117 +1155,9 @@ function resolveCatalog(ctx: ToolSearchToolContext): ToolSearchCatalogSession {
   throw new ToolInputError("Tool Search catalog is unavailable for this run.");
 }
 
-function compactSchemaType(schema: unknown, depth = 0): string {
-  if (!isRecord(schema) || depth >= MAX_COMPACT_SCHEMA_DEPTH) {
-    return "unknown";
-  }
-  const enumValues =
-    Array.isArray(schema.enum) &&
-    schema.enum.length > 0 &&
-    schema.enum.length <= 6 &&
-    schema.enum.every(
-      (value): value is string | number | boolean | null =>
-        value === null ||
-        typeof value === "string" ||
-        (typeof value === "number" && Number.isFinite(value)) ||
-        typeof value === "boolean",
-    )
-      ? schema.enum
-      : [];
-  if (enumValues.length > 0 && enumValues.length <= 6) {
-    const rendered = enumValues.map((value) => JSON.stringify(value)).join(" | ");
-    if (rendered.length <= 96) {
-      return rendered;
-    }
-  }
-  const type = schema.type;
-  if (Array.isArray(type)) {
-    if (type.length > MAX_COMPACT_UNION_TYPES) {
-      return "unknown";
-    }
-    const types = type
-      .filter((value): value is string => typeof value === "string")
-      .map((value) => compactSchemaType({ ...schema, type: value }, depth + 1));
-    return types.length > 0 ? types.join(" | ") : "unknown";
-  }
-  if (type === "integer" || type === "number") {
-    return "number";
-  }
-  if (type === "array") {
-    return `Array<${compactSchemaType(schema.items, depth + 1)}>`;
-  }
-  if (type === "string" || type === "boolean" || type === "null" || type === "object") {
-    return type;
-  }
-  return "unknown";
-}
-
-function compactInputHint(parameters: unknown): string {
-  if (!isRecord(parameters)) {
-    return "unknown";
-  }
-  if (!isRecord(parameters.properties)) {
-    if (parameters.type !== "object") {
-      return compactSchemaType(parameters);
-    }
-    const hasRequired =
-      Array.isArray(parameters.required) &&
-      parameters.required.some((value) => typeof value === "string");
-    return hasRequired || parameters.additionalProperties !== false ? "{ ... }" : "{}";
-  }
-  const properties = parameters.properties;
-  const requiredValues = Array.isArray(parameters.required) ? parameters.required : [];
-  const required = new Set(
-    requiredValues
-      .slice(0, MAX_COMPACT_INPUT_PROPERTIES)
-      .filter((value): value is string => typeof value === "string"),
-  );
-  // Search hits cross the model/guest boundary. Required-first sorting and
-  // work/output bounds keep prompt bytes deterministic without exposing full schemas.
-  const selected = new Set<string>();
-  const keys: string[] = [];
-  for (const key of required) {
-    if (Object.hasOwn(properties, key)) {
-      selected.add(key);
-      keys.push(key);
-    }
-  }
-  let omitted =
-    requiredValues.length > MAX_COMPACT_INPUT_PROPERTIES ||
-    requiredValues
-      .slice(0, MAX_COMPACT_INPUT_PROPERTIES)
-      .some((value) => typeof value === "string" && !Object.hasOwn(properties, value)) ||
-    parameters.additionalProperties === true;
-  for (const key in properties) {
-    if (!Object.hasOwn(properties, key) || selected.has(key)) {
-      continue;
-    }
-    if (keys.length >= MAX_COMPACT_INPUT_PROPERTIES) {
-      omitted = true;
-      break;
-    }
-    selected.add(key);
-    keys.push(key);
-  }
-  keys.sort((a, b) => Number(required.has(b)) - Number(required.has(a)) || a.localeCompare(b));
-  const parts: string[] = [];
-  for (const key of keys) {
-    const name = /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(key) ? key : JSON.stringify(key);
-    const part = `${name}${required.has(key) ? "" : "?"}: ${compactSchemaType(properties[key])}`;
-    const next = `{ ${[...parts, part].join("; ")} }`;
-    if (next.length > MAX_COMPACT_INPUT_HINT_CHARS) {
-      omitted = true;
-      break;
-    }
-    parts.push(part);
-  }
-  if (parts.length === 0) {
-    return keys.length === 0 && !omitted ? "{}" : "{ ... }";
-  }
-  return `{ ${parts.join("; ")}${omitted ? "; ..." : ""} }`;
-}
-
 export function compactToolSearchCatalogEntry(entry: ToolSearchCatalogEntry) {
+  const output =
+    entry.source === "openclaw" ? compactToolOutputHint(entry.outputSchema) : undefined;
   return {
     id: entry.id,
     source: entry.source,
@@ -1272,7 +1168,8 @@ export function compactToolSearchCatalogEntry(entry: ToolSearchCatalogEntry) {
     description: entry.description,
     // MCP schemas are server-provided, untrusted metadata. Keep them deferred
     // until the model explicitly describes or calls the selected tool.
-    ...(entry.source === "mcp" ? {} : { input: compactInputHint(entry.parameters) }),
+    ...(entry.source === "mcp" ? {} : { input: compactToolInputHint(entry.parameters) }),
+    ...(output ? { output } : {}),
   };
 }
 
@@ -1654,6 +1551,7 @@ function describeEntry(entry: ToolSearchCatalogEntry) {
   return {
     ...compactToolSearchCatalogEntry(entry),
     parameters: entry.parameters ?? {},
+    ...(entry.outputSchema ? { outputSchema: entry.outputSchema } : {}),
   };
 }
 
@@ -1859,6 +1757,56 @@ function getTelemetry(catalog: ToolSearchCatalogSession) {
   };
 }
 
+let schemaValidatorModulePromise:
+  | Promise<typeof import("../plugins/schema-validator.js")>
+  | undefined;
+
+async function validateCatalogOutputValue(
+  entry: ToolSearchCatalogEntry,
+  value: unknown,
+): Promise<
+  ReturnType<typeof import("../plugins/schema-validator.js").validateJsonSchemaValue> | undefined
+> {
+  if (!entry.outputSchema) {
+    return undefined;
+  }
+  try {
+    schemaValidatorModulePromise ??= import("../plugins/schema-validator.js");
+    const { validateJsonSchemaValue } = await schemaValidatorModulePromise;
+    return validateJsonSchemaValue({
+      schema: entry.outputSchema as never,
+      // The shared validator fingerprints schema changes under the caller key,
+      // so a rebuilt same-id catalog cannot retain a stale compiled contract.
+      cacheKey: `tool-output:${entry.id}`,
+      value,
+    });
+  } catch (error) {
+    throw new Error(`Tool "${entry.id}" has an invalid outputSchema.`, { cause: error });
+  }
+}
+
+async function assertCatalogOutputSchemaIsValid(entry: ToolSearchCatalogEntry): Promise<void> {
+  // Compile before execution. A bad contract must not turn a successful side
+  // effect into a retryable post-execution schema failure.
+  await validateCatalogOutputValue(entry, undefined);
+}
+
+async function assertCatalogOutputMatchesSchema(
+  entry: ToolSearchCatalogEntry,
+  result: AgentToolResult<unknown>,
+): Promise<void> {
+  const validation = await validateCatalogOutputValue(entry, unwrapToolResultValue(result));
+  if (!validation) {
+    return;
+  }
+  if (validation.ok) {
+    return;
+  }
+  throw new Error(
+    `Tool "${entry.id}" returned details that do not match its declared outputSchema.`,
+  );
+}
+
 function sanitizeToolCallIdPart(value: string): string {
   const trimmed = value.trim();
   const safe = trimmed.replace(/[^A-Za-z0-9_.:-]+/g, "_").slice(0, 120);
@@ -1966,6 +1914,7 @@ export class ToolSearchRuntime {
     },
   ) => {
     catalog.callCount += 1;
+    await assertCatalogOutputSchemaIsValid(entry);
     const parentId = sanitizeToolCallIdPart(options?.parentToolCallId ?? "direct");
     const toolCallId = `tool_search_code:${parentId}:${entry.name}:${++this.callSequence}`;
     const executeTool =
@@ -1989,6 +1938,9 @@ export class ToolSearchRuntime {
       signal: options?.signal ?? this.ctx.abortSignal,
       onUpdate: options?.onUpdate,
     });
+    // Hooks may replace details after execution, so validate the final catalog
+    // value at the host boundary before Code Mode trusts the declared shape.
+    await assertCatalogOutputMatchesSchema(entry, result);
     return {
       tool: compactToolSearchCatalogEntry(entry),
       result,

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -1190,7 +1190,7 @@ export function compactToolSearchCatalogEntry(entry: ToolSearchCatalogEntry) {
     description: entry.description,
     // Remote MCP and client schemas are untrusted metadata. Keep them deferred
     // rather than repeatedly traversing attacker-sized property maps on search.
-    ...(entry.source === "openclaw" ? { input: compactToolInputHint(entry.parameters) } : {}),
+    input: entry.source === "openclaw" ? compactToolInputHint(entry.parameters) : "unknown",
     ...(output ? { output } : {}),
   };
 }

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -17,6 +17,7 @@ import { Type, type TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
 import {
+  isPreExecutionBlockedToolResult,
   isToolWrappedWithBeforeToolCallHook,
   rewrapToolWithBeforeToolCallHook,
   type HookContext,
@@ -1817,6 +1818,9 @@ async function assertCatalogOutputMatchesSchema(
   entry: ToolSearchCatalogEntry,
   result: AgentToolResult<unknown>,
 ): Promise<void> {
+  if (isPreExecutionBlockedToolResult(result)) {
+    return;
+  }
   const validation = await validateCatalogOutputValue(entry, unwrapToolResultValue(result));
   if (!validation) {
     return;

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -962,9 +962,15 @@ function freezeJsonSnapshot(value: unknown): unknown {
 function snapshotToolSearchTargetTranscriptResult(
   result: AgentToolResult<unknown>,
 ): AgentToolResult<unknown> {
+  const hasDetails = "details" in result;
   const snapshot = toJsonSafe(result);
   if (!isRecord(snapshot)) {
     throw new Error("Tool Search target result could not be captured for transcript projection.");
+  }
+  if (hasDetails && !("details" in snapshot)) {
+    // `details` presence selects callValue unwrapping. JSON serialization drops
+    // an explicit undefined, so restore that marker before freezing the envelope.
+    snapshot.details = result.details === undefined ? undefined : toJsonSafe(result.details);
   }
   return freezeJsonSnapshot(snapshot) as AgentToolResult<unknown>;
 }

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -959,7 +959,7 @@ function freezeJsonSnapshot(value: unknown): unknown {
 }
 
 /** Capture a stable JSON-safe result before delayed transcript settlement. */
-export function snapshotToolSearchTargetTranscriptResult(
+function snapshotToolSearchTargetTranscriptResult(
   result: AgentToolResult<unknown>,
 ): AgentToolResult<unknown> {
   const snapshot = toJsonSafe(result);

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -90,6 +90,9 @@ export type ToolSearchCatalogToolExecutor = (params: {
   input: unknown;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
+  acceptResultBeforeProjection: (
+    result: AgentToolResult<unknown>,
+  ) => Promise<AgentToolResult<unknown>>;
 }) => Promise<AgentToolResult<unknown>>;
 
 /** Transcript projection for target tool calls made through Tool Search. */
@@ -943,6 +946,27 @@ export function projectToolSearchTargetTranscriptMessages(
     inserted.add(projection);
   }
   return projected;
+}
+
+function freezeJsonSnapshot(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  for (const nested of Object.values(value)) {
+    freezeJsonSnapshot(nested);
+  }
+  return Object.freeze(value);
+}
+
+/** Capture a stable JSON-safe result before delayed transcript settlement. */
+export function snapshotToolSearchTargetTranscriptResult(
+  result: AgentToolResult<unknown>,
+): AgentToolResult<unknown> {
+  const snapshot = toJsonSafe(result);
+  if (!isRecord(snapshot)) {
+    throw new Error("Tool Search target result could not be captured for transcript projection.");
+  }
+  return freezeJsonSnapshot(snapshot) as AgentToolResult<unknown>;
 }
 
 /** Create an explicit catalog holder for callers that cannot rely on session keys. */
@@ -1953,14 +1977,24 @@ export class ToolSearchRuntime {
     const toolCallId = `tool_search_code:${parentId}:${entry.name}:${++this.callSequence}`;
     const executeTool =
       this.ctx.executeTool ??
-      (async (params: Parameters<ToolSearchCatalogToolExecutor>[0]) =>
-        await params.tool.execute(
+      (async (params: Parameters<ToolSearchCatalogToolExecutor>[0]) => {
+        const result = await params.tool.execute(
           params.toolCallId,
           params.input,
           params.signal,
           params.onUpdate,
           undefined as never,
-        ));
+        );
+        return await params.acceptResultBeforeProjection(result);
+      });
+    const acceptResultBeforeProjection = async (candidate: AgentToolResult<unknown>) => {
+      if (isPreExecutionBlockedToolResult(candidate)) {
+        await assertCatalogOutputMatchesSchema(entry, candidate);
+      }
+      const snapshot = snapshotToolSearchTargetTranscriptResult(candidate);
+      await assertCatalogOutputMatchesSchema(entry, snapshot);
+      return snapshot;
+    };
     const result = await executeTool({
       tool: entry.tool,
       toolName: entry.name,
@@ -1971,13 +2005,14 @@ export class ToolSearchRuntime {
       input: input ?? {},
       signal: options?.signal ?? this.ctx.abortSignal,
       onUpdate: options?.onUpdate,
+      acceptResultBeforeProjection,
     });
-    // Hooks may replace details after execution, so validate the final catalog
-    // value at the host boundary before Code Mode trusts the declared shape.
-    await assertCatalogOutputMatchesSchema(entry, result);
+    // Production executors queue the accepted snapshot. Repeat acceptance here
+    // so headless/custom executors cannot return a mutable unvalidated value.
+    const acceptedResult = await acceptResultBeforeProjection(result);
     return {
       tool: compactToolSearchCatalogEntry(entry),
-      result,
+      result: acceptedResult,
     };
   };
 

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -1818,8 +1818,16 @@ async function assertCatalogOutputMatchesSchema(
   entry: ToolSearchCatalogEntry,
   result: AgentToolResult<unknown>,
 ): Promise<void> {
-  if (isPreExecutionBlockedToolResult(result)) {
+  if (!entry.outputSchema) {
     return;
+  }
+  if (isPreExecutionBlockedToolResult(result)) {
+    const details = unwrapToolResultValue(result);
+    const reason =
+      isRecord(details) && typeof details.reason === "string" && details.reason.trim()
+        ? details.reason
+        : "Tool call blocked by policy";
+    throw new Error(`Tool "${entry.id}" was blocked before execution: ${reason}`);
   }
   const validation = await validateCatalogOutputValue(entry, unwrapToolResultValue(result));
   if (!validation) {

--- a/src/agents/tools/agents-list-tool.test.ts
+++ b/src/agents/tools/agents-list-tool.test.ts
@@ -56,10 +56,12 @@ describe("agents_list tool", () => {
       },
     } as unknown as OpenClawConfig);
 
-    const result = await createAgentsListTool({ agentSessionKey: "agent:main:main" }).execute(
-      "call",
-      {},
-    );
+    const tool = createAgentsListTool({ agentSessionKey: "agent:main:main" });
+    expect(tool.outputSchema).toMatchObject({
+      type: "object",
+      required: ["requester", "allowAny", "agents"],
+    });
+    const result = await tool.execute("call", {});
     const details = result.details as AgentListDetails;
 
     expect(details).toStrictEqual({

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -20,6 +20,43 @@ import { jsonResult } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
 
 const AgentsListToolSchema = Type.Object({});
+const AgentRuntimeSourceSchema = Type.Union([
+  Type.Literal("env"),
+  Type.Literal("agent"),
+  Type.Literal("defaults"),
+  Type.Literal("model"),
+  Type.Literal("provider"),
+  Type.Literal("implicit"),
+  Type.Literal("session"),
+  Type.Literal("session-key"),
+]);
+const AgentsListOutputSchema = Type.Object(
+  {
+    requester: Type.String(),
+    allowAny: Type.Boolean(),
+    agents: Type.Array(
+      Type.Object(
+        {
+          id: Type.String(),
+          name: Type.Optional(Type.String()),
+          configured: Type.Boolean(),
+          model: Type.Optional(Type.String()),
+          agentRuntime: Type.Optional(
+            Type.Object(
+              {
+                id: Type.String(),
+                source: AgentRuntimeSourceSchema,
+              },
+              { additionalProperties: false },
+            ),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
 
 type AgentListEntry = {
   id: string;
@@ -50,6 +87,7 @@ export function createAgentsListTool(opts?: {
     name: "agents_list",
     description: 'List ids allowed for `sessions_spawn(runtime:"subagent")`.',
     parameters: AgentsListToolSchema,
+    outputSchema: AgentsListOutputSchema,
     execute: async () => {
       const cfg = getRuntimeConfig();
       const { mainKey, alias } = resolveMainSessionAlias(cfg);

--- a/src/plugin-sdk/tool-plugin.test.ts
+++ b/src/plugin-sdk/tool-plugin.test.ts
@@ -10,6 +10,13 @@ import { defineToolPlugin, getToolPluginMetadata } from "./tool-plugin.js";
 
 describe("defineToolPlugin", () => {
   it("registers declared tools and wraps plain object results", async () => {
+    const outputSchema = Type.Object(
+      {
+        symbol: Type.String(),
+        configured: Type.Boolean(),
+      },
+      { additionalProperties: false },
+    );
     const entry = defineToolPlugin({
       id: "stock-quotes",
       name: "Stock Quotes",
@@ -25,6 +32,7 @@ describe("defineToolPlugin", () => {
           parameters: Type.Object({
             symbol: Type.String(),
           }),
+          outputSchema,
           async execute(params, config) {
             expectTypeOf(params.symbol).toEqualTypeOf<string>();
             expectTypeOf(config.apiKey).toEqualTypeOf<string>();
@@ -46,7 +54,9 @@ describe("defineToolPlugin", () => {
       name: "quote",
       label: "Quote",
       description: "Fetch a quote.",
+      outputSchema,
     });
+    expect(getToolPluginMetadata(entry)?.tools[0]?.outputSchema).toBe(outputSchema);
     const result = await expectDefined(
       captured.tools[0],
       "captured.tools[0] test invariant",

--- a/src/plugin-sdk/tool-plugin.ts
+++ b/src/plugin-sdk/tool-plugin.ts
@@ -67,6 +67,8 @@ export type ToolPluginToolDefinition<
 > = ToolPluginToolDefinitionBase<TParamsSchema> &
   (
     | {
+        /** Optional schema for the JSON value returned in `AgentToolResult.details`. */
+        outputSchema?: TSchema;
         /** Execute one concrete tool call and return either plain text or JSON-serializable data. */
         execute: (
           params: Static<TParamsSchema>,
@@ -81,6 +83,8 @@ export type ToolPluginToolDefinition<
           context: ToolPluginFactoryContext<TConfig>,
         ) => AnyAgentTool | AnyAgentTool[] | null | undefined;
         execute?: never;
+        /** Factory tools declare output schemas on their returned `AnyAgentTool` objects. */
+        outputSchema?: never;
       }
   );
 
@@ -89,6 +93,7 @@ type DefinedToolPluginTool = {
   label: string;
   description: string;
   parameters: TSchema;
+  outputSchema?: TSchema;
   optional: boolean;
   execute?: (params: unknown, config: unknown, context: ToolPluginExecutionContext) => unknown;
   factory?: (
@@ -102,6 +107,7 @@ export type ToolPluginStaticToolMetadata = {
   label: string;
   description: string;
   parameters: JsonSchemaObject;
+  outputSchema?: JsonSchemaObject;
   optional?: boolean;
 };
 
@@ -151,6 +157,7 @@ function createToolPluginToolFactory<TConfig>(): ToolPluginToolFactory<TConfig> 
     label: definition.label ?? definition.name,
     description: definition.description,
     parameters: definition.parameters,
+    outputSchema: definition.outputSchema,
     optional: definition.optional === true,
     execute: definition.execute as DefinedToolPluginTool["execute"],
     factory: definition.factory as DefinedToolPluginTool["factory"],
@@ -180,6 +187,7 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
       label: tool.label,
       description: tool.description,
       parameters: tool.parameters as JsonSchemaObject,
+      ...(tool.outputSchema ? { outputSchema: tool.outputSchema as JsonSchemaObject } : {}),
       ...(tool.optional ? { optional: true } : {}),
     })),
   };
@@ -218,6 +226,7 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
             label: tool.label,
             description: tool.description,
             parameters: tool.parameters,
+            ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
             execute: async (toolCallId, params, signal, onUpdate) =>
               wrapToolPluginResult(
                 await execute(params, config, {

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -62,6 +62,7 @@ describe("plugin tool descriptor cache keys", () => {
   });
 
   it("preserves required gateway client capabilities in cached descriptors", () => {
+    const outputSchema = { type: "object", properties: { ok: { type: "boolean" } } } as const;
     const cached = capturePluginToolDescriptor({
       pluginId: "demo",
       optional: false,
@@ -70,12 +71,14 @@ describe("plugin tool descriptor cache keys", () => {
         label: "Inline demo",
         description: "Render a demo",
         parameters: { type: "object", properties: {} },
+        outputSchema,
         requiredClientCaps: ["inline-widgets"],
         execute: async () => ({ content: [], details: {} }),
       },
     });
 
     expect(cached.requiredClientCaps).toEqual(["inline-widgets"]);
+    expect(cached.descriptor.outputSchema).toBe(outputSchema);
   });
 
   it("isolates descriptor caches by declared gateway client capabilities", () => {

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -165,6 +165,7 @@ export function capturePluginToolDescriptor(params: {
       ...(title ? { title } : {}),
       description: params.tool.description,
       inputSchema: asJsonObject(params.tool.parameters),
+      ...(params.tool.outputSchema ? { outputSchema: asJsonObject(params.tool.outputSchema) } : {}),
       owner: { kind: "plugin", pluginId: params.pluginId },
       executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
     },

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2287,10 +2287,12 @@ describe("resolvePluginTools optional tools", () => {
   });
 
   it("caches plugin tool descriptors and uses the runtime only on execution", async () => {
+    const outputSchema = { type: "object", properties: { ok: { type: "boolean" } } };
     const factory = vi.fn((rawCtx: unknown) => {
       const ctx = rawCtx as { sessionId?: string };
       return {
         ...makeTool("cached_tool"),
+        outputSchema,
         async execute() {
           return { content: [{ type: "text", text: ctx.sessionId ?? "missing" }] };
         },
@@ -2321,6 +2323,8 @@ describe("resolvePluginTools optional tools", () => {
     expectResolvedToolNames(second, ["cached_tool"]);
     expect(factory).toHaveBeenCalledTimes(1);
     expect(second[0]).not.toBe(first[0]);
+    expect(first[0]?.outputSchema).toBe(outputSchema);
+    expect(second[0]?.outputSchema).toBe(outputSchema);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
 
     await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -769,6 +769,7 @@ function createCachedDescriptorPluginTool(params: {
     label: descriptor.title ?? descriptor.name,
     description: descriptor.description,
     parameters: descriptor.inputSchema as never,
+    ...(descriptor.outputSchema ? { outputSchema: descriptor.outputSchema as never } : {}),
     ...(params.descriptor.requiredClientCaps
       ? { requiredClientCaps: [...params.descriptor.requiredClientCaps] }
       : {}),


### PR DESCRIPTION
Related: #109288
Follow-up to #109651 and #109290

AI-assisted: Yes (Codex)

## What Problem This Solves

Code Mode learned exact tool ids and compact input signatures from #109651, but every tool result still appeared as unknown. Even when a tool had a stable structured result, models often spent one exec returning the raw value and another exec processing fields they could have known up front. This left avoidable model turns, tokens, and latency in common multi-operation workflows.

## Why This Change Was Made

Trusted OpenClaw core and plugin tools can now declare an optional `outputSchema` for `AgentToolResult.details`. Code Mode and Tool Search expose a bounded TypeScript-style output hint only when that schema is complete and closed; open, oversized, unsupported, MCP, and client schemas remain unknown and raw-first.

OpenClaw compiles trusted output schemas before execution, then validates final details after normal hooks. The embedded executor converts accepted results into deep-frozen JSON-safe snapshots before queuing transcript projections, preserves the result envelope's `details` presence marker, validates that exact snapshot, and returns it for a second host-boundary acceptance pass; rejected or later-mutated values therefore cannot enter session history as successful hidden-tool results, and an explicit `details: undefined` cannot redirect unwrapping or validation to the whole envelope. Framework-owned pre-execution policy blocks remain outside the success schema and are recognized by object identity, so calls reject with the denial reason before generated code can treat a block as a successful value; tool-authored blocked lookalikes still fail validation. Runtime/provider normalization preserves the result contract when it clones tool definitions. The compact renderer has strict depth/property/character/union bounds and normalizes AJV-style nullable schemas so every validator-accepted `null` remains visible to generated code. Remote and client schemas stay deferred as `input: "unknown"` and use object identity for catalog reuse, preventing attacker-sized metadata walks while preserving schema-replacement invalidation. `agents_list` adopts the contract as the first built-in example.

The change also promotes Code Mode to a dedicated `/tools/code-mode` documentation page with Quickstart, runtime semantics, guest API, output-contract authoring, trust/validation rules, fallback behavior, debugging, and validation guidance. The old `/reference/code-mode` route redirects to it.

## Maintainer Decision

Approve `outputSchema` as the supported optional plugin API for describing and validating `AgentToolResult.details` across Code Mode and Tool Search. Tools that omit it retain existing behavior. Opted-in tools get pre-execution schema compilation, final-details validation, and framework-owned policy-result preservation.

## User Impact

Code Mode can call and process tools with declared result shapes in the first exec instead of paying a raw-inspection round trip. Unknown outputs keep the safe existing raw-first behavior. Plugin authors get one documented result contract shared by Tool Search and Code Mode, without trusting remote MCP or client schema claims.

## Evidence

Live multi-provider matrix: four validated Code Mode tasks per provider over the real Agent runtime and a 72-tool catalog with adversarial decoys. Baseline is merged #109651; after is this branch.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Validated tasks | 11/12 | 12/12 | +1 |
| Model turns | 29 | 26 | -10% |
| Code Mode exec calls | 17 | 14 | -18% |
| Decoy calls | 0 | 0 | unchanged |
| Total latency | 81.4s | 70.4s | -13% |
| Input tokens | 38,827 | 36,025 | -7% |
| Output tokens | 2,388 | 2,380 | unchanged |

Stress: three complete Code Mode matrices produced 34/36 validated tasks, 78 turns, 42 exec calls, 57 underlying service calls, and zero decoy calls. Anthropic and Google were 12/12; OpenAI was 10/12. Both misses were the model filtering singular fixture value `plum` with the plural word `plums` after selecting the correct real tool, not a discovery, transport, schema, or decoy failure. A final OpenAI/Google pass kept every completed task at two turns and one exec. The final Anthropic retry hit provider overload before tokens or tools; earlier Anthropic stress was 12/12.

Validation:

- Exact final head: 276 focused tests passed across the live-bench parser, Code Mode, Tool Search, transcript projection ordering, explicit undefined result markers, runtime normalization, schema hints, `agents_list`, plugin SDK, descriptor cache, and optional tool metadata.
- Blacksmith Testbox: the final projection patch passed exact 4-file core/test typechecks, lint with zero warnings or errors, SDK API/boundary checks, import-cycle analysis, formatting, and architecture guards. An earlier branch-wide Testbox pass also completed 254 focused tests, all changed gates, and the full production build. Fresh hosted CI runs again before merge.
- Adversarial regressions cover malformed schemas before side effects, post-hook result validation, validation before transcript projection, immutable accepted-result snapshots, explicit undefined result markers, mutation after executor acceptance, policy-block rejection with preserved reason, blocked-lookalike rejection, nullable scalar/object contracts, cloned runtime tools retaining hints and validation, schema replacement, empty/oversized/intersected unions failing closed, closed/truncated/unsupported shapes, huge keys/catalogs, untrusted client/MCP schema deferral, and zero traversal of hostile schema proxies.
- Source-blind behavior contract: satisfied at 0.86 confidence; all seven clauses passed, including state-changing irrigation, missing-tool recovery, zero decoys, provider-error classification, and docs navigation/redirect behavior.
- Autoreview: final full branch clean at 0.86 confidence; explicit undefined-marker fix clean at 0.97; union fail-closed fix clean at 0.96; projection-order and immutable-snapshot fix clean at 0.92; runtime-normalization fix clean at 0.97; policy-block contract fix clean at 0.95; nullable-contract fix clean at 0.94. Earlier review-driven fixes added pre-execution compilation, explicit completeness tracking, unsupported-shape rejection, bounded untrusted metadata handling, and the documented `input: "unknown"` sentinel.
