### PR TITLE
refactor(ci): remove retired window-open declaration

### DIFF
--- a/scripts/check-no-raw-window-open.d.mts
+++ b/scripts/check-no-raw-window-open.d.mts
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-/**
- * Finds raw `window.open(...)` or `globalThis.open(...)` call lines.
- */
-export function findRawWindowOpenLines(content: unknown, fileName?: string): unknown[];
-/**
- * Runs the raw window.open guard.
- */
-export function main(): Promise<void>;


### PR DESCRIPTION
## What Problem This Solves

Removes a declaration file left behind when the custom raw `window.open` guard and its TypeScript consumer were deleted in #95368. The orphan no longer describes a runnable module or exported API.

## Why This Change Was Made

The focused Oxlint rule is now the sole owner of this boundary check. Keeping a declaration for the retired script creates false source surface and dead maintenance work.

## User Impact

No user-visible behavior change. CI/tooling source stays aligned with the implementation that actually runs.

## Evidence

- `rg -n 'check-no-raw-window-open|findRawWindowOpenLines' . --glob '!node_modules/**' --glob '!pnpm-lock.yaml'` returned no references.
- `git diff --check` passed.
- `node scripts/check-changed.mjs -- scripts/check-no-raw-window-open.d.mts` passed the full scripts/tooling Testbox gate, including scripts typecheck and Oxlint: https://github.com/openclaw/openclaw/actions/runs/29574199952
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` returned clean with no accepted/actionable findings (0.99 confidence).
