### PR TITLE
fix: stop orphan recovery test mock leakage

### DIFF
--- a/test/vitest/vitest.agents-paths.mjs
+++ b/test/vitest/vitest.agents-paths.mjs
@@ -11,6 +11,7 @@ export const agentsCoreIsolatedTestFiles = [
   "src/agents/model-auth-env.provider-aliases.test.ts",
   "src/agents/model-selection.plugin-runtime.test.ts",
   "src/agents/models-config.runtime-source-snapshot.test.ts",
+  "src/agents/subagent-orphan-recovery.test.ts",
   "src/agents/video-generation-task-status.test.ts",
 ];
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the compact agents CI shard consistently failed two orphan-recovery assertions even though the focused test passed, because the suite's shared module mocks ran in the non-isolated agents worker.

## Why This Change Was Made

Routes the existing orphan-recovery suite through the repository's purpose-built isolated agents test config. This keeps its config, session, transcript-reader, and registry mocks separate without weakening or deleting behavior coverage.

## User Impact

No product behavior changes. Maintainer CI can validate agent changes without the shard-order-dependent false failure.

## Evidence

- Reproduced on exact-head CI three times in `checks-node-compact-large-6`: two assertions received the mock's default empty transcript; the same file passed alone (28/28).
- `node scripts/run-vitest.mjs src/agents/subagent-orphan-recovery.test.ts` now selects `vitest.agents-core-isolated.config.ts` and passes 28/28.
- `node scripts/check-changed.mjs -- test/vitest/vitest.agents-paths.mjs` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29567580277
- Autoreview: clean, 0.99 confidence.

AI-assisted: yes. I reviewed the test's mocks, the shared worker configuration, and the existing isolated-suite routing contract.
