### PR TITLE
fix(nostr): accept uppercase Bech32 keys in setup and DM targeting

### DIFF
--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -159,7 +159,7 @@ describe("nostr outbound cfg threading", () => {
   });
 
   it("recognizes uppercase npub targets", () => {
-    expect(nostrPlugin.messaging?.targetResolver?.looksLikeId("NPUB1XYZ123")).toBe(true);
+    expect(nostrPlugin.messaging?.targetResolver?.looksLikeId?.("NPUB1XYZ123")).toBe(true);
   });
 
   it("backs declared message adapter capabilities with outbound sends", async () => {

--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -158,6 +158,10 @@ describe("nostr outbound cfg threading", () => {
     await cleanup.stop();
   });
 
+  it("recognizes uppercase npub targets", () => {
+    expect(nostrPlugin.messaging?.targetResolver?.looksLikeId("NPUB1XYZ123")).toBe(true);
+  });
+
   it("backs declared message adapter capabilities with outbound sends", async () => {
     installOutboundRuntime();
     const { cleanup, sendDm } = await startOutboundAccount();

--- a/extensions/nostr/src/channel.setup.test.ts
+++ b/extensions/nostr/src/channel.setup.test.ts
@@ -1,0 +1,19 @@
+// Nostr tests cover the lightweight setup plugin behavior.
+import { nip19 } from "nostr-tools";
+import { describe, expect, it } from "vitest";
+import { nostrSetupPlugin } from "./channel.setup.js";
+import { TEST_HEX_PRIVATE_KEY } from "./test-fixtures.js";
+
+describe("nostr setup plugin", () => {
+  it("accepts uppercase bech32 private keys", () => {
+    const nsec = nip19.nsecEncode(Buffer.from(TEST_HEX_PRIVATE_KEY, "hex")).toUpperCase();
+
+    expect(
+      nostrSetupPlugin.setup?.validateInput?.({
+        cfg: {},
+        accountId: "default",
+        input: { privateKey: nsec },
+      } as never),
+    ).toBeNull();
+  });
+});

--- a/extensions/nostr/src/channel.setup.ts
+++ b/extensions/nostr/src/channel.setup.ts
@@ -91,7 +91,11 @@ function resolveSetupNostrAccount(params: {
 }
 
 function looksLikeNostrPrivateKey(privateKey: string): boolean {
-  return privateKey.startsWith("nsec1") || /^[0-9a-fA-F]{64}$/.test(privateKey);
+  return (
+    privateKey.startsWith("nsec1") ||
+    privateKey.startsWith("NSEC1") ||
+    /^[0-9a-fA-F]{64}$/.test(privateKey)
+  );
 }
 
 const nostrSetupAdapter = createNostrSetupAdapter({

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -137,7 +137,11 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = createChatChanne
       targetResolver: {
         looksLikeId: (input) => {
           const trimmed = input.trim();
-          return trimmed.startsWith("npub1") || /^[0-9a-fA-F]{64}$/.test(trimmed);
+          return (
+            trimmed.startsWith("npub1") ||
+            trimmed.startsWith("NPUB1") ||
+            /^[0-9a-fA-F]{64}$/.test(trimmed)
+          );
         },
         hint: "<npub|hex pubkey|nostr:npub...>",
       },

--- a/extensions/nostr/src/nostr-bus.test.ts
+++ b/extensions/nostr/src/nostr-bus.test.ts
@@ -62,6 +62,18 @@ describe("validatePrivateKey", () => {
   });
 
   describe("nsec format", () => {
+    it("accepts uppercase bech32 private keys", () => {
+      const nsec = nip19.nsecEncode(Buffer.from(TEST_HEX_PRIVATE_KEY, "hex"));
+
+      expect(validatePrivateKey(nsec.toUpperCase())).toEqual(validatePrivateKey(nsec));
+    });
+
+    it("rejects mixed-case bech32 private keys", () => {
+      const nsec = nip19.nsecEncode(Buffer.from(TEST_HEX_PRIVATE_KEY, "hex"));
+
+      expectThrowsError(() => validatePrivateKey(`N${nsec.slice(1)}`));
+    });
+
     it("rejects invalid nsec (wrong checksum)", () => {
       const badNsec = "nsec1invalidinvalidinvalidinvalidinvalidinvalidinvalidinvalid";
       expectThrowsError(() => validatePrivateKey(badNsec));
@@ -112,6 +124,14 @@ describe("normalizePubkey", () => {
 
     it("trims surrounding whitespace before decoding", () => {
       expect(normalizePubkey(`  ${NPUB}  `)).toBe(HEX);
+    });
+
+    it("decodes uppercase bech32 public keys", () => {
+      expect(normalizePubkey(NPUB.toUpperCase())).toBe(HEX);
+    });
+
+    it("rejects mixed-case bech32 public keys", () => {
+      expectThrowsError(() => normalizePubkey(`N${NPUB.slice(1)}`));
     });
   });
 });

--- a/extensions/nostr/src/nostr-key-utils.ts
+++ b/extensions/nostr/src/nostr-key-utils.ts
@@ -8,7 +8,7 @@ export function validatePrivateKey(key: string): Uint8Array {
   const trimmed = key.trim();
 
   // Handle nsec (bech32) format
-  if (trimmed.startsWith("nsec1")) {
+  if (trimmed.startsWith("nsec1") || trimmed.startsWith("NSEC1")) {
     const decoded = nip19.decode(trimmed);
     if (decoded.type !== "nsec") {
       throw new Error("Invalid nsec key: wrong type");
@@ -44,7 +44,7 @@ export function normalizePubkey(input: string): string {
   const trimmed = input.trim();
 
   // npub format - decode to hex
-  if (trimmed.startsWith("npub1")) {
+  if (trimmed.startsWith("npub1") || trimmed.startsWith("NPUB1")) {
     const decoded = nip19.decode(trimmed);
     if (decoded.type !== "npub" || typeof decoded.data !== "string") {
       throw new Error("Invalid npub key");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Nostr users could not configure an all-uppercase NSEC private key or send to an all-uppercase NPUB target. Bech32 permits an encoding to be entirely lowercase or entirely uppercase, but OpenClaw rejected the uppercase form before `nostr-tools` could decode it.

## Why This Change Was Made

The Nostr key boundary now recognizes both canonical lowercase prefixes and valid all-uppercase prefixes, then continues to delegate checksum and mixed-case validation to `nostr-tools`. The lightweight setup entry and target shape detector follow the same rule; mixed-case Bech32 remains rejected.

## User Impact

Users can paste uppercase NSEC/NPUB values, including values copied from uppercase QR representations, into Nostr setup and DM targets without converting them to lowercase first.

## Evidence

- Regression red on `origin/main`: four focused assertions failed for uppercase NSEC parsing, uppercase NPUB normalization, setup validation, and target recognition.
- Focused green after the current-main rebase: `channel.outbound.test.ts`, `channel.setup.test.ts`, and `nostr-bus.test.ts` passed 28/28; the final review run added `session-route.test.ts` and passed 29/29.
- Affected Nostr suite: remaining focused groups passed 78/78 and 135/135 before the test-only control update; production code did not change afterward.
- The exact extensions test TypeScript config passed: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`.
- Formatting, `git diff --check`, targeted Oxlint, and Codex review passed on the six changed files.
- Live NIP-04 proof against `wss://relay.nostr.net` with randomly generated one-use keys:
  - control on `origin/main`: lowercase NSEC/NPUB published, was queried back from the relay, and decrypted successfully;
  - before: uppercase NSEC and NPUB were both rejected before publish;
  - after: uppercase NSEC and NPUB were accepted, and the encrypted DM published, was queried back, and decrypted successfully.
- The full changed-file gate is left to official CI because the local Node 22.22.0 runtime is below the repository's supported 22.22.3 floor.
