### PR TITLE
fix: test typechecks fail on missing error-format declaration

### DIFF
--- a/scripts/lib/error-format.d.mts
+++ b/scripts/lib/error-format.d.mts
@@ -1,0 +1,2 @@
+/** Return a readable message for Error and non-Error thrown values. */
+export function formatErrorMessage(error: unknown): string;


### PR DESCRIPTION
## What Problem This Solves

`check-test-types` is red on `main`: recent release-tooling changes import `scripts/lib/error-format.mjs` from TypeScript (`scripts/openclaw-npm-postpublish-verify.ts:32`), and the module has no sibling `.d.mts` declaration, so the test-types lane fails with TS7016 for every PR.

## Why This Change Was Made

Every `scripts/lib/*.mjs` module consumed from TypeScript carries a sibling `.d.mts` in this repo; this one was missed. All PR ci-gates are currently blocked on it.

## User Impact

None at runtime — restores a green `check-test-types` lane repo-wide.

## Evidence

- Before: `pnpm check:test-types` fails with `scripts/openclaw-npm-postpublish-verify.ts(32,36): error TS7016 ... error-format.mjs implicitly has an 'any' type`.
- After: `pnpm check:test-types` passes locally (exit 0, no TS errors). Declaration mirrors the module's single export (`formatErrorMessage(error: unknown): string`).
