### PR TITLE
fix(openrouter): cancel response body on OAuth key exchange error

### DIFF
--- a/extensions/openrouter/oauth.test.ts
+++ b/extensions/openrouter/oauth.test.ts
@@ -32,6 +32,7 @@ function boundedTextErrorResponse(
   const encoded = new TextEncoder().encode(body);
   let read = false;
   const cancel = vi.fn(async () => undefined);
+  const cancelBody = vi.fn(async () => undefined);
   const releaseLock = vi.fn();
   const text = vi.fn(async () => {
     throw new Error("response.text() should not be called");
@@ -41,6 +42,7 @@ function boundedTextErrorResponse(
     status,
     headers: new Headers(),
     body: {
+      cancel: cancelBody,
       getReader: () => ({
         read: async () => {
           if (read) {
@@ -56,7 +58,7 @@ function boundedTextErrorResponse(
     text,
   } as unknown as Response;
 
-  return { response, cancel, releaseLock, text };
+  return { response, cancel, cancelBody, releaseLock, text };
 }
 
 function oversizedJsonResponse(): { response: Response; wasCanceled: () => boolean } {
@@ -364,6 +366,7 @@ describe("OpenRouter OAuth", () => {
     expect(message).not.toContain("tail-marker");
     expect(errorResponse.text).not.toHaveBeenCalled();
     expect(errorResponse.cancel).toHaveBeenCalledTimes(1);
+    expect(errorResponse.cancelBody).toHaveBeenCalledTimes(1);
     expect(errorResponse.releaseLock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/openrouter/oauth.ts
+++ b/extensions/openrouter/oauth.ts
@@ -198,6 +198,7 @@ async function exchangeOpenRouterOAuthCode(params: {
   });
   const body = await readResponseBody(response);
   if (!response.ok) {
+    void response.body?.cancel()?.catch(() => {});
     const message = extractOpenRouterError(body);
     throw new Error(
       `OpenRouter OAuth key exchange failed (${response.status})${message ? `: ${message}` : ""}`,


### PR DESCRIPTION
AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

`exchangeOpenRouterCode()` uses raw `fetch(url, { ... })` to exchange an OAuth authorization code for an API key. On non-ok responses, `readResponseBody()` reads the error body with `readResponseTextLimited` (8 KiB cap) and throws. When the error body exceeds the cap, unconsumed bytes keep the TCP connection open until GC — there is no guarded-fetch release mechanism on the raw fetch path.

## Why This Change Was Made

Add `void response.body?.cancel()?.catch(() => {})` on the error path before throwing. Follows the `cancelUnreadResponseBody` pattern.

## User Impact

OpenRouter OAuth key exchange errors now release TCP connections promptly. Successful exchanges are unaffected.

## Evidence

- `node scripts/run-vitest.mjs extensions/openrouter/oauth.test.ts --run`: **10/10 passed**.
- `git diff --check`: passed.
- Mock extended with `body.cancel`; test verifies `cancelBody` is called on the error path.

### Before vs After

```
BEFORE: readResponseTextLimited(response, 8192) → reader cancelled at limit
        → throw → TCP may stay ESTABLISHED for unconsumed bytes

AFTER:  readResponseTextLimited(response, 8192) → reader cancelled at limit
       → response.body.cancel() → fetch aborted → throw → TCP closed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)