### PR TITLE
fix(cli): guard plugins JSON.parse against malformed input

### DIFF
--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -298,6 +298,24 @@ describe("plugin authoring commands", () => {
     ).rejects.toThrow("plugin entry not found: ./dist/index.js");
   });
 
+  it("throws a user-friendly error when package.json is malformed JSON", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-bad-json-"));
+    const entryPath = writeSourceToolPluginProject({
+      tmpDir,
+      packageName: "openclaw-plugin-bad-json",
+      pluginId: "bad-json",
+      toolName: "bad_json_echo",
+    });
+    fs.writeFileSync(path.join(tmpDir, "package.json"), "{invalid json");
+    try {
+      await expect(runPluginsBuildCommand({ root: tmpDir, entry: entryPath })).rejects.toThrow(
+        /Malformed JSON in /,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
   it("loads source entries that import the OpenClaw plugin SDK package subpath", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-source-"));
     const entryPath = writeSourceToolPluginProject({

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -56,7 +56,12 @@ const CLAWHUB_PACKAGE_PUBLISH_WORKFLOW_REF = "9d49df109d4ad3dc8a6ecf05d26b39f46d
 const toolPluginEntryModuleLoaders = createPluginModuleLoaderCache();
 
 function readJsonFile(filePath: string): JsonObject {
-  return JSON.parse(fs.readFileSync(filePath, "utf8")) as JsonObject;
+  const raw = fs.readFileSync(filePath, "utf8");
+  try {
+    return JSON.parse(raw) as JsonObject;
+  } catch (err) {
+    throw new Error(`Malformed JSON in ${formatOutputPath(filePath)}`, { cause: err });
+  }
 }
 
 function writeJsonFile(filePath: string, value: unknown): void {

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -60,7 +60,7 @@ function readJsonFile(filePath: string): JsonObject {
   try {
     return JSON.parse(raw) as JsonObject;
   } catch (err) {
-    throw new Error(`Malformed JSON in ${formatOutputPath(filePath)}`, { cause: err });
+    throw new Error(`Malformed JSON in ${filePath}`, { cause: err });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`readJsonFile` in the plugins-authoring command uses `JSON.parse` without try-catch when reading user-authored `package.json` files. A malformed or corrupted package.json file produces an unhelpful `SyntaxError` traceback instead of a user-friendly error message.

## Why This Change Was Made

Same pattern as #109721 and #109754: JSON data from external/file sources should be guarded with try-catch to prevent SyntaxError escape and provide better error messages.

## Evidence

- Wraps `JSON.parse(raw)` in try-catch, throwing `Malformed JSON in <path>` on failure
- Test coverage: 18 new lines in plugins-authoring-command.test.ts verify the error message format

## Merge Risk

Low. The try-catch specifically targets the `JSON.parse` call in `readJsonFile`, preserving the existing behavior for valid JSON.