### PR TITLE
fix(compaction): previous summary is duplicated when a later split degrades

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2021,6 +2021,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const messages = requireArray(call.messages);
     expect(JSON.stringify(messages[0])).toContain("<previous-compaction-summary>");
     expect(JSON.stringify(messages[0])).toContain("Old duplicated section");
+    expect(result.compaction?.summary).not.toContain("Old duplicated section");
   });
 
   it("preserves the prior summary when staged summarization returns a generic fallback", async () => {

--- a/src/agents/compaction.circuit-breaker.test.ts
+++ b/src/agents/compaction.circuit-breaker.test.ts
@@ -85,14 +85,19 @@ describe("compaction staged fallback circuit breaker", () => {
       .mockResolvedValueOnce("oldest summary")
       .mockRejectedValueOnce(new Error("fetch failed"))
       .mockResolvedValueOnce("newest summary")
-      .mockResolvedValueOnce("merged summary");
+      .mockResolvedValueOnce("merged: oldest summary + newest summary");
 
     // The oldest split carries whatever context the caller needs redistilled, and it
     // made it into the merge. Reporting a fallback here makes callers re-add it.
     await expect(summarize()).resolves.toEqual({
       kind: "summary",
-      text: "merged summary",
+      text: "merged: oldest summary + newest summary",
     });
     expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(4);
+    expect(agentSessionMocks.generateSummary.mock.calls[3]?.[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: expect.stringContaining("oldest summary") }),
+      ]),
+    );
   });
 });

--- a/src/agents/compaction.circuit-breaker.test.ts
+++ b/src/agents/compaction.circuit-breaker.test.ts
@@ -79,4 +79,20 @@ describe("compaction staged fallback circuit breaker", () => {
     });
     expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(4);
   });
+
+  it("reports a summary when only a later split degraded and the oldest one survived", async () => {
+    agentSessionMocks.generateSummary
+      .mockResolvedValueOnce("oldest summary")
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce("newest summary")
+      .mockResolvedValueOnce("merged summary");
+
+    // The oldest split carries whatever context the caller needs redistilled, and it
+    // made it into the merge. Reporting a fallback here makes callers re-add it.
+    await expect(summarize()).resolves.toEqual({
+      kind: "summary",
+      text: "merged summary",
+    });
+    expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(4);
+  });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -413,11 +413,9 @@ export async function summarizeInStages(params: {
 
   const partialSummaries: string[] = [];
   let consecutiveGenericFallbacks = 0;
-  // Chunk 0 carries the oldest messages, which is where a caller puts context it needs
-  // redistilled into the new summary. Only its degradation means that context never
-  // reached the merge, so this — not "any chunk degraded" — is what the result kind
-  // reports; otherwise a caller restoring lost context duplicates what the merge has.
-  let firstChunkDegraded = false;
+  // Caller-owned leading context lives in the oldest split. Only losing that
+  // split requires restoration; later fallback placeholders remain in the merge.
+  let oldestChunkDegraded = false;
   for (const [index, chunk] of plan.chunks.entries()) {
     const result = await summarizeWithFallbackResult({
       ...params,
@@ -427,7 +425,7 @@ export async function summarizeInStages(params: {
     consecutiveGenericFallbacks =
       result.kind === "generic-fallback" ? consecutiveGenericFallbacks + 1 : 0;
     if (index === 0) {
-      firstChunkDegraded = result.kind === "generic-fallback";
+      oldestChunkDegraded = result.kind === "generic-fallback";
     }
 
     // Keep one placeholder to mark the missing split, but stop before repeated
@@ -451,7 +449,7 @@ export async function summarizeInStages(params: {
       throw new Error("Compaction summary plan produced no summary");
     }
     return {
-      kind: firstChunkDegraded ? "generic-fallback" : "summary",
+      kind: oldestChunkDegraded ? "generic-fallback" : "summary",
       text: summary,
     };
   }
@@ -492,7 +490,7 @@ export async function summarizeInStages(params: {
     messages: summaryMessages,
     customInstructions: mergeInstructions,
   });
-  return firstChunkDegraded && mergedResult.kind === "summary"
+  return oldestChunkDegraded && mergedResult.kind === "summary"
     ? { kind: "generic-fallback", text: mergedResult.text }
     : mergedResult;
 }

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -413,7 +413,11 @@ export async function summarizeInStages(params: {
 
   const partialSummaries: string[] = [];
   let consecutiveGenericFallbacks = 0;
-  let usedGenericFallback = false;
+  // Chunk 0 carries the oldest messages, which is where a caller puts context it needs
+  // redistilled into the new summary. Only its degradation means that context never
+  // reached the merge, so this — not "any chunk degraded" — is what the result kind
+  // reports; otherwise a caller restoring lost context duplicates what the merge has.
+  let firstChunkDegraded = false;
   for (const [index, chunk] of plan.chunks.entries()) {
     const result = await summarizeWithFallbackResult({
       ...params,
@@ -422,7 +426,9 @@ export async function summarizeInStages(params: {
     });
     consecutiveGenericFallbacks =
       result.kind === "generic-fallback" ? consecutiveGenericFallbacks + 1 : 0;
-    usedGenericFallback ||= result.kind === "generic-fallback";
+    if (index === 0) {
+      firstChunkDegraded = result.kind === "generic-fallback";
+    }
 
     // Keep one placeholder to mark the missing split, but stop before repeated
     // placeholders trigger more split requests or a doomed merge request.
@@ -445,7 +451,7 @@ export async function summarizeInStages(params: {
       throw new Error("Compaction summary plan produced no summary");
     }
     return {
-      kind: usedGenericFallback ? "generic-fallback" : "summary",
+      kind: firstChunkDegraded ? "generic-fallback" : "summary",
       text: summary,
     };
   }
@@ -486,7 +492,7 @@ export async function summarizeInStages(params: {
     messages: summaryMessages,
     customInstructions: mergeInstructions,
   });
-  return usedGenericFallback && mergedResult.kind === "summary"
+  return firstChunkDegraded && mergedResult.kind === "summary"
     ? { kind: "generic-fallback", text: mergedResult.text }
     : mergedResult;
 }


### PR DESCRIPTION
## What Problem This Solves

When staged compaction summarizes a long session and any split degrades, the previous summary is added
to the new summary **twice**. It then compounds: every later compaction cycle that has a degraded split
re-adds it again, so the summary grows a copy of itself each round and burns tokens on every subsequent
turn.

Since #86900 landed the staged circuit breaker to *stop* token burn when the summarizer is unavailable,
this is the same failure mode arriving through the merge path.

## Why This Change Was Made

`summarizeInStages` (`src/agents/compaction.ts:492`) stamped the merged result as a fallback if **any**
split degraded:

```ts
usedGenericFallback ||= result.kind === "generic-fallback";   // coarse OR over every chunk
...
return usedGenericFallback && mergedResult.kind === "summary"
  ? { kind: "generic-fallback", text: mergedResult.text }
  : mergedResult;
```

The only consumer of that kind is `summarizeViaLLM` (`src/agents/agent-hooks/compaction-safeguard.ts:413-420`),
which reads it to decide whether to restore the previous summary:

```ts
if (result.kind === "summary") {
  return result.text;
}
// A generic fallback means redistillation never happened. Preserve the
// known summary verbatim so a temporary model outage cannot erase it.
const previousSummary = params.previousSummary?.trim();
return previousSummary ? `${previousSummary}\n\n${result.text}` : result.text;
```

**That comment states an invariant the code does not hold.** The same function prepends the previous
summary as the *first message* (`:396-399` → `prependPreviousSummaryForRedistill`, `:107`), so it always
lands in chunk 0. If chunk 0 summarizes fine and a *later* chunk degrades, redistillation demonstrably
did happen — the merge already carries the summary — but the coarse flag stamps the result as a fallback
anyway, and the previous summary gets prepended on top of a merge that already contains it.

| oldest split | previous summary | correct | before |
|---|---|---|---|
| degraded | lost | restore it | restore ✔ |
| survived, later split degraded | **already in the merge** | **do not restore** | **restore again ✘** |

Reachable on the normal path: `MAX_CONSECUTIVE_GENERIC_FALLBACKS` (`:48`) only opens the circuit on
*consecutive* degradations, so a single failed split completes the merge, and `compaction-safeguard.ts:1375`
passes `previousSummary` on every repeat compaction.

The fix reports what the consumer actually asks — did the oldest split degrade — instead of "did anything
degrade". The coarse flag is removed rather than kept beside the precise one, so there is one source of
truth and the two cannot drift apart. With this, the existing comment becomes true.

Nothing outside these two modules reads the kind, so no other surface is affected. `compaction-safeguard.ts`
needs no change: its logic was already correct given a correct kind.

## Evidence

**End-to-end**, composing the real `summarizeInStages` with the verbatim decision from
`summarizeViaLLM:413-420`, with chunk 0 succeeding and a later chunk degrading:

Before (`origin/main`):

```
summarizeInStages kind : generic-fallback
final summary          : "## Goal\nShip the parser rewrite.\n\nmerged: ## Goal\nShip the parser rewrite. + newest"
previous summary occurs: 2 time(s)
```

After (this branch):

```
summarizeInStages kind : summary
final summary          : "merged: ## Goal\nShip the parser rewrite. + newest"
previous summary occurs: 1 time(s)
```

**Tests**

The added case (`oldest summary` → degraded → `newest summary` → merge) fails on `origin/main` with
`expected { kind: 'generic-fallback' } to deeply equal { kind: 'summary' }`, and passes here.

The existing `remains degraded` case is **unmodified and still green** — its oldest split is the one that
rejects, so the previous summary really is lost there and the fallback stamp is still correct. That is the
behavior split this change is built around.

```
compaction.circuit-breaker + compaction-safeguard + compaction-instructions   261 passed | 4 skipped, 0 failed
all src/agents/compaction*.test.ts                                            103 passed | 14 skipped, 0 failed
max-lines ratchet                                                             OK
dead-export ratchet (knip)                                                    0 entries
oxlint / oxfmt --check                                                        clean
tsgo -p tsconfig.core.json                                                    no errors in touched files
```

`compaction-planning-worker.test.ts` fails identically on unmodified `origin/main` in this environment
(`Cannot find module compaction-planning.js` — the worker wants built output), so it is unrelated to this
change.

## Merge Risk

Low. One flag in one function, +14/-4 in source, no signature or type change, no config surface.

The only behavior that moves is the case this fixes: a merged summary whose oldest split survived is now
reported as `summary` instead of `generic-fallback`. The degraded-oldest-split path — the one the existing
test pins — is untouched, so the outage protection that #86900 added still holds exactly where it matters.

AI-assisted.