### PR TITLE
style(infra): format spawn ps helper

### DIFF
--- a/src/infra/spawn-ps.ts
+++ b/src/infra/spawn-ps.ts
@@ -1,10 +1,7 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 
 /** Run a bounded ps probe without letting an ignored SIGTERM extend the synchronous wait. */
-export function spawnPsSync(
-  args: readonly string[],
-  timeoutMs: number,
-): SpawnSyncReturns<string> {
+export function spawnPsSync(args: readonly string[], timeoutMs: number): SpawnSyncReturns<string> {
   return spawnSync("ps", args, {
     encoding: "utf8",
     killSignal: "SIGKILL",


### PR DESCRIPTION
## Summary

Format `src/infra/spawn-ps.ts` with the repository formatter.

The file became the sole whole-repo format failure after #109731 landed. Any PR touching docs activates `pnpm format:check`, so this main-only issue blocks otherwise unrelated exact-head CI.

## Evidence

- `./node_modules/.bin/oxfmt --check src/infra/spawn-ps.ts`: passed.
- `git diff --check`: passed.
- Autoreview: no accepted or actionable findings, correctness 0.99.

Behavior-neutral formatting only.
