### PR TITLE
fix(ci): bound CLI installer smoke curl with connect and max-time

### DIFF
--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -589,4 +589,4 @@ run_install_smoke_container --rm -t \
   -e OPENCLAW_NO_ONBOARD=1 \
   -e OPENCLAW_NO_PROMPT=1 \
   -e DEBIAN_FRONTEND=noninteractive \
-  "$NONROOT_IMAGE" -lc "curl -fsSL \"$CLI_INSTALL_URL\" | bash -s -- --set-npm-prefix --no-onboard"
+  "$NONROOT_IMAGE" -lc "set -o pipefail; curl -fsSL --connect-timeout 30 --max-time 300 \"$CLI_INSTALL_URL\" | bash -s -- --set-npm-prefix --no-onboard"


### PR DESCRIPTION
## What Problem This Solves

The non-root CLI installer smoke (`scripts/test-install-sh-docker.sh`) pipes `curl` directly into `bash` inside the non-root container with no curl-level timeout:

```bash
"$NONROOT_IMAGE" -lc "curl -fsSL \"$CLI_INSTALL_URL\" | bash -s -- --set-npm-prefix --no-onboard"
```

`curl` has no default connect or total timeout, so a stalled CDN connect or hung response body pins the container until the outer `INSTALL_SMOKE_DOCKER_RUN_TIMEOUT` docker-run budget kills the run. The same shape was already fixed for the main installer smoke (`scripts/docker/install-sh-smoke/run.sh`) and the install-sh-e2e runner (`scripts/docker/install-sh-e2e/run.sh`), but the CLI installer smoke was left bare.

## Why This Change Was Made

Bound the curl with the same `--connect-timeout 30 --max-time 300` shape already used by the sibling install-sh-smoke and install-sh-e2e runners, and enable `pipefail` so curl download failures are not masked by the bash consumer that follows.

## User Impact

CI lane reliability. The CLI installer smoke lane can no longer be held hostage by a single hung connect or partial response body.

## Evidence

- `bash -n scripts/test-install-sh-docker.sh` parses cleanly before and after.
- Diff is a single one-line change to the docker `-lc` argument.
- Same `--connect-timeout 30 --max-time 300` shape as `scripts/docker/install-sh-smoke/run.sh` and `scripts/docker/install-sh-e2e/run.sh`.