### PR TITLE
fix(ui): restore first-run setup redirect after reconnect

### DIFF
--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -17,7 +17,7 @@ import { createSessionCapability } from "../lib/sessions/index.ts";
 import { createWorkboardCapability } from "../lib/workboard/capability.ts";
 import {
   isDefaultChatLanding,
-  locationsMatch,
+  locationsMatchDefaultLanding,
   startModelSetupFirstRunRedirect,
 } from "../pages/model-setup/first-run.ts";
 import { createAgentSelectionCapability } from "./agent-selection.ts";
@@ -409,10 +409,17 @@ export function bootstrapApplication(): ApplicationRuntime {
     revalidate: (routeId) => router.revalidate(context, routeId),
     preload: (routeId) => router.preloadRoute(routeId, context),
   };
+  const isStillDefaultLanding = () => {
+    return locationsMatchDefaultLanding(
+      history.location(),
+      expectedDefaultLanding,
+      gateway.snapshot.hello,
+    );
+  };
   const stopModelSetupRedirect = firstRunDefaultLanding
     ? startModelSetupFirstRunRedirect({
         context,
-        isStillDefaultLanding: () => locationsMatch(history.location(), expectedDefaultLanding),
+        isStillDefaultLanding,
       })
     : () => undefined;
   return {

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -31,6 +31,45 @@ describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
     await server?.close();
   });
 
+  it("retries first-run detection after a Gateway reconnect and opens setup", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["openclaw.setup.detect"],
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.setup.detect"],
+      methodResponses: {
+        "openclaw.setup.detect": {
+          candidates: [],
+          manualProviders: [],
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("openclaw.setup.detect");
+      await gateway.closeLatest(1012, "first-run detection interrupted");
+
+      await expect.poll(() => gateway.getSocketCount(), { timeout: 15_000 }).toBeGreaterThan(1);
+      await expect
+        .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length, {
+          timeout: 15_000,
+        })
+        .toBe(2);
+      await page.getByRole("heading", { name: "Connect your AI" }).waitFor();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("hands first-run model setup to the custodian in onboarding chrome", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -145,9 +145,12 @@ describe("model setup first-run redirect", () => {
       },
     };
     const replace = vi.fn();
+    let currentSnapshot = snapshot;
     const context = {
       gateway: {
-        snapshot,
+        get snapshot() {
+          return currentSnapshot;
+        },
         subscribe: (next: GatewayListener) => {
           listener = next;
           return () => undefined;
@@ -161,7 +164,7 @@ describe("model setup first-run redirect", () => {
     await vi.waitFor(() => expect(firstRequest).toHaveBeenCalledOnce());
 
     const reconnected = { ...snapshot, client: secondClient };
-    context.gateway.snapshot = reconnected as typeof context.gateway.snapshot;
+    currentSnapshot = reconnected;
     listener!(reconnected as Parameters<GatewayListener>[0]);
     await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
 

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -173,6 +173,53 @@ describe("model setup first-run redirect", () => {
     expect(consumeCachedModelSetupDetection(secondClient)).toEqual(result);
   });
 
+  it("does not repeat completed detection with a replacement client", async () => {
+    const result = {
+      candidates: [],
+      manualProviders: [],
+      workspace: "/tmp/workspace",
+      setupComplete: true,
+    };
+    const firstRequest = vi.fn().mockResolvedValue(result);
+    const firstClient = { request: firstRequest } as unknown as GatewayBrowserClient;
+    const secondRequest = vi.fn();
+    const secondClient = { request: secondRequest } as unknown as GatewayBrowserClient;
+    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
+    let listener: GatewayListener | null = null;
+    const snapshot = {
+      connected: true,
+      client: firstClient,
+      hello: {
+        auth: { role: "operator", scopes: ["operator.admin"] },
+        features: { methods: ["openclaw.setup.detect"] },
+      },
+    };
+    let currentSnapshot = snapshot;
+    const context = {
+      gateway: {
+        get snapshot() {
+          return currentSnapshot;
+        },
+        subscribe: (next: GatewayListener) => {
+          listener = next;
+          return () => undefined;
+        },
+      },
+      replace: vi.fn(),
+    } as unknown as ApplicationContext<RouteId>;
+
+    startModelSetupFirstRunRedirect({ context, isStillDefaultLanding: () => true });
+    listener!(snapshot as Parameters<GatewayListener>[0]);
+    await vi.waitFor(() => expect(consumeCachedModelSetupDetection(firstClient)).toEqual(result));
+
+    const reconnected = { ...snapshot, client: secondClient };
+    currentSnapshot = reconnected;
+    listener!(reconnected as Parameters<GatewayListener>[0]);
+
+    expect(firstRequest).toHaveBeenCalledOnce();
+    expect(secondRequest).not.toHaveBeenCalled();
+  });
+
   it("does not detect without admin scope or an advertised setup method", () => {
     const request = vi.fn();
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import { routeIdFromPath } from "../../app-routes.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { consumeCachedModelSetupDetection } from "./detect-cache.ts";
-import { isDefaultChatLanding, startModelSetupFirstRunRedirect } from "./first-run.ts";
+import {
+  isDefaultChatLanding,
+  locationsMatchDefaultLanding,
+  startModelSetupFirstRunRedirect,
+} from "./first-run.ts";
 
 describe("model setup first-run redirect", () => {
   it("recognizes only the implicit chat landing without a session deep link", () => {
@@ -33,6 +37,34 @@ describe("model setup first-run redirect", () => {
         { pathname: "/settings/general", search: "", hash: "" },
         "",
         routeIdFromPath,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the canonical main session on the default landing", () => {
+    const hello = {
+      snapshot: {
+        sessionDefaults: {
+          defaultAgentId: "dev",
+          mainKey: "main",
+          mainSessionKey: "agent:dev:main",
+        },
+      },
+    } as GatewayHelloOk;
+    const expected = { pathname: "/chat", search: "?session=main", hash: "" };
+
+    expect(
+      locationsMatchDefaultLanding(
+        { pathname: "/chat", search: "?session=agent%3Adev%3Amain", hash: "" },
+        expected,
+        hello,
+      ),
+    ).toBe(true);
+    expect(
+      locationsMatchDefaultLanding(
+        { pathname: "/chat", search: "?session=agent%3Adev%3Aother", hash: "" },
+        expected,
+        hello,
       ),
     ).toBe(false);
   });

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -201,7 +201,7 @@ describe("model setup first-run redirect", () => {
     await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
 
     expect(secondRequest).toHaveBeenCalledOnce();
-    expect(replace).toHaveBeenCalledWith("model-setup");
+    expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
     expect(consumeCachedModelSetupDetection(secondClient)).toEqual(result);
   });
 

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -123,6 +123,53 @@ describe("model setup first-run redirect", () => {
     expect(consumeCachedModelSetupDetection(client)).toEqual(result);
   });
 
+  it("retries detection with the replacement client after a transient failure", async () => {
+    const result = {
+      candidates: [],
+      manualProviders: [],
+      workspace: "/tmp/workspace",
+      setupComplete: false,
+    };
+    const firstRequest = vi.fn().mockRejectedValue(new Error("gateway disconnected"));
+    const firstClient = { request: firstRequest } as unknown as GatewayBrowserClient;
+    const secondRequest = vi.fn().mockResolvedValue(result);
+    const secondClient = { request: secondRequest } as unknown as GatewayBrowserClient;
+    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
+    let listener: GatewayListener | null = null;
+    const snapshot = {
+      connected: true,
+      client: firstClient,
+      hello: {
+        auth: { role: "operator", scopes: ["operator.admin"] },
+        features: { methods: ["openclaw.setup.detect"] },
+      },
+    };
+    const replace = vi.fn();
+    const context = {
+      gateway: {
+        snapshot,
+        subscribe: (next: GatewayListener) => {
+          listener = next;
+          return () => undefined;
+        },
+      },
+      replace,
+    } as unknown as ApplicationContext<RouteId>;
+
+    startModelSetupFirstRunRedirect({ context, isStillDefaultLanding: () => true });
+    listener!(snapshot as Parameters<GatewayListener>[0]);
+    await vi.waitFor(() => expect(firstRequest).toHaveBeenCalledOnce());
+
+    const reconnected = { ...snapshot, client: secondClient };
+    context.gateway.snapshot = reconnected as typeof context.gateway.snapshot;
+    listener!(reconnected as Parameters<GatewayListener>[0]);
+    await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
+
+    expect(secondRequest).toHaveBeenCalledOnce();
+    expect(replace).toHaveBeenCalledWith("model-setup");
+    expect(consumeCachedModelSetupDetection(secondClient)).toEqual(result);
+  });
+
   it("does not detect without admin scope or an advertised setup method", () => {
     const request = vi.fn();
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -1,4 +1,5 @@
 import type { RouteLocation } from "@openclaw/uirouter";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -23,7 +23,7 @@ export function isDefaultChatLanding(
   return !searchSession && !hashSession;
 }
 
-export function locationsMatch(left: RouteLocation, right: RouteLocation): boolean {
+function locationsMatch(left: RouteLocation, right: RouteLocation): boolean {
   return (
     left.pathname === right.pathname && left.search === right.search && left.hash === right.hash
   );

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -33,9 +33,11 @@ export function startModelSetupFirstRunRedirect(params: {
   isStillDefaultLanding: () => boolean;
 }): () => void {
   let attemptedClient: GatewayBrowserClient | null = null;
+  let detectionComplete = false;
   let redirected = false;
   return params.context.gateway.subscribe((snapshot) => {
     if (
+      detectionComplete ||
       redirected ||
       !snapshot.connected ||
       !snapshot.client ||
@@ -50,12 +52,12 @@ export function startModelSetupFirstRunRedirect(params: {
     void detectModelSetup(client)
       .then((result) => {
         cacheModelSetupDetection(client, result);
-        if (
-          !result.setupComplete &&
-          !redirected &&
-          params.context.gateway.snapshot.client === client &&
-          params.isStillDefaultLanding()
-        ) {
+        if (params.context.gateway.snapshot.client !== client) {
+          return;
+        }
+        // A current-client result is terminal; only transport failures retry after reconnect.
+        detectionComplete = true;
+        if (!result.setupComplete && !redirected && params.isStillDefaultLanding()) {
           redirected = true;
           params.context.replace("model-setup", { search: "?firstRun=1" });
         }

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -31,31 +31,38 @@ export function startModelSetupFirstRunRedirect(params: {
   context: ApplicationContext<RouteId>;
   isStillDefaultLanding: () => boolean;
 }): () => void {
-  let attempted = false;
+  let attemptedClient: GatewayBrowserClient | null = null;
   let redirected = false;
   return params.context.gateway.subscribe((snapshot) => {
     if (
-      attempted ||
       redirected ||
       !snapshot.connected ||
       !snapshot.client ||
+      attemptedClient === snapshot.client ||
       !hasOperatorAdminAccess(snapshot.hello?.auth ?? null) ||
       isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") !== true
     ) {
       return;
     }
-    attempted = true;
     const client = snapshot.client;
+    attemptedClient = client;
     void detectModelSetup(client)
       .then((result) => {
         cacheModelSetupDetection(client, result);
-        if (!result.setupComplete && !redirected && params.isStillDefaultLanding()) {
+        if (
+          !result.setupComplete &&
+          !redirected &&
+          params.context.gateway.snapshot.client === client &&
+          params.isStillDefaultLanding()
+        ) {
           redirected = true;
           params.context.replace("model-setup", { search: "?firstRun=1" });
         }
       })
       .catch(() => {
-        // First-run guidance is best effort. The page offers an explicit retry.
+        if (attemptedClient === client) {
+          attemptedClient = null;
+        }
       });
   });
 }

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -1,9 +1,10 @@
 import type { RouteLocation } from "@openclaw/uirouter";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import { resolveSessionKey } from "../../lib/sessions/index.ts";
 import { cacheModelSetupDetection } from "./detect-cache.ts";
 import { detectModelSetup } from "./rpc.ts";
 
@@ -25,6 +26,29 @@ export function isDefaultChatLanding(
 export function locationsMatch(left: RouteLocation, right: RouteLocation): boolean {
   return (
     left.pathname === right.pathname && left.search === right.search && left.hash === right.hash
+  );
+}
+
+export function locationsMatchDefaultLanding(
+  current: RouteLocation,
+  expected: RouteLocation,
+  hello: GatewayHelloOk | null,
+): boolean {
+  if (locationsMatch(current, expected)) {
+    return true;
+  }
+  if (!hello || current.pathname !== expected.pathname || current.hash !== expected.hash) {
+    return false;
+  }
+  // Gateway hello adopts the canonical main-session key after bootstrap; that is not navigation.
+  const currentSearch = new URLSearchParams(current.search);
+  const expectedSearch = new URLSearchParams(expected.search);
+  const currentSession = resolveSessionKey(currentSearch.get("session"), hello);
+  const expectedSession = resolveSessionKey(expectedSearch.get("session"), hello);
+  currentSearch.delete("session");
+  expectedSearch.delete("session");
+  return (
+    currentSession === expectedSession && currentSearch.toString() === expectedSearch.toString()
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where first-time Control UI users could remain on an unconfigured chat screen after `openclaw.setup.detect` failed during a transient Gateway disconnect. The first-run redirect recorded the failed request as its only attempt, so a reconnect could not recover setup guidance.

A real-Gateway reproduction also exposed that Gateway hello canonicalizes the default session alias from `main` to `agent:<id>:main`. The old exact-URL guard treated that internal adoption as user navigation and suppressed the redirect even after a successful incomplete-setup result.

## Why This Change Was Made

Detection attempts are scoped to the Gateway client that owns them. Failed attempts become retryable, late results from obsolete clients cannot redirect the page, and a successful current-client result remains terminal across later reconnects.

The default-landing guard now resolves only the `session` query parameter through the existing Gateway session-default contract before comparison. Path, hash, other query parameters, and genuinely different sessions still have to match exactly.

## User Impact

Fresh users who lose the Gateway during the initial setup check are guided to Model Setup after reconnection without reloading the Control UI. Gateway canonicalization of the default chat session no longer blocks that guidance, while explicit session navigation still wins.

## Real behavior proof

- **Behavior addressed:** An interrupted first-run setup detection retries against a reconnected real Gateway and redirects after the successful incomplete-setup response.
- **Real environment tested:** Linux x86_64, Node 24.15.0, Google Chrome, commit `c24e9a79ce17` (tree `e3e0589860b2`, matching the tested checkout).
- **Current-head refresh:** GitHub head `beb7be792770` (tree `98064f009736`) is rebased on upstream `52d49a69b2f`. The conflict resolution retains current `main` Custodian onboarding behavior, preserves the reconnect E2E scenario, and aligns its redirect assertion with the current `?firstRun=1` navigation contract. Exact-head GitHub CI passed, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/29640959950/job/88071729624.
- **Exact steps or command run after this patch:** A one-shot `node --input-type=module` Playwright harness launched the source Vite Control UI and an isolated real `openclaw gateway run`, killed the Gateway immediately after the first browser `openclaw.setup.detect` frame, restarted the same isolated Gateway, and waited for the visible Model Setup route.
- **Evidence after fix:** Terminal capture of the real `node` + Gateway + Chrome run (copied live stdout):

  ```text
  RESULT gateway_starts=2 browser_sockets=7 detect_requests=3 detect_responses=1 final_path=/settings/model-setup heading=1
  PASS real Gateway reconnect recovered first-run setup redirect
  ```

- **Observed result after fix:** The browser survived repeated reconnect attempts, retried setup detection until one response completed, changed to `/settings/model-setup`, and rendered the `Connect your AI` heading.
- **What was not tested:** The real Gateway used an isolated local state directory and explicit loopback `auth=none`; a credential-bearing remote Gateway was not used. The separate deterministic Chromium regression continues to use the repository Gateway WebSocket mock.

## Tests and validation

```text
$ node scripts/run-vitest.mjs ui/src/pages/model-setup/first-run.test.ts
Test Files  1 passed (1)
Tests       7 passed (7)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-setup.e2e.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)

$ node scripts/ui.js build
✓ built in 6.80s

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json ui/src/app/bootstrap.ts ui/src/pages/model-setup/first-run.ts ui/src/pages/model-setup/first-run.test.ts
EXIT=0

$ git diff --check upstream/main...HEAD
EXIT=0
```

The regressions cover failure followed by a replacement client, completion followed by a later replacement, canonical main-session adoption, explicit navigation to another session, one-request deduplication, and one-redirect behavior.

## Risk checklist

- User-visible behavior: Yes - first-run setup guidance recovers after reconnect.
- Config/env/migration behavior: No - no persisted state or configuration changes.
- Security/auth/secrets/network/tool execution: No - existing admin-scope and advertised-method gates are unchanged.
- Plugins/providers/channels/SDK: No - Control UI-only lifecycle and navigation comparison.
- Highest-risk area: Treating internal session-key adoption as equivalent without masking real user navigation.
- Mitigation: Only the `session` value is canonicalized with the existing Gateway hello contract; path, hash, other query parameters, and non-default session keys remain strict, with focused tests and real-Gateway proof.

## AI assistance

This PR was created with AI assistance. I reviewed the full first-run, Gateway session adoption, route, and cache paths. The repository autoreview helper was attempted with its default Codex engine after the final edits, but the review service failed before producing findings.

Closes: N/A (no existing issue)

Allow edits from maintainers: Enabled.
