### PR TITLE
fix(doctor): repair ALTER-appended operator approval schema instead of wedging startup

### DIFF
--- a/src/state/openclaw-state-db-operator-approval-migration.test.ts
+++ b/src/state/openclaw-state-db-operator-approval-migration.test.ts
@@ -24,17 +24,59 @@ function legacyTwoKindCreateSql(): string {
     .replace(/'exec',\s*'plugin',\s*'system-agent'/, "'exec', 'plugin'");
 }
 
-function seedRow(db: DatabaseSync, kind: string): void {
-  db.exec(`
+function withoutResolutionRefColumn(sql: string): string {
+  const resolutionRefStart = sql.indexOf("\n  resolution_ref ");
+  const followingColumnStart = sql.indexOf("\n  kind ", resolutionRefStart);
+  if (resolutionRefStart < 0 || followingColumnStart < 0) {
+    throw new Error("resolution_ref column not found");
+  }
+  return sql.slice(0, resolutionRefStart) + sql.slice(followingColumnStart);
+}
+
+function createAlterAppendedLegacyTable(db: DatabaseSync, strict: boolean): void {
+  const createSql = withoutResolutionRefColumn(
+    strict ? legacyTwoKindCreateSql().replace(/\);$/u, ") STRICT;") : legacyTwoKindCreateSql(),
+  );
+  db.exec(createSql);
+  db.exec("ALTER TABLE operator_approvals ADD COLUMN resolution_ref TEXT;");
+}
+
+const RESOLUTION_REF = "ref0000000000000000000000000000000000000000";
+
+function seedRow(
+  db: DatabaseSync,
+  kind: string,
+  resolutionRef: string | null = RESOLUTION_REF,
+  approvalId = "a1",
+): void {
+  db.prepare(`
     INSERT INTO operator_approvals (
       approval_id, resolution_ref, kind, status, presentation_json,
       reviewer_device_ids_json, audience_session_keys_json, runtime_epoch,
       created_at_ms, expires_at_ms, updated_at_ms
     ) VALUES (
-      'a1', 'ref0000000000000000000000000000000000000000', '${kind}',
-      'pending', '{}', '[]', '[]', 1, 1, 1, 1
+      ?, ?, ?, 'pending', '{}', '[]', '[]', 1, 1, 1, 1
     );
-  `);
+  `).run(approvalId, resolutionRef, kind);
+}
+
+function expectAlterAppendedLegacyRepair(strict: boolean): void {
+  const db = new DatabaseSync(":memory:");
+  createAlterAppendedLegacyTable(db, strict);
+  seedRow(db, "exec");
+
+  expect(repairOperatorApprovalSchema(db)).toEqual([
+    "Migrated shared state operator approvals → OpenClaw system changes",
+  ]);
+
+  expect(() => assertCanonicalOperatorApprovalKinds(db, ":memory:")).not.toThrow();
+  expect(
+    db.prepare("SELECT approval_id, kind, resolution_ref FROM operator_approvals").all(),
+  ).toEqual([{ approval_id: "a1", kind: "exec", resolution_ref: RESOLUTION_REF }]);
+  expect(
+    db.prepare("SELECT strict FROM pragma_table_list WHERE name = 'operator_approvals'").get(),
+  ).toEqual({ strict: 1 });
+  db.close();
 }
 
 describe("repairOperatorApprovalKinds", () => {
@@ -51,11 +93,48 @@ describe("repairOperatorApprovalKinds", () => {
     ]);
 
     expect(() => assertCanonicalOperatorApprovalKinds(db, ":memory:")).not.toThrow();
-    const rows = db.prepare("SELECT approval_id, kind FROM operator_approvals").all();
-    expect(rows).toEqual([{ approval_id: "a1", kind: "exec" }]);
+    const rows = db
+      .prepare("SELECT approval_id, kind, resolution_ref FROM operator_approvals")
+      .all();
+    expect(rows).toEqual([{ approval_id: "a1", kind: "exec", resolution_ref: RESOLUTION_REF }]);
     expect(
       db.prepare("SELECT strict FROM pragma_table_list WHERE name = 'operator_approvals'").get(),
     ).toEqual({ strict: 1 });
+    db.close();
+  });
+
+  it("migrates the ALTER-appended non-STRICT legacy shape", () => {
+    expectAlterAppendedLegacyRepair(false);
+  });
+
+  it("migrates the ALTER-appended STRICT legacy shape", () => {
+    expectAlterAppendedLegacyRepair(true);
+  });
+
+  it("drops pre-ref rows that violate the canonical resolution_ref shape", () => {
+    const db = new DatabaseSync(":memory:");
+    createAlterAppendedLegacyTable(db, false);
+    seedRow(db, "exec");
+    seedRow(db, "exec", null, "a2-null-ref");
+    seedRow(db, "plugin", "short", "a3-bad-ref");
+    // Non-STRICT legacy tables can hold a BLOB in the TEXT column; it must be
+    // filtered out or the STRICT destination insert aborts the whole repair.
+    db.prepare(`
+      INSERT INTO operator_approvals (
+        approval_id, resolution_ref, kind, status, presentation_json,
+        reviewer_device_ids_json, audience_session_keys_json, runtime_epoch,
+        created_at_ms, expires_at_ms, updated_at_ms
+      ) VALUES ('a4-blob-ref', ?, 'exec', 'pending', '{}', '[]', '[]', 1, 1, 1, 1);
+    `).run(Buffer.from("ref0000000000000000000000000000000000000000"));
+
+    expect(repairOperatorApprovalSchema(db)).toEqual([
+      "Migrated shared state operator approvals → OpenClaw system changes",
+    ]);
+
+    expect(() => assertCanonicalOperatorApprovalKinds(db, ":memory:")).not.toThrow();
+    expect(db.prepare("SELECT approval_id, resolution_ref FROM operator_approvals").all()).toEqual([
+      { approval_id: "a1", resolution_ref: RESOLUTION_REF },
+    ]);
     db.close();
   });
 
@@ -66,7 +145,7 @@ describe("repairOperatorApprovalKinds", () => {
     db.close();
   });
 
-  it("refuses to replace a look-alike table with the same columns but different constraints", () => {
+  it("refuses to replace an arbitrarily different table", () => {
     const db = new DatabaseSync(":memory:");
     // Same column names, but a different (non-canonical) kind constraint — the
     // fail-closed guard must not copy its rows under today's schema.

--- a/src/state/openclaw-state-db-operator-approval-migration.ts
+++ b/src/state/openclaw-state-db-operator-approval-migration.ts
@@ -89,8 +89,21 @@ function canonicalOperatorApprovalCreateSql(): string {
   return OPENCLAW_STATE_SCHEMA_SQL.slice(start, end + tableTerminator.length);
 }
 
-// The only legacy shape this repair may destructively replace is the exact
-// prior canonical table with the two-kind constraint (before 'system-agent').
+function alterAppendedResolutionRefCreateSql(sql: string): string {
+  const resolutionRefStart = sql.indexOf("\n  resolution_ref ");
+  const followingColumnStart = sql.indexOf("\n  kind ", resolutionRefStart);
+  const tailColumn = "\n  consumed_by TEXT,";
+  const tailColumnStart = sql.indexOf(tailColumn, followingColumnStart);
+  if (resolutionRefStart < 0 || followingColumnStart < 0 || tailColumnStart < 0) {
+    throw new Error("canonical operator approval resolution reference schema is unavailable");
+  }
+  const withoutResolutionRef = sql.slice(0, resolutionRefStart) + sql.slice(followingColumnStart);
+  return withoutResolutionRef.replace(tailColumn, `${tailColumn} resolution_ref TEXT,`);
+}
+
+// The only legacy shapes this repair may destructively replace are the exact
+// prior canonical table with the two-kind constraint (before 'system-agent')
+// and its shipped ALTER-appended resolution_ref variant.
 // Matching column names alone is not fail-closed: a table with the same names
 // but different constraints/defaults/types would get its rows copied under a
 // schema that silently discards those semantics.
@@ -103,10 +116,13 @@ function hasExactLegacyOperatorApprovalSchema(db: DatabaseSync): boolean {
     // sqlite_master stores the CREATE statement without "IF NOT EXISTS".
     .replace("CREATE TABLE IF NOT EXISTS operator_approvals (", "CREATE TABLE operator_approvals (")
     .replace(/'exec',\s*'plugin',\s*'system-agent'/, "'exec', 'plugin'");
-  const expectedStrictLegacy = normalizeDdl(exactStrictLegacy);
-  const expectedFlexibleLegacy = normalizeDdl(exactStrictLegacy.replace(/\) STRICT;$/u, ");"));
   const normalizedLive = normalizeDdl(live);
-  return normalizedLive === expectedStrictLegacy || normalizedLive === expectedFlexibleLegacy;
+  const alterAppendedStrictLegacy = alterAppendedResolutionRefCreateSql(exactStrictLegacy);
+  return [exactStrictLegacy, alterAppendedStrictLegacy].some((strictLegacy) =>
+    [strictLegacy, strictLegacy.replace(/\) STRICT;$/u, ");")]
+      .map(normalizeDdl)
+      .includes(normalizedLive),
+  );
 }
 
 function canonicalCreateSql(): string {
@@ -114,6 +130,22 @@ function canonicalCreateSql(): string {
     "CREATE TABLE IF NOT EXISTS operator_approvals (",
     "CREATE TABLE operator_approvals_migration_new (",
   );
+}
+
+// Rebuilding the table drops its indexes. Replay only the operator-approval
+// index statements: executing the full schema here fails on many-versions-
+// behind databases whose other tables still lack columns the later additive
+// and STRICT repairs add (e.g. "no such column: agent_id").
+function operatorApprovalIndexSql(): string {
+  const statements = OPENCLAW_STATE_SCHEMA_SQL.split(";")
+    .map((statement) => statement.trim())
+    .filter((statement) =>
+      /^CREATE (?:UNIQUE )?INDEX IF NOT EXISTS idx_operator_approvals_/.test(statement),
+    );
+  if (statements.length === 0) {
+    throw new Error("canonical operator approval index schema is unavailable");
+  }
+  return `${statements.join(";\n")};`;
 }
 
 function repairOperatorApprovalKinds(db: DatabaseSync): boolean {
@@ -130,13 +162,21 @@ function repairOperatorApprovalKinds(db: DatabaseSync): boolean {
   // recreate an empty canonical table and abandon them.
   runSqliteImmediateTransactionSync(db, () => {
     db.exec(canonicalCreateSql());
+    // The ALTER-appended variant is nullable, so pre-ref rows can hold NULL or
+    // junk that violates the canonical NOT NULL/shape CHECK. Approvals are
+    // transient runtime state: drop nonconforming rows instead of aborting the
+    // whole repair and re-wedging startup. The filter mirrors the canonical
+    // CHECK exactly.
     db.exec(`
       INSERT INTO operator_approvals_migration_new (${columns})
-      SELECT ${columns} FROM operator_approvals;
+      SELECT ${columns} FROM operator_approvals
+      WHERE typeof(resolution_ref) = 'text'
+        AND length(resolution_ref) = 43
+        AND resolution_ref NOT GLOB '*[^A-Za-z0-9_-]*';
       DROP TABLE operator_approvals;
       ALTER TABLE operator_approvals_migration_new RENAME TO operator_approvals;
     `);
-    db.exec(OPENCLAW_STATE_SCHEMA_SQL);
+    db.exec(operatorApprovalIndexSql());
   });
   return true;
 }

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2101,6 +2101,37 @@ describe("openclaw state database", () => {
     expect(migratedSql.sql).toContain("'system-agent'");
   });
 
+  it("does not recursively recommend doctor when operator approval repair refuses a shape", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const database = openOpenClawStateDatabase(options);
+    const databasePath = database.path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const customizedDb = new DatabaseSync(databasePath);
+    const currentSql = (
+      customizedDb
+        .prepare(
+          "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'operator_approvals'",
+        )
+        .get() as { sql: string }
+    ).sql;
+    customizedDb.exec("ALTER TABLE operator_approvals RENAME TO operator_approvals_current");
+    customizedDb.exec(
+      currentSql.replace("'exec', 'plugin', 'system-agent'", "'exec', 'plugin', 'custom-thing'"),
+    );
+    customizedDb.exec("DROP TABLE operator_approvals_current");
+    customizedDb.close();
+
+    const result = repairOpenClawStateDatabaseSchema(options);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("automatic repair refused the unrecognized schema shape"),
+    ]);
+    expect(result.warnings[0]).not.toContain("run openclaw doctor --fix");
+  });
+
   it("adds managed-image typed columns before creating canonical indexes", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -850,9 +850,15 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
     );
     return { changes, warnings: [] };
   } catch (err) {
+    // Reaching this catch inside doctor means repair itself refused or failed,
+    // so the runtime asserts' "run openclaw doctor --fix" advice is circular here.
+    const reason = String(err).replace(
+      /has a legacy ([a-z ]+) schema; run openclaw doctor --fix to migrate it\./u,
+      "has a legacy $1 schema; automatic repair refused the unrecognized schema shape.",
+    );
     return {
       changes: [],
-      warnings: [`Failed migrating shared state database schema at ${pathname}: ${String(err)}`],
+      warnings: [`Failed migrating shared state database schema at ${pathname}: ${reason}`],
     };
   } finally {
     if (db.isOpen) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a hard startup wedge where `openclaw gateway` refuses to start and `openclaw doctor --fix` circularly reports "has a legacy operator approval schema; run openclaw doctor --fix to migrate it" — leaving the user with no working path. Hit in production on a macOS install whose state database predates the `resolution_ref` column.

## Why This Change Was Made

The fail-closed matcher in `openclaw-state-db-operator-approval-migration.ts` only accepted the exact canonical-position legacy DDL. A real shipped upgrade path added `resolution_ref` via `ALTER TABLE … ADD COLUMN` (see `ensureAdditiveStateColumns`), producing a tail-appended nullable column. That shape failed the exact match, the repair no-oped, and `assertCanonicalStateSchemaShape` threw the same message doctor tells you to fix with doctor.

Three fixes, all fail-closed:
1. The matcher now accepts exactly four enumerated shapes: canonical-position or ALTER-appended `resolution_ref`, each STRICT or non-STRICT. Arbitrary schema differences still refuse migration.
2. The copy filters rows that cannot satisfy the canonical `resolution_ref TEXT NOT NULL CHECK(length = 43, charset)` constraint (pre-ref rows hold NULL; non-STRICT tables can even hold BLOBs). Approvals are transient runtime state, so nonconforming rows are dropped rather than aborting the repair and re-wedging startup.
3. The table rebuild now replays only the operator-approval index statements instead of the entire canonical schema — executing the full schema mid-repair fails on many-versions-behind databases whose other tables still lack columns the later additive/STRICT repairs add ("no such column: agent_id").

Also: when the repair itself refuses or fails inside doctor, the warning no longer recursively recommends `doctor --fix`.

## User Impact

Users on older state databases can upgrade again: `openclaw doctor --fix` completes (verified against the affected production database: operator approvals migrated, 83 tables migrated to STRICT typing) and the gateway starts. No behavior change for canonical databases.

## Evidence

- `node scripts/run-vitest.mjs src/state/openclaw-state-db-operator-approval-migration.test.ts src/state/openclaw-state-db.test.ts` — 85 tests pass (new coverage: ALTER-appended STRICT/non-STRICT repair, NULL/short/BLOB `resolution_ref` row filtering, fail-closed refusal of unrecognized shapes, non-circular doctor warning).
- `pnpm check:changed` gate clean (format, typechecks, lint, boundaries, database-first guards).
- Live proof: doctor --fix on the wedged production DB completed and the gateway now serves (previously hard-wedged).
