### PR TITLE
fix(ci): keep startup memory gate above runner variance

### DIFF
--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -99,9 +99,9 @@ function resolveDefaultLimitsMb(platform = process.platform) {
     // Plugin discovery is heavier than help, but must stay below the doctor/channel
     // runtime graph that an empty metadata-only invocation must not import.
     pluginsList: platform === "darwin" ? 500 : 400,
-    // Node 24 status startup sits near 400 MB; retain regression signal without
-    // failing on sub-megabyte runner RSS variance.
-    statusJson: 425,
+    // Node 24 status startup reaches ~430 MB on current Linux runner images;
+    // retain useful regression headroom without failing on allocator variance.
+    statusJson: 450,
     gatewayStatus: 500,
   };
 }

--- a/test/scripts/check-cli-startup-memory.test.ts
+++ b/test/scripts/check-cli-startup-memory.test.ts
@@ -92,7 +92,7 @@ describe("check-cli-startup-memory", () => {
   });
 
   it("keeps status startup headroom above Linux runner RSS variance", () => {
-    expect(testing.resolveDefaultLimitsMb("linux").statusJson).toBe(425);
+    expect(testing.resolveDefaultLimitsMb("linux").statusJson).toBe(450);
   });
 
   it("uses the median of three cold-start RSS samples", () => {
@@ -115,10 +115,11 @@ describe("check-cli-startup-memory", () => {
       return;
     }
 
-    const helpSamplesMb = [120, 110, 80];
+    const helpLimitMb = testing.resolveDefaultLimitsMb(process.platform).help;
+    const helpSamplesMb = [helpLimitMb + 20, helpLimitMb + 10, 80];
 
     expect(() => runStartupMemoryCheckWithHelpSamples(helpSamplesMb)).toThrow(
-      "--help median max RSS 110.0 MB exceeded 100 MB",
+      `--help median max RSS ${(helpLimitMb + 10).toFixed(1)} MB exceeded ${helpLimitMb} MB`,
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where otherwise-green pull requests cannot pass the required CI gate because current Linux runner images report stable `status --json` startup RSS around 426–429 MB, just above the 425 MB budget.

## Why This Change Was Made

Recalibrates only the status-command budget to 450 MB. The other startup budgets stay unchanged, and the status gate keeps roughly 20 MB of regression headroom above current measurements. The adjacent median-sampling test now derives its budget from the active platform, removing a pre-existing Darwin-only test failure.

## User Impact

No product behavior changes. Maintainer CI keeps detecting meaningful CLI startup-memory regressions without rejecting current runner allocator behavior.

## Evidence

- Before: exact-head runs [29569536799](https://github.com/openclaw/openclaw/actions/runs/29569536799) and [29570108197](https://github.com/openclaw/openclaw/actions/runs/29570108197) reported three-sample medians of 426.7 MB and 427.5 MB while all affected-PR checks passed.
- Historical comparison: [29562623838](https://github.com/openclaw/openclaw/actions/runs/29562623838) reported 404.8–408.1 MB on the previous runner behavior.
- `node scripts/run-vitest.mjs test/scripts/check-cli-startup-memory.test.ts`: 14 tests passed on macOS.
- `node scripts/check-changed.mjs -- scripts/check-cli-startup-memory.mjs test/scripts/check-cli-startup-memory.test.ts`: green on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/29570899772).
- Fresh uncommitted and branch autoreview passes: clean, no accepted/actionable findings.

AI-assisted: implementation and validation performed with Codex; maintainer understands the change.
