### PR TITLE
fix(matrix): add defensive guard for thread routing messageId param

### DIFF
--- a/extensions/matrix/src/matrix/monitor/threads.test.ts
+++ b/extensions/matrix/src/matrix/monitor/threads.test.ts
@@ -66,4 +66,16 @@ describe("resolveMatrixThreadRouting", () => {
       threadId: undefined,
     });
   });
+
+  it("handles missing messageId gracefully without crashing", () => {
+    // The TypeScript type says `messageId: string`, but runtime callers
+    // could pass unexpected values. The ?. guard prevents a crash.
+    expect(
+      resolveMatrixThreadRouting({
+        isDirectMessage: false,
+        threadReplies: "always",
+        messageId: undefined as unknown as string,
+      }),
+    ).toEqual({ threadId: undefined });
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/threads.ts
+++ b/extensions/matrix/src/matrix/monitor/threads.ts
@@ -49,7 +49,7 @@ export function resolveMatrixThreadRouting(params: {
     params.isDirectMessage && params.dmThreadReplies !== undefined
       ? params.dmThreadReplies
       : params.threadReplies;
-  const messageId = params.messageId.trim();
+  const messageId = params.messageId?.trim() ?? "";
   const threadRootId = params.threadRootId?.trim();
   const inboundThreadId = threadRootId && threadRootId !== messageId ? threadRootId : undefined;
   const threadId =


### PR DESCRIPTION
## What Problem This Solves

`resolveMatrixThreadRouting` called `.trim()` directly on `params.messageId` without defensive null handling, unlike `params.threadRootId?.trim()` on the very next line.

## Why This Change Was Made

Add optional chaining with empty string fallback (`?.trim() ?? ""`) matching the existing defensive pattern already used for `threadRootId` in the same function.

## User Impact

Matrix thread routing gracefully handles edge cases without crashes.

## Evidence

### Tests (6 passed, 1 file)
```
 ✓ keeps sessions flat when threadReplies is off
 ✓ uses the inbound thread root when replies arrive inside an existing thread
 ✓ keeps top-level inbound messages flat when threadReplies is inbound
 ✓ uses the triggering message as the thread id when threadReplies is always
 ✓ lets dm.threadReplies override room threading behavior
 ✓ handles missing messageId gracefully without crashing
```

### Test Coverage
- Missing messageId gracefully returns `{ threadId: undefined }` instead of crashing
- Same `?.` pattern as existing `threadRootId?.trim()` guard