### PR TITLE
fix(sqlite): add 10s SIGKILL timeout to mount lookup during WAL safety check

### DIFF
--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -18,6 +18,7 @@ const LINUX_NFS_SUPER_MAGIC = 0x6969;
 const LINUX_SMB_SUPER_MAGIC = 0x517b;
 const LINUX_CIFS_SUPER_MAGIC = 0xff534d42;
 const LINUX_SMB2_SUPER_MAGIC = 0xfe534d42;
+const MOUNT_LOOKUP_TIMEOUT_MS = 10_000;
 const PROC_MOUNTINFO_PATH = "/proc/self/mountinfo";
 const NETWORK_FILESYSTEM_TYPES = new Set(["cifs", "smbfs", "smb2", "smb3"]);
 const JOURNAL_MODE_RETRY_INTERVAL_MS = 10;
@@ -172,7 +173,14 @@ function readMountEntries(): MountEntry[] {
     // Linux superblock magic, so keep this fallback for named filesystem types.
   }
   try {
-    return parseMountCommandEntries(String(childProcess.execFileSync("mount", [])));
+    return parseMountCommandEntries(
+      String(
+        childProcess.execFileSync("mount", [], {
+          timeout: MOUNT_LOOKUP_TIMEOUT_MS,
+          killSignal: "SIGKILL",
+        }),
+      ),
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

When `/proc/self/mountinfo` is unavailable on Linux, the SQLite WAL safety check falls back to `childProcess.execFileSync("mount", [])`. This mount command can hang indefinitely on unresponsive network filesystems (NFS, CIFS), blocking the calling thread and stalling the database open path.

## Why This Change Was Made

The mount command has no default timeout, so a stuck network mount causes an unbounded block. Adding a 10-second timeout with `SIGKILL` ensures it fails fast.

## Evidence

- Adds `timout: 10_000` and `killSignal: "SIGKILL"` to `execFileSync("mount", [])`
- The existing catch block already returns `[]` on failure, so timeout/error handling is already in place

## Merge Risk

Low. The timeout only applies to the fallback path when `/proc/self/mountinfo` is unavailable. On systems where mount works fine, there is no behavioral change.