### PR TITLE
fix(clickclack): cancel response body on HTTP error path

### DIFF
--- a/extensions/clickclack/src/http-client.test.ts
+++ b/extensions/clickclack/src/http-client.test.ts
@@ -96,11 +96,13 @@ function streamedErrorResponse(body: string, limit: number) {
     throw new Error("raw response.text() should not be used");
   });
 
+  const cancelBody = vi.fn(async () => undefined);
   const response = {
     ok: false,
     status: 502,
     text,
     body: {
+      cancel: cancelBody,
       getReader: () => ({
         read: async () => {
           if (readCount > 0) {
@@ -118,6 +120,7 @@ function streamedErrorResponse(body: string, limit: number) {
   return {
     response,
     cancel,
+    cancelBody,
     releaseLock,
     text,
     expectedDetail: body.slice(0, limit),
@@ -270,6 +273,7 @@ describe("ClickClack HTTP client", () => {
 
     expect(streamed.text).not.toHaveBeenCalled();
     expect(streamed.cancel).toHaveBeenCalledTimes(1);
+    expect(streamed.cancelBody).toHaveBeenCalledTimes(1);
     expect(streamed.releaseLock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -122,6 +122,7 @@ export function createClickClackClient(options: ClientOptions) {
     const response = await fetcher(`${baseUrl}${path}`, { ...init, headers: requestHeaders });
     if (!response.ok) {
       const detail = await readResponseTextLimited(response, CLICKCLACK_ERROR_BODY_LIMIT_BYTES);
+      void response.body?.cancel()?.catch(() => {});
       throw new ClickClackHttpError(response.status, detail, new Headers(response.headers));
     }
     return await readProviderJsonResponse<T>(response, "ClickClack response", {


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

`createClickClackClient.request()` uses raw `fetch` (no guarded-fetch release mechanism). On non-ok responses it reads the error body with `readResponseTextLimited` (8 KiB cap) and throws `ClickClackHttpError`. When the error body exceeds the cap, `readResponseTextPrefix` cancels the **reader** but the underlying `response.body` stream may retain unconsumed bytes, keeping the TCP connection open until GC.

## Why This Change Was Made

Add `void response.body?.cancel()?.catch(() => {})` after reading the error body, before throwing. This explicitly signals the fetch implementation to abort the TCP connection for unconsumed bytes. Follows the same pattern as `cancelUnreadResponseBody` in lmstudio and `response.body?.cancel()` in anthropic/clawrouter/venice.

## User Impact

ClickClack API error responses now release TCP connections promptly instead of waiting for GC. Successful responses are unaffected.

## Evidence

- `node scripts/run-vitest.mjs extensions/clickclack/src/http-client.test.ts --run`: **20/20 passed**.
- `git diff --check`: passed.
- Mock extended with `body.cancel`; test verifies `cancelBody` is called on the error path.
- Rebasing onto current `origin/main`: no conflicts.

### Before vs After

```
BEFORE: readResponseTextLimited(response, 8192) → reader cancelled at limit
        → TCP socket may stay ESTABLISHED for unconsumed bytes → GC cleanup

AFTER:  readResponseTextLimited(response, 8192) → reader cancelled at limit
       → response.body.cancel() → fetch aborted → TCP socket closed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)