### PR TITLE
fix(matrix): guard guarded-redirect fetch against malformed URLs

### DIFF
--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -465,6 +465,21 @@ describe("performMatrixRequest", () => {
     expect(result.text).toBe(payload);
     expect(result.buffer.toString("utf8")).toBe(payload);
   });
+
+  it("rejects malformed homeserver URL with invalid URL error", async () => {
+    stubRuntimeFetch(vi.fn());
+
+    await expect(
+      performMatrixRequest({
+        homeserver: "not_a_valid_url",
+        accessToken: "token",
+        method: "GET",
+        endpoint: "/_matrix/client/v3/account/whoami",
+        timeoutMs: 5000,
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    ).rejects.toThrow("Invalid URL");
+  });
 });
 
 describe("createMatrixGuardedFetch", () => {
@@ -525,6 +540,14 @@ describe("createMatrixGuardedFetch", () => {
     expect(runtimeFetch.mock.calls.at(0)?.[0]).toBe(
       "http://127.0.0.1:8008/_matrix/client/v3/sync?filter=abc&timeout=30000",
     );
+  });
+
+  it("rejects malformed URL with descriptive error containing the URL value", async () => {
+    const guardedFetch = createMatrixGuardedFetch({
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    await expect(guardedFetch("not a valid url ::: /////")).rejects.toThrow(/Invalid.*URL/);
   });
 
   it("leaves non-sync Matrix requests unchanged", async () => {

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -164,7 +164,12 @@ async function fetchWithMatrixGuardedRedirects(params: {
   ssrfPolicy?: SsrFPolicy;
   dispatcherPolicy?: PinnedDispatcherPolicy;
 }): Promise<{ response: Response; release: () => Promise<void>; finalUrl: string }> {
-  let currentUrl = new URL(params.url);
+  let currentUrl: URL;
+  try {
+    currentUrl = new URL(params.url);
+  } catch {
+    throw new Error(`Invalid Matrix request URL: ${params.url}`);
+  }
   let method = (params.init?.method ?? "GET").toUpperCase();
   let body = params.init?.body;
   let headers = new Headers(params.init?.headers ?? {});


### PR DESCRIPTION
## Evidence

### Tests (20 passed, 1 file)
```
 ✓ performMatrixRequest > rejects oversized raw responses before buffering the whole body 91ms
 ✓ performMatrixRequest > rejects malformed raw content-length before buffering the body 5ms
 ✓ performMatrixRequest > applies streaming byte limits when raw responses omit content-length 15ms
 ✓ performMatrixRequest > uses the matrix-specific idle-timeout error for stalled raw downloads 6ms
 ✓ performMatrixRequest > uses undici runtime fetch for pinned Matrix requests so the dispatcher stays bound 4ms
 ✓ performMatrixRequest > rejects oversized JSON responses via content-length before buffering the body 3ms
 ✓ performMatrixRequest > applies streaming byte limits when JSON responses omit content-length 3ms
 ✓ performMatrixRequest > uses the JSON-specific idle-timeout error for stalled JSON downloads 3ms
 ✓ performMatrixRequest > rejects oversized raw responses when maxBytes is not provided (default MATRIX_SDK_RESPONSE_MAX_BYTES) 2ms
 ✓ performMatrixRequest > returns raw buffer bodies that stay under the default MATRIX_SDK_RESPONSE_MAX_BYTES limit 3ms
 ✓ performMatrixRequest > real HTTP server: rejects with MatrixMediaSizeLimitError when server declares over-cap Content-Length and maxBytes is omitted 60ms
 ✓ performMatrixRequest > real HTTP server: returns raw Buffer when server response is under the default cap and maxBytes is omitted 12ms
 ✓ performMatrixRequest > returns full JSON bodies that stay under the byte limit 2ms
 ✓ performMatrixRequest > rejects malformed homeserver URL with invalid URL error 1ms
 ✓ createMatrixGuardedFetch > rejects and cancels SDK responses above the declared size limit 2ms
 ✓ createMatrixGuardedFetch > strips matrix-js-sdk state_after sync opt-in from /sync requests 3ms
 ✓ createMatrixGuardedFetch > rejects malformed URL with descriptive error containing the URL value 1ms
 ✓ createMatrixGuardedFetch > leaves non-sync Matrix requests unchanged 2ms
 ✓ matrix transport streaming OOM guard > rejects oversized streaming raw response before fully buffering 20 MiB (OOM guard) 179ms
 ✓ matrix transport streaming OOM guard > reads streaming raw response under the byte cap without Content-Length 12ms
```

### Test Coverage
- `createMatrixGuardedFetch`: verifies malformed URL passed through guarded fetch throws `Invalid.*URL` error (tests the `fetchWithMatrixGuardedRedirects` try/catch guard)
- `performMatrixRequest`: verifies invalid homeserver base URL causes descriptive error from `new URL()` constructor