### PR TITLE
fix(config): reject gateway.port values outside the 1–65535 TCP range

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2858,6 +2858,68 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
   });
 });
 
+describe("gateway.port out-of-range repair migrate", () => {
+  it("removes gateway.port above TCP max and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 65_536 },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed out-of-range gateway.port (65536). Valid TCP ports are 1–65535; the gateway will use the default port 18789.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("removes gateway.port zero and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 0 },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed out-of-range gateway.port (0). Valid TCP ports are 1–65535; the gateway will use the default port 18789.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("preserves valid gateway.port values", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 65_535 },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("preserves other gateway keys when removing the port", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 65_536, bind: "loopback" },
+    });
+
+    expect(res.config?.gateway).toEqual({ bind: "loopback" });
+    expect(res.changes.length).toBeGreaterThan(0);
+  });
+
+  it("is idempotent for out-of-range values", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { port: 65_536 },
+    });
+    expect(first.changes.length).toBe(1);
+    expect(first.config).not.toHaveProperty("gateway");
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
+  });
+
+  it("leaves gateway.port set to 1 (valid minimum) untouched", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 1 },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+});
+
 describe("legacy model compat migrate", () => {
   it("upgrades the retired xAI quality image slug without pinning active aliases", () => {
     const raw = {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2899,6 +2899,19 @@ describe("gateway.port out-of-range repair migrate", () => {
     expect(res.changes.length).toBeGreaterThan(0);
   });
 
+  it("seeds non-loopback Control UI origins with the fallback port", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 65_536, bind: "lan" },
+    });
+
+    expect(res.config?.gateway).toMatchObject({
+      bind: "lan",
+      controlUi: {
+        allowedOrigins: ["http://localhost:18789", "http://127.0.0.1:18789"],
+      },
+    });
+  });
+
   it("is idempotent for out-of-range values", () => {
     const first = migrateLegacyConfigForTest({
       gateway: { port: 65_536 },

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -14,6 +14,13 @@ import {
 } from "../../../config/legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "../../../config/paths.js";
 
+const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "port"],
+  message:
+    'gateway.port is outside the valid TCP range (1–65535) and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
+  match: (value) => typeof value === "number" && (value < 1 || value > 65_535),
+};
+
 const GATEWAY_BIND_RULE: LegacyConfigRule = {
   path: ["gateway", "bind"],
   message:
@@ -152,6 +159,31 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       gateway.bind = mapped;
       raw.gateway = gateway;
       changes.push(`Normalized gateway.bind "${escapeControlForLog(bindRaw)}" → "${mapped}".`);
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "gateway.port-oob-repair",
+    describe: "Remove out-of-range gateway.port to avoid post-schema-tightening startup failures",
+    legacyRules: [GATEWAY_PORT_OOB_RULE],
+    apply: (raw, changes) => {
+      const gateway = getRecord(raw.gateway);
+      if (!gateway || !Object.hasOwn(gateway, "port")) {
+        return;
+      }
+      const port = gateway.port;
+      if (typeof port !== "number" || (port >= 1 && port <= 65_535)) {
+        return;
+      }
+      delete gateway.port;
+      if (Object.keys(gateway).length > 0) {
+        raw.gateway = gateway;
+      } else {
+        delete raw.gateway;
+      }
+      changes.push(
+        `Removed out-of-range gateway.port (${String(port)}). ` +
+          `Valid TCP ports are 1–65535; the gateway will use the default port ${DEFAULT_GATEWAY_PORT}.`,
+      );
     },
   }),
 ];

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -96,6 +96,31 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
     },
   }),
   defineLegacyConfigMigration({
+    id: "gateway.port-oob-repair",
+    describe: "Remove out-of-range gateway.port to avoid post-schema-tightening startup failures",
+    legacyRules: [GATEWAY_PORT_OOB_RULE],
+    apply: (raw, changes) => {
+      const gateway = getRecord(raw.gateway);
+      if (!gateway || !Object.hasOwn(gateway, "port")) {
+        return;
+      }
+      const port = gateway.port;
+      if (typeof port !== "number" || (port >= 1 && port <= 65_535)) {
+        return;
+      }
+      delete gateway.port;
+      if (Object.keys(gateway).length > 0) {
+        raw.gateway = gateway;
+      } else {
+        delete raw.gateway;
+      }
+      changes.push(
+        `Removed out-of-range gateway.port (${String(port)}). ` +
+          `Valid TCP ports are 1–65535; the gateway will use the default port ${DEFAULT_GATEWAY_PORT}.`,
+      );
+    },
+  }),
+  defineLegacyConfigMigration({
     id: "gateway.controlUi.allowedOrigins-seed-for-non-loopback",
     describe: "Seed gateway.controlUi.allowedOrigins for existing non-loopback gateway installs",
     apply: (raw, changes) => {
@@ -159,31 +184,6 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       gateway.bind = mapped;
       raw.gateway = gateway;
       changes.push(`Normalized gateway.bind "${escapeControlForLog(bindRaw)}" → "${mapped}".`);
-    },
-  }),
-  defineLegacyConfigMigration({
-    id: "gateway.port-oob-repair",
-    describe: "Remove out-of-range gateway.port to avoid post-schema-tightening startup failures",
-    legacyRules: [GATEWAY_PORT_OOB_RULE],
-    apply: (raw, changes) => {
-      const gateway = getRecord(raw.gateway);
-      if (!gateway || !Object.hasOwn(gateway, "port")) {
-        return;
-      }
-      const port = gateway.port;
-      if (typeof port !== "number" || (port >= 1 && port <= 65_535)) {
-        return;
-      }
-      delete gateway.port;
-      if (Object.keys(gateway).length > 0) {
-        raw.gateway = gateway;
-      } else {
-        delete raw.gateway;
-      }
-      changes.push(
-        `Removed out-of-range gateway.port (${String(port)}). ` +
-          `Valid TCP ports are 1–65535; the gateway will use the default port ${DEFAULT_GATEWAY_PORT}.`,
-      );
     },
   }),
 ];

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -208,3 +208,31 @@ describe("config validation SecretRef policy guards", () => {
     }
   });
 });
+
+describe("config validation gateway.port policy", () => {
+  it("rejects gateway.port values outside the 1–65535 TCP range", () => {
+    // port 0 — not a valid TCP port
+    const zero = validateConfigObjectRaw({ gateway: { port: 0 } });
+    expect(zero.ok).toBe(false);
+    if (!zero.ok) {
+      const issue = requireIssue(zero.issues, "gateway.port");
+      expect(issue.message).toContain("expected number to be >=1");
+    }
+
+    // port 65536 — above TCP max
+    const above = validateConfigObjectRaw({ gateway: { port: 65_536 } });
+    expect(above.ok).toBe(false);
+    if (!above.ok) {
+      const issue = requireIssue(above.issues, "gateway.port");
+      expect(issue.message).toBeDefined();
+    }
+
+    // port 65535 — valid TCP max
+    const valid = validateConfigObjectRaw({ gateway: { port: 65_535 } });
+    expect(valid.ok).toBe(true);
+
+    // port 1 — valid TCP min
+    const min = validateConfigObjectRaw({ gateway: { port: 1 } });
+    expect(min.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -13,7 +13,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 export const GatewayConfigSchema = z
   .strictObject({
-    port: z.number().int().positive().optional(),
+    port: z.number().int().min(1).max(65_535).optional(),
     mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
     bind: z
       .union([


### PR DESCRIPTION
## What Problem This Solves

Fixes openclaw/openclaw#109293

Config validation accepted `gateway.port` values outside the valid TCP port range (1–65535). The schema only checked for a positive integer, so invalid ports like `0` or `65536` passed validation even though the runtime gateway port parser silently falls back to the default port for out-of-range values.

After this PR, invalid ports are rejected at config-load time with a clear error message, and a Doctor migration (`openclaw doctor --fix`) automatically repairs existing configs that contain out-of-range port values so they do not fail startup after the schema tightening.

## Why This Change Was Made

The primary `gateway.port` zod schema used `z.number().int().positive()` which allows values above 65535. This is inconsistent with:
- `gateway.remote.remotePort` (already bounded to 1..65535)
- `resolveGatewayPort()` runtime parser (ignores values ≤0, falls back to DEFAULT_GATEWAY_PORT=18789)

The fix aligns `gateway.port` with the TCP port range used everywhere else and adds a Doctor migration that safely removes out-of-range values from existing configs.

## User Impact

- **Fresh configs**: invalid port values are rejected at config-load time with a descriptive error.
- **Existing configs**: `openclaw doctor --fix` automatically removes out-of-range `gateway.port` values and logs a change message. The gateway then uses the default port (18789), which matches the previous runtime fallback behavior.
- **Upgrade safety**: validated by Doctor migration + raw validation integration test.

## Evidence

### 1. Schema validation — BEFORE vs AFTER

**BEFORE** — `gateway.port: 65536` passed validation with `ok: true`:

```sh
$ node --import tsx -e "
import { validateConfigObjectRaw } from './src/config/validation.ts';
console.log(JSON.stringify(validateConfigObjectRaw({gateway:{port:65536}}), null, 2));
"
# {"ok": true, "config": {"gateway": {"port": 65536}}}
```

**AFTER** — `gateway.port: 65536` is now rejected:

```sh
$ node --import tsx -e "
import { validateConfigObjectRaw } from './src/config/validation.ts';
console.log(JSON.stringify(validateConfigObjectRaw({gateway:{port:65536}}), null, 2));
"
# {
#   "ok": false,
#   "issues": [{
#     "path": "gateway.port",
#     "message": "Too big: expected number to be <=65535 (maximum: 65535)"
#   }]
# }

$ node --import tsx -e "
import { validateConfigObjectRaw } from './src/config/validation.ts';
const r = validateConfigObjectRaw({gateway:{port:0}});
console.log('ok:', r.ok);
"
# ok: false — port 0 rejected (below TCP min)

$ node --import tsx -e "
import { validateConfigObjectRaw } from './src/config/validation.ts';
console.log('65535 ok:', validateConfigObjectRaw({gateway:{port:65535}}).ok);
console.log('1 ok:', validateConfigObjectRaw({gateway:{port:1}}).ok);
"
# 65535 ok: true
# 1 ok: true
```

### 2. Doctor migration — upgrade path proof

**port 65536** — migration removes the value, validation passes on the result:

```sh
$ node --import tsx -e "
import { applyLegacyDoctorMigrations } from './src/commands/doctor/shared/legacy-config-compat.js';
import { validateConfigObjectRaw } from './src/config/validation.ts';
const raw = {gateway:{port:65536}};
const { next, changes } = applyLegacyDoctorMigrations(raw);
console.log('changes:', JSON.stringify(changes));
const result = validateConfigObjectRaw(next);
console.log('validation ok:', result.ok);
"
# changes: ["Removed out-of-range gateway.port (65536). Valid TCP ports are 1–65535; the gateway will use the default port 18789."]
# validation ok: true
```

**port 0** — similarly removed:

```sh
$ node --import tsx -e "
import { applyLegacyDoctorMigrations } from './src/commands/doctor/shared/legacy-config-compat.js';
const raw = {gateway:{port:0}};
const { next, changes } = applyLegacyDoctorMigrations(raw);
console.log('changes:', JSON.stringify(changes));
console.log('next:', JSON.stringify(next));
"
# changes: ["Removed out-of-range gateway.port (0). Valid TCP ports are 1–65535; the gateway will use the default port 18789."]
# next: {}
```

**port 65535 (valid)** — no migration triggered, no changes:

```sh
$ node --import tsx -e "
import { applyLegacyDoctorMigrations } from './src/commands/doctor/shared/legacy-config-compat.js';
const raw = {gateway:{port:65535}};
const { changes } = applyLegacyDoctorMigrations(raw);
console.log('changes:', changes);
"
# changes: []
```

**Other gateway keys preserved** — removing port 65536 keeps bind:

```sh
$ node --import tsx -e "
import { applyLegacyDoctorMigrations } from './src/commands/doctor/shared/legacy-config-compat.js';
const raw = {gateway:{port:65536, bind:'loopback'}};
const { next, changes } = applyLegacyDoctorMigrations(raw);
console.log('changes:', changes);
console.log('next:', JSON.stringify(next));
"
# changes: ["Removed out-of-range gateway.port (65536)..."]
# next: {"gateway":{"bind":"loopback"}}
```

### 3. Test results

```
✓ validation.policy.test.ts — 8 tests passed (new: "rejects gateway.port values outside the 1–65535 TCP range")
✓ legacy-config-migrate.test.ts — 157 tests passed (6 new: gateway.port out-of-range repair migrate)
```