### PR TITLE
fix(memory-wiki): reject oversized apply body files

### DIFF
--- a/docs/cli/wiki.md
+++ b/docs/cli/wiki.md
@@ -178,7 +178,7 @@ openclaw wiki get syntheses/alpha-summary.md --from 1 --lines 80
 
 Apply narrow mutations without freeform page surgery:
 
-- `apply synthesis <title>`: create or refresh a synthesis page with a managed summary body
+- `apply synthesis <title>`: create or refresh a synthesis page with a managed summary body. `--body-file` accepts regular files up to 1 MiB and rejects larger or non-regular files before writing the page.
 - `apply metadata <lookup>`: update metadata on an existing page
 
 Both accept `--source-id`, `--contradiction`, `--question` (each repeatable), `--confidence <n>` (0-1), and `--status <status>`. `apply metadata` also accepts `--clear-confidence` to remove a stored confidence value. This is the supported way to evolve wiki pages so managed generated blocks stay intact.

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -1,6 +1,6 @@
+import { constants as fsConstants } from "node:fs";
 // Memory Wiki tests cover cli plugin behavior.
 import fs from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -259,6 +259,40 @@ describe("memory-wiki cli", () => {
     expect(index).not.toContain("Oversized Body");
   });
 
+  it("rejects non-regular apply synthesis --body-file before opening the path", async () => {
+    const { config } = await createCliVault();
+    const statSpy = vi.spyOn(fs, "stat").mockResolvedValue({ isFile: () => false } as never);
+    const openSpy = vi.spyOn(fs, "open").mockRejectedValue(new Error("should not open"));
+    const program = new Command();
+    program.name("test");
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: () => {},
+    });
+    registerWikiCli(program, { config });
+
+    await expect(
+      program.parseAsync(
+        [
+          "wiki",
+          "apply",
+          "synthesis",
+          "Named Pipe",
+          "--body-file",
+          "ignored.pipe",
+          "--source-id",
+          "source.alpha",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("wiki apply synthesis --body-file must point to a regular file.");
+
+    expect(openSpy).not.toHaveBeenCalled();
+    statSpy.mockRestore();
+    openSpy.mockRestore();
+  });
+
   it("resolves --agent for local commands and requires it with multiple agent vaults", async () => {
     const { rootDir, config } = await createCliVault({
       config: { vault: { scope: "agent" } },

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -1,5 +1,6 @@
 // Memory Wiki tests cover cli plugin behavior.
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -259,10 +260,16 @@ describe("memory-wiki cli", () => {
     expect(index).not.toContain("Oversized Body");
   });
 
-  it("rejects non-regular apply synthesis --body-file before opening the path", async () => {
+  it("rejects non-regular apply synthesis --body-file after opening the path", async () => {
     const { config } = await createCliVault();
-    const statSpy = vi.spyOn(fs, "stat").mockResolvedValue({ isFile: () => false } as never);
-    const openSpy = vi.spyOn(fs, "open").mockRejectedValue(new Error("should not open"));
+    const handleStatMock = vi.fn().mockResolvedValue({ isFile: () => false } as never);
+    const handleReadMock = vi.fn();
+    const handleCloseMock = vi.fn().mockResolvedValue(undefined);
+    const openSpy = vi.spyOn(fs, "open").mockResolvedValue({
+      stat: handleStatMock,
+      read: handleReadMock,
+      close: handleCloseMock,
+    } as never);
     const program = new Command();
     program.name("test");
     program.exitOverride();
@@ -288,8 +295,13 @@ describe("memory-wiki cli", () => {
       ),
     ).rejects.toThrow("wiki apply synthesis --body-file must point to a regular file.");
 
-    expect(openSpy).not.toHaveBeenCalled();
-    statSpy.mockRestore();
+    expect(openSpy).toHaveBeenCalledWith(
+      "ignored.pipe",
+      fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK ?? 0),
+    );
+    expect(handleStatMock).toHaveBeenCalledTimes(1);
+    expect(handleReadMock).not.toHaveBeenCalled();
+    expect(handleCloseMock).toHaveBeenCalledTimes(1);
     openSpy.mockRestore();
   });
 

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -224,7 +224,7 @@ describe("memory-wiki cli", () => {
     const { rootDir, config } = await createCliVault();
     const bodyPath = path.join(rootDir, "oversized-body.md");
     await fs.mkdir(rootDir, { recursive: true });
-    await fs.writeFile(bodyPath, `${"x".repeat(1_048_577)}`, "utf8");
+    await fs.writeFile(bodyPath, "x".repeat(1_048_577), "utf8");
     const program = new Command();
     program.name("test");
     program.exitOverride();

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -192,6 +192,73 @@ describe("memory-wiki cli", () => {
     );
   });
 
+  it("registers apply synthesis and reads the body from --body-file", async () => {
+    const { rootDir, config } = await createCliVault();
+    const bodyPath = path.join(rootDir, "synthesis-body.md");
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.writeFile(bodyPath, "Alpha from a body file.", "utf8");
+    const program = new Command();
+    program.name("test");
+    registerWikiCli(program, { config });
+
+    await program.parseAsync(
+      [
+        "wiki",
+        "apply",
+        "synthesis",
+        "CLI Body File",
+        "--body-file",
+        bodyPath,
+        "--source-id",
+        "source.alpha",
+      ],
+      { from: "user" },
+    );
+
+    const page = await fs.readFile(path.join(rootDir, "syntheses", "cli-body-file.md"), "utf8");
+    expect(page).toContain("Alpha from a body file.");
+    expect(page).toContain("source.alpha");
+  });
+
+  it("rejects oversized apply synthesis --body-file before writing a synthesis page", async () => {
+    const { rootDir, config } = await createCliVault();
+    const bodyPath = path.join(rootDir, "oversized-body.md");
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.writeFile(bodyPath, `${"x".repeat(1_048_577)}`, "utf8");
+    const program = new Command();
+    program.name("test");
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: () => {},
+    });
+    registerWikiCli(program, { config });
+
+    await expect(
+      program.parseAsync(
+        [
+          "wiki",
+          "apply",
+          "synthesis",
+          "Oversized Body",
+          "--body-file",
+          bodyPath,
+          "--source-id",
+          "source.alpha",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(
+      "wiki apply synthesis --body-file is too large (1,048,577 bytes); limit is 1,048,576 bytes.",
+    );
+
+    await expect(
+      fs.readFile(path.join(rootDir, "syntheses", "oversized-body.md"), "utf8"),
+    ).rejects.toThrow();
+    const index = await fs.readFile(path.join(rootDir, "index.md"), "utf8").catch(() => "");
+    expect(index).not.toContain("Oversized Body");
+  });
+
   it("resolves --agent for local commands and requires it with multiple agent vaults", async () => {
     const { rootDir, config } = await createCliVault({
       config: { vault: { scope: "agent" } },

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -58,6 +58,7 @@ const GATEWAY_TERMINAL_STRING_MAX_CHARS = 2_000;
 const GATEWAY_RESPONSE_MAX_ARRAY_ITEMS = 10_000;
 const GATEWAY_RESPONSE_MAX_STRING_CHARS = 10_000;
 const GATEWAY_RESPONSE_MAX_CODE_CHARS = 256;
+const WIKI_APPLY_BODY_FILE_MAX_BYTES = 1_048_576;
 const ANSI_ESCAPE_SEQUENCE_PATTERN = new RegExp(
   String.raw`(?:\x1B\[[0-?]*[ -/]*[@-~]|\x1B[@-Z\\-_]|\x9B[0-?]*[ -/]*[@-~])`,
   "g",
@@ -375,12 +376,58 @@ function parseWikiSearchEnumOption<T extends string>(
   throw new Error(`Invalid ${label}: ${value}. Expected one of: ${allowed.join(", ")}`);
 }
 
+function formatBytes(value: number): string {
+  return `${value.toLocaleString("en-US")} bytes`;
+}
+
+function createOversizedWikiApplyBodyFileError(size?: number): Error {
+  const observed = typeof size === "number" ? ` (${formatBytes(size)})` : "";
+  return new Error(
+    `wiki apply synthesis --body-file is too large${observed}; limit is ${formatBytes(WIKI_APPLY_BODY_FILE_MAX_BYTES)}.`,
+  );
+}
+
+async function readWikiApplyBodyFile(bodyFile: string): Promise<string> {
+  const handle = await fs.open(bodyFile, "r");
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error("wiki apply synthesis --body-file must point to a regular file.");
+    }
+    if (stat.size > WIKI_APPLY_BODY_FILE_MAX_BYTES) {
+      throw createOversizedWikiApplyBodyFileError(stat.size);
+    }
+
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let position = 0;
+    while (totalBytes <= WIKI_APPLY_BODY_FILE_MAX_BYTES) {
+      const nextLength = Math.min(64 * 1024, WIKI_APPLY_BODY_FILE_MAX_BYTES + 1 - totalBytes);
+      const chunk = Buffer.alloc(nextLength);
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, position);
+      if (bytesRead === 0) {
+        break;
+      }
+      chunks.push(chunk.subarray(0, bytesRead));
+      totalBytes += bytesRead;
+      position += bytesRead;
+      if (totalBytes > WIKI_APPLY_BODY_FILE_MAX_BYTES) {
+        throw createOversizedWikiApplyBodyFileError(totalBytes);
+      }
+    }
+
+    return Buffer.concat(chunks, totalBytes).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
 async function resolveWikiApplyBody(params: { body?: string; bodyFile?: string }): Promise<string> {
   if (params.body?.trim()) {
     return params.body;
   }
   if (params.bodyFile?.trim()) {
-    return await fs.readFile(params.bodyFile, "utf8");
+    return await readWikiApplyBodyFile(params.bodyFile);
   }
   throw new Error("wiki apply synthesis requires --body or --body-file.");
 }

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -61,8 +61,7 @@ const GATEWAY_RESPONSE_MAX_STRING_CHARS = 10_000;
 const GATEWAY_RESPONSE_MAX_CODE_CHARS = 256;
 const WIKI_APPLY_BODY_FILE_MAX_BYTES = 1_048_576;
 // Open non-blocking so FIFO swaps do not stall before descriptor validation.
-const WIKI_APPLY_BODY_FILE_OPEN_FLAGS =
-  fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK ?? 0);
+const WIKI_APPLY_BODY_FILE_OPEN_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK ?? 0);
 const ANSI_ESCAPE_SEQUENCE_PATTERN = new RegExp(
   String.raw`(?:\x1B\[[0-?]*[ -/]*[@-~]|\x1B[@-Z\\-_]|\x9B[0-?]*[ -/]*[@-~])`,
   "g",

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -1,4 +1,5 @@
 // Memory Wiki plugin module implements cli behavior.
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
@@ -59,6 +60,9 @@ const GATEWAY_RESPONSE_MAX_ARRAY_ITEMS = 10_000;
 const GATEWAY_RESPONSE_MAX_STRING_CHARS = 10_000;
 const GATEWAY_RESPONSE_MAX_CODE_CHARS = 256;
 const WIKI_APPLY_BODY_FILE_MAX_BYTES = 1_048_576;
+// Open non-blocking so FIFO swaps do not stall before descriptor validation.
+const WIKI_APPLY_BODY_FILE_OPEN_FLAGS =
+  fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK ?? 0);
 const ANSI_ESCAPE_SEQUENCE_PATTERN = new RegExp(
   String.raw`(?:\x1B\[[0-?]*[ -/]*[@-~]|\x1B[@-Z\\-_]|\x9B[0-?]*[ -/]*[@-~])`,
   "g",
@@ -388,16 +392,16 @@ function createOversizedWikiApplyBodyFileError(size?: number): Error {
 }
 
 async function readWikiApplyBodyFile(bodyFile: string): Promise<string> {
-  const stat = await fs.stat(bodyFile);
-  if (!stat.isFile()) {
-    throw new Error("wiki apply synthesis --body-file must point to a regular file.");
-  }
-  if (stat.size > WIKI_APPLY_BODY_FILE_MAX_BYTES) {
-    throw createOversizedWikiApplyBodyFileError(stat.size);
-  }
-
-  const handle = await fs.open(bodyFile, "r");
+  const handle = await fs.open(bodyFile, WIKI_APPLY_BODY_FILE_OPEN_FLAGS);
   try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error("wiki apply synthesis --body-file must point to a regular file.");
+    }
+    if (stat.size > WIKI_APPLY_BODY_FILE_MAX_BYTES) {
+      throw createOversizedWikiApplyBodyFileError(stat.size);
+    }
+
     const chunks: Buffer[] = [];
     let totalBytes = 0;
     let position = 0;

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -388,16 +388,16 @@ function createOversizedWikiApplyBodyFileError(size?: number): Error {
 }
 
 async function readWikiApplyBodyFile(bodyFile: string): Promise<string> {
+  const stat = await fs.stat(bodyFile);
+  if (!stat.isFile()) {
+    throw new Error("wiki apply synthesis --body-file must point to a regular file.");
+  }
+  if (stat.size > WIKI_APPLY_BODY_FILE_MAX_BYTES) {
+    throw createOversizedWikiApplyBodyFileError(stat.size);
+  }
+
   const handle = await fs.open(bodyFile, "r");
   try {
-    const stat = await handle.stat();
-    if (!stat.isFile()) {
-      throw new Error("wiki apply synthesis --body-file must point to a regular file.");
-    }
-    if (stat.size > WIKI_APPLY_BODY_FILE_MAX_BYTES) {
-      throw createOversizedWikiApplyBodyFileError(stat.size);
-    }
-
     const chunks: Buffer[] = [];
     let totalBytes = 0;
     let position = 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw wiki apply synthesis --body-file ...` with an oversized body file could have that file fully buffered before the command failed or reached mutation handling.

## Why This Change Was Made

The CLI now reads synthesis body files through a bounded file handle with a 1 MiB cap, rejects non-regular or oversized files with a clear error, and preserves existing inline `--body` behavior.

## User Impact

Users get a friendly size-limit error for oversized synthesis body files, and normal `--body-file` synthesis creation continues to work for valid inputs.

## Evidence

Current head: `13d0f7cb8bd0b5f75d0f640f13af656c45e5309f`.

- GitHub Actions `Real behavior proof` passed on the current head.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/memory-wiki/src/cli.test.ts` passed on the current head (1 file, 20 tests).
- `git diff --check` passed on the current head.