### PR TITLE
fix(feishu): honor abortSignal during app registration poll interval

### DIFF
--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -242,6 +242,38 @@ describe("Feishu app registration", () => {
     await expect(poll).resolves.toEqual({ status: "timeout" });
   });
 
+  it("stops polling promptly when abortSignal fires during the poll interval", async () => {
+    const fetchImpl = withFetchPreconnect(
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "authorization_pending" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    ) as FeishuAppRegistrationFetch;
+    const controller = new AbortController();
+    const started = Date.now();
+
+    const poll = pollAppRegistration({
+      deviceCode: "device-code",
+      interval: 30,
+      expireIn: 600,
+      abortSignal: controller.signal,
+      fetchImpl,
+      lookupFn: hermeticPublicLookup,
+    });
+    // Let the first poll resolve and the loop enter its 30s interval sleep.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 200);
+    });
+    controller.abort();
+
+    await expect(poll).resolves.toEqual({ status: "timeout" });
+    expect(Date.now() - started).toBeLessThan(10_000);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("prints scan-to-create QR codes with compact terminal rendering", async () => {
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 

--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -243,35 +243,38 @@ describe("Feishu app registration", () => {
   });
 
   it("stops polling promptly when abortSignal fires during the poll interval", async () => {
-    const fetchImpl = withFetchPreconnect(
-      vi.fn(
-        async () =>
-          new Response(JSON.stringify({ error: "authorization_pending" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-      ),
-    ) as FeishuAppRegistrationFetch;
-    const controller = new AbortController();
-    const started = Date.now();
+    let requestCount = 0;
+    await withRegistrationServer(
+      (_req, res) => {
+        requestCount += 1;
+        writeJson(res, { error: "authorization_pending" });
+      },
+      async ({ fetchImpl, lookupFn }) => {
+        const controller = new AbortController();
+        const started = Date.now();
 
-    const poll = pollAppRegistration({
-      deviceCode: "device-code",
-      interval: 30,
-      expireIn: 600,
-      abortSignal: controller.signal,
-      fetchImpl,
-      lookupFn: hermeticPublicLookup,
-    });
-    // Let the first poll resolve and the loop enter its 30s interval sleep.
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 200);
-    });
-    controller.abort();
+        const poll = pollAppRegistration({
+          deviceCode: "device-code",
+          interval: 30,
+          expireIn: 600,
+          abortSignal: controller.signal,
+          fetchImpl,
+          lookupFn,
+        });
+        // Let the first poll resolve and the loop enter its 30s interval sleep.
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 200);
+        });
+        controller.abort();
 
-    await expect(poll).resolves.toEqual({ status: "timeout" });
-    expect(Date.now() - started).toBeLessThan(10_000);
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+        await expect(poll).resolves.toEqual({ status: "timeout" });
+        expect(Date.now() - started).toBeLessThan(10_000);
+        expect(requestCount).toBe(1);
+        console.log(
+          `[feishu pollAppRegistration abort proof] interval=30s aborted_after=200ms elapsed=${Date.now() - started}ms requests=${requestCount} outcome=timeout`,
+        );
+      },
+    );
   });
 
   it("prints scan-to-create QR codes with compact terminal rendering", async () => {

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -1,6 +1,6 @@
 // Feishu plugin module implements app registration behavior.
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
-import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 /**
  * Feishu app registration via OAuth device-code flow.
  *
@@ -257,7 +257,7 @@ export async function pollAppRegistration(params: {
       );
     } catch {
       // Transient network error — keep polling.
-      await sleepRegistrationPollInterval(currentInterval);
+      await sleepRegistrationPollInterval(currentInterval, abortSignal);
       continue;
     }
 
@@ -303,7 +303,7 @@ export async function pollAppRegistration(params: {
       }
     }
 
-    await sleepRegistrationPollInterval(currentInterval);
+    await sleepRegistrationPollInterval(currentInterval, abortSignal);
   }
 
   return { status: "timeout" };
@@ -394,9 +394,14 @@ export async function getAppOwnerOpenId(params: {
   }
 }
 
-function sleepRegistrationPollInterval(intervalSeconds: number): Promise<void> {
+async function sleepRegistrationPollInterval(
+  intervalSeconds: number,
+  abortSignal?: AbortSignal,
+): Promise<void> {
   const intervalMs =
     finiteSecondsToTimerSafeMilliseconds(intervalSeconds) ??
     DEFAULT_REGISTRATION_POLL_INTERVAL_SECONDS * 1_000;
-  return sleep(intervalMs);
+  // Swallow the abort rejection: the poll loop's `aborted` check owns the exit
+  // path so PollOutcome stays "timeout" instead of an unhandled rejection.
+  await sleepWithAbort(intervalMs, abortSignal).catch(() => {});
 }


### PR DESCRIPTION
## What Problem This Solves

`pollAppRegistration` in `extensions/feishu/src/app-registration.ts` accepts an `abortSignal` and checks it at the top of each poll iteration, but the interval sleep between polls runs on a bare timer. When the signal fires mid-interval, the loop keeps sleeping through the full remaining interval — which `slow_down` responses keep raising by 5s at a time — before the abort is noticed.

## Why This Change Was Made

The interval helper now sleeps via `sleepWithAbort` from `openclaw/plugin-sdk/runtime-env`, the same abort-aware helper recently adopted for retry backoffs in sibling plugins (#109604 telegram startup probe, #108561 discord gateway READY retry, #108408 feishu comment reply retry). The abort rejection is swallowed inside the helper so the loop's existing top-of-iteration `aborted` check remains the single exit path and the `PollOutcome` contract (resolve with `{ status: "timeout" }`, never throw) stays unchanged.

Note: the only in-tree caller today (the `runScanToCreate` setup wizard) does not pass a signal. This change completes the function's existing public contract so the `abortSignal` parameter is honored everywhere it is already accepted — the bare interval sleep was the one remaining gap next to the loop's own `aborted` check.

## Changes

- Thread `abortSignal` into `sleepRegistrationPollInterval` at both call sites (transient-error path and normal path) and sleep via `sleepWithAbort`.
- Add a regression test: a real loopback HTTP server that counts requests and always returns `authorization_pending`, a 30s poll interval, and an abort fired 200ms in; asserts the poll resolves `{ status: "timeout" }` promptly and issues no second poll request.

## User Impact

Callers that cancel app registration polling (setup teardown, plugin lifecycle shutdown) now stop promptly instead of waiting out the remaining poll interval — which `slow_down` responses can raise well beyond the default 5s.

## Evidence

Exact head: `c13e59662cbb538d7ff33eb100d2c26300b6f076`.

After-fix terminal proof — production `pollAppRegistration` driven outside Vitest (`node --import tsx`) against a real loopback HTTP server that counts requests and always returns `authorization_pending`, 30s poll interval, abort fired 200ms in:

```text
[proof] outcome={"status":"timeout"} elapsed=203ms requests=1 interval=30s abort_after=200ms
[proof] OK: abort interrupted the poll interval promptly, no second request
```

Same script against the pre-change implementation (`extensions/feishu/src/app-registration.ts` at `upstream/main`):

```text
[proof] outcome={"status":"timeout"} elapsed=30126ms requests=1 interval=30s abort_after=200ms
[proof] FAILED: abort did not interrupt the poll interval promptly
```

Regression suite (the abort test also uses a real loopback server):

```text
node scripts/run-vitest.mjs run extensions/feishu/src/app-registration.test.ts
Test Files  1 passed (1)
Tests  11 passed (11)
```

`oxlint` clean on both changed files; `tsgo` extensions test project reports no errors in feishu files.

## Intentionally out of scope

- In-flight registration POSTs keep their existing 10s `APP_REGISTRATION_REQUEST_TIMEOUT_MS` budget; aborting an active request is unchanged.
- No change to the poll interval or the `slow_down` escalation policy.