### PR TITLE
fix: restore bundled plugin boundary checks after Meet export coverage

### DIFF
--- a/extensions/google-meet/src/cli.test.ts
+++ b/extensions/google-meet/src/cli.test.ts
@@ -6,7 +6,6 @@ import { Command } from "commander";
 import JSZip from "jszip";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { registerGoogleMeetCli, testing } from "./cli.js";
 import { resolveGoogleMeetConfig } from "./config.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
@@ -25,8 +24,6 @@ const fetchGuardMocks = vi.hoisted(() => ({
     }),
   ),
 }));
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
@@ -721,7 +718,7 @@ describe("google-meet CLI", () => {
   it("neutralizes spreadsheet formulas in exported attendance CSV files", async () => {
     stubMeetArtifactsApi({ participantDisplayName: "\uFF1D1+1" });
     const stdout = captureStdout();
-    const tempDir = tempDirs.make("openclaw-google-meet-export-csv-");
+    const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-export-csv-"));
 
     try {
       await setupCli({}).parseAsync(
@@ -744,6 +741,7 @@ describe("google-meet CLI", () => {
       );
     } finally {
       stdout.restore();
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
Related: #109725

AI-assisted: Yes (Codex)

## What Problem This Solves

Resolves a new `main` regression where Google Meet export coverage imported a repository-only test helper across the bundled plugin boundary. This made both the extension boundary contract and the built-artifact gate fail for every pull request merged with current `main`.

## Why This Change Was Made

The affected test now uses the Node temporary-directory primitives already used throughout the same file and removes its directory in the existing `finally` block. No production behavior changes.

## User Impact

No user-visible behavior change. Bundled plugin isolation checks and downstream pull-request CI can pass again.

## Evidence

- `node --import tsx scripts/check-no-extension-test-core-imports.ts` — pass, 2,578 extension files checked.
- `node scripts/run-vitest.mjs extensions/google-meet/src/cli.test.ts test/extension-test-boundary.test.ts` — 60/60 passed.
- Autoreview — clean, 0 findings, confidence 0.98.
