### PR TITLE
fix(narrator): remove abort listener on manual stopTurn

### DIFF
--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -133,6 +133,7 @@ function createProgressNarrator(params: {
   };
 
   const stopTurn = () => {
+    params.abortSignal?.removeEventListener("abort", stopTurn);
     if (!turnActive) {
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

The `stopTurn` function in the progress narrator is registered as an abort listener on `params.abortSignal`. When `stopTurn()` is called manually by callers (it is returned in the public API), the abort listener was never removed, keeping a stale reference on the `AbortSignal`.

## Why This Change Was Made

Same pattern as #109708 and #109868 and #109879: exposed cleanup functions that also serve as abort listeners must self-detach on manual invocation to prevent listener leaks.

## Evidence

- Existing progress-narrator tests: 23/23 passed
- The fix is a single line: `params.abortSignal?.removeEventListener("abort", stopTurn)` at the top of `stopTurn`, matching the established pattern

## Merge Risk

Low. The `removeEventListener` call is harmless when the listener was already auto-removed by `{ once: true }`, and correctly detaches it on manual `stopTurn()` calls.