### PR TITLE
fix(googlechat): guard auth request URL parsing against malformed input

### DIFF
--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -348,6 +348,23 @@ describe("googlechat google auth runtime", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it("rejects malformed URL with descriptive error containing the URL value", async () => {
+    const release = vi.fn();
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response("ok", { status: 200 }),
+      release,
+    });
+
+    const guardedFetch = await createGoogleAuthTransportFetch();
+
+    await expect(
+      guardedFetch("http://%zz/", {
+        method: "GET",
+      } as RequestInit),
+    ).rejects.toThrow(/Invalid.*URL/);
+    expect(release).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed auth content-length before reading the body", async () => {
     const release = vi.fn();
     const arrayBuffer = vi.fn(async () => new ArrayBuffer(16));

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -357,10 +357,17 @@ function resolveGoogleAuthDispatcherPolicy(
   dispatcherPolicy?: PinnedDispatcherPolicy;
   init?: RequestInit;
 } {
-  const requestUrl =
-    input instanceof Request
-      ? new URL(input.url)
-      : new URL(typeof input === "string" ? input : input.toString());
+  let requestUrl: URL;
+  try {
+    requestUrl =
+      input instanceof Request
+        ? new URL(input.url)
+        : new URL(typeof input === "string" ? input : input.toString());
+  } catch {
+    throw new Error(
+      `Invalid Google Chat request URL: ${typeof input === "string" ? input : input instanceof Request ? input.url : String(input)}`,
+    );
+  }
   const nextInit = sanitizeGoogleAuthInit(init);
   const googleAuthInit = (init ?? {}) as GoogleAuthTransportInit;
   const tlsOptions = resolveGoogleAuthTlsOptions(googleAuthInit, requestUrl);


### PR DESCRIPTION
## Evidence

### Tests (19 passed, 1 file)
```
 ✓ googlechat google auth runtime > rejects malformed URL with descriptive error containing the URL value 1ms
 ✓ googlechat google auth runtime > ... (18 existing tests all pass)
```

### Test Coverage
- `createGoogleAuthTransportFetch` (via `resolveGoogleAuthDispatcherPolicy` try/catch guard): passes `http://%zz/` (malformed URL) and verifies it throws `Invalid.*URL` error
- Verifies the SSRF guard `release` is not called when the URL parsing fails early (no network request made)