### PR TITLE
fix(approval): preserve Unicode in native-route approval slug truncation

### DIFF
--- a/src/infra/approval-native-route-notice.test.ts
+++ b/src/infra/approval-native-route-notice.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   describeApprovalDeliveryDestination,
+  resolveApprovalDeliveryFailedNoticeText,
   resolveApprovalRoutedElsewhereNoticeText,
 } from "./approval-native-route-notice.js";
 
@@ -48,5 +49,62 @@ describe("resolveApprovalRoutedElsewhereNoticeText", () => {
 
   it("suppresses the notice when there are no destinations", () => {
     expect(resolveApprovalRoutedElsewhereNoticeText([])).toBeNull();
+  });
+});
+
+describe("resolveApprovalDeliveryFailedNoticeText", () => {
+  it("shortens exec approval ids to an 8-char slug", () => {
+    const id = "abc12345-extra-suffix";
+    const result = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: id,
+      approvalKind: "exec",
+    });
+    expect(result).toContain("/approve abc12345");
+  });
+
+  it("keeps short exec ids unshortened", () => {
+    const result = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: "abc",
+      approvalKind: "exec",
+    });
+    expect(result).toContain("/approve abc");
+  });
+
+  it("keeps plugin approval ids unshortened regardless of length", () => {
+    const longId = "x".repeat(20);
+    const result = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: longId,
+      approvalKind: "plugin",
+    });
+    expect(result).toContain(`/approve ${longId}`);
+  });
+
+  // 🦞 is U+1F99E = surrogate pair 🦞
+  it("does not produce a lone surrogate when an emoji straddles the 8-char slug boundary", () => {
+    // 7 ASCII chars + lobster emoji (2 code units) = 9 code units
+    const id = "1234567🦞extra";
+    const result = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: id,
+      approvalKind: "exec",
+    });
+
+    const slugMatch = result.match(/\/approve (\S+)/);
+    expect(slugMatch).not.toBeNull();
+    const slug = slugMatch![1]!;
+
+    // The slug must not end with a lone high surrogate.
+    const lastChar = slug.charCodeAt(slug.length - 1);
+    const isHighSurrogate = lastChar >= 0xd800 && lastChar <= 0xdbff;
+    expect(isHighSurrogate).toBe(false);
+  });
+
+  it("preserves an emoji fully within the 8-char slug boundary", () => {
+    // 6 ASCII + lobster (2 code units) = 8 code units exactly at limit
+    const id = "123456🦞extra";
+    const result = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: id,
+      approvalKind: "exec",
+    });
+    expect(result).toContain("/approve 123456🦞");
   });
 });

--- a/src/infra/approval-native-route-notice.ts
+++ b/src/infra/approval-native-route-notice.ts
@@ -1,5 +1,6 @@
 // Formats native-route approval notices shown when command approvals leave the current channel.
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatHumanList } from "../shared/human-list.js";
 import type { ChannelApprovalNativePlannedTarget } from "./approval-native-delivery.js";
 
@@ -37,7 +38,7 @@ export function resolveApprovalDeliveryFailedNoticeText(params: {
 }): string {
   const commandId =
     params.approvalKind === "exec" && params.approvalId.length > 8
-      ? params.approvalId.slice(0, 8)
+      ? sliceUtf16Safe(params.approvalId, 0, 8)
       : params.approvalId;
   // Exec approval ids are long command ids in chat UX; plugin ids can be short
   // semantic ids, so only shorten exec ids and keep the full-id fallback visible.


### PR DESCRIPTION
## What Problem This Solves

When exec approval command IDs contain multi-byte Unicode characters near the 8-character slug boundary, raw `.slice(0, 8)` could split UTF-16 surrogate pairs, producing garbled short codes in user-facing approval notices.

## Why This Change Was Made

Replace `.slice(0, 8)` with `sliceUtf16Safe` from `@openclaw/normalization-core/utf16-slice`, matching the pattern already used in `src/logging/redact.ts` and `src/tui/tui-local-shell.ts`.

## User Impact

Approval fallback notices (`/approve <slug> <decisions>`) will display correct Unicode characters instead of potentially corrupted short codes.

## Evidence

### Unit Tests (9 passed, 1 file)
```
 ✓ labels approver-DM-only delivery as channel DMs
 ✓ labels mixed-surface delivery as the channel itself
 ✓ reports sorted unique destinations
 ✓ suppresses the notice when there are no destinations
 ✓ shortens exec approval ids to an 8-char slug
 ✓ keeps short exec ids unshortened
 ✓ keeps plugin approval ids unshortened regardless of length
 ✓ does not produce a lone surrogate when an emoji straddles the 8-char slug boundary
 ✓ preserves an emoji fully within the 8-char slug boundary
```

### Test Coverage
- **Straddling surrogate pair**: 🦞 (U+1F99E) at position 7-8 of a 9+ char exec id — verifies no lone high surrogate (0xD800–0xDBFF) in the slug
- **Emoji within limit**: 🦞 at positions 6-7 (within 8-char boundary) — verified preserved in "/approve" output
- **Short ids**: exec ids ≤ 8 chars and all plugin ids kept unshortened

### Real Environment Behavior Proof

Terminal transcript of the fix running against the real `sliceUtf16Safe` dependency in the OpenClaw development environment (`script -q` recorded, executed via `tsx`):

```
─── Scenario 1: Emoji straddles 8-char boundary ─────────────────────
  Input exec approval ID:  "1234567🦞extra"
  ❌ OLD: .slice(0, 8) → "1234567\ud83e"  ⚠️ LONE SURROGATE!
  ✅ NEW: sliceUtf16Safe → "1234567"       ✓ OK

─── Scenario 2: Emoji fully within 8-char boundary ──────────────────
  Input exec approval ID:  "123456🦞extra"
  OLD: .slice(0, 8)  → "123456🦞" ✓
  NEW: sliceUtf16Safe → "123456🦞" ✓

─── Scenario 3: Short exec ID (≤ 8 chars) kept unshortened ─────────
  Input exec approval ID:  "abc12345"
  OLD: .slice(0, 8)  → "abc12345" ✓
  NEW: sliceUtf16Safe → "abc12345" ✓

─── Scenario 4: Plugin approval ID never shortened ──────────────────
  Input plugin approval ID: "very-long-plugin-id-that-should-never-be-truncated"
  Plugin ID not truncated ✓

─── Scenario 5: CJK characters near boundary ────────────────────────
  Input exec approval ID:  "审批审批审批extra"
  OLD: .slice(0, 8) → "审批审批审批ex"  ✓ (BMP, no surrogate issue)
  NEW: sliceUtf16Safe → "审批审批审批ex"  ✓
```

**Key finding**: Old `.slice(0, 8)` produces a lone high surrogate (0xD83E) when 🦞 (U+1F99E, surrogate pair 🦞) straddles the 8-char boundary. The new `sliceUtf16Safe` correctly adjusts the boundary to avoid splitting surrogate pairs, producing clean Unicode output.

Full transcript: `docs/.local/109840/verify.log` (available in the repository)