### PR TITLE
fix(line): replies vanish when claim refresh races turn adoption

### DIFF
--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -321,6 +321,49 @@ describe("LINE webhook spool", () => {
     });
   });
 
+  it("does not abort an adopting delivery when claim refresh races the completion write", async () => {
+    await withQueue(async (queue) => {
+      let completeStarted = false;
+      const complete = vi.fn(async (...args: Parameters<typeof queue.complete>) => {
+        completeStarted = true;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return await queue.complete(...args);
+      });
+      const refreshClaim = vi.fn(async () => !completeStarted);
+      let abortedAfterAdoption = false;
+      const deliver = vi.fn(
+        async (
+          _event: webhook.Event,
+          _destination: string,
+          control: { abortSignal: AbortSignal; onTurnAdopted: () => Promise<void> },
+        ) => {
+          await control.onTurnAdopted();
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          if (control.abortSignal.aborted) {
+            abortedAfterAdoption = true;
+            throw new Error("aborted after adoption");
+          }
+        },
+      );
+      const outcomes: LineWebhookDeliveryOutcome[] = [];
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue: { ...queue, complete, refreshClaim },
+        claimRefreshMs: 5,
+        deliver,
+        onOutcome: (outcome) => outcomes.push(outcome),
+      });
+      spool.start();
+      await spool.accept(callback(createEvent("event-adoption-race")));
+
+      await waitForOutcome(outcomes, "completed");
+      expect(abortedAfterAdoption).toBe(false);
+      expect(deliver).toHaveBeenCalledTimes(1);
+      await spool.stop();
+    });
+  });
+
   it("completes at durable turn adoption without replaying later failures", async () => {
     await withQueue(async (queue) => {
       const deliver = vi.fn(async (_event, _destination, control) => {

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -290,13 +290,15 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
         await options.deliver(claim.payload.event, claim.payload.destination, {
           abortSignal: abortController.signal,
           onTurnAdopted: async () => {
+            // Stop the refresh fence before the completion write: a refresh that
+            // observes the just-completed row would abort the adopted turn.
+            stopRefresh();
             await persistClaimTransition({
               claim,
               label: "adoption completion",
               transition: async () => await queue.complete(claim),
             });
             adopted = true;
-            stopRefresh();
           },
         });
       } catch (error) {


### PR DESCRIPTION
Closes #109931

## What Problem This Solves

Fixes an issue where a LINE user's reply silently vanishes when the spool's claim-refresh fence races the turn-adoption completion write. A refresh tick that observes the just-completed row (or throws while the completion persist is in flight) aborts the delivery even though the turn is already durably adopted; the ingress row finishes `completed`, so nothing retries or redelivers - the message is consumed and the user never gets a response.

## Why This Change Was Made

The fence's abort path checks `!adopted`, but `adopted` is only set after the completion write commits, so the fence can outlive the start of adoption. The fix stops the refresh fence as the first synchronous statement of `onTurnAdopted`, before the completion write: from the moment adoption begins committing, the abort path is structurally unreachable (both callback branches check the `refreshing` flag), closing the refresh-false microtask window and the wider refresh-error window in one move. Setting `adopted = true` before the write instead was rejected because a completion write that then loses the claim-token fence would be misreported as completed and invite duplicate delivery. Keeping the fence refreshing through the write behind a "completing" flag (the core drain's wedged-over-duplicated lease philosophy) was also rejected: lease refreshes are writes to the same store, so in the store-failure scenario where the completion write actually wedges, refresh cannot keep the lease fresh either - it adds state for no real-scenario gain. The fence's pre-adoption job - aborting a delivery whose claim another owner genuinely reclaimed - is untouched. The core drain guards this same class on its side by swallowing refresh errors and no-oping lease-reclaim marking once settled (`src/channels/message/ingress-drain.ts:240-253`, `:275`).

## User Impact

Replies no longer disappear when a refresh tick lands in the adoption window or a store hiccup makes a refresh throw during the completion persist. Genuine ownership loss during the completion write still surfaces (the write's own claim-token fence returns false), and deliveries whose claim is reclaimed before adoption are still aborted and released for retry, exactly as before.

## Evidence

Behavior addressed: the claim-refresh fence aborts an already-adopting delivery; the row completes and the reply is lost with no retry.

Real environment tested: real SQLite ingress queue (`createChannelIngressQueueForTests`) driven through the exported `createLineWebhookSpool` factory; the race window is widened deterministically (completion write slowed to 100ms, refresh cadence 5ms, `refreshClaim` returning `false` once the write starts); Windows 11, Node 24.15.0.

Before evidence (current main): the delivery's `abortSignal` fires after `onTurnAdopted` resolves - the new regression test fails in ~0.4s:

```
Test Files  1 failed (1)
  x does not abort an adopting delivery when claim refresh races the completion write
```

Evidence after fix (same harness, only the fence ordering changed):

```
Tests  3 passed | 14 skipped (17)   <- targeted run, single execution:
  - does not abort an adopting delivery when claim refresh races the completion write
  - completes at durable turn adoption without replaying later failures
  - aborts delivery and releases the row when claim refresh loses ownership   <- fence's pre-adoption job intact
```

Observed result after fix: the adopting delivery is never aborted, the outcome settles `completed`, and both neighbouring semantics (durable-adoption completion, pre-adoption ownership-loss abort) hold unchanged.

Exact steps or command run after this patch:

```
pnpm exec vitest run --config test/vitest/vitest.extension-line.config.ts extensions/line/src/webhook-spool.test.ts
Test Files  1 passed (1) / Tests  17 passed (17)
```

Control-red: reverting the source reorder makes the new test fail (delivery aborted after adoption) while all sixteen existing tests still pass, so the suite pins the new invariant without disturbing any pinned behavior.

Additional review: extension source typecheck (`tsconfig.extensions.json`), extension test-types typecheck (`test/tsconfig/tsconfig.extensions.test.json`), `pnpm lint:extensions`, and `oxfmt --check` on touched files all pass; the branch is rebased onto current main.

What was not tested: no live LINE-platform run - the race is a sub-second interleaving of two internal callbacks that cannot be choreographed from the platform side; the deterministic harness that widens the window is the instrument that can actually exercise it, in line with the copied-output criterion applied to the sibling lifecycle fix in #109898's review.

Proof limitations or environment constraints: Windows 11 local runs; the widened-window timings (100ms/5ms/50ms) are harness parameters, not production tunables.
