### PR TITLE
fix(feishu): suppress fallback after intentional silent DM replies

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -81,6 +81,10 @@ vi.mock("./accounts.js", () => ({
   resolveFeishuRuntimeAccount: resolveFeishuAccountMock,
 }));
 vi.mock("./runtime.js", () => ({ getFeishuRuntime: getFeishuRuntimeMock }));
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+}));
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
@@ -144,6 +148,7 @@ import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 afterAll(() => {
   vi.doUnmock("./accounts.js");
   vi.doUnmock("./runtime.js");
+  vi.doUnmock("openclaw/plugin-sdk/reply-runtime");
   vi.doUnmock("./send.js");
   vi.doUnmock("./media.js");
   vi.doUnmock("./client.js");
@@ -2122,6 +2127,20 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("does not send no-visible-reply fallback after an intentional silent block", async () => {
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: false,
+      skippedFinalReason: "silent",
+    });
+  });
+
   it("sends no-visible-reply fallback when a final fails after an earlier silent skip", async () => {
     useNonStreamingAutoAccount();
     const runtime = createRuntimeLogger();
@@ -2138,6 +2157,32 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
     expect(String(firstMockArg(sendMessageFeishuMock, "send message params").text)).toBe(
       "Later visible final",
+    );
+    expect(String(sendMessageFeishuMock.mock.calls[1]?.[0]?.text)).toContain(
+      "without visible content",
+    );
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: true,
+      skippedFinalReason: null,
+    });
+  });
+
+  it("sends no-visible-reply fallback when a block fails after an earlier silent skip", async () => {
+    useNonStreamingBlockAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
+
+    await expect(
+      options.deliver({ text: "Later visible block" }, { kind: "block" }),
+    ).rejects.toThrow("send failed");
+    await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(true);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(String(firstMockArg(sendMessageFeishuMock, "send message params").text)).toBe(
+      "Later visible block",
     );
     expect(String(sendMessageFeishuMock.mock.calls[1]?.[0]?.text)).toContain(
       "without visible content",

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2141,6 +2141,32 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("preserves a later silent skip when an earlier queued block fails", async () => {
+    useNonStreamingBlockAccount();
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    options.onSkip?.(
+      { text: "NO_REPLY" },
+      { kind: "block", reason: "silent", assistantMessageIndex: 2 },
+    );
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
+
+    await expect(
+      options.deliver(
+        { text: "Earlier visible block" },
+        { kind: "block", assistantMessageIndex: 1 },
+      ),
+    ).rejects.toThrow("send failed");
+    await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: false,
+      skippedFinalReason: "silent",
+    });
+  });
+
   it("sends no-visible-reply fallback when a final fails after an earlier silent skip", async () => {
     useNonStreamingAutoAccount();
     const runtime = createRuntimeLogger();
@@ -2172,11 +2198,14 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const runtime = createRuntimeLogger();
     const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
 
-    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    options.onSkip?.(
+      { text: "NO_REPLY" },
+      { kind: "block", reason: "silent", assistantMessageIndex: 1 },
+    );
     sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
 
     await expect(
-      options.deliver({ text: "Later visible block" }, { kind: "block" }),
+      options.deliver({ text: "Later visible block" }, { kind: "block", assistantMessageIndex: 2 }),
     ).rejects.toThrow("send failed");
     await expect(result.ensureNoVisibleReplyFallback("failed-block")).resolves.toBe(true);
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -285,6 +285,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingCloseErroredForReply = false;
   let visibleReplySent = false;
   let skippedFinalReason: string | null = null;
+  let skippedFinalAssistantMessageIndex: number | undefined;
   let idleSideEffectsPromise: Promise<void> = Promise.resolve();
   let replyLifecycleStateInitialized = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
@@ -672,6 +673,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     onSkip: (_payload, info) => {
       if (info.kind === "final" || (info.kind === "block" && info.reason === "silent")) {
         skippedFinalReason = info.reason;
+        skippedFinalAssistantMessageIndex = info.assistantMessageIndex;
       }
     },
     onReplyStart: async () => {
@@ -683,6 +685,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         streamingCloseErroredForReply = false;
         visibleReplySent = false;
         skippedFinalReason = null;
+        skippedFinalAssistantMessageIndex = undefined;
       }
       if (streamingEnabled && renderMode === "card") {
         startStreaming();
@@ -690,7 +693,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       await Promise.resolve(typingCallbacks?.onReplyStart?.());
     },
     deliver: async (payload: ReplyPayload, info) => {
-      skippedFinalReason = null;
+      // Delivery is serialized after enqueue-time skips. An older queued send
+      // must not erase a silent decision from a later assistant message.
+      if (
+        skippedFinalAssistantMessageIndex === undefined ||
+        info.assistantMessageIndex === undefined ||
+        info.assistantMessageIndex >= skippedFinalAssistantMessageIndex
+      ) {
+        skippedFinalReason = null;
+        skippedFinalAssistantMessageIndex = undefined;
+      }
       const payloadText =
         payload.isReasoning && payload.text ? formatReasoningMessage(payload.text) : payload.text;
       const reply = resolveSendableOutboundReplyParts({ ...payload, text: payloadText });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -670,7 +670,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       conversationType: chatId.startsWith("oc_") ? "group" : "direct",
     },
     onSkip: (_payload, info) => {
-      if (info.kind === "final") {
+      if (info.kind === "final" || (info.kind === "block" && info.reason === "silent")) {
         skippedFinalReason = info.reason;
       }
     },
@@ -690,9 +690,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       await Promise.resolve(typingCallbacks?.onReplyStart?.());
     },
     deliver: async (payload: ReplyPayload, info) => {
-      if (info?.kind === "final") {
-        skippedFinalReason = null;
-      }
+      skippedFinalReason = null;
       const payloadText =
         payload.isReasoning && payload.text ? formatReasoningMessage(payload.text) : payload.text;
       const reply = resolveSendableOutboundReplyParts({ ...payload, text: payloadText });


### PR DESCRIPTION
Closes #109912

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Feishu DM users received a misleading "reply completed without visible content" warning when an agent intentionally returned `NO_REPLY` through the message-end block-reply path.

## Why This Change Was Made

Feishu now records an explicitly silent block reply as intentional silence, matching the existing final-reply behavior without weakening the fallback for genuinely empty DM turns. The state is ordered by assistant-message index: an older queued delivery cannot erase a newer silent skip, while a same-message or later visible delivery still clears the skip so a real send failure receives the recovery fallback.

The regression suite mocks the dispatcher through its current public Plugin SDK seam, matching the channel-runtime boundary on `main`.

## User Impact

Intentional `NO_REPLY` results in Feishu DMs remain silent. Users still receive the existing recovery warning when a same-message or later visible block or final reply fails to send.

## Evidence

- Behavior addressed: message-end `NO_REPLY` arrives as `{ kind: "block", reason: "silent" }`; before this patch, `ensureNoVisibleReplyFallback()` returned `true` and sent the warning.
- The ordering regression covers an older queued block whose send fails after a newer assistant message was intentionally skipped. The newer silence marker remains authoritative and no fallback is sent.
- The inverse regression covers a later visible block failure and confirms that the recovery fallback is still sent.
- `node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts` passed all 95 tests on Node 24.16.0.
- `./node_modules/.bin/oxfmt --check extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts` passed.
- `./node_modules/.bin/oxlint extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts` passed.
- Both commits on the rebased branch have verified signatures.
- Live Feishu tenant proof remains unavailable because this environment has no Feishu credentials. The issue supplies the live before-fix report; after-fix evidence currently exercises the production dispatcher with the repository's mocked Feishu transport.

Disclosure: AI was used to understand the codebase and review the fix.
