### PR TITLE
fix(ui): blend chat pane header with window chrome and stroke workspace chip icons

### DIFF
--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -2143,7 +2143,6 @@ class ChatPane extends OpenClawLightDomElement {
     });
     return renderChatPaneHeader({
       paneId: this.paneId,
-      active: this.active,
       narrow: this.narrow,
       mergedChrome: this.mergedChrome,
       title: this.paneTitle,

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -32,7 +32,6 @@ function mount(patch: Partial<ChatPaneHeaderProps> = {}) {
   containers.push(container);
   const props: ChatPaneHeaderProps = {
     paneId: "pane-1",
-    active: true,
     narrow: false,
     mergedChrome: false,
     title: "Session title",

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -16,7 +16,6 @@ export type ChatPaneHeaderAction = "reveal" | "copy-path" | "copy-branch";
 
 type ChatPaneHeaderProps = {
   paneId: string;
-  active: boolean;
   narrow: boolean;
   mergedChrome: boolean;
   title: string;
@@ -123,10 +122,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
   const copied = props.copiedAction === "copy-path" || props.copiedAction === "copy-branch";
 
   return html`
-    <div
-      class="chat-pane__header ${props.active ? "chat-pane__header--active" : ""}"
-      @mousedown=${beginNativeWindowDrag}
-    >
+    <div class="chat-pane__header" @mousedown=${beginNativeWindowDrag}>
       ${props.mergedChrome
         ? html`<openclaw-tooltip .content=${t("nav.expand")}>
             <button

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -134,10 +134,6 @@ openclaw-chat-pane {
   -webkit-user-select: none;
 }
 
-.chat-pane__header--active {
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-}
-
 /* The title hugs its text so the workspace chip sits right after it (the
    header's shared 8px gap provides the spacing); it may shrink with ellipsis
    when space runs out, and the action row pushes itself to the right edge. */
@@ -204,6 +200,13 @@ openclaw-chat-pane {
 .chat-pane__workspace-chip svg {
   width: 14px;
   height: 14px;
+  /* Lucide outline icons: without this the paths render browser-default
+     black fill, which reads as a solid dark blob on the chip. */
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .chat-pane__workspace-menu {


### PR DESCRIPTION
## What Problem This Solves

The chat pane header renders an accent-tinted "peel" whenever the pane is active. With a single pane that is always, so the title-bar strip sits on a red-tinted band (pink in light mode) that clashes with the neutral window chrome next to it — most visibly in the macOS app where this header is the top window surface beside the traffic lights, but the same seam shows on the web next to the sidebar.

The workspace chip's folder icon (and the cloud globe for cloud-worker sessions) also rendered as solid black shapes: the Lucide outline icons in this header never received the `fill: none; stroke: currentColor` treatment, so the paths fell back to browser-default black fill — a dark blob on both themes.

## Why This Change Was Made

- The active-header wash (`.chat-pane__header--active`, 8% `--accent`) is redundant: a lone pane needs no focus marker, and split view already outlines the focused pane with the `.chat-split-view__cell--active` accent ring. Deleting the wash (rather than retinting it) leaves one canonical focus indicator and lets the header blend with the surrounding chrome in every theme. The now-unused `active` prop was removed from `ChatPaneHeaderProps` and its caller.
- The chip/cloud icon rule gains the same Lucide stroke treatment `.btn svg` uses (`fill: none; stroke: currentColor; stroke-width: 1.5px`, round caps/joins), with a comment explaining why it must stay.

## User Impact

The chat header now blends seamlessly with the window chrome on web and in the macOS app, in dark and light themes. The workspace folder and cloud icons render as proper outlined glyphs matching the muted chip text. Split view keeps a clear focused-pane indicator via the existing cell ring.

**Before / after (dark):**

| Before | After |
| --- | --- |
| ![before dark](https://artifacts.openclaw.ai/pr-header-peel-20260717/before-dark-header.png) | ![after dark](https://artifacts.openclaw.ai/pr-header-peel-20260717/after-dark-header.png) |

**Before / after (light):**

| Before | After |
| --- | --- |
| ![before light](https://artifacts.openclaw.ai/pr-header-peel-20260717/before-light-header.png) | ![after light](https://artifacts.openclaw.ai/pr-header-peel-20260717/after-light-header.png) |

**Full page before (dark):** https://artifacts.openclaw.ai/pr-header-peel-20260717/before-dark.png · **after:** https://artifacts.openclaw.ai/pr-header-peel-20260717/after-dark.png

**Split view after (active pane still marked by the cell ring):** https://artifacts.openclaw.ai/pr-header-peel-20260717/after-split-dark.png

Artifact manifest: https://artifacts.openclaw.ai/pr-header-peel-20260717/artifact-manifest.json

## Evidence

- Screenshots above captured with the Control UI e2e mock-gateway harness (`ui/src/test-helpers/control-ui-e2e.ts`) + Playwright, dark and light `colorScheme`, before and after the change on this branch.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-pane-header.test.ts ui/src/pages/chat/chat-pane.test.ts` — 49 tests pass.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` and `node scripts/run-oxlint.mjs ui/src/pages/chat ui/src/styles` — clean.
- Lane classification (`node scripts/changed-lanes.mjs`) marks this UI-only; the Blacksmith Testbox backend was unreachable (request timeout), so per repo policy the trusted-source lanes above ran locally. Full gates run on hosted CI for this PR.
- Codex autoreview (`gpt-5.6-sol`, xhigh) on the diff: clean, no actionable findings.
