### PR TITLE
fix(ollama): one broken local model no longer bricks interactive setup

### DIFF
--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -596,10 +596,43 @@ describe("ollama setup", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(promptAndConfigureOllama({ cfg: {}, prompter })).rejects.toThrow(
-      "Failed to inspect Ollama model llama3:8b",
-    );
+    const result = await promptAndConfigureOllama({ cfg: {}, prompter });
+
     expect(prompter.confirm).not.toHaveBeenCalled();
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("could not be inspected"),
+      "Ollama",
+    );
+    expect(result.config.models?.providers?.ollama).toBeDefined();
+  });
+
+  it("skips a broken model and continues setup when one inspection fails", async () => {
+    const prompter = {
+      ...createLocalPrompter(),
+      confirm: vi.fn(),
+    } as unknown as WizardPrompter;
+    const baseFetch = createOllamaFetchMock({
+      tags: ["broken:20b", "gemma4:e4b"],
+      capabilities: { "gemma4:e4b": ["tools"] },
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      if (requestUrl(input).endsWith("/api/show")) {
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (body.name === "broken:20b") {
+          return new Response("boom", { status: 500 });
+        }
+      }
+      return await baseFetch(input, init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await promptAndConfigureOllama({ cfg: {}, prompter });
+
+    expect(prompter.confirm).not.toHaveBeenCalled();
+    expect(prompter.note).toHaveBeenCalledWith(expect.stringContaining("broken:20b"), "Ollama");
+    expect(
+      result.config.models?.providers?.ollama?.models?.find((model) => model.id === "gemma4:e4b"),
+    ).toMatchObject({ compat: { supportsTools: true } });
   });
 
   it("checks all installed Ollama models before offering a recommended pull", async () => {

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -617,7 +617,7 @@ describe("ollama setup", () => {
     });
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       if (requestUrl(input).endsWith("/api/show")) {
-        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
         if (body.name === "broken:20b") {
           return new Response("boom", { status: 500 });
         }

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -588,9 +588,10 @@ async function inspectOllamaModelsForSetup(
   baseUrl: string,
   models: OllamaModelWithContext[],
   signal?: AbortSignal,
-): Promise<OllamaModelWithContext[]> {
+): Promise<{ inspected: OllamaModelWithContext[]; inspectionFailures: string[] }> {
   const apiBase = resolveOllamaApiBase(baseUrl);
   const inspected: OllamaModelWithContext[] = [];
+  const inspectionFailures: string[] = [];
   for (let index = 0; index < models.length; index += OLLAMA_TOOLS_SCAN_CONCURRENCY) {
     signal?.throwIfAborted();
     const batch = models.slice(index, index + OLLAMA_TOOLS_SCAN_CONCURRENCY);
@@ -627,13 +628,18 @@ async function inspectOllamaModelsForSetup(
           }
         } catch (error) {
           signal?.throwIfAborted();
-          throw new Error(`Failed to inspect Ollama model ${model.name}`, { cause: error });
+          // Fail open per model: one stale/corrupt local model (observed: a
+          // months-old pull whose /api/show returns HTTP 500) must not brick
+          // the whole setup. Unenriched models carry no capabilities, so the
+          // tools-capable selection below skips them naturally.
+          inspectionFailures.push(`${model.name}: ${formatErrorMessage(error)}`);
+          return model;
         }
       }),
     );
     inspected.push(...results);
   }
-  return inspected;
+  return { inspected, inspectionFailures };
 }
 
 async function promptAndConfigureHostBackedOllama(params: {
@@ -651,26 +657,44 @@ async function promptAndConfigureHostBackedOllama(params: {
     throw new WizardCancelledError("Ollama not reachable");
   }
 
-  let inspectedModels = await inspectOllamaModelsForSetup(
+  const firstScan = await inspectOllamaModelsForSetup(
     baseUrl,
     models.slice(0, OLLAMA_CONTEXT_ENRICH_LIMIT),
     params.signal,
   );
+  let inspectedModels = firstScan.inspected;
+  const inspectionFailures = [...firstScan.inspectionFailures];
   const supportsTools = (model: OllamaModelWithContext) =>
     model.capabilities?.includes("tools") === true;
   let hasToolsCapableModel = inspectedModels.some(supportsTools);
   if (!hasToolsCapableModel && models.length > OLLAMA_CONTEXT_ENRICH_LIMIT) {
-    const remainingModels = await inspectOllamaModelsForSetup(
+    const remainingScan = await inspectOllamaModelsForSetup(
       baseUrl,
       models.slice(OLLAMA_CONTEXT_ENRICH_LIMIT),
       params.signal,
     );
-    inspectedModels = [...inspectedModels, ...remainingModels];
-    hasToolsCapableModel = remainingModels.some(supportsTools);
+    inspectedModels = [...inspectedModels, ...remainingScan.inspected];
+    inspectionFailures.push(...remainingScan.inspectionFailures);
+    hasToolsCapableModel = remainingScan.inspected.some(supportsTools);
+  }
+  if (inspectionFailures.length > 0) {
+    await params.prompter.note(
+      [
+        "Some installed models could not be inspected and were skipped:",
+        ...inspectionFailures.slice(0, 5).map((line) => `- ${line}`),
+        ...(inspectionFailures.length > 5 ? [`…and ${inspectionFailures.length - 5} more`] : []),
+      ].join("\n"),
+      "Ollama",
+    );
   }
   const discoveredModelsByName = new Map(inspectedModels.map((model) => [model.name, model]));
   let discoveredModelNames = models.map((model) => model.name);
-  if (!hasToolsCapableModel) {
+  // A pull offer is only meaningful when inspection actually worked: if every
+  // scan failed we cannot know what is installed, so recommending a multi-GB
+  // download would be guesswork against a misbehaving server.
+  const inspectionUsable =
+    inspectedModels.length === 0 || inspectionFailures.length < inspectedModels.length;
+  if (!hasToolsCapableModel && inspectionUsable) {
     const shouldPullRecommended = await params.prompter.confirm({
       message: `No tools-capable Ollama model is installed. Pull ${OLLAMA_RECOMMENDED_TOOLS_MODEL} (${OLLAMA_RECOMMENDED_TOOLS_MODEL_SIZE})?`,
       initialValue: false,
@@ -687,11 +711,20 @@ async function promptAndConfigureHostBackedOllama(params: {
         throw new WizardCancelledError("Failed to download recommended Ollama model");
       }
       params.signal?.throwIfAborted();
-      const [recommendedModel] = await inspectOllamaModelsForSetup(
+      const recommendedScan = await inspectOllamaModelsForSetup(
         baseUrl,
         [{ name: OLLAMA_RECOMMENDED_TOOLS_MODEL }],
         params.signal,
       );
+      // Unlike the pre-existing-model scan, a just-pulled model that cannot be
+      // verified is a hard failure: configuring it unenriched would silently
+      // drop the tools capability the pull was for.
+      if (recommendedScan.inspectionFailures.length > 0) {
+        throw new WizardCancelledError(
+          `Failed to verify pulled Ollama model: ${recommendedScan.inspectionFailures[0]}`,
+        );
+      }
+      const [recommendedModel] = recommendedScan.inspected;
       if (recommendedModel) {
         discoveredModelsByName.set(recommendedModel.name, recommendedModel);
       }


### PR DESCRIPTION
Related: #109228

## What Problem This Solves

Found by live E2E: interactive Ollama setup exits 1 when any installed model's `/api/show` fails. This was observed with a months-old `gpt-oss:20b` pull returning HTTP 500 on a real machine. One stale model bricks the whole guided path.

## Why This Change Was Made

Per-model inspection now fails open: the failing model is skipped (unenriched, so it is naturally excluded from tools-capable selection), and a note lists skipped models, capped at five. Two guards remain: when every inspection fails, the multi-GB pull recommendation is suppressed because inspection is unusable and recommending a download would be guesswork; and a just-pulled recommended model that cannot be verified stays a hard failure because configuring it unenriched would silently drop the tools capability the pull was for.

## User Impact

`openclaw onboard --auth-choice ollama` now works on machines with a stale or corrupt model. Users see which models were skipped and why.

## Evidence

- `node scripts/run-vitest.mjs extensions/ollama` — 382 passed. The all-fail contract test now proves setup proceeds without a pull offer and emits a note; a new partial-failure regression proves the broken model is skipped while healthy `gemma4:e4b` keeps `supportsTools`.
- Live proof against the real broken instance: the previously crashing flow completed with 31 models configured, and the note named `gpt-oss:20b` with HTTP 500.
- Autoreview: one accepted finding (pulled-model verification must stay loud) fixed; final run clean, 0.91.
