### PR TITLE
test(google-meet): keep temp cleanup inside plugin boundary

### DIFF
--- a/extensions/google-meet/src/cli.test.ts
+++ b/extensions/google-meet/src/cli.test.ts
@@ -6,7 +6,6 @@ import { Command } from "commander";
 import JSZip from "jszip";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { registerGoogleMeetCli, testing } from "./cli.js";
 import { resolveGoogleMeetConfig } from "./config.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
@@ -25,8 +24,6 @@ const fetchGuardMocks = vi.hoisted(() => ({
     }),
   ),
 }));
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
@@ -721,7 +718,7 @@ describe("google-meet CLI", () => {
   it("neutralizes spreadsheet formulas in exported attendance CSV files", async () => {
     stubMeetArtifactsApi({ participantDisplayName: "\uFF1D1+1" });
     const stdout = captureStdout();
-    const tempDir = tempDirs.make("openclaw-google-meet-export-csv-");
+    const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-export-csv-"));
 
     try {
       await setupCli({}).parseAsync(
@@ -744,6 +741,7 @@ describe("google-meet CLI", () => {
       );
     } finally {
       stdout.restore();
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every pull request fails the extension boundary gate after the Google Meet attendance CSV regression test imported a repo-only core test helper.

## Why This Change Was Made

The one test that needs a temporary output directory now creates and removes it locally in its existing `finally` block. No plugin SDK surface or shared helper is added for a single test use.

## User Impact

No product behavior changes. The Google Meet regression test remains leak-free and the required extension boundary gate passes again.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/src/cli.test.ts`: 49 tests passed.
- `node --import tsx scripts/check-no-extension-test-core-imports.ts`: passed; 2,578 extension files checked.
- `git diff --check`: passed.
- Fresh uncommitted autoreview: clean, no accepted/actionable findings.
- Before: [Mattermost exact-head CI](https://github.com/openclaw/openclaw/actions/runs/29572534312) failed only because `extensions/google-meet/src/cli.test.ts` crossed the test boundary.

AI-assisted: implementation and validation performed with Codex; maintainer understands the change.
