### PR TITLE
fix(codex): continue after optional input timeout

### DIFF
--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -1,8 +1,10 @@
 // Codex tests cover user input bridge plugin behavior.
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveCodexUserInputAction } from "./user-input-actions.js";
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
+
+const AUTO_RESOLUTION_MS = 60_000;
 
 function createParams(): EmbeddedRunAttemptParams {
   return {
@@ -24,6 +26,36 @@ function expectFirstBlockReplyText(params: EmbeddedRunAttemptParams): string {
   }
   return payload.text;
 }
+
+function createAutoResolutionRequest(params: {
+  id: string;
+  itemId: string;
+  autoResolutionMs?: number;
+}) {
+  return {
+    id: params.id,
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: params.itemId,
+      autoResolutionMs: params.autoResolutionMs ?? AUTO_RESOLUTION_MS,
+      questions: [
+        {
+          id: "choice",
+          header: "Mode",
+          question: "Pick a mode",
+          isOther: false,
+          isSecret: false,
+          options: [{ label: "Fast", description: "Use less reasoning" }],
+        },
+      ],
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("Codex app-server user input bridge", () => {
   it("prompts the originating chat and resolves request_user_input from the next queued message", async () => {
@@ -63,6 +95,112 @@ describe("Codex app-server user input bridge", () => {
     await expect(response).resolves.toEqual({
       answers: { choice: { answers: ["Deep"] } },
     });
+  });
+
+  it("auto-resolves non-blocking requests after the requested window", async () => {
+    vi.useFakeTimers();
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    let settled = false;
+    const response = bridge.handleRequest(
+      createAutoResolutionRequest({ id: "input-timeout", itemId: "tool-timeout" }),
+    );
+    void response.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_RESOLUTION_MS - 1);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(response).resolves.toEqual({ answers: {} });
+    expect(bridge.handleQueuedMessage("too late")).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears auto-resolution after a human answer", async () => {
+    vi.useFakeTimers();
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const response = bridge.handleRequest(
+      createAutoResolutionRequest({ id: "input-answer", itemId: "tool-answer" }),
+    );
+
+    expect(vi.getTimerCount()).toBe(1);
+    expect(bridge.handleQueuedMessage("1")).toBe(true);
+    await expect(response).resolves.toEqual({
+      answers: { choice: { answers: ["Fast"] } },
+    });
+    expect(vi.getTimerCount()).toBe(0);
+    const eventCount = vi.mocked(params.onAgentEvent!).mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(AUTO_RESOLUTION_MS);
+    expect(vi.mocked(params.onAgentEvent!).mock.calls).toHaveLength(eventCount);
+    expect(bridge.handleQueuedMessage("too late")).toBe(false);
+  });
+
+  it("clears auto-resolution when the run aborts", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      signal: controller.signal,
+    });
+    const response = bridge.handleRequest(
+      createAutoResolutionRequest({ id: "input-abort", itemId: "tool-abort" }),
+    );
+
+    expect(vi.getTimerCount()).toBe(1);
+    controller.abort();
+    await expect(response).resolves.toEqual({ answers: {} });
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(AUTO_RESOLUTION_MS);
+    expect(bridge.handleQueuedMessage("too late")).toBe(false);
+  });
+
+  it("clears the replaced request timer without shortening the replacement window", async () => {
+    vi.useFakeTimers();
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const firstResponse = bridge.handleRequest(
+      createAutoResolutionRequest({ id: "input-first-timer", itemId: "tool-first-timer" }),
+    );
+    let replacementSettled = false;
+    const replacementResponse = bridge.handleRequest(
+      createAutoResolutionRequest({
+        id: "input-second-timer",
+        itemId: "tool-second-timer",
+        autoResolutionMs: AUTO_RESOLUTION_MS * 2,
+      }),
+    );
+    void replacementResponse.then(() => {
+      replacementSettled = true;
+    });
+
+    await expect(firstResponse).resolves.toEqual({ answers: {} });
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(AUTO_RESOLUTION_MS);
+    expect(replacementSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(AUTO_RESOLUTION_MS);
+
+    await expect(replacementResponse).resolves.toEqual({ answers: {} });
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("emits a web question card and typed channel actions", async () => {

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -97,8 +97,13 @@ export function createCodexUserInputBridge(params: {
       return new Promise<JsonValue>((resolve) => {
         const abortListener = () => resolvePending(emptyUserInputResponse());
         let disposeAction = () => {};
+        let autoResolutionTimer: ReturnType<typeof setTimeout> | undefined;
         const cleanup = () => {
           params.signal?.removeEventListener("abort", abortListener);
+          if (autoResolutionTimer !== undefined) {
+            clearTimeout(autoResolutionTimer);
+            autoResolutionTimer = undefined;
+          }
           disposeAction();
           emitQuestionEvent(params.paramsForRun, "resolved", requestParams.itemId);
         };
@@ -124,6 +129,14 @@ export function createCodexUserInputBridge(params: {
         if (params.signal?.aborted) {
           resolvePending(emptyUserInputResponse());
           return;
+        }
+        if (requestParams.autoResolutionMs !== undefined) {
+          // The app-server wire value is the client auto-resolution window. Route
+          // expiry through cleanup so a late timer cannot settle a replacement.
+          autoResolutionTimer = setTimeout(() => {
+            autoResolutionTimer = undefined;
+            resolvePendingIfCurrent(current, emptyUserInputResponse());
+          }, requestParams.autoResolutionMs);
         }
         emitQuestionEvent(
           params.paramsForRun,
@@ -190,6 +203,7 @@ function readUserInputParams(value: JsonValue | undefined):
       turnId: string;
       itemId: string;
       questions: AgentHarnessUserInputQuestion[];
+      autoResolutionMs?: number;
     }
   | undefined {
   if (!isJsonObject(value)) {
@@ -205,7 +219,14 @@ function readUserInputParams(value: JsonValue | undefined):
   const questions = questionsRaw
     .map(readQuestion)
     .filter((question): question is AgentHarnessUserInputQuestion => Boolean(question));
-  return { threadId, turnId, itemId, questions };
+  const rawAutoResolutionMs = value.autoResolutionMs;
+  const autoResolutionMs =
+    typeof rawAutoResolutionMs === "number" &&
+    Number.isSafeInteger(rawAutoResolutionMs) &&
+    rawAutoResolutionMs >= 0
+      ? rawAutoResolutionMs
+      : undefined;
+  return { threadId, turnId, itemId, questions, autoResolutionMs };
 }
 
 function readQuestion(value: JsonValue): AgentHarnessUserInputQuestion | undefined {


### PR DESCRIPTION
Related: #109724

AI-assisted: Codex was used to implement and review this change.

## What Problem This Solves

Fixes an issue where users running Codex through the app-server integration could see an optional input question keep the turn waiting for a human answer or a broader run timeout, even when Codex supplied an automatic-resolution window.

## Why This Change Was Made

The user-input bridge now preserves the optional app-server deadline, returns an empty answer set when that exact window expires, and clears the timer through the existing request cleanup path after a human answer, abort, replacement request, or server-side resolution.

The implementation follows the current upstream Codex contract at `openai/codex@315195492c80fdade38e917c18f9584efd599304`: [`autoResolutionMs` is the optional client auto-resolution window](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/core/src/tools/handlers/request_user_input_spec.rs#L71-L77), [Codex bounds it before dispatch](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/core/src/tools/handlers/request_user_input_spec.rs#L123-L133), and [app-server forwards the value to its client](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/app-server/src/bespoke_event_handling.rs#L703-L746). [The TUI's fixed countdown is an explicitly client-specific policy](https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs#L281-L300), so OpenClaw honors the app-server wire value instead of copying that policy.

The branch also updates the Codex binding test fixture for the `features.goals: false` entry introduced by #109724. This is a test-only baseline correction; it does not change runtime configuration.

## User Impact

Optional Codex questions can now release the waiting turn automatically at the requested deadline. Human answers still win when submitted in time, and completed or replaced requests leave no stale timer that can affect a later question.

## Evidence

- Real Codex app-server 0.144.1 behavior proof over stdio, using the production client and bridge with a real 60-second clock (no mocked transport or fake timers):

```json
{"phase":"initialized","serverVersion":"0.144.1","transport":"stdio"}
{"phase":"completed","requestCount":1,"observedAutoResolutionMs":60000,"requestElapsedMs":60006,"emptyAnswers":true,"requestedEventCount":1,"resolvedEventCount":1,"protocolResolvedCount":1,"blockReplyCount":1,"turnCompleted":true,"continuationTokenSeen":true,"passed":true}
```

- The live run proves the optional request returned an empty answer after its wire deadline, emitted exactly one requested/resolved lifecycle pair and one protocol resolution, then the same turn continued to its expected assistant marker.
- Node 24.15 focused proof: `node scripts/run-vitest.mjs extensions/codex/src/app-server/user-input-bridge.test.ts` - 1 file and 16 tests passed.
- Node 24.15 binding proof: `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.binding.test.ts` - 1 file and 63 tests passed.
- Fake-timer coverage verifies exact expiry, human-answer cleanup with no second settlement, abort cleanup, and replacement-request timer isolation.
- `oxfmt --check` passed for all three changed files.
- `git diff --check` passed.
- Fresh independent Codex adversarial review found no accepted or actionable findings after checking callers, cleanup races, the binding fixture, and the upstream protocol contract.
