### PR TITLE
fix(setup): preserve chat handoff during inference repair

### DIFF
--- a/src/commands/system-agent-with-inference.test.ts
+++ b/src/commands/system-agent-with-inference.test.ts
@@ -205,6 +205,7 @@ describe("runSystemAgentWithInference", () => {
     expect(runGuidedOnboarding).toHaveBeenCalledWith(
       { workspace: "/tmp/work", acceptRisk: true },
       currentRuntime,
+      { handoffMode: "chat" },
     );
     expect(runSystemAgent).not.toHaveBeenCalled();
   });

--- a/src/commands/system-agent-with-inference.ts
+++ b/src/commands/system-agent-with-inference.ts
@@ -130,5 +130,5 @@ export async function runSystemAgentWithInference(
   runtime.log("OpenClaw requires working inference. Starting guided AI setup…");
   const runGuidedOnboarding =
     deps.runGuidedOnboarding ?? (await import("./onboard-guided.js")).runGuidedOnboarding;
-  await runGuidedOnboarding(onboardingOptions, runtime);
+  await runGuidedOnboarding(onboardingOptions, runtime, { handoffMode: "chat" });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where interactive `openclaw setup` users with failed inference verification could be moved into local setup application and the agent TUI instead of continuing the requested conversational repair flow.

## Why This Change Was Made

The inference gate now calls guided onboarding with an explicit `chat` handoff. Plain `openclaw onboard` keeps its new local hatch default, while setup repair preserves its established conversational owner boundary.

## User Impact

Users who run `openclaw setup` to repair expired or broken model access return to the setup chat after guided AI recovery. The ordinary first-run onboarding hatch and remote onboarding behavior are unchanged.

## Real behavior proof

- **Behavior addressed:** Interactive `openclaw setup` repair no longer inherits the local onboarding hatch after its initial inference verification fails.
- **Real environment tested:** Linux x86_64, Node 24.15.0, GitHub head `25a45c717f48` (tree `581152a9f446`), branch `fix/setup-repair-chat-handoff`.
- **Exact steps or command run after this patch:** A one-shot `node --import tsx --input-type=module` PTY harness launched the real `src/entry.ts setup` command with isolated HOME/state/config and a loopback OpenAI Responses-compatible provider. The provider intentionally returned HTTP 500 for the first inference probe, then a real SSE completion for guided activation. The harness waited for the actual system-agent chat surface and exited it with Ctrl-C.
- **Evidence after fix:** Terminal capture of the real `node` + PTY + provider-transport run (live stdout):

  ```text
  RESULT requests=2 first_probe_failed=1 chat_surface=1 exit_code=0
  PASS interactive setup repair returned to chat
  ```

- **Observed result after fix:** The first configured-model probe failed, guided setup activated the same route on the next live completion, and `openclaw setup` visibly entered the `openclaw setup - openclaw local` chat with `local ready | idle` instead of launching the hatch TUI.
- **What was not tested:** The proof used an isolated loopback OpenAI Responses-compatible provider with a synthetic key, not a credential-bearing external provider. It exercised the real setup command, provider transport, failure classification, guided activation, config persistence, and final chat handoff without external credentials.

## Tests and validation

```text
$ node scripts/run-vitest.mjs src/commands/system-agent-with-inference.test.ts
Test Files  1 passed (1)
Tests       16 passed (16)

$ git diff --check
EXIT=0
```

The updated assertion failed before the source change because guided onboarding received no handoff override, then passed with the explicit setup-repair contract.

## Risk checklist

- User-visible behavior: Yes - failed inference repair returns to setup chat.
- Config/env/migration behavior: No - no persisted configuration changes.
- Security/auth/secrets/network/tool execution: No - verification and credential handling are unchanged.
- Plugins/providers/channels/SDK: No - command orchestration only.
- Highest-risk area: Accidentally changing plain onboarding's intended hatch behavior.
- Mitigation: The override is applied only at the shared inference-repair caller, with a focused argument-contract test.

Closes: N/A (no existing issue)

AI-assisted: Yes. I reviewed the generated change and understand the caller-specific handoff contract.

Allow edits from maintainers: Enabled.
