### PR TITLE
fix(discord): Activity OAuth no longer holds failed Discord connections

### DIFF
--- a/extensions/discord/src/activities/discord-api.test.ts
+++ b/extensions/discord/src/activities/discord-api.test.ts
@@ -1,0 +1,36 @@
+import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { fetchDiscordJson } from "./discord-api.js";
+
+describe("Discord Activity API", () => {
+  it("cancels non-OK response bodies before releasing the dispatcher", async () => {
+    const lifecycle: string[] = [];
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("unauthorized"));
+        },
+        cancel() {
+          lifecycle.push("cancel");
+        },
+      }),
+      { status: 401 },
+    );
+    const fetchGuard = vi.fn(async () => ({
+      response,
+      release: async () => {
+        lifecycle.push("release");
+      },
+    })) as unknown as typeof fetchWithSsrFGuard;
+
+    await expect(
+      fetchDiscordJson({
+        fetchGuard,
+        url: "https://discord.com/api/v10/users/@me",
+        init: { headers: { Authorization: "Bearer test-token" } },
+        auditContext: "discord.activities.oauth.user",
+      }),
+    ).resolves.toEqual({ ok: false, status: 401 });
+    expect(lifecycle).toEqual(["cancel", "release"]);
+  });
+});

--- a/extensions/discord/src/activities/discord-api.test.ts
+++ b/extensions/discord/src/activities/discord-api.test.ts
@@ -33,4 +33,30 @@ describe("Discord Activity API", () => {
     ).resolves.toEqual({ ok: false, status: 401 });
     expect(lifecycle).toEqual(["cancel", "release"]);
   });
+
+  it("preserves the HTTP status when response cancellation fails", async () => {
+    const response = new Response(
+      new ReadableStream({
+        cancel() {
+          throw new Error("cancel failed");
+        },
+      }),
+      { status: 429 },
+    );
+    const release = vi.fn(async () => undefined);
+    const fetchGuard = vi.fn(async () => ({
+      response,
+      release,
+    })) as unknown as typeof fetchWithSsrFGuard;
+
+    await expect(
+      fetchDiscordJson({
+        fetchGuard,
+        url: "https://discord.com/api/v10/users/@me",
+        init: { headers: { Authorization: "Bearer test-token" } },
+        auditContext: "discord.activities.oauth.user",
+      }),
+    ).resolves.toEqual({ ok: false, status: 429 });
+    expect(release).toHaveBeenCalledOnce();
+  });
 });

--- a/extensions/discord/src/activities/discord-api.ts
+++ b/extensions/discord/src/activities/discord-api.ts
@@ -43,6 +43,7 @@ export async function fetchDiscordJson(params: {
   });
   try {
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       return { ok: false, status: response.status };
     }
     return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord Activities OAuth recovery could keep a failed Discord API response open after token exchange or user lookup was rejected. Repeated rejected launches could hold connection resources longer than necessary and delay later OAuth attempts.

Pattern context (not a duplicate): #109718 and #109677.

## Why This Change Was Made

Cancel the unread non-success response body before releasing the guarded dispatcher. Successful Discord JSON responses and the existing public behavior remain unchanged.

## User Impact

Discord Activities users can recover cleanly after Discord rejects an OAuth-related request without leaving the failed request body attached to the connection lifecycle.

## Evidence

- Regression test first failed with lifecycle `["release"]`; it now passes with `["cancel", "release"]`.
- Focused green: `vitest run extensions/discord/src/activities/discord-api.test.ts` (1 file, 1 test).
- Real third-party proof against Discord's official `GET /api/v10/users/@me` endpoint with a randomized temporary bearer value:
  - before: HTTP 401, production `fetchDiscordJson`, `responseBodyUsedAfterReturn=false`
  - after: HTTP 401, production `fetchDiscordJson`, `responseBodyUsedAfterReturn=true`
  - no Discord or iCenter channel message was sent.
- Discord API contract checked against https://docs.discord.com/developers/resources/user and https://docs.discord.com/developers/topics/oauth2.
- Static checks: targeted `oxfmt --check`, targeted `oxlint`, and `git diff --check` passed.
- Broader Discord test configuration was attempted once but stopped before completion when the local machine exhausted swap; it is not reported as passing. The focused regression and live provider proof completed successfully.
- Automated Codex review could not complete because the current egress returned HTTP 403 for both WebSocket and HTTPS Responses transports; the final two-file diff was reviewed manually.
