### PR TITLE
fix(proxy): guard JSON.parse in proxy error response parsing

### DIFF
--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -198,7 +198,11 @@ async function readProxyErrorData(
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Proxy error body stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(new TextDecoder().decode(bytes)) as { error?: string };
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as { error?: string };
+  } catch {
+    return undefined;
+  }
 }
 
 async function readProxySseChunk(


### PR DESCRIPTION
## What Problem This Solves

Malformed JSON in proxy error responses causes an unhandled `JSON.parse` exception, crashing the proxy request handler instead of returning a graceful error to the caller.

## Why This Change Was Made

Single try-catch wrap around `JSON.parse` at the proxy error boundary. On parse failure, returns `undefined` which causes the caller at proxy.ts:332 to fall back to the generic `Proxy error: {status} {statusText}` message — consistent with how other network error paths behave.

## Evidence

```
$ npx vitest run src/agents/runtime/proxy.test.ts --no-coverage

 RUN  v4.1.9 /home/0668001435/.openclaw/browser/openclaw

 Test Files  2 passed (2)
      Tests  28 passed (28)
   Start at  17:16:00
   Duration  5.39s (transform 3.53s, setup 2.32s, import 1.32s, tests 1.25s, environment 0ms)
```

## Merge Risk

Low — 5-line defensive try-catch at a single call site. Falls back to existing generic error path on failure.
