### PR TITLE
fix(qqbot): reject blank client secret env fallback

### DIFF
--- a/extensions/qqbot/src/bridge/config.ts
+++ b/extensions/qqbot/src/bridge/config.ts
@@ -11,6 +11,7 @@ import {
   resolveAccountBase,
   resolveDefaultAccountId,
 } from "../engine/config/resolve.js";
+import { normalizeOptionalString } from "../engine/utils/string-normalize.js";
 import type { ResolvedQQBotAccount, QQBotAccountConfig } from "../types.js";
 
 export const DEFAULT_ACCOUNT_ID = ENGINE_DEFAULT_ACCOUNT_ID;
@@ -149,9 +150,12 @@ export function resolveQQBotAccount(
     } catch {
       secretSource = "none";
     }
-  } else if (process.env.QQBOT_CLIENT_SECRET && base.accountId === DEFAULT_ACCOUNT_ID) {
-    clientSecret = process.env.QQBOT_CLIENT_SECRET;
-    secretSource = "env";
+  } else {
+    const envClientSecret = normalizeOptionalString(process.env.QQBOT_CLIENT_SECRET);
+    if (envClientSecret && base.accountId === DEFAULT_ACCOUNT_ID) {
+      clientSecret = envClientSecret;
+      secretSource = "env";
+    }
   }
 
   return {

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -28,7 +28,6 @@ import { qqbotChannelConfigSchema } from "./config-schema.js";
 import { qqbotDoctor } from "./doctor.js";
 import { loadCredentialBackup, saveCredentialBackup } from "./engine/config/credential-backup.js";
 import { clearAccountCredentials } from "./engine/config/credentials.js";
-import { normalizeOptionalString } from "./engine/utils/string-normalize.js";
 import { chunkQQBotMarkdownText } from "./engine/messaging/markdown-table-chunking.js";
 import type { OutboundMediaAccessContext } from "./engine/messaging/outbound-types.js";
 import {
@@ -36,6 +35,7 @@ import {
   looksLikeQQBotTarget,
   parseTarget,
 } from "./engine/messaging/target-parser.js";
+import { normalizeOptionalString } from "./engine/utils/string-normalize.js";
 import { resolveQQBotGroupToolPolicy } from "./group-policy.js";
 import type { ResolvedQQBotAccount } from "./types.js";
 

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -28,6 +28,7 @@ import { qqbotChannelConfigSchema } from "./config-schema.js";
 import { qqbotDoctor } from "./doctor.js";
 import { loadCredentialBackup, saveCredentialBackup } from "./engine/config/credential-backup.js";
 import { clearAccountCredentials } from "./engine/config/credentials.js";
+import { normalizeOptionalString } from "./engine/utils/string-normalize.js";
 import { chunkQQBotMarkdownText } from "./engine/messaging/markdown-table-chunking.js";
 import type { OutboundMediaAccessContext } from "./engine/messaging/outbound-types.js";
 import {
@@ -438,7 +439,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
 
       const resolved = resolveQQBotAccount((changed ? nextCfg : cfg) as OpenClawConfig, accountId);
       const loggedOut = resolved.secretSource === "none";
-      const envToken = Boolean(process.env.QQBOT_CLIENT_SECRET);
+      const envToken = Boolean(normalizeOptionalString(process.env.QQBOT_CLIENT_SECRET));
 
       return { ok: true, cleared, envToken, loggedOut };
     },

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -287,23 +287,26 @@ describe("qqbot config", () => {
   it.each([
     { value: "   ", secret: "", source: "none", configured: false },
     { value: "  fixture-secret  ", secret: "fixture-secret", source: "env", configured: true },
-  ])("normalizes QQBOT_CLIENT_SECRET environment fallback %#", ({ value, secret, source, configured }) => {
-    const cfg = { channels: { qqbot: { appId: "123456" } } } as OpenClawConfig;
-    const previous = process.env.QQBOT_CLIENT_SECRET;
-    process.env.QQBOT_CLIENT_SECRET = value;
-    try {
-      const resolved = resolveQQBotAccount(cfg, DEFAULT_ACCOUNT_ID);
-      expect(resolved.clientSecret).toBe(secret);
-      expect(resolved.secretSource).toBe(source);
-      expect(qqbotSetupPlugin.config.isConfigured?.(resolved, cfg)).toBe(configured);
-    } finally {
-      if (previous === undefined) {
-        delete process.env.QQBOT_CLIENT_SECRET;
-      } else {
-        process.env.QQBOT_CLIENT_SECRET = previous;
+  ])(
+    "normalizes QQBOT_CLIENT_SECRET environment fallback %#",
+    ({ value, secret, source, configured }) => {
+      const cfg = { channels: { qqbot: { appId: "123456" } } } as OpenClawConfig;
+      const previous = process.env.QQBOT_CLIENT_SECRET;
+      process.env.QQBOT_CLIENT_SECRET = value;
+      try {
+        const resolved = resolveQQBotAccount(cfg, DEFAULT_ACCOUNT_ID);
+        expect(resolved.clientSecret).toBe(secret);
+        expect(resolved.secretSource).toBe(source);
+        expect(qqbotSetupPlugin.config.isConfigured?.(resolved, cfg)).toBe(configured);
+      } finally {
+        if (previous === undefined) {
+          delete process.env.QQBOT_CLIENT_SECRET;
+        } else {
+          process.env.QQBOT_CLIENT_SECRET = previous;
+        }
       }
-    }
-  });
+    },
+  );
 
   it("resolves env SecretRefs on runtime resolution", () => {
     const cfg = makeQqbotSecretRefConfig();

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -297,8 +297,11 @@ describe("qqbot config", () => {
       expect(resolved.secretSource).toBe(source);
       expect(qqbotSetupPlugin.config.isConfigured?.(resolved, cfg)).toBe(configured);
     } finally {
-      if (previous === undefined) delete process.env.QQBOT_CLIENT_SECRET;
-      else process.env.QQBOT_CLIENT_SECRET = previous;
+      if (previous === undefined) {
+        delete process.env.QQBOT_CLIENT_SECRET;
+      } else {
+        process.env.QQBOT_CLIENT_SECRET = previous;
+      }
     }
   });
 

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -284,6 +284,24 @@ describe("qqbot config", () => {
     },
   );
 
+  it.each([
+    { value: "   ", secret: "", source: "none", configured: false },
+    { value: "  fixture-secret  ", secret: "fixture-secret", source: "env", configured: true },
+  ])("normalizes QQBOT_CLIENT_SECRET environment fallback %#", ({ value, secret, source, configured }) => {
+    const cfg = { channels: { qqbot: { appId: "123456" } } } as OpenClawConfig;
+    const previous = process.env.QQBOT_CLIENT_SECRET;
+    process.env.QQBOT_CLIENT_SECRET = value;
+    try {
+      const resolved = resolveQQBotAccount(cfg, DEFAULT_ACCOUNT_ID);
+      expect(resolved.clientSecret).toBe(secret);
+      expect(resolved.secretSource).toBe(source);
+      expect(qqbotSetupPlugin.config.isConfigured?.(resolved, cfg)).toBe(configured);
+    } finally {
+      if (previous === undefined) delete process.env.QQBOT_CLIENT_SECRET;
+      else process.env.QQBOT_CLIENT_SECRET = previous;
+    }
+  });
+
   it("resolves env SecretRefs on runtime resolution", () => {
     const cfg = makeQqbotSecretRefConfig();
     const previous = process.env.QQBOT_CLIENT_SECRET;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QQ Bot users who export a whitespace-only `QQBOT_CLIENT_SECRET` would see the default account marked configured during setup/status even though runtime auth has no usable secret.

## Why This Change Was Made

The implicit env fallback in `resolveQQBotAccount` now normalizes `QQBOT_CLIENT_SECRET` with the existing `normalizeOptionalString` helper before treating it as configured, matching other QQ Bot string normalization paths. Risk note: this only changes the default-account env fallback; config/file/SecretRef resolution is unchanged.

## User Impact

Whitespace-only or empty `QQBOT_CLIENT_SECRET` values no longer make the QQ Bot channel look configured when the secret is unusable. Valid secrets with surrounding whitespace are trimmed instead of passed through verbatim.

## Evidence

**Before (upstream/main)** — production module proof via `pnpm exec tsx .local/proof-blank-client-secret.ts` importing `extensions/qqbot/src/bridge/config.ts`:

```text
case=empty secretSource=none clientSecret="" configured=false
case=whitespace secretSource=env clientSecret="   " configured=true
case=valid-trimmed secretSource=env clientSecret="  real-secret  " configured=true
```

**After (this branch)** — same harness:

```text
case=empty secretSource=none clientSecret="" configured=false
case=whitespace secretSource=none clientSecret="" configured=false
case=valid-trimmed secretSource=env clientSecret="real-secret" configured=true
```

Focused tests:

```text
node scripts/run-vitest.mjs run extensions/qqbot/src/config.test.ts -t "QQBOT_CLIENT_SECRET"
# 2 passed, 20 skipped
```

What was not tested: live QQ Bot API token exchange with real credentials; the proof exercises the config resolution path that gates setup/status before network auth.

AI-assisted: Cursor Agent; proof run manually on this machine.
