### PR TITLE
fix(telegram): stop draft-stream final flush promptly when discarded during retry_after wait

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -944,6 +944,104 @@ describe("createTelegramDraftStream", () => {
     }
   });
 
+  it("returns stop's final flush promptly when discarded during the retry_after wait", async () => {
+    vi.useFakeTimers();
+    try {
+      const api = createMockDraftApi();
+      api.editMessageText.mockRejectedValueOnce(
+        Object.assign(new Error("429: retry after 5"), {
+          error_code: 429,
+          parameters: { retry_after: 5 },
+        }),
+      );
+      const stream = createDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+      stream.update("Hello again");
+      await stream.flush();
+      stream.update("Hello final");
+      expect(api.editMessageText).toHaveBeenCalledTimes(1);
+
+      let stopSettled = false;
+      const stopPromise = stream.stop().then(() => {
+        stopSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(stopSettled).toBe(false);
+
+      // Teardown (clear/discard via stopForClear) must wake the parked wait;
+      // the final text is undeliverable once the stream is stopped.
+      await stream.discard();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(stopSettled).toBe(true);
+      await stopPromise;
+      expect(api.editMessageText).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors a new retry_after window after a discarded stream resets", async () => {
+    vi.useFakeTimers();
+    try {
+      const api = createMockDraftApi();
+      api.editMessageText
+        .mockRejectedValueOnce(
+          Object.assign(new Error("429: retry after 1"), {
+            error_code: 429,
+            parameters: { retry_after: 1 },
+          }),
+        )
+        .mockRejectedValueOnce(
+          Object.assign(new Error("429: retry after 1"), {
+            error_code: 429,
+            parameters: { retry_after: 1 },
+          }),
+        );
+      const stream = createDraftStream(api);
+
+      stream.update("Hello");
+      await stream.flush();
+      stream.update("Hello again");
+      await stream.flush();
+      stream.update("Hello final");
+
+      let firstStopSettled = false;
+      const firstStop = stream.stop().then(() => {
+        firstStopSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await stream.discard();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(firstStopSettled).toBe(true);
+      await firstStop;
+      expect(api.editMessageText).toHaveBeenCalledTimes(1);
+
+      // A later turn reuses the stream; a fresh suspension must still gate the
+      // full window instead of inheriting the discarded stream's aborted wait.
+      stream.forceNewMessage();
+      await vi.advanceTimersByTimeAsync(1100);
+      stream.update("Next");
+      await stream.flush();
+      stream.update("Next again");
+      await stream.flush();
+      stream.update("Next final");
+      expect(api.editMessageText).toHaveBeenCalledTimes(2);
+
+      const secondStop = stream.stop();
+      await vi.advanceTimersByTimeAsync(999);
+      expect(api.editMessageText).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
+      await secondStop;
+
+      expect(api.editMessageText).toHaveBeenCalledTimes(3);
+      expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Next final");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops the preview after repeated retryable edit failures", async () => {
     const api = createMockDraftApi();
     api.editMessageText.mockRejectedValue(

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -7,6 +7,7 @@ import {
 import type { MarkdownTableMode, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 import {
   escapeTelegramHtml,
@@ -289,7 +290,27 @@ export function createTelegramDraftStream(params: {
       replyTargetState = { kind: "retained", generation: sendGeneration, messageId };
     }
   };
-  const streamState = { stopped: false, final: false };
+  // Aborting on the stopped transition wakes the final flush's retry_after
+  // waits: stopForClear (clear/discard teardown) marks stopped through the
+  // shared controls state, so a parked stop() must not sleep out the flood
+  // window for text that will never be delivered. Re-armed when the stream
+  // resets to a new message.
+  let streamStoppedController = new AbortController();
+  let streamStopped = false;
+  const streamState = {
+    get stopped() {
+      return streamStopped;
+    },
+    set stopped(value: boolean) {
+      if (value && !streamStopped) {
+        streamStoppedController.abort();
+      } else if (!value && streamStopped) {
+        streamStoppedController = new AbortController();
+      }
+      streamStopped = value;
+    },
+    final: false,
+  };
   let messageSendAttempted = false;
   let suspendedUntilMs = 0;
   let consecutivePreviewFailures = 0;
@@ -669,9 +690,11 @@ export function createTelegramDraftStream(params: {
     const waitForRetryAfter = async () => {
       const delayMs = Math.max(0, suspendedUntilMs - Date.now());
       if (delayMs > 0) {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, delayMs);
-        });
+        // Stop-aware: a concurrent discard/clear aborts the wait instead of
+        // parking the flush until the window expires; the stopped re-check
+        // below owns the early return. A graceful stop still waits the full
+        // retry_after before sending.
+        await sleepWithAbort(delayMs, streamStoppedController.signal).catch(() => {});
       }
     };
     streamState.final = true;


### PR DESCRIPTION
## What Problem This Solves

`stop()` in `extensions/telegram/src/draft-stream.ts:667` gates its final flush on Telegram's `retry_after` flood window via `waitForRetryAfter()` (`draft-stream.ts:669-676`), which sleeps on a bare `setTimeout(resolve, delayMs)` (line 673). The `stopped` flag is only re-checked *after* the sleep completes (lines 686, 700), so when the stream is torn down mid-wait — `clear()`/`discard()` via `stopForClear`, e.g. a superseded reply turn (`bot-message-dispatch-draft.ts:449`), a text-deliverer discard (`lane-delivery-text-deliverer.ts:241`), or a terminal preview failure (`draft-stream.ts:538`) — the parked `stop()` keeps sleeping out the rest of the window even though the final text will never be delivered. The window is capped at `MAX_PREVIEW_FLOOD_SUSPEND_MS = 60_000` (line 53) per wait, and `stop()` waits once before the initial flush (line 685) plus up to twice in the bounded resume loop (line 699), so a discard during the final flush can leave the reply turn parked for tens of seconds (worst case ~120s+), delaying the reply turn's teardown while the account is stopping.

## Why This Change Was Made

The wait is now stop-aware. `streamState.stopped` transitions abort a per-stream `AbortController`, and `waitForRetryAfter` races the window against that signal with `sleepWithAbort` (`openclaw/plugin-sdk/runtime-env`) — the same helper and pattern as the merged sibling fix in this extension (#109604, `probe.ts:197`) and #108561 (discord). The interception lives on the `streamState` accessor because teardown marks `stopped` through the shared SDK controls state (`stopForClear` → `markStopped`, `src/channels/draft-stream-controls.ts:92-97`); catching the write at the state object covers the SDK path and the three local `stopped = true` sites (lines 449, 538, 899) in one place without touching shared channel code. The controller re-arms when the stream resets to a new message (`resetStreamToNewMessage`, line 744), so later turns still honor fresh flood windows. On wake, the existing `generation !== stopGeneration || streamState.stopped` re-checks own the early return, exactly as before.

Scope discipline — deliberately unchanged:

- `MAX_PREVIEW_FLOOD_SUSPEND_MS` (60s cap) and the `retry_after` bookkeeping.
- The 2-attempt bounded resume loop and all existing early-return checks.
- Graceful-path behavior: a non-discarded `stop()` still waits the full `retry_after` before sending (rate-limit compliance).
- The detached delete scheduling (`scheduleDetachedDelete`, line ~797), which is fire-and-forget by design and never stalls teardown.

No new config, no new env, no SDK or shared-core change: 1 source file, +27/-4 lines.

## User Impact

Discarding or clearing a Telegram draft stream while its final flush is parked behind a `retry_after` window now lets `stop()` return immediately instead of holding the reply turn (and account teardown) for up to ~60s per remaining wait. Rate-limit compliance is unchanged for graceful stops: the full window is still honored before the final edit is attempted.

## Evidence

### Real behavior proof — production `stop()` path, real wall-clock timers

Uncommitted `scratchpad/draft-stream-stop-aware-retry-wait.mts` drives the real `createTelegramDraftStream` through its public `api` seam (no module mocks, no fake timers). A real 429-shaped `editMessageText` rejection (`error_code: 429, parameters: { retry_after: 5 }`) arms the suspension through the production `readTelegramRetryAfterMs` path; `stop()` starts its final flush and `discard()` (the teardown path used by `cleanup(superseded)`) fires at +200ms.

**Before** (origin/main @ e01027dd28):

```json
{
  "discardRun":  { "scenario": "discard-mid-wait", "stopElapsedMs": 5005, "finalEditDelivered": false },
  "gracefulRun": { "scenario": "graceful", "stopElapsedMs": 5007, "finalEditDelivered": true,
                   "editCalls": [{ "atMs": 1, "text": "Hello again" }, { "atMs": 5009, "text": "Hello final" }] }
}
PARKED: stop() stayed behind the retry_after window for 5005ms despite discard at +200ms
OK: graceful stop() honored the window (5007ms)
```

**After** (this PR):

```json
{
  "discardRun":  { "scenario": "discard-mid-wait", "stopElapsedMs": 201, "finalEditDelivered": false },
  "gracefulRun": { "scenario": "graceful", "stopElapsedMs": 5006, "finalEditDelivered": true,
                   "editCalls": [{ "atMs": 0, "text": "Hello again" }, { "atMs": 5007, "text": "Hello final" }] }
}
OK: stop() returned 201ms after discard at +200ms
OK: graceful stop() honored the window (5006ms)
```

Same script, same harness: discard-mid-wait drops 5005ms → 201ms (≈ the +200ms discard point), no final edit is attempted after discard, and the graceful run still waits the full ~5000ms window and delivers the final text at 5007ms — retry_after compliance preserved.

### Control-red (mutation) verification

`git checkout origin/main -- extensions/telegram/src/draft-stream.ts` (keeping the new tests) →

- `returns stop's final flush promptly when discarded during the retry_after wait` **fails** immediately: `expect(stopSettled).toBe(true)` receives `false` — the wait stays parked on the bare timer.
- `honors a new retry_after window after a discarded stream resets` **hangs** at `await firstStop` — the pre-fix code cannot leave the window without the fake clock advancing, which is exactly the parking behavior under test.

Restoring the fix makes both pass.

### Regression coverage

- New: `returns stop's final flush promptly when discarded during the retry_after wait` — discard mid-wait settles `stop()` without advancing the fake clock into the window; the final text is never sent.
- New: `honors a new retry_after window after a discarded stream resets` — after discard + `forceNewMessage()`, a fresh suspension still gates `stop()` for the full window (guards the controller re-arm; without it the resumed stream would skip `retry_after`).
- Existing: `gates stop's initial final flush on an existing retry_after window` and the bounded-resume pagination tests continue to lock the graceful path.

### Validation

```
node scripts/run-vitest.mjs run extensions/telegram/src/draft-stream.test.ts
# Test Files  1 passed (1) — Tests 86 passed (86)

oxlint extensions/telegram/src/draft-stream.ts extensions/telegram/src/draft-stream.test.ts
# exit=0

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
# exit=0

git diff --check origin/main
# clean
```
