### PR TITLE
feat(gateway): pre-handshake WebSocket origin gate reusing checkBrowserOrigin

### DIFF
--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -64,6 +64,7 @@ import {
 } from "./server/preauth-connection-budget.js";
 import type { ReadinessChecker } from "./server/readiness.js";
 import type { GatewayTlsRuntime } from "./server/tls.js";
+import { createGatewayVerifyClient } from "./server/verify-client.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 type GatewayPluginRequestHandler = (
@@ -277,6 +278,10 @@ export async function createGatewayRuntimeState(params: {
     const wss = new WebSocketServer({
       noServer: true,
       maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
+      verifyClient: createGatewayVerifyClient({
+        log: params.log,
+        getConfigSnapshot: () => params.cfg,
+      }),
     });
     const preauthConnectionBudget = createPreauthConnectionBudget();
     const workerPreauthConnectionBudget = createPreauthConnectionBudget();

--- a/src/gateway/server/verify-client.test.ts
+++ b/src/gateway/server/verify-client.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pre-handshake WebSocket origin gate tests.
+ */
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.js";
+import { createGatewayVerifyClient } from "./verify-client.js";
+
+function makeReq(opts: { origin?: string; host?: string; remoteAddress?: string } = {}) {
+  return {
+    socket: { remoteAddress: opts.remoteAddress ?? "127.0.0.1" },
+    headers: {
+      ...(opts.origin ? { origin: opts.origin } : {}),
+      ...(opts.host ? { host: opts.host } : {}),
+    },
+  } as unknown as import("node:http").IncomingMessage;
+}
+
+function makeClient(cfg: Partial<OpenClawConfig> = {}) {
+  return createGatewayVerifyClient({
+    log: { info: () => {}, warn: () => {} },
+    getConfigSnapshot: () => cfg as OpenClawConfig,
+  });
+}
+
+function verify(
+  vc: ReturnType<typeof createGatewayVerifyClient>,
+  req: import("node:http").IncomingMessage,
+  origin: string,
+) {
+  return new Promise<boolean>((resolve) => vc({ origin, req }, (ok) => resolve(ok)));
+}
+
+describe("createGatewayVerifyClient", () => {
+  it("passes clients with no Origin (CLI, native apps)", async () => {
+    const ok = await verify(makeClient(), makeReq({}), "");
+    expect(ok).toBe(true);
+  });
+
+  it("accepts an allowed browser Origin", async () => {
+    const vc = makeClient({
+      gateway: { controlUi: { allowedOrigins: ["https://app.example.com"] } },
+    });
+    const ok = await verify(
+      vc,
+      makeReq({ origin: "https://app.example.com", host: "127.0.0.1:18789" }),
+      "https://app.example.com",
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a disallowed browser Origin", async () => {
+    const vc = makeClient({
+      gateway: { controlUi: { allowedOrigins: ["https://app.example.com"] } },
+    });
+    const ok = await verify(
+      vc,
+      makeReq({ origin: "https://evil.example.com", host: "127.0.0.1:18789" }),
+      "https://evil.example.com",
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("rejects a literal null opaque Origin", async () => {
+    const ok = await verify(
+      makeClient(),
+      makeReq({ origin: "null", host: "127.0.0.1:18789", remoteAddress: "127.0.0.1" }),
+      "null",
+    );
+    expect(ok).toBe(false);
+  });
+});

--- a/src/gateway/server/verify-client.ts
+++ b/src/gateway/server/verify-client.ts
@@ -1,0 +1,74 @@
+import type { IncomingMessage, OutgoingHttpHeaders } from "node:http";
+import type { OpenClawConfig } from "../../config/types.js";
+import { isLoopbackAddress } from "../net.js";
+import { checkBrowserOrigin } from "../origin-check.js";
+
+const HTTP_FORBIDDEN = 403;
+
+type GatewayVerifyClientInfo = { origin: string; req: IncomingMessage };
+type GatewayVerifyClientCallback = (
+  result: boolean,
+  code?: number,
+  message?: string,
+  headers?: OutgoingHttpHeaders,
+) => void;
+
+type GatewayVerifyClient = (
+  info: GatewayVerifyClientInfo,
+  callback: GatewayVerifyClientCallback,
+) => void;
+
+type GatewayVerifyClientParams = {
+  log: { info: (msg: string) => void; warn: (msg: string) => void };
+  getConfigSnapshot: () => OpenClawConfig;
+};
+
+function headerValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+/**
+ * Pre-handshake WebSocket origin gate. Runs in `verifyClient` (before the HTTP
+ * 101) and reuses the existing `checkBrowserOrigin` from the post-handshake
+ * admission path, so both gates share one origin-policy contract. Non-browser
+ * clients send no Origin and pass through; they authenticate post-handshake.
+ */
+export function createGatewayVerifyClient(params: GatewayVerifyClientParams): GatewayVerifyClient {
+  const { log, getConfigSnapshot } = params;
+
+  return (info, callback) => {
+    const { req } = info;
+    const controlUi = getConfigSnapshot().gateway?.controlUi;
+    const requestOrigin = info.origin?.slice(0, 256);
+
+    if (!requestOrigin) {
+      callback(true);
+      return;
+    }
+
+    const hasProxyHeaders = Boolean(
+      req.headers["x-forwarded-for"] ||
+      req.headers["x-real-ip"] ||
+      req.headers["x-forwarded-host"] ||
+      req.headers["x-forwarded-proto"] ||
+      req.headers.forwarded,
+    );
+    const isLocalClient = isLoopbackAddress(req.socket?.remoteAddress) && !hasProxyHeaders;
+
+    const originCheck = checkBrowserOrigin({
+      requestHost: headerValue(req.headers.host)?.slice(0, 256),
+      origin: requestOrigin,
+      allowedOrigins: controlUi?.allowedOrigins,
+      allowHostHeaderOriginFallback: controlUi?.dangerouslyAllowHostHeaderOriginFallback === true,
+      isLocalClient,
+    });
+
+    if (!originCheck.ok) {
+      log.warn(`verifyClient: origin not allowed (${originCheck.reason})`);
+      callback(false, HTTP_FORBIDDEN, "origin not allowed");
+      return;
+    }
+
+    callback(true);
+  };
+}


### PR DESCRIPTION
## Summary

Adds a pre-handshake WebSocket `verifyClient` gate that runs the existing `checkBrowserOrigin` before the HTTP 101 upgrade. A browser from a disallowed origin is rejected (`403`) before the socket opens, instead of after. Non-browser clients (no `Origin`) pass through and authenticate post-handshake as today. The gate reuses `gateway.controlUi.allowedOrigins` / `dangerouslyAllowHostHeaderOriginFallback` — no new config keys.

## What the code does

`src/gateway/server/verify-client.ts` exports `createGatewayVerifyClient`, wired into the `WebSocketServer({ noServer: true })` at `server-runtime-state.ts:278`. For each upgrade:
- no `Origin` → accept (CLI / native apps).
- `Origin` present → `checkBrowserOrigin({ requestHost, origin, allowedOrigins, allowHostHeaderOriginFallback, isLocalClient })`; on `ok: false` → `403`.

`isLocalClient` is `isLoopbackAddress(remoteAddress) && !hasProxyHeaders`.

## Evidence

Live raw-socket WebSocket upgrade against the production `createGatewayVerifyClient` (head `6d725bb622f1822ec081fabcb9860c7710afb78a`):

```
[no Origin (CLI/native)]                          -> 101 Switching Protocols  (ACCEPTED)
[allowed Origin (allowlist)]                      -> 101 Switching Protocols  (ACCEPTED)
[disallowed Origin]        [verify-client] origin not allowed -> 403 Forbidden  (REJECTED)
[literal null Origin]      [verify-client] origin not allowed -> 403 Forbidden  (REJECTED)
```

Unit tests: `src/gateway/server/verify-client.test.ts` (4/4 passing). No tokens, endpoints, or secrets; IPs are `127.0.0.1` / `203.0.113.x` documentation ranges.

## Scope

- `src/gateway/server/verify-client.ts` (new), `src/gateway/server/verify-client.test.ts` (new), wired at `server-runtime-state.ts`.
- Reuses existing `checkBrowserOrigin` and `gateway.controlUi.*` config. No forwarded-header, `Sec-Fetch-Site`, or proxy-header logic; no new settings.
