### PR TITLE
fix(whatsapp): resolve abortPromise when stop signal already fired

### DIFF
--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -1054,9 +1054,10 @@ describe("WhatsAppConnectionController", () => {
     }
   });
 
-  it("resolves waitForClose as aborted when the stop signal is already aborted", async () => {
+  it("settles close and cancels setup when the stop signal is already aborted", async () => {
     const abort = new AbortController();
-    abort.abort();
+    const stopReason = new Error("already stopped");
+    abort.abort(stopReason);
     const preAbortedController = new WhatsAppConnectionController({
       accountId: "work",
       authDir: "/tmp/wa-auth",
@@ -1076,14 +1077,29 @@ describe("WhatsAppConnectionController", () => {
       abortSignal: abort.signal,
     });
 
-    createWaSocketMock.mockResolvedValueOnce(createSocketWithTransportEmitter() as never);
-    waitForWaConnectionMock.mockResolvedValueOnce(undefined);
-    await preAbortedController.openConnection({
-      connectionId: "conn-pre-aborted",
-      createListener: async () => createListenerStub() as never,
+    let ownerAcquireSignal: AbortSignal | undefined;
+    connectionOwnerMocks.acquire.mockImplementationOnce(async (_authDir, signal) => {
+      ownerAcquireSignal = signal;
+      return { release: connectionOwnerMocks.release };
     });
 
-    await expect(preAbortedController.waitForClose()).resolves.toBe("aborted");
-    await preAbortedController.shutdown();
+    try {
+      const abortPromise = (
+        preAbortedController as unknown as { abortPromise?: Promise<"aborted"> }
+      ).abortPromise;
+      await expect(abortPromise).resolves.toBe("aborted");
+      await expect(
+        preAbortedController.openConnection({
+          connectionId: "conn-pre-aborted",
+          createListener: async () => createListenerStub() as never,
+        }),
+      ).rejects.toThrow("controller is shutting down");
+
+      expect(ownerAcquireSignal?.aborted).toBe(true);
+      expect(ownerAcquireSignal?.reason).toBe(stopReason);
+      expect(createWaSocketMock).not.toHaveBeenCalled();
+    } finally {
+      await preAbortedController.shutdown();
+    }
   });
 });

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -1076,7 +1076,7 @@ describe("WhatsAppConnectionController", () => {
       abortSignal: abort.signal,
     });
 
-    createWaSocketMock.mockResolvedValueOnce({ ws: { close: vi.fn() } } as never);
+    createWaSocketMock.mockResolvedValueOnce(createSocketWithTransportEmitter() as never);
     waitForWaConnectionMock.mockResolvedValueOnce(undefined);
     await preAbortedController.openConnection({
       connectionId: "conn-pre-aborted",

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -1053,4 +1053,37 @@ describe("WhatsAppConnectionController", () => {
       vi.useRealTimers();
     }
   });
+
+  it("resolves waitForClose as aborted when the stop signal is already aborted", async () => {
+    const abort = new AbortController();
+    abort.abort();
+    const preAbortedController = new WhatsAppConnectionController({
+      accountId: "work",
+      authDir: "/tmp/wa-auth",
+      verbose: false,
+      keepAlive: false,
+      heartbeatSeconds: 30,
+      transportTimeoutMs: 60_000,
+      messageTimeoutMs: 60_000,
+      watchdogCheckMs: 5_000,
+      reconnectPolicy: {
+        initialMs: 250,
+        maxMs: 1_000,
+        factor: 2,
+        jitter: 0,
+        maxAttempts: 5,
+      },
+      abortSignal: abort.signal,
+    });
+
+    createWaSocketMock.mockResolvedValueOnce({ ws: { close: vi.fn() } } as never);
+    waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+    await preAbortedController.openConnection({
+      connectionId: "conn-pre-aborted",
+      createListener: async () => createListenerStub() as never,
+    });
+
+    await expect(preAbortedController.waitForClose()).resolves.toBe("aborted");
+    await preAbortedController.shutdown();
+  });
 });

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -518,6 +518,8 @@ export class WhatsAppConnectionController {
     if (abortSignal?.aborted) {
       this.abortPromise = Promise.resolve("aborted");
       this.stopDisconnectRetries();
+      this.ownerAcquireAbortController.abort(abortSignal.reason);
+      this.setupAbortController.abort(abortSignal.reason);
     } else if (abortSignal) {
       this.abortPromise = new Promise<"aborted">((resolve) => {
         abortSignal.addEventListener("abort", () => resolve("aborted"), {

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -514,18 +514,18 @@ export class WhatsAppConnectionController {
       ...params.socketTiming,
     };
     this.socketRef = { current: null };
-    this.abortPromise =
-      params.abortSignal &&
-      new Promise<"aborted">((resolve) => {
-        params.abortSignal?.addEventListener("abort", () => resolve("aborted"), { once: true });
-      });
-
     if (params.abortSignal?.aborted) {
+      this.abortPromise = Promise.resolve("aborted");
       this.stopDisconnectRetries();
       this.ownerAcquireAbortController.abort(params.abortSignal.reason);
       this.setupAbortController.abort(params.abortSignal.reason);
-    } else {
-      params.abortSignal?.addEventListener(
+    } else if (params.abortSignal) {
+      this.abortPromise = new Promise<"aborted">((resolve) => {
+        params.abortSignal.addEventListener("abort", () => resolve("aborted"), {
+          once: true,
+        });
+      });
+      params.abortSignal.addEventListener(
         "abort",
         () => {
           this.stopDisconnectRetries();

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -515,26 +515,20 @@ export class WhatsAppConnectionController {
     };
     this.socketRef = { current: null };
     const abortSignal = params.abortSignal;
-    if (abortSignal?.aborted) {
-      this.abortPromise = Promise.resolve("aborted");
-      this.stopDisconnectRetries();
-      this.ownerAcquireAbortController.abort(abortSignal.reason);
-      this.setupAbortController.abort(abortSignal.reason);
-    } else if (abortSignal) {
+    if (abortSignal) {
       this.abortPromise = new Promise<"aborted">((resolve) => {
-        abortSignal.addEventListener("abort", () => resolve("aborted"), {
-          once: true,
-        });
-      });
-      abortSignal.addEventListener(
-        "abort",
-        () => {
+        const stop = () => {
+          resolve("aborted");
           this.stopDisconnectRetries();
           this.ownerAcquireAbortController.abort(abortSignal.reason);
           this.setupAbortController.abort(abortSignal.reason);
-        },
-        { once: true },
-      );
+        };
+        if (abortSignal.aborted) {
+          stop();
+        } else {
+          abortSignal.addEventListener("abort", stop, { once: true });
+        }
+      });
     }
   }
 

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -514,23 +514,22 @@ export class WhatsAppConnectionController {
       ...params.socketTiming,
     };
     this.socketRef = { current: null };
-    if (params.abortSignal?.aborted) {
+    const abortSignal = params.abortSignal;
+    if (abortSignal?.aborted) {
       this.abortPromise = Promise.resolve("aborted");
       this.stopDisconnectRetries();
-      this.ownerAcquireAbortController.abort(params.abortSignal.reason);
-      this.setupAbortController.abort(params.abortSignal.reason);
-    } else if (params.abortSignal) {
+    } else if (abortSignal) {
       this.abortPromise = new Promise<"aborted">((resolve) => {
-        params.abortSignal.addEventListener("abort", () => resolve("aborted"), {
+        abortSignal.addEventListener("abort", () => resolve("aborted"), {
           once: true,
         });
       });
-      params.abortSignal.addEventListener(
+      abortSignal.addEventListener(
         "abort",
         () => {
           this.stopDisconnectRetries();
-          this.ownerAcquireAbortController.abort(params.abortSignal?.reason);
-          this.setupAbortController.abort(params.abortSignal?.reason);
+          this.ownerAcquireAbortController.abort(abortSignal.reason);
+          this.setupAbortController.abort(abortSignal.reason);
         },
         { once: true },
       );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping a WhatsApp account during or immediately after connection startup would leave `WhatsAppConnectionController.waitForClose()` pending forever when the gateway stop `AbortSignal` was already aborted. Channel shutdown then waits on that race and never completes.

## Why This Change Was Made

The controller built `abortPromise` with an `abort` listener but, when the signal was already aborted at construction time, only called `stopDisconnectRetries()` and never settled `abortPromise`. `waitForClose()` races on that promise, so a pre-aborted stop signal could hang indefinitely. The fix resolves `abortPromise` immediately when `abortSignal.aborted` is already true, matching the existing pre-aborted handling for disconnect retries. Risk note: proof uses the exported controller with a synthetic open connection; live WhatsApp/Baileys sessions were not used.

## User Impact

WhatsApp channel stop/restart no longer hangs when shutdown is requested with an already-aborted stop signal (for example during fast gateway restarts or overlapping account lifecycle transitions).

## Evidence

**Before (upstream constructor on pre-aborted signal — `waitForClose()` hangs):**

```
$ git stash push -m proof-before -- extensions/whatsapp/src/connection-controller.ts
$ WA_LABEL=before-fix node --import tsx /tmp/whatsapp-abort-proof.mjs
Worktree: /srv/projects/openclaw-wt-whatsapp-abort-startup
{
  "label": "before-fix",
  "elapsedMs": 501,
  "resolved": false,
  "value": "timeout"
}
$ echo $?
1
```

**After (same harness with fix applied — resolves immediately):**

```
$ WA_LABEL=after-fix node --import tsx /tmp/whatsapp-abort-proof.mjs
Worktree: /srv/projects/openclaw-wt-whatsapp-abort-startup
{
  "label": "after-fix",
  "elapsedMs": 0,
  "resolved": true,
  "value": "aborted"
}
$ echo $?
0
```

The harness drives the exported `WhatsAppConnectionController` with a pre-aborted `AbortController`, injects an open connection whose close promise never settles, and races `waitForClose()` against a 500ms timeout.

**Focused tests:**

```
$ node scripts/run-vitest.mjs run extensions/whatsapp/src/connection-controller.test.ts
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

**What was not tested:** Live WhatsApp WebSocket/Baileys session with production credentials; local harness proves the pre-aborted `abortPromise` settlement bug and fix on the real exported class.

AI-assisted: Cursor Composer — proof runs executed manually on this machine.