### PR TITLE
fix: timed-out agent runs no longer retain MCP processes

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -404,20 +404,54 @@ export function buildBundleMcpToolsFromCatalog(params: {
   return tools;
 }
 
+export class BundleMcpRunLeaseDisposedError extends Error {
+  constructor(sessionId: string) {
+    super(`bundle-mcp run lease disposed for session ${sessionId}`);
+    this.name = "BundleMcpRunLeaseDisposedError";
+  }
+}
+
 export async function materializeBundleMcpToolsForRun(params: {
   runtime: SessionMcpRuntime;
   reservedToolNames?: Iterable<string>;
   disposeRuntime?: () => Promise<void>;
+  onLeaseAcquired?: (handle: Pick<BundleMcpToolRuntime, "dispose">) => void;
 }): Promise<BundleMcpToolRuntime> {
   let disposed = false;
   let allowedAppToolsByServer: Map<string, Set<string>> | undefined;
   const releaseLease = params.runtime.acquireLease?.();
+  const dispose = async () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    // Reset/delete can request retirement while this run owns the lease.
+    // Dispose as soon as the final run, view, or other independent lease has released.
+    await releaseRuntimeLease({ runtime: params.runtime, releaseLease });
+    await params.disposeRuntime?.();
+  };
+  const assertLeaseActive = () => {
+    if (disposed) {
+      throw new BundleMcpRunLeaseDisposedError(params.runtime.sessionId);
+    }
+  };
+  try {
+    // Register immediately after acquisition: catalog discovery can itself hang,
+    // so waiting for materialization would leave the run lease unreachable.
+    params.onLeaseAcquired?.({ dispose });
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
   params.runtime.markUsed();
   let catalog;
   try {
     catalog = await params.runtime.getCatalog();
+    // A lane timeout can revoke the run lease while catalog startup is still
+    // pending. Never return tools whose owning run was already abandoned.
+    assertLeaseActive();
   } catch (error) {
-    await releaseRuntimeLease({ runtime: params.runtime, releaseLease });
+    await dispose();
     throw error;
   }
   const reservedToolNames = params.reservedToolNames
@@ -427,6 +461,7 @@ export async function materializeBundleMcpToolsForRun(params: {
     catalog,
     reservedToolNames,
     createExecute: (tool) => async (toolCallId: string, input: unknown) => {
+      assertLeaseActive();
       params.runtime.markUsed();
       const result = await params.runtime.callTool(tool.serverName, tool.toolName, input);
       const agentResult = toAgentToolResult({
@@ -463,6 +498,7 @@ export async function materializeBundleMcpToolsForRun(params: {
     },
     createResourceListExecute: params.runtime.listResources
       ? (serverName) => async () => {
+          assertLeaseActive();
           params.runtime.markUsed();
           return toJsonAgentToolResult({
             serverName,
@@ -473,6 +509,7 @@ export async function materializeBundleMcpToolsForRun(params: {
       : undefined,
     createResourceReadExecute: params.runtime.readResource
       ? (serverName) => async (_toolCallId: string, input: unknown) => {
+          assertLeaseActive();
           params.runtime.markUsed();
           return toJsonAgentToolResult({
             serverName,
@@ -483,6 +520,7 @@ export async function materializeBundleMcpToolsForRun(params: {
       : undefined,
     createPromptListExecute: params.runtime.listPrompts
       ? (serverName) => async () => {
+          assertLeaseActive();
           params.runtime.markUsed();
           return toJsonAgentToolResult({
             serverName,
@@ -493,6 +531,7 @@ export async function materializeBundleMcpToolsForRun(params: {
       : undefined,
     createPromptGetExecute: params.runtime.getPrompt
       ? (serverName) => async (_toolCallId: string, input: unknown) => {
+          assertLeaseActive();
           params.runtime.markUsed();
           return toJsonAgentToolResult({
             serverName,
@@ -531,16 +570,7 @@ export async function materializeBundleMcpToolsForRun(params: {
       }
       allowedAppToolsByServer = next;
     },
-    dispose: async () => {
-      if (disposed) {
-        return;
-      }
-      disposed = true;
-      // Reset/delete can request retirement while this run owns the lease.
-      // Dispose as soon as the final run, view, or request lease has released.
-      await releaseRuntimeLease({ runtime: params.runtime, releaseLease });
-      await params.disposeRuntime?.();
-    },
+    dispose,
   };
 }
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -21,7 +21,7 @@ import {
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,
 } from "./agent-bundle-mcp-tools.js";
-import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+import type { McpToolCatalog, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { writeExecutable } from "./bundle-mcp-shared.test-harness.js";
 
 vi.mock("./embedded-agent-mcp.js", () => ({
@@ -834,6 +834,56 @@ describe("session MCP runtime", () => {
     await materialized.dispose();
 
     expect(activeLeases).toBe(0);
+  });
+
+  it("rejects pending catalog materialization after its run lease is disposed", async () => {
+    let activeLeases = 0;
+    const releaseLease = vi.fn(() => {
+      activeLeases -= 1;
+    });
+    const baseRuntime = makeRuntime([
+      { toolName: "bundle_probe", description: "Bundle MCP probe" },
+    ]);
+    const catalog = await baseRuntime.getCatalog();
+    let resolveCatalog: ((value: McpToolCatalog) => void) | undefined;
+    const pendingCatalog = new Promise<McpToolCatalog>((resolve) => {
+      resolveCatalog = resolve;
+    });
+    const runtime = {
+      ...baseRuntime,
+      acquireLease: () => {
+        activeLeases += 1;
+        return releaseLease;
+      },
+      getCatalog: () => pendingCatalog,
+    };
+    let timeoutHandle: { dispose(): Promise<void> } | undefined;
+    let exposedTools: unknown;
+
+    const materializing = materializeBundleMcpToolsForRun({
+      runtime,
+      onLeaseAcquired: (handle) => {
+        timeoutHandle = handle;
+      },
+    }).then((materialized) => {
+      exposedTools = materialized.tools;
+      return materialized;
+    });
+
+    expect(timeoutHandle).toBeDefined();
+    expect(activeLeases).toBe(1);
+    await timeoutHandle?.dispose();
+    await timeoutHandle?.dispose();
+    expect(activeLeases).toBe(0);
+    expect(releaseLease).toHaveBeenCalledOnce();
+
+    const rejected = expect(materializing).rejects.toMatchObject({
+      name: "BundleMcpRunLeaseDisposedError",
+    });
+    resolveCatalog?.(catalog);
+    await rejected;
+    expect(exposedTools).toBeUndefined();
+    expect(releaseLease).toHaveBeenCalledOnce();
   });
 
   it("releases a runtime lease when catalog materialization fails", async () => {
@@ -2069,6 +2119,34 @@ process.on("SIGINT", shutdown);`,
 
     await materialized.dispose();
     expect(testing.getCachedSessionIds()).not.toContain("session-run-lease");
+  });
+
+  it("releases only the materialized run lease while an independent lease stays active", async () => {
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-run-with-independent-lease",
+      sessionKey: "agent:test:session-run-with-independent-lease",
+      workspaceDir: "/workspace",
+      cfg: { mcp: { sessionIdleTtlMs: 0 } },
+    });
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const releaseIndependentLease = runtime.acquireLease?.();
+
+    await expect(
+      retireSessionMcpRuntime({
+        sessionId: "session-run-with-independent-lease",
+        reason: "gateway-session-cleanup",
+        preserveActiveLeases: true,
+      }),
+    ).resolves.toBe(true);
+    expect(runtime.activeLeases).toBe(2);
+
+    await materialized.dispose();
+    expect(runtime.activeLeases).toBe(1);
+    expect(testing.getCachedSessionIds()).toContain("session-run-with-independent-lease");
+
+    releaseIndependentLease?.();
+    await completeDeferredSessionMcpRuntimeRetirement(runtime);
+    expect(testing.getCachedSessionIds()).not.toContain("session-run-with-independent-lease");
   });
 
   it("keeps an active MCP child and its database lock until deferred retirement completes", async () => {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -3,7 +3,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { validateToolArguments } from "openclaw/plugin-sdk/llm";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import {
   buildBundleMcpToolsFromCatalog,
@@ -250,6 +250,85 @@ describe("createBundleMcpToolRuntime", () => {
     expect(result.details).toEqual({
       mcpServer: "bundleProbe",
       mcpTool: "bundle_probe",
+    });
+  });
+
+  it("rejects new MCP tool, resource, and prompt calls after the run lease is disposed", async () => {
+    const base = makeToolRuntime({ serverName: "knowledge" });
+    const catalog = await base.getCatalog();
+    const callTool = vi.fn(base.callTool);
+    const listResources = vi.fn(async () => [{ uri: "memo://one", name: "memo" }]);
+    const readResource = vi.fn(async (_serverName: string, uri: string) => ({
+      contents: [{ uri, text: "memo text" }],
+    }));
+    const listPrompts = vi.fn(async () => [{ name: "brief" }]);
+    const getPrompt = vi.fn(async (_serverName: string, name: string) => ({ name }));
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: {
+        ...base,
+        getCatalog: async () => ({
+          ...catalog,
+          servers: {
+            knowledge: {
+              ...catalog.servers.knowledge,
+              resources: { listChanged: true },
+              prompts: { listChanged: true },
+            },
+          },
+        }),
+        callTool,
+        listResources,
+        readResource,
+        listPrompts,
+        getPrompt,
+      },
+    });
+
+    await runtime.dispose();
+    const calls: Array<[string, Record<string, unknown>]> = [
+      ["knowledge__bundle_probe", {}],
+      ["knowledge__resources_list", {}],
+      ["knowledge__resources_read", { uri: "memo://one" }],
+      ["knowledge__prompts_list", {}],
+      ["knowledge__prompts_get", { name: "brief" }],
+    ];
+    for (const [name, input] of calls) {
+      const tool = expectDefined(
+        runtime.tools.find((candidate) => candidate.name === name),
+        `${name} test invariant`,
+      );
+      await expect(
+        tool.execute(`call-after-dispose-${name}`, input, undefined, undefined),
+      ).rejects.toMatchObject({ name: "BundleMcpRunLeaseDisposedError" });
+    }
+    expect(callTool).not.toHaveBeenCalled();
+    expect(listResources).not.toHaveBeenCalled();
+    expect(readResource).not.toHaveBeenCalled();
+    expect(listPrompts).not.toHaveBeenCalled();
+    expect(getPrompt).not.toHaveBeenCalled();
+  });
+
+  it("allows an MCP tool call already in flight to settle after run lease disposal", async () => {
+    let resolveCall: ((result: CallToolResult) => void) | undefined;
+    const pendingCall = new Promise<CallToolResult>((resolve) => {
+      resolveCall = resolve;
+    });
+    const sessionRuntime = makeToolRuntime();
+    sessionRuntime.callTool = vi.fn(() => pendingCall);
+    const runtime = await materializeBundleMcpToolsForRun({ runtime: sessionRuntime });
+
+    const execution = expectDefined(runtime.tools[0], "runtime.tools[0] test invariant").execute(
+      "call-already-in-flight",
+      {},
+      undefined,
+      undefined,
+    );
+    expect(sessionRuntime.callTool).toHaveBeenCalledOnce();
+
+    await runtime.dispose();
+    resolveCall?.({ content: [{ type: "text", text: "settled" }], isError: false });
+    await expect(execution).resolves.toMatchObject({
+      content: [{ type: "text", text: "settled" }],
     });
   });
 

--- a/src/agents/embedded-agent-runner/run.compaction-loop-guard.test.ts
+++ b/src/agents/embedded-agent-runner/run.compaction-loop-guard.test.ts
@@ -299,6 +299,10 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
 
   it("releases a native lane when a timed-out attempt ignores cancellation", async () => {
     vi.useFakeTimers();
+    const events: string[] = [];
+    const disposeMcpRunLease = vi.fn(async () => {
+      events.push("lease-released");
+    });
     let settleAttempt: ((value: ReturnType<typeof makeAttemptResult>) => void) | undefined;
     let resolveAttemptStarted: (() => void) | undefined;
     const attemptStarted = new Promise<void>((resolve) => {
@@ -306,16 +310,24 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
     });
     try {
       mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
-        const { onAttemptTimeoutArmed, onAttemptTimeout } = attemptParams as {
-          onAttemptTimeoutArmed?: () => void;
-          onAttemptTimeout?: (reason: Error) => void;
-        };
+        const { onAttemptTimeoutArmed, onAttemptTimeout, onBundleMcpLeaseAcquired } =
+          attemptParams as {
+            onAttemptTimeoutArmed?: () => void;
+            onAttemptTimeout?: (reason: Error) => void;
+            onBundleMcpLeaseAcquired?: (handle: { dispose(): Promise<void> }) => void;
+          };
         resolveAttemptStarted?.();
+        // Catalog startup remains pending after the run-owned lease is acquired.
+        onBundleMcpLeaseAcquired?.({ dispose: disposeMcpRunLease });
         onAttemptTimeoutArmed?.();
         onAttemptTimeout?.(new Error("attempt timed out"));
         return await new Promise((resolve) => {
           settleAttempt = resolve;
         });
+      });
+      mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
+        events.push("next-attempt");
+        return makeAttemptResult();
       });
 
       const run = runEmbeddedAgent({
@@ -337,10 +349,92 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
 
       expect(settled).toBe(true);
       await expect(run).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
+      expect(disposeMcpRunLease).toHaveBeenCalledOnce();
+
+      await expect(
+        runEmbeddedAgent({
+          ...baseParams,
+          runId: "run-after-native-timeout-lane-release",
+          agentHarnessRuntimeOverride: "openclaw",
+        }),
+      ).resolves.toMatchObject({ meta: { aborted: false } });
+      expect(events).toEqual(["lease-released", "next-attempt"]);
     } finally {
       settleAttempt?.(makeAttemptResult());
       vi.useRealTimers();
     }
+  });
+
+  it("disposes a native MCP run lease acquired after the lane already timed out", async () => {
+    vi.useFakeTimers();
+    const disposeLateMcpRunLease = vi.fn(async () => {});
+    let registerLateLease: ((handle: { dispose(): Promise<void> }) => void) | undefined;
+    let settleAttempt: ((value: ReturnType<typeof makeAttemptResult>) => void) | undefined;
+    let resolveAttemptStarted: (() => void) | undefined;
+    const attemptStarted = new Promise<void>((resolve) => {
+      resolveAttemptStarted = resolve;
+    });
+    try {
+      mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+        const { onAttemptTimeoutArmed, onAttemptTimeout, onBundleMcpLeaseAcquired } =
+          attemptParams as {
+            onAttemptTimeoutArmed?: () => void;
+            onAttemptTimeout?: (reason: Error) => void;
+            onBundleMcpLeaseAcquired?: (handle: { dispose(): Promise<void> }) => void;
+          };
+        registerLateLease = onBundleMcpLeaseAcquired;
+        resolveAttemptStarted?.();
+        onAttemptTimeoutArmed?.();
+        onAttemptTimeout?.(new Error("attempt timed out"));
+        return await new Promise((resolve) => {
+          settleAttempt = resolve;
+        });
+      });
+
+      const run = runEmbeddedAgent({
+        ...baseParams,
+        runId: "run-native-late-mcp-lease-after-timeout",
+        timeoutMs: 48 * 60 * 60 * 1000,
+        agentHarnessRuntimeOverride: "openclaw",
+      });
+      const runRejected = expect(run).rejects.toMatchObject({
+        name: "CommandLaneTaskTimeoutError",
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await attemptStarted;
+      await vi.advanceTimersByTimeAsync(30_001);
+      await runRejected;
+
+      expect(registerLateLease).toBeDefined();
+      registerLateLease?.({ dispose: disposeLateMcpRunLease });
+      expect(disposeLateMcpRunLease).toHaveBeenCalledOnce();
+    } finally {
+      settleAttempt?.(makeAttemptResult());
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves an already-disposed native MCP lease alone after normal completion", async () => {
+    const disposeMcpRunLease = vi.fn(async () => {});
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+      const { onBundleMcpLeaseAcquired } = attemptParams as {
+        onBundleMcpLeaseAcquired?: (handle: { dispose(): Promise<void> }) => void;
+      };
+      const handle = { dispose: disposeMcpRunLease };
+      onBundleMcpLeaseAcquired?.(handle);
+      await handle.dispose();
+      return makeAttemptResult();
+    });
+
+    await expect(
+      runEmbeddedAgent({
+        ...baseParams,
+        runId: "run-native-normal-lease-cleanup",
+        agentHarnessRuntimeOverride: "openclaw",
+      }),
+    ).resolves.toMatchObject({ meta: { aborted: false } });
+    expect(disposeMcpRunLease).toHaveBeenCalledOnce();
   });
 
   it("releases a native lane when an explicit abort ignores cancellation", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -40,11 +40,19 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
   it("disposes prepared bundle runtimes when later policy setup fails", async () => {
     const disposeMcp = vi.fn(async () => {});
     const disposeLsp = vi.fn(async () => {});
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
-    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+    const onBundleMcpLeaseAcquired = vi.fn();
+    const leaseHandle = { dispose: disposeMcp };
+    const materializedMcpRuntime = {
       tools: [],
       dispose: disposeMcp,
-    });
+    };
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.materializeBundleMcpToolsForRun.mockImplementation(
+      async (params: { onLeaseAcquired?: (handle: typeof leaseHandle) => void }) => {
+        params.onLeaseAcquired?.(leaseHandle);
+        return materializedMcpRuntime;
+      },
+    );
     mocks.createBundleLspToolRuntime.mockResolvedValue({
       tools: [],
       dispose: disposeLsp,
@@ -63,6 +71,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
         runId: "run",
         runtimePlan: {},
         sessionId: "session",
+        onBundleMcpLeaseAcquired,
       },
       effectiveWorkspace: "/tmp/workspace",
       getCurrentAttemptPluginMetadataSnapshot: () => undefined,
@@ -80,6 +89,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     } as unknown as Parameters<typeof prepareEmbeddedAttemptBundleTools>[0];
 
     await expect(prepareEmbeddedAttemptBundleTools(input)).rejects.toThrow("bundle policy failed");
+    expect(onBundleMcpLeaseAcquired).toHaveBeenCalledWith(leaseHandle);
     expect(disposeMcp).toHaveBeenCalledOnce();
     expect(disposeLsp).toHaveBeenCalledOnce();
   });

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -98,6 +98,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
   const bundleMcpRuntime = bundleMcpSessionRuntime
     ? await materializeBundleMcpToolsForRun({
         runtime: bundleMcpSessionRuntime,
+        onLeaseAcquired: params.attempt.onBundleMcpLeaseAcquired,
         reservedToolNames: [
           ...tools.map((tool) => tool.name),
           ...(clientTools?.map((tool) => tool.function.name) ?? []),

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -75,8 +75,12 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
     notifyToolResult,
     resolveAttemptFastModeParam,
   } = runInput.progressController;
-  const { laneTaskAbortController, laneTaskReleaseController, noteLaneTaskProgress } =
-    runInput.laneController;
+  const {
+    laneTaskAbortController,
+    laneTaskReleaseController,
+    noteLaneTaskProgress,
+    registerLaneTimeoutMcpLease,
+  } = runInput.laneController;
   const {
     requestedModelId,
     beforeAgentStartResult,
@@ -218,6 +222,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
       laneTaskAbortController,
       laneTaskReleaseController,
       noteLaneTaskProgress,
+      registerLaneTimeoutMcpLease,
       onToolOutcome: input.observeToolOutcome,
       allocateToolOutcomeOrdinal: input.allocateToolOutcomeOrdinal,
       onToolStreamBoundary: maybeAnnounceFastModeAutoOff,

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -8,6 +8,7 @@ import {
 import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../../process/command-queue.js";
 import type { CommandQueueEnqueueOptions } from "../../../process/command-queue.types.js";
 import { withSessionPlacementTurnAdmission } from "../../session-placement-admission.js";
+import { log } from "../logger.js";
 import type { EmbeddedAgentRunResult } from "../types.js";
 import {
   EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
@@ -36,6 +37,8 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   const laneTaskTimeoutMs = resolveEmbeddedRunLaneTimeoutMs(initialParams.timeoutMs);
   const laneTaskAbortController = new AbortController();
   const laneTaskReleaseController = new AbortController();
+  let laneTimeoutMcpLease: { dispose(): Promise<void> } | undefined;
+  let laneTimeoutReached = false;
   let laneTaskProgressAtMs = Date.now();
 
   const noteLaneTaskProgress = () => {
@@ -57,6 +60,36 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     abortError.name = "AbortError";
     throw abortError;
   };
+  const disposeMcpLeaseHandle = (handle: { dispose(): Promise<void> }) => {
+    // Materialized runtime disposal releases only this attempt's run lease.
+    // Independent MCP leases keep their own owners and lifetimes.
+    const logCleanupError = (error: unknown) => {
+      const params = options.getParams();
+      log.warn(
+        `bundle-mcp lane-timeout lease cleanup failed: runId=${params.runId} sessionId=${params.sessionId} error=${String(error)}`,
+      );
+    };
+    try {
+      void handle.dispose().catch(logCleanupError);
+    } catch (error) {
+      logCleanupError(error);
+    }
+  };
+  const registerLaneTimeoutMcpLease = (handle: { dispose(): Promise<void> }) => {
+    if (laneTimeoutReached) {
+      disposeMcpLeaseHandle(handle);
+      return;
+    }
+    laneTimeoutMcpLease = handle;
+  };
+  const disposeLaneTimeoutMcpLease = () => {
+    laneTimeoutReached = true;
+    const handle = laneTimeoutMcpLease;
+    laneTimeoutMcpLease = undefined;
+    if (handle) {
+      disposeMcpLeaseHandle(handle);
+    }
+  };
   const withLaneTimeout = (opts?: CommandQueueEnqueueOptions) =>
     withEmbeddedRunLaneTimeout(
       {
@@ -65,6 +98,13 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
         taskTimeoutAbortSignal: laneTaskAbortController.signal,
         taskTimeoutAbortGraceMs: EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
         taskTimeoutReleaseSignal: laneTaskReleaseController.signal,
+        onTaskTimeout: () => {
+          try {
+            opts?.onTaskTimeout?.();
+          } finally {
+            disposeLaneTimeoutMcpLease();
+          }
+        },
       },
       laneTaskTimeoutMs,
     );
@@ -187,6 +227,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     laneTaskAbortController,
     laneTaskReleaseController,
     noteLaneTaskProgress,
+    registerLaneTimeoutMcpLease,
     throwIfAborted,
   };
 }

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -73,6 +73,7 @@ type AttemptControl = {
   laneTaskAbortController: AbortController;
   laneTaskReleaseController: AbortController;
   noteLaneTaskProgress: () => void;
+  registerLaneTimeoutMcpLease: (handle: { dispose(): Promise<void> }) => void;
   onToolOutcome: ToolOutcomeObserver;
   allocateToolOutcomeOrdinal: (toolCallId?: string) => number;
   onToolStreamBoundary: NonNullable<EmbeddedRunAttemptParams["onToolStreamBoundary"]>;
@@ -303,6 +304,9 @@ export async function dispatchEmbeddedRunAttempt(input: {
         control.laneTaskAbortController.abort();
       }
     },
+    ...(control.pluginHarnessOwnsTransport
+      ? {}
+      : { onBundleMcpLeaseAcquired: control.registerLaneTimeoutMcpLease }),
     replyOperation: params.replyOperation,
     shouldEmitToolResult: params.shouldEmitToolResult,
     shouldEmitToolOutput: params.shouldEmitToolOutput,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -142,6 +142,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   onAttemptTimeout?: (reason: Error) => void;
   /** Signals an explicit cancellation through the active native run handle. */
   onAttemptAbort?: () => void;
+  /** OpenClaw-host cleanup handle registered as soon as the run-owned MCP lease is acquired. */
+  onBundleMcpLeaseAcquired?: (handle: { dispose(): Promise<void> }) => void;
   /** Supplies run-global model-call ordering for parallel tool outcomes. */
   allocateToolOutcomeOrdinal?: (toolCallId?: string) => number;
   model: Model;

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -49,7 +49,7 @@ type InternalEmbeddedRunAttemptParams =
 
 export type AgentHarnessAttemptParams = Omit<
   InternalEmbeddedRunAttemptParams,
-  "trajectoryRecorder"
+  "onBundleMcpLeaseAcquired" | "trajectoryRecorder"
 >;
 export type AgentHarnessAttemptResult =
   import("../embedded-agent-runner/run/types.js").EmbeddedRunAttemptResult;

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -638,11 +638,18 @@ describe("command queue", () => {
     vi.useFakeTimers();
     try {
       const releaseController = new AbortController();
+      const abortController = new AbortController();
+      const events: string[] = [];
       const first = enqueueCommandInLane(lane, async () => new Promise<never>(() => {}), {
         taskTimeoutMs: 48 * 60 * 60 * 1000,
         taskTimeoutProgressAtMs: () => Date.now(),
+        taskTimeoutAbortSignal: abortController.signal,
         taskTimeoutAbortGraceMs: 25,
         taskTimeoutReleaseSignal: releaseController.signal,
+        onTaskTimeout: () => {
+          events.push("cleanup");
+          throw new Error("cleanup failed");
+        },
       });
       const firstRejected = expect(first).rejects.toMatchObject({
         name: "CommandLaneTaskTimeoutError",
@@ -653,15 +660,23 @@ describe("command queue", () => {
       let secondRan = false;
       const second = enqueueCommandInLane(lane, async () => {
         secondRan = true;
+        events.push("second");
         return "second";
       });
 
+      abortController.abort();
       releaseController.abort();
       await vi.advanceTimersByTimeAsync(0);
 
       await firstRejected;
       await expect(second).resolves.toBe("second");
       expect(secondRan).toBe(true);
+      expect(events).toEqual(["cleanup", "second"]);
+      expect(
+        diagnosticMocks.diag.warn.mock.calls.some(([message]) =>
+          String(message).includes("lane task timeout cleanup failed"),
+        ),
+      ).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -91,6 +91,7 @@ type QueueEntry = {
   taskTimeoutAbortSignal?: AbortSignal;
   taskTimeoutAbortGraceMs?: number;
   taskTimeoutReleaseSignal?: AbortSignal;
+  onTaskTimeout?: () => void;
   onWait?: (waitMs: number, queuedAhead: number) => void;
 };
 
@@ -335,7 +336,17 @@ async function runQueueEntryTask(lane: string, entry: QueueEntry): Promise<unkno
         | { cause: "abort-grace"; graceMs: number }
         | { cause: "release-signal" },
     ) => {
+      if (timedOut) {
+        return;
+      }
       timedOut = true;
+      try {
+        // Owner cleanup must run before the lane admits a replacement task;
+        // keep this callback synchronous so a broken owner cannot strand the queue.
+        entry.onTaskTimeout?.();
+      } catch (err) {
+        diag.warn(`lane task timeout cleanup failed: lane=${lane} error="${String(err)}"`);
+      }
       reject(
         new CommandLaneTaskTimeoutError(lane, {
           ...details,
@@ -550,6 +561,7 @@ export function enqueueCommandInLane<T>(
       taskTimeoutAbortSignal: opts?.taskTimeoutAbortSignal,
       taskTimeoutAbortGraceMs: normalizeTaskTimeoutMs(opts?.taskTimeoutAbortGraceMs),
       taskTimeoutReleaseSignal: opts?.taskTimeoutReleaseSignal,
+      onTaskTimeout: opts?.onTaskTimeout,
       onWait: opts?.onWait,
     });
     logLaneEnqueue(cleaned, getLaneDepth(state));

--- a/src/process/command-queue.types.ts
+++ b/src/process/command-queue.types.ts
@@ -11,6 +11,8 @@ export type CommandQueueEnqueueOptions = {
   taskTimeoutAbortGraceMs?: number;
   /** Ends the task after a caller-owned timeout cleanup grace has already elapsed. */
   taskTimeoutReleaseSignal?: AbortSignal;
+  /** Synchronous owner cleanup immediately before a timed-out lane admits later work. */
+  onTaskTimeout?: () => void;
   priority?: "foreground" | "normal" | "background";
 };
 


### PR DESCRIPTION
Related: #92569

Follow-up to #93559.

## What Problem This Solves

Fixes an issue where an embedded agent run that times out while its MCP catalog is still starting can leave its run lease alive. The command lane continues, but stale MCP processes can remain pinned after the abandoned run.

## Why This Change Was Made

The command queue now invokes a synchronous timeout hook before admitting later work, and a materialized MCP run registers an idempotent disposer immediately after lease acquisition. Leases acquired after the timeout are revoked immediately, while the deferred-retirement mechanism introduced by #93559 remains responsible for shared runtime shutdown.

This is intentionally complementary to #93559: it covers command-lane timeouts rather than session reset or deletion. It does not force-close shared runtimes or revoke independent leases.

## User Impact

Timed-out or cancellation-resistant agent runs no longer retain their MCP run lease indefinitely. MCP calls already in flight may finish normally, and unrelated request or app-view leases remain active.

## Evidence

- 148 focused tests pass after rebasing onto current `main`: 38 process tests and 110 agent tests across 5 files.
- Coverage includes callback failure isolation, lease acquisition after timeout, pending catalog resolution, all tool/resource/prompt surfaces after disposal, in-flight calls, independent leases, and normal idempotent cleanup.
- `oxfmt --check` passes on all 14 changed files.
- `oxlint`, `git diff --check`, and `git show --check` pass.
- The stable patch id is `6bf450efc8958df2b7663edf1f97bff2aeb8eece`, unchanged from the independently reviewed build.

Local focused tests used the existing shared dependency tree with Vitest 4.1.9; repository CI will validate against the lockfile version.
