### PR TITLE
style(google-meet): format setup status test

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -417,10 +417,7 @@ async function getTwilioVoiceCallCredentialsCheck(params: {
     },
   );
   const tool = tools[0] as {
-    execute: (
-      id: string,
-      params: unknown,
-    ) => Promise<{ details: { checks?: unknown[] } }>;
+    execute: (id: string, params: unknown) => Promise<{ details: { checks?: unknown[] } }>;
   };
 
   const result = await tool.execute("id", { action: "setup_status" });


### PR DESCRIPTION
## Summary

- apply the repository formatter to the Google Meet setup-status test type

## Why

Exact-head CI run 29568697169 fails `check-lint` because `oxfmt --check` reports `extensions/google-meet/index.test.ts`.

## Validation

- `pnpm exec oxfmt --write extensions/google-meet/index.test.ts`
- `git diff --check`
- autoreview clean
