### PR TITLE
feat(gateway): add ticketed read-only MCP App host

### DIFF
--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -1,0 +1,247 @@
+import type { IncomingMessage } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { makeMockHttpResponse } from "./test-http-response.js";
+
+const mocks = vi.hoisted(() => ({
+  getMcpAppViewLease: vi.fn(),
+  peekSessionMcpRuntime: vi.fn(),
+}));
+
+vi.mock("../agents/agent-bundle-mcp-runtime.js", () => ({
+  peekSessionMcpRuntime: mocks.peekSessionMcpRuntime,
+}));
+vi.mock("../agents/mcp-ui-resource.js", () => ({
+  getMcpAppViewLease: mocks.getMcpAppViewLease,
+}));
+
+import {
+  createMcpAppStandaloneTicket,
+  handleMcpAppStandaloneHttpRequest,
+  verifyMcpAppStandaloneTicket,
+} from "./mcp-app-standalone.js";
+
+function issueTicket(params: Parameters<typeof createMcpAppStandaloneTicket>[0]) {
+  const issued = createMcpAppStandaloneTicket(params);
+  if (!issued) {
+    throw new Error("ticket capacity unexpectedly exhausted");
+  }
+  return issued;
+}
+
+const nowMs = 1_800_000_000_000;
+const secret = Buffer.alloc(32, 7);
+const runtime = { sessionId: "runtime-session", mcpAppsEnabled: true };
+const view = {
+  viewId: "mcp-app-view",
+  sessionId: runtime.sessionId,
+  runtime,
+  html: "<!doctype html><p>private fixture</p>",
+  csp: { connectDomains: ["https://api.example.com"] },
+  toolInput: { city: "Paris" },
+  toolResult: { content: [{ type: "text", text: "sunny" }] },
+  expiresAtMs: nowMs + 10 * 60_000,
+};
+
+function request(params: {
+  url: string;
+  method?: "GET" | "HEAD" | "POST";
+  authorization?: string;
+  now?: number;
+}) {
+  const { res, end, setHeader } = makeMockHttpResponse();
+  const handled = handleMcpAppStandaloneHttpRequest(
+    {
+      url: params.url,
+      method: params.method ?? "GET",
+      headers: params.authorization ? { authorization: params.authorization } : {},
+      socket: {},
+    } as IncomingMessage,
+    res,
+    {
+      gatewayPort: 18_789,
+      sandboxPort: 18_790,
+      nowMs: params.now ?? nowMs,
+      ticketSecret: secret,
+    },
+  );
+  return { handled, res, end, setHeader };
+}
+
+describe("MCP App standalone host", () => {
+  beforeEach(() => {
+    mocks.peekSessionMcpRuntime.mockReset().mockReturnValue(runtime);
+    mocks.getMcpAppViewLease.mockReset().mockReturnValue(view);
+  });
+
+  it("mints a short-lived opaque ticket bound to the runtime session and view", () => {
+    const issued = issueTicket({
+      sessionKey: "agent:main:main",
+      view,
+      nowMs,
+      secret,
+    });
+
+    expect(issued.ticket).toMatch(/^v1\.[A-Za-z0-9_-]+\.\d+\.[A-Za-z0-9_-]+$/u);
+    expect(issued.ticket).not.toContain("agent:main:main");
+    expect(issued.expiresAtMs).toBe(nowMs + 2 * 60_000);
+    expect(
+      issueTicket({
+        sessionKey: "agent:main:main",
+        view,
+        nowMs: nowMs + 1,
+        secret,
+      }),
+    ).toEqual(issued);
+    const refreshed = issueTicket({
+      sessionKey: "agent:main:main",
+      view,
+      nowMs: issued.expiresAtMs - 10_000,
+      secret,
+    });
+    expect(refreshed.ticket).not.toBe(issued.ticket);
+    expect(refreshed.expiresAtMs).toBeGreaterThan(issued.expiresAtMs);
+    expect(
+      verifyMcpAppStandaloneTicket(issued.ticket, {
+        nowMs: issued.expiresAtMs - 10_000,
+        secret,
+      }),
+    ).toBeDefined();
+    expect(
+      verifyMcpAppStandaloneTicket(issued.ticket, {
+        sessionKey: "agent:main:main",
+        sessionId: runtime.sessionId,
+        viewId: view.viewId,
+        nowMs,
+        secret,
+      }),
+    ).toMatchObject({ sessionKey: "agent:main:main", viewId: view.viewId });
+
+    expect(
+      verifyMcpAppStandaloneTicket(issued.ticket, {
+        sessionKey: "agent:other:main",
+        sessionId: runtime.sessionId,
+        viewId: view.viewId,
+        nowMs,
+        secret,
+      }),
+    ).toBeUndefined();
+    expect(
+      verifyMcpAppStandaloneTicket(issued.ticket, {
+        sessionKey: "agent:main:main",
+        sessionId: "other-runtime",
+        viewId: view.viewId,
+        nowMs,
+        secret,
+      }),
+    ).toBeUndefined();
+    expect(
+      verifyMcpAppStandaloneTicket(issued.ticket, {
+        sessionKey: "agent:main:main",
+        sessionId: runtime.sessionId,
+        viewId: "mcp-app-other",
+        nowMs,
+        secret,
+      }),
+    ).toBeUndefined();
+    expect(
+      verifyMcpAppStandaloneTicket(`${issued.ticket.slice(0, -1)}x`, {
+        nowMs,
+        secret,
+      }),
+    ).toBeUndefined();
+    expect(
+      verifyMcpAppStandaloneTicket(issued.ticket, {
+        nowMs: issued.expiresAtMs + 1,
+        secret,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("never lets a ticket outlive the view lease", () => {
+    const shortLived = issueTicket({
+      sessionKey: "agent:main:main",
+      view: { ...view, expiresAtMs: nowMs + 1_000 },
+      nowMs,
+      secret,
+    });
+    expect(shortLived.expiresAtMs).toBe(nowMs + 1_000);
+    expect(
+      issueTicket({
+        sessionKey: "agent:main:main",
+        view: { ...view, expiresAtMs: nowMs + 1_000 },
+        nowMs: nowMs + 500,
+        secret,
+      }),
+    ).toEqual(shortLived);
+    expect(
+      createMcpAppStandaloneTicket({
+        sessionKey: "agent:main:main",
+        view: { ...view, expiresAtMs: nowMs },
+        nowMs,
+        secret,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("serves a static shell without embedding tickets or per-view data", () => {
+    const result = request({ url: "/__openclaw__/mcp-app" });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.statusCode).toBe(200);
+    const body = String(result.end.mock.calls[0]?.[0]);
+    expect(body).toContain("location.hash");
+    expect(body).not.toContain("serverTools");
+    expect(body).not.toContain("serverResources");
+    expect(body).not.toContain(view.html);
+    expect(body).not.toContain("agent:main:main");
+    expect(result.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+    expect(result.setHeader).toHaveBeenCalledWith(
+      "Content-Security-Policy",
+      expect.stringContaining("connect-src 'self'"),
+    );
+  });
+
+  it("returns view data only for a valid ticket backed by the same live view", () => {
+    const issued = issueTicket({
+      sessionKey: "agent:main:main",
+      view,
+      nowMs,
+      secret,
+    });
+    const route = "/__openclaw__/mcp-app/view";
+
+    expect(request({ url: route }).res.statusCode).toBe(401);
+    expect(request({ url: `${route}?ticket=${issued.ticket}` }).res.statusCode).toBe(401);
+    expect(
+      request({ url: route, authorization: `MCP-App ${issued.ticket.slice(0, -1)}x` }).res
+        .statusCode,
+    ).toBe(401);
+
+    const accepted = request({ url: route, authorization: `MCP-App ${issued.ticket}` });
+    expect(accepted.res.statusCode).toBe(200);
+    const payload = JSON.parse(String(accepted.end.mock.calls[0]?.[0]));
+    expect(payload).toMatchObject({
+      html: view.html,
+      toolInput: view.toolInput,
+      toolResult: view.toolResult,
+      sandboxPort: 18_790,
+    });
+    expect(payload.sandboxUrl).toMatch(/^\/mcp-app-sandbox\?csp=/u);
+    expect(accepted.setHeader).toHaveBeenCalledWith("Vary", "Authorization");
+
+    // Reloads within the ticket and view lease are appropriate reuse.
+    expect(request({ url: route, authorization: `MCP-App ${issued.ticket}` }).res.statusCode).toBe(
+      200,
+    );
+
+    mocks.getMcpAppViewLease.mockReturnValue({ ...view, viewId: "mcp-app-replaced" });
+    expect(request({ url: route, authorization: `MCP-App ${issued.ticket}` }).res.statusCode).toBe(
+      401,
+    );
+  });
+
+  it("keeps the standalone surface read-only and path-scoped", () => {
+    expect(request({ url: "/__openclaw__/mcp-app", method: "POST" }).res.statusCode).toBe(404);
+    expect(request({ url: "/__openclaw__/mcp-app/other" }).handled).toBe(false);
+  });
+});

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -1,0 +1,425 @@
+import { createHmac, randomBytes } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
+import { buildMcpAppSandboxPath, resolveMcpAppSandboxPort } from "../agents/mcp-app-sandbox.js";
+import { getMcpAppViewLease, type McpAppViewLease } from "../agents/mcp-ui-resource.js";
+import { safeEqualSecret } from "../security/secret-equal.js";
+
+const MCP_APP_STANDALONE_PATH = "/__openclaw__/mcp-app";
+const MCP_APP_STANDALONE_VIEW_PATH = `${MCP_APP_STANDALONE_PATH}/view`;
+const MCP_APP_STANDALONE_TICKET_SCOPE = "mcp-app-standalone-view";
+const MCP_APP_STANDALONE_TICKET_TTL_MS = 2 * 60_000;
+const MCP_APP_STANDALONE_TICKET_MIN_REMAINING_MS = 15_000;
+const MCP_APP_STANDALONE_TICKET_MAX_ENTRIES = 256;
+const MCP_APP_STABLE_PROTOCOL_VERSION = "2026-01-26";
+const ticketSecret = randomBytes(32);
+
+type StandaloneTicketBinding = {
+  nonce: string;
+  sessionKey: string;
+  sessionId: string;
+  viewId: string;
+  expiresAtMs: number;
+};
+
+type StandaloneTicket = { ticket: string; url: string; expiresAtMs: number };
+
+const ticketBindings = new Map<string, StandaloneTicketBinding>();
+
+function pruneTicketBindings(nowMs: number): void {
+  for (const [nonce, binding] of ticketBindings) {
+    if (binding.expiresAtMs <= nowMs) {
+      ticketBindings.delete(nonce);
+    }
+  }
+}
+
+function signTicket(nonce: string, expiresAtMs: number, secret: Buffer): string {
+  return createHmac("sha256", secret)
+    .update(`${MCP_APP_STANDALONE_TICKET_SCOPE}\0${nonce}\0${expiresAtMs}`)
+    .digest("base64url");
+}
+
+function formatTicket(binding: StandaloneTicketBinding, secret: Buffer): string {
+  return `v1.${binding.nonce}.${binding.expiresAtMs}.${signTicket(binding.nonce, binding.expiresAtMs, secret)}`;
+}
+
+export function createMcpAppStandaloneTicket(params: {
+  sessionKey: string;
+  view: Pick<McpAppViewLease, "viewId" | "sessionId" | "expiresAtMs">;
+  nowMs?: number;
+  secret?: Buffer;
+}): StandaloneTicket | undefined {
+  const nowMs = params.nowMs ?? Date.now();
+  if (!Number.isSafeInteger(nowMs) || params.view.expiresAtMs <= nowMs) {
+    return undefined;
+  }
+  const expiresAtMs = Math.min(params.view.expiresAtMs, nowMs + MCP_APP_STANDALONE_TICKET_TTL_MS);
+  pruneTicketBindings(nowMs);
+  let reusable: StandaloneTicketBinding | undefined;
+  for (const binding of ticketBindings.values()) {
+    if (
+      binding.sessionKey === params.sessionKey &&
+      binding.sessionId === params.view.sessionId &&
+      binding.viewId === params.view.viewId
+    ) {
+      if (binding.expiresAtMs > params.view.expiresAtMs) {
+        ticketBindings.delete(binding.nonce);
+        continue;
+      }
+      if (!reusable || binding.expiresAtMs > reusable.expiresAtMs) {
+        reusable = binding;
+      }
+    }
+  }
+  if (
+    reusable &&
+    (reusable.expiresAtMs >= expiresAtMs ||
+      reusable.expiresAtMs - nowMs >= MCP_APP_STANDALONE_TICKET_MIN_REMAINING_MS)
+  ) {
+    const ticket = formatTicket(reusable, params.secret ?? ticketSecret);
+    return {
+      ticket,
+      url: `${MCP_APP_STANDALONE_PATH}#${ticket}`,
+      expiresAtMs: reusable.expiresAtMs,
+    };
+  }
+  // Standalone issuance is additive to the existing authenticated view API.
+  // At capacity, omit the link rather than failing that pre-existing path.
+  if (ticketBindings.size >= MCP_APP_STANDALONE_TICKET_MAX_ENTRIES) {
+    return undefined;
+  }
+  const nonce = randomBytes(24).toString("base64url");
+  const binding: StandaloneTicketBinding = {
+    nonce,
+    sessionKey: params.sessionKey,
+    sessionId: params.view.sessionId,
+    viewId: params.view.viewId,
+    expiresAtMs,
+  };
+  ticketBindings.set(nonce, binding);
+  const ticket = formatTicket(binding, params.secret ?? ticketSecret);
+  return {
+    ticket,
+    url: `${MCP_APP_STANDALONE_PATH}#${ticket}`,
+    expiresAtMs,
+  };
+}
+
+export function verifyMcpAppStandaloneTicket(
+  value: string,
+  expected: {
+    sessionKey?: string;
+    sessionId?: string;
+    viewId?: string;
+    nowMs?: number;
+    secret?: Buffer;
+  } = {},
+): StandaloneTicketBinding | undefined {
+  const nowMs = expected.nowMs ?? Date.now();
+  if (!Number.isSafeInteger(nowMs)) {
+    return undefined;
+  }
+  const parts = value.split(".");
+  if (parts.length !== 4 || parts[0] !== "v1") {
+    return undefined;
+  }
+  const [, nonce, rawExpiresAtMs, signature] = parts;
+  if (!nonce || nonce.length !== 32 || !rawExpiresAtMs || !signature) {
+    return undefined;
+  }
+  const expiresAtMs = Number(rawExpiresAtMs);
+  if (!Number.isSafeInteger(expiresAtMs) || expiresAtMs <= nowMs) {
+    return undefined;
+  }
+  const expectedSignature = signTicket(nonce, expiresAtMs, expected.secret ?? ticketSecret);
+  if (!safeEqualSecret(signature, expectedSignature)) {
+    return undefined;
+  }
+  const binding = ticketBindings.get(nonce);
+  if (
+    !binding ||
+    binding.expiresAtMs !== expiresAtMs ||
+    (expected.sessionKey !== undefined && binding.sessionKey !== expected.sessionKey) ||
+    (expected.sessionId !== undefined && binding.sessionId !== expected.sessionId) ||
+    (expected.viewId !== undefined && binding.viewId !== expected.viewId)
+  ) {
+    return undefined;
+  }
+  return binding;
+}
+
+function resolveTicketView(
+  value: string,
+  nowMs: number,
+  secret: Buffer,
+): McpAppViewLease | undefined {
+  const binding = verifyMcpAppStandaloneTicket(value, { nowMs, secret });
+  if (!binding) {
+    return undefined;
+  }
+  const runtime = peekSessionMcpRuntime({ sessionKey: binding.sessionKey });
+  if (!runtime || runtime.mcpAppsEnabled !== true || runtime.sessionId !== binding.sessionId) {
+    return undefined;
+  }
+  const view = getMcpAppViewLease(binding.viewId, runtime);
+  if (
+    !view ||
+    view.viewId !== binding.viewId ||
+    view.sessionId !== binding.sessionId ||
+    view.expiresAtMs <= nowMs ||
+    binding.expiresAtMs > view.expiresAtMs
+  ) {
+    return undefined;
+  }
+  return view;
+}
+
+function ticketFromRequest(req: IncomingMessage): string | undefined {
+  const authorization = req.headers.authorization;
+  if (!authorization?.startsWith("MCP-App ")) {
+    return undefined;
+  }
+  const value = authorization.slice("MCP-App ".length).trim();
+  return value || undefined;
+}
+
+function sendText(res: ServerResponse, statusCode: number, body: string): void {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.end(body);
+}
+
+function standaloneHostHtml(): string {
+  return `<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>OpenClaw MCP App</title>
+<style>html,body{height:100%;margin:0;background:#fff;color:#111;font:14px system-ui,sans-serif}main{height:100%}iframe{display:block;width:100%;height:600px;border:0}.error{padding:16px;color:#b91c1c}</style>
+<main id="host" aria-live="polite"></main>
+<script>
+(() => {
+  "use strict";
+  const host = document.getElementById("host");
+  const ticket = location.hash.startsWith("#") ? location.hash.slice(1) : "";
+  let frame;
+  let payload;
+  let initialized = false;
+  let requestId = 0;
+  let teardownId;
+  const fail = (message) => {
+    host.replaceChildren(Object.assign(document.createElement("p"), { className: "error", textContent: message }));
+  };
+  const post = (message) => frame?.contentWindow?.postMessage(message, "*");
+  const notify = (method, params = {}) => post({ jsonrpc: "2.0", method, params });
+  const respond = (id, result) => post({ jsonrpc: "2.0", id, result });
+  const reject = (id, method) => post({
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message: "Method not available in read-only host: " + method },
+  });
+  const removeFrame = () => {
+    frame?.remove();
+    frame = undefined;
+    teardownId = undefined;
+  };
+  const resolveSandboxUrl = (view) => {
+    const base = view.sandboxOrigin ? new URL(view.sandboxOrigin) : new URL(location.origin);
+    if (!view.sandboxOrigin) base.port = String(view.sandboxPort);
+    base.pathname = "/";
+    base.search = "";
+    base.hash = "";
+    const resolved = new URL(view.sandboxUrl, base);
+    if (
+      !["http:", "https:"].includes(resolved.protocol) ||
+      resolved.origin !== base.origin ||
+      resolved.origin === location.origin ||
+      resolved.pathname !== "/mcp-app-sandbox"
+    ) throw new Error("MCP App sandbox URL is invalid");
+    return resolved.href;
+  };
+  const deliverInitialState = () => {
+    if (initialized) return;
+    initialized = true;
+    notify("ui/notifications/tool-input", {
+      arguments: payload.toolInput && typeof payload.toolInput === "object" && !Array.isArray(payload.toolInput)
+        ? payload.toolInput
+        : {},
+    });
+    notify("ui/notifications/tool-result", payload.toolResult);
+  };
+  window.addEventListener("message", (event) => {
+    if (event.source !== frame?.contentWindow || !event.data || event.data.jsonrpc !== "2.0") return;
+    const message = event.data;
+    if (message.method === "ui/notifications/sandbox-proxy-ready") {
+      notify("ui/notifications/sandbox-resource-ready", { html: payload.html, csp: payload.csp });
+      return;
+    }
+    if (message.method === "ui/initialize" && message.id !== undefined) {
+      respond(message.id, {
+        protocolVersion: ${JSON.stringify(MCP_APP_STABLE_PROTOCOL_VERSION)},
+        hostInfo: { name: "OpenClaw read-only host", version: "1.0.0" },
+        hostCapabilities: { sandbox: { csp: payload.csp ?? {} } },
+        hostContext: {
+          theme: matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light",
+          displayMode: "inline",
+          availableDisplayModes: ["inline"],
+          containerDimensions: { width: Math.max(1, innerWidth), height: 600 },
+          locale: navigator.language,
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          platform: "web",
+        },
+      });
+      return;
+    }
+    if (message.method === "ui/notifications/initialized") {
+      deliverInitialState();
+      return;
+    }
+    if (message.method === "ui/notifications/size-changed") {
+      const height = message.params?.height;
+      if (typeof height === "number" && Number.isFinite(height)) {
+        frame.style.height = Math.min(1200, Math.max(160, Math.round(height))) + "px";
+      }
+      return;
+    }
+    if (message.method === "ui/notifications/request-teardown") {
+      const id = ++requestId;
+      teardownId = id;
+      post({ jsonrpc: "2.0", id, method: "ui/resource-teardown", params: {} });
+      setTimeout(() => { if (teardownId === id) removeFrame(); }, 1_000);
+      return;
+    }
+    if (teardownId !== undefined && message.id === teardownId && message.method === undefined) {
+      removeFrame();
+      return;
+    }
+    if (message.id !== undefined && typeof message.method === "string") reject(message.id, message.method);
+  });
+  window.addEventListener("pagehide", () => {
+    if (frame?.contentWindow) post({ jsonrpc: "2.0", id: ++requestId, method: "ui/resource-teardown", params: {} });
+  });
+  if (!ticket) {
+    fail("MCP App ticket is missing");
+    return;
+  }
+  fetch(${JSON.stringify(MCP_APP_STANDALONE_VIEW_PATH)}, {
+    headers: { Authorization: "MCP-App " + ticket },
+    cache: "no-store",
+    credentials: "omit",
+  }).then(async (response) => {
+    if (!response.ok) throw new Error("MCP App ticket was rejected");
+    payload = await response.json();
+    frame = document.createElement("iframe");
+    frame.title = "MCP App";
+    frame.referrerPolicy = "origin";
+    frame.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+    frame.src = resolveSandboxUrl(payload);
+    host.replaceChildren(frame);
+  }).catch((error) => fail(error instanceof Error ? error.message : String(error)));
+})();
+</script>`;
+}
+
+function resolveShellSandboxOrigin(params: {
+  req: IncomingMessage;
+  sandboxOrigin?: string;
+  sandboxPort: number;
+}): string {
+  if (params.sandboxOrigin) {
+    return new URL(params.sandboxOrigin).origin;
+  }
+  const protocol =
+    "encrypted" in params.req.socket && params.req.socket.encrypted ? "https:" : "http:";
+  const base = new URL(`${protocol}//${params.req.headers.host ?? "localhost"}`);
+  base.port = String(params.sandboxPort);
+  return base.origin;
+}
+
+export function handleMcpAppStandaloneHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: {
+    gatewayPort?: number;
+    sandboxPort?: number;
+    sandboxOrigin?: string;
+    nowMs?: number;
+    ticketSecret?: Buffer;
+  } = {},
+): boolean {
+  let url: URL;
+  try {
+    url = new URL(req.url ?? "/", "http://localhost");
+  } catch {
+    return false;
+  }
+  if (url.pathname !== MCP_APP_STANDALONE_PATH && url.pathname !== MCP_APP_STANDALONE_VIEW_PATH) {
+    return false;
+  }
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    sendText(res, 404, "Not Found");
+    return true;
+  }
+
+  const gatewayPort = options.gatewayPort ?? req.socket.localPort;
+  if (!gatewayPort) {
+    sendText(res, 503, "MCP App host unavailable");
+    return true;
+  }
+  let sandboxPort: number;
+  try {
+    sandboxPort = resolveMcpAppSandboxPort(gatewayPort, options.sandboxPort);
+  } catch {
+    sendText(res, 503, "MCP App host unavailable");
+    return true;
+  }
+
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  if (url.pathname === MCP_APP_STANDALONE_PATH) {
+    const frameOrigin = resolveShellSandboxOrigin({
+      req,
+      sandboxOrigin: options.sandboxOrigin,
+      sandboxPort,
+    });
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader(
+      "Content-Security-Policy",
+      `default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; frame-src ${frameOrigin}; base-uri 'none'; form-action 'none'; object-src 'none'`,
+    );
+    res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+    res.end(req.method === "HEAD" ? undefined : standaloneHostHtml());
+    return true;
+  }
+
+  res.setHeader("Vary", "Authorization");
+  const ticket = ticketFromRequest(req);
+  const view = ticket
+    ? resolveTicketView(ticket, options.nowMs ?? Date.now(), options.ticketSecret ?? ticketSecret)
+    : undefined;
+  if (!view) {
+    res.setHeader("WWW-Authenticate", "MCP-App");
+    sendText(res, 401, "Unauthorized");
+    return true;
+  }
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(
+    req.method === "HEAD"
+      ? undefined
+      : JSON.stringify({
+          sandboxUrl: buildMcpAppSandboxPath(view.csp),
+          sandboxPort,
+          ...(options.sandboxOrigin
+            ? { sandboxOrigin: new URL(options.sandboxOrigin).origin }
+            : {}),
+          html: view.html,
+          ...(view.csp ? { csp: view.csp } : {}),
+          toolInput: view.toolInput,
+          toolResult: view.toolResult,
+        }),
+  );
+  return true;
+}

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -255,6 +255,10 @@ function standaloneHostHtml(): string {
       notify("ui/notifications/sandbox-resource-ready", { html: payload.html, csp: payload.csp });
       return;
     }
+    if (message.method === "ping" && message.id !== undefined) {
+      respond(message.id, {});
+      return;
+    }
     if (message.method === "ui/initialize" && message.id !== undefined) {
       respond(message.id, {
         protocolVersion: ${JSON.stringify(MCP_APP_STABLE_PROTOCOL_VERSION)},

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -100,6 +100,8 @@ const getManagedImageAttachmentsModule = createLazyRuntimeModule(
   () => import("./managed-image-attachments.js"),
 );
 
+const getMcpAppStandaloneModule = createLazyRuntimeModule(() => import("./mcp-app-standalone.js"));
+
 const getPluginIconHttpModule = createLazyRuntimeModule(() => import("./plugin-icon-http.js"));
 
 const getModelsHttpModule = createLazyRuntimeModule(() => import("./models-http.js"));
@@ -181,6 +183,10 @@ function getCachedPluginGatewayAuthBypassPaths(
 
 function isOpenAiModelsPath(pathname: string): boolean {
   return pathname === "/v1/models" || pathname.startsWith("/v1/models/");
+}
+
+function isMcpAppStandalonePath(pathname: string): boolean {
+  return pathname === "/__openclaw__/mcp-app" || pathname === "/__openclaw__/mcp-app/view";
 }
 
 function isEmbeddingsPath(pathname: string): boolean {
@@ -786,6 +792,16 @@ export function createGatewayHttpServer(opts: {
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,
+            }),
+        });
+      }
+      if (configSnapshot.mcp?.apps?.enabled === true && isMcpAppStandalonePath(scopedRequestPath)) {
+        requestStages.push({
+          name: "mcp-app-standalone",
+          run: async () =>
+            (await getMcpAppStandaloneModule()).handleMcpAppStandaloneHttpRequest(req, res, {
+              sandboxPort: configSnapshot.mcp?.apps?.sandboxPort,
+              sandboxOrigin: configSnapshot.mcp?.apps?.sandboxOrigin,
             }),
         });
       }

--- a/src/gateway/server-methods/mcp-app.test.ts
+++ b/src/gateway/server-methods/mcp-app.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   getMcpAppViewLease: vi.fn(),
   peekSessionMcpRuntime: vi.fn(),
   restoreMcpAppView: vi.fn(),
+  createMcpAppStandaloneTicket: vi.fn(),
 }));
 
 vi.mock("../../agents/mcp-ui-resource.js", () => ({
@@ -21,6 +22,9 @@ vi.mock("../../agents/agent-bundle-mcp-runtime.js", () => ({
 }));
 vi.mock("../mcp-app-reconstruction.js", () => ({
   restoreMcpAppView: mocks.restoreMcpAppView,
+}));
+vi.mock("../mcp-app-standalone.js", () => ({
+  createMcpAppStandaloneTicket: mocks.createMcpAppStandaloneTicket,
 }));
 
 import { mcpAppHandlers } from "./mcp-app.js";
@@ -109,6 +113,11 @@ describe("MCP App gateway bridge", () => {
     mocks.completeDeferredSessionMcpRuntimeRetirement.mockReset().mockResolvedValue(false);
     mocks.peekSessionMcpRuntime.mockReset().mockReturnValue(runtime());
     mocks.restoreMcpAppView.mockReset().mockResolvedValue(undefined);
+    mocks.createMcpAppStandaloneTicket.mockReset().mockReturnValue({
+      ticket: "ticket",
+      url: "/__openclaw__/mcp-app#ticket",
+      expiresAtMs: 1_800_000_120_000,
+    });
   });
 
   it("returns the ephemeral view payload only for the bound session", async () => {
@@ -124,13 +133,33 @@ describe("MCP App gateway bridge", () => {
         sandboxOrigin: "https://apps.example.com",
         html: "<html>demo</html>",
         toolInput: { city: "Paris" },
+        standaloneUrl: "/__openclaw__/mcp-app#ticket",
+        standaloneExpiresAtMs: 1_800_000_120_000,
       }),
     );
     expect(mocks.getMcpAppViewLease).toHaveBeenCalledWith("cv_app", expect.any(Object));
+    expect(mocks.createMcpAppStandaloneTicket).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      view,
+    });
     const activeRuntime = mocks.peekSessionMcpRuntime.mock.results[0]?.value;
     expect(activeRuntime.acquireLease).toHaveBeenCalledOnce();
     expect(activeRuntime.acquireLease.mock.results[0]?.value).toHaveBeenCalledOnce();
     expect(mocks.completeDeferredSessionMcpRuntimeRetirement).toHaveBeenCalledWith(activeRuntime);
+  });
+
+  it("preserves the existing view payload when standalone ticket issuance is unavailable", async () => {
+    mocks.createMcpAppStandaloneTicket.mockImplementation(() => {
+      throw new Error("ticket unavailable");
+    });
+    const respond = await invoke("mcp.app.view", {
+      sessionKey: "agent:main:main",
+      viewId: "cv_app",
+    });
+
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    expect(respond.mock.calls[0]?.[1]).toMatchObject({ html: "<html>demo</html>" });
+    expect(respond.mock.calls[0]?.[1]).not.toHaveProperty("standaloneUrl");
   });
 
   it("does not replace a completed bridge response with a cleanup error", async () => {

--- a/src/gateway/server-methods/mcp-app.ts
+++ b/src/gateway/server-methods/mcp-app.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { logWarn } from "../../logger.js";
 import { restoreMcpAppView } from "../mcp-app-reconstruction.js";
+import { createMcpAppStandaloneTicket } from "../mcp-app-standalone.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 function requireString(params: Record<string, unknown>, key: string): string {
@@ -145,6 +146,17 @@ export const mcpAppHandlers: GatewayRequestHandlers = {
               throw new Error("MCP App sandbox listener is unavailable; restart the Gateway");
             }
             const configuredOrigin = context.getRuntimeConfig().mcp?.apps?.sandboxOrigin;
+            let standalone: ReturnType<typeof createMcpAppStandaloneTicket> = undefined;
+            try {
+              standalone = createMcpAppStandaloneTicket({
+                sessionKey: requireString(params, "sessionKey"),
+                view,
+              });
+            } catch (error) {
+              // Standalone links are additive; issuance must never break the
+              // existing authenticated Control UI view payload.
+              logWarn(`mcp-app: standalone ticket unavailable: ${formatErrorMessage(error)}`);
+            }
             return {
               sandboxUrl: buildMcpAppSandboxPath(view.csp),
               sandboxPort,
@@ -153,6 +165,12 @@ export const mcpAppHandlers: GatewayRequestHandlers = {
               ...(view.csp ? { csp: view.csp } : {}),
               toolInput: view.toolInput,
               toolResult: view.toolResult,
+              ...(standalone
+                ? {
+                    standaloneUrl: standalone.url,
+                    standaloneExpiresAtMs: standalone.expiresAtMs,
+                  }
+                : {}),
             };
           },
           context.getRuntimeConfig(),

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -219,21 +219,21 @@ async function mountControlUiHost(page: Page): Promise<void> {
   await page.route(`${controlUiServer.baseUrl}mcp-conformance`, async (route) => {
     await route.fulfill({
       contentType: "text/html",
-      body: "<!doctype html><main id=mount></main>",
+      body: `<!doctype html><main id="mount"></main>
+<script type="module">
+import { GatewayBrowserClient } from "/src/api/gateway.ts";
+import "/src/components/mcp-app-view-registration.ts";
+window.mcpConformanceGatewayBrowserClient = GatewayBrowserClient;
+</script>`,
     });
   });
   await page.goto(`${controlUiServer.baseUrl}mcp-conformance`);
   await page.evaluate(
     async (params) => {
-      const importModule = async (specifier: string): Promise<Record<string, unknown>> =>
-        await import(/* @vite-ignore */ specifier);
-      const [gatewayModule] = await Promise.all([
-        importModule("/src/api/gateway.ts"),
-        importModule("/src/components/mcp-app-view-registration.ts"),
-      ]);
-      const GatewayBrowserClient = gatewayModule.GatewayBrowserClient as new (
-        options: Record<string, unknown>,
-      ) => {
+      const GatewayBrowserClient = Reflect.get(
+        window,
+        "mcpConformanceGatewayBrowserClient",
+      ) as new (options: Record<string, unknown>) => {
         start(): void;
         request(method: string, params: unknown): Promise<unknown>;
       };

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -224,10 +224,9 @@ async function mountControlUiHost(page: Page): Promise<void> {
   });
   await page.goto(`${controlUiServer.baseUrl}mcp-conformance`);
   await page.evaluate(
-    async ({ gatewayUrl, authValue, sessionKey, viewId }) => {
-      const importModule = new Function("specifier", "return import(specifier)") as (
-        specifier: string,
-      ) => Promise<Record<string, unknown>>;
+    async (params) => {
+      const importModule = async (specifier: string): Promise<Record<string, unknown>> =>
+        await import(/* @vite-ignore */ specifier);
       const [gatewayModule] = await Promise.all([
         importModule("/src/api/gateway.ts"),
         importModule("/src/components/mcp-app-view-registration.ts"),
@@ -245,8 +244,8 @@ async function mountControlUiHost(page: Page): Promise<void> {
         rejectHello = reject;
       });
       const client = new GatewayBrowserClient({
-        url: gatewayUrl,
-        token: authValue,
+        url: params.gatewayUrl,
+        token: params.authValue,
         onHello: () => resolveHello(),
         onClose: (info: { reason: string }) =>
           rejectHello(new Error(`Gateway connection closed: ${info.reason}`)),
@@ -254,19 +253,19 @@ async function mountControlUiHost(page: Page): Promise<void> {
       client.start();
       await Promise.race([
         connected,
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error("Gateway connection timed out")), 10_000),
-        ),
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error("Gateway connection timed out")), 10_000);
+        }),
       ]);
       const view = document.createElement("mcp-app-view");
       Reflect.set(view, "context", {
         gateway: {
           snapshot: { client },
-          connection: { gatewayUrl },
+          connection: { gatewayUrl: params.gatewayUrl },
         },
       });
-      view.sessionKey = sessionKey;
-      view.viewId = viewId;
+      view.sessionKey = params.sessionKey;
+      view.viewId = params.viewId;
       view.title = "Conformance app";
       document.getElementById("mount")?.appendChild(view);
       Object.assign(window, { mcpConformanceClient: client, mcpConformanceView: view });
@@ -282,11 +281,14 @@ async function mountControlUiHost(page: Page): Promise<void> {
 
 async function requestStandaloneUrl(page: Page): Promise<string> {
   return await page.evaluate(
-    async ({ sessionKey, viewId }) => {
+    async (params) => {
       const client = Reflect.get(window, "mcpConformanceClient") as {
         request(method: string, params: unknown): Promise<unknown>;
       };
-      const payload = (await client.request("mcp.app.view", { sessionKey, viewId })) as {
+      const payload = (await client.request("mcp.app.view", {
+        sessionKey: params.sessionKey,
+        viewId: params.viewId,
+      })) as {
         standaloneUrl: string;
       };
       return payload.standaloneUrl;
@@ -333,9 +335,9 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
       response.end(appModuleSource);
     });
     appAssetServer = fixtureAssetServer;
-    await new Promise<void>((resolve) =>
-      fixtureAssetServer.listen(appAssetPort, "127.0.0.1", resolve),
-    );
+    await new Promise<void>((resolve) => {
+      fixtureAssetServer.listen(appAssetPort, "127.0.0.1", resolve);
+    });
     const appModuleUrl = `http://127.0.0.1:${appAssetPort}/app.js`;
     const resourceOrigin = new URL(appModuleUrl).origin;
     const controlUiOrigin = new URL(controlUiServer.baseUrl).origin;
@@ -405,9 +407,9 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     await gateway?.close({ reason: "MCP App conformance complete" });
     await disposeAllSessionMcpRuntimes();
     if (appAssetServer) {
-      await new Promise<void>((resolve, reject) =>
-        appAssetServer?.close((error) => (error ? reject(error) : resolve())),
-      );
+      await new Promise<void>((resolve, reject) => {
+        appAssetServer?.close((error) => (error ? reject(error) : resolve()));
+      });
     }
     await controlUiServer?.close();
     clearConfigCache();
@@ -439,7 +441,9 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     try {
       app = await findAppFrame(controlPage);
     } catch (error) {
-      throw new Error(`${String(error)}; browser=${JSON.stringify(browserDiagnostics)}`);
+      throw new Error(`${String(error)}; browser=${JSON.stringify(browserDiagnostics)}`, {
+        cause: error,
+      });
     }
     await waitForText(app.locator("#input"), '{"city":"Paris"}');
     await waitForTextContaining(app.locator("#result"), "initial-result");
@@ -503,7 +507,9 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     lease.expiresAtMs = expiresAtMs;
     const expiring = await requestStandaloneUrl(controlPage);
     const expiringUrl = `http://127.0.0.1:${gatewayPort}${expiring}`;
-    await new Promise((resolve) => setTimeout(resolve, Math.max(0, expiresAtMs - Date.now() + 50)));
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.max(0, expiresAtMs - Date.now() + 50));
+    });
     await standalonePage.goto(expiringUrl);
     await standalonePage.reload();
     await waitForText(standalonePage.locator(".error"), "MCP App ticket was rejected");

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -314,7 +314,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     const appEntryPath = require.resolve("@modelcontextprotocol/ext-apps/app-with-deps");
     const appModuleSource = await fs.readFile(appEntryPath, "utf8");
     const appAssetPort = await getFreeGatewayPort();
-    appAssetServer = createHttpServer((request, response) => {
+    const fixtureAssetServer = createHttpServer((request, response) => {
       if (request.url !== "/app.js") {
         response.writeHead(404).end();
         return;
@@ -327,7 +327,10 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
       });
       response.end(appModuleSource);
     });
-    await new Promise<void>((resolve) => appAssetServer.listen(appAssetPort, "127.0.0.1", resolve));
+    appAssetServer = fixtureAssetServer;
+    await new Promise<void>((resolve) =>
+      fixtureAssetServer.listen(appAssetPort, "127.0.0.1", resolve),
+    );
     const appModuleUrl = `http://127.0.0.1:${appAssetPort}/app.js`;
     const resourceOrigin = new URL(appModuleUrl).origin;
     const controlUiOrigin = new URL(controlUiServer.baseUrl).origin;
@@ -365,7 +368,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
       cfg,
     });
     const materialized = await materializeBundleMcpToolsForRun({ runtime });
-    materialized.restrictAppTools?.([...materialized.tools, ...materialized.appTools]);
+    materialized.restrictAppTools?.([...materialized.tools, ...(materialized.appTools ?? [])]);
     const show = materialized.tools.find((tool) => tool.name === "conformance__show");
     if (!show) {
       throw new Error("Official MCP App fixture tool did not materialize");

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -84,6 +84,7 @@ function appHtml(appModuleUrl: string): string {
 <button id="request-teardown">Request teardown</button>
 <output id="initialized">pending</output>
 <output id="capabilities"></output>
+<output id="ping"></output>
 <output id="input"></output>
 <output id="result"></output>
 <output id="app-tool"></output>
@@ -91,7 +92,7 @@ function appHtml(appModuleUrl: string): string {
 <output id="resource"></output>
 <output id="isolation"></output>
 <script type="module">
-import { App } from ${JSON.stringify(appModuleUrl)};
+import { App, McpUiResourceTeardownResultSchema } from ${JSON.stringify(appModuleUrl)};
 const write = (id, value) => { document.getElementById(id).textContent = value; };
 try { void window.top.document; write("isolation", "failed"); } catch { write("isolation", "isolated"); }
 const app = new App({ name: "OpenClaw conformance fixture", version: "1.0.0" });
@@ -118,6 +119,10 @@ document.getElementById("read-resource").onclick = async () => {
 document.getElementById("request-teardown").onclick = () => app.requestTeardown();
 await app.connect();
 write("capabilities", JSON.stringify(app.getHostCapabilities() ?? {}));
+write("ping", JSON.stringify(await app.request(
+  { method: "ping", params: {} },
+  McpUiResourceTeardownResultSchema,
+)));
 write("initialized", "ready");
 </script>`;
 }
@@ -440,6 +445,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     await waitForTextContaining(app.locator("#result"), "initial-result");
     await waitForTextContaining(app.locator("#capabilities"), "serverTools");
     await waitForTextContaining(app.locator("#capabilities"), "serverResources");
+    await waitForText(app.locator("#ping"), "{}");
     await waitForText(app.locator("#isolation"), "isolated");
     await app.locator("#call-app").click();
     await waitForTextContaining(app.locator("#app-tool"), "companion-called");
@@ -468,6 +474,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     await waitForTextContaining(app.locator("#result"), "initial-result");
     await waitForTextContaining(app.locator("#capabilities"), "serverTools", false);
     await waitForTextContaining(app.locator("#capabilities"), "serverResources", false);
+    await waitForText(app.locator("#ping"), "{}");
     await waitForText(app.locator("#isolation"), "isolated");
     await app.locator("#call-app").click();
     await waitForTextContaining(app.locator("#app-tool"), "denied:");

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -1,0 +1,501 @@
+// MCP Apps conformance uses the locked official ext-apps App implementation over real browser,
+// Gateway WebSocket/HTTP, stdio MCP, and nested postMessage transports.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Frame,
+  type Locator,
+  type Page,
+} from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { materializeBundleMcpToolsForRun } from "../../../src/agents/agent-bundle-mcp-materialize.js";
+import {
+  disposeAllSessionMcpRuntimes,
+  getOrCreateSessionMcpRuntime,
+} from "../../../src/agents/agent-bundle-mcp-runtime.js";
+import { getMcpAppViewLease } from "../../../src/agents/mcp-ui-resource.js";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  readConfigFileSnapshotWithPluginMetadata,
+} from "../../../src/config/config.js";
+import type { OpenClawConfig } from "../../../src/config/types.openclaw.js";
+import { startGatewayServer } from "../../../src/gateway/server.js";
+import { getFreeGatewayPort } from "../../../src/gateway/test-helpers.e2e.js";
+import { captureEnv, setTestEnvValue } from "../../../src/test-utils/env.js";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const require = createRequire(import.meta.url);
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeConformance = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const authValue = "test";
+const sessionKey = "agent:main:mcp-app-conformance";
+
+let browser: Browser;
+let controlUiServer: ControlUiE2eServer;
+let gateway: Awaited<ReturnType<typeof startGatewayServer>>;
+let gatewayPort: number;
+let sandboxPort: number;
+let tempRoot: string;
+let viewId: string;
+let appAssetServer: HttpServer | undefined;
+let runtime: Awaited<ReturnType<typeof getOrCreateSessionMcpRuntime>>;
+let envSnapshot: ReturnType<typeof captureEnv>;
+
+const openContexts = new Set<BrowserContext>();
+
+async function waitForText(locator: Locator, expected: string): Promise<void> {
+  await expect.poll(() => locator.textContent({ timeout: 500 })).toBe(expected);
+}
+
+async function waitForTextContaining(
+  locator: Locator,
+  expected: string,
+  present = true,
+): Promise<void> {
+  const assertion = expect.poll(() => locator.textContent());
+  if (present) {
+    await assertion.toContain(expected);
+  } else {
+    await assertion.not.toContain(expected);
+  }
+}
+
+function appHtml(appModuleUrl: string): string {
+  return `<!doctype html>
+<meta charset="utf-8" />
+<button id="call-app">Call app tool</button>
+<button id="call-model">Call model tool</button>
+<button id="read-resource">Read resource</button>
+<button id="request-teardown">Request teardown</button>
+<output id="initialized">pending</output>
+<output id="capabilities"></output>
+<output id="input"></output>
+<output id="result"></output>
+<output id="app-tool"></output>
+<output id="model-tool"></output>
+<output id="resource"></output>
+<output id="isolation"></output>
+<script type="module">
+import { App } from ${JSON.stringify(appModuleUrl)};
+const write = (id, value) => { document.getElementById(id).textContent = value; };
+try { void window.top.document; write("isolation", "failed"); } catch { write("isolation", "isolated"); }
+const app = new App({ name: "OpenClaw conformance fixture", version: "1.0.0" });
+app.ontoolinput = ({ arguments: args }) => write("input", JSON.stringify(args ?? {}));
+app.ontoolresult = (value) => write("result", JSON.stringify(value.structuredContent ?? value));
+app.onteardown = async () => ({});
+app.onerror = (error) => console.error("mcp-conformance-app", error);
+document.getElementById("call-app").onclick = async () => {
+  try {
+    const value = await app.callServerTool({ name: "app_companion", arguments: {} });
+    write("app-tool", JSON.stringify(value.structuredContent ?? value));
+  } catch (error) { write("app-tool", "denied:" + error); }
+};
+document.getElementById("call-model").onclick = async () => {
+  try { await app.callServerTool({ name: "model_only", arguments: {} }); write("model-tool", "allowed"); }
+  catch (error) { write("model-tool", "denied:" + error); }
+};
+document.getElementById("read-resource").onclick = async () => {
+  try {
+    const value = await app.readServerResource({ uri: "data://conformance/value" });
+    write("resource", JSON.stringify(value));
+  } catch (error) { write("resource", "denied:" + error); }
+};
+document.getElementById("request-teardown").onclick = () => app.requestTeardown();
+await app.connect();
+write("capabilities", JSON.stringify(app.getHostCapabilities() ?? {}));
+write("initialized", "ready");
+</script>`;
+}
+
+async function writeFixtureServer(
+  serverPath: string,
+  html: string,
+  resourceOrigin: string,
+): Promise<void> {
+  const sdkMcpServerPath = require.resolve("@modelcontextprotocol/sdk/server/mcp.js");
+  const sdkStdioServerPath = require.resolve("@modelcontextprotocol/sdk/server/stdio.js");
+  await fs.writeFile(
+    serverPath,
+    `#!/usr/bin/env node
+import { McpServer } from ${JSON.stringify(sdkMcpServerPath)};
+import { StdioServerTransport } from ${JSON.stringify(sdkStdioServerPath)};
+const appUri = "ui://conformance/app";
+const server = new McpServer({ name: "mcp-app-conformance", version: "1.0.0" });
+const show = server.tool("show", "Show the conformance app", async () => ({
+  content: [{ type: "text", text: "initial-result" }],
+  structuredContent: { value: "initial-result" },
+}));
+show.update({ _meta: { ui: { resourceUri: appUri } } });
+const appOnly = server.tool("app_companion", "App-only companion", async () => ({
+  content: [{ type: "text", text: "companion-called" }],
+  structuredContent: { value: "companion-called" },
+}));
+appOnly.update({ _meta: { ui: { visibility: ["app"] } } });
+const modelOnly = server.tool("model_only", "Model-only tool", async () => ({
+  content: [{ type: "text", text: "model-called" }],
+}));
+modelOnly.update({ _meta: { ui: { visibility: ["model"] } } });
+server.registerResource("conformance_app", appUri, { mimeType: "text/html;profile=mcp-app" }, async (uri) => ({
+  contents: [{
+    uri: uri.href,
+    mimeType: "text/html;profile=mcp-app",
+    text: ${JSON.stringify(html)},
+    _meta: { ui: { csp: { resourceDomains: [${JSON.stringify(resourceOrigin)}] } } },
+  }],
+}));
+server.registerResource("conformance_data", "data://conformance/value", { mimeType: "text/plain" }, async (uri) => ({
+  contents: [{ uri: uri.href, mimeType: "text/plain", text: "resource-ok" }],
+}));
+await server.connect(new StdioServerTransport());
+`,
+    { encoding: "utf8", mode: 0o755 },
+  );
+}
+
+async function findAppFrame(page: Page): Promise<Frame> {
+  try {
+    await expect
+      .poll(
+        async () => {
+          for (const frame of page.frames()) {
+            if ((await frame.locator("#initialized").count()) > 0) {
+              return 1;
+            }
+          }
+          return 0;
+        },
+        { timeout: 20_000 },
+      )
+      .toBeGreaterThan(0);
+  } catch (error) {
+    const component = await page.evaluate(() => {
+      const view = document.querySelector("mcp-app-view");
+      return {
+        exists: Boolean(view),
+        error: view?.shadowRoot?.querySelector(".error")?.textContent ?? null,
+        shadow: view?.shadowRoot?.textContent ?? null,
+      };
+    });
+    throw new Error(
+      `MCP App inner frame not found: ${JSON.stringify({ component, frames: page.frames().map((frame) => frame.url()) })}`,
+      { cause: error },
+    );
+  }
+  let frame: Frame | undefined;
+  for (const candidate of page.frames()) {
+    if ((await candidate.locator("#initialized").count()) > 0) {
+      frame = candidate;
+      break;
+    }
+  }
+  if (!frame) {
+    throw new Error("MCP App inner frame not found");
+  }
+  await waitForText(frame.locator("#initialized"), "ready");
+  return frame;
+}
+
+async function mountControlUiHost(page: Page): Promise<void> {
+  await page.route(`${controlUiServer.baseUrl}mcp-conformance`, async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: "<!doctype html><main id=mount></main>",
+    });
+  });
+  await page.goto(`${controlUiServer.baseUrl}mcp-conformance`);
+  await page.evaluate(
+    async ({ gatewayUrl, authValue, sessionKey, viewId }) => {
+      const importModule = new Function("specifier", "return import(specifier)") as (
+        specifier: string,
+      ) => Promise<Record<string, unknown>>;
+      const [gatewayModule] = await Promise.all([
+        importModule("/src/api/gateway.ts"),
+        importModule("/src/components/mcp-app-view-registration.ts"),
+      ]);
+      const GatewayBrowserClient = gatewayModule.GatewayBrowserClient as new (
+        options: Record<string, unknown>,
+      ) => {
+        start(): void;
+        request(method: string, params: unknown): Promise<unknown>;
+      };
+      let resolveHello!: () => void;
+      let rejectHello!: (error: Error) => void;
+      const connected = new Promise<void>((resolve, reject) => {
+        resolveHello = resolve;
+        rejectHello = reject;
+      });
+      const client = new GatewayBrowserClient({
+        url: gatewayUrl,
+        token: authValue,
+        onHello: () => resolveHello(),
+        onClose: (info: { reason: string }) =>
+          rejectHello(new Error(`Gateway connection closed: ${info.reason}`)),
+      });
+      client.start();
+      await Promise.race([
+        connected,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("Gateway connection timed out")), 10_000),
+        ),
+      ]);
+      const view = document.createElement("mcp-app-view");
+      Reflect.set(view, "context", {
+        gateway: {
+          snapshot: { client },
+          connection: { gatewayUrl },
+        },
+      });
+      view.sessionKey = sessionKey;
+      view.viewId = viewId;
+      view.title = "Conformance app";
+      document.getElementById("mount")?.appendChild(view);
+      Object.assign(window, { mcpConformanceClient: client, mcpConformanceView: view });
+    },
+    {
+      gatewayUrl: `ws://127.0.0.1:${gatewayPort}`,
+      authValue,
+      sessionKey,
+      viewId,
+    },
+  );
+}
+
+async function requestStandaloneUrl(page: Page): Promise<string> {
+  return await page.evaluate(
+    async ({ sessionKey, viewId }) => {
+      const client = Reflect.get(window, "mcpConformanceClient") as {
+        request(method: string, params: unknown): Promise<unknown>;
+      };
+      const payload = (await client.request("mcp.app.view", { sessionKey, viewId })) as {
+        standaloneUrl: string;
+      };
+      return payload.standaloneUrl;
+    },
+    { sessionKey, viewId },
+  );
+}
+
+describeConformance("MCP App Control UI and standalone host conformance", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    envSnapshot = captureEnv([
+      "HOME",
+      "OPENCLAW_STATE_DIR",
+      "OPENCLAW_CONFIG_PATH",
+      "OPENCLAW_GATEWAY_TOKEN",
+      "OPENCLAW_SKIP_CHANNELS",
+      "OPENCLAW_SKIP_CRON",
+      "OPENCLAW_SKIP_PROVIDERS",
+      "OPENCLAW_BUNDLED_PLUGINS_DIR",
+    ]);
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mcp-app-conformance-"));
+    const stateDir = path.join(tempRoot, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const fixturePath = path.join(tempRoot, "fixture-server.mjs");
+    await fs.mkdir(path.join(tempRoot, "empty-plugins"), { recursive: true });
+    controlUiServer = await startControlUiE2eServer();
+    const appEntryPath = require.resolve("@modelcontextprotocol/ext-apps/app-with-deps");
+    const appModuleSource = await fs.readFile(appEntryPath, "utf8");
+    const appAssetPort = await getFreeGatewayPort();
+    appAssetServer = createHttpServer((request, response) => {
+      if (request.url !== "/app.js") {
+        response.writeHead(404).end();
+        return;
+      }
+      response.writeHead(200, {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-store",
+        "Content-Type": "text/javascript; charset=utf-8",
+        "Cross-Origin-Resource-Policy": "cross-origin",
+      });
+      response.end(appModuleSource);
+    });
+    await new Promise<void>((resolve) => appAssetServer.listen(appAssetPort, "127.0.0.1", resolve));
+    const appModuleUrl = `http://127.0.0.1:${appAssetPort}/app.js`;
+    const resourceOrigin = new URL(appModuleUrl).origin;
+    const controlUiOrigin = new URL(controlUiServer.baseUrl).origin;
+    await writeFixtureServer(fixturePath, appHtml(appModuleUrl), resourceOrigin);
+    gatewayPort = await getFreeGatewayPort();
+    do {
+      sandboxPort = await getFreeGatewayPort();
+    } while (sandboxPort === gatewayPort);
+    const cfg: OpenClawConfig = {
+      gateway: {
+        auth: { mode: "token", token: authValue },
+        controlUi: { allowedOrigins: [controlUiOrigin] },
+      },
+      mcp: {
+        apps: { enabled: true, sandboxPort },
+        servers: { conformance: { command: process.execPath, args: [fixturePath], cwd: tempRoot } },
+      },
+    };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`);
+    setTestEnvValue("HOME", tempRoot);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    setTestEnvValue("OPENCLAW_GATEWAY_TOKEN", authValue);
+    setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+    setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+    setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+    setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(tempRoot, "empty-plugins"));
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: `mcp-app-conformance-${randomUUID()}`,
+      sessionKey,
+      workspaceDir: tempRoot,
+      cfg,
+    });
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    materialized.restrictAppTools?.([...materialized.tools, ...materialized.appTools]);
+    const show = materialized.tools.find((tool) => tool.name === "conformance__show");
+    if (!show) {
+      throw new Error("Official MCP App fixture tool did not materialize");
+    }
+    const result = await show.execute("mcp-app-conformance-call", { city: "Paris" });
+    viewId =
+      (result.details as { mcpAppPreview?: { mcpApp?: { viewId?: string } } }).mcpAppPreview?.mcpApp
+        ?.viewId ?? "";
+    if (!viewId) {
+      throw new Error("MCP App fixture did not create a view");
+    }
+    const startupConfigSnapshotRead = await readConfigFileSnapshotWithPluginMetadata({
+      observe: false,
+    });
+    gateway = await startGatewayServer(gatewayPort, {
+      bind: "loopback",
+      auth: { mode: "token", token: authValue },
+      controlUiEnabled: false,
+      startupConfigSnapshotRead,
+    });
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  }, 120_000);
+
+  afterAll(async () => {
+    for (const context of openContexts) {
+      await context.close();
+    }
+    await browser?.close();
+    await gateway?.close({ reason: "MCP App conformance complete" });
+    await disposeAllSessionMcpRuntimes();
+    if (appAssetServer) {
+      await new Promise<void>((resolve, reject) =>
+        appAssetServer?.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+    await controlUiServer?.close();
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    envSnapshot?.restore();
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it("drives the authenticated Control UI bridge and read-only standalone host", async () => {
+    const controlContext = await browser.newContext({ permissions: ["local-network-access"] });
+    openContexts.add(controlContext);
+    const controlPage = await controlContext.newPage();
+    const browserDiagnostics: string[] = [];
+    controlPage.on("console", (message) => {
+      browserDiagnostics.push(`console:${message.type()}:${message.text()}`);
+    });
+    controlPage.on("requestfailed", (request) => {
+      browserDiagnostics.push(`requestfailed:${request.url()}:${request.failure()?.errorText}`);
+    });
+    controlPage.on("response", (response) => {
+      if (response.url().includes("mcp-app-sandbox")) {
+        browserDiagnostics.push(`response:${response.status()}:${response.url()}`);
+      }
+    });
+    await mountControlUiHost(controlPage);
+    let app: Frame;
+    try {
+      app = await findAppFrame(controlPage);
+    } catch (error) {
+      throw new Error(`${String(error)}; browser=${JSON.stringify(browserDiagnostics)}`);
+    }
+    await waitForText(app.locator("#input"), '{"city":"Paris"}');
+    await waitForTextContaining(app.locator("#result"), "initial-result");
+    await waitForTextContaining(app.locator("#capabilities"), "serverTools");
+    await waitForTextContaining(app.locator("#capabilities"), "serverResources");
+    await waitForText(app.locator("#isolation"), "isolated");
+    await app.locator("#call-app").click();
+    await waitForTextContaining(app.locator("#app-tool"), "companion-called");
+    await app.locator("#call-model").click();
+    await waitForTextContaining(app.locator("#model-tool"), "denied:");
+    await app.locator("#read-resource").click();
+    await waitForTextContaining(app.locator("#resource"), "resource-ok");
+
+    const standaloneUrl = await requestStandaloneUrl(controlPage);
+    await controlPage.evaluate(() => Reflect.get(window, "mcpConformanceView")?.remove());
+
+    const standaloneContext = await browser.newContext({ permissions: ["local-network-access"] });
+    openContexts.add(standaloneContext);
+    const authorizationHeaders: string[] = [];
+    standaloneContext.on("request", (request) => {
+      const authorization = request.headers().authorization;
+      if (authorization) {
+        authorizationHeaders.push(authorization);
+      }
+    });
+    const standalonePage = await standaloneContext.newPage();
+    const absoluteStandaloneUrl = `http://127.0.0.1:${gatewayPort}${standaloneUrl}`;
+    await standalonePage.goto(absoluteStandaloneUrl);
+    app = await findAppFrame(standalonePage);
+    await waitForText(app.locator("#input"), '{"city":"Paris"}');
+    await waitForTextContaining(app.locator("#result"), "initial-result");
+    await waitForTextContaining(app.locator("#capabilities"), "serverTools", false);
+    await waitForTextContaining(app.locator("#capabilities"), "serverResources", false);
+    await waitForText(app.locator("#isolation"), "isolated");
+    await app.locator("#call-app").click();
+    await waitForTextContaining(app.locator("#app-tool"), "denied:");
+    await app.locator("#read-resource").click();
+    await waitForTextContaining(app.locator("#resource"), "denied:");
+    expect(authorizationHeaders).toHaveLength(1);
+    expect(authorizationHeaders[0]).toMatch(/^MCP-App v1\./u);
+    expect(authorizationHeaders).not.toContain(`Bearer ${authValue}`);
+
+    await app.locator("#request-teardown").click();
+    await expect.poll(() => standalonePage.frames().length).toBe(1);
+    await standalonePage.reload();
+    app = await findAppFrame(standalonePage);
+    await waitForTextContaining(app.locator("#result"), "initial-result");
+
+    const tampered = `${absoluteStandaloneUrl.slice(0, -1)}${absoluteStandaloneUrl.endsWith("a") ? "b" : "a"}`;
+    await standalonePage.goto(tampered);
+    await standalonePage.reload();
+    await waitForText(standalonePage.locator(".error"), "MCP App ticket was rejected");
+
+    const lease = getMcpAppViewLease(viewId, runtime);
+    if (!lease) {
+      throw new Error("MCP App view lease missing");
+    }
+    const expiresAtMs = Date.now() + 2_000;
+    lease.expiresAtMs = expiresAtMs;
+    const expiring = await requestStandaloneUrl(controlPage);
+    const expiringUrl = `http://127.0.0.1:${gatewayPort}${expiring}`;
+    await new Promise((resolve) => setTimeout(resolve, Math.max(0, expiresAtMs - Date.now() + 50)));
+    await standalonePage.goto(expiringUrl);
+    await standalonePage.reload();
+    await waitForText(standalonePage.locator(".error"), "MCP App ticket was rejected");
+  }, 90_000);
+});


### PR DESCRIPTION
AI-assisted: yes (Codex). I understand the implementation and completed fresh autoreview passes with no accepted/actionable findings. No agent transcript is included because separate approval was not provided.

Closes #109851

## Summary

- Add a generic standalone MCP App host that exchanges a short-lived signed view ticket instead of exposing the operator Gateway bearer token.
- Keep the trusted shell on the Gateway origin and reuse the separate static sandbox listener; no view secret or dynamic app data enters the listener document.
- Keep the standalone host deliberately read-only and add one official `@modelcontextprotocol/ext-apps` fixture that drives both the existing authenticated Control UI host and the new standalone host over the real browser/transport path.

## What Problem This Solves

Future channel and standalone browser launches need to render one MCP App view without handing the page a reusable operator credential. The existing authenticated Control UI host is not a least-privilege launch boundary for an external browser surface.

## Why This Change Was Made

A process-local HMAC capability is bound to the current OpenClaw session key, MCP runtime session, view id, and view-lease deadline. The new HTTP boundary reconstructs only that live view, while the static host implements the stable MCP Apps initialization, ping, input/result, sizing, and teardown messages and rejects tool/resource requests.

This reuses the existing MCP runtime, view lease, sandbox proxy, and Gateway configuration. It adds no config/env surface, protocol version, channel launch UX, approval flow, or privileged capability.

## User Impact

When MCP Apps are already enabled, an authenticated Gateway client can obtain a standalone URL for the current view and open it without exposing the Gateway bearer token. Existing Control UI behavior is unchanged. There is no new default UI or channel action in this PR.

## Independent Landing and Backward Safety

- Existing `mcp.app.view` fields and semantics are preserved. `standaloneUrl` and its expiry are optional additions; ticket capacity, expiry races, or unexpected issuance failures omit those fields while returning the original successful view payload.
- The two new HTTP paths exist only behind the existing `mcp.apps.enabled` gate. Disabled installations and all other routes retain current behavior.
- The standalone URL is fully functional on this PR alone: initialize, ping, input/result delivery, read-only denials, reload, teardown, and rejection states require no later MCP Apps PR.
- The existing Control UI keeps its current app-only tool/resource authority. The conformance fixture proves shared/app-only tools and app resources remain available there while model-only tools remain denied.
- No current UI consumes the optional standalone field, and no current capability advertisement changes.

Exact dormant/additive boundary: the new route and optional Gateway response field are additive behind the existing MCP Apps gate. No launch button, channel integration, approval UI, tool/resource capability, or later-PR contract is advertised. A later PR may expose the already-working URL in channel UX, but is not required for any behavior enabled here.

## Evidence

- Real transport/browser path: an official self-contained `@modelcontextprotocol/ext-apps@1.7.4` app ran through a real stdio MCP server, Gateway WebSocket authentication, Control UI Vite host, Gateway HTTP routes, static sandbox listener, and nested postMessage transports.
- Both hosts completed the stable `2026-01-26` initialize handshake and standard MCP `ping`, then received the original tool input and result.
- Control UI baseline: server tool/resource capabilities were advertised; the app-only companion tool and app resource succeeded; a model-only tool was denied.
- Standalone boundary: neither server tools nor server resources were advertised; tool and resource calls were denied; the only authorization header was `MCP-App v1...`, never `Bearer test`.
- Lifecycle: app-requested teardown removed the frame, reload reconstructed it, and a second load received the original result.
- Ticket security: unit/integration coverage rejects tampered, expired, wrong-session, wrong-runtime, wrong-view, replaced-view, and inappropriate reuse states; the browser scenario proves tampered and expired URLs fail.
- Origin/CSP review: the shell is static on the Gateway origin, the iframe is restricted to the exact separate sandbox origin, the listener stays static, the ticket remains in the URL fragment and is sent only in the dedicated authorization header, responses are no-store/no-referrer, and the shell never receives the Gateway token.
- Two final full-branch autoreviews after simplification/fixes reported no actionable findings. A reviewer-found missing standard `ping` response was fixed and exercised in both host modes before the clean final pass.

## Verification

- `pnpm build` — full runtime and Control UI production build passed, including plugin SDK export and Control UI performance gates.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed with the frozen lockfile.
- `node scripts/run-vitest.mjs src/gateway/mcp-app-standalone.test.ts src/gateway/server-methods/mcp-app.test.ts ui/src/e2e/mcp-app-conformance.e2e.test.ts` — 13 gateway assertions and the complete Chromium conformance scenario passed.
- `git diff --check` and targeted `oxfmt` — passed.
- Repeated canonical-base updates were rebased without conflicts; every final `git range-diff` showed all three commits patch-identical. The push used a fresh `upstream/main` fetch and verified ancestry immediately before publication.
- Blacksmith Testbox passed the build and broad static gates before exposing two strict fixture type errors that were fixed. Two later Testbox leases failed during delegated file sync before executing code, so trusted-source exact-head fallback proof ran in isolated temporary clones with frozen dependencies.

## Simplification and Scope

The PR is six files: three production files plus two focused Gateway tests and one maintained browser fixture. Net production growth is 463 LOC. Most of that is the single standalone module owning the capability store, HTTP/security boundary, static shell, and minimal protocol bridge; keeping those concerns together avoids a new public abstraction or duplicated policy. The remaining production additions are narrow route and optional-response wiring. No cleanup, config, launch UI, or privileged capability is mixed in.

## Known Gaps

- This does not add channel launch UX, approval UI, or standalone tool/resource authority.
- Tickets are intentionally process-local and expire no later than the view lease; a Gateway restart invalidates them.
- At the bounded live-ticket capacity, existing view responses continue to work but omit a standalone URL until capacity expires.
- Required GitHub CI on the published head remains the final landing gate.
