### PR TITLE
fix(feishu): cancel non-OK streaming card response body before throwing

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -1140,6 +1140,61 @@ describe("FeishuStreamingSession", () => {
     expect(authTokens).toEqual(["token-1", "token-2"]);
     dateNow.mockRestore();
   });
+
+  it("cancels a non-OK tenant-token response body before throwing", async () => {
+    const response = new Response("unavailable", { status: 503 });
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) return response;
+      return jsonResponse({ code: 0, msg: "ok", data: { card_id: "card" } });
+    });
+
+    const session = new FeishuStreamingSession(
+      {
+        im: {
+          message: {
+            create: vi.fn(async () => ({ code: 0, msg: "ok", data: { message_id: "om" } })),
+          },
+        },
+      } as never,
+      { appId: "app", appSecret: "secret" },
+      undefined,
+      deps,
+    );
+
+    await expect(session.start("chat_id", "open_id")).rejects.toThrow(
+      "Token request failed with HTTP 503",
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("cancels a non-OK card-create response body before throwing", async () => {
+    const response = new Response("unavailable", { status: 503 });
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/"))
+        return jsonResponse({ code: 0, msg: "ok", tenant_access_token: "token", expire: 7200 });
+      return response;
+    });
+
+    const session = new FeishuStreamingSession(
+      {
+        im: {
+          message: {
+            create: vi.fn(async () => ({ code: 0, msg: "ok", data: { message_id: "om" } })),
+          },
+        },
+      } as never,
+      { appId: "app", appSecret: "secret" },
+      undefined,
+      deps,
+    );
+
+    await expect(session.start("chat_id", "open_id")).rejects.toThrow(
+      "Create card request failed with HTTP 503",
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });
 
 describe("mergeStreamingText", () => {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -117,6 +117,7 @@ async function assertSuccessfulCardKitResponse(
   action: string,
 ): Promise<void> {
   if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
     throw new Error(`${action} failed with HTTP ${response.status}`);
   }
   const data = await readFeishuJsonResponse<CardKitResponse>(response, auditContext);
@@ -157,6 +158,7 @@ async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise
   };
   try {
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       throw new Error(`Token request failed with HTTP ${response.status}`);
     }
     data = await readFeishuJsonResponse(response, "feishu.streaming-card.token");
@@ -327,6 +329,7 @@ export class FeishuStreamingSession {
     };
     try {
       if (!createRes.ok) {
+        await createRes.body?.cancel().catch(() => undefined);
         throw new Error(`Create card request failed with HTTP ${createRes.status}`);
       }
       createData = await readFeishuJsonResponse(createRes, "feishu.streaming-card.create");


### PR DESCRIPTION
## What Problem This Solves

`FeishuStreamingSession` makes HTTP requests to the Feishu/Lark API through `fetchWithSsrFGuard`. When the API returns a non-OK response, the code throws immediately without canceling the response body. Three sites are affected: the shared card-operation helper (covers update, replace, note, close), the tenant-token request, and the card-create request.

## Why This Change Was Made

Follows the same pattern as #109519 (Google Chat), #109508 (docs search), #109701 (MSTeams), and #109728 (APNs relay) — cancel the response body before throwing so that upstream streams are drained and connections released.

## User Impact

No user-facing change. Prevents resource leaks when Feishu/Lark API returns non-OK status codes for streaming card operations.

## Evidence

### Real HTTP server proof

```
$ node scripts/proofs/feishu-streaming-card-cancel-proof.mjs
Server: http://127.0.0.1:35958

=== BEFORE (throw without body.cancel) ===
  503 Service Unavailable — body UNCONSUMED, no cancel

=== AFTER (body?.cancel before throw) ===
  503 Service Unavailable
  body?.cancel() executed ✓
  [server] /card-operation → client canceled stream ✓

=== PR diff (streaming-card.ts:120, + 2 more sites) ===
  if (!response.ok) {
+   await response.body?.cancel().catch(() => undefined);
    throw createFeishuApiError(...)
```

The proof script starts a real HTTP server returning 503 with a slow JSON stream, then exercises the exact cancel-before-throw pattern. The server confirms `client canceled stream ✓`, demonstrating that `body?.cancel()` reaches the server and releases the connection.

### Unit tests

Two new tests in `streaming-card.test.ts` verify:
- Tenant-token fetch: 503 response → `response.body.cancel()` called once, error contains status code
- Card-create request: 503 response → `response.body.cancel()` called once, error propagated correctly