### PR TITLE
fix(heartbeat): remove abort listener on manual stop

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -2908,6 +2908,7 @@ export function startHeartbeatRunner(opts: {
   updateConfig(state.cfg);
 
   const cleanup = () => {
+    opts.abortSignal?.removeEventListener("abort", cleanup);
     if (state.stopped) {
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

The `cleanup` function in `startHeartbeatRunner` is registered as an abort listener via `addEventListener("abort", cleanup, { once: true })`. It is also returned as `stop` for manual teardown. When called manually via `stop()`, the abort listener was never removed, keeping a stale reference on the `AbortSignal`.

## Why This Change Was Made

Same pattern as #109708 and #109868: exposed cleanup functions that double as abort listeners must detach themselves on manual invocation to prevent listener leaks.

## Evidence

- Existing heartbeat-runner scheduler tests continue to pass (25/28, the 3 timing-related failures are pre-existing flaky tests that also fail on main)
- The fix is a single line addition of `removeEventListener` at the top of `cleanup`, mirroring the established pattern in `channel-runtime-contexts.ts` and `compaction-safety-timeout.ts`

## Merge Risk

Low. The `removeEventListener` call is a no-op if the listener was already auto-removed by `{ once: true }` on abort, and correctly detaches it when `stop()` is called manually.