### PR TITLE
perf(ci): correct pack hints from measured stripe walls

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -125,14 +125,18 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
   // PTY timing suites still need a lightly packed lane; the exclusive-bin cap
   // leaves only trivial co-groups next to this measured runtime.
   ["core-runtime-tui-pty", 103],
-  ["core-tooling-1", 85],
-  ["core-tooling-2", 112],
-  ["core-tooling-3", 106],
-  ["core-tooling-4", 105],
-  ["core-tooling-isolated", 58],
-  ["core-unit-fast-1", 60],
-  ["core-unit-fast-2", 60],
-  ["core-unit-fast-isolated", 25],
+  // Stripe walls measured from compact run 29564411446 group timestamps.
+  ["core-tooling-1", 87],
+  ["core-tooling-2", 80],
+  ["core-tooling-3", 82],
+  ["core-tooling-4", 71],
+  ["core-tooling-isolated", 45],
+  ["core-unit-fast-1", 40],
+  ["core-unit-fast-2", 40],
+  // Fork-per-file isolation parallelizes poorly on 4 vCPU (78.6s measured in
+  // compact run 29564411446); keep it on the 8 vCPU class where the same
+  // segment runs ~50s.
+  ["core-unit-fast-isolated", 50],
   ["core-unit-src-security", 108],
   ["core-unit-support", 15],
 ]);
@@ -256,6 +260,7 @@ const KEEP_LARGE_NODE_TEST_RUNNER = new Set([
   "core-runtime-media-ui",
   "core-unit-fast-1",
   "core-unit-fast-2",
+  "core-unit-fast-isolated",
   "core-unit-src-security",
 ]);
 const RELEASE_ONLY_PLUGIN_SHARDS = new Set(["agentic-plugins"]);

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -242,10 +242,9 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     const jobOf = (name: string) =>
       compact.findIndex((shard) => shard.groups.some((group) => group.shard_name === name));
     expect(jobOf("agentic-agents-core-runner-embedded")).toBeGreaterThanOrEqual(0);
+    // Cheap stripes may legally co-locate in one bin; only existence matters.
     expect(jobOf("core-unit-fast-1")).toBeGreaterThanOrEqual(0);
     expect(jobOf("core-unit-fast-2")).toBeGreaterThanOrEqual(0);
-    expect(jobOf("core-unit-fast-1")).not.toBe(jobOf("core-unit-fast-2"));
-    expect(jobOf("agentic-agents-core-runner-embedded")).not.toBe(jobOf("core-unit-fast-1"));
     // Spawn/signal-timing suites never mix with regular groups, and every
     // compact bin runs serially: overlapping Vitest runs flake timing-
     // sensitive tests on both runner classes.


### PR DESCRIPTION
## What Problem This Solves

First measured feedback loop after #109769: the compact PR plan's packing tail dropped 419s -> 299s, but the new tail bin (`compact-small-11`) was overfilled because `core-unit-fast-isolated` actually costs **78.6s on a 4 vCPU runner** against a 25s hint — fork-per-file isolation parallelizes poorly on the small class. Unit-fast stripes also measured far cheaper than hinted (~25-37s vs 100/60) and tooling stripes measured 71-87s.

## Why This Change Was Made

Hint drift directly sets PR wall time now that packing is cost-aware; these are the first corrections from real post-landing group walls (parsed from `[shard:*]` timestamps in compact run 29564411446).

## User Impact

Compact PR bins repack closer to the 220s target: the isolated shard moves to the 8 vCPU class (measured ~50s there), and honest stripe hints stop the packer from overfilling small bins. Expected compact tail: ~250s -> ~230s and better balance; no coverage or topology changes.

## Evidence

- Group walls measured from compact run 29564411446: `core-unit-fast-isolated` 78.6s (4 vCPU), `core-unit-fast-2` 36.7s, `core-tooling-1..4` 87/80/82/71s, `core-tooling-isolated` 44.6s.
- `core-unit-fast-isolated` joins `KEEP_LARGE_NODE_TEST_RUNNER`; verified both plans now route it to `blacksmith-8vcpu` (full-plan shard runner and compact bin class).
- Planner suite green: ci-node-test-plan, ci-changed-node-test-plan, ci-workflow-guards, ci-run-node-test-shard (126 passed, 1 skipped). The compact test now only requires stripe presence — with honest hints, cheap stripes legally co-locate in one bin.
- Codex autoreview (gpt-5.6-sol, xhigh): clean.
