### PR TITLE
fix(cli): cap config patch file input

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2389,6 +2389,31 @@ describe("config cli", () => {
       expect(resolveOptions).toBeTypeOf("object");
     });
 
+    it("rejects oversized config patch files before parse or write", async () => {
+      const pathname = path.join(
+        os.tmpdir(),
+        `openclaw-config-patch-oversized-${Date.now()}-${Math.random()
+          .toString(16)
+          .slice(2)}.json5`,
+      );
+      fs.writeFileSync(pathname, `${" ".repeat(1024 * 1024 + 1)}{bad`, "utf8");
+      try {
+        await expect(
+          runConfigCommand(["config", "patch", "--file", pathname, "--dry-run"]),
+        ).rejects.toThrow("__exit__:1");
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("config patch mode error: --file input exceeds 1048576 bytes");
+      expectErrorIncludes("split the patch into smaller changes");
+      expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+        "Failed to parse --file as JSON5",
+      );
+    });
+
     it("emits the resolved config path in config patch JSON", async () => {
       const home = path.join(os.tmpdir(), "openclaw-home-token-config-patch");
       const configPath = path.join(home, ".openclaw", "openclaw.json");

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2400,7 +2400,7 @@ describe("config cli", () => {
       try {
         await expect(
           runConfigCommand(["config", "patch", "--file", pathname, "--dry-run"]),
-        ).rejects.toThrow("__exit__:1");
+        ).rejects.toThrow("config patch mode error: --file input exceeds 1048576 bytes");
       } finally {
         fs.rmSync(pathname, { force: true });
       }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1497,26 +1497,33 @@ async function readStdinText(): Promise<string> {
 }
 
 function readConfigPatchFileText(file: string): string {
-  const fd = fs.openSync(file, "r");
   try {
-    const chunks: Buffer[] = [];
-    const buffer = Buffer.allocUnsafe(64 * 1024);
-    let bytes = 0;
-    for (;;) {
-      const read = fs.readSync(fd, buffer, 0, buffer.length, null);
-      if (read === 0) {
-        return Buffer.concat(chunks, bytes).toString("utf8");
+    const fd = fs.openSync(file, "r");
+    try {
+      const chunks: Buffer[] = [];
+      const buffer = Buffer.allocUnsafe(64 * 1024);
+      let bytes = 0;
+      for (;;) {
+        const read = fs.readSync(fd, buffer, 0, buffer.length, null);
+        if (read === 0) {
+          return Buffer.concat(chunks, bytes).toString("utf8");
+        }
+        bytes += read;
+        if (bytes > CONFIG_PATCH_FILE_MAX_BYTES) {
+          throw configPatchModeError(
+            `--file input exceeds ${CONFIG_PATCH_FILE_MAX_BYTES} bytes; split the patch into smaller changes.`,
+          );
+        }
+        chunks.push(Buffer.from(buffer.subarray(0, read)));
       }
-      bytes += read;
-      if (bytes > CONFIG_PATCH_FILE_MAX_BYTES) {
-        throw configPatchModeError(
-          `--file input exceeds ${CONFIG_PATCH_FILE_MAX_BYTES} bytes; split the patch into smaller changes.`,
-        );
-      }
-      chunks.push(Buffer.from(buffer.subarray(0, read)));
+    } finally {
+      fs.closeSync(fd);
     }
-  } finally {
-    fs.closeSync(fd);
+  } catch (err) {
+    if (hasErrnoCode(err, "ENOENT")) {
+      throw new Error(`--file not found: ${file}`, { cause: err });
+    }
+    throw err;
   }
 }
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -332,6 +332,7 @@ const CONFIG_PATCH_DESCRIPTION = [
 ].join("\n");
 const CONFIG_SET_POLICY_ERROR_MAX_ISSUES = 5;
 const CONFIG_PATCH_STDIN_MAX_BYTES = 1024 * 1024;
+const CONFIG_PATCH_FILE_MAX_BYTES = CONFIG_PATCH_STDIN_MAX_BYTES;
 
 class ConfigSetDryRunValidationError extends Error {
   constructor(readonly result: ConfigSetDryRunResult) {
@@ -1495,6 +1496,30 @@ async function readStdinText(): Promise<string> {
   return bytes.toString("utf8");
 }
 
+function readConfigPatchFileText(file: string): string {
+  const fd = fs.openSync(file, "r");
+  try {
+    const chunks: Buffer[] = [];
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let bytes = 0;
+    for (;;) {
+      const read = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (read === 0) {
+        return Buffer.concat(chunks, bytes).toString("utf8");
+      }
+      bytes += read;
+      if (bytes > CONFIG_PATCH_FILE_MAX_BYTES) {
+        throw configPatchModeError(
+          `--file input exceeds ${CONFIG_PATCH_FILE_MAX_BYTES} bytes; split the patch into smaller changes.`,
+        );
+      }
+      chunks.push(Buffer.from(buffer.subarray(0, read)));
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> {
   const file = normalizeOptionalString(opts.file);
   const stdin = Boolean(opts.stdin);
@@ -1502,19 +1527,7 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
     throw configPatchModeError("provide exactly one of --file <path> or --stdin.");
   }
   const sourceLabel = stdin ? "--stdin" : "--file";
-  let raw: string;
-  if (stdin) {
-    raw = await readStdinText();
-  } else {
-    try {
-      raw = fs.readFileSync(file as string, "utf8");
-    } catch (err) {
-      if (hasErrnoCode(err, "ENOENT")) {
-        throw new Error(`--file not found: ${file}`, { cause: err });
-      }
-      throw err;
-    }
-  }
+  const raw = stdin ? await readStdinText() : readConfigPatchFileText(file as string);
   try {
     return JSON5.parse(raw);
   } catch (err) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw config patch --file` with a patch file over 1 MiB could have the whole patch file read into memory before parsing instead of getting the same bounded-input protection as `--stdin`.

## Why This Change Was Made

This applies the existing 1 MiB config patch byte ceiling to `--file` input with a bounded read loop while preserving the existing missing-file diagnostic for nonexistent paths. Oversized files now fail before JSON5 parsing, config snapshot loading, dry-run validation, or config writes.

## User Impact

Users get a clear `--file input exceeds 1048576 bytes` error for oversized config patch files and keep the actionable `--file not found: <path>` message for missing files. Valid patch files and existing dry-run semantics continue to work.

## Evidence

Current head: `7a5b00074c91c9bd56578caba02e9a4bbd656f03`.

- `node scripts/run-vitest.mjs src/cli/config-cli.test.ts` passed: 143 tests covered the oversized `--file` regression and the existing config patch cases.
- `git diff --check` passed with no output.
