### PR TITLE
fix(agents): sanitize native Anthropic text_delta for MiniMax stream noise

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2266,6 +2266,66 @@ describe("anthropic transport stream", () => {
     ]);
   });
 
+  it("sanitizes native text_delta the same way as compatibility content deltas (#104403)", async () => {
+    const boundary = "[e~[`";
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 4, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "Visible reply" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: boundary },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: boundary + boundary },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 4, output_tokens: 2 },
+        },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "MiniMax-M3",
+        name: "MiniMax M3",
+        provider: "minimax-portal",
+        baseUrl: "https://api.minimax.io/anthropic",
+      }),
+      {
+        messages: [{ role: "user", content: "hi" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-minimax-test",
+      },
+    );
+
+    const textBlock = result.content.find((block) => block.type === "text");
+    expect(textBlock).toMatchObject({ type: "text", text: "Visible reply" });
+    expect(JSON.stringify(result.content)).not.toContain(boundary);
+  });
+
   it("preserves native text_delta chunks that also carry reasoning_content", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -1652,11 +1652,20 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               delta?.type === "text_delta" &&
               typeof delta.text === "string"
             ) {
-              block.text += delta.text;
+              // Native Anthropic text_delta previously bypassed the shared
+              // sanitizer while the compatibility-shaped delta.content branch
+              // did not. That let provider framing / stream-boundary noise
+              // (e.g. minimax-portal anthropic-messages) land in assistantTexts,
+              // trajectory, next-turn prompts, and delivered replies (#104403).
+              const text = sanitizeTransportPayloadText(delta.text);
+              if (text.length === 0) {
+                continue;
+              }
+              block.text += text;
               eventSink.push({
                 type: "text_delta",
                 contentIndex: index,
-                delta: delta.text,
+                delta: text,
                 partial: output as never,
               });
               continue;
@@ -1666,11 +1675,15 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               delta?.type === "thinking_delta" &&
               typeof delta.thinking === "string"
             ) {
-              block.thinking += delta.thinking;
+              const thinking = sanitizeTransportPayloadText(delta.thinking);
+              if (thinking.length === 0) {
+                continue;
+              }
+              block.thinking += thinking;
               eventSink.push({
                 type: "thinking_delta",
                 contentIndex: index,
-                delta: delta.thinking,
+                delta: thinking,
                 partial: output as never,
               });
               continue;

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -28,6 +28,17 @@ describe("transport stream shared helpers", () => {
     );
   });
 
+  it("strips MiniMax stream-boundary markers reported in #104403", () => {
+    expect(sanitizeTransportPayloadText("hello [e~[`")).toBe("hello ");
+    expect(sanitizeTransportPayloadText("done[e~[`[e~[`[e~[`")).toBe("done");
+    expect(sanitizeTransportPayloadText("mid [e~[` text")).toBe("mid  text");
+  });
+
+  it("preserves lookalike prose that is not the provider framing marker", () => {
+    expect(sanitizeTransportPayloadText("array index e~[0] look")).toBe("array index e~[0] look");
+    expect(sanitizeTransportPayloadText("code: e~[`template`]")).toBe("code: e~[`template`]");
+  });
+
   it.each([
     ["empty", ""],
     ["whitespace-only", " \n\t "],

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -45,11 +45,27 @@ export function encodeAssistantTextSignatureV1(
   return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
 }
 
+/**
+ * MiniMax portal (and similar Anthropic-compat streams) can append a framing
+ * sentinel into native text_delta chunks. The token is not present in OpenClaw
+ * sources; it arrives only on the wire. Strip whole and repeated occurrences so
+ * completed assistant text, next-turn prompts, and channel delivery stay clean.
+ *
+ * Reported marker (issue #104403): the character sequence [ e ~ [ ` ] without
+ * spaces — may appear once or repeated up to a few times at the end of a reply.
+ */
+const MINIMAX_STREAM_BOUNDARY_MARKER = "[e~[`";
+const MINIMAX_STREAM_BOUNDARY_GLOBAL = /(?:\[e~\[`)+/g;
+
 export function sanitizeTransportPayloadText(text: string): string {
   if (typeof text !== "string") {
     return "";
   }
-  return sanitizeSurrogates(text);
+  let cleaned = sanitizeSurrogates(text);
+  if (cleaned.includes(MINIMAX_STREAM_BOUNDARY_MARKER)) {
+    cleaned = cleaned.replace(MINIMAX_STREAM_BOUNDARY_GLOBAL, "");
+  }
+  return cleaned;
 }
 
 export function sanitizeNonEmptyTransportPayloadText(


### PR DESCRIPTION
## Summary

Native Anthropic `text_delta` chunks previously appended `delta.text` into the completed assistant block **without** running `sanitizeTransportPayloadText`, while the compatibility-shaped `delta.content` branch already sanitized. That asymmetry let MiniMax portal (and similar) framing sentinels land in:

- completed `assistantTexts`
- trajectory JSONL
- next-turn `finalPromptText`
- user-visible channel replies

This routes native `text_delta` / `thinking_delta` through the shared sanitizer and strips the reported stream-boundary marker sequence used by the MiniMax-style anthropic-messages path.

## Motivation

Fixes #104403. ClawSweeper identified the specific source paths: native text is appended unchanged (`anthropic-transport-stream` content_block_delta handler) while adjacent sanitization already exists.

## Verification

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts \
  src/agents/transport-stream-shared.test.ts \
  src/agents/anthropic-transport-stream.test.ts
```

Results: **121 tests passed** (2 files).

## Files

- `src/agents/anthropic-transport-stream.ts` — sanitize native text/thinking deltas
- `src/agents/transport-stream-shared.ts` — strip known stream-boundary marker after surrogate cleanup
- matching unit coverage for sanitizer + MiniMax-shaped SSE fixture

## Notes

- Diff is intentionally small and transport-local (no product behavior change for clean providers).
- Official Anthropic streams only lose unpaired surrogates (pre-existing sanitizer behavior) plus any accidental occurrence of the exact framing marker sequence (highly unlikely in real prose; lookalike strings without the exact prefix pattern are preserved).