### PR TITLE
fix(discord): cancel response body on webhook error path

### DIFF
--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -64,6 +64,7 @@ async function throwWebhookResponseError(response: Response): Promise<never> {
   const raw = await readResponseTextLimited(response, DISCORD_WEBHOOK_ERROR_BODY_LIMIT_BYTES).catch(
     () => "",
   );
+  void response.body?.cancel()?.catch(() => {});
   const parsed = coerceWebhookErrorBody(raw);
   if (response.status === 429) {
     throw new RateLimitError(response, {


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

`throwWebhookResponseError()` reads the error body with `readResponseTextLimited` (8 KiB cap) and throws a `RateLimitError` or `DiscordError`. The caller uses `proxyFetch ?? fetch` — neither provides a guarded-fetch release mechanism. When the error body exceeds the cap, unconsumed bytes keep the TCP connection open until GC.

## Why This Change Was Made

Add `void response.body?.cancel()?.catch(() => {})` after reading the error body, before the branching throw. One line covers both the 429 rate-limit path and the generic error path. Follows the `cancelUnreadResponseBody` pattern.

## User Impact

Discord webhook error responses now release TCP connections promptly. Successful webhook deliveries are unaffected.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/send.webhook.proxy.test.ts --run`: **12/12 passed**.
- `git diff --check`: passed.
- `throwWebhookResponseError` has two throw sites (429 and generic); the cancel is placed before the branching so both paths benefit.

### Before vs After

```
BEFORE: readResponseTextLimited(response, 8192) → reader cancelled at limit
        → throw RateLimitError/DiscordError → TCP may stay open

AFTER:  readResponseTextLimited(response, 8192) → reader cancelled at limit
       → response.body.cancel() → fetch aborted → throw → TCP closed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)