### PR TITLE
fix(mcp): doctor probes no longer start every server at once

### DIFF
--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -6,6 +6,7 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as mcpHttpFetch from "../agents/mcp-http-fetch.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
+import { createDeferred } from "../shared/deferred.js";
 import { registerMcpCli } from "./mcp-cli.js";
 
 const mocks = vi.hoisted(() => {
@@ -544,12 +545,9 @@ describe("mcp cli", () => {
         ]);
       }
 
-      let releaseChecks!: () => void;
-      const checksBlocked = new Promise<void>((resolve) => {
-        releaseChecks = resolve;
-      });
+      const checksBlocked = createDeferred();
       readMcpOAuthCredentialsStatus.mockImplementation(async () => {
-        await checksBlocked;
+        await checksBlocked.promise;
         return {
           hasTokens: false,
           hasClientInformation: false,
@@ -567,7 +565,7 @@ describe("mcp cli", () => {
         setImmediate(resolve);
       });
       const startedBeforeRelease = readMcpOAuthCredentialsStatus.mock.calls.length;
-      releaseChecks();
+      checksBlocked.resolve();
       await doctorPromise;
 
       expect(readMcpOAuthCredentialsStatus).toHaveBeenCalledTimes(6);

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -527,6 +527,75 @@ describe("mcp cli", () => {
     });
   });
 
+  it("bounds concurrent MCP doctor server checks", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      for (let index = 0; index < 6; index += 1) {
+        await runMcpCommand([
+          "mcp",
+          "set",
+          `server-${index}`,
+          JSON.stringify({
+            url: `https://mcp-${index}.example.com`,
+            transport: "streamable-http",
+            auth: "oauth",
+          }),
+        ]);
+      }
+
+      let releaseChecks!: () => void;
+      const checksBlocked = new Promise<void>((resolve) => {
+        releaseChecks = resolve;
+      });
+      readMcpOAuthCredentialsStatus.mockImplementation(async () => {
+        await checksBlocked;
+        return {
+          hasTokens: false,
+          hasClientInformation: false,
+          hasCodeVerifier: false,
+          hasDiscoveryState: false,
+          hasLastAuthorizationUrl: false,
+        };
+      });
+
+      const doctorPromise = runMcpCommand(["mcp", "doctor", "--json"]);
+      await vi.waitFor(() => {
+        expect(readMcpOAuthCredentialsStatus.mock.calls.length).toBeGreaterThanOrEqual(4);
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      const startedBeforeRelease = readMcpOAuthCredentialsStatus.mock.calls.length;
+      releaseChecks();
+      await doctorPromise;
+
+      expect(readMcpOAuthCredentialsStatus).toHaveBeenCalledTimes(6);
+      expect(startedBeforeRelease).toBe(4);
+      expect(
+        JSON.parse(lastLogLine()).servers.map((server: { name: string }) => server.name),
+      ).toEqual(["server-0", "server-1", "server-2", "server-3", "server-4", "server-5"]);
+    });
+  });
+
+  it("surfaces unexpected MCP doctor check errors", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      readMcpOAuthCredentialsStatus.mockRejectedValueOnce(new Error("credential store failed"));
+
+      await expect(runMcpCommand(["mcp", "doctor", "--json"])).rejects.toThrow(
+        "credential store failed",
+      );
+    });
+  });
+
   it("does not fail MCP doctor for disabled-only overrides", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -35,6 +35,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
 import { defaultRuntime } from "../runtime.js";
+import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { formatCliCommand } from "./command-format.js";
 import { resolveGatewayAuthOptions } from "./gateway-secret-options.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
@@ -182,6 +183,8 @@ type McpDoctorServerResult = {
   ok: boolean;
   issues: McpDoctorIssue[];
 };
+
+const MCP_DOCTOR_CONCURRENCY = 4;
 
 const SENSITIVE_HEADER_NAMES = new Set([
   "authorization",
@@ -799,24 +802,36 @@ export function registerMcpCli(program: Command) {
           `No MCP server named "${name}" in ${loaded.path}. Run ${formatCliCommand("openclaw mcp list")} to see configured servers.`,
         );
       }
-      const servers = await Promise.all(
-        Object.entries(selected)
-          .toSorted(([a], [b]) => a.localeCompare(b))
-          .map(async ([serverName, server]): Promise<McpDoctorServerResult> => {
-            const issues = await collectMcpDoctorIssues({
-              name: serverName,
-              server,
-              config: loaded.config,
-              path: loaded.path,
-              probe: Boolean(opts.probe),
-            });
-            return {
-              name: serverName,
-              ok: !issues.some((entry) => entry.level === "error"),
-              issues,
-            };
-          }),
-      );
+      const tasks = Object.entries(selected)
+        .toSorted(([a], [b]) => a.localeCompare(b))
+        .map(([serverName, server]) => async (): Promise<McpDoctorServerResult> => {
+          const issues = await collectMcpDoctorIssues({
+            name: serverName,
+            server,
+            config: loaded.config,
+            path: loaded.path,
+            probe: Boolean(opts.probe),
+          });
+          return {
+            name: serverName,
+            ok: !issues.some((entry) => entry.level === "error"),
+            issues,
+          };
+        });
+      // A probe can start one process or connection per server. Keep large
+      // registries from fanning out every transport at once.
+      const {
+        results: servers,
+        firstError,
+        hasError,
+      } = await runTasksWithConcurrency({
+        tasks,
+        limit: MCP_DOCTOR_CONCURRENCY,
+        errorMode: "stop",
+      });
+      if (hasError) {
+        throw firstError;
+      }
       const ok = servers.every((server) => server.ok);
       if (opts.json) {
         printJson({ path: loaded.path, ok, servers });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -35,6 +35,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
 import { defaultRuntime } from "../runtime.js";
+import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { formatCliCommand } from "./command-format.js";
 import { resolveGatewayAuthOptions } from "./gateway-secret-options.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
@@ -819,7 +820,6 @@ export function registerMcpCli(program: Command) {
         });
       // A probe can start one process or connection per server. Keep large
       // registries from fanning out every transport at once.
-      const { runTasksWithConcurrency } = await import("../utils/run-with-concurrency.js");
       const {
         results: servers,
         firstError,
@@ -827,7 +827,6 @@ export function registerMcpCli(program: Command) {
       } = await runTasksWithConcurrency({
         tasks,
         limit: MCP_DOCTOR_CONCURRENCY,
-        errorMode: "stop",
       });
       if (hasError) {
         throw firstError;

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -35,7 +35,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
 import { defaultRuntime } from "../runtime.js";
-import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { formatCliCommand } from "./command-format.js";
 import { resolveGatewayAuthOptions } from "./gateway-secret-options.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
@@ -820,6 +819,7 @@ export function registerMcpCli(program: Command) {
         });
       // A probe can start one process or connection per server. Keep large
       // registries from fanning out every transport at once.
+      const { runTasksWithConcurrency } = await import("../utils/run-with-concurrency.js");
       const {
         results: servers,
         firstError,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw mcp doctor --probe` would start a connection or stdio process for every configured MCP server at once. Large registries could therefore create an unbounded burst of external work during a single doctor run.

## Why This Change Was Made

The doctor action now runs at most four per-server checks concurrently through the existing bounded task helper. Results remain sorted by server name, and unexpected check failures still propagate instead of being converted into successful doctor output. This is a focused operation bound; it adds no configuration or broader runtime refactor.

## User Impact

Operators can probe large MCP registries without `mcp doctor` launching every server simultaneously. All configured servers are still checked and reported in the same deterministic order.

## Scope and Competition Check

A fresh semantic open-PR scan on the pinned main snapshot found no equivalent fix. In particular, #103970 repairs legacy disabled-server migration in the top-level doctor/config flow, #108676 prevents disabled MCP servers from spawning, and #108104 isolates per-server runtime failures; none bounds the checks started by `openclaw mcp doctor --probe`.

The change is limited to doctor-action scheduling and regression coverage. It does not change MCP runtime defaults, configuration, public APIs, transport behavior, or ordinary agent MCP concurrency.

## Evidence

Regression proof before the production change:

```text
bounds concurrent MCP doctor server checks
expected 6 to be 4
```

Focused verification after the change:

```text
node scripts/run-vitest.mjs src/cli/mcp-cli.test.ts
27 passed

node scripts/run-oxlint.mjs src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts
passed

pnpm exec oxfmt --check src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts
All matched files use the correct format.
```

Real stdio behavior proof ran the actual `mcp doctor --probe --json` action in a separate process against six configured MCP SDK servers. Each server was a real child process held at its initialization boundary until the harness released it:

```json
{
  "configuredServers": 6,
  "starts": 6,
  "startsBeforeRelease": 4,
  "peakActive": 4,
  "allServersOk": true,
  "orderedNames": [
    "server-0",
    "server-1",
    "server-2",
    "server-3",
    "server-4",
    "server-5"
  ],
  "endEvents": 6,
  "livePidsAfter": []
}
```

This covers the production CLI action, per-server runtime creation, real stdio spawn, MCP SDK handshake, catalog collection, and runtime disposal.

Not covered: a live remote vendor MCP endpoint over HTTP/SSE. The near-real proof uses six actual local stdio MCP SDK servers so concurrency and child cleanup are deterministic without third-party credentials. The remaining risk is limited to scheduling: each existing per-server check is unchanged, and tests cover ordered results plus unexpected-error propagation.
