### PR TITLE
fix(tlon): bound auth response draining

### DIFF
--- a/extensions/tlon/src/urbit/auth.ssrf.test.ts
+++ b/extensions/tlon/src/urbit/auth.ssrf.test.ts
@@ -54,6 +54,7 @@ describe("tlon urbit auth ssrf", () => {
       },
       cancel() {
         cancelled = true;
+        return new Promise(() => {});
       },
     });
     const mockFetch = vi.fn().mockResolvedValue(
@@ -76,5 +77,83 @@ describe("tlon urbit auth ssrf", () => {
     expect(cookie).toContain("urbauth-~zod=123");
     expect(cancelled).toBe(true);
     expect(chunks).toBeLessThanOrEqual(5);
+  });
+
+  it("times out a partial successful login body that stops producing chunks", async () => {
+    let cancelled = false;
+    let chunks = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (chunks === 0) {
+          chunks += 1;
+          controller.enqueue(new Uint8Array(1024));
+        }
+      },
+      cancel() {
+        cancelled = true;
+        return new Promise(() => {});
+      },
+    });
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: {
+          "set-cookie": "urbauth-~zod=123; Path=/; HttpOnly",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    const lookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+    const cookie = await authenticate("http://127.0.0.1:8080", "code", {
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    expect(cookie).toContain("urbauth-~zod=123");
+    expect(cancelled).toBe(true);
+    expect(chunks).toBe(1);
+  });
+
+  it("uses one deadline for a slow successful login body trickle", async () => {
+    let cancelled = false;
+    let chunks = 0;
+    let interval: ReturnType<typeof setInterval> | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        interval = setInterval(() => {
+          chunks += 1;
+          controller.enqueue(new Uint8Array(1));
+        }, 50);
+      },
+      cancel() {
+        cancelled = true;
+        if (interval) {
+          clearInterval(interval);
+        }
+        return new Promise(() => {});
+      },
+    });
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: {
+          "set-cookie": "urbauth-~zod=123; Path=/; HttpOnly",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    const lookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+    const cookie = await authenticate("http://127.0.0.1:8080", "code", {
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    expect(cookie).toContain("urbauth-~zod=123");
+    expect(cancelled).toBe(true);
+    expect(chunks).toBeLessThan(20);
   });
 });

--- a/extensions/tlon/src/urbit/auth.ssrf.test.ts
+++ b/extensions/tlon/src/urbit/auth.ssrf.test.ts
@@ -43,4 +43,38 @@ describe("tlon urbit auth ssrf", () => {
     expect(cookie).toContain("urbauth-~zod=123");
     expect(mockFetch).toHaveBeenCalled();
   });
+
+  it("bounds successful login response body draining before returning the cookie", async () => {
+    let cancelled = false;
+    let chunks = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        chunks += 1;
+        controller.enqueue(new Uint8Array(16 * 1024));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: {
+          "set-cookie": "urbauth-~zod=123; Path=/; HttpOnly",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    const lookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+    const cookie = await authenticate("http://127.0.0.1:8080", "code", {
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    expect(cookie).toContain("urbauth-~zod=123");
+    expect(cancelled).toBe(true);
+    expect(chunks).toBeLessThanOrEqual(5);
+  });
 });

--- a/extensions/tlon/src/urbit/auth.ts
+++ b/extensions/tlon/src/urbit/auth.ts
@@ -3,6 +3,8 @@ import type { LookupFn, SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { UrbitAuthError } from "./errors.js";
 import { urbitFetch } from "./fetch.js";
 
+const AUTH_RESPONSE_DRAIN_MAX_BYTES = 64 * 1024;
+
 type UrbitAuthenticateOptions = {
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
@@ -37,7 +39,7 @@ export async function authenticate(
     }
 
     // Some Urbit setups require the response body to be read before cookie headers finalize.
-    await response.text().catch(() => {});
+    await drainAuthResponseBody(response);
     const cookie = response.headers.get("set-cookie");
     if (!cookie) {
       throw new UrbitAuthError("missing_cookie", "No authentication cookie received");
@@ -45,5 +47,31 @@ export async function authenticate(
     return cookie;
   } finally {
     await release();
+  }
+}
+
+async function drainAuthResponseBody(response: Response): Promise<void> {
+  try {
+    if (!response.body) {
+      await response.text().catch(() => {});
+      return;
+    }
+
+    const reader = response.body.getReader();
+    let remaining = AUTH_RESPONSE_DRAIN_MAX_BYTES;
+    try {
+      while (remaining > 0) {
+        const { done, value } = await reader.read();
+        if (done || !value?.byteLength) {
+          return;
+        }
+        remaining -= value.byteLength;
+      }
+      await reader.cancel().catch(() => {});
+    } finally {
+      reader.releaseLock();
+    }
+  } catch {
+    // Body drain is compatibility-only; cookie handling below owns auth success/failure.
   }
 }

--- a/extensions/tlon/src/urbit/auth.ts
+++ b/extensions/tlon/src/urbit/auth.ts
@@ -4,6 +4,7 @@ import { UrbitAuthError } from "./errors.js";
 import { urbitFetch } from "./fetch.js";
 
 const AUTH_RESPONSE_DRAIN_MAX_BYTES = 64 * 1024;
+const AUTH_RESPONSE_DRAIN_TIMEOUT_MS = 250;
 
 type UrbitAuthenticateOptions = {
   ssrfPolicy?: SsrFPolicy;
@@ -59,19 +60,53 @@ async function drainAuthResponseBody(response: Response): Promise<void> {
 
     const reader = response.body.getReader();
     let remaining = AUTH_RESPONSE_DRAIN_MAX_BYTES;
+    let releaseLock = true;
+    const deadlineMs = Date.now() + AUTH_RESPONSE_DRAIN_TIMEOUT_MS;
     try {
       while (remaining > 0) {
-        const { done, value } = await reader.read();
+        const timeoutMs = deadlineMs - Date.now();
+        if (timeoutMs <= 0) {
+          releaseLock = false;
+          void reader.cancel().catch(() => {});
+          return;
+        }
+        const result = await readAuthResponseChunk(reader, timeoutMs);
+        if (result === "timeout") {
+          releaseLock = false;
+          void reader.cancel().catch(() => {});
+          return;
+        }
+        const { done, value } = result;
         if (done || !value?.byteLength) {
           return;
         }
         remaining -= value.byteLength;
       }
-      await reader.cancel().catch(() => {});
+      void reader.cancel().catch(() => {});
     } finally {
-      reader.releaseLock();
+      if (releaseLock) {
+        reader.releaseLock();
+      }
     }
   } catch {
     // Body drain is compatibility-only; cookie handling below owns auth success/failure.
+  }
+}
+
+async function readAuthResponseChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array> | "timeout"> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeout = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([reader.read(), timeoutPromise]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where successful Tlon / Urbit login responses could make `openclaw` drain an arbitrarily large or slowly streaming response body before returning the authentication cookie.

## Why This Change Was Made

The Tlon auth path still performs a best-effort body drain for Urbit setups that finalize cookies after response consumption, but now bounds that compatibility drain by both a 64 KiB byte cap and one short overall drain deadline. When either bound is reached, the body is cancelled without waiting for a non-settling cancellation callback.

## User Impact

Users can still authenticate against normal Urbit responses, while oversized, stalled, or slow-trickling successful login bodies no longer keep the login flow tied to unbounded response consumption.

## Evidence

- Current head: `33fb710a8ed4c7b7fd5235c228f641e2a5ad35b9`.
- GitHub Actions `Real behavior proof` passed on the current head: `https://github.com/openclaw/openclaw/actions/runs/29637400875`.
- GitHub Actions `checks-node-changed` passed on the current head: `https://github.com/openclaw/openclaw/actions/runs/29637401847`.
- GitHub Actions `check-lint` passed on the current head: `https://github.com/openclaw/openclaw/actions/runs/29637401847`.
- GitHub Actions `openclaw/ci-gate` passed on the current head: `https://github.com/openclaw/openclaw/actions/runs/29637401847`.
- `git diff --check refs/remotes/upstream/pr/109871^ refs/remotes/upstream/pr/109871` - passed.