### PR TITLE
Bound QA runtime parity mock request reads

### DIFF
--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -66,6 +66,8 @@ async function seedRuntimeParityTranscript(params: {
 async function captureRuntimeParityWithMockRequests(params: {
   messages?: Array<Record<string, unknown>>;
   requests: Array<Record<string, unknown>>;
+  responseBody?: string;
+  responseStatus?: number;
   scenarioResult?: Parameters<typeof captureRuntimeParityCell>[0]["scenarioResult"];
 }) {
   const parentPrompt = "Delegate one bounded QA task to a subagent.";
@@ -85,8 +87,11 @@ async function captureRuntimeParityWithMockRequests(params: {
       response.end();
       return;
     }
+    if (params.responseStatus !== undefined) {
+      response.statusCode = params.responseStatus;
+    }
     response.setHeader("Content-Type", "application/json");
-    response.end(JSON.stringify(requests));
+    response.end(params.responseBody ?? JSON.stringify(requests));
   });
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
@@ -264,6 +269,33 @@ describe("runtime parity", () => {
     expect(
       resolveRuntimeParityUsagePolicy({ expectation: "not-applicable", reason: "   " }),
     ).toEqual({ expectation: "assistant-message-required" });
+  });
+
+  it("returns no mock tool calls when the runtime parity mock endpoint is not OK", async () => {
+    const cell = await captureRuntimeParityWithMockRequests({
+      requests: [{ plannedToolName: "read_file" }],
+      responseStatus: 500,
+    });
+
+    expect(cell.toolCalls).toEqual([]);
+  });
+
+  it("returns no mock tool calls for oversized runtime parity mock responses", async () => {
+    const cell = await captureRuntimeParityWithMockRequests({
+      requests: [],
+      responseBody: "x".repeat(256 * 1024 + 1),
+    });
+
+    expect(cell.toolCalls).toEqual([]);
+  });
+
+  it("returns no mock tool calls for malformed runtime parity mock JSON", async () => {
+    const cell = await captureRuntimeParityWithMockRequests({
+      requests: [],
+      responseBody: "{",
+    });
+
+    expect(cell.toolCalls).toEqual([]);
   });
 
   it("classifies planned-only matching tool calls as failure-mode", async () => {

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -2,6 +2,7 @@ import {
   listSessionEntries,
   loadTranscriptEventsSync,
 } from "openclaw/plugin-sdk/session-store-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 // Qa Lab plugin module implements runtime parity behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -15,6 +16,9 @@ import {
   type GatewayLogSentinelFinding,
 } from "./gateway-log-sentinel.js";
 import * as parity from "./parity-shared.js";
+
+const RUNTIME_PARITY_MOCK_REQUESTS_MAX_BYTES = 256 * 1024;
+const RUNTIME_PARITY_MOCK_REQUESTS_IDLE_TIMEOUT_MS = 30_000;
 
 export type RuntimeId = "openclaw" | "codex";
 
@@ -1054,7 +1058,7 @@ async function loadRuntimeParityMockToolCalls(
       if (!response.ok) {
         return null;
       }
-      payload = await response.json();
+      payload = await readRuntimeParityMockRequestsJson(response);
     } finally {
       await release();
     }
@@ -1076,6 +1080,17 @@ async function loadRuntimeParityMockToolCalls(
   } catch {
     return null;
   }
+}
+
+async function readRuntimeParityMockRequestsJson(response: Response): Promise<unknown> {
+  const bytes = await readResponseWithLimit(response, RUNTIME_PARITY_MOCK_REQUESTS_MAX_BYTES, {
+    chunkTimeoutMs: RUNTIME_PARITY_MOCK_REQUESTS_IDLE_TIMEOUT_MS,
+    onOverflow: ({ maxBytes }) =>
+      new Error(`runtime parity mock requests exceed ${maxBytes} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`runtime parity mock requests stalled after ${chunkTimeoutMs}ms`),
+  });
+  return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
 }
 
 export async function captureRuntimeParityCell(

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1,8 +1,8 @@
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   listSessionEntries,
   loadTranscriptEventsSync,
 } from "openclaw/plugin-sdk/session-store-runtime";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 // Qa Lab plugin module implements runtime parity behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {


### PR DESCRIPTION
## What Problem This Solves

QA runtime-parity reads `${mockBaseUrl}/debug/requests` from a local mock server and previously used `response.json()` directly. That endpoint should return a small request snapshot array, but a broken mock server could return a large successful body and make the QA process buffer it before any validation.

## Why This Change Was Made

This replaces the unbounded `response.json()` call with the shared `readResponseWithLimit` helper using a 256 KiB cap and a 30s idle timeout. The existing fail-closed behavior is preserved: non-OK, malformed, oversized, or stalled mock responses are caught by `loadRuntimeParityMockToolCalls` and treated as missing mock tool-call data.

## User Impact

QA runtime-parity remains tolerant of unavailable or malformed mock debug data, but successful mock responses are now bounded before JSON parsing. Valid mock request arrays still resolve tool-call order normally.

## Evidence

**Scope:** 2 files.
- `extensions/qa-lab/src/runtime-parity.ts` (+16/-1): bounded response read with 256 KiB cap and 30s idle timeout.
- `extensions/qa-lab/src/runtime-parity.test.ts` (+33/-1): regression tests for bounded reads.

### Regression Test

Added runtime-parity tests in `extensions/qa-lab/src/runtime-parity.test.ts` covering:

- non-OK `/debug/requests` returns no mock tool calls;
- oversized successful `/debug/requests` response returns no mock tool calls under the byte cap;
- malformed successful JSON returns no mock tool calls.

### Pre-submit checks: ✅ PASSED on Linux

All checks validated on Linux checkout with Node.js v24.15.0:

```bash
$ oxfmt --check extensions/qa-lab/src/runtime-parity.ts extensions/qa-lab/src/runtime-parity.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 113ms on 2 files using 8 threads.

$ node scripts/run-oxlint.mjs --tsconfig tsconfig.json extensions/qa-lab/src/runtime-parity.ts extensions/qa-lab/src/runtime-parity.test.ts
# No errors, passed cleanly

$ pnpm test extensions/qa-lab/src/runtime-parity.test.ts
 RUN  v4.1.10 /home/0668001344/Desktop/openclaw

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  19:17:24
   Duration  5.97s (transform 1.78s, setup 400ms, import 3.18s, tests 2.16s, environment 0ms)

[test] passed 1 Vitest shard in 11.17s

$ $autoreview
# No findings, exit code 0
```

### Full Extension Suite Test

```bash
$ pnpm test extensions/qa-lab/

Test Files  136 passed (136)
     Tests  1570 passed (1570)
   Duration  52.94s
```

All 1570 tests in the QA Lab extension pass with zero failures, confirming no regressions from the runtime-parity bounded read changes.

### Notes

- Initial test failures were due to Node.js v24.13.1 embedding SQLite 3.51.2 (affected by WAL-reset bug), not code issues.
- All tests pass cleanly with Node.js v24.15.0 (embeds SQLite 3.51.2+ with WAL fix).
- Full extension suite test confirms zero regressions.
- All pre-submit checks passed. Ready for merge.

## Change Type / Scope / Security Impact

- Type: audit-fix / bounded response read
- Scope: QA Lab runtime-parity mock debug endpoint only
- Security: reduces memory exposure from malformed local/private mock responses; no dependency, credential, or network-policy changes
