### PR TITLE
fix(browser): cap fields-file reads

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -172,6 +172,7 @@ openclaw browser scrollintoview <ref>
 openclaw browser drag <startRef> <endRef>
 openclaw browser select <ref> OptionA OptionB
 openclaw browser fill --fields '[{"ref":"1","value":"Ada"}]'
+openclaw browser fill --fields-file ./fields.json
 openclaw browser wait --text "Done"
 openclaw browser evaluate --fn '(el) => el.textContent' --ref <ref>
 openclaw browser evaluate --fn 'const title = document.title; return title;'
@@ -181,6 +182,8 @@ openclaw browser evaluate --timeout-ms 30000 --fn 'async () => { await window.re
 `evaluate --fn` accepts a function source, an expression, or a statement body. Statement bodies are wrapped as async functions, so use `return` for the value you want back. Use `--timeout-ms` when the page-side function may need longer than the default evaluate timeout. `browser.evaluateEnabled=false` (default: `true`) disables both `evaluate` and `wait --fn`.
 
 Action responses return the current raw `targetId` after action-triggered page replacement when OpenClaw can prove the replacement tab. Scripts should still store and pass `suggestedTargetId`/labels for long-lived workflows.
+
+`fill --fields-file` accepts a UTF-8 JSON array file up to 1 MiB (1,048,576 bytes). Larger files are rejected before JSON parsing so automation cannot accidentally buffer arbitrarily large form descriptors.
 
 File + dialog helpers:
 

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
@@ -13,6 +13,7 @@ import {
 } from "../browser-cli-shared.js";
 import { danger, defaultRuntime } from "../core-api.js";
 import {
+  BROWSER_FIELDS_FILE_MAX_BYTES,
   callBrowserAct,
   logBrowserActionResult,
   readFields,
@@ -44,7 +45,10 @@ export function registerBrowserFormWaitEvalCommands(
     .command("fill")
     .description("Fill a form with JSON field descriptors")
     .option("--fields <json>", "JSON array of field objects")
-    .option("--fields-file <path>", "Read JSON array from a file")
+    .option(
+      "--fields-file <path>",
+      `Read JSON array from a file, max ${BROWSER_FIELDS_FILE_MAX_BYTES} bytes`,
+    )
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .action(async (opts, cmd) => {
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.test.ts
@@ -58,6 +58,24 @@ describe("readFields", () => {
     }
   });
 
+  it("accepts a fields file at the documented byte limit", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-browser-fields-"));
+    try {
+      const fieldsFile = path.join(dir, "fields.json");
+      const prefix = '[{"ref":"exact","value":"';
+      const suffix = '"}]';
+      const valueLength =
+        BROWSER_FIELDS_FILE_MAX_BYTES - Buffer.byteLength(prefix + suffix, "utf8");
+      await fs.writeFile(fieldsFile, `${prefix}${"a".repeat(valueLength)}${suffix}`, "utf8");
+
+      await expect(readFields({ fieldsFile })).resolves.toEqual([
+        { ref: "exact", type: "text", value: "a".repeat(valueLength) },
+      ]);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects oversized fields files before parsing", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-browser-fields-"));
     const parseSpy = vi.spyOn(JSON, "parse");

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.test.ts
@@ -3,7 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { BROWSER_FIELDS_FILE_MAX_BYTES, readFields } from "./shared.js";
+import { readFields } from "./shared.js";
+
+const BROWSER_FIELDS_FILE_MAX_BYTES = 1024 * 1024;
 
 describe("readFields", () => {
   it.each([

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.test.ts
@@ -1,6 +1,9 @@
 // Browser tests cover shared plugin behavior.
-import { describe, expect, it } from "vitest";
-import { readFields } from "./shared.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { BROWSER_FIELDS_FILE_MAX_BYTES, readFields } from "./shared.js";
 
 describe("readFields", () => {
   it.each([
@@ -37,5 +40,36 @@ describe("readFields", () => {
 
   it("throws descriptive error on empty fields", async () => {
     await expect(readFields({ fields: "" })).rejects.toThrow("fields are required");
+  });
+
+  it("reads valid fields from a file", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-browser-fields-"));
+    try {
+      const fieldsFile = path.join(dir, "fields.json");
+      await fs.writeFile(fieldsFile, '[{"ref":"9","value":"from file"}]', "utf8");
+
+      await expect(readFields({ fieldsFile })).resolves.toEqual([
+        { ref: "9", type: "text", value: "from file" },
+      ]);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects oversized fields files before parsing", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-browser-fields-"));
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      const fieldsFile = path.join(dir, "fields.json");
+      await fs.writeFile(fieldsFile, "x".repeat(BROWSER_FIELDS_FILE_MAX_BYTES + 1), "utf8");
+
+      await expect(readFields({ fieldsFile })).rejects.toThrow(
+        `fields file exceeds ${BROWSER_FIELDS_FILE_MAX_BYTES} bytes`,
+      );
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -20,6 +20,7 @@ type BrowserActionContext = {
 };
 
 const DEFAULT_BROWSER_ACTION_TIMEOUT_MS = 20000;
+export const BROWSER_FIELDS_FILE_MAX_BYTES = 1024 * 1024;
 
 /** Adds gateway slack to a Browser action timeout so route work can finish cleanly. */
 export function withBrowserActionTimeoutSlack(timeoutMs: number | undefined): number {
@@ -85,7 +86,29 @@ export function requireRef(ref: string | undefined) {
 }
 
 async function readFile(path: string): Promise<string> {
-  return await fs.readFile(path, "utf8");
+  const handle = await fs.open(path, "r");
+  try {
+    const buffer = Buffer.alloc(BROWSER_FIELDS_FILE_MAX_BYTES + 1);
+    let totalBytes = 0;
+    while (totalBytes < buffer.length) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        totalBytes,
+        buffer.length - totalBytes,
+        null,
+      );
+      if (bytesRead === 0) {
+        break;
+      }
+      totalBytes += bytesRead;
+    }
+    if (totalBytes > BROWSER_FIELDS_FILE_MAX_BYTES) {
+      throw new Error(`fields file exceeds ${BROWSER_FIELDS_FILE_MAX_BYTES} bytes`);
+    }
+    return buffer.subarray(0, totalBytes).toString("utf8");
+  } finally {
+    await handle.close();
+  }
 }
 
 /** Reads and validates JSON form-field descriptors from inline text or a file. */

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -20,7 +20,7 @@ type BrowserActionContext = {
 };
 
 const DEFAULT_BROWSER_ACTION_TIMEOUT_MS = 20000;
-const BROWSER_FIELDS_FILE_MAX_BYTES = 1024 * 1024;
+export const BROWSER_FIELDS_FILE_MAX_BYTES = 1024 * 1024;
 
 /** Adds gateway slack to a Browser action timeout so route work can finish cleanly. */
 export function withBrowserActionTimeoutSlack(timeoutMs: number | undefined): number {

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -20,7 +20,7 @@ type BrowserActionContext = {
 };
 
 const DEFAULT_BROWSER_ACTION_TIMEOUT_MS = 20000;
-export const BROWSER_FIELDS_FILE_MAX_BYTES = 1024 * 1024;
+const BROWSER_FIELDS_FILE_MAX_BYTES = 1024 * 1024;
 
 /** Adds gateway slack to a Browser action timeout so route work can finish cleanly. */
 export function withBrowserActionTimeoutSlack(timeoutMs: number | undefined): number {
@@ -91,12 +91,7 @@ async function readFile(path: string): Promise<string> {
     const buffer = Buffer.alloc(BROWSER_FIELDS_FILE_MAX_BYTES + 1);
     let totalBytes = 0;
     while (totalBytes < buffer.length) {
-      const { bytesRead } = await handle.read(
-        buffer,
-        totalBytes,
-        buffer.length - totalBytes,
-        null,
-      );
+      const { bytesRead } = await handle.read(buffer, totalBytes, buffer.length - totalBytes, null);
       if (bytesRead === 0) {
         break;
       }


### PR DESCRIPTION
## What Problem This Solves

Browser CLI action commands accept `--fields-file` for form field descriptors. The previous reader loaded the whole file into memory before validating or parsing it, so a very large fields file could be fully buffered before the CLI rejected it.

## Why This Change Was Made

This keeps the narrow 1 MiB byte cap on `--fields-file` reads, rejects oversized files before JSON parsing, documents the limit in Browser CLI help and docs, and leaves inline `--fields` behavior unchanged.

## User Impact

Users get a clear size-limit error for oversized Browser CLI fields files instead of the CLI buffering arbitrarily large input. Existing valid fields files up to the documented 1 MiB limit and inline JSON fields continue to work.

## Evidence

Current head: `d2a80f755ed48484190b482001d3101d4ad2701b`.

- `Real behavior proof` passed on the current head (`https://github.com/openclaw/openclaw/actions/runs/29637151651/job/88061375088`).
- `gh pr checks 109830 --repo openclaw/openclaw` currently shows no failed checks; the prior `build-artifacts` red was on the older head and is no longer present after refresh.