### PR TITLE
fix(hooks): prevent rejected inbound conversation claims

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -112,19 +112,6 @@ describe("message hook mappers", () => {
             },
           },
         },
-        {
-          pluginId: "rejecting-claim-chat",
-          source: "test",
-          plugin: {
-            ...createChannelTestPluginBase({
-              id: "rejecting-claim-chat",
-              label: "Rejecting claim chat",
-            }),
-            messaging: {
-              resolveInboundConversation: () => null,
-            },
-          },
-        },
       ]),
     );
   });
@@ -480,11 +467,14 @@ describe("message hook mappers", () => {
   it("does not fall back when a channel rejects inbound claim resolution", () => {
     const canonical = deriveInboundMessageHookContext(
       makeInboundCtx({
-        Provider: "rejecting-claim-chat",
-        Surface: "rejecting-claim-chat",
-        OriginatingChannel: "rejecting-claim-chat",
+        Provider: "claim-chat",
+        Surface: "claim-chat",
+        OriginatingChannel: "claim-chat",
+        From: undefined,
         To: "channel:room-123",
         OriginatingTo: "channel:room-123",
+        GroupChannel: undefined,
+        GroupSubject: undefined,
       }),
     );
 

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -112,6 +112,19 @@ describe("message hook mappers", () => {
             },
           },
         },
+        {
+          pluginId: "rejecting-claim-chat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "rejecting-claim-chat",
+              label: "Rejecting claim chat",
+            }),
+            messaging: {
+              resolveInboundConversation: () => null,
+            },
+          },
+        },
       ]),
     );
   });
@@ -462,6 +475,21 @@ describe("message hook mappers", () => {
       parentSpanId: undefined,
       callDepth: undefined,
     });
+  });
+
+  it("does not fall back when a channel rejects inbound claim resolution", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        Provider: "rejecting-claim-chat",
+        Surface: "rejecting-claim-chat",
+        OriginatingChannel: "rejecting-claim-chat",
+        To: "channel:room-123",
+        OriginatingTo: "channel:room-123",
+      }),
+    );
+
+    expect(toPluginInboundClaimContext(canonical).conversationId).toBeUndefined();
+    expect(toPluginInboundClaimEvent(canonical).conversationId).toBeUndefined();
   });
 
   it("passes thread parent ids to channel plugin claim resolvers", () => {

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -323,7 +323,11 @@ function resolveInboundConversation(canonical: CanonicalInboundMessageHookContex
         threadParentId: canonical.threadParentId,
         isGroup: canonical.isGroup,
       })
-    : null;
+    : undefined;
+  if (pluginResolved === null) {
+    // A plugin-owned null is an explicit rejection, so generic parsing must not reclaim it.
+    return {};
+  }
   if (pluginResolved) {
     return {
       conversationId: normalizeOptionalString(pluginResolved.conversationId),


### PR DESCRIPTION
Closes #109300

## What Problem This Solves

Fixes an issue where an inbound claim hook could associate a message with a conversation even after the owning channel plugin explicitly rejected that target.

## Why This Change Was Made

The mapper now distinguishes a missing or non-applicable resolver from an explicit `null` rejection. Generic parsing remains available when no plugin claims the target, while a plugin-owned rejection is preserved.

## User Impact

Plugin-integrated agents no longer bind unsupported inbound targets to an incorrect conversation or session. Channels without an applicable resolver keep their existing fallback behavior.

## Evidence

- Node 24.18.0: `node scripts/run-vitest.mjs src/hooks/message-hook-mappers.test.ts` (16 tests passed)
- Exact-head runtime probe loaded the production Matrix channel plugin into the active plugin registry and passed both required paths:

  ```json
  {"activePlugin":"matrix","explicitNull":{"targetClass":"matrix-user-target","conversationIdPresent":false},"absentResolver":{"targetClass":"generic-channel-target","conversationId":"room-redacted"}}
  ```

  The one-shot probe passed 1/1 and was removed after the run; it is not part of the submitted patch.
- `oxfmt --check src/hooks/message-hook-mappers.ts src/hooks/message-hook-mappers.test.ts`
- `git diff --check upstream/main...HEAD`
- Fresh autoreview after rebasing onto latest `upstream/main`: no accepted or actionable findings
- Non-visual runtime mapping change; screenshots are not applicable

AI-assisted: yes. I reviewed the implementation, affected callers, sibling conversation-resolution behavior, and the focused regression coverage.
