### PR TITLE
fix(link-understanding): cancel response body on non-OK status before throwing

### DIFF
--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -199,4 +199,26 @@ describe("runLinkUnderstanding", () => {
       }),
     );
   });
+
+  it("cancels the response body on non-OK status before throwing", async () => {
+    const cancelSpy = vi.spyOn(ReadableStream.prototype, "cancel").mockResolvedValue(undefined);
+    try {
+      const release = vi.fn(async () => {});
+      mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: new Response("not found", { status: 404 }),
+        finalUrl: "https://example.com/404",
+        release,
+      });
+
+      await runLinkUnderstanding({
+        cfg: cfg({ type: "cli", command: "summarize" }),
+        ctx: ctx("see https://example.com/404"),
+      });
+
+      expect(cancelSpy).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      cancelSpy.mockRestore();
+    }
+  });
 });

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -102,6 +102,7 @@ async function fetchLinkContent(params: {
   });
   try {
     if (!response.ok) {
+      await response.body?.cancel();
       throw new Error(`Link fetch failed with HTTP ${response.status}`);
     }
     const buffer = await readResponseWithLimit(response, CLI_OUTPUT_MAX_BUFFER);


### PR DESCRIPTION
## What Problem This Solves

`fetchLinkContent()` in `link-understanding/runner.ts` throws on non-OK HTTP status without cancelling the response body first. An unread response body leaves the underlying connection open, causing a resource leak.

## Why This Change Was Made

Three recently merged PRs follow the same pattern of cancelling the response body before throwing on non-OK status:

- #109701 `fix(msteams): cancel non-OK consent upload response body before throwing`
- #109718 `fix(lmstudio): cancel model discovery response body on non-ok`
- #109677 `fix(chutes): cancel userinfo error response body before returning null`

## Evidence

**Test**: `cancels the response body on non-OK status before throwing` — creates a 404 response, verifies `ReadableStream.prototype.cancel` is called before the function returns.

```
✓ cancels the response body on non-OK status before throwing
```

All 7 tests pass.

## Merge Risk

Low. The fix adds one `await response.body?.cancel()` line before the existing `throw`. The `release()` call in the `finally` block still runs and is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)