### PR TITLE
fix(signal): validate container message param types before use

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -1080,6 +1080,90 @@ describe("containerRpcRequest send", () => {
     expect(body).not.toHaveProperty("quote_author");
     expect(body).not.toHaveProperty("quote_message");
   });
+
+  it("falls back to empty string when account is a non-string value", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(JSON.stringify({ timestamp: "1700000000000" })),
+    });
+
+    await containerRpcRequest(
+      "send",
+      {
+        account: 12345,
+        recipient: ["+15550001111"],
+        message: "Hello world",
+      },
+      { baseUrl: "http://localhost:8080" },
+    );
+
+    const body = parseFetchBody();
+    expect(body.number).toBe("");
+  });
+
+  it("falls back to empty string when message is a non-string value", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(JSON.stringify({ timestamp: "1700000000000" })),
+    });
+
+    await containerRpcRequest(
+      "send",
+      {
+        account: "+14259798283",
+        recipient: ["+15550001111"],
+        message: { text: "not a string" },
+      },
+      { baseUrl: "http://localhost:8080" },
+    );
+
+    const body = parseFetchBody();
+    expect(body.message).toBe("");
+  });
+
+  it("falls back to empty string when account is null", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(JSON.stringify({ timestamp: "1700000000000" })),
+    });
+
+    await containerRpcRequest(
+      "send",
+      {
+        account: null,
+        recipient: ["+15550001111"],
+        message: "Hello world",
+      },
+      { baseUrl: "http://localhost:8080" },
+    );
+
+    const body = parseFetchBody();
+    expect(body.number).toBe("");
+  });
+
+  it("falls back to empty string when message is undefined", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(JSON.stringify({ timestamp: "1700000000000" })),
+    });
+
+    await containerRpcRequest(
+      "send",
+      {
+        account: "+14259798283",
+        recipient: ["+15550001111"],
+        // message intentionally omitted
+      },
+      { baseUrl: "http://localhost:8080" },
+    );
+
+    const body = parseFetchBody();
+    expect(body.message).toBe("");
+  });
 });
 
 describe("containerSendReceipt", () => {

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -784,9 +784,9 @@ export async function containerRpcRequest<T = unknown>(
       const quoteAuthor = normalizeContainerQuoteText(p.quoteAuthor ?? p["quote-author"]);
       const result = await containerSendMessage({
         baseUrl: opts.baseUrl,
-        account: (p.account as string) ?? "",
+        account: typeof p.account === "string" ? p.account : "",
         recipients: finalRecipients,
-        message: (p.message as string) ?? "",
+        message: typeof p.message === "string" ? p.message : "",
         textStyles,
         attachments: p.attachments as string[] | undefined,
         maxAttachmentBytes: opts.maxAttachmentBytes,


### PR DESCRIPTION
## Evidence

### Tests (69 passed, 1 file)

新增 4 个测试用例验证 `containerRpcRequest("send", ...)` 中的 typeof 类型守卫：

- `falls back to empty string when account is a non-string value` — 传入数字 12345 作为 account, 验证被替换为空字符串
- `falls back to empty string when message is a non-string value` — 传入对象作为 message, 验证被替换为空字符串
- `falls back to empty string when account is null` — 传入 null 作为 account, 验证被替换为空字符串
- `falls back to empty string when message is undefined` — 不传 message 字段, 验证被替换为空字符串

所有 69 个测试用例通过 (65 个已有 + 4 个新增)。

### Test Coverage

- 覆盖了 `containerRpcRequest` send 分支中 `typeof p.account === "string"` 和 `typeof p.message === "string"` 守卫的正确性
- 验证了非字符串类型值 (number, object, null, undefined) 被安全 fallback 为空字符串，避免非字符串值透传导致下游异常
