### PR TITLE
fix(signal): recover inbound messages after crashes

### DIFF
--- a/extensions/signal/src/client-adapter.ts
+++ b/extensions/signal/src/client-adapter.ts
@@ -222,7 +222,7 @@ export async function streamSignalEvents(params: {
   accountId?: string;
   abortSignal?: AbortSignal;
   timeoutMs?: number;
-  onEvent: (event: SignalSseEvent) => void;
+  onEvent: (event: SignalSseEvent) => unknown;
   logger?: { log?: (msg: string) => void; error?: (msg: string) => void };
   apiMode?: SignalApiMode;
 }): Promise<void> {

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -216,7 +216,7 @@ function delayedBodyStream(
   };
 }
 const wsMockState = vi.hoisted(() => ({
-  behavior: "close" as "close" | "open" | "error" | "unexpected-response",
+  behavior: "close" as "close" | "open" | "error" | "message" | "unexpected-response",
   urls: [] as string[],
   options: [] as Array<{ maxPayload?: number; handshakeTimeout?: number } | undefined>,
 }));
@@ -277,6 +277,9 @@ vi.mock("ws", () => ({
           this.emit("error", new Error("WebSocket failed"));
         } else if (wsMockState.behavior === "unexpected-response") {
           this.emit("unexpected-response", {}, { statusCode: 200, statusMessage: "OK" });
+        } else if (wsMockState.behavior === "message") {
+          this.emit("message", Buffer.from('{"envelope":{"timestamp":1}}'));
+          this.emit("close", 1000, Buffer.from("done"));
         } else {
           this.emit("close", 1000, Buffer.from("done"));
         }
@@ -1477,6 +1480,21 @@ describe("streamContainerEvents", () => {
     const abortHandler = addEventListener.mock.calls.find((call) => call[0] === "abort")?.[1];
     expect(abortHandler).toBeTypeOf("function");
     expect(removeEventListener).toHaveBeenCalledWith("abort", abortHandler);
+  });
+
+  it("propagates receive-handler failures to the stream", async () => {
+    wsMockState.behavior = "message";
+    const appendError = new Error("durable append failed");
+
+    await expect(
+      streamContainerEvents({
+        baseUrl: "http://localhost:8080",
+        account: "+14259798283",
+        onEvent: async () => {
+          throw appendError;
+        },
+      }),
+    ).rejects.toBe(appendError);
   });
 });
 

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -349,7 +349,7 @@ export async function streamContainerEvents(params: {
   account?: string;
   abortSignal?: AbortSignal;
   timeoutMs?: number;
-  onEvent: (event: ContainerWebSocketMessage) => void;
+  onEvent: (event: ContainerWebSocketMessage) => unknown;
   logger?: { log?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<void> {
   const normalized = normalizeBaseUrl(params.baseUrl);
@@ -362,18 +362,31 @@ export async function streamContainerEvents(params: {
 
   return new Promise((resolve, reject) => {
     let ws: WebSocket;
-    let resolved = false;
+    let settled = false;
+    let eventChain = Promise.resolve();
     let abortHandler: (() => void) | undefined;
 
     const cleanup = () => {
-      if (resolved) {
-        return;
-      }
-      resolved = true;
       if (abortHandler) {
         params.abortSignal?.removeEventListener("abort", abortHandler);
         abortHandler = undefined;
       }
+    };
+    const resolveOnce = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const rejectOnce = (error: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(toLintErrorObject(error, "Signal WebSocket receive handler failed"));
     };
 
     try {
@@ -391,11 +404,25 @@ export async function streamContainerEvents(params: {
     });
 
     ws.on("message", (data: Buffer) => {
+      if (settled) {
+        return;
+      }
       try {
         const text = data.toString();
         const envelope = JSON.parse(text) as ContainerWebSocketMessage;
         if (envelope) {
-          params.onEvent(envelope);
+          // WebSocket callbacks are synchronous. Chain async durable appends so
+          // transport delivery order and receive-handler failures are preserved.
+          eventChain = eventChain.then(async () => {
+            await params.onEvent(envelope);
+          });
+          void eventChain.catch((err: unknown) => {
+            logError(
+              `[signal-ws] receive handler failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            rejectOnce(err);
+            ws.close();
+          });
         }
       } catch (err) {
         logError(`[signal-ws] parse error: ${err instanceof Error ? err.message : String(err)}`);
@@ -410,8 +437,7 @@ export async function streamContainerEvents(params: {
     ws.on("close", (code, reason) => {
       const reasonStr = reason?.toString() || "no reason";
       log(`[signal-ws] closed (code=${code}, reason=${reasonStr})`);
-      cleanup();
-      resolve(); // Let the outer loop handle reconnection
+      void eventChain.then(resolveOnce, rejectOnce); // Let the outer loop handle reconnection.
     });
 
     ws.on("ping", () => {
@@ -425,9 +451,8 @@ export async function streamContainerEvents(params: {
     if (params.abortSignal) {
       abortHandler = () => {
         log("[signal-ws] aborted, closing connection");
-        cleanup();
         ws.close();
-        resolve();
+        resolveOnce();
       };
       params.abortSignal.addEventListener("abort", abortHandler, { once: true });
     }

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -290,6 +290,23 @@ describe("streamSignalEvents", () => {
     expect(events).toEqual([{ id: "42", event: "message", data: '{"group":true}' }]);
   });
 
+  it("propagates receive-handler failures to the stream", async () => {
+    const appendError = new Error("durable append failed");
+    const baseUrl = await withSignalServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.end('event: receive\ndata: {"envelope":{}}\n\n');
+    });
+
+    await expect(
+      streamSignalEvents({
+        baseUrl,
+        onEvent: async () => {
+          throw appendError;
+        },
+      }),
+    ).rejects.toBe(appendError);
+  });
+
   it("reports HTTP status failures from the event stream", async () => {
     const baseUrl = await withSignalServer((_req, res) => {
       res.writeHead(503, "Unavailable");

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -337,7 +337,7 @@ export async function streamSignalEvents(params: {
   account?: string;
   abortSignal?: AbortSignal;
   timeoutMs?: number;
-  onEvent: (event: SignalSseEvent) => void;
+  onEvent: (event: SignalSseEvent) => unknown;
 }): Promise<void> {
   const url = resolveSignalEndpointUrl(params.baseUrl, "/api/v1/events");
   if (params.account) {
@@ -355,11 +355,11 @@ export async function streamSignalEvents(params: {
   let currentEvent: SignalSseEvent = {};
   let currentEventDataBytes = 0;
 
-  const flushEvent = () => {
+  const flushEvent = async () => {
     if (!currentEvent.data && !currentEvent.event && !currentEvent.id) {
       return;
     }
-    params.onEvent({
+    await params.onEvent({
       event: currentEvent.event,
       data: currentEvent.data,
       id: currentEvent.id,
@@ -368,9 +368,9 @@ export async function streamSignalEvents(params: {
     currentEventDataBytes = 0;
   };
 
-  const processLine = (line: string) => {
+  const processLine = async (line: string) => {
     if (line === "") {
-      flushEvent();
+      await flushEvent();
       return;
     }
     if (line.startsWith(":")) {
@@ -397,7 +397,7 @@ export async function streamSignalEvents(params: {
     }
   };
 
-  const drainCompleteLines = () => {
+  const drainCompleteLines = async () => {
     let lineEnd = buffer.indexOf("\n");
     while (lineEnd !== -1) {
       let line = buffer.slice(0, lineEnd);
@@ -405,7 +405,7 @@ export async function streamSignalEvents(params: {
       if (line.endsWith("\r")) {
         line = line.slice(0, -1);
       }
-      processLine(line);
+      await processLine(line);
       lineEnd = buffer.indexOf("\n");
     }
     bufferedBytes = Buffer.byteLength(buffer, "utf8");
@@ -419,7 +419,7 @@ export async function streamSignalEvents(params: {
         throw new Error("Signal SSE buffer exceeded size limit");
       }
       buffer += decoder.decode(value, { stream: true });
-      drainCompleteLines();
+      await drainCompleteLines();
     }
     const tail = decoder.decode();
     if (tail) {
@@ -429,12 +429,12 @@ export async function streamSignalEvents(params: {
     if (bufferedBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
       throw new Error("Signal SSE buffer exceeded size limit");
     }
-    drainCompleteLines();
+    await drainCompleteLines();
   } finally {
     cleanup();
   }
 
-  flushEvent();
+  await flushEvent();
 }
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -271,9 +271,7 @@ describe("monitorSignalProvider autostart", () => {
       settled = true;
     });
 
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(stop).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(stop).toHaveBeenCalledTimes(1));
     expect(settled).toBe(false);
 
     resolveStop();

--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -176,7 +176,7 @@ describe("monitorSignalProvider tool results", () => {
     });
     replyMock.mockResolvedValue({ text: "accepted reply" });
     streamMock.mockImplementation(async ({ onEvent }) => {
-      onEvent({
+      await onEvent({
         event: "receive",
         data: JSON.stringify({
           envelope: {
@@ -187,6 +187,7 @@ describe("monitorSignalProvider tool results", () => {
           },
         }),
       });
+      await vi.waitFor(() => expect(replyMock).toHaveBeenCalledTimes(1));
       abortController.abort(new Error("monitor stopped"));
     });
 

--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -51,6 +51,10 @@ async function receiveSignalPayloads(params: {
         data: JSON.stringify(payload),
       });
     }
+    // Durable receive returns after append; let the drain start before simulating shutdown.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     abortController.abort();
   });
 
@@ -508,58 +512,48 @@ describe("monitorSignalProvider tool results", () => {
     expect(sendMock.mock.calls[0]?.[2]).not.toHaveProperty("replyToBody");
   });
 
-  it("quotes the last inbound message for multi-message batched-mode turns", async () => {
-    vi.useFakeTimers();
-    try {
-      setSignalToolResultTestConfig({
-        ...createSignalToolResultConfig({
-          autoStart: false,
-          replyToMode: "batched",
-        }),
-        messages: { inbound: { debounceMs: 10 } },
-      });
-      replyMock.mockResolvedValue([{ text: "first reply" }, { text: "second reply" }]);
-      const abortController = new AbortController();
-      streamMock.mockImplementation(async ({ onEvent }) => {
-        for (const [timestamp, message] of [
-          [1700000000001, "first debounced message"],
-          [1700000000002, "second debounced message"],
-        ] as const) {
-          await onEvent({
-            event: "receive",
-            data: JSON.stringify({
-              envelope: {
-                sourceNumber: "+15550001111",
-                sourceName: "Ada",
-                timestamp,
-                dataMessage: { message },
-              },
-            }),
-          });
-        }
-        await vi.advanceTimersByTimeAsync(10);
-        abortController.abort();
-      });
-
-      await runMonitorWithMocks({
+  it("keeps durable conversation events separate in batched reply mode", async () => {
+    setSignalToolResultTestConfig({
+      ...createSignalToolResultConfig({
         autoStart: false,
-        baseUrl: SIGNAL_BASE_URL,
-        abortSignal: abortController.signal,
-      });
+        replyToMode: "batched",
+      }),
+      messages: { inbound: { debounceMs: 10 } },
+    });
+    replyMock.mockResolvedValue({ text: "reply" });
+    const abortController = new AbortController();
+    streamMock.mockImplementation(async ({ onEvent }) => {
+      for (const [timestamp, message] of [
+        [1700000000001, "first message"],
+        [1700000000002, "second message"],
+      ] as const) {
+        await onEvent({
+          event: "receive",
+          data: JSON.stringify({
+            envelope: {
+              sourceNumber: "+15550001111",
+              sourceName: "Ada",
+              timestamp,
+              dataMessage: { message },
+            },
+          }),
+        });
+      }
+      await vi.waitFor(() => expect(replyMock).toHaveBeenCalledTimes(2));
+      abortController.abort();
+    });
 
-      await vi.waitFor(() => {
-        expect(sendMock).toHaveBeenCalledTimes(2);
-      });
-      expect(sendMock.mock.calls[0]?.[2]).toMatchObject({
-        replyToId: "1700000000002",
-        replyToAuthor: "+15550001111",
-        replyToBody: "second debounced message",
-      });
-      expect(sendMock.mock.calls[1]?.[2]).not.toHaveProperty("replyToId");
-      expect(sendMock.mock.calls[1]?.[2]).not.toHaveProperty("replyToAuthor");
-      expect(sendMock.mock.calls[1]?.[2]).not.toHaveProperty("replyToBody");
-    } finally {
-      vi.useRealTimers();
+    await runMonitorWithMocks({
+      autoStart: false,
+      baseUrl: SIGNAL_BASE_URL,
+      abortSignal: abortController.signal,
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    for (const call of sendMock.mock.calls) {
+      expect(call[2]).not.toHaveProperty("replyToId");
+      expect(call[2]).not.toHaveProperty("replyToAuthor");
+      expect(call[2]).not.toHaveProperty("replyToBody");
     }
   });
 

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -1,7 +1,17 @@
 // Signal plugin module implements monitor.tool result harness behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import type { SignalDaemonHandle } from "./daemon.js";
+import { setSignalRuntime } from "./runtime.js";
+import { clearSignalRuntimeForTest } from "./runtime.test-support.js";
 
 type SignalDaemonExitEvent = Awaited<SignalDaemonHandle["exited"]>;
 
@@ -33,6 +43,7 @@ const spawnSignalDaemonMock = vi.hoisted(() => vi.fn()) as unknown as MockFn;
 const signalToolResultSessionStorePath = vi.hoisted(
   () => `/tmp/openclaw-signal-tool-result-sessions-${process.pid}.json`,
 );
+let signalToolResultStateDir: string | undefined;
 
 export function getSignalToolResultTestMocks(): SignalToolResultTestMocks {
   return {
@@ -129,6 +140,9 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
     dispatchInboundMessage: async (params: {
       ctx: unknown;
       cfg: unknown;
+      replyOptions?: {
+        turnAdoptionLifecycle?: { onAdopted?: () => void | Promise<void> };
+      };
       dispatcher: {
         sendFinalReply: (payload: {
           text?: string;
@@ -177,6 +191,7 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
       }
       params.dispatcher.markComplete?.();
       await params.dispatcher.waitForIdle?.();
+      await params.replyOptions?.turnAdoptionLifecycle?.onAdopted?.();
       return { queuedFinal };
     },
   };
@@ -257,6 +272,36 @@ export function installSignalToolResultTestHooks() {
       import("openclaw/plugin-sdk/system-event-runtime"),
     ]);
     resetInboundDedupe();
+    const createdStateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-signal-tool-result-state-"),
+    );
+    const stateDir = await fs.realpath(createdStateDir);
+    signalToolResultStateDir = stateDir;
+    setSignalRuntime({
+      logging: {
+        getChildLogger: () => ({
+          debug: vi.fn(),
+          error: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+        }),
+      },
+      state: {
+        resolveStateDir: () => stateDir,
+        openKeyedStore: () => {
+          throw new Error("keyed store is not configured in Signal monitor tests");
+        },
+        openChannelIngressQueue: (
+          options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+        ) => {
+          return createChannelIngressQueueForTests({
+            ...options,
+            channelId: "signal",
+            stateDir: options?.stateDir ?? stateDir,
+          });
+        },
+      },
+    } as unknown as PluginRuntime);
     config = {
       messages: { responsePrefix: "PFX" },
       session: { store: signalToolResultSessionStorePath },
@@ -278,5 +323,14 @@ export function installSignalToolResultTestHooks() {
     enqueueSystemEventMock.mockReset();
 
     resetSystemEventsForTest();
+  });
+
+  afterEach(async () => {
+    clearSignalRuntimeForTest();
+    closeOpenClawStateDatabaseForTest();
+    if (signalToolResultStateDir) {
+      await fs.rm(signalToolResultStateDir, { recursive: true, force: true });
+      signalToolResultStateDir = undefined;
+    }
   });
 }

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -60,6 +60,7 @@ import type {
 } from "./monitor/event-handler.types.js";
 import { materializeSignalPresentationFallback } from "./presentation-fallback.js";
 import { sendMessageSignal } from "./send.js";
+import { startSignalIngressMonitor, type SignalIngressMonitor } from "./signal-ingress.js";
 import { runSignalSseLoop } from "./sse-reconnect.js";
 
 export type MonitorSignalOpts = {
@@ -87,19 +88,17 @@ export type MonitorSignalOpts = {
   waitForTransportReady?: typeof waitForTransportReady;
 };
 
-function resolveRuntime(opts: MonitorSignalOpts): RuntimeEnv {
-  return opts.runtime ?? createNonExitingRuntime();
-}
-
 function createSignalMonitorTaskRunner(runtime: RuntimeEnv) {
   const inFlight = new Set<Promise<void>>();
   return {
-    runTask(task: () => Promise<void>): void {
-      const trackedTask = Promise.resolve()
-        .then(task)
-        .catch((err: unknown) => runtime.error?.(`signal monitor task failed: ${String(err)}`))
-        .finally(() => inFlight.delete(trackedTask));
+    runTask(task: () => Promise<void>): Promise<void> {
+      const trackedTask = Promise.resolve().then(task);
       inFlight.add(trackedTask);
+      void trackedTask.catch((err: unknown) =>
+        runtime.error?.(`signal monitor task failed: ${String(err)}`),
+      );
+      void trackedTask.finally(() => inFlight.delete(trackedTask)).catch(() => undefined);
+      return trackedTask;
     },
     async waitForIdle(): Promise<void> {
       while (inFlight.size > 0) {
@@ -112,19 +111,24 @@ function createSignalMonitorTaskRunner(runtime: RuntimeEnv) {
 function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
   let daemonHandle: SignalDaemonHandle | null = null;
   let daemonStopRequested = false;
+  let daemonStopPromise: Promise<void> | undefined;
   let daemonExitError: Error | undefined;
   const daemonAbortController = new AbortController();
   const abortSignal = params.abortSignal
     ? AbortSignal.any([params.abortSignal, daemonAbortController.signal])
     : daemonAbortController.signal;
   const stop = (): Promise<void> => {
+    if (daemonStopPromise) {
+      return daemonStopPromise;
+    }
     daemonStopRequested = true;
     if (!daemonAbortController.signal.aborted) {
       daemonAbortController.abort(
         params.abortSignal?.reason ?? new Error("Signal monitor stopped"),
       );
     }
-    return daemonHandle?.stop() ?? Promise.resolve();
+    daemonStopPromise = daemonHandle?.stop() ?? Promise.resolve();
+    return daemonStopPromise;
   };
   const attach = (handle: SignalDaemonHandle) => {
     daemonHandle = handle;
@@ -145,10 +149,6 @@ function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
     getExitError,
     abortSignal,
   };
-}
-
-function normalizeAllowList(raw?: Array<string | number>): string[] {
-  return normalizeStringEntries(raw);
 }
 
 function resolveSignalReactionTargets(reaction: SignalReactionMessage): SignalReactionTarget[] {
@@ -528,7 +528,7 @@ function createSignalNativeReplyResolver(params: {
 }
 
 export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promise<void> {
-  const runtime = resolveRuntime(opts);
+  const runtime = opts.runtime ?? createNonExitingRuntime();
   const cfg = opts.config ?? getRuntimeConfig();
   const accountInfo = resolveSignalAccount({
     cfg,
@@ -547,8 +547,8 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const account =
     normalizeOptionalString(opts.account) ?? normalizeOptionalString(accountInfo.config.account);
   const dmPolicy = accountInfo.config.dmPolicy ?? "pairing";
-  const allowFrom = normalizeAllowList(opts.allowFrom ?? accountInfo.config.allowFrom);
-  const groupAllowFrom = normalizeAllowList(
+  const allowFrom = normalizeStringEntries(opts.allowFrom ?? accountInfo.config.allowFrom);
+  const groupAllowFrom = normalizeStringEntries(
     opts.groupAllowFrom ??
       accountInfo.config.groupAllowFrom ??
       (accountInfo.config.allowFrom && accountInfo.config.allowFrom.length > 0
@@ -569,7 +569,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     log: (message) => runtime.log?.(message),
   });
   const reactionMode = accountInfo.config.reactionNotifications ?? "own";
-  const reactionAllowlist = normalizeAllowList(accountInfo.config.reactionAllowlist);
+  const reactionAllowlist = normalizeStringEntries(accountInfo.config.reactionAllowlist);
   const mediaMaxBytes = (opts.mediaMaxMb ?? accountInfo.config.mediaMaxMb ?? 8) * 1024 * 1024;
   const ignoreAttachments = opts.ignoreAttachments ?? accountInfo.config.ignoreAttachments ?? false;
   const sendReadReceipts = Boolean(opts.sendReadReceipts ?? accountInfo.config.sendReadReceipts);
@@ -585,6 +585,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const daemonLifecycle = createSignalDaemonLifecycle({ abortSignal: opts.abortSignal });
   const monitorTaskRunner = createSignalMonitorTaskRunner(runtime);
   let daemonHandle: SignalDaemonHandle | null = null;
+  let ingressMonitor: SignalIngressMonitor | undefined;
 
   if (autoStart && configuredApiMode === "container") {
     throw new Error(
@@ -614,9 +615,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     daemonLifecycle.attach(daemonHandle);
   }
 
-  const onAbort = () => {
-    void daemonLifecycle.stop();
-  };
+  const onAbort = () => void daemonLifecycle.stop();
   opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
   try {
@@ -658,7 +657,9 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     const handleEvent = createSignalEventHandler({
       runtime,
       abortSignal: daemonLifecycle.abortSignal,
-      runTrackedTask: (task) => monitorTaskRunner.runTask(task),
+      runTrackedTask: (task) => {
+        void monitorTaskRunner.runTask(task);
+      },
       cfg,
       baseUrl,
       account,
@@ -686,6 +687,15 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       buildSignalReactionSystemEventText,
     });
 
+    ingressMonitor = await startSignalIngressMonitor({
+      accountId: accountInfo.accountId,
+      dispatch: handleEvent,
+      runtime,
+      runTrackedTask: (task) => {
+        void monitorTaskRunner.runTask(task);
+      },
+    });
+
     await runSignalSseLoop({
       baseUrl,
       account,
@@ -695,9 +705,8 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       timeoutMs: 0,
       apiMode: configuredApiMode,
       policy: opts.reconnectPolicy,
-      onEvent: (event) => {
-        monitorTaskRunner.runTask(() => handleEvent(event));
-      },
+      onEvent: (event) =>
+        monitorTaskRunner.runTask(async () => await ingressMonitor?.receive(event)),
     });
     const daemonExitError = daemonLifecycle.getExitError();
     if (daemonExitError) {
@@ -710,6 +719,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     }
     throw err;
   } finally {
+    await ingressMonitor?.stop();
     // Daemon attachment finishes before monitor tasks start. Keep teardown open until both the
     // child has exited and already-started reply work has drained.
     await Promise.all([daemonLifecycle.stop(), monitorTaskRunner.waitForIdle()]);

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -5,6 +5,7 @@ import {
   normalizeCommandBody,
 } from "openclaw/plugin-sdk/command-auth-native";
 import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
+import type { SignalIngressLifecycle } from "../signal-ingress.js";
 
 export type SignalInboundEntry = {
   senderName: string;
@@ -32,6 +33,7 @@ export type SignalInboundEntry = {
   replyToBody?: string;
   replyToSender?: string;
   replyToIsQuote?: boolean;
+  turnAdoptionLifecycle?: SignalIngressLifecycle;
 };
 
 type TrackedSignalInboundLane = {

--- a/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
+++ b/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
@@ -1,0 +1,195 @@
+// Signal tests cover drain claim ownership through debounce, merge, and skip.
+import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SignalIngressLifecycle } from "../signal-ingress.js";
+
+vi.useRealTimers();
+let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
+let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
+let createSignalEventHandler: typeof import("./event-handler.js").createSignalEventHandler;
+
+type DispatchParams = {
+  ctx: MsgContext;
+  replyOptions?: { turnAdoptionLifecycle?: { onAdopted: () => Promise<void> | void } };
+};
+
+const { dispatchInboundMessageMock, recordInboundSessionMock, dispatchCapture, dispatchBehavior } =
+  vi.hoisted(() => {
+    const captured: DispatchParams[] = [];
+    const behavior = { adoptDuringDispatch: true };
+    return {
+      dispatchCapture: captured,
+      dispatchBehavior: behavior,
+      recordInboundSessionMock: vi.fn(),
+      dispatchInboundMessageMock: vi.fn(async (params: DispatchParams) => {
+        captured.push(params);
+        if (behavior.adoptDuringDispatch) {
+          // Mirror the real reply lane: adoption fires while dispatch runs.
+          await params.replyOptions?.turnAdoptionLifecycle?.onAdopted();
+        }
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      }),
+    };
+  });
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendTypingSignal: vi.fn(),
+  sendReadReceiptSignal: vi.fn(),
+}));
+
+vi.mock("../send-reactions.js", () => ({
+  sendReactionSignal: vi.fn(async () => ({ ok: true })),
+  removeReactionSignal: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
+    "openclaw/plugin-sdk/reply-runtime",
+  );
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+    dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
+    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
+    "openclaw/plugin-sdk/channel-inbound",
+  );
+  type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
+  return {
+    ...actual,
+    runChannelInboundEvent: (params: RunParams) => {
+      const resolveTurn = params.adapter.resolveTurn;
+      return actual.runChannelInboundEvent({
+        ...params,
+        adapter: {
+          ...params.adapter,
+          resolveTurn: async (input, eventClass, preflight) => {
+            const resolved = await resolveTurn(input, eventClass, preflight);
+            if (!("route" in resolved) || !("runDispatch" in resolved)) {
+              return resolved;
+            }
+            const { route, ...turn } = resolved;
+            return {
+              ...turn,
+              routeSessionKey: route.sessionKey,
+              storePath: "/tmp/openclaw/signal-sessions.json",
+              recordInboundSession: recordInboundSessionMock,
+            };
+          },
+        },
+      });
+    },
+  };
+});
+
+beforeAll(async () => {
+  const harness = await import("./event-handler.test-harness.js");
+  createBaseSignalEventHandlerDeps = harness.createBaseSignalEventHandlerDeps;
+  createSignalReceiveEvent = harness.createSignalReceiveEvent;
+  ({ createSignalEventHandler } = await import("./event-handler.js"));
+});
+
+function createTrackedLifecycle(): SignalIngressLifecycle & {
+  adoptedCount: () => number;
+  abandonedCount: () => number;
+} {
+  let adopted = 0;
+  let abandoned = 0;
+  return {
+    abortSignal: new AbortController().signal,
+    onAdopted: async () => {
+      adopted += 1;
+    },
+    onDeferred: () => {},
+    onAdoptionFinalizing: () => {},
+    onAbandoned: () => {
+      abandoned += 1;
+    },
+    adoptedCount: () => adopted,
+    abandonedCount: () => abandoned,
+  };
+}
+
+function createDataEvent(params: { timestamp: number; message: string; source?: string }) {
+  return createSignalReceiveEvent({
+    sourceUuid: "11111111-2222-3333-4444-555555555555",
+    timestamp: params.timestamp,
+    dataMessage: { timestamp: params.timestamp, message: params.message },
+    ...(params.source ? { sourceNumber: params.source } : {}),
+  });
+}
+
+describe("signal drain claim ownership", () => {
+  beforeEach(() => {
+    dispatchCapture.length = 0;
+    dispatchBehavior.adoptDuringDispatch = true;
+    dispatchInboundMessageMock.mockClear();
+  });
+
+  it("defers a drain-claimed event and completes the claim at reply adoption", async () => {
+    const handler = createSignalEventHandler(createBaseSignalEventHandlerDeps());
+    const lifecycle = createTrackedLifecycle();
+
+    const result = await handler(
+      createDataEvent({ timestamp: 1700000001000, message: "hello there" }),
+      lifecycle,
+    );
+
+    // Deferred, never completed-at-enqueue: a crash inside the debounce window
+    // must leave the claim held so the queue replays the message.
+    expect(result).toEqual({ kind: "deferred" });
+    await vi.waitFor(() => expect(lifecycle.adoptedCount()).toBe(1), { timeout: 5_000 });
+    expect(dispatchCapture[0]?.replyOptions?.turnAdoptionLifecycle).toBeDefined();
+    expect(lifecycle.abandonedCount()).toBe(0);
+  });
+
+  it("completes every constituent claim when debounced entries merge into one turn", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 40 } } },
+      }),
+    );
+    const first = createTrackedLifecycle();
+    const second = createTrackedLifecycle();
+
+    const results = [
+      await handler(createDataEvent({ timestamp: 1700000002000, message: "part one" }), first),
+      await handler(createDataEvent({ timestamp: 1700000003000, message: "part two" }), second),
+    ];
+    expect(results).toEqual([{ kind: "deferred" }, { kind: "deferred" }]);
+
+    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1), {
+      timeout: 5_000,
+    });
+    await vi.waitFor(
+      () => {
+        expect(first.adoptedCount()).toBe(1);
+        expect(second.adoptedCount()).toBe(1);
+      },
+      { timeout: 5_000 },
+    );
+  });
+
+  it("settles the claim for a turn that finishes without adoption", async () => {
+    // Dispatch resolves without the reply lane ever adopting (gated/no-reply):
+    // the flush must complete the claim, or the stall watchdog would
+    // dead-letter a deliberately handled message.
+    dispatchBehavior.adoptDuringDispatch = false;
+    const handler = createSignalEventHandler(createBaseSignalEventHandlerDeps());
+    const lifecycle = createTrackedLifecycle();
+
+    const result = await handler(
+      createDataEvent({ timestamp: 1700000004000, message: "no adoption" }),
+      lifecycle,
+    );
+
+    expect(result).toEqual({ kind: "deferred" });
+    await vi.waitFor(() => expect(lifecycle.adoptedCount()).toBe(1), { timeout: 5_000 });
+    expect(lifecycle.abandonedCount()).toBe(0);
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -666,7 +666,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const lifecycles = entries
       .map((entry) => entry.turnAdoptionLifecycle)
       .filter((lifecycle) => lifecycle !== undefined);
-    if (lifecycles.length === 0) {
+    const [firstLifecycle] = lifecycles;
+    if (!firstLifecycle) {
       return { lifecycle: undefined, settle: async () => {} };
     }
     let handedOff = false;
@@ -679,7 +680,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       lifecycle: {
         abortSignal:
           lifecycles.length === 1
-            ? lifecycles[0].abortSignal
+            ? firstLifecycle.abortSignal
             : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
         onAdopted: async () => {
           handedOff = true;
@@ -952,7 +953,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   return async (
     event: { event?: string; data?: string },
     turnAdoptionLifecycle?: SignalIngressLifecycle,
-  ): Promise<{ kind: "failed-retryable"; error: unknown } | void> => {
+  ): Promise<{ kind: "deferred" } | { kind: "failed-retryable"; error: unknown } | void> => {
     if (event.event !== "receive" || !event.data) {
       return;
     }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -27,7 +27,10 @@ import {
   runChannelInboundEvent,
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
-import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  bindIngressLifecycleToReplyOptions,
+  createChannelMessageReplyPipeline,
+} from "openclaw/plugin-sdk/channel-outbound";
 import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
@@ -82,6 +85,7 @@ import {
   type SignalReactionOpts,
 } from "../send-reactions.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
+import type { SignalIngressLifecycle } from "../signal-ingress.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
 import {
   createSignalPendingInboundRegistry,
@@ -597,6 +601,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
                 dispatcher,
                 replyOptions: {
                   ...replyOptions,
+                  ...(entry.turnAdoptionLifecycle
+                    ? bindIngressLifecycleToReplyOptions(entry.turnAdoptionLifecycle)
+                    : {}),
                   disableBlockStreaming:
                     typeof deps.blockStreaming === "boolean" ? !deps.blockStreaming : undefined,
                   ...(statusReactionController
@@ -648,13 +655,76 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
   }
 
+  // Fan one settlement out to every constituent claim of a (possibly merged)
+  // flush, and track whether the reply lane took ownership. A merged turn owns
+  // ALL constituent queue claims: adoption must complete each of them or the
+  // unmerged events would stall and redeliver duplicates.
+  function buildFlushIngressLifecycle(entries: SignalInboundEntry[]): {
+    lifecycle: SignalIngressLifecycle | undefined;
+    settle: () => Promise<void>;
+  } {
+    const lifecycles = entries
+      .map((entry) => entry.turnAdoptionLifecycle)
+      .filter((lifecycle) => lifecycle !== undefined);
+    if (lifecycles.length === 0) {
+      return { lifecycle: undefined, settle: async () => {} };
+    }
+    let handedOff = false;
+    const adoptAll = async () => {
+      for (const lifecycle of lifecycles) {
+        await lifecycle.onAdopted();
+      }
+    };
+    return {
+      lifecycle: {
+        abortSignal:
+          lifecycles.length === 1
+            ? lifecycles[0].abortSignal
+            : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
+        onAdopted: async () => {
+          handedOff = true;
+          await adoptAll();
+        },
+        onDeferred: () => {
+          handedOff = true;
+          for (const lifecycle of lifecycles) {
+            lifecycle.onDeferred();
+          }
+        },
+        onAdoptionFinalizing: () => {
+          for (const lifecycle of lifecycles) {
+            lifecycle.onAdoptionFinalizing();
+          }
+        },
+        onAbandoned: () => {
+          handedOff = true;
+          for (const lifecycle of lifecycles) {
+            lifecycle.onAbandoned();
+          }
+        },
+      },
+      // Terminal no-dispatch (gated, whitespace-only, deliberate skip) must
+      // still tombstone the claims — mirrors the drain's skipped→completed
+      // mapping; leaving them deferred would watchdog-dead-letter live turns.
+      settle: async () => {
+        if (!handedOff) {
+          await adoptAll();
+        }
+      },
+    };
+  }
+
   async function flushSignalInboundEntries(entries: SignalInboundEntry[]): Promise<void> {
     const last = entries.at(-1);
     if (!last) {
       return;
     }
+    const { lifecycle, settle } = buildFlushIngressLifecycle(entries);
     if (entries.length === 1) {
-      await handleSignalInboundMessage(last);
+      await handleSignalInboundMessage(
+        lifecycle ? { ...last, turnAdoptionLifecycle: lifecycle } : last,
+      );
+      await settle();
       return;
     }
     const combinedText = entries
@@ -666,12 +736,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       .filter(Boolean)
       .join("\\n");
     if (!combinedText.trim()) {
+      await settle();
       return;
     }
     await handleSignalInboundMessage({
       ...last,
       bodyText: combinedText,
       commandBody: combinedCommandBody,
+      ...(lifecycle ? { turnAdoptionLifecycle: lifecycle } : {}),
       isBatched: true,
       nativeReplyBody: last.nativeReplyBody ?? last.bodyText,
       mediaPath: undefined,
@@ -679,6 +751,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaPaths: undefined,
       mediaTypes: undefined,
     });
+    await settle();
   }
 
   async function retrySignalInboundFlush(
@@ -736,7 +809,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       }
       // Keep the current keyed debounce task reserved through backoff so a
       // newer same-conversation flush cannot overtake this failed batch.
-      const retryTask = retrySignalInboundFlush(entries, err);
+      const retryTask = retrySignalInboundFlush(entries, err).catch((terminalError: unknown) => {
+        // Exhausted retries: release the drain claims so queue retry policy
+        // owns redelivery instead of the stall watchdog dead-lettering them.
+        for (const entry of entries) {
+          entry.turnAdoptionLifecycle?.onAbandoned();
+        }
+        throw terminalError;
+      });
       deps.runTrackedTask?.(() => retryTask.catch(() => undefined));
       await retryTask;
     }
@@ -753,13 +833,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     cfg: deps.cfg,
     channel: "signal",
     buildKey: (entry) => resolveSignalInboundDebounceKey(deps.accountId, entry),
-    shouldDebounce: (entry) => {
-      return shouldDebounceTextInbound({
+    shouldDebounce: (entry) =>
+      shouldDebounceTextInbound({
         text: entry.commandBody,
         cfg: deps.cfg,
         hasMedia: Boolean(entry.mediaPath || entry.mediaType || entry.mediaPaths?.length),
-      });
-    },
+      }),
     onFlush: flushNormalSignalInboundEntries,
     onError: reportSignalInboundFlushError,
     onCancel: pendingInboundRegistry.complete,
@@ -870,7 +949,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     return true;
   }
 
-  return async (event: { event?: string; data?: string }) => {
+  return async (
+    event: { event?: string; data?: string },
+    turnAdoptionLifecycle?: SignalIngressLifecycle,
+  ): Promise<{ kind: "failed-retryable"; error: unknown } | void> => {
     if (event.event !== "receive" || !event.data) {
       return;
     }
@@ -1298,6 +1380,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,
+      turnAdoptionLifecycle,
     };
     pendingInboundRegistry.cancelPendingOnAbort(entry, debouncer.cancelKey);
     // Normal and stateful turns stay on the existing ingress path so core session admission owns
@@ -1313,6 +1396,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       await inboundLane.enqueue(entry);
     } finally {
       activeEnqueueEntries.delete(entry);
+    }
+    if (turnAdoptionLifecycle) {
+      // Debounce merging stays on under the drain: the claim defers (held,
+      // watchdog armed) and completes when the merged turn adopts. Returning
+      // completed here would tombstone before the buffered flush dispatches,
+      // losing the message if the gateway dies inside the debounce window.
+      return { kind: "deferred" };
     }
   };
 }

--- a/extensions/signal/src/runtime.test-support.ts
+++ b/extensions/signal/src/runtime.test-support.ts
@@ -1,0 +1,12 @@
+// Signal test support owns cleanup for process-global plugin runtime state.
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+
+const { clearRuntime } = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "signal",
+  errorMessage: "Signal runtime not initialized",
+});
+
+export function clearSignalRuntimeForTest(): void {
+  clearRuntime();
+}

--- a/extensions/signal/src/runtime.test-support.ts
+++ b/extensions/signal/src/runtime.test-support.ts
@@ -1,6 +1,49 @@
 // Signal test support owns cleanup for process-global plugin runtime state.
+import type {
+  ChannelIngressDrain,
+  ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+import type { SignalSseEvent } from "./client-adapter.js";
+import "./signal-ingress.js";
+
+export type SignalIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  event: SignalSseEvent;
+};
+
+type SignalIngressEnqueueResult =
+  | Awaited<ReturnType<ChannelIngressQueue<SignalIngressPayload>["enqueue"]>>
+  | { kind: "ignored" };
+
+type SignalIngressTestApi = {
+  createSignalIngressDrain(params: {
+    queue: ChannelIngressQueue<SignalIngressPayload>;
+    dispatch: (
+      event: SignalSseEvent,
+      lifecycle: {
+        abortSignal: AbortSignal;
+        onAdopted: () => void | Promise<void>;
+        onDeferred: () => void;
+        onAdoptionFinalizing: () => void;
+        onAbandoned: () => void;
+      },
+    ) => unknown;
+  }): ChannelIngressDrain;
+  enqueueSignalIngressEvent(params: {
+    queue: ChannelIngressQueue<SignalIngressPayload>;
+    event: SignalSseEvent;
+    now?: number;
+  }): Promise<SignalIngressEnqueueResult>;
+  resolveSignalIngressEventId(event: SignalSseEvent): string | null;
+  resolveSignalIngressLaneKey(event: SignalSseEvent): string | null;
+};
+
+export const signalIngressTesting = (globalThis as Record<PropertyKey, unknown>)[
+  Symbol.for("openclaw.signalIngressTestApi")
+] as SignalIngressTestApi;
 
 const { clearRuntime } = createPluginRuntimeStore<PluginRuntime>({
   pluginId: "signal",

--- a/extensions/signal/src/signal-ingress.test.ts
+++ b/extensions/signal/src/signal-ingress.test.ts
@@ -1,0 +1,258 @@
+// Signal durable ingress tests cover append, recovery, and tombstone dedupe.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SignalSseEvent } from "./client-adapter.js";
+import { setSignalRuntime } from "./runtime.js";
+import { clearSignalRuntimeForTest } from "./runtime.test-support.js";
+import {
+  createSignalIngressDrain,
+  enqueueSignalIngressEvent,
+  resolveSignalIngressEventId,
+  resolveSignalIngressLaneKey,
+  startSignalIngressMonitor,
+  type SignalIngressPayload,
+} from "./signal-ingress.js";
+
+function signalEvent(params?: {
+  senderNumber?: string;
+  senderUuid?: string;
+  timestamp?: number;
+  groupId?: string;
+  message?: string;
+}): SignalSseEvent {
+  const timestamp = params?.timestamp ?? 1_700_000_000_001;
+  return {
+    event: "receive",
+    data: JSON.stringify({
+      envelope: {
+        sourceNumber: params?.senderNumber ?? "+15550001111",
+        ...(params?.senderUuid ? { sourceUuid: params.senderUuid } : {}),
+        timestamp,
+        dataMessage: {
+          timestamp,
+          message: params?.message ?? "hello",
+          ...(params?.groupId ? { groupInfo: { groupId: params.groupId } } : {}),
+        },
+      },
+    }),
+  };
+}
+
+async function withQueue<T>(
+  fn: (queue: ChannelIngressQueue<SignalIngressPayload>, stateDir: string) => Promise<T>,
+): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-ingress-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<SignalIngressPayload>({
+    channelId: "signal",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await fn(queue, stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  clearSignalRuntimeForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("Signal durable ingress", () => {
+  it("propagates durable append failure before dispatch scheduling", async () => {
+    await withQueue(async (queue) => {
+      const appendError = new Error("sqlite unavailable");
+      const failingQueue = {
+        ...queue,
+        enqueue: vi.fn().mockRejectedValue(appendError),
+      } satisfies ChannelIngressQueue<SignalIngressPayload>;
+      setSignalRuntime({
+        state: { openChannelIngressQueue: () => failingQueue },
+      } as unknown as PluginRuntime);
+      const dispatch = vi.fn();
+      const monitor = await startSignalIngressMonitor({
+        accountId: "default",
+        dispatch,
+        runtime: { error: vi.fn(), log: vi.fn() },
+        runTrackedTask: vi.fn(),
+      });
+      try {
+        await expect(monitor.receive(signalEvent())).rejects.toBe(appendError);
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("recovers an uncompleted append with a fresh drain and dispatches exactly once", async () => {
+    await withQueue(async (queue) => {
+      const event = signalEvent();
+      await enqueueSignalIngressEvent({ queue, event });
+
+      const dispatch = vi.fn().mockResolvedValue(undefined);
+      const recoveredDrain = createSignalIngressDrain({ queue, dispatch });
+      await recoveredDrain.drainOnce();
+      await recoveredDrain.waitForIdle();
+      recoveredDrain.dispose();
+
+      const restartedDrain = createSignalIngressDrain({ queue, dispatch });
+      await restartedDrain.drainOnce();
+      await restartedDrain.waitForIdle();
+      restartedDrain.dispose();
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith(event, expect.any(Object));
+    });
+  });
+
+  it("keeps a completion tombstone so a duplicate cannot dispatch twice", async () => {
+    await withQueue(async (queue) => {
+      const event = signalEvent();
+      const first = await enqueueSignalIngressEvent({ queue, event });
+      expect(first.kind).toBe("accepted");
+
+      const dispatch = vi.fn().mockResolvedValue(undefined);
+      const drain = createSignalIngressDrain({ queue, dispatch });
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      const duplicate = await enqueueSignalIngressEvent({ queue, event });
+      expect(duplicate.kind).toBe("completed");
+      await drain.drainOnce();
+      await drain.waitForIdle();
+      drain.dispose();
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("completes only when deferred dispatch adoption becomes durable", async () => {
+    await withQueue(async (queue) => {
+      const event = signalEvent();
+      await enqueueSignalIngressEvent({ queue, event });
+      let adopt: (() => void | Promise<void>) | undefined;
+      const drain = createSignalIngressDrain({
+        queue,
+        dispatch: (_event, lifecycle) => {
+          adopt = lifecycle.onAdopted;
+          lifecycle.onDeferred();
+          return { kind: "deferred" };
+        },
+      });
+
+      await drain.drainOnce();
+      await vi.waitFor(async () => {
+        expect(await queue.listClaims()).toHaveLength(1);
+      });
+      expect((await enqueueSignalIngressEvent({ queue, event })).kind).toBe("claimed");
+
+      await adopt?.();
+      await drain.waitForIdle();
+      expect((await enqueueSignalIngressEvent({ queue, event })).kind).toBe("completed");
+      drain.dispose();
+    });
+  });
+
+  it("dead-letters malformed persisted payloads without retry", async () => {
+    await withQueue(async (queue) => {
+      await queue.enqueue(
+        "malformed-event",
+        {
+          version: 1,
+          receivedAt: 1,
+          event: { event: "receive", data: "{" },
+        },
+        { receivedAt: 1, laneKey: "direct:number:+15550001111" },
+      );
+      const dispatch = vi.fn();
+      const drain = createSignalIngressDrain({ queue, dispatch });
+
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      expect((await queue.enqueue("malformed-event", {} as SignalIngressPayload)).kind).toBe(
+        "failed",
+      );
+      expect(dispatch).not.toHaveBeenCalled();
+      drain.dispose();
+    });
+  });
+
+  it("dedupes a concrete Signal redelivery by sender and timestamp", async () => {
+    await withQueue(async (queue) => {
+      const original = signalEvent({
+        senderNumber: "+15550002222",
+        senderUuid: "123e4567-e89b-12d3-a456-426614174000",
+        timestamp: 1_700_000_000_099,
+        message: "redelivered message",
+      });
+      const redelivery = signalEvent({
+        senderNumber: "+15550002222",
+        senderUuid: "123e4567-e89b-12d3-a456-426614174000",
+        timestamp: 1_700_000_000_099,
+        message: "redelivered message",
+      });
+      expect(resolveSignalIngressEventId(original)).toBe(resolveSignalIngressEventId(redelivery));
+
+      await enqueueSignalIngressEvent({ queue, event: original });
+      const dispatch = vi.fn().mockResolvedValue(undefined);
+      const drain = createSignalIngressDrain({ queue, dispatch });
+      await drain.drainOnce();
+      await drain.waitForIdle();
+
+      const duplicate = await enqueueSignalIngressEvent({ queue, event: redelivery });
+      expect(duplicate.kind).toBe("completed");
+      await drain.drainOnce();
+      await drain.waitForIdle();
+      drain.dispose();
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("uses a direct-sender or group-conversation lane and stores the raw event", async () => {
+    await withQueue(async (queue) => {
+      const direct = signalEvent({ senderUuid: "123e4567-e89b-12d3-a456-426614174000" });
+      const group = signalEvent({ groupId: "group-123" });
+
+      expect(resolveSignalIngressLaneKey(direct)).toBe(
+        "direct:uuid:123e4567-e89b-12d3-a456-426614174000",
+      );
+      expect(resolveSignalIngressLaneKey(group)).toBe("group:group-123");
+
+      await enqueueSignalIngressEvent({ queue, event: group });
+      const pending = await queue.listPending({ limit: "all" });
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.payload.event).toEqual(group);
+      expect(pending[0]?.laneKey).toBe("group:group-123");
+    });
+  });
+
+  it.each([
+    ["sync", { envelope: { sourceNumber: "+15550001111", timestamp: 1, syncMessage: {} } }],
+    ["receipt", { envelope: { sourceNumber: "+15550001111", timestamp: 2, receiptMessage: {} } }],
+    ["typing", { envelope: { sourceNumber: "+15550001111", timestamp: 3, typingMessage: {} } }],
+  ])("does not journal %s envelopes", async (_label, payload) => {
+    await withQueue(async (queue) => {
+      const result = await enqueueSignalIngressEvent({
+        queue,
+        event: { event: "receive", data: JSON.stringify(payload) },
+      });
+      expect(result.kind).toBe("ignored");
+      await expect(queue.listPending({ limit: "all" })).resolves.toHaveLength(0);
+    });
+  });
+});

--- a/extensions/signal/src/signal-ingress.test.ts
+++ b/extensions/signal/src/signal-ingress.test.ts
@@ -11,15 +11,25 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SignalSseEvent } from "./client-adapter.js";
 import { setSignalRuntime } from "./runtime.js";
-import { clearSignalRuntimeForTest } from "./runtime.test-support.js";
 import {
-  createSignalIngressDrain,
-  enqueueSignalIngressEvent,
-  resolveSignalIngressEventId,
-  resolveSignalIngressLaneKey,
-  startSignalIngressMonitor,
+  clearSignalRuntimeForTest,
+  signalIngressTesting,
   type SignalIngressPayload,
-} from "./signal-ingress.js";
+} from "./runtime.test-support.js";
+import { startSignalIngressMonitor } from "./signal-ingress.js";
+
+const createSignalIngressDrain = (
+  ...args: Parameters<typeof signalIngressTesting.createSignalIngressDrain>
+) => signalIngressTesting.createSignalIngressDrain(...args);
+const enqueueSignalIngressEvent = (
+  ...args: Parameters<typeof signalIngressTesting.enqueueSignalIngressEvent>
+) => signalIngressTesting.enqueueSignalIngressEvent(...args);
+const resolveSignalIngressEventId = (
+  ...args: Parameters<typeof signalIngressTesting.resolveSignalIngressEventId>
+) => signalIngressTesting.resolveSignalIngressEventId(...args);
+const resolveSignalIngressLaneKey = (
+  ...args: Parameters<typeof signalIngressTesting.resolveSignalIngressLaneKey>
+) => signalIngressTesting.resolveSignalIngressLaneKey(...args);
 
 function signalEvent(params?: {
   senderNumber?: string;

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -31,7 +31,7 @@ type SignalIngressEventFacts = {
   laneKey: string;
 };
 
-export type SignalIngressPayload = {
+type SignalIngressPayload = {
   version: 1;
   receivedAt: number;
   event: SignalSseEvent;
@@ -152,11 +152,11 @@ function inspectSignalIngressEvent(event: SignalSseEvent): SignalIngressEventFac
   };
 }
 
-export function resolveSignalIngressEventId(event: SignalSseEvent): string | null {
+function resolveSignalIngressEventId(event: SignalSseEvent): string | null {
   return inspectSignalIngressEvent(event)?.eventId ?? null;
 }
 
-export function resolveSignalIngressLaneKey(event: SignalSseEvent): string | null {
+function resolveSignalIngressLaneKey(event: SignalSseEvent): string | null {
   return inspectSignalIngressEvent(event)?.laneKey ?? null;
 }
 
@@ -165,7 +165,7 @@ type SignalIngressEnqueueResult =
   | { kind: "ignored" };
 
 /** Durable receive chokepoint. Metadata comes from raw fields; payload stays byte-equivalent JSON. */
-export async function enqueueSignalIngressEvent(params: {
+async function enqueueSignalIngressEvent(params: {
   queue: ChannelIngressQueue<SignalIngressPayload>;
   event: SignalSseEvent;
   now?: number;
@@ -195,7 +195,7 @@ function resolveSignalIngressNonRetryableFailure(error: unknown) {
     : null;
 }
 
-export function createSignalIngressDrain(params: {
+function createSignalIngressDrain(params: {
   queue: ChannelIngressQueue<SignalIngressPayload>;
   dispatch: SignalIngressDispatch;
   abortSignal?: AbortSignal;
@@ -295,5 +295,14 @@ export async function startSignalIngressMonitor(params: {
       await drainPass?.catch(() => undefined);
       drain.dispose();
     },
+  };
+}
+
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.signalIngressTestApi")] = {
+    createSignalIngressDrain,
+    enqueueSignalIngressEvent,
+    resolveSignalIngressEventId,
+    resolveSignalIngressLaneKey,
   };
 }

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -1,0 +1,299 @@
+// Signal plugin module owns raw-envelope durable ingress mapping and draining.
+import {
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressDrain,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import type { SignalSseEvent } from "./client-adapter.js";
+import { getOptionalSignalRuntime } from "./runtime.js";
+
+const SIGNAL_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const SIGNAL_INGRESS_COMPLETED_MAX_ENTRIES = 1000;
+const SIGNAL_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const SIGNAL_INGRESS_FAILED_MAX_ENTRIES = 1000;
+const SIGNAL_INGRESS_DRAIN_INTERVAL_MS = 1_000;
+
+type SignalIngressEnvelope = {
+  sourceNumber?: unknown;
+  sourceUuid?: unknown;
+  timestamp?: unknown;
+  syncMessage?: unknown;
+  dataMessage?: unknown;
+  editMessage?: { dataMessage?: unknown } | null;
+  reactionMessage?: unknown;
+};
+
+type SignalIngressEventFacts = {
+  eventId: string;
+  laneKey: string;
+};
+
+export type SignalIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  event: SignalSseEvent;
+};
+
+export type SignalIngressLifecycle = {
+  abortSignal: AbortSignal;
+  onAdopted: () => void | Promise<void>;
+  onDeferred: () => void;
+  onAdoptionFinalizing: () => void;
+  onAbandoned: () => void;
+};
+
+type SignalIngressDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type SignalIngressDispatch = (
+  event: SignalSseEvent,
+  lifecycle: SignalIngressLifecycle,
+) => Promise<SignalIngressDispatchResult | void> | SignalIngressDispatchResult | void;
+
+class SignalIngressPermanentError extends Error {
+  constructor(
+    readonly reason: "parse-error" | "missing-sender" | "missing-timestamp" | "unsupported-event",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "SignalIngressPermanentError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeRawString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+function parseReceiveEnvelope(event: SignalSseEvent): SignalIngressEnvelope | null {
+  if (event.event !== "receive" || !event.data) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(event.data);
+  } catch (error) {
+    throw new SignalIngressPermanentError(
+      "parse-error",
+      "Signal receive event contains invalid JSON",
+      {
+        cause: error,
+      },
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new SignalIngressPermanentError(
+      "parse-error",
+      "Signal receive event must contain a JSON object",
+    );
+  }
+  return isRecord(parsed.envelope) ? (parsed.envelope as SignalIngressEnvelope) : null;
+}
+
+function resolveDataMessage(envelope: SignalIngressEnvelope): Record<string, unknown> | null {
+  if (isRecord(envelope.dataMessage)) {
+    return envelope.dataMessage;
+  }
+  return isRecord(envelope.editMessage?.dataMessage) ? envelope.editMessage.dataMessage : null;
+}
+
+function inspectSignalIngressEvent(event: SignalSseEvent): SignalIngressEventFacts | null {
+  const envelope = parseReceiveEnvelope(event);
+  if (!envelope || "syncMessage" in envelope) {
+    return null;
+  }
+  const dataMessage = resolveDataMessage(envelope);
+  const reactionMessage = isRecord(envelope.reactionMessage) ? envelope.reactionMessage : null;
+  if (!dataMessage && !reactionMessage) {
+    // Receipts, typing notifications, and other transport-only envelopes never dispatch.
+    return null;
+  }
+  const senderUuid = normalizeRawString(envelope.sourceUuid);
+  const senderNumber = normalizeRawString(envelope.sourceNumber);
+  const senderKey = senderUuid
+    ? `uuid:${senderUuid}`
+    : senderNumber
+      ? `number:${senderNumber}`
+      : null;
+  if (!senderKey) {
+    throw new SignalIngressPermanentError(
+      "missing-sender",
+      "Signal dispatchable envelope is missing sourceUuid/sourceNumber",
+    );
+  }
+  const timestamp =
+    normalizeTimestamp(envelope.timestamp) ?? normalizeTimestamp(dataMessage?.timestamp);
+  if (timestamp === null) {
+    throw new SignalIngressPermanentError(
+      "missing-timestamp",
+      "Signal dispatchable envelope is missing a stable timestamp",
+    );
+  }
+  const dataGroup = isRecord(dataMessage?.groupInfo) ? dataMessage.groupInfo : null;
+  const reactionGroup = isRecord(reactionMessage?.groupInfo) ? reactionMessage.groupInfo : null;
+  const groupId =
+    normalizeRawString(dataGroup?.groupId) ?? normalizeRawString(reactionGroup?.groupId);
+  return {
+    eventId: JSON.stringify([senderKey, timestamp]),
+    laneKey: groupId ? `group:${groupId}` : `direct:${senderKey}`,
+  };
+}
+
+export function resolveSignalIngressEventId(event: SignalSseEvent): string | null {
+  return inspectSignalIngressEvent(event)?.eventId ?? null;
+}
+
+export function resolveSignalIngressLaneKey(event: SignalSseEvent): string | null {
+  return inspectSignalIngressEvent(event)?.laneKey ?? null;
+}
+
+type SignalIngressEnqueueResult =
+  | Awaited<ReturnType<ChannelIngressQueue<SignalIngressPayload>["enqueue"]>>
+  | { kind: "ignored" };
+
+/** Durable receive chokepoint. Metadata comes from raw fields; payload stays byte-equivalent JSON. */
+export async function enqueueSignalIngressEvent(params: {
+  queue: ChannelIngressQueue<SignalIngressPayload>;
+  event: SignalSseEvent;
+  now?: number;
+}): Promise<SignalIngressEnqueueResult> {
+  const facts = inspectSignalIngressEvent(params.event);
+  if (!facts) {
+    return { kind: "ignored" };
+  }
+  const receivedAt = params.now ?? Date.now();
+  await params.queue.prune({
+    completedTtlMs: SIGNAL_INGRESS_COMPLETED_TTL_MS,
+    completedMaxEntries: SIGNAL_INGRESS_COMPLETED_MAX_ENTRIES,
+    failedTtlMs: SIGNAL_INGRESS_FAILED_TTL_MS,
+    failedMaxEntries: SIGNAL_INGRESS_FAILED_MAX_ENTRIES,
+    ...(params.now === undefined ? {} : { now: params.now }),
+  });
+  return await params.queue.enqueue(
+    facts.eventId,
+    { version: 1, receivedAt, event: params.event },
+    { receivedAt, laneKey: facts.laneKey },
+  );
+}
+
+function resolveSignalIngressNonRetryableFailure(error: unknown) {
+  return error instanceof SignalIngressPermanentError
+    ? { reason: error.reason, message: error.message }
+    : null;
+}
+
+export function createSignalIngressDrain(params: {
+  queue: ChannelIngressQueue<SignalIngressPayload>;
+  dispatch: SignalIngressDispatch;
+  abortSignal?: AbortSignal;
+  onLog?: (message: string) => void;
+}): ChannelIngressDrain {
+  return createChannelIngressDrain<SignalIngressPayload>({
+    queue: params.queue,
+    retryPolicy: {
+      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+    },
+    resolveNonRetryableFailure: resolveSignalIngressNonRetryableFailure,
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    ...(params.onLog ? { onLog: params.onLog } : {}),
+    dispatchClaimedEvent: async (record, lifecycle) => {
+      if (!inspectSignalIngressEvent(record.payload.event)) {
+        throw new SignalIngressPermanentError(
+          "unsupported-event",
+          "Signal ingress row no longer contains a dispatchable envelope",
+        );
+      }
+      return await params.dispatch(record.payload.event, lifecycle);
+    },
+  });
+}
+
+export type SignalIngressMonitor = {
+  receive: (event: SignalSseEvent) => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+/** Open the account queue, recover it, and keep newly appended rows draining. */
+export async function startSignalIngressMonitor(params: {
+  accountId: string;
+  dispatch: SignalIngressDispatch;
+  runtime: Pick<RuntimeEnv, "error" | "log">;
+  runTrackedTask: (task: () => Promise<void>) => void;
+}): Promise<SignalIngressMonitor> {
+  const pluginRuntime = getOptionalSignalRuntime();
+  if (!pluginRuntime) {
+    throw new Error("Signal runtime not initialized for durable ingress");
+  }
+  const queue = pluginRuntime.state.openChannelIngressQueue<SignalIngressPayload>({
+    accountId: params.accountId,
+  });
+  const drain = createSignalIngressDrain({
+    queue,
+    dispatch: params.dispatch,
+    onLog: (message) => params.runtime.log?.(`signal ${message}`),
+  });
+  let drainPass: Promise<void> | undefined;
+  let drainRequested = false;
+
+  const requestDrain = (): Promise<void> => {
+    drainRequested = true;
+    if (!drainPass) {
+      drainPass = (async () => {
+        while (drainRequested) {
+          drainRequested = false;
+          const result = await drain.drainOnce();
+          if (result.started > 0) {
+            params.runTrackedTask(async () => {
+              await drain.waitForIdle();
+              await requestDrain();
+            });
+          }
+        }
+      })().finally(() => {
+        drainPass = undefined;
+        if (drainRequested) {
+          void requestDrain().catch((error: unknown) => {
+            params.runtime.error?.(`signal ingress drain failed: ${String(error)}`);
+          });
+        }
+      });
+    }
+    return drainPass;
+  };
+
+  await requestDrain();
+  const timer = setInterval(() => {
+    void requestDrain().catch((error: unknown) => {
+      params.runtime.error?.(`signal ingress drain failed: ${String(error)}`);
+    });
+  }, SIGNAL_INGRESS_DRAIN_INTERVAL_MS);
+  timer.unref?.();
+
+  return {
+    receive: async (event) => {
+      const result = await enqueueSignalIngressEvent({ queue, event });
+      if (result.kind !== "ignored") {
+        await requestDrain();
+      }
+    },
+    stop: async () => {
+      clearInterval(timer);
+      await drainPass?.catch(() => undefined);
+      drain.dispose();
+    },
+  };
+}

--- a/extensions/signal/src/sse-reconnect.ts
+++ b/extensions/signal/src/sse-reconnect.ts
@@ -21,7 +21,7 @@ type RunSignalSseLoopParams = {
   account?: string;
   abortSignal?: AbortSignal;
   runtime: RuntimeEnv;
-  onEvent: (event: SignalSseEvent) => void;
+  onEvent: (event: SignalSseEvent) => unknown;
   timeoutMs?: number;
   apiMode?: SignalApiMode;
   policy?: Partial<BackoffPolicy>;
@@ -61,9 +61,9 @@ export async function runSignalSseLoop({
         abortSignal,
         timeoutMs,
         apiMode,
-        onEvent: (event: SignalSseEvent) => {
+        onEvent: async (event: SignalSseEvent) => {
           reconnectAttempts = 0;
-          onEvent(event);
+          await onEvent(event);
         },
         logger: {
           log: runtime.log,


### PR DESCRIPTION
Related: #109657

AI-assisted implementation and review.

## What Problem This Solves

Fixes an issue where Signal users could silently lose an inbound message when OpenClaw crashed after signal-cli delivered it but before the agent turn adopted it. Signal's receive stream does not re-emit an already-consumed envelope after reconnect, so the prior in-memory receive loop had no recovery path.

## Why This Change Was Made

Signal now journals each raw receive envelope at the single transport chokepoint before returning ownership. A stable event ID derived from `[sender, timestamp]` supplies durable cross-restart deduplication, while direct messages use sender lanes and group messages use group lanes to preserve conversation ordering.

Ingress claims remain deferred through debounce. One merged turn fans its adoption or abandonment settlement across every constituent claim, and deliberately handled no-adoption paths settle their claims instead of stalling. No durable Signal replay guard existed before this change; this adds durable deduplication rather than replacing a prior guard.

## User Impact

Signal messages received before a crash can now replay after restart until an agent turn durably adopts them. Adopted duplicates remain rejected by durable tombstones, conversation ordering stays isolated by sender or group, and debounced messages retain correct claim ownership.

## Evidence

- `PATH=/Users/steipete/Projects/openclaw/node_modules/.bin:$PATH node scripts/run-vitest.mjs extensions/signal` — 37 files and 571 tests passed, including three new claim-ownership regression tests for deferred adoption, merged debounce fan-out, and handled no-adoption settlement.
- `node scripts/check-deadcode-exports.mjs` — zero unused exports across production, full-tree, and script scans.
- `node scripts/check-deadcode-unused-files.mjs` — zero unused files across production and full-tree scans.
- `/Users/steipete/Projects/openclaw/node_modules/.bin/oxfmt --check extensions/signal/src` and `node scripts/run-oxlint.mjs extensions/signal/src` — clean.
- `git diff --check origin/main -- extensions/signal` — clean.

The initial structured autoreview was blocked by the isolated reviewer sandbox's network access. Manual review covered receive chokepoints, queue lifecycle, client stream ordering and error propagation, debounce and control lanes, merged fan-out, non-dispatch settlement, retry abandonment, and the core ingress-drain contract; it caught and fixed an earlier debounce bypass and unsettled gated-claim path. A fresh targeted autoreview of the follow-up helper-privacy fix completed clean; a later full-branch retry reproduced the network stall.
