### PR TITLE
fix(line): gateway shutdown hangs when the state store keeps failing during webhook claim writes

### DIFF
--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -321,6 +321,35 @@ describe("LINE webhook spool", () => {
     });
   });
 
+  it("bounds terminal-persistence retries so shutdown cannot hang on a failing store", async () => {
+    await withQueue(async (queue) => {
+      let reportFirstFailure: (() => void) | undefined;
+      const firstFailure = new Promise<void>((resolve) => {
+        reportFirstFailure = resolve;
+      });
+      const complete = vi.fn(async () => {
+        reportFirstFailure?.();
+        throw new Error("database busy");
+      });
+      const deliver = vi.fn(async () => {});
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue: { ...queue, complete },
+        deliver,
+      });
+      spool.start();
+      await spool.accept(callback(createEvent("event-persist-bound")));
+      await firstFailure;
+
+      await spool.stop();
+
+      expect(complete).toHaveBeenCalledTimes(8);
+      expect(deliver).toHaveBeenCalledTimes(1);
+      expect(await queue.listClaims()).toHaveLength(1);
+    });
+  });
+
   it("completes at durable turn adoption without replaying later failures", async () => {
     await withQueue(async (queue) => {
       const deliver = vi.fn(async (_event, _destination, control) => {

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -12,6 +12,7 @@ import { getLineRuntime } from "./runtime.js";
 
 const LINE_WEBHOOK_SPOOL_VERSION = 1;
 const LINE_WEBHOOK_MAX_ATTEMPTS = 8;
+const LINE_WEBHOOK_PERSIST_MAX_ATTEMPTS = 8;
 const LINE_WEBHOOK_RETRY_BASE_MS = 1_000;
 const LINE_WEBHOOK_RETRY_MAX_MS = 3 * 60_000;
 const LINE_WEBHOOK_CLAIM_STALE_MS = 30_000;
@@ -145,6 +146,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       accountId: options.accountId,
     });
   const ownerId = `${process.pid}:${randomUUID()}`;
+  const stopController = new AbortController();
   const maxAttempts = Math.max(1, options.maxAttempts ?? LINE_WEBHOOK_MAX_ATTEMPTS);
   const retryBaseMs = Math.max(0, options.retryBaseMs ?? LINE_WEBHOOK_RETRY_BASE_MS);
   const retryMaxMs = Math.max(retryBaseMs, options.retryMaxMs ?? LINE_WEBHOOK_RETRY_MAX_MS);
@@ -206,7 +208,6 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     claim: ChannelIngressQueueClaim<LineWebhookSpoolPayload>;
     label: string;
     transition: () => Promise<boolean>;
-    abortSignal?: AbortSignal;
   }): Promise<void> => {
     let persistenceAttempt = 0;
     while (true) {
@@ -220,13 +221,23 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
           throw error;
         }
         persistenceAttempt += 1;
+        if (persistenceAttempt >= LINE_WEBHOOK_PERSIST_MAX_ATTEMPTS) {
+          options.runtime.error?.(
+            danger(
+              `line: webhook event ${params.claim.id} ${params.label} persist failed after ${persistenceAttempt} attempts; holding claim for lease recovery: ${errorText(error)}`,
+            ),
+          );
+          throw error;
+        }
         const delayMs = Math.min(5_000, 250 * 2 ** Math.min(persistenceAttempt - 1, 5));
         options.runtime.error?.(
           danger(
             `line: webhook event ${params.claim.id} ${params.label} persist failed; retrying: ${errorText(error)}`,
           ),
         );
-        await sleepWithAbort(delayMs, params.abortSignal);
+        // Shutdown cuts the retry backoff, never the bounded write attempts, so
+        // a delivered turn still gets its completion persisted through stop().
+        await sleepWithAbort(delayMs, stopController.signal).catch(() => undefined);
       }
     }
   };
@@ -525,6 +536,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     },
     stop: async () => {
       running = false;
+      stopController.abort();
       if (drainTimer) {
         clearTimeout(drainTimer);
         drainTimer = undefined;


### PR DESCRIPTION
Closes #109897

## What Problem This Solves

Fixes an issue where gateway shutdown hangs forever when the shared SQLite state store keeps failing while a LINE webhook delivery is persisting its claim transition. The spool retries the failed write in an unbounded loop, `stop()` waits on the in-flight delivery, and operators end up hard-killing the process during a store failure, exactly when an unclean kill is most dangerous.

## Why This Change Was Made

The claim-write loop diverged from the bounds the core ingress drain already ships in `commitClaimWriteWithRetry` (`src/channels/message/ingress-drain.ts`): a write-attempt cap of 8, an abortable backoff sleep, and a "holding claim" give-up that leaves the row for lease recovery. This change applies the same three bounds to the LINE spool's `persistClaimTransition`. Copying the core drain's stop semantics verbatim (abandon remaining retries as soon as stop is signalled) was considered and rejected: the spool's existing tests pin that a delivered turn's completion persist keeps retrying through `stop()` so a brief store blip cannot become a redelivered duplicate - therefore shutdown cuts only the backoff sleeps, never the bounded write attempts. Migrating LINE onto the core ingress drain wholesale remains a larger architectural move for maintainers to schedule. The unused `abortSignal` parameter on the transition helper (no call site passed it) is removed.

## User Impact

Gateway shutdown now completes even while the state store is failing: worst case is the 8 bounded write attempts (~45s when every attempt burns the full SQLite busy timeout) instead of hanging until the store heals or the process is killed. No messages are lost at the new give-up point: the claim is held, stale-claim lease recovery re-delivers the event once the store recovers. Behavior under a transient single failure is unchanged - the completion still persists through shutdown, exactly as the existing regression tests require.

## Evidence

Behavior addressed: a persistently failing claim write keeps `stop()` pending indefinitely; bounded semantics should give up, hold the claim, and let shutdown finish.

Real environment tested: real SQLite ingress queue (`createChannelIngressQueueForTests`) driven through the exported `createLineWebhookSpool` factory, with a genuine write lock (`BEGIN IMMEDIATE` from a second `node:sqlite` connection) producing real `database is locked` failures; Windows 11, Node 24.15.0.

Before evidence (current main; each attempt blocks on the ~5s busy timeout, then backs off and retries forever):

```
[t+0.1s]   stop() called (gateway shutdown)
[t+5.6s]   completion persist failed; retrying: database is locked   (attempt 1)
[t+11.4s]  attempt 2 ... [t+17.5s] attempt 3 ... [t+146.7s] attempt 16
[t+150.1s] VERDICT: stop() still pending after 150s of persistent SQLITE_BUSY
[t+151.7s] stop() resolved only after the external lock was released
```

Evidence after fix (same harness, same real lock, only the persistence loop changed):

```
[t+0.1s]   stop() called (gateway shutdown)
[t+5.6s]   ... attempts 1-7, backoff sleeps cut by shutdown ...
[t+44.4s]  completion persist failed after 8 attempts; holding claim for lease recovery: database is locked
[t+44.4s]  stop() resolved after 44.3s          <- store still failing
[t+44.4s]  claim held for lease recovery: yes
[t+44.4s]  (lock released) recovery spool re-delivered the event -> {"kind":"completed"}
[t+44.9s]  VERDICT: event recovered and completed after the store healed (no loss)
```

Observed result after fix: shutdown is bounded, the claim survives for lease recovery, and the event completes exactly once after the store heals.

Exact steps or command run after this patch:

```
pnpm exec vitest run --config test/vitest/vitest.extension-line.config.ts extensions/line/src/webhook-spool.test.ts
Test Files  1 passed (1) / Tests  17 passed (17)
```

Control-red: with the source change reverted, the new test "bounds terminal-persistence retries so shutdown cannot hang on a failing store" fails by hanging until the 120s test timeout - the bug demonstrates itself - while the existing single-failure shutdown test still passes, so the suite pins both halves of the semantics.

Additional review: extension source typecheck (`tsconfig.extensions.json`), extension test-types typecheck (`test/tsconfig/tsconfig.extensions.test.json`), `pnpm lint:extensions`, and `oxfmt --check` on touched files all pass; the branch is rebased onto current main and the focused suite re-ran green on the rebased head.

What was not tested: no live LINE-platform run - this is process-shutdown behavior whose platform interaction ends at the 200 acknowledgement; the repro drives the exported factory against the real SQLite store with genuine lock contention instead.

Proof limitations or environment constraints: Windows 11 local runs; timeline timestamps vary with the store's busy-timeout scheduling (±0.5s).
