### PR TITLE
fix(ollama): failed inspections must not advertise tools capability

### DIFF
--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -633,6 +633,9 @@ describe("ollama setup", () => {
     expect(
       result.config.models?.providers?.ollama?.models?.find((model) => model.id === "gemma4:e4b"),
     ).toMatchObject({ compat: { supportsTools: true } });
+    expect(
+      result.config.models?.providers?.ollama?.models?.find((model) => model.id === "broken:20b"),
+    ).toMatchObject({ compat: { supportsTools: false } });
   });
 
   it("checks all installed Ollama models before offering a recommended pull", async () => {

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -630,10 +630,12 @@ async function inspectOllamaModelsForSetup(
           signal?.throwIfAborted();
           // Fail open per model: one stale/corrupt local model (observed: a
           // months-old pull whose /api/show returns HTTP 500) must not brick
-          // the whole setup. Unenriched models carry no capabilities, so the
-          // tools-capable selection below skips them naturally.
+          // the whole setup. Mark the failure with EMPTY capabilities: undefined
+          // means "never inspected" and downstream config building optimistically
+          // defaults that to supportsTools, which would advertise a broken model
+          // as tools-capable (ClawSweeper P2 on #109797).
           inspectionFailures.push(`${model.name}: ${formatErrorMessage(error)}`);
-          return model;
+          return Object.assign({}, model, { capabilities: [] as string[] });
         }
       }),
     );


### PR DESCRIPTION
Related: #109228
Related: #109895

## What Problem This Solves

Follow-up to the ClawSweeper P2 on the fail-open inspection landing: models whose `/api/show` inspection failed were retained with capabilities undefined, and downstream `buildOllamaModelDefinition` optimistically defaults undefined capabilities to `supportsTools: true`, so a broken model could be configured and ranked as tools-capable.

## Why This Change Was Made

Failed inspections now carry `EMPTY` capabilities (known-not-tools), preserving the optimistic default only for genuinely uninspected models beyond the enrich limit. The code comment cites the P2.

## User Impact

A stale or corrupt local model can no longer masquerade as tools-capable in the configured catalog.

## Evidence

- `node scripts/run-vitest.mjs extensions/ollama` — 382 passed.
- Regression tightened: the broken model now asserts `supportsTools: false` in written config while the healthy model keeps `supportsTools: true`.
- Autoreview clean (0.96).
