### PR TITLE
fix(approval): preserve Unicode in exec approval slug truncation

### DIFF
--- a/src/infra/exec-approval-forwarder-slug.test.ts
+++ b/src/infra/exec-approval-forwarder-slug.test.ts
@@ -1,0 +1,147 @@
+// Tests that sliceUtf16Safe is exercised for approval slugs with emoji IDs.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createExecApprovalForwarder } from "./exec-approval-forwarder.js";
+
+const { mockLogError } = vi.hoisted(() => ({ mockLogError: vi.fn() }));
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    subsystem: "gateway/exec-approvals",
+    isEnabled: () => false,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: mockLogError,
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
+const baseRequest = {
+  id: "req-1",
+  request: {
+    command: "echo hello",
+    agentId: "main",
+    sessionKey: "agent:main:main",
+  },
+  createdAtMs: 1000,
+  expiresAtMs: 6000,
+};
+
+const activeForwarders: Array<ReturnType<typeof createExecApprovalForwarder>> = [];
+
+afterEach(() => {
+  for (const fwd of activeForwarders.splice(0)) {
+    fwd.stop();
+  }
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const emptyRegistry = createTestRegistry([]);
+const defaultRegistry = createTestRegistry([
+  { pluginId: "telegram", plugin: createChannelTestPluginBase({ id: "telegram" }), source: "test" },
+]);
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    throw new Error("expected " + label + " to be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireFirstCallArg(
+  mock: ReturnType<typeof vi.fn>,
+  label: string,
+): Record<string, unknown> {
+  const firstCall = mock.mock.calls[0];
+  if (!firstCall) {
+    throw new Error("expected " + label + " call");
+  }
+  return requireRecord(firstCall[0], label);
+}
+
+function requireFirstPayload(deliver: ReturnType<typeof vi.fn>): ReplyPayload {
+  const delivery = requireFirstCallArg(deliver, "delivery params") as { payloads?: ReplyPayload[] };
+  const payload = delivery.payloads?.[0];
+  if (!payload) {
+    throw new Error("expected first delivery payload");
+  }
+  return payload;
+}
+
+function makeTargetsCfg(targets: Array<{ channel: string; to: string }>): OpenClawConfig {
+  return { approvals: { exec: { enabled: true, mode: "targets", targets } } } as OpenClawConfig;
+}
+
+const TARGETS_CFG = makeTargetsCfg([{ channel: "slack", to: "U123" }]);
+
+function createForwarder(params: { cfg: OpenClawConfig; deliver?: ReturnType<typeof vi.fn> }) {
+  const deliver = params.deliver ?? vi.fn().mockResolvedValue([]);
+  const forwarder = createExecApprovalForwarder({
+    getConfig: () => params.cfg,
+    deliver: deliver as (...args: unknown[]) => Promise<unknown[]>,
+    nowMs: () => 1000,
+  });
+  activeForwarders.push(forwarder);
+  return { deliver, forwarder };
+}
+
+describe("exec approval slug safety", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(defaultRegistry);
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("handles approval IDs with emoji without crashing", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    // Construct emoji at runtime to avoid source-file encoding issues.
+    const emojiId = "1234567" + String.fromCharCode(0xd83d, 0xdc68) + "X";
+
+    // handleRequested should succeed without throwing.
+    await expect(forwarder.handleRequested({ ...baseRequest, id: emojiId })).resolves.toBe(true);
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    // The payload should have a non-empty approvalSlug.
+    const payload = requireFirstPayload(deliver);
+    const meta = requireRecord(payload.channelData?.execApproval, "exec approval metadata");
+    const slug = String(meta.approvalSlug);
+    expect(typeof slug).toBe("string");
+    expect(slug.length).toBeGreaterThan(0);
+
+    // handleResolved should also succeed.
+    deliver.mockClear();
+    await forwarder.handleResolved({
+      id: emojiId,
+      decision: "allow-once",
+      resolvedBy: "slack:U123",
+      ts: 2000,
+    });
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("produces valid approval slugs for normal IDs", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(forwarder.handleRequested({ ...baseRequest, id: "req-abc123" })).resolves.toBe(
+      true,
+    );
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    const payload = requireFirstPayload(deliver);
+    const meta = requireRecord(payload.channelData?.execApproval, "exec approval metadata");
+    // Normal IDs should produce a slug (first 8 chars, safe).
+    expect(meta.approvalSlug).toBe("req-abc1");
+  });
+});

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import {
   getLoadedChannelPlugin,
@@ -435,7 +436,7 @@ function buildExecPendingPayload(params: {
       buildTypedApprovalPendingReplyPayload({
         approvalKind: "exec",
         approvalId: params.request.id,
-        approvalSlug: params.request.id.slice(0, 8),
+        approvalSlug: sliceUtf16Safe(params.request.id, 0, 8),
         text: buildExecApprovalRequestMessage(params.request, params.nowMs),
         agentId: params.request.request.agentId ?? null,
         allowedDecisions: resolveExecApprovalRequestAllowedDecisions(params.request.request),
@@ -456,7 +457,7 @@ function buildExecResolvedPayload(params: {
     buildFallback: () =>
       buildApprovalResolvedReplyPayload({
         approvalId: params.resolved.id,
-        approvalSlug: params.resolved.id.slice(0, 8),
+        approvalSlug: sliceUtf16Safe(params.resolved.id, 0, 8),
         text: buildResolvedMessage(params.resolved),
       }),
   });


### PR DESCRIPTION
## Evidence

### Tests (2 passed, 1 file)

```
 ✓ |infra| exec approval slug safety > handles approval IDs with emoji without crashing
 ✓ |infra| exec approval slug safety > produces valid approval slugs for normal IDs
```

### Test Coverage
- `handles approval IDs with emoji without crashing`: Verifies sliceUtf16Safe is exercised by passing an emoji-containing approval ID (with surrogate pair at 8-char boundary) through handleRequested and handleResolved. Confirms the forwarder does not crash and produces a non-empty approval slug.
- `produces valid approval slugs for normal IDs`: Verifies that normal approval IDs produce the expected 8-character slug via sliceUtf16Safe.

---

### Real behavior proof (Unicode safety demonstration)

A live demo script was run to compare the old behavior (`String.prototype.slice(0, 8)`) vs the new behavior (`sliceUtf16Safe(id, 0, 8)`) across various Unicode approval IDs:

```
╔══════════════════════════════════════════════════════════════╗
║  Exec Approval Slug — Unicode Safety Demonstration       ║
╚══════════════════════════════════════════════════════════════╝

This demonstrates the difference between the OLD approach
(String.prototype.slice(0, 8)) and the NEW approach
(sliceUtf16Safe(id, 0, 8)) for truncated approval slugs.

The approval slug is the first ~8 chars of the approval ID,
shown to users in the channel to identify which approval to
respond to (approve/deny). If the boundary splits an emoji,
users see a broken character and may not recognize the ID.


  emoji at 8-char boundary
  ------------------------
  Full ID:   "1234567👨"
  ID length: 9 code units
  Hex codes: 31 32 33 34 35 36 37 1f468

  OLD (slice(0,8)):         "1234567�"   ← 🔴 CONTAINS LONE SURROGATE — broken!
  NEW (sliceUtf16Safe):     "1234567"   ← ✅ FIXED — no broken surrogate
  Notes: slice(0,8) splits the emoji; sliceUtf16Safe backtracks to keep the pair intact

  emoji just past boundary
  ------------------------
  Full ID:   "123456😀"
  ID length: 8 code units
  Hex codes: 31 32 33 34 35 36 1f600

  OLD (slice(0,8)):         "123456😀"
  NEW (sliceUtf16Safe):     "123456😀"
  Notes: The emoji is the 7th/8th char; sliceUtf16Safe includes both surrogates

  normal ASCII ID
  ---------------
  Full ID:   "req-abc123"
  ID length: 10 code units
  Hex codes: 72 65 71 2d 61 62 63 31 32 33

  OLD (slice(0,8)):         "req-abc1"
  NEW (sliceUtf16Safe):     "req-abc1"
  Notes: No Unicode — both slice and sliceUtf16Safe produce identical output

  mixed CJK and emoji
  -------------------
  Full ID:   "中😀文-abc"
  ID length: 8 code units
  Hex codes: 4e2d 1f600 6587 2d 61 62 63

  OLD (slice(0,8)):         "中😀文-abc"
  NEW (sliceUtf16Safe):     "中😀文-abc"
  Notes: CJK chars are BMP (1 code unit each); emoji is a surrogate pair

  long string with emoji at position 7-8
  --------------------------------------
  Full ID:   "1234567🚀-rest"
  ID length: 14 code units
  Hex codes: 31 32 33 34 35 36 37 1f680 2d 72 65 73 74

  OLD (slice(0,8)):         "1234567�"   ← 🔴 CONTAINS LONE SURROGATE — broken!
  NEW (sliceUtf16Safe):     "1234567"   ← ✅ FIXED — no broken surrogate
  Notes: The emoji is at positions 7-8; sliceUtf16Safe backtracks to exclude the whole emoji

  multiple emoji scattered
  ------------------------
  Full ID:   "abc😀👍🚀defghijklmn"
  ID length: 20 code units
  Hex codes: 61 62 63 1f600 1f44d 1f680 64 65 66 67 68 69 6a 6b 6c 6d 6e

  OLD (slice(0,8)):         "abc😀👍�"   ← 🔴 CONTAINS LONE SURROGATE — broken!
  NEW (sliceUtf16Safe):     "abc😀👍"   ← ✅ FIXED — no broken surrogate
  Notes: First emoji at position 3-4, second at 5-6 — first 8 chars span multiple surrogate pairs

  full-width + emoji mix
  ----------------------
  Full ID:   "用户😀id-123456789"
  ID length: 16 code units
  Hex codes: 7528 6237 1f600 69 64 2d 31 32 33 34 35 36 37 38 39

  OLD (slice(0,8)):         "用户😀id-1"
  NEW (sliceUtf16Safe):     "用户😀id-1"
  Notes: CJK chars are BMP-safe (1 unit each), but CJK + emoji mixed still triggers the boundary case
```

**Key findings:**

| Input ID | Old (`slice(0,8)`) | New (`sliceUtf16Safe`) |
|----------|---------------------|-------------------------|
| `1234567👨` (len=9) | `1234567�` — broken surrogate | `1234567` — backtracked |
| `1234567🚀-rest` (len=14) | `1234567�` — broken surrogate | `1234567` — backtracked |
| `abc😀👍🚀def…` (len=20) | `abc😀👍�` — broken surrogate | `abc😀👍` — backtracked |
| `req-abc123` (ASCII) | `req-abc1` | `req-abc1` |

### Test suite verification

All affected tests pass (25 tests across 2 test files):

```
 ✓ |infra| exec approval slug safety (2 tests) — slug-specific tests
 ✓ |infra| exec approval forwarder (23 tests) — full forwarder test suite
 ✓ |packages/normalization-core| utf16-slice (21 tests) — core utility tests
```

The fix is minimal (2 lines changed, 1 import added) and has zero behavioral change for ASCII-only approval IDs — only Unicode surrogate pairs at the truncation boundary are affected, and only in the positive direction (no broken characters).