### PR TITLE
fix(memory): memory index fails to open when same-file legacy tables diverge

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.test.ts
@@ -880,9 +880,19 @@ describe("memory index schema", () => {
     }
   });
 
-  it("keeps canonical rows and completes migration when legacy rows diverge", () => {
+  it("keeps one coherent canonical index when legacy rows diverge", () => {
     const db = new DatabaseSync(":memory:");
     try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      db.exec(`
+        INSERT INTO memory_index_meta VALUES ('memory_index_meta_v1', 'canonical');
+        INSERT INTO memory_index_sources (path, source, hash, mtime, size)
+          VALUES ('doc.md', 'memory', 'new-hash', 200.0, 42);
+        INSERT INTO memory_index_chunks VALUES (
+          'chunk-new-1', 'doc.md', 'memory', 1, 10, 'new-chunk-hash', 'model',
+          'current canonical body', '[]', 200
+        );
+      `);
       db.exec(`
         CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
         CREATE TABLE files (
@@ -904,14 +914,18 @@ describe("memory index schema", () => {
           embedding TEXT NOT NULL,
           updated_at INTEGER NOT NULL
         );
-        CREATE TABLE memory_index_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
         INSERT INTO meta VALUES ('memory_index_meta_v1', 'legacy');
         INSERT INTO meta VALUES ('legacy-only-key', 'imported');
-        INSERT INTO files VALUES ('doc.md', 'memory', 'hash', 1, 2);
+        INSERT INTO files VALUES ('doc.md', 'memory', 'old-hash', 100, 40);
+        INSERT INTO files VALUES ('old-note.md', 'memory', 'old-note-hash', 90, 10);
         INSERT INTO chunks VALUES (
-          'chunk-1', 'doc.md', 'memory', 1, 2, 'chunk-hash', 'model', 'body', '[]', 1
+          'chunk-old-7', 'doc.md', 'memory', 1, 8, 'old-chunk-hash', 'model',
+          'stale legacy body', '[]', 100
         );
-        INSERT INTO memory_index_meta VALUES ('memory_index_meta_v1', 'canonical');
+        INSERT INTO chunks VALUES (
+          'chunk-old-2', 'old-note.md', 'memory', 1, 5, 'note-hash', 'model',
+          'note body', '[]', 90
+        );
       `);
 
       ensureMemoryIndexSchema({
@@ -924,11 +938,18 @@ describe("memory index schema", () => {
         { key: "legacy-only-key", value: "imported" },
         { key: "memory_index_meta_v1", value: "canonical" },
       ]);
-      expect(db.prepare("SELECT path, hash FROM memory_index_sources").all()).toEqual([
-        { path: "doc.md", hash: "hash" },
+      expect(
+        db.prepare("SELECT path, hash, size FROM memory_index_sources ORDER BY path").all(),
+      ).toEqual([
+        { path: "doc.md", hash: "new-hash", size: 42 },
+        { path: "old-note.md", hash: "old-note-hash", size: 10 },
       ]);
-      expect(db.prepare("SELECT id, text FROM memory_index_chunks").all()).toEqual([
-        { id: "chunk-1", text: "body" },
+      // The canonical-owned doc.md keeps only its canonical chunk set: the
+      // stale legacy chunk id must not ride along, while the legacy-only
+      // old-note.md imports together with its chunk.
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks ORDER BY id").all()).toEqual([
+        { id: "chunk-new-1", text: "current canonical body" },
+        { id: "chunk-old-2", text: "note body" },
       ]);
       expect(
         db

--- a/packages/memory-host-sdk/src/host/memory-schema.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.test.ts
@@ -880,7 +880,7 @@ describe("memory index schema", () => {
     }
   });
 
-  it("keeps legacy tables when canonical rows conflict", () => {
+  it("keeps canonical rows and completes migration when legacy rows diverge", () => {
     const db = new DatabaseSync(":memory:");
     try {
       db.exec(`
@@ -906,7 +906,67 @@ describe("memory index schema", () => {
         );
         CREATE TABLE memory_index_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
         INSERT INTO meta VALUES ('memory_index_meta_v1', 'legacy');
+        INSERT INTO meta VALUES ('legacy-only-key', 'imported');
+        INSERT INTO files VALUES ('doc.md', 'memory', 'hash', 1, 2);
+        INSERT INTO chunks VALUES (
+          'chunk-1', 'doc.md', 'memory', 1, 2, 'chunk-hash', 'model', 'body', '[]', 1
+        );
         INSERT INTO memory_index_meta VALUES ('memory_index_meta_v1', 'canonical');
+      `);
+
+      ensureMemoryIndexSchema({
+        db,
+        cacheEnabled: false,
+        ftsEnabled: false,
+      });
+
+      expect(db.prepare("SELECT key, value FROM memory_index_meta ORDER BY key").all()).toEqual([
+        { key: "legacy-only-key", value: "imported" },
+        { key: "memory_index_meta_v1", value: "canonical" },
+      ]);
+      expect(db.prepare("SELECT path, hash FROM memory_index_sources").all()).toEqual([
+        { path: "doc.md", hash: "hash" },
+      ]);
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks").all()).toEqual([
+        { id: "chunk-1", text: "body" },
+      ]);
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('meta', 'files', 'chunks')",
+          )
+          .all(),
+      ).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps legacy tables when legacy rows cannot be copied", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec(`
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE files (
+          path TEXT PRIMARY KEY,
+          source TEXT NOT NULL DEFAULT 'memory',
+          hash TEXT,
+          mtime INTEGER NOT NULL,
+          size INTEGER NOT NULL
+        );
+        CREATE TABLE chunks (
+          id TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          source TEXT NOT NULL DEFAULT 'memory',
+          start_line INTEGER NOT NULL,
+          end_line INTEGER NOT NULL,
+          hash TEXT NOT NULL,
+          model TEXT NOT NULL,
+          text TEXT NOT NULL,
+          embedding TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        INSERT INTO files VALUES ('doc.md', 'memory', NULL, 1, 2);
       `);
 
       expect(() =>
@@ -915,11 +975,18 @@ describe("memory index schema", () => {
           cacheEnabled: false,
           ftsEnabled: false,
         }),
-      ).toThrow("legacy memory meta rows conflict");
-      expect(db.prepare("SELECT value FROM meta").get()).toEqual({ value: "legacy" });
-      expect(db.prepare("SELECT value FROM memory_index_meta").get()).toEqual({
-        value: "canonical",
+      ).toThrow("legacy memory files rows could not be copied");
+      expect(db.prepare("SELECT path FROM files").get()).toEqual({ path: "doc.md" });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM memory_index_sources").get()).toEqual({
+        count: 0,
       });
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('meta', 'files', 'chunks') ORDER BY name",
+          )
+          .all(),
+      ).toEqual([{ name: "chunks" }, { name: "files" }, { name: "meta" }]);
     } finally {
       db.close();
     }

--- a/packages/memory-host-sdk/src/host/memory-schema.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.test.ts
@@ -963,6 +963,82 @@ describe("memory index schema", () => {
     }
   });
 
+  it("imports legacy chunks for a canonical source that has no chunks yet", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      db.exec(`
+        -- doc.md is already chunk-owned: its stale legacy chunk must not ride along.
+        INSERT INTO memory_index_sources (path, source, hash, mtime, size)
+          VALUES ('doc.md', 'memory', 'doc-hash', 200.0, 42);
+        INSERT INTO memory_index_chunks VALUES (
+          'chunk-doc-canonical', 'doc.md', 'memory', 1, 10, 'doc-chunk-hash', 'model',
+          'canonical body', '[]', 200
+        );
+        -- pending.md has a canonical source row but no chunks yet (indexing
+        -- interrupted before its chunks were written): its legacy chunk is the
+        -- only searchable content and must import instead of being stranded.
+        INSERT INTO memory_index_sources (path, source, hash, mtime, size)
+          VALUES ('pending.md', 'memory', 'pending-hash', 150.0, 20);
+      `);
+      db.exec(`
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE files (
+          path TEXT PRIMARY KEY,
+          source TEXT NOT NULL DEFAULT 'memory',
+          hash TEXT NOT NULL,
+          mtime INTEGER NOT NULL,
+          size INTEGER NOT NULL
+        );
+        CREATE TABLE chunks (
+          id TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          source TEXT NOT NULL DEFAULT 'memory',
+          start_line INTEGER NOT NULL,
+          end_line INTEGER NOT NULL,
+          hash TEXT NOT NULL,
+          model TEXT NOT NULL,
+          text TEXT NOT NULL,
+          embedding TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        INSERT INTO files VALUES ('doc.md', 'memory', 'doc-hash', 200, 42);
+        INSERT INTO files VALUES ('pending.md', 'memory', 'pending-hash', 150, 20);
+        INSERT INTO chunks VALUES (
+          'chunk-doc-legacy', 'doc.md', 'memory', 1, 8, 'stale-hash', 'model',
+          'stale legacy body', '[]', 100
+        );
+        INSERT INTO chunks VALUES (
+          'chunk-pending-legacy', 'pending.md', 'memory', 1, 6, 'pending-chunk-hash', 'model',
+          'only searchable content for pending', '[]', 150
+        );
+      `);
+
+      ensureMemoryIndexSchema({
+        db,
+        cacheEnabled: false,
+        ftsEnabled: false,
+      });
+
+      // doc.md keeps only its canonical chunk (stale legacy chunk excluded);
+      // pending.md, whose canonical source had no chunks, imports its legacy
+      // chunk so the file is not left silently unsearchable.
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks ORDER BY id").all()).toEqual([
+        { id: "chunk-doc-canonical", text: "canonical body" },
+        { id: "chunk-pending-legacy", text: "only searchable content for pending" },
+      ]);
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('meta', 'files', 'chunks')",
+          )
+          .all(),
+      ).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("keeps legacy tables when legacy rows cannot be copied", () => {
     const db = new DatabaseSync(":memory:");
     try {
@@ -999,6 +1075,113 @@ describe("memory index schema", () => {
       ).toThrow("legacy memory files rows could not be copied");
       expect(db.prepare("SELECT path FROM files").get()).toEqual({ path: "doc.md" });
       expect(db.prepare("SELECT COUNT(*) AS count FROM memory_index_sources").get()).toEqual({
+        count: 0,
+      });
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('meta', 'files', 'chunks') ORDER BY name",
+          )
+          .all(),
+      ).toEqual([{ name: "chunks" }, { name: "files" }, { name: "meta" }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps legacy tables when legacy meta rows cannot be copied", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec(`
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE files (
+          path TEXT PRIMARY KEY,
+          source TEXT NOT NULL DEFAULT 'memory',
+          hash TEXT NOT NULL,
+          mtime INTEGER NOT NULL,
+          size INTEGER NOT NULL
+        );
+        CREATE TABLE chunks (
+          id TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          source TEXT NOT NULL DEFAULT 'memory',
+          start_line INTEGER NOT NULL,
+          end_line INTEGER NOT NULL,
+          hash TEXT NOT NULL,
+          model TEXT NOT NULL,
+          text TEXT NOT NULL,
+          embedding TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        INSERT INTO meta VALUES ('broken-key', NULL);
+      `);
+
+      expect(() =>
+        ensureMemoryIndexSchema({
+          db,
+          cacheEnabled: false,
+          ftsEnabled: false,
+        }),
+      ).toThrow("legacy memory meta rows could not be copied");
+      expect(
+        db
+          .prepare("SELECT COUNT(*) AS count FROM memory_index_meta WHERE key = 'broken-key'")
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('meta', 'files', 'chunks') ORDER BY name",
+          )
+          .all(),
+      ).toEqual([{ name: "chunks" }, { name: "files" }, { name: "meta" }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps legacy tables when legacy chunk rows cannot be copied", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec(`
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE files (
+          path TEXT PRIMARY KEY,
+          source TEXT NOT NULL DEFAULT 'memory',
+          hash TEXT NOT NULL,
+          mtime INTEGER NOT NULL,
+          size INTEGER NOT NULL
+        );
+        CREATE TABLE chunks (
+          id TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          source TEXT NOT NULL DEFAULT 'memory',
+          start_line INTEGER NOT NULL,
+          end_line INTEGER NOT NULL,
+          hash TEXT NOT NULL,
+          model TEXT NOT NULL,
+          text TEXT NOT NULL,
+          embedding TEXT,
+          updated_at INTEGER NOT NULL
+        );
+        INSERT INTO files VALUES ('note.md', 'memory', 'note-hash', 90, 10);
+        -- Legacy-only source (canonical owns no chunks for it), so this chunk
+        -- must copy; a NULL embedding makes it uncopyable under STRICT and the
+        -- whole migration must abort with legacy tables retained.
+        INSERT INTO chunks VALUES (
+          'chunk-broken', 'note.md', 'memory', 1, 5, 'chunk-hash', 'model',
+          'body', NULL, 90
+        );
+      `);
+
+      expect(() =>
+        ensureMemoryIndexSchema({
+          db,
+          cacheEnabled: false,
+          ftsEnabled: false,
+        }),
+      ).toThrow("legacy memory chunks rows could not be copied");
+      expect(db.prepare("SELECT COUNT(*) AS count FROM memory_index_chunks").get()).toEqual({
         count: 0,
       });
       expect(

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -367,15 +367,19 @@ function copyLegacyMemoryIndexRows(
   schema: string,
   preservedEmbeddingCacheTable?: string,
 ): void {
-  // A (path, source) already tracked canonically keeps both its row and its
-  // whole chunk set: importing legacy chunk ids under a canonical-owned source
-  // would mix stale text into a file sync considers current and never
-  // re-indexes. Legacy chunks migrate only with sources the canonical index
-  // does not track yet.
+  // A (path, source) the canonical index already has CHUNKS for keeps its whole
+  // canonical chunk set: importing legacy chunk ids there would mix stale text
+  // into a file sync considers current and never re-indexes. But a source with
+  // only a canonical row and no chunks yet (indexing interrupted before its
+  // chunks were written, or embedding pending/failed) still needs its legacy
+  // chunks — dropping them would leave the file silently unsearchable, since the
+  // matching source hash stops sync from re-indexing it. Snapshot the
+  // chunk-owning sources before the import so the exclusion (and the chunks
+  // assertion) sees canonical state from before these inserts add legacy chunks.
   db.exec(`
-    DROP TABLE IF EXISTS temp.legacy_import_canonical_sources;
-    CREATE TEMP TABLE legacy_import_canonical_sources AS
-    SELECT path, source FROM main.${MEMORY_INDEX_SOURCES_TABLE};
+    DROP TABLE IF EXISTS temp.legacy_import_chunk_owned_sources;
+    CREATE TEMP TABLE legacy_import_chunk_owned_sources AS
+    SELECT DISTINCT path, source FROM main.${MEMORY_INDEX_CHUNKS_TABLE};
   `);
   try {
     db.exec(`
@@ -392,7 +396,7 @@ function copyLegacyMemoryIndexRows(
       SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
       FROM ${schema}.chunks AS legacy
       WHERE NOT EXISTS (
-        SELECT 1 FROM temp.legacy_import_canonical_sources AS owned
+        SELECT 1 FROM temp.legacy_import_chunk_owned_sources AS owned
         WHERE owned.path = legacy.path AND owned.source IS legacy.source
       );
     `);
@@ -426,13 +430,13 @@ function copyLegacyMemoryIndexRows(
          WHERE canonical.id = legacy.id
        )
        AND NOT EXISTS (
-         SELECT 1 FROM temp.legacy_import_canonical_sources AS owned
+         SELECT 1 FROM temp.legacy_import_chunk_owned_sources AS owned
          WHERE owned.path = legacy.path AND owned.source IS legacy.source
        )`,
       "chunks",
     );
   } finally {
-    db.exec("DROP TABLE IF EXISTS temp.legacy_import_canonical_sources");
+    db.exec("DROP TABLE IF EXISTS temp.legacy_import_chunk_owned_sources");
   }
   if (
     preservedEmbeddingCacheTable !== "embedding_cache" &&

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -367,51 +367,73 @@ function copyLegacyMemoryIndexRows(
   schema: string,
   preservedEmbeddingCacheTable?: string,
 ): void {
+  // A (path, source) already tracked canonically keeps both its row and its
+  // whole chunk set: importing legacy chunk ids under a canonical-owned source
+  // would mix stale text into a file sync considers current and never
+  // re-indexes. Legacy chunks migrate only with sources the canonical index
+  // does not track yet.
   db.exec(`
-    INSERT OR IGNORE INTO main.${MEMORY_INDEX_META_TABLE} (key, value)
-    SELECT key, value FROM ${schema}.meta;
-
-    INSERT OR IGNORE INTO main.${MEMORY_INDEX_SOURCES_TABLE} (path, source, hash, mtime, size)
-    SELECT path, source, hash, mtime, size
-    FROM ${schema}.files;
-
-    INSERT OR IGNORE INTO main.${MEMORY_INDEX_CHUNKS_TABLE} (
-      id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
-    )
-    SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
-    FROM ${schema}.chunks;
+    DROP TABLE IF EXISTS temp.legacy_import_canonical_sources;
+    CREATE TEMP TABLE legacy_import_canonical_sources AS
+    SELECT path, source FROM main.${MEMORY_INDEX_SOURCES_TABLE};
   `);
-  assertLegacyRowsCopied(
-    db,
-    `SELECT COUNT(*) AS missing
-     FROM ${schema}.meta AS legacy
-     WHERE NOT EXISTS (
-       SELECT 1 FROM main.${MEMORY_INDEX_META_TABLE} AS canonical
-       WHERE canonical.key = legacy.key
-     )`,
-    "meta",
-  );
-  assertLegacyRowsCopied(
-    db,
-    `SELECT COUNT(*) AS missing
-     FROM ${schema}.files AS legacy
-     WHERE NOT EXISTS (
-       SELECT 1 FROM main.${MEMORY_INDEX_SOURCES_TABLE} AS canonical
-       WHERE canonical.path = legacy.path
-         AND canonical.source IS legacy.source
-     )`,
-    "files",
-  );
-  assertLegacyRowsCopied(
-    db,
-    `SELECT COUNT(*) AS missing
-     FROM ${schema}.chunks AS legacy
-     WHERE NOT EXISTS (
-       SELECT 1 FROM main.${MEMORY_INDEX_CHUNKS_TABLE} AS canonical
-       WHERE canonical.id = legacy.id
-     )`,
-    "chunks",
-  );
+  try {
+    db.exec(`
+      INSERT OR IGNORE INTO main.${MEMORY_INDEX_META_TABLE} (key, value)
+      SELECT key, value FROM ${schema}.meta;
+
+      INSERT OR IGNORE INTO main.${MEMORY_INDEX_SOURCES_TABLE} (path, source, hash, mtime, size)
+      SELECT path, source, hash, mtime, size
+      FROM ${schema}.files;
+
+      INSERT OR IGNORE INTO main.${MEMORY_INDEX_CHUNKS_TABLE} (
+        id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
+      )
+      SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
+      FROM ${schema}.chunks AS legacy
+      WHERE NOT EXISTS (
+        SELECT 1 FROM temp.legacy_import_canonical_sources AS owned
+        WHERE owned.path = legacy.path AND owned.source IS legacy.source
+      );
+    `);
+    assertLegacyRowsCopied(
+      db,
+      `SELECT COUNT(*) AS missing
+       FROM ${schema}.meta AS legacy
+       WHERE NOT EXISTS (
+         SELECT 1 FROM main.${MEMORY_INDEX_META_TABLE} AS canonical
+         WHERE canonical.key = legacy.key
+       )`,
+      "meta",
+    );
+    assertLegacyRowsCopied(
+      db,
+      `SELECT COUNT(*) AS missing
+       FROM ${schema}.files AS legacy
+       WHERE NOT EXISTS (
+         SELECT 1 FROM main.${MEMORY_INDEX_SOURCES_TABLE} AS canonical
+         WHERE canonical.path = legacy.path
+           AND canonical.source IS legacy.source
+       )`,
+      "files",
+    );
+    assertLegacyRowsCopied(
+      db,
+      `SELECT COUNT(*) AS missing
+       FROM ${schema}.chunks AS legacy
+       WHERE NOT EXISTS (
+         SELECT 1 FROM main.${MEMORY_INDEX_CHUNKS_TABLE} AS canonical
+         WHERE canonical.id = legacy.id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM temp.legacy_import_canonical_sources AS owned
+         WHERE owned.path = legacy.path AND owned.source IS legacy.source
+       )`,
+      "chunks",
+    );
+  } finally {
+    db.exec("DROP TABLE IF EXISTS temp.legacy_import_canonical_sources");
+  }
   if (
     preservedEmbeddingCacheTable !== "embedding_cache" &&
     hasLegacyEmbeddingCacheTable(db, schema)

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -242,10 +242,18 @@ function tableExists(db: DatabaseSync, tableName: string): boolean {
   return row?.found === 1;
 }
 
+// Same-identity value mismatches keep the canonical row: every copied table is
+// derived search state that normal sync rebuilds, and aborting on them wedges
+// every later index open on the untouched legacy tables (same canonical-wins
+// rule as the sidecar import in memory-core's doctor contract). Only a row the
+// copy could not place at all (e.g. STRICT rejected it) still aborts, so
+// legacy rows are never silently dropped.
 function assertLegacyRowsCopied(db: DatabaseSync, query: string, tableName: string): void {
   const row = db.prepare(query).get() as { missing?: unknown } | undefined;
   if (Number(row?.missing ?? 0) > 0) {
-    throw new Error(`legacy memory ${tableName} rows conflict with canonical memory index rows`);
+    throw new Error(
+      `legacy memory ${tableName} rows could not be copied into canonical memory index rows`,
+    );
   }
 }
 
@@ -379,7 +387,7 @@ function copyLegacyMemoryIndexRows(
      FROM ${schema}.meta AS legacy
      WHERE NOT EXISTS (
        SELECT 1 FROM main.${MEMORY_INDEX_META_TABLE} AS canonical
-       WHERE canonical.key = legacy.key AND canonical.value IS legacy.value
+       WHERE canonical.key = legacy.key
      )`,
     "meta",
   );
@@ -391,9 +399,6 @@ function copyLegacyMemoryIndexRows(
        SELECT 1 FROM main.${MEMORY_INDEX_SOURCES_TABLE} AS canonical
        WHERE canonical.path = legacy.path
          AND canonical.source IS legacy.source
-         AND canonical.hash IS legacy.hash
-         AND canonical.mtime IS legacy.mtime
-         AND canonical.size IS legacy.size
      )`,
     "files",
   );
@@ -404,15 +409,6 @@ function copyLegacyMemoryIndexRows(
      WHERE NOT EXISTS (
        SELECT 1 FROM main.${MEMORY_INDEX_CHUNKS_TABLE} AS canonical
        WHERE canonical.id = legacy.id
-         AND canonical.path IS legacy.path
-         AND canonical.source IS legacy.source
-         AND canonical.start_line IS legacy.start_line
-         AND canonical.end_line IS legacy.end_line
-         AND canonical.hash IS legacy.hash
-         AND canonical.model IS legacy.model
-         AND canonical.text IS legacy.text
-         AND canonical.embedding IS legacy.embedding
-         AND canonical.updated_at IS legacy.updated_at
      )`,
     "chunks",
   );
@@ -447,9 +443,6 @@ function copyLegacyMemoryIndexRows(
            AND canonical.model = legacy.model
            AND canonical.provider_key = legacy.provider_key
            AND canonical.hash = legacy.hash
-           AND canonical.embedding IS legacy.embedding
-           AND canonical.dims IS legacy.dims
-           AND canonical.updated_at IS legacy.updated_at
        )`,
       "embedding_cache",
     );


### PR DESCRIPTION
Related: #108532
Related: #107220

## What Problem This Solves

Fixes an issue where operators whose per-agent memory database still contains the legacy `meta`/`files`/`chunks` tables would have every Memory Core index open fail with `legacy memory meta rows conflict with canonical memory index rows` once those legacy rows diverge from the canonical `memory_index_*` rows — for example after an upgrade → downgrade → upgrade cycle, where the downgraded build re-creates and re-indexes the legacy tables. The failure repeats on every open (runtime and doctor), and `openclaw doctor --fix` cannot converge it.

#108652 applied the canonical-wins recovery rule to the legacy **sidecar** import in memory-core's doctor contract, but the **same-file** legacy migration in `packages/memory-host-sdk/src/host/memory-schema.ts` kept the old hard-fail, so this sibling path still wedges — including from inside the sidecar migration itself, where `ensureMemoryIndexSchema` runs outside the conflict-recovery catch.

## Why This Change Was Made

The same-file migration now follows the same rule the sidecar import adopted in #108652: every copied table is derived search state, so a same-identity value mismatch keeps the canonical row and the migration completes (legacy tables are dropped, normal sync rebuilds any skipped rows). The merge is coherent per source: a `(path, source)` the canonical index already tracks keeps **both** its row and its whole chunk set — legacy chunk ids are never imported under a canonical-owned source, so stale legacy text cannot ride into a file that sync considers current (this addresses the review finding on mixed-source coherence). Legacy chunks migrate only together with their legacy-only sources. A legacy row that could not be placed at all by identity (e.g. STRICT rejected it) still aborts and leaves the legacy tables in place, so legacy rows are never silently dropped. Non-goal: the sidecar import path is untouched — it already recovers atomically.

## User Impact

Operators with diverged same-file legacy memory tables get a working memory index and a clean one-time migration on the next start, instead of a permanently failing index open that requires manual SQLite surgery. Canonical index rows and their chunk sets are preserved intact; legacy-only files still migrate with their chunks. Repeated opens are idempotent.

## Evidence

### Real behavior proof (real on-disk database, before/after)

Method: a driver script (kept outside the repo per the proof-asset rule) exercises the real production `ensureMemoryIndexSchema` from `packages/memory-host-sdk/src/host/memory-schema.ts` against a real SQLite file on disk (`node:sqlite` `DatabaseSync`, Node 25.9, via tsx). Nothing is mocked. The database is shaped like the operator upgrade → downgrade → upgrade cycle: a new build creates the canonical index and indexes content (`vectorDims: 1024`, `MEMORY.md` at `new-hash` with canonical chunk `chunk-1` "current canonical body"), then a downgraded build re-creates legacy `meta`/`files`/`chunks` in the same file with diverged values at the same identities (`vectorDims: 512`, `old-hash`, "stale legacy body") **plus a distinct stale legacy chunk id under the canonical-owned file (`chunk-old-7`, "stale legacy tail body")**, plus rows the canonical index does not have (`legacy-only-key`, `old-note.md` with its chunk `chunk-old-2`). The only variable between runs is the `memory-schema.ts` blob (`git hash-object`: `a79b2e4a3835` = origin/main, `df34397c1e41` = this PR).

**BEFORE — origin/main blob `a79b2e4a3835`:** wedged on every open, exactly the released failure from #108532:

```text
=== BEFORE (origin/main memory-schema.ts) ===
open attempt 1: FAILED -> legacy memory meta rows conflict with canonical memory index rows
open attempt 2: FAILED -> legacy memory meta rows conflict with canonical memory index rows
```

**AFTER — this PR, blob `df34397c1e41` (head `880730ae8c`):** first open migrates and recovers; canonical values win; the stale legacy chunk id under the canonical-owned file is **not** imported; legacy-only rows import with their source; legacy tables drop once; second open is idempotent with identical state:

```text
=== AFTER (with coherence repair) ===
open attempt 1: OK
  legacy tables present: (none)
  memory_index_meta: [{"key":"legacy-only-key","value":"legacy-only-value"},{"key":"memory_index_meta_v1","value":"{\"vectorDims\":1024}"}]
  memory_index_sources: [{"path":"MEMORY.md","hash":"new-hash","size":42},{"path":"old-note.md","hash":"old-note-hash","size":10}]
  memory_index_chunks: [{"id":"chunk-1","text":"current canonical body"},{"id":"chunk-old-2","text":"note body"}]
open attempt 2: OK
  legacy tables present: (none)
  memory_index_meta: [{"key":"legacy-only-key","value":"legacy-only-value"},{"key":"memory_index_meta_v1","value":"{\"vectorDims\":1024}"}]
  memory_index_sources: [{"path":"MEMORY.md","hash":"new-hash","size":42},{"path":"old-note.md","hash":"old-note-hash","size":10}]
  memory_index_chunks: [{"id":"chunk-1","text":"current canonical body"},{"id":"chunk-old-2","text":"note body"}]
```

**Structural-failure retention (both versions):** a legacy `files` row with a `NULL` hash (uncopyable into the STRICT canonical table) still aborts and keeps the legacy tables in place, so legacy rows are never silently dropped:

```text
structural scenario: aborted -> legacy memory files rows could not be copied into canonical memory index rows
  legacy tables retained: chunks, files, meta
  legacy files row retained: [{"path":"broken.md","hash":null}]
```

### Focused tests and lanes

- Regression test "keeps one coherent canonical index when legacy rows diverge" covers the review's mixed-source scenario: conflicting file identity (`doc.md` diverged hash) **with a distinct stale legacy chunk id (`chunk-old-7`)** — asserts the canonical chunk set stays intact, the stale legacy chunk is not imported, the legacy-only source imports with its chunk, and the legacy tables drop. On unpatched `main` this scenario fails with the exact production error string from #108532.
- Negative test "keeps legacy tables when legacy rows cannot be copied" locks the structural-failure abort (savepoint rollback retains legacy tables).
- `pnpm test packages/memory-host-sdk/src/host/memory-schema.test.ts` → 24/24 passed (re-run after each rebase).
- `pnpm test src/state/openclaw-database-maintenance.test.ts` → 12/12 passed.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` → clean.
- `node scripts/run-oxlint.mjs` and `pnpm format:check` on the two touched files → clean.
- `extensions/memory-core/doctor-contract-api.test.ts` fails identically on my machine on **clean main** (34× Windows `EBUSY: resource busy` during SQLite temp-dir cleanup), so that suite is environment-blocked locally, not affected by this change; `pnpm check:changed` delegates to Blacksmith Testbox, which is not available to an external contributor — CI on this PR is the authoritative run for those lanes.
- CI note: `build-artifacts` → "Check CLI startup memory" fails on the `status --json` RSS ceiling across runs of this PR on different `main` merge-bases (427.6, 429.4, 427.8 MB vs the 425 MB limit), and unrelated open PRs currently fail the identical step with the same overage (e.g. #109890 at 428.4 MB) while others pass at the same time — the metric is sitting at the ceiling on current `main` merge commits and runner variance decides the outcome. This diff removes production lines in an existing migration function and adds no imports, so it cannot move startup RSS. Per CONTRIBUTING I am not attempting to fix or tune this known `main`-side gate in this PR. (Earlier `check-lint` failures were transient unformatted files landed on `main` — `test/scripts/test-install-sh-docker.test.ts`, then `src/infra/spawn-ps.ts` — each fixed on `main` shortly after; cleared by rebasing onto the fixes. Current head `880730ae8c` on latest `main`, source blob `df34397c1e41`.)

AI-assisted: yes — authored with an AI coding agent (Claude); I reviewed the migration ownership boundary, the #108652 sibling semantics, SQLite `INSERT OR IGNORE`/STRICT behavior, and all touched tests. The `autoreview` skill was not available in my environment.
