### PR TITLE
test: serialize Vitest mock resolution in isolate:false shared workers

### DIFF
--- a/test/non-isolated-runner.resolve-mocks.test.ts
+++ b/test/non-isolated-runner.resolve-mocks.test.ts
@@ -1,25 +1,33 @@
 // Guards the resolveMocks serialization pin: concurrent callers must coalesce
-// into one shared pass so a late second pass cannot re-register and invalidate
-// already-evaluated manual mock modules mid-import-chain.
+// into one shared drain so a late second pass cannot re-register and invalidate
+// already-evaluated manual mock modules mid-import-chain, while ids queued
+// during an in-flight pass still get registered before callers proceed.
 import { describe, expect, it } from "vitest";
 import { serializeMockerResolveMocks } from "./non-isolated-runner.js";
 
-// Mirrors BareModuleMocker: pendingIds is a static queue that each pass
-// snapshots at start and reassigns to [] at the end.
+// Mirrors BareModuleMocker.resolveMocks: snapshots the static queue's contents
+// at pass start, awaits its RPCs, then reassigns the static to [] so ids
+// pushed during the await land in the abandoned array.
 class FakeMocker {
   static pendingIds: unknown[] = [];
   passes = 0;
   active = 0;
   maxConcurrentPasses = 0;
+  processed: unknown[] = [];
 
   async resolveMocks(): Promise<void> {
+    if (FakeMocker.pendingIds.length === 0) {
+      return;
+    }
     this.active += 1;
     this.maxConcurrentPasses = Math.max(this.maxConcurrentPasses, this.active);
     this.passes += 1;
+    const snapshot = [...FakeMocker.pendingIds];
     // Simulate the parallel resolveId RPC round-trips inside one pass.
     await new Promise((resolve) => {
       setTimeout(resolve, 1);
     });
+    this.processed.push(...snapshot);
     FakeMocker.pendingIds = [];
     this.active -= 1;
   }
@@ -35,6 +43,25 @@ describe("serializeMockerResolveMocks", () => {
 
     expect(mocker.maxConcurrentPasses).toBe(1);
     expect(mocker.passes).toBe(1);
+    expect(mocker.processed).toEqual(["mock-a", "mock-b"]);
+    expect(FakeMocker.pendingIds).toEqual([]);
+  });
+
+  it("registers ids queued while a pass is in flight before callers proceed", async () => {
+    FakeMocker.pendingIds = ["mock-a"];
+    const mocker = new FakeMocker();
+    serializeMockerResolveMocks(mocker);
+
+    const first = mocker.resolveMocks();
+    // Upstream would abandon this push when it reassigns pendingIds to [];
+    // the wrapper must requeue it into a follow-up pass.
+    FakeMocker.pendingIds.push("mock-late");
+    const coalesced = mocker.resolveMocks();
+    await Promise.all([first, coalesced]);
+
+    expect(mocker.processed).toEqual(["mock-a", "mock-late"]);
+    expect(mocker.maxConcurrentPasses).toBe(1);
+    expect(mocker.passes).toBe(2);
     expect(FakeMocker.pendingIds).toEqual([]);
   });
 
@@ -61,6 +88,7 @@ describe("serializeMockerResolveMocks", () => {
     await mocker.resolveMocks();
 
     expect(mocker.passes).toBe(2);
+    expect(mocker.processed).toEqual(["mock-a", "mock-b"]);
     expect(FakeMocker.pendingIds).toEqual([]);
   });
 });

--- a/test/non-isolated-runner.resolve-mocks.test.ts
+++ b/test/non-isolated-runner.resolve-mocks.test.ts
@@ -1,0 +1,66 @@
+// Guards the resolveMocks serialization pin: concurrent callers must coalesce
+// into one shared pass so a late second pass cannot re-register and invalidate
+// already-evaluated manual mock modules mid-import-chain.
+import { describe, expect, it } from "vitest";
+import { serializeMockerResolveMocks } from "./non-isolated-runner.js";
+
+// Mirrors BareModuleMocker: pendingIds is a static queue that each pass
+// snapshots at start and reassigns to [] at the end.
+class FakeMocker {
+  static pendingIds: unknown[] = [];
+  passes = 0;
+  active = 0;
+  maxConcurrentPasses = 0;
+
+  async resolveMocks(): Promise<void> {
+    this.active += 1;
+    this.maxConcurrentPasses = Math.max(this.maxConcurrentPasses, this.active);
+    this.passes += 1;
+    // Simulate the parallel resolveId RPC round-trips inside one pass.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1);
+    });
+    FakeMocker.pendingIds = [];
+    this.active -= 1;
+  }
+}
+
+describe("serializeMockerResolveMocks", () => {
+  it("coalesces concurrent resolveMocks callers into one pass", async () => {
+    FakeMocker.pendingIds = ["mock-a", "mock-b"];
+    const mocker = new FakeMocker();
+    serializeMockerResolveMocks(mocker);
+
+    await Promise.all([mocker.resolveMocks(), mocker.resolveMocks(), mocker.resolveMocks()]);
+
+    expect(mocker.maxConcurrentPasses).toBe(1);
+    expect(mocker.passes).toBe(1);
+    expect(FakeMocker.pendingIds).toEqual([]);
+  });
+
+  it("does not double-wrap when installed repeatedly", async () => {
+    FakeMocker.pendingIds = ["mock-a"];
+    const mocker = new FakeMocker();
+    serializeMockerResolveMocks(mocker);
+    // Identity check: a second install must keep the first wrapper in place.
+    const wrapped: unknown = Reflect.get(mocker, "resolveMocks");
+    serializeMockerResolveMocks(mocker);
+
+    expect(Reflect.get(mocker, "resolveMocks")).toBe(wrapped);
+    await mocker.resolveMocks();
+    expect(mocker.passes).toBe(1);
+  });
+
+  it("allows a fresh pass after the previous one settles", async () => {
+    FakeMocker.pendingIds = ["mock-a"];
+    const mocker = new FakeMocker();
+    serializeMockerResolveMocks(mocker);
+    await mocker.resolveMocks();
+
+    FakeMocker.pendingIds = ["mock-b"];
+    await mocker.resolveMocks();
+
+    expect(mocker.passes).toBe(2);
+    expect(FakeMocker.pendingIds).toEqual([]);
+  });
+});

--- a/test/non-isolated-runner.resolve-mocks.test.ts
+++ b/test/non-isolated-runner.resolve-mocks.test.ts
@@ -1,7 +1,7 @@
-// Guards the resolveMocks serialization pin: concurrent callers must coalesce
-// into one shared drain so a late second pass cannot re-register and invalidate
-// already-evaluated manual mock modules mid-import-chain, while ids queued
-// during an in-flight pass still get registered before callers proceed.
+// Guards the resolveMocks serialization pin: passes run sequentially so a
+// drained snapshot is never registered (and its mock modules never
+// invalidated) twice, while every caller's pass starts at or after its call so
+// previously queued ids are registered before the caller's fetch proceeds.
 import { describe, expect, it } from "vitest";
 import { serializeMockerResolveMocks } from "./non-isolated-runner.js";
 
@@ -34,7 +34,7 @@ class FakeMocker {
 }
 
 describe("serializeMockerResolveMocks", () => {
-  it("coalesces concurrent resolveMocks callers into one pass", async () => {
+  it("serializes concurrent callers and never re-registers a drained snapshot", async () => {
     FakeMocker.pendingIds = ["mock-a", "mock-b"];
     const mocker = new FakeMocker();
     serializeMockerResolveMocks(mocker);
@@ -42,26 +42,29 @@ describe("serializeMockerResolveMocks", () => {
     await Promise.all([mocker.resolveMocks(), mocker.resolveMocks(), mocker.resolveMocks()]);
 
     expect(mocker.maxConcurrentPasses).toBe(1);
+    // Later chained passes see the cleared queue and no-op instead of
+    // re-registering (and re-invalidating) the same snapshot.
     expect(mocker.passes).toBe(1);
     expect(mocker.processed).toEqual(["mock-a", "mock-b"]);
     expect(FakeMocker.pendingIds).toEqual([]);
   });
 
-  it("registers ids queued while a pass is in flight before callers proceed", async () => {
+  it("registers ids queued while a pass is in flight before the later caller resolves", async () => {
     FakeMocker.pendingIds = ["mock-a"];
     const mocker = new FakeMocker();
     serializeMockerResolveMocks(mocker);
 
     const first = mocker.resolveMocks();
     // Upstream would abandon this push when it reassigns pendingIds to [];
-    // the wrapper must requeue it into a follow-up pass.
+    // the wrapper must requeue it and the second caller's own chained pass
+    // must register it before that caller proceeds with its fetch.
     FakeMocker.pendingIds.push("mock-late");
-    const coalesced = mocker.resolveMocks();
-    await Promise.all([first, coalesced]);
+    const second = mocker.resolveMocks();
+    await second;
 
     expect(mocker.processed).toEqual(["mock-a", "mock-late"]);
     expect(mocker.maxConcurrentPasses).toBe(1);
-    expect(mocker.passes).toBe(2);
+    await first;
     expect(FakeMocker.pendingIds).toEqual([]);
   });
 

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -243,7 +243,7 @@ const SERIALIZED_RESOLVE_MOCKS = Symbol.for("openclaw.serializedResolveMocks");
 // already-evaluated manual mock modules mid-import-chain, so importers before
 // the wipe hold one factory instance and later importers get a fresh one
 // (vi.mocked(...) on the test's binding silently stops reaching prod). Coalesce
-// concurrent callers into one shared pass so registration happens exactly once
+// concurrent callers into one shared drain so registration happens exactly once
 // before any awaiting import proceeds.
 export function serializeMockerResolveMocks(
   mocker: SerializableMocker & { [SERIALIZED_RESOLVE_MOCKS]?: boolean },
@@ -253,9 +253,24 @@ export function serializeMockerResolveMocks(
   }
   mocker[SERIALIZED_RESOLVE_MOCKS] = true;
   const original = mocker.resolveMocks.bind(mocker);
+  const statics = mocker.constructor as { pendingIds?: unknown[] };
+  const drain = async (): Promise<void> => {
+    do {
+      const queue = statics.pendingIds;
+      const processedCount = queue?.length ?? 0;
+      await original();
+      // Upstream snapshots the queue contents at pass start and reassigns the
+      // pendingIds static to [] at the end, so ids queued during the pass's
+      // RPC window land in the abandoned array. Requeue them or a coalesced
+      // caller's vi.mock registration would be silently dropped.
+      if (queue && queue !== statics.pendingIds && queue.length > processedCount) {
+        statics.pendingIds?.push(...queue.slice(processedCount));
+      }
+    } while ((statics.pendingIds?.length ?? 0) > 0);
+  };
   let inflight: Promise<void> | null = null;
   mocker.resolveMocks = () => {
-    inflight ??= original().finally(() => {
+    inflight ??= drain().finally(() => {
       inflight = null;
     });
     return inflight;

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -14,8 +14,13 @@ type EvaluatedModules = {
   idToModuleMap: Map<string, EvaluatedModuleNode>;
 };
 
+type SerializableMocker = {
+  reset?: () => void;
+  resolveMocks?: () => Promise<void>;
+};
+
 type TestRunnerInternals = {
-  moduleRunner?: { mocker?: { reset?: () => void } };
+  moduleRunner?: { mocker?: SerializableMocker };
   workerState: { evaluatedModules: unknown };
 };
 
@@ -227,9 +232,43 @@ function resetOpenClawGlobalDiagnosticState(): void {
   Reflect.deleteProperty(globalStore, DIAGNOSTIC_EVENTS_STATE);
 }
 
+const SERIALIZED_RESOLVE_MOCKS = Symbol.for("openclaw.serializedResolveMocks");
+
+// Vitest's BareModuleMocker.resolveMocks has no in-flight guard: pendingIds is
+// cleared only after all parallel resolveId RPCs settle, and every registration
+// re-invalidates the mock module node. In a shared isolate:false worker, stray
+// async work from an earlier file (a leaked timer running a dynamic import) can
+// start a second concurrent pass over the same pendingIds while the next file's
+// vi.mock registrations resolve. The slower pass then re-registers and wipes
+// already-evaluated manual mock modules mid-import-chain, so importers before
+// the wipe hold one factory instance and later importers get a fresh one
+// (vi.mocked(...) on the test's binding silently stops reaching prod). Coalesce
+// concurrent callers into one shared pass so registration happens exactly once
+// before any awaiting import proceeds.
+export function serializeMockerResolveMocks(
+  mocker: SerializableMocker & { [SERIALIZED_RESOLVE_MOCKS]?: boolean },
+): void {
+  if (!mocker.resolveMocks || mocker[SERIALIZED_RESOLVE_MOCKS]) {
+    return;
+  }
+  mocker[SERIALIZED_RESOLVE_MOCKS] = true;
+  const original = mocker.resolveMocks.bind(mocker);
+  let inflight: Promise<void> | null = null;
+  mocker.resolveMocks = () => {
+    inflight ??= original().finally(() => {
+      inflight = null;
+    });
+    return inflight;
+  };
+}
+
 export default class OpenClawNonIsolatedRunner extends TestRunner {
   override onCollectStart(file: RunnerTestFile) {
     super.onCollectStart(file);
+    const internals = this as unknown as TestRunnerInternals;
+    if (internals.moduleRunner?.mocker) {
+      serializeMockerResolveMocks(internals.moduleRunner.mocker);
+    }
     restoreRealTimers();
     restoreNativeTimerGlobals();
     restoreSharedTestHomeAfterEnvUnstub(getSharedTestHome());

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -242,9 +242,20 @@ const SERIALIZED_RESOLVE_MOCKS = Symbol.for("openclaw.serializedResolveMocks");
 // vi.mock registrations resolve. The slower pass then re-registers and wipes
 // already-evaluated manual mock modules mid-import-chain, so importers before
 // the wipe hold one factory instance and later importers get a fresh one
-// (vi.mocked(...) on the test's binding silently stops reaching prod). Coalesce
-// concurrent callers into one shared drain so registration happens exactly once
-// before any awaiting import proceeds.
+// (vi.mocked(...) on the test's binding silently stops reaching prod).
+//
+// The pin chains each caller onto its own sequential pass instead of sharing
+// one in-flight pass. Two invariants both matter:
+// - Serialization: a pass queued behind an in-flight one sees the cleared
+//   queue and no-ops, so a snapshot is never registered (and its mock modules
+//   never invalidated) twice.
+// - Freshness: every caller's pass starts at or after its call, so ids the
+//   caller queued (vi.mock/doMock/doUnmock before a dynamic import) are
+//   registered before its fetch proceeds. Sharing one pass breaks this — a
+//   caller can coalesce onto a pass snapshotted before its ids were queued and
+//   then import with mock state unresolved (observed: auth-provenance's
+//   doUnmock + Promise.all imports loading the real provider-auth warm worker
+//   and a 120s oauth refresh instead of the mocked provider hook).
 export function serializeMockerResolveMocks(
   mocker: SerializableMocker & { [SERIALIZED_RESOLVE_MOCKS]?: boolean },
 ): void {
@@ -254,26 +265,28 @@ export function serializeMockerResolveMocks(
   mocker[SERIALIZED_RESOLVE_MOCKS] = true;
   const original = mocker.resolveMocks.bind(mocker);
   const statics = mocker.constructor as { pendingIds?: unknown[] };
-  const drain = async (): Promise<void> => {
-    do {
-      const queue = statics.pendingIds;
-      const processedCount = queue?.length ?? 0;
-      await original();
-      // Upstream snapshots the queue contents at pass start and reassigns the
-      // pendingIds static to [] at the end, so ids queued during the pass's
-      // RPC window land in the abandoned array. Requeue them or a coalesced
-      // caller's vi.mock registration would be silently dropped.
-      if (queue && queue !== statics.pendingIds && queue.length > processedCount) {
-        statics.pendingIds?.push(...queue.slice(processedCount));
-      }
-    } while ((statics.pendingIds?.length ?? 0) > 0);
+  const runPass = async (): Promise<void> => {
+    const queue = statics.pendingIds;
+    const processedCount = queue?.length ?? 0;
+    await original();
+    // Upstream snapshots the queue contents at pass start and reassigns the
+    // pendingIds static to [] at the end, so ids queued during the pass's RPC
+    // window land in the abandoned array. Requeue them so the next chained
+    // pass registers them instead of silently dropping the registration.
+    if (queue && queue !== statics.pendingIds && queue.length > processedCount) {
+      statics.pendingIds?.push(...queue.slice(processedCount));
+    }
   };
-  let inflight: Promise<void> | null = null;
+  let tail: Promise<void> = Promise.resolve();
   mocker.resolveMocks = () => {
-    inflight ??= drain().finally(() => {
-      inflight = null;
-    });
-    return inflight;
+    const pass = tail.then(runPass);
+    // Keep the chain alive after a rejected pass; the rejection still reaches
+    // the caller that owns that pass, matching upstream behavior.
+    tail = pass.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pass;
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

`subagent-orphan-recovery` tests flaked on main (run 29566318167): vi.mock factory state silently split into two instances in isolate:false shared workers, so configured mocks never reached prod code.

## Why This Change Was Made

Root cause is an upstream Vitest 4 mocker re-entrancy hole: `BareModuleMocker.resolveMocks()` has no in-flight guard — concurrent passes over the same `pendingIds` re-register manual mocks and invalidate the mock module mid-import-chain, splitting importers across two factory instances (deterministically reproduced with the exact CI signature).

The fix wraps `resolveMocks` in the shared runner (`test/non-isolated-runner.ts`) so each caller **chains onto its own sequential pass**. This preserves both invariants the mocker's callers rely on:
- **Serialization** — a pass queued behind an in-flight one sees the cleared queue and no-ops, so a snapshot is never registered/invalidated twice (fixes the instance-split disease).
- **Freshness** — every caller's pass starts at or after its call, so `vi.doUnmock` + immediate dynamic imports resolve against current state.

An earlier iteration of this PR used shared-pass coalescing, which violated freshness and regressed the auth shard on this PR's own CI (a caller could ride a pass snapshotted before its unmock was queued, loading the real provider-auth warm worker and a 120s oauth refresh timeout). That was caught here, root-caused, and replaced — details in the commit body. Abandoned-id requeue from the first review round is preserved.

Upstream note: the missing in-flight guard is a genuine `@vitest/mocker` bug worth filing against vitest 4.

## User Impact

None at runtime — test-runner infrastructure only; hardens every isolate:false shard.

## Evidence

- Original disease: poison-file + resolveId-jitter repro reproduces the exact CI failure on the unfixed runner; 5/5 green with the chained pin; A/B both directions.
- Freshness regression: cold-cache auth shard (exact CI include list, 37 files / 528 tests) fails 3/3 under coalescing, passes 20s on the unfixed runner, and passes 3/3 (~20–30s) under the chained design.
- Warm sanity: subagents shard (63 files / 1220 tests) + auth shard green at OPENCLAW_VITEST_MAX_WORKERS=6; wrapper unit tests assert serialization, freshness, requeue, idempotent install.
- oxlint / format / check:test-types / git diff --check clean; autoreview clean ("patch is correct 0.88").
