### PR TITLE
improve(tests): reuse device pairing database fixture

### DIFF
--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1,5 +1,5 @@
 // Covers device pairing, token, and role lifecycle behavior.
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import {
   FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -9,6 +9,7 @@ import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } from "./device-bootstrap.js";
 import {
   loadDevicePairingStoreState,
+  persistDeviceBootstrapTokenRecords,
   persistDevicePairingStoreState,
 } from "./device-pairing-store.js";
 import {
@@ -190,14 +191,23 @@ async function clearPairedOperatorApprovalBaseline(baseDir: string) {
 }
 
 const suiteRootTracker = createSuiteTempRootTracker({ prefix: "openclaw-device-pairing-" });
+let suiteBaseDir = "";
 
 async function makeDevicePairingDir(): Promise<string> {
-  return await suiteRootTracker.make("case");
+  if (!suiteBaseDir) {
+    throw new Error("device pairing test root is not initialized");
+  }
+  return suiteBaseDir;
 }
 
 describe("device pairing tokens", () => {
   beforeAll(async () => {
-    await suiteRootTracker.setup();
+    suiteBaseDir = await suiteRootTracker.setup();
+  });
+
+  beforeEach(() => {
+    persistDevicePairingStoreState({ pendingById: {}, pairedByDeviceId: {} }, suiteBaseDir, "both");
+    persistDeviceBootstrapTokenRecords({}, suiteBaseDir);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## What Problem This Solves

The device-pairing unit suite rebuilt the complete shared-state SQLite schema for almost every test case, making 58 otherwise small behavior checks take about 1.27 seconds.

## Why This Change Was Made

Reuse one suite-scoped SQLite fixture and clear the pairing and bootstrap-token tables before every case. This preserves case isolation while avoiding 50 redundant database/schema setups. Production code and CI behavior are unchanged.

## User Impact

No user-visible behavior change. Maintainer test feedback for device-pairing changes is substantially faster.

## Evidence

- Three-run median file duration: 1272.2 ms before, 164.9 ms after (87.0% reduction).
- Fresh rebased-head Testbox: `pnpm test src/infra/device-pairing.test.ts` — 58/58 passed, 187 ms test time.
- Testbox changed gate: format, core-test typecheck, changed-file lint, and guards passed.
- Autoreview: no accepted/actionable findings.
