### PR TITLE
fix: restore repository formatting gate

### DIFF
--- a/extensions/browser/src/browser/server-context.tab-discovery-poll-abort.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-discovery-poll-abort.test.ts
@@ -138,9 +138,9 @@ describe("browser tab discovery poll abort", () => {
     const openPromise = openclaw.openTab("about:blank", { signal: controller.signal });
 
     await vi.advanceTimersByTimeAsync(0);
-    expect(
-      setTimeoutSpy.mock.calls.some((call) => call[1] === OPEN_TAB_DISCOVERY_POLL_MS),
-    ).toBe(true);
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === OPEN_TAB_DISCOVERY_POLL_MS)).toBe(
+      true,
+    );
     expect(vi.getTimerCount()).toBe(1);
     controller.abort();
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the repository-wide formatting gate fails on the newly added browser poll-abort regression test.

## Why This Change Was Made

Applies the repository formatter to the existing assertion. Test behavior and coverage stay unchanged.

## User Impact

No product behavior changes. Maintainer CI can complete the formatting gate again.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29567453222
- `node scripts/run-vitest.mjs extensions/browser/src/browser/server-context.tab-discovery-poll-abort.test.ts` — 3 passed.
- `oxfmt --check extensions/browser/src/browser/server-context.tab-discovery-poll-abort.test.ts` — passed.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.

AI-assisted maintainer fix. I reviewed and understand the change.
