### PR TITLE
fix(line): prevent silent webhook loss after acknowledgment

### DIFF
--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -439,11 +439,10 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
       return;
     }
 
-    await processMessage(messageContext, {
-      ...(context.turnAdoptionLifecycle
-        ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle }
-        : {}),
-    });
+    await processMessage(
+      messageContext,
+      context.turnAdoptionLifecycle ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle } : {},
+    );
     historyReservation.commit();
   } finally {
     historyReservation.release();
@@ -495,11 +494,10 @@ async function handlePostbackEvent(
     return;
   }
 
-  await context.processMessage(postbackContext, {
-    ...(context.turnAdoptionLifecycle
-      ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle }
-      : {}),
-  });
+  await context.processMessage(
+    postbackContext,
+    context.turnAdoptionLifecycle ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle } : {},
+  );
 }
 
 export async function handleLineWebhookEvents(

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -39,6 +39,7 @@ import { reserveLineGroupHistory } from "./group-history.js";
 import { resolveLineGroupConfigEntry } from "./group-keys.js";
 import { pushMessageLine, replyMessageLine } from "./send.js";
 import type { LineGroupConfig, ResolvedLineAccount } from "./types.js";
+import type { LineWebhookTurnAdoptionLifecycle } from "./webhook-spool.js";
 
 type FollowEvent = webhook.FollowEvent;
 type JoinEvent = webhook.JoinEvent;
@@ -73,10 +74,9 @@ interface LineHandlerContext {
   mediaMaxBytes: number;
   processMessage: (
     ctx: LineInboundContext,
-    control: { abortSignal?: AbortSignal; onTurnAdopted?: () => Promise<void> },
+    control: { turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle },
   ) => Promise<void>;
-  abortSignal?: AbortSignal;
-  onTurnAdopted?: () => Promise<void>;
+  turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle;
   groupHistories?: Map<string, HistoryEntry[]>;
   historyLimit?: number;
 }
@@ -440,8 +440,9 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     }
 
     await processMessage(messageContext, {
-      ...(context.abortSignal ? { abortSignal: context.abortSignal } : {}),
-      ...(context.onTurnAdopted ? { onTurnAdopted: context.onTurnAdopted } : {}),
+      ...(context.turnAdoptionLifecycle
+        ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle }
+        : {}),
     });
     historyReservation.commit();
   } finally {
@@ -495,8 +496,9 @@ async function handlePostbackEvent(
   }
 
   await context.processMessage(postbackContext, {
-    ...(context.abortSignal ? { abortSignal: context.abortSignal } : {}),
-    ...(context.onTurnAdopted ? { onTurnAdopted: context.onTurnAdopted } : {}),
+    ...(context.turnAdoptionLifecycle
+      ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle }
+      : {}),
   });
 }
 

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -12,7 +12,10 @@ import { resolveLineAccount } from "./accounts.js";
 import { handleLineWebhookEvents } from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
-import { createLineWebhookSpool } from "./webhook-spool.js";
+import {
+  createLineWebhookSpool,
+  type LineWebhookTurnAdoptionLifecycle,
+} from "./webhook-spool.js";
 
 interface LineBotOptions {
   channelAccessToken: string;
@@ -23,7 +26,7 @@ interface LineBotOptions {
   mediaMaxMb?: number;
   onMessage?: (
     ctx: LineInboundContext,
-    control: { abortSignal?: AbortSignal; onTurnAdopted?: () => Promise<void> },
+    control: { turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle },
   ) => Promise<void>;
 }
 
@@ -60,8 +63,9 @@ export function createLineBot(opts: LineBotOptions): LineBot {
         runtime,
         mediaMaxBytes,
         processMessage,
-        ...(control.abortSignal ? { abortSignal: control.abortSignal } : {}),
-        ...(control.onTurnAdopted ? { onTurnAdopted: control.onTurnAdopted } : {}),
+        ...(control.turnAdoptionLifecycle
+          ? { turnAdoptionLifecycle: control.turnAdoptionLifecycle }
+          : {}),
         groupHistories,
         historyLimit: cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
       }),

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -12,10 +12,7 @@ import { resolveLineAccount } from "./accounts.js";
 import { handleLineWebhookEvents } from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
-import {
-  createLineWebhookSpool,
-  type LineWebhookTurnAdoptionLifecycle,
-} from "./webhook-spool.js";
+import { createLineWebhookSpool, type LineWebhookTurnAdoptionLifecycle } from "./webhook-spool.js";
 
 interface LineBotOptions {
   channelAccessToken: string;

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -166,6 +166,7 @@ export async function monitorLineProvider(
       logVerbose(`line: received message from ${displayName} (${ctxPayload.From})`);
       let replyTokenUsed = false;
       let turnAdopted = false;
+      const ingressLifecycle = deliveryControl.turnAdoptionLifecycle;
 
       try {
         const textLimit = 5000;
@@ -175,12 +176,12 @@ export async function monitorLineProvider(
           accountId: route.accountId,
           raw: ctx,
           turnAdoptionLifecycle: {
+            ...(ingressLifecycle ?? {}),
             admission: "exclusive",
             onAdopted: async () => {
-              await deliveryControl.onTurnAdopted?.();
+              await ingressLifecycle?.onAdopted();
               turnAdopted = true;
             },
-            ...(deliveryControl.abortSignal ? { abortSignal: deliveryControl.abortSignal } : {}),
           },
           adapter: {
             ingest: () => ({
@@ -195,8 +196,8 @@ export async function monitorLineProvider(
               ctxPayload,
               record: ctx.turn.record,
               replyPipeline: {},
-              ...(deliveryControl.abortSignal
-                ? { replyOptions: { abortSignal: deliveryControl.abortSignal } }
+              ...(ingressLifecycle?.abortSignal
+                ? { replyOptions: { abortSignal: ingressLifecycle.abortSignal } }
                 : {}),
               delivery: {
                 durable: (payload, info) =>

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -176,7 +176,7 @@ export async function monitorLineProvider(
           accountId: route.accountId,
           raw: ctx,
           turnAdoptionLifecycle: {
-            ...(ingressLifecycle ?? {}),
+            ...ingressLifecycle,
             admission: "exclusive",
             onAdopted: async () => {
               await ingressLifecycle?.onAdopted();

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -202,7 +202,9 @@ describe("LINE webhook spool", () => {
 
         await spool.accept(callback(ninth));
         // Hold the eight adopted-but-unfinished deliveries across two timer pumps.
-        await new Promise((resolve) => setTimeout(resolve, 1_100));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1_100);
+        });
 
         expect(deliver).toHaveBeenCalledTimes(8);
         expect(maxActiveDeliveries).toBe(8);
@@ -244,7 +246,9 @@ describe("LINE webhook spool", () => {
       const stopping = first.stop().then(() => {
         stopSettled = true;
       });
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
       expect(stopSettled).toBe(false);
       expect(await queue.listClaims()).toHaveLength(1);
 
@@ -321,7 +325,9 @@ describe("LINE webhook spool", () => {
         await waitForVerdict(queue, "message:message-event-duplicate", "completed");
 
         await spool.accept(callback(event));
-        await new Promise((resolve) => setTimeout(resolve, 600));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 600);
+        });
 
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {
@@ -351,7 +357,9 @@ describe("LINE webhook spool", () => {
         await spool.accept(
           callback(createEvent({ webhookEventId: "delivery-b", messageId: "shared-message" })),
         );
-        await new Promise((resolve) => setTimeout(resolve, 600));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 600);
+        });
 
         expect(deliver).toHaveBeenCalledTimes(1);
       } finally {

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -1,10 +1,11 @@
-// Line tests cover durable webhook admission, replay, and dead-lettering.
+// Line tests cover durable webhook admission, replay, and core-drain recovery.
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { webhook } from "@line/bot-sdk";
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests as createChannelIngressQueue,
@@ -14,27 +15,32 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLineNodeWebhookHandler } from "./webhook-node.js";
 import { createLineWebhookSpool, LineWebhookTerminalDeliveryError } from "./webhook-spool.js";
 
-type LineWebhookDeliveryOutcome = Parameters<
-  NonNullable<Parameters<typeof createLineWebhookSpool>[0]["onOutcome"]>
->[0];
-
 type SpoolPayload = {
   version: number;
+  rawEvent: string;
   destination: string;
-  event: webhook.Event;
 };
 
 const runtime = (): RuntimeEnv => ({ error: vi.fn(), exit: vi.fn(), log: vi.fn() });
 
-function createEvent(eventId: string, userId = "user-1"): webhook.Event {
+function createEvent(params: {
+  webhookEventId: string;
+  messageId?: string;
+  userId?: string;
+  text?: string;
+}): webhook.Event {
   return {
     type: "message",
-    message: { id: `message-${eventId}`, type: "text", text: "hello" },
-    replyToken: "test-auth-token",
+    message: {
+      id: params.messageId ?? `message-${params.webhookEventId}`,
+      type: "text",
+      text: params.text ?? "hello",
+    },
+    replyToken: "test-reply-token",
     timestamp: Date.now(),
-    source: { type: "user", userId },
+    source: { type: "user", userId: params.userId ?? "user-1" },
     mode: "active",
-    webhookEventId: eventId,
+    webhookEventId: params.webhookEventId,
     deliveryContext: { isRedelivery: false },
   } as webhook.MessageEvent;
 }
@@ -43,11 +49,15 @@ function callback(event: webhook.Event): webhook.CallbackRequest {
   return { destination: "destination-1", events: [event] };
 }
 
+function payloadFor(event: webhook.Event): SpoolPayload {
+  return { version: 1, rawEvent: JSON.stringify(event), destination: "destination-1" };
+}
+
 async function withQueue<T>(
-  fn: (queue: ReturnType<typeof createChannelIngressQueue<SpoolPayload>>) => Promise<T>,
+  fn: (queue: ChannelIngressQueue<SpoolPayload>) => Promise<T>,
 ): Promise<T> {
-  const stateDir = path.join(os.tmpdir(), `openclaw-line-spool-${crypto.randomUUID()}`);
-  await fs.mkdir(stateDir);
+  const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-line-spool-"));
+  const stateDir = await fs.realpath(createdDir);
   const queue = createChannelIngressQueue<SpoolPayload>({
     channelId: "line",
     accountId: "default",
@@ -61,18 +71,22 @@ async function withQueue<T>(
   }
 }
 
-async function waitForOutcome(
-  outcomes: LineWebhookDeliveryOutcome[],
-  kind: LineWebhookDeliveryOutcome["kind"],
-): Promise<LineWebhookDeliveryOutcome> {
-  await vi.waitFor(() => {
-    expect(outcomes.some((outcome) => outcome.kind === kind)).toBe(true);
-  });
-  const outcome = outcomes.find((candidate) => candidate.kind === kind);
-  if (!outcome) {
-    throw new Error(`Expected LINE webhook spool outcome ${kind}`);
-  }
-  return outcome;
+async function waitForVerdict(
+  queue: ChannelIngressQueue<SpoolPayload>,
+  eventId: string,
+  expected: "completed" | "failed",
+): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const verdict = await queue.enqueue(eventId, {
+        version: 1,
+        rawEvent: "{}",
+        destination: "",
+      });
+      expect(verdict.kind).toBe(expected);
+    },
+    { timeout: 4_000 },
+  );
 }
 
 function createResponse(): ServerResponse & { body?: string } {
@@ -89,568 +103,307 @@ function createResponse(): ServerResponse & { body?: string } {
   return response as unknown as ServerResponse & { body?: string };
 }
 
+async function invokeSignedWebhook(params: {
+  handler: ReturnType<typeof createLineNodeWebhookHandler>;
+  body: string;
+  channelSecret: string;
+}): Promise<ServerResponse & { body?: string }> {
+  const response = createResponse();
+  await params.handler(
+    {
+      method: "POST",
+      headers: {
+        "x-line-signature": crypto
+          .createHmac("SHA256", params.channelSecret)
+          .update(params.body)
+          .digest("base64"),
+      },
+    } as unknown as IncomingMessage,
+    response,
+  );
+  return response;
+}
+
 describe("LINE webhook spool", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
   });
 
-  it("acknowledges only after durable persistence even when delivery fails", async () => {
+  it("does not acknowledge when durable enqueue fails", async () => {
     await withQueue(async (queue) => {
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
+      const enqueue = vi.fn(async () => {
+        throw new Error("sqlite unavailable");
+      });
+      const failingQueue: ChannelIngressQueue<SpoolPayload> = { ...queue, enqueue };
+      const deliver = vi.fn(async () => {});
       const spool = createLineWebhookSpool({
         accountId: "default",
         runtime: runtime(),
-        queue,
-        maxAttempts: 1,
-        retryBaseMs: 0,
-        deliver: async () => {
-          throw new Error("dispatch failed");
-        },
-        onOutcome: (outcome) => outcomes.push(outcome),
+        queue: failingQueue,
+        deliver,
       });
-      spool.start();
-      const body = JSON.stringify(callback(createEvent("event-ack")));
-      const channelSecret = "test-auth-token";
+      const body = JSON.stringify(callback(createEvent({ webhookEventId: "event-ack-fail" })));
+      const channelSecret = "test-channel-secret";
       const handler = createLineNodeWebhookHandler({
         channelSecret,
         bot: { handleWebhook: spool.accept },
         runtime: runtime(),
         readBody: async () => body,
       });
-      const response = createResponse();
 
-      await handler(
-        {
-          method: "POST",
-          headers: {
-            "x-line-signature": crypto
-              .createHmac("SHA256", channelSecret)
-              .update(body)
-              .digest("base64"),
-          },
-        } as unknown as IncomingMessage,
-        response,
-      );
+      try {
+        const response = await invokeSignedWebhook({ handler, body, channelSecret });
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBe(JSON.stringify({ status: "ok" }));
-      const outcome = await waitForOutcome(outcomes, "dead-lettered");
-      expect(outcome).toMatchObject({
-        eventId: "event-ack",
-        attempt: 1,
-        reason: "retry-limit-exceeded",
-      });
-      expect((await queue.enqueue("event-ack", {} as SpoolPayload)).kind).toBe("failed");
-      await spool.stop();
-    });
-  });
-
-  it("recovers an in-flight event after restart and delivers it", async () => {
-    await withQueue(async (queue) => {
-      const event = createEvent("event-restart");
-      await queue.enqueue(
-        "event-restart",
-        { version: 1, destination: "destination-1", event },
-        { laneKey: "user:user-1" },
-      );
-      expect(await queue.claim("event-restart", { ownerId: "dead-gateway" })).not.toBeNull();
-      const delivered = vi.fn(async () => {});
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const restartedSpool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        claimStaleMs: 25,
-        retryBaseMs: 0,
-        deliver: delivered,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      restartedSpool.start();
-
-      await waitForOutcome(outcomes, "completed");
-      expect(delivered).toHaveBeenCalledTimes(1);
-      expect((await queue.enqueue("event-restart", {} as SpoolPayload)).kind).toBe("completed");
-      await restartedSpool.stop();
-    });
-  });
-
-  it("does not reclaim a fresh claim held by another live spool", async () => {
-    await withQueue(async (queue) => {
-      const event = createEvent("event-live-owner");
-      await queue.enqueue(
-        "event-live-owner",
-        { version: 1, destination: "destination-1", event },
-        { laneKey: "user:user-1" },
-      );
-      expect(await queue.claim("event-live-owner", { ownerId: "live-gateway" })).not.toBeNull();
-      const deliver = vi.fn(async () => {});
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        claimStaleMs: 60_000,
-        deliver,
-      });
-      spool.start();
-
-      await vi.waitFor(async () => {
-        expect(await queue.listClaims()).toHaveLength(1);
-      });
-      expect(deliver).not.toHaveBeenCalled();
-      await spool.stop();
-    });
-  });
-
-  it("bounds poison-event retries and records a typed dead letter", async () => {
-    await withQueue(async (queue) => {
-      const deliver = vi.fn(async () => {
-        throw new Error("poison");
-      });
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        maxAttempts: 3,
-        retryBaseMs: 0,
-        retryMaxMs: 0,
-        deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-poison")));
-
-      const outcome = await waitForOutcome(outcomes, "dead-lettered");
-      expect(outcome).toEqual({
-        kind: "dead-lettered",
-        eventId: "event-poison",
-        attempt: 3,
-        reason: "retry-limit-exceeded",
-        error: "poison",
-      });
-      expect(deliver).toHaveBeenCalledTimes(3);
-      const duplicate = await queue.enqueue("event-poison", {} as SpoolPayload);
-      expect(duplicate.kind).toBe("failed");
-      if (duplicate.kind === "failed") {
-        expect(duplicate.record.reason).toBe("retry-limit-exceeded");
-      }
-      await spool.stop();
-    });
-  });
-
-  it("dead-letters without retry after delivery side effects commit", async () => {
-    await withQueue(async (queue) => {
-      const deliver = vi.fn(async () => {
-        throw new LineWebhookTerminalDeliveryError("reply token consumed");
-      });
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-terminal")));
-
-      const outcome = await waitForOutcome(outcomes, "dead-lettered");
-      expect(outcome).toMatchObject({
-        eventId: "event-terminal",
-        attempt: 1,
-        reason: "delivery-side-effects-committed",
-      });
-      expect(deliver).toHaveBeenCalledTimes(1);
-      await spool.stop();
-    });
-  });
-
-  it("retries completion persistence without redelivering", async () => {
-    await withQueue(async (queue) => {
-      const complete = vi
-        .fn(queue.complete.bind(queue))
-        .mockRejectedValueOnce(new Error("database busy"));
-      const deliver = vi.fn(async () => {});
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue: { ...queue, complete },
-        claimRefreshMs: 1,
-        deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-completion-retry")));
-
-      await waitForOutcome(outcomes, "completed");
-      expect(complete).toHaveBeenCalledTimes(2);
-      expect(deliver).toHaveBeenCalledTimes(1);
-      await spool.stop();
-    });
-  });
-
-  it("finishes completion persistence when shutdown follows successful delivery", async () => {
-    await withQueue(async (queue) => {
-      let reportFirstFailure: (() => void) | undefined;
-      const firstFailure = new Promise<void>((resolve) => {
-        reportFirstFailure = resolve;
-      });
-      const complete = vi.fn(queue.complete.bind(queue)).mockImplementationOnce(async () => {
-        reportFirstFailure?.();
-        throw new Error("database busy");
-      });
-      const deliver = vi.fn(async () => {});
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue: { ...queue, complete },
-        deliver,
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-completion-stop")));
-      await firstFailure;
-
-      await spool.stop();
-
-      expect(complete).toHaveBeenCalledTimes(2);
-      expect(deliver).toHaveBeenCalledTimes(1);
-      expect((await queue.enqueue("event-completion-stop", {} as SpoolPayload)).kind).toBe(
-        "completed",
-      );
-    });
-  });
-
-  it("completes at durable turn adoption without replaying later failures", async () => {
-    await withQueue(async (queue) => {
-      const deliver = vi.fn(async (_event, _destination, control) => {
-        await control.onTurnAdopted();
-        throw new Error("settle failed after adoption");
-      });
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-adopted")));
-
-      await waitForOutcome(outcomes, "completed");
-      expect(deliver).toHaveBeenCalledTimes(1);
-      expect((await queue.enqueue("event-adopted", {} as SpoolPayload)).kind).toBe("completed");
-      await spool.stop();
-    });
-  });
-
-  it("keeps an adopted delivery cancellable until the turn settles", async () => {
-    await withQueue(async (queue) => {
-      const adopted = vi.fn();
-      const deliver = vi.fn(async (_event, _destination, control) => {
-        await control.onTurnAdopted();
-        adopted();
-        await new Promise<void>((_resolve, reject) => {
-          control.abortSignal.addEventListener("abort", () => reject(new Error("aborted")), {
-            once: true,
-          });
-        });
-      });
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-adopted-stop")));
-      await vi.waitFor(() => {
-        expect(adopted).toHaveBeenCalledTimes(1);
-      });
-
-      await spool.stop();
-
-      expect(outcomes).toContainEqual({ kind: "completed", eventId: "event-adopted-stop" });
-      expect((await queue.enqueue("event-adopted-stop", {} as SpoolPayload)).kind).toBe(
-        "completed",
-      );
-    });
-  });
-
-  it("retries terminal-state persistence without redelivering", async () => {
-    await withQueue(async (queue) => {
-      const fail = vi.fn(queue.fail.bind(queue)).mockRejectedValueOnce(new Error("database busy"));
-      const deliver = vi.fn(async () => {
-        throw new LineWebhookTerminalDeliveryError("reply token consumed");
-      });
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue: { ...queue, fail },
-        claimRefreshMs: 1,
-        deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-terminal-retry")));
-
-      await waitForOutcome(outcomes, "dead-lettered");
-      expect(fail).toHaveBeenCalledTimes(2);
-      expect(deliver).toHaveBeenCalledTimes(1);
-      await spool.stop();
-    });
-  });
-
-  it("drains a persisted batch prefix when a later enqueue fails", async () => {
-    await withQueue(async (queue) => {
-      let enqueueCount = 0;
-      const enqueue: typeof queue.enqueue = async (...args) => {
-        enqueueCount += 1;
-        if (enqueueCount === 2) {
-          throw new Error("database busy");
-        }
-        return await queue.enqueue(...args);
-      };
-      const deliver = vi.fn(async () => {});
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue: { ...queue, enqueue },
-        deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
-      });
-      spool.start();
-
-      await expect(
-        spool.accept({
-          destination: "destination-1",
-          events: [createEvent("event-prefix-1"), createEvent("event-prefix-2")],
-        }),
-      ).rejects.toThrow("database busy");
-      await waitForOutcome(outcomes, "completed");
-      expect(deliver).toHaveBeenCalledTimes(1);
-      expect(deliver).toHaveBeenCalledWith(
-        expect.objectContaining({ webhookEventId: "event-prefix-1" }),
-        "destination-1",
-        expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
-      );
-      await spool.stop();
-    });
-  });
-
-  it("stops refreshing and releases a pre-adoption claim on shutdown", async () => {
-    await withQueue(async (queue) => {
-      let finishRelease: (() => void) | undefined;
-      const releaseAllowed = new Promise<void>((resolve) => {
-        finishRelease = resolve;
-      });
-      const release = vi.fn(async (...args: Parameters<typeof queue.release>) => {
-        await releaseAllowed;
-        return await queue.release(...args);
-      });
-      const deliver = vi.fn(
-        async (
-          _event: webhook.Event,
-          _destination: string,
-          control: { abortSignal: AbortSignal },
-        ) =>
-          await new Promise<void>((_resolve, reject) => {
-            control.abortSignal.addEventListener("abort", () => reject(new Error("aborted")), {
-              once: true,
-            });
-          }),
-      );
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue: { ...queue, release },
-        deliver,
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-stop")));
-      await vi.waitFor(async () => {
-        expect(await queue.listClaims()).toHaveLength(1);
-      });
-
-      let stopped = false;
-      const stop = spool.stop().then(() => {
-        stopped = true;
-      });
-      await vi.waitFor(() => {
-        expect(release).toHaveBeenCalledTimes(1);
-      });
-      expect(stopped).toBe(false);
-      finishRelease?.();
-      await stop;
-
-      expect(await queue.listClaims()).toHaveLength(0);
-      expect(await queue.listPending()).toHaveLength(1);
-      expect(deliver).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("dead-letters terminal delivery errors even when shutdown aborts the attempt", async () => {
-    await withQueue(async (queue) => {
-      const deliver = vi.fn(
-        async (
-          _event: webhook.Event,
-          _destination: string,
-          control: { abortSignal: AbortSignal },
-        ) =>
-          await new Promise<void>((_resolve, reject) => {
-            control.abortSignal.addEventListener(
-              "abort",
-              () => reject(new LineWebhookTerminalDeliveryError("reply token consumed")),
-              { once: true },
-            );
-          }),
-      );
-      const spool = createLineWebhookSpool({
-        accountId: "default",
-        runtime: runtime(),
-        queue,
-        deliver,
-      });
-      spool.start();
-      await spool.accept(callback(createEvent("event-terminal-stop")));
-      await vi.waitFor(async () => {
-        expect(await queue.listClaims()).toHaveLength(1);
-      });
-
-      await spool.stop();
-
-      expect(await queue.listPending()).toHaveLength(0);
-      const duplicate = await queue.enqueue("event-terminal-stop", {} as SpoolPayload);
-      expect(duplicate.kind).toBe("failed");
-      if (duplicate.kind === "failed") {
-        expect(duplicate.record.reason).toBe("delivery-side-effects-committed");
+        expect(response.statusCode).toBe(500);
+        expect(enqueue).toHaveBeenCalledTimes(1);
+        expect(deliver).not.toHaveBeenCalled();
+      } finally {
+        await spool.stop();
       }
     });
   });
 
-  it("aborts delivery and releases the row when claim refresh loses ownership", async () => {
+  it("recovers an uncompleted event with a fresh drain and dispatches once", async () => {
     await withQueue(async (queue) => {
-      const refreshClaim = vi.fn(async () => false);
-      const deliver = vi.fn(
-        async (
-          _event: webhook.Event,
-          _destination: string,
-          control: { abortSignal: AbortSignal },
-        ) =>
-          await new Promise<void>((_resolve, reject) => {
-            control.abortSignal.addEventListener("abort", () => reject(new Error("aborted")), {
-              once: true,
-            });
-          }),
-      );
-      const spool = createLineWebhookSpool({
+      const event = createEvent({ webhookEventId: "event-restart" });
+      const first = createLineWebhookSpool({
         accountId: "default",
         runtime: runtime(),
-        queue: { ...queue, refreshClaim },
-        claimRefreshMs: 1,
+        queue,
+        deliver: async () => {
+          throw new Error("first drain must not dispatch");
+        },
+      });
+      await first.accept(callback(event));
+      await first.stop();
+
+      const deliver = vi.fn(async (_event, _destination, control) => {
+        await control.turnAdoptionLifecycle.onAdopted();
+      });
+      const restarted = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
         deliver,
       });
-      spool.start();
-      await spool.accept(callback(createEvent("event-refresh-loss")));
-
-      await vi.waitFor(async () => {
-        expect(refreshClaim).toHaveBeenCalled();
-        expect(await queue.listClaims()).toHaveLength(0);
-        expect(await queue.listPending()).toHaveLength(1);
-      });
-      expect(deliver).toHaveBeenCalledTimes(1);
-      await spool.stop();
+      restarted.start();
+      try {
+        await waitForVerdict(queue, "message:message-event-restart", "completed");
+        expect(deliver).toHaveBeenCalledTimes(1);
+      } finally {
+        await restarted.stop();
+      }
     });
   });
 
-  it("releases a claim won concurrently with shutdown before delivery starts", async () => {
+  it("keeps a completion tombstone and rejects a repeated delivery", async () => {
     await withQueue(async (queue) => {
-      let reportClaimed: (() => void) | undefined;
-      const claimed = new Promise<void>((resolve) => {
-        reportClaimed = resolve;
+      const event = createEvent({ webhookEventId: "event-duplicate" });
+      const deliver = vi.fn(async (_event, _destination, control) => {
+        await control.turnAdoptionLifecycle.onAdopted();
       });
-      let releaseClaimResult: (() => void) | undefined;
-      const returnClaim = new Promise<void>((resolve) => {
-        releaseClaimResult = resolve;
-      });
-      const claimNext: typeof queue.claimNext = async (...args) => {
-        const claim = await queue.claimNext(...args);
-        reportClaimed?.();
-        await returnClaim;
-        return claim;
-      };
-      const deliver = vi.fn(async () => {});
       const spool = createLineWebhookSpool({
         accountId: "default",
         runtime: runtime(),
-        queue: { ...queue, claimNext },
+        queue,
         deliver,
       });
       spool.start();
-      await spool.accept(callback(createEvent("event-stop-race")));
-      await claimed;
+      try {
+        await spool.accept(callback(event));
+        await waitForVerdict(queue, "message:message-event-duplicate", "completed");
 
-      const stop = spool.stop();
-      releaseClaimResult?.();
-      await stop;
+        await spool.accept(callback(event));
+        await new Promise((resolve) => setTimeout(resolve, 600));
 
-      await vi.waitFor(async () => {
-        expect(await queue.listClaims()).toHaveLength(0);
-        expect(await queue.listPending()).toHaveLength(1);
-      });
-      expect(deliver).not.toHaveBeenCalled();
+        expect(deliver).toHaveBeenCalledTimes(1);
+      } finally {
+        await spool.stop();
+      }
     });
   });
 
-  it("delivers ready lanes beyond a full page of delayed retries", async () => {
+  it("deduplicates a redelivered message id even when webhookEventId changes", async () => {
     await withQueue(async (queue) => {
-      for (let index = 0; index < 100; index += 1) {
-        const eventId = `a-delayed-${String(index).padStart(3, "0")}`;
-        const event = createEvent(eventId, `user-delayed-${index}`);
-        await queue.enqueue(
-          eventId,
-          { version: 1, destination: "destination-1", event },
-          {
-            laneKey: `user:user-delayed-${index}`,
-          },
+      const deliver = vi.fn(async (_event, _destination, control) => {
+        await control.turnAdoptionLifecycle.onAdopted();
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      spool.start();
+      try {
+        await spool.accept(
+          callback(createEvent({ webhookEventId: "delivery-a", messageId: "shared-message" })),
         );
-        const claim = await queue.claim(eventId);
-        if (!claim) {
-          throw new Error(`Expected delayed LINE claim ${eventId}`);
-        }
-        await queue.release(claim, { lastError: "delayed" });
+        await waitForVerdict(queue, "message:shared-message", "completed");
+
+        await spool.accept(
+          callback(createEvent({ webhookEventId: "delivery-b", messageId: "shared-message" })),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        expect(deliver).toHaveBeenCalledTimes(1);
+      } finally {
+        await spool.stop();
       }
-      const readyEvent = createEvent("z-ready", "user-ready");
+    });
+  });
+
+  it("stores raw event JSON and normalizes it only during dispatch", async () => {
+    await withQueue(async (queue) => {
+      const event = createEvent({ webhookEventId: "event-raw", text: "before" });
+      const deliveredText: string[] = [];
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver: async (delivered, _destination, control) => {
+          if (delivered.type === "message" && delivered.message.type === "text") {
+            deliveredText.push(delivered.message.text);
+          }
+          await control.turnAdoptionLifecycle.onAdopted();
+        },
+      });
+      await spool.accept(callback(event));
+      const pending = await queue.listPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.laneKey).toBe("user:user-1");
+      expect(pending[0]?.payload).toEqual({
+        version: 1,
+        rawEvent: JSON.stringify(event),
+        destination: "destination-1",
+      });
+      (event as webhook.MessageEvent & { message: { type: "text"; text: string } }).message.text =
+        "after";
+
+      spool.start();
+      try {
+        await waitForVerdict(queue, "message:message-event-raw", "completed");
+        expect(deliveredText).toEqual(["before"]);
+      } finally {
+        await spool.stop();
+      }
+    });
+  });
+
+  it("dead-letters malformed stored JSON without dispatch", async () => {
+    await withQueue(async (queue) => {
       await queue.enqueue(
-        "z-ready",
-        { version: 1, destination: "destination-1", event: readyEvent },
-        { laneKey: "user:user-ready" },
+        "message:malformed",
+        { version: 1, rawEvent: "{", destination: "destination-1" },
+        { laneKey: "user:user-1" },
       );
-      const outcomes: LineWebhookDeliveryOutcome[] = [];
       const deliver = vi.fn(async () => {});
       const spool = createLineWebhookSpool({
         accountId: "default",
         runtime: runtime(),
         queue,
-        retryBaseMs: 60_000,
-        retryMaxMs: 60_000,
         deliver,
-        onOutcome: (outcome) => outcomes.push(outcome),
       });
       spool.start();
+      try {
+        await waitForVerdict(queue, "message:malformed", "failed");
+        expect(deliver).not.toHaveBeenCalled();
+        const verdict = await queue.enqueue("message:malformed", {
+          version: 1,
+          rawEvent: "{}",
+          destination: "",
+        });
+        expect(verdict.kind).toBe("failed");
+        if (verdict.kind === "failed") {
+          expect(verdict.record.reason).toBe("invalid-event");
+        }
+      } finally {
+        await spool.stop();
+      }
+    });
+  });
 
-      await waitForOutcome(outcomes, "completed");
-      expect(deliver).toHaveBeenCalledWith(
-        readyEvent,
-        "destination-1",
-        expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
-      );
-      await spool.stop();
+  it("retries transient dispatch errors", async () => {
+    await withQueue(async (queue) => {
+      const event = createEvent({ webhookEventId: "event-retry" });
+      const deliver = vi.fn(async (_event, _destination, control) => {
+        if (deliver.mock.calls.length === 1) {
+          throw new Error("temporary dispatch outage");
+        }
+        await control.turnAdoptionLifecycle.onAdopted();
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      spool.start();
+      try {
+        await spool.accept(callback(event));
+        await waitForVerdict(queue, "message:message-event-retry", "completed");
+        expect(deliver).toHaveBeenCalledTimes(2);
+      } finally {
+        await spool.stop();
+      }
+    });
+  });
+
+  it("dead-letters LINE API authentication failures without retry", async () => {
+    await withQueue(async (queue) => {
+      const event = createEvent({ webhookEventId: "event-auth" });
+      const deliver = vi.fn(async () => {
+        throw Object.assign(new Error("invalid channel access token"), { status: 401 });
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      spool.start();
+      try {
+        await spool.accept(callback(event));
+        const eventId = "message:message-event-auth";
+        await waitForVerdict(queue, eventId, "failed");
+        expect(deliver).toHaveBeenCalledTimes(1);
+        const verdict = await queue.enqueue(eventId, payloadFor(event));
+        expect(verdict.kind).toBe("failed");
+        if (verdict.kind === "failed") {
+          expect(verdict.record.reason).toBe("authentication-failed");
+        }
+      } finally {
+        await spool.stop();
+      }
+    });
+  });
+
+  it("dead-letters delivery failures after side effects", async () => {
+    await withQueue(async (queue) => {
+      const event = createEvent({ webhookEventId: "event-terminal" });
+      const deliver = vi.fn(async () => {
+        throw new LineWebhookTerminalDeliveryError("reply token consumed");
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      spool.start();
+      try {
+        await spool.accept(callback(event));
+        const eventId = "message:message-event-terminal";
+        await waitForVerdict(queue, eventId, "failed");
+        expect(deliver).toHaveBeenCalledTimes(1);
+        const verdict = await queue.enqueue(eventId, payloadFor(event));
+        expect(verdict.kind).toBe("failed");
+        if (verdict.kind === "failed") {
+          expect(verdict.record.reason).toBe("delivery-side-effects-committed");
+        }
+      } finally {
+        await spool.stop();
+      }
     });
   });
 });

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -163,6 +163,62 @@ describe("LINE webhook spool", () => {
     });
   });
 
+  it("caps active deliveries across repeated drain pumps", async () => {
+    await withQueue(async (queue) => {
+      let releaseDeliveries = () => {};
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDeliveries = resolve;
+      });
+      let activeDeliveries = 0;
+      let maxActiveDeliveries = 0;
+      const deliver = vi.fn(async (_event, _destination, control) => {
+        activeDeliveries += 1;
+        maxActiveDeliveries = Math.max(maxActiveDeliveries, activeDeliveries);
+        await control.turnAdoptionLifecycle.onAdopted();
+        try {
+          await deliveryGate;
+        } finally {
+          activeDeliveries -= 1;
+        }
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      const firstBatch = Array.from({ length: 8 }, (_, index) =>
+        createEvent({
+          webhookEventId: `event-concurrency-${index}`,
+          userId: `user-${index}`,
+        }),
+      );
+      const ninth = createEvent({ webhookEventId: "event-concurrency-8", userId: "user-8" });
+
+      spool.start();
+      try {
+        await spool.accept({ destination: "destination-1", events: firstBatch });
+        await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(8));
+
+        await spool.accept(callback(ninth));
+        // Hold the eight adopted-but-unfinished deliveries across two timer pumps.
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+        expect(deliver).toHaveBeenCalledTimes(8);
+        expect(maxActiveDeliveries).toBe(8);
+
+        releaseDeliveries();
+        await vi.waitFor(() => expect(activeDeliveries).toBe(0));
+        await spool.accept(callback(ninth));
+        await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(9));
+        expect(maxActiveDeliveries).toBe(8);
+      } finally {
+        releaseDeliveries();
+        await spool.stop();
+      }
+    });
+  });
+
   it("recovers an uncompleted event with a fresh drain and dispatches once", async () => {
     await withQueue(async (queue) => {
       const event = createEvent({ webhookEventId: "event-restart" });

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -219,6 +219,57 @@ describe("LINE webhook spool", () => {
     });
   });
 
+  it("waits for active delivery before releasing its claim on stop", async () => {
+    await withQueue(async (queue) => {
+      let releaseDelivery = () => {};
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDelivery = resolve;
+      });
+      const firstDeliver = vi.fn(async () => {
+        await deliveryGate;
+      });
+      const first = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver: firstDeliver,
+      });
+      const event = createEvent({ webhookEventId: "event-stop-active" });
+
+      first.start();
+      await first.accept(callback(event));
+      await vi.waitFor(() => expect(firstDeliver).toHaveBeenCalledTimes(1));
+
+      let stopSettled = false;
+      const stopping = first.stop().then(() => {
+        stopSettled = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(stopSettled).toBe(false);
+      expect(await queue.listClaims()).toHaveLength(1);
+
+      releaseDelivery();
+      await stopping;
+
+      const restartedDeliver = vi.fn(async (_event, _destination, control) => {
+        await control.turnAdoptionLifecycle.onAdopted();
+      });
+      const restarted = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver: restartedDeliver,
+      });
+      restarted.start();
+      try {
+        await waitForVerdict(queue, "message:message-event-stop-active", "completed");
+        expect(restartedDeliver).toHaveBeenCalledTimes(1);
+      } finally {
+        await restarted.stop();
+      }
+    });
+  });
+
   it("recovers an uncompleted event with a fresh drain and dispatches once", async () => {
     await withQueue(async (queue) => {
       const event = createEvent({ webhookEventId: "event-restart" });
@@ -399,6 +450,45 @@ describe("LINE webhook spool", () => {
         await spool.accept(callback(event));
         await waitForVerdict(queue, "message:message-event-retry", "completed");
         expect(deliver).toHaveBeenCalledTimes(2);
+      } finally {
+        await spool.stop();
+      }
+    });
+  });
+
+  it("dead-letters the eighth retryable failure without a minimum-age floor", async () => {
+    await withQueue(async (queue) => {
+      const event = createEvent({ webhookEventId: "event-retry-limit" });
+      const eventId = "message:message-event-retry-limit";
+      await queue.enqueue(eventId, payloadFor(event), { laneKey: "user:user-1" });
+      for (let attempt = 0; attempt < 7; attempt += 1) {
+        const claim = await queue.claim(eventId);
+        if (!claim) {
+          throw new Error(`failed to seed LINE retry attempt ${attempt + 1}`);
+        }
+        await queue.release(claim, {
+          lastError: "seeded transient failure",
+          releasedAt: Date.now() - 4 * 60_000,
+        });
+      }
+      const deliver = vi.fn(async () => {
+        throw new Error("persistent transient failure");
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      spool.start();
+      try {
+        await waitForVerdict(queue, eventId, "failed");
+        expect(deliver).toHaveBeenCalledTimes(1);
+        const verdict = await queue.enqueue(eventId, payloadFor(event));
+        expect(verdict.kind).toBe("failed");
+        if (verdict.kind === "failed") {
+          expect(verdict.record.reason).toBe("retry-limit-exceeded");
+        }
       } finally {
         await spool.stop();
       }

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -1,46 +1,33 @@
-// Line plugin module owns durable webhook admission and replay.
-import { createHash, randomUUID } from "node:crypto";
+// Line plugin module owns durable webhook admission and core-drain wiring.
 import type { webhook } from "@line/bot-sdk";
-import type {
-  ChannelIngressQueue,
-  ChannelIngressQueueClaim,
-  ChannelIngressQueueRecord,
+import {
+  bindIngressLifecycleToReplyOptions,
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_ADOPTION_STALL_MS,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { danger, sleepWithAbort, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { getLineRuntime } from "./runtime.js";
 
 const LINE_WEBHOOK_SPOOL_VERSION = 1;
-const LINE_WEBHOOK_MAX_ATTEMPTS = 8;
-const LINE_WEBHOOK_RETRY_BASE_MS = 1_000;
-const LINE_WEBHOOK_RETRY_MAX_MS = 3 * 60_000;
-const LINE_WEBHOOK_CLAIM_STALE_MS = 30_000;
-const LINE_WEBHOOK_CLAIM_REFRESH_MS = 10_000;
-const LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES = 8;
+const LINE_WEBHOOK_DRAIN_INTERVAL_MS = 500;
+const LINE_WEBHOOK_DRAIN_START_LIMIT = 8;
 const LINE_WEBHOOK_DRAIN_SCAN_LIMIT = 100;
 const LINE_WEBHOOK_TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60_000;
-
-type LineWebhookDeadLetterReason =
-  | "delivery-side-effects-committed"
-  | "invalid-event"
-  | "retry-limit-exceeded";
-
-type LineWebhookDeliveryOutcome =
-  | { kind: "completed"; eventId: string }
-  | { kind: "retry-scheduled"; eventId: string; attempt: number; error: string }
-  | {
-      kind: "dead-lettered";
-      eventId: string;
-      attempt: number;
-      reason: LineWebhookDeadLetterReason;
-      error: string;
-    };
+const LINE_WEBHOOK_TOMBSTONE_MAX_ENTRIES = 4096;
 
 type LineWebhookSpoolPayload = {
   version: number;
+  rawEvent: string;
   destination: string;
-  event: webhook.Event;
 };
+
+export type LineWebhookTurnAdoptionLifecycle = ReturnType<
+  typeof bindIngressLifecycleToReplyOptions
+>["turnAdoptionLifecycle"];
 
 type LineWebhookSpoolOptions = {
   accountId: string;
@@ -48,28 +35,15 @@ type LineWebhookSpoolOptions = {
   deliver: (
     event: webhook.Event,
     destination: string,
-    control: { abortSignal: AbortSignal; onTurnAdopted: () => Promise<void> },
+    control: { turnAdoptionLifecycle: LineWebhookTurnAdoptionLifecycle },
   ) => Promise<void>;
   queue?: ChannelIngressQueue<LineWebhookSpoolPayload>;
-  maxAttempts?: number;
-  retryBaseMs?: number;
-  retryMaxMs?: number;
-  claimStaleMs?: number;
-  claimRefreshMs?: number;
-  onOutcome?: (outcome: LineWebhookDeliveryOutcome) => void;
 };
 
-class LineWebhookClaimOwnershipError extends Error {
-  constructor(eventId: string) {
-    super(`LINE webhook spool event ${eventId} lost claim ownership.`);
-    this.name = "LineWebhookClaimOwnershipError";
-  }
-}
-
-class LineWebhookClaimRefreshError extends Error {
-  constructor(eventId: string, options?: { cause?: unknown }) {
-    super(`LINE webhook spool event ${eventId} claim refresh failed.`, options);
-    this.name = "LineWebhookClaimRefreshError";
+class LineWebhookPayloadError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "LineWebhookPayloadError";
   }
 }
 
@@ -88,54 +62,90 @@ type LineWebhookSpool = {
   stop: () => Promise<void>;
 };
 
-function eventIdFor(event: webhook.Event): string {
-  const eventId = (event as { webhookEventId?: unknown }).webhookEventId;
-  if (typeof eventId === "string" && eventId.trim()) {
-    return eventId.trim();
-  }
-  return `invalid:${createHash("sha256").update(JSON.stringify(event)).digest("hex")}`;
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function laneKeyFor(event: webhook.Event): string {
-  const source = (event as { source?: webhook.Event["source"] }).source;
+/** Message ids preserve the shipped replay-guard keyspace; other events use LINE's delivery id. */
+function eventIdFor(event: unknown): string {
+  if (!event || typeof event !== "object") {
+    throw new LineWebhookPayloadError("LINE webhook event must be an object.");
+  }
+  const candidate = event as {
+    type?: unknown;
+    message?: { id?: unknown };
+    webhookEventId?: unknown;
+  };
+  if (candidate.type === "message") {
+    const messageId = nonEmptyString(candidate.message?.id);
+    if (messageId) {
+      return `message:${messageId}`;
+    }
+  }
+  const webhookEventId = nonEmptyString(candidate.webhookEventId);
+  if (webhookEventId) {
+    return `event:${webhookEventId}`;
+  }
+  throw new LineWebhookPayloadError("LINE webhook event is missing a stable delivery id.");
+}
+
+function laneKeyFor(event: unknown, eventId: string): string {
+  if (!event || typeof event !== "object") {
+    return eventId;
+  }
+  const source = (event as { source?: Record<string, unknown> }).source;
   if (source?.type === "group") {
-    return `group:${source.groupId}`;
+    const groupId = nonEmptyString(source.groupId);
+    if (groupId) {
+      return `group:${groupId}`;
+    }
   }
   if (source?.type === "room") {
-    return `room:${source.roomId}`;
+    const roomId = nonEmptyString(source.roomId);
+    if (roomId) {
+      return `room:${roomId}`;
+    }
   }
   if (source?.type === "user") {
-    return `user:${source.userId}`;
+    const userId = nonEmptyString(source.userId);
+    if (userId) {
+      return `user:${userId}`;
+    }
   }
-  return `event:${eventIdFor(event)}`;
+  return eventId;
 }
 
-function isValidPayload(payload: LineWebhookSpoolPayload): boolean {
-  return (
-    payload.version === LINE_WEBHOOK_SPOOL_VERSION &&
-    typeof payload.destination === "string" &&
-    typeof payload.event === "object" &&
-    payload.event !== null &&
-    typeof (payload.event as { webhookEventId?: unknown }).webhookEventId === "string" &&
-    Boolean((payload.event as { webhookEventId: string }).webhookEventId.trim())
-  );
+function parseClaimedEvent(payload: LineWebhookSpoolPayload, claimedId: string): webhook.Event {
+  if (
+    payload.version !== LINE_WEBHOOK_SPOOL_VERSION ||
+    typeof payload.rawEvent !== "string" ||
+    typeof payload.destination !== "string"
+  ) {
+    throw new LineWebhookPayloadError("LINE webhook spool payload is invalid.");
+  }
+  let event: unknown;
+  try {
+    event = JSON.parse(payload.rawEvent);
+  } catch (error) {
+    throw new LineWebhookPayloadError("LINE webhook event JSON is invalid.", { cause: error });
+  }
+  if (eventIdFor(event) !== claimedId) {
+    throw new LineWebhookPayloadError("LINE webhook event id changed after durable admission.");
+  }
+  return event as webhook.Event;
 }
 
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function retryDelayMs(
-  record: ChannelIngressQueueRecord<LineWebhookSpoolPayload>,
-  now: number,
-  baseMs: number,
-  maxMs: number,
-): number {
-  if (record.attempts < 1 || record.lastAttemptAt === undefined) {
-    return 0;
+function isLineAuthenticationFailure(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
   }
-  const delay = Math.min(maxMs, baseMs * 2 ** Math.min(record.attempts - 1, 8));
-  return Math.max(0, record.lastAttemptAt + delay - now);
+  // @line/bot-sdk HTTPFetchError exposes the response code as `status`.
+  const status = (error as { status?: unknown }).status;
+  return status === 401 || status === 403;
 }
 
 export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWebhookSpool {
@@ -144,355 +154,66 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     getLineRuntime().state.openChannelIngressQueue<LineWebhookSpoolPayload>({
       accountId: options.accountId,
     });
-  const ownerId = `${process.pid}:${randomUUID()}`;
-  const maxAttempts = Math.max(1, options.maxAttempts ?? LINE_WEBHOOK_MAX_ATTEMPTS);
-  const retryBaseMs = Math.max(0, options.retryBaseMs ?? LINE_WEBHOOK_RETRY_BASE_MS);
-  const retryMaxMs = Math.max(retryBaseMs, options.retryMaxMs ?? LINE_WEBHOOK_RETRY_MAX_MS);
-  const claimStaleMs = Math.max(0, options.claimStaleMs ?? LINE_WEBHOOK_CLAIM_STALE_MS);
-  const claimRefreshMs = Math.max(1, options.claimRefreshMs ?? LINE_WEBHOOK_CLAIM_REFRESH_MS);
-  let running = false;
-  let draining = false;
-  let drainRequested = false;
-  let drainTimer: ReturnType<typeof setTimeout> | undefined;
-  let drainDeadline: number | undefined;
-  const drainTasks = new Set<Promise<void>>();
-  const activeDeliveries = new Map<string, Promise<void>>();
-  const activeClaims = new Map<
-    string,
-    { abortController: AbortController; stopRefresh: () => void }
-  >();
-  const backoffBlockedLanes = new Map<string, number>();
-
-  const prune = async (): Promise<void> => {
-    await queue.prune({
-      completedTtlMs: LINE_WEBHOOK_TOMBSTONE_TTL_MS,
-      failedTtlMs: LINE_WEBHOOK_TOMBSTONE_TTL_MS,
-    });
-  };
-
-  const scheduleDrain = (delayMs: number): void => {
-    if (!running) {
-      return;
-    }
-    const deadline = Date.now() + Math.max(0, delayMs);
-    if (drainTimer && drainDeadline !== undefined && drainDeadline <= deadline) {
-      return;
-    }
-    if (drainTimer) {
-      clearTimeout(drainTimer);
-    }
-    drainDeadline = deadline;
-    drainTimer = setTimeout(
-      () => {
-        drainTimer = undefined;
-        drainDeadline = undefined;
-        // Timers preserve the HTTP request's admission context. Give every drain
-        // its own tracked root so durable work can continue after the request ACK.
-        const task = runDetachedWebhookWork(drain).catch((error: unknown) => {
-          options.runtime.error?.(
-            danger(`line: webhook spool admission failed: ${errorText(error)}`),
-          );
-          scheduleDrain(retryBaseMs || 1_000);
-        });
-        drainTasks.add(task);
-        void task.finally(() => drainTasks.delete(task));
-      },
-      Math.max(0, deadline - Date.now()),
-    );
-    drainTimer.unref?.();
-  };
-
-  const persistClaimTransition = async (params: {
-    claim: ChannelIngressQueueClaim<LineWebhookSpoolPayload>;
-    label: string;
-    transition: () => Promise<boolean>;
-    abortSignal?: AbortSignal;
-  }): Promise<void> => {
-    let persistenceAttempt = 0;
-    while (true) {
-      try {
-        if (!(await params.transition())) {
-          throw new LineWebhookClaimOwnershipError(params.claim.id);
-        }
-        return;
-      } catch (error) {
-        if (error instanceof LineWebhookClaimOwnershipError) {
-          throw error;
-        }
-        persistenceAttempt += 1;
-        const delayMs = Math.min(5_000, 250 * 2 ** Math.min(persistenceAttempt - 1, 5));
-        options.runtime.error?.(
-          danger(
-            `line: webhook event ${params.claim.id} ${params.label} persist failed; retrying: ${errorText(error)}`,
-          ),
-        );
-        await sleepWithAbort(delayMs, params.abortSignal);
+  const shutdown = new AbortController();
+  const drain = createChannelIngressDrain<LineWebhookSpoolPayload>({
+    queue,
+    abortSignal: shutdown.signal,
+    adoptionStallTimeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
+    orderBy: "received",
+    scanLimit: LINE_WEBHOOK_DRAIN_SCAN_LIMIT,
+    startLimit: LINE_WEBHOOK_DRAIN_START_LIMIT,
+    retryPolicy: {
+      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+    },
+    resolveNonRetryableFailure: (error) => {
+      if (error instanceof LineWebhookPayloadError) {
+        return { reason: "invalid-event", message: error.message };
       }
-    }
-  };
-
-  const finishClaim = async (
-    claim: ChannelIngressQueueClaim<LineWebhookSpoolPayload>,
-  ): Promise<LineWebhookDeliveryOutcome> => {
-    const attempt = claim.attempts + 1;
-    const abortController = new AbortController();
-    let adopted = false;
-    let refreshing = true;
-    const claimRefreshTimer = setInterval(() => {
-      if (!refreshing) {
-        return;
+      if (error instanceof LineWebhookTerminalDeliveryError) {
+        return { reason: error.reason, message: error.message };
       }
-      void (async () => {
-        try {
-          const refreshed = await queue.refreshClaim?.(claim);
-          if (refreshed !== true && !adopted && refreshing) {
-            throw new LineWebhookClaimOwnershipError(claim.id);
-          }
-        } catch (error) {
-          if (adopted || !refreshing) {
-            return;
-          }
-          options.runtime.error?.(
-            danger(`line: webhook spool claim refresh failed: ${errorText(error)}`),
-          );
-          stopRefresh();
-          abortController.abort(new LineWebhookClaimRefreshError(claim.id, { cause: error }));
-        }
-      })();
-    }, claimRefreshMs);
-    claimRefreshTimer.unref?.();
-    const stopRefresh = () => {
-      if (!refreshing) {
-        return;
+      if (isLineAuthenticationFailure(error)) {
+        return { reason: "authentication-failed", message: errorText(error) };
       }
-      refreshing = false;
-      clearInterval(claimRefreshTimer);
-    };
-    activeClaims.set(claim.id, { abortController, stopRefresh });
-    try {
-      if (!isValidPayload(claim.payload)) {
-        const error = "LINE webhook spool payload was invalid.";
-        await persistClaimTransition({
-          claim,
-          label: "invalid dead-letter",
-          transition: async () =>
-            await queue.fail(claim, { reason: "invalid-event", message: error }),
-        });
-        return {
-          kind: "dead-lettered",
-          eventId: claim.id,
-          attempt,
-          reason: "invalid-event",
-          error,
-        };
-      }
-      try {
-        await options.deliver(claim.payload.event, claim.payload.destination, {
-          abortSignal: abortController.signal,
-          onTurnAdopted: async () => {
-            await persistClaimTransition({
-              claim,
-              label: "adoption completion",
-              transition: async () => await queue.complete(claim),
-            });
-            adopted = true;
-            stopRefresh();
-          },
-        });
-      } catch (error) {
-        if (adopted) {
-          return { kind: "completed", eventId: claim.id };
-        }
-        const message = errorText(error);
-        if (error instanceof LineWebhookTerminalDeliveryError) {
-          await persistClaimTransition({
-            claim,
-            label: "terminal dead-letter",
-            transition: async () => await queue.fail(claim, { reason: error.reason, message }),
-          });
-          return {
-            kind: "dead-lettered",
-            eventId: claim.id,
-            attempt,
-            reason: error.reason,
-            error: message,
-          };
-        }
-        if (abortController.signal.aborted) {
-          const refreshFailed =
-            abortController.signal.reason instanceof LineWebhookClaimRefreshError;
-          await persistClaimTransition({
-            claim,
-            label: refreshFailed ? "refresh-failure release" : "shutdown release",
-            transition: async () =>
-              await queue.release(
-                claim,
-                refreshFailed
-                  ? { lastError: errorText(abortController.signal.reason) }
-                  : { recordAttempt: false },
-              ),
-          });
-          throw error;
-        }
-        if (attempt >= maxAttempts) {
-          await persistClaimTransition({
-            claim,
-            label: "retry-limit dead-letter",
-            transition: async () =>
-              await queue.fail(claim, { reason: "retry-limit-exceeded", message }),
-          });
-          return {
-            kind: "dead-lettered",
-            eventId: claim.id,
-            attempt,
-            reason: "retry-limit-exceeded",
-            error: message,
-          };
-        }
-        await persistClaimTransition({
-          claim,
-          label: "retry release",
-          transition: async () => await queue.release(claim, { lastError: message }),
-        });
-        return { kind: "retry-scheduled", eventId: claim.id, attempt, error: message };
-      }
-
-      if (adopted) {
-        return { kind: "completed", eventId: claim.id };
-      }
-
-      await persistClaimTransition({
-        claim,
-        label: "completion",
-        transition: async () => await queue.complete(claim),
+      return null;
+    },
+    onLog: (message) => options.runtime.error?.(danger(`line: ${message}`)),
+    dispatchClaimedEvent: async (claimed, lifecycle) => {
+      const event = parseClaimedEvent(claimed.payload, claimed.id);
+      await options.deliver(event, claimed.payload.destination, {
+        turnAdoptionLifecycle: bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
       });
-      return { kind: "completed", eventId: claim.id };
-    } finally {
-      activeClaims.delete(claim.id);
-      stopRefresh();
-    }
-  };
+    },
+  });
+  let running = false;
+  let drainRequested = false;
+  let drainTask: Promise<void> | undefined;
+  let drainTimer: ReturnType<typeof setInterval> | undefined;
 
-  const drain = async (): Promise<void> => {
-    if (!running) {
+  const requestDrain = (): void => {
+    if (!running || shutdown.signal.aborted) {
       return;
     }
-    if (draining) {
-      drainRequested = true;
+    drainRequested = true;
+    if (drainTask) {
       return;
     }
-    draining = true;
-    drainRequested = false;
-    try {
-      // The short lease recovers a crashed predecessor before LINE's reply-token
-      // use window, while refreshes protect a still-live rolling-restart owner.
-      await queue.recoverStaleClaims({ staleMs: claimStaleMs });
-      const claims = await queue.listClaims();
-      const now = Date.now();
-      let nextDelay = Number.POSITIVE_INFINITY;
-      for (const claim of claims) {
-        nextDelay = Math.min(nextDelay, Math.max(0, claim.claim.claimedAt + claimStaleMs - now));
+    drainTask = runDetachedWebhookWork(async () => {
+      while (running && drainRequested && !shutdown.signal.aborted) {
+        drainRequested = false;
+        await drain.drainOnce({ shouldStop: () => !running || shutdown.signal.aborted });
       }
-      const blockedLaneKeys = new Set(activeDeliveries.keys());
-      for (const [laneKey, deadline] of backoffBlockedLanes) {
-        if (deadline <= now) {
-          backoffBlockedLanes.delete(laneKey);
-        } else {
-          blockedLaneKeys.add(laneKey);
-          nextDelay = Math.min(nextDelay, deadline - now);
+    })
+      .catch((error: unknown) => {
+        options.runtime.error?.(danger(`line: webhook spool drain failed: ${errorText(error)}`));
+      })
+      .finally(() => {
+        drainTask = undefined;
+        if (running && drainRequested && !shutdown.signal.aborted) {
+          requestDrain();
         }
-      }
-      for (const claim of claims) {
-        if (claim.laneKey) {
-          blockedLaneKeys.add(claim.laneKey);
-        }
-      }
-      let scanned = 0;
-      while (
-        activeDeliveries.size < LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES &&
-        scanned < LINE_WEBHOOK_DRAIN_SCAN_LIMIT
-      ) {
-        if (!running) {
-          break;
-        }
-        const claim = await queue.claimNext({
-          ownerId,
-          blockedLaneKeys,
-          orderBy: "id",
-          scanLimit: LINE_WEBHOOK_DRAIN_SCAN_LIMIT,
-        });
-        if (!claim) {
-          break;
-        }
-        scanned += 1;
-        if (!running) {
-          await persistClaimTransition({
-            claim,
-            label: "shutdown claim release",
-            transition: async () => await queue.release(claim, { recordAttempt: false }),
-          });
-          break;
-        }
-        const laneKey = claim.laneKey ?? `event:${claim.id}`;
-        blockedLaneKeys.add(laneKey);
-        const delay = retryDelayMs(claim, now, retryBaseMs, retryMaxMs);
-        if (delay > 0) {
-          backoffBlockedLanes.set(laneKey, now + delay);
-          nextDelay = Math.min(nextDelay, delay);
-          await persistClaimTransition({
-            claim,
-            label: "backoff release",
-            transition: async () => await queue.release(claim, { recordAttempt: false }),
-          });
-          continue;
-        }
-        // The scan root may finish immediately after launching work. Reserve a
-        // separate admitted continuation for the full delivery lifecycle.
-        const delivery = runDetachedWebhookWork(() => finishClaim(claim))
-          .then((outcome) => {
-            options.onOutcome?.(outcome);
-            if (outcome.kind === "retry-scheduled") {
-              options.runtime.error?.(
-                danger(
-                  `line: webhook event ${outcome.eventId} delivery failed on attempt ${outcome.attempt}: ${outcome.error}`,
-                ),
-              );
-            } else if (outcome.kind === "dead-lettered") {
-              options.runtime.error?.(
-                danger(
-                  `line: webhook event ${outcome.eventId} dead-lettered (${outcome.reason}): ${outcome.error}`,
-                ),
-              );
-            }
-          })
-          .catch((error: unknown) => {
-            options.runtime.error?.(
-              danger(`line: webhook event ${claim.id} worker failed: ${errorText(error)}`),
-            );
-          })
-          .finally(() => {
-            if (activeDeliveries.get(laneKey) === delivery) {
-              activeDeliveries.delete(laneKey);
-            }
-            scheduleDrain(0);
-          });
-        activeDeliveries.set(laneKey, delivery);
-      }
-      if (scanned >= LINE_WEBHOOK_DRAIN_SCAN_LIMIT) {
-        scheduleDrain(0);
-      }
-      if (Number.isFinite(nextDelay)) {
-        scheduleDrain(nextDelay);
-      }
-    } catch (error) {
-      options.runtime.error?.(danger(`line: webhook spool drain failed: ${errorText(error)}`));
-      scheduleDrain(retryBaseMs || 1_000);
-    } finally {
-      draining = false;
-      if (drainRequested) {
-        scheduleDrain(0);
-      }
-    }
+      });
   };
 
   return {
@@ -501,40 +222,48 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       if (events.length === 0) {
         return;
       }
-      await prune();
+      await queue.prune({
+        completedTtlMs: LINE_WEBHOOK_TOMBSTONE_TTL_MS,
+        completedMaxEntries: LINE_WEBHOOK_TOMBSTONE_MAX_ENTRIES,
+        failedTtlMs: LINE_WEBHOOK_TOMBSTONE_TTL_MS,
+        failedMaxEntries: LINE_WEBHOOK_TOMBSTONE_MAX_ENTRIES,
+      });
       const receivedAt = Date.now();
       for (const event of events) {
+        const eventId = eventIdFor(event);
         await queue.enqueue(
-          eventIdFor(event),
+          eventId,
           {
             version: LINE_WEBHOOK_SPOOL_VERSION,
+            rawEvent: JSON.stringify(event),
             destination: body.destination ?? "",
-            event,
           },
-          { receivedAt, laneKey: laneKeyFor(event) },
+          { receivedAt, laneKey: laneKeyFor(event, eventId) },
         );
-        scheduleDrain(0);
       }
+      requestDrain();
     },
     start: () => {
       if (running) {
         return;
       }
       running = true;
-      scheduleDrain(0);
+      requestDrain();
+      drainTimer = setInterval(requestDrain, LINE_WEBHOOK_DRAIN_INTERVAL_MS);
+      drainTimer.unref?.();
     },
     stop: async () => {
+      if (!running && shutdown.signal.aborted) {
+        return;
+      }
       running = false;
       if (drainTimer) {
-        clearTimeout(drainTimer);
+        clearInterval(drainTimer);
         drainTimer = undefined;
-        drainDeadline = undefined;
       }
-      for (const active of activeClaims.values()) {
-        active.stopRefresh();
-        active.abortController.abort();
-      }
-      await Promise.allSettled([...drainTasks, ...activeDeliveries.values()]);
+      shutdown.abort();
+      drain.dispose();
+      await drainTask;
     },
   };
 }

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -209,7 +209,10 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       return;
     }
     drainTask = runDetachedWebhookWork(async () => {
-      while (running && drainRequested && !shutdown.signal.aborted) {
+      while (drainRequested && !shutdown.signal.aborted) {
+        if (!running) {
+          break;
+        }
         drainRequested = false;
         await drain.drainOnce({
           // startLimit caps one pump. Keep later timer pumps from exceeding this
@@ -281,7 +284,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       await drainTask;
       // Keep the claim owner live until every real delivery and core handler exits;
       // disposing earlier lets a replacement drain recover work still producing replies.
-      await Promise.allSettled([...activeDeliveries]);
+      await Promise.allSettled(activeDeliveries);
       await drain.waitForIdle();
       drain.dispose();
     },

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -14,7 +14,7 @@ import { getLineRuntime } from "./runtime.js";
 
 const LINE_WEBHOOK_SPOOL_VERSION = 1;
 const LINE_WEBHOOK_DRAIN_INTERVAL_MS = 500;
-const LINE_WEBHOOK_DRAIN_START_LIMIT = 8;
+const LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES = 8;
 const LINE_WEBHOOK_DRAIN_SCAN_LIMIT = 100;
 const LINE_WEBHOOK_TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60_000;
 const LINE_WEBHOOK_TOMBSTONE_MAX_ENTRIES = 4096;
@@ -155,13 +155,15 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       accountId: options.accountId,
     });
   const shutdown = new AbortController();
+  // Match the predecessor worker's per-spool cap across repeated drain pumps.
+  let activeDeliveries = 0;
   const drain = createChannelIngressDrain<LineWebhookSpoolPayload>({
     queue,
     abortSignal: shutdown.signal,
     adoptionStallTimeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
     orderBy: "received",
     scanLimit: LINE_WEBHOOK_DRAIN_SCAN_LIMIT,
-    startLimit: LINE_WEBHOOK_DRAIN_START_LIMIT,
+    startLimit: LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
     retryPolicy: {
       maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
       deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
@@ -180,10 +182,16 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     },
     onLog: (message) => options.runtime.error?.(danger(`line: ${message}`)),
     dispatchClaimedEvent: async (claimed, lifecycle) => {
-      const event = parseClaimedEvent(claimed.payload, claimed.id);
-      await options.deliver(event, claimed.payload.destination, {
-        turnAdoptionLifecycle: bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
-      });
+      activeDeliveries += 1;
+      try {
+        const event = parseClaimedEvent(claimed.payload, claimed.id);
+        await options.deliver(event, claimed.payload.destination, {
+          turnAdoptionLifecycle:
+            bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
+        });
+      } finally {
+        activeDeliveries -= 1;
+      }
     },
   });
   let running = false;
@@ -202,7 +210,14 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     drainTask = runDetachedWebhookWork(async () => {
       while (running && drainRequested && !shutdown.signal.aborted) {
         drainRequested = false;
-        await drain.drainOnce({ shouldStop: () => !running || shutdown.signal.aborted });
+        await drain.drainOnce({
+          // startLimit caps one pump. Keep later timer pumps from exceeding this
+          // spool's delivery cap after an early turn adoption frees the core lane.
+          shouldStop: () =>
+            !running ||
+            shutdown.signal.aborted ||
+            activeDeliveries >= LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
+        });
       }
     })
       .catch((error: unknown) => {

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -4,7 +4,6 @@ import {
   bindIngressLifecycleToReplyOptions,
   createChannelIngressDrain,
   DEFAULT_INGRESS_ADOPTION_STALL_MS,
-  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -156,7 +155,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     });
   const shutdown = new AbortController();
   // Match the predecessor worker's per-spool cap across repeated drain pumps.
-  let activeDeliveries = 0;
+  const activeDeliveries = new Set<Promise<void>>();
   const drain = createChannelIngressDrain<LineWebhookSpoolPayload>({
     queue,
     abortSignal: shutdown.signal,
@@ -166,7 +165,9 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     startLimit: LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
     retryPolicy: {
       maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+      // LINE previously dead-lettered on attempt eight. The generic 24-hour floor
+      // would let one poison event block its user/group lane for a full day.
+      deadLetterMinAgeMs: 0,
     },
     resolveNonRetryableFailure: (error) => {
       if (error instanceof LineWebhookPayloadError) {
@@ -182,15 +183,15 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     },
     onLog: (message) => options.runtime.error?.(danger(`line: ${message}`)),
     dispatchClaimedEvent: async (claimed, lifecycle) => {
-      activeDeliveries += 1;
+      const event = parseClaimedEvent(claimed.payload, claimed.id);
+      const delivery = options.deliver(event, claimed.payload.destination, {
+        turnAdoptionLifecycle: bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
+      });
+      activeDeliveries.add(delivery);
       try {
-        const event = parseClaimedEvent(claimed.payload, claimed.id);
-        await options.deliver(event, claimed.payload.destination, {
-          turnAdoptionLifecycle:
-            bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
-        });
+        await delivery;
       } finally {
-        activeDeliveries -= 1;
+        activeDeliveries.delete(delivery);
       }
     },
   });
@@ -216,7 +217,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
           shouldStop: () =>
             !running ||
             shutdown.signal.aborted ||
-            activeDeliveries >= LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
+            activeDeliveries.size >= LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
         });
       }
     })
@@ -277,8 +278,12 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
         drainTimer = undefined;
       }
       shutdown.abort();
-      drain.dispose();
       await drainTask;
+      // Keep the claim owner live until every real delivery and core handler exits;
+      // disposing earlier lets a replacement drain recover work still producing replies.
+      await Promise.allSettled([...activeDeliveries]);
+      await drain.waitForIdle();
+      drain.dispose();
     },
   };
 }


### PR DESCRIPTION
Related: #109657

AI-assisted maintainer change. The implementation and final merged-tree behavior were manually reviewed.

## What Problem This Solves

Fixes the LINE ingress path where a webhook could be acknowledged with HTTP 200 before detached event processing had durably completed, allowing a gateway crash or dispatch failure to silently lose inbound messages. The interim LINE-private worker also duplicated claim, retry, dead-letter, and adoption behavior now owned by the shared channel ingress drain.

## Why This Change Was Made

LINE now writes each raw webhook event to the shared SQLite ingress queue before acknowledgment and dispatches it through the core durable ingress drain. The adapter preserves per-source lane ordering, adopts the shared turn lifecycle, retains the prior per-spool eight-delivery concurrency cap across repeated timer pumps, waits for active deliveries before releasing drain ownership on shutdown, and preserves LINE's attempt-eight dead-letter policy. Completion tombstones use message IDs for messages and retain 30 days / 4,096 entries, strictly covering the removed guard's 10 minute / 4,096-entry window even when LINE changes `webhookEventId` on redelivery.

## User Impact

Accepted LINE events survive gateway restarts and transient dispatch failures, while duplicate redeliveries remain suppressed. Enqueue failure prevents the HTTP 200 acknowledgment so LINE can retry. Shutdown cannot hand a still-running delivery to a replacement drain, and a poison event does not block its user/group lane behind the generic 24-hour retry-age floor. No new configuration or public plugin API is introduced, and the core-drain adoption removes 247 net production lines.

## Evidence

- `node scripts/run-vitest.mjs extensions/line`: 30 files, 384 tests passed on exact head `d9a6d3702cc0`.
- Source-blind focused behavior validation: 12/12 spool scenarios passed, including no acknowledgment on enqueue failure, restart recovery, active-delivery shutdown ownership, completion-tombstone rejection, changed-`webhookEventId` guard parity, raw-event persistence, retry, attempt-eight dead-letter, authentication dead-letter, no retry after committed delivery side effects, and the eight-delivery cap across repeated drain pumps.
- `git diff --check` and direct `oxfmt --check` passed for all six changed files.
- `node scripts/check-deadcode-exports.mjs` and `node scripts/check-deadcode-unused-files.mjs`: hard-zero gates passed.
- Review identified three lifecycle regressions in the first core-drain adoption: per-pump concurrency growth, early drain-owner disposal, and adoption of the generic 24-hour retry-age floor. All three were fixed with focused regressions; fresh post-fix autoreview was clean.
- The original autoreview bundle hit the documented secret-scanner false positive on the synthetic HMAC fixture `test-channel-secret`; all five implementation files and the caller/callee/core-drain evidence map were manually reviewed as the fallback. The final full-branch review's compatibility/retention warnings were verified as non-actionable because the predecessor spool is unshipped and present in no published `v*` release tag, while the 30 day / 4,096 tombstone policy strictly exceeds the shipped 10 minute / 4,096 replay guard.
