### PR TITLE
refactor(whatsapp): scope temp cleanup to each test

### DIFF
--- a/extensions/whatsapp/src/connection-owner.test.ts
+++ b/extensions/whatsapp/src/connection-owner.test.ts
@@ -1,25 +1,18 @@
 // Whatsapp tests cover exclusive auth-backed connection ownership.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   acquireWhatsAppGatewayConnectionOwner,
   acquireWhatsAppStandaloneConnectionOwner,
 } from "./connection-owner.js";
 
 describe("WhatsApp connection owner", () => {
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await Promise.all(
-      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
-    );
-  });
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   it("rejects a second process-local owner until the first lease is released", async () => {
-    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-owner-"));
-    tempDirs.push(parent);
+    const parent = tempDirs.make("openclaw-wa-owner-");
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
 
@@ -35,8 +28,7 @@ describe("WhatsApp connection owner", () => {
   });
 
   it("lets the gateway wait for a process-local standalone owner", async () => {
-    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-owner-"));
-    tempDirs.push(parent);
+    const parent = tempDirs.make("openclaw-wa-owner-");
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
 
@@ -51,8 +43,7 @@ describe("WhatsApp connection owner", () => {
   it.runIf(process.platform !== "win32")(
     "treats symlink aliases as the same process-local owner",
     async () => {
-      const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-owner-"));
-      tempDirs.push(parent);
+      const parent = tempDirs.make("openclaw-wa-owner-");
       const authDir = path.join(parent, "auth");
       const authAlias = path.join(parent, "auth-alias");
       await fs.mkdir(authDir);
@@ -68,8 +59,7 @@ describe("WhatsApp connection owner", () => {
   );
 
   it("recovers an unchanged lock owned by a definitely dead process", async () => {
-    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-owner-"));
-    tempDirs.push(parent);
+    const parent = tempDirs.make("openclaw-wa-owner-");
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
     await fs.writeFile(
@@ -82,8 +72,7 @@ describe("WhatsApp connection owner", () => {
   });
 
   it("cancels cross-process owner retries during shutdown", async () => {
-    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-owner-"));
-    tempDirs.push(parent);
+    const parent = tempDirs.make("openclaw-wa-owner-");
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
     await fs.writeFile(

--- a/extensions/whatsapp/src/connection-owner.test.ts
+++ b/extensions/whatsapp/src/connection-owner.test.ts
@@ -1,18 +1,24 @@
 // Whatsapp tests cover exclusive auth-backed connection ownership.
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { describe, expect, it, onTestFinished } from "vitest";
 import {
   acquireWhatsAppGatewayConnectionOwner,
   acquireWhatsAppStandaloneConnectionOwner,
 } from "./connection-owner.js";
 
-describe("WhatsApp connection owner", () => {
-  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+async function createTempParent(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wa-owner-"));
+  onTestFinished(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+  return dir;
+}
 
+describe("WhatsApp connection owner", () => {
   it("rejects a second process-local owner until the first lease is released", async () => {
-    const parent = tempDirs.make("openclaw-wa-owner-");
+    const parent = await createTempParent();
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
 
@@ -28,7 +34,7 @@ describe("WhatsApp connection owner", () => {
   });
 
   it("lets the gateway wait for a process-local standalone owner", async () => {
-    const parent = tempDirs.make("openclaw-wa-owner-");
+    const parent = await createTempParent();
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
 
@@ -43,7 +49,7 @@ describe("WhatsApp connection owner", () => {
   it.runIf(process.platform !== "win32")(
     "treats symlink aliases as the same process-local owner",
     async () => {
-      const parent = tempDirs.make("openclaw-wa-owner-");
+      const parent = await createTempParent();
       const authDir = path.join(parent, "auth");
       const authAlias = path.join(parent, "auth-alias");
       await fs.mkdir(authDir);
@@ -59,7 +65,7 @@ describe("WhatsApp connection owner", () => {
   );
 
   it("recovers an unchanged lock owned by a definitely dead process", async () => {
-    const parent = tempDirs.make("openclaw-wa-owner-");
+    const parent = await createTempParent();
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
     await fs.writeFile(
@@ -72,7 +78,7 @@ describe("WhatsApp connection owner", () => {
   });
 
   it("cancels cross-process owner retries during shutdown", async () => {
-    const parent = tempDirs.make("openclaw-wa-owner-");
+    const parent = await createTempParent();
     const authDir = path.join(parent, "auth");
     await fs.mkdir(authDir);
     await fs.writeFile(


### PR DESCRIPTION
Related: #109886

## What Problem This Solves

The WhatsApp connection-owner regression tests kept suite-wide mutable state solely to remove temporary directories after each test. That made the cleanup lifecycle broader and more verbose than needed.

## Why This Change Was Made

This maintainer-requested follow-up registers each directory's asynchronous cleanup directly with Vitest's `onTestFinished`. Cleanup remains plugin-local, each test owns its directory lifecycle, and the combined diff removes five net lines.

AI-assisted.

## User Impact

No user-visible behavior change. Test setup and cleanup become smaller and test-scoped without crossing the plugin boundary.

## Evidence

- `node scripts/run-vitest.mjs extensions/whatsapp/src/connection-owner.test.ts`: 1 file passed, 5 tests passed.
- `node scripts/run-vitest.mjs test/extension-test-boundary.test.ts`: 1 file passed, 11 tests passed.
- `node --import tsx scripts/check-no-extension-test-core-imports.ts`: 2,580 extension files checked; zero violations.
- Final exact-head branch autoreview: clean, no accepted/actionable findings; patch correctness 0.98.
- `git diff --check`: passed.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/29574251712
