### PR TITLE
fix(qqbot): validate required reminder params instead of non-null assertions

### DIFF
--- a/extensions/qqbot/src/engine/tools/remind-logic.test.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.test.ts
@@ -94,6 +94,59 @@ describe("engine/tools/remind-logic", () => {
       });
     });
 
+    it("runs cron.add with valid cron expression", async () => {
+      const calls: RemindCronAction[] = [];
+      const result = await executeScheduledRemind(
+        {
+          action: "add",
+          content: "daily report",
+          to: "qqbot:c2c:123",
+          time: "0 9 * * *",
+          timezone: "Asia/Shanghai",
+        },
+        {},
+        async (params) => {
+          calls.push(params);
+          return { id: "cron-1" };
+        },
+      );
+
+      expect(calls).toHaveLength(1);
+      const call = calls[0];
+      expect(call?.action).toBe("add");
+      if (call?.action !== "add") {
+        throw new Error("expected add cron action");
+      }
+      expect(call.job.schedule).toEqual({
+        kind: "cron",
+        expr: "0 9 * * *",
+        tz: "Asia/Shanghai",
+      });
+      expect(call.job.name).toBe("Reminder: daily report");
+      expect(call.job.payload).toEqual({
+        kind: "agentTurn",
+        message: expect.stringContaining("daily report"),
+      });
+      expect(result.details).toEqual({
+        ok: true,
+        action: "add",
+        summary: expect.stringContaining('"daily report"'),
+        cronResult: { id: "cron-1" },
+      });
+    });
+
+    it("returns error when content is missing for cron reminders", async () => {
+      const result = await executeScheduledRemind(
+        { action: "add", time: "0 * * * *" },
+        {},
+        async () => {
+          throw new Error("unexpected scheduler call");
+        },
+      );
+
+      expect((result.details as { error: string }).error).toContain("content");
+    });
+
     it("rejects relative reminders whose scheduled time exceeds the Date range", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(8_640_000_000_000_000));

--- a/extensions/qqbot/src/engine/tools/remind-logic.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.ts
@@ -222,14 +222,21 @@ function buildOnceJob(params: RemindParams, atMs: number, to: string, accountId:
 
 /** Build cron job params for a recurring cron reminder. */
 function buildCronJob(params: RemindParams, to: string, accountId: string) {
-  const content = params.content!;
+  const content = params.content;
+  if (!content) {
+    throw new Error("Reminder content is required for cron job");
+  }
   const name = params.name || generateJobName(content);
   const tz = params.timezone || QQBOT_DEFAULT_REMINDER_TIMEZONE;
+  const timeExpr = params.time?.trim();
+  if (!timeExpr) {
+    throw new Error("Reminder time expression is required for cron job");
+  }
   return {
     action: "add" as const,
     job: {
       name,
-      schedule: { kind: "cron" as const, expr: params.time!.trim(), tz },
+      schedule: { kind: "cron" as const, expr: timeExpr, tz },
       sessionTarget: "isolated" as const,
       wakeMode: "now" as const,
       payload: {


### PR DESCRIPTION
## Evidence

### Tests (7 passed, 1 file)

```
 ✓ engine/tools/remind-logic > executeScheduledRemind > runs cron.add directly for relative reminders
 ✓ engine/tools/remind-logic > executeScheduledRemind > runs cron list and remove through the scheduler
 ✓ engine/tools/remind-logic > executeScheduledRemind > does not call scheduler when validation fails
 ✓ engine/tools/remind-logic > executeScheduledRemind > returns a clear error when Gateway cron fails
 ✓ engine/tools/remind-logic > executeScheduledRemind > runs cron.add with valid cron expression
 ✓ engine/tools/remind-logic > executeScheduledRemind > returns error when content is missing for cron reminders
 ✓ engine/tools/remind-logic > executeScheduledRemind > rejects relative reminders whose scheduled time exceeds the Date range
```

### Test Coverage
- `runs cron.add with valid cron expression`: Exercises buildCronJob with valid params (content, time, timezone), verifies the cron job schedule, name, and payload are correctly built.
- `returns error when content is missing for cron reminders`: Verifies that missing content with a cron expression time returns an appropriate error (content guard is exercised).
