### PR TITLE
fix(gateway): remove abort listener after deferred account start Promise.race

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -231,12 +231,20 @@ async function waitForDeferredAccountStart(
   if (abortSignal.aborted) {
     return;
   }
-  await Promise.race([
-    deferred,
-    new Promise<void>((resolve) => {
-      abortSignal.addEventListener("abort", () => resolve(), { once: true });
-    }),
-  ]);
+  let onAbort: (() => void) | undefined;
+  try {
+    await Promise.race([
+      deferred,
+      new Promise<void>((resolve) => {
+        onAbort = () => resolve();
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      }),
+    ]);
+  } finally {
+    if (onAbort) {
+      abortSignal.removeEventListener("abort", onAbort);
+    }
+  }
 }
 
 export type ChannelManager = {


### PR DESCRIPTION
## What Problem This Solves

`waitForDeferredAccountStart()` in `server-channels.ts` uses `Promise.race` with an anonymous abort listener. When `deferred` resolves first (the common path), the anonymous listener remains registered on `abortSignal`, leaking both the listener and its closure.

## Why This Change Was Made

The same `Promise.race` + abort listener pattern already has proper cleanup in `cron/trigger-script.ts` (lines 296-306) using a `try/finally` with `removeEventListener`. This fix applies the identical pattern to `waitForDeferredAccountStart`.

## Evidence

Existing tests pass (49/49). The fix follows the established pattern:

```typescript
// cron/trigger-script.ts (existing clean pattern)
let onAbort: ...;
try {
  signal.addEventListener("abort", onAbort, { once: true });
  return await Promise.race([promise, aborted]);
} finally {
  if (onAbort) signal.removeEventListener("abort", onAbort);
}
```

```
✓ server-channels.test.ts: 49/49 passed
```

## Merge Risk

Low. The change stores the listener in a variable and removes it in a `finally` block. When the signal has already fired, `removeEventListener` is a safe no-op. When `deferred` resolves first, the listener is properly cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)