### PR TITLE
fix(cli): report malformed plugin JSON paths

### DIFF
--- a/extensions/google-meet/src/cli.test.ts
+++ b/extensions/google-meet/src/cli.test.ts
@@ -6,7 +6,6 @@ import { Command } from "commander";
 import JSZip from "jszip";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { registerGoogleMeetCli, testing } from "./cli.js";
 import { resolveGoogleMeetConfig } from "./config.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
@@ -25,8 +24,6 @@ const fetchGuardMocks = vi.hoisted(() => ({
     }),
   ),
 }));
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
@@ -721,7 +718,7 @@ describe("google-meet CLI", () => {
   it("neutralizes spreadsheet formulas in exported attendance CSV files", async () => {
     stubMeetArtifactsApi({ participantDisplayName: "\uFF1D1+1" });
     const stdout = captureStdout();
-    const tempDir = tempDirs.make("openclaw-google-meet-export-csv-");
+    const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-export-csv-"));
 
     try {
       await setupCli({}).parseAsync(
@@ -744,6 +741,7 @@ describe("google-meet CLI", () => {
       );
     } finally {
       stdout.restore();
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Type } from "typebox";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { defineToolPlugin, getToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
 import { defaultRuntime } from "../runtime.js";
 import { VERSION } from "../version.js";
@@ -15,6 +16,8 @@ import {
   runPluginsInitCommand,
   validateToolPluginProject,
 } from "./plugins-authoring-command.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createDemoMetadata() {
   const entry = defineToolPlugin({
@@ -296,6 +299,22 @@ describe("plugin authoring commands", () => {
     await expect(
       loadToolPlugin({ rootDir: tmpDir, entryPath: path.join(tmpDir, "dist/index.js") }),
     ).rejects.toThrow("plugin entry not found: ./dist/index.js");
+  });
+
+  it("throws a user-friendly error when package.json is malformed JSON", async () => {
+    const tmpDir = tempDirs.make("openclaw-plugin-bad-json-");
+    const packagePath = path.join(tmpDir, "package.json");
+    const entryPath = writeSourceToolPluginProject({
+      tmpDir,
+      packageName: "openclaw-plugin-bad-json",
+      pluginId: "bad-json",
+      toolName: "bad_json_echo",
+    });
+    fs.writeFileSync(packagePath, "{invalid json");
+
+    await expect(runPluginsBuildCommand({ root: tmpDir, entry: entryPath })).rejects.toThrow(
+      `Malformed JSON in ${packagePath}`,
+    );
   });
 
   it("loads source entries that import the OpenClaw plugin SDK package subpath", async () => {

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -56,7 +56,12 @@ const CLAWHUB_PACKAGE_PUBLISH_WORKFLOW_REF = "9d49df109d4ad3dc8a6ecf05d26b39f46d
 const toolPluginEntryModuleLoaders = createPluginModuleLoaderCache();
 
 function readJsonFile(filePath: string): JsonObject {
-  return JSON.parse(fs.readFileSync(filePath, "utf8")) as JsonObject;
+  const raw = fs.readFileSync(filePath, "utf8");
+  try {
+    return JSON.parse(raw) as JsonObject;
+  } catch (err) {
+    throw new Error(`Malformed JSON in ${filePath}`, { cause: err });
+  }
 }
 
 function writeJsonFile(filePath: string, value: unknown): void {


### PR DESCRIPTION
Related: #109730

## What Problem This Solves

Fixes an issue where plugin authors running build or validate commands would receive a pathless JSON parse error when a package or plugin manifest was malformed.

## Why This Change Was Made

The existing owner-local JSON reader now wraps only parse failures with the exact file path while preserving the original error as its cause. Filesystem read failures and valid JSON behavior remain unchanged. This carries forward #109730 on a maintainer branch because repeated fork-head CI retriggers prevented the required exact-head gate from stabilizing; the original contributor remains a co-author.

## User Impact

Plugin authors can immediately identify which package or manifest file needs repair.

## Evidence

- Blacksmith Testbox: 14/14 focused plugin-authoring command tests passed on current main ([Actions run 29573041588](https://github.com/openclaw/openclaw/actions/runs/29573041588)).
- Regression covers the exact malformed package path and uses the repository temp-directory cleanup tracker.
- Fresh Autoreview: no findings, correctness confidence 0.98.
- `git diff --check` passed.
