### PR TITLE
fix(onboard): keep configured AI route when guarded setup is skipped

### DIFF
--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -803,68 +803,7 @@ describe("runGuidedOnboarding", () => {
     expect(promptAuthChoiceGrouped).toHaveBeenCalledOnce();
   });
 
-  it("keeps a configured route when guarded discovery and replacement are skipped", async () => {
-    readConfigFileSnapshot.mockResolvedValue({
-      exists: true,
-      valid: true,
-      path: "/tmp/openclaw.json",
-      issues: [],
-      config: {
-        agents: {
-          defaults: {
-            workspace: "/tmp/configured-workspace",
-            model: { primary: "openai/gpt-5.6" },
-          },
-        },
-        wizard: {
-          accessMode: "guarded",
-          securityAcknowledgedAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-    });
-    promptAuthChoiceGrouped.mockResolvedValueOnce("skip");
-    const prompter = createWizardPrompter(undefined, {
-      selectValues: ["guarded", "manual"],
-    });
-    const deps = {
-      ...setupDeps({ prompter }),
-      listManualOptions: vi.fn(async () => ({
-        manualProviders: [{ id: "openai-api-key", label: "OpenAI" }],
-        authOptions: [],
-        workspace: "/tmp/configured-workspace",
-        setupComplete: true,
-      })),
-    };
-
-    await runGuidedOnboarding({ acceptRisk: true }, makeRuntime(), deps);
-
-    expect(deps.applySetup).not.toHaveBeenCalled();
-    expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/configured-workspace");
-    const notes = JSON.stringify((prompter.note as ReturnType<typeof vi.fn>).mock.calls);
-    expect(notes).toContain("Keeping the working AI you already have.");
-    expect(notes).toContain("already set up");
-    expect(notes).not.toContain("Add AI later");
-  });
-
   it("keeps a configured route when guarded setup has no replacement options", async () => {
-    readConfigFileSnapshot.mockResolvedValue({
-      exists: true,
-      valid: true,
-      path: "/tmp/openclaw.json",
-      issues: [],
-      config: {
-        agents: {
-          defaults: {
-            workspace: "/tmp/configured-workspace",
-            model: { primary: "openai/gpt-5.6" },
-          },
-        },
-        wizard: {
-          accessMode: "guarded",
-          securityAcknowledgedAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-    });
     const prompter = createWizardPrompter(undefined, {
       selectValues: ["guarded", "manual"],
     });
@@ -873,7 +812,7 @@ describe("runGuidedOnboarding", () => {
       listManualOptions: vi.fn(async () => ({
         manualProviders: [],
         authOptions: [],
-        workspace: "/tmp/configured-workspace",
+        workspace: "/tmp/openclaw-workspace",
         setupComplete: true,
       })),
     };
@@ -881,9 +820,11 @@ describe("runGuidedOnboarding", () => {
     await runGuidedOnboarding({ acceptRisk: true }, makeRuntime(), deps);
 
     expect(promptAuthChoiceGrouped).not.toHaveBeenCalled();
-    expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/configured-workspace");
+    expect(deps.applySetup).not.toHaveBeenCalled();
+    expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/openclaw-workspace");
     const notes = JSON.stringify((prompter.note as ReturnType<typeof vi.fn>).mock.calls);
     expect(notes).toContain("Keeping the working AI you already have.");
+    expect(notes).toContain("already set up");
     expect(notes).not.toContain("No AI setup options are available");
   });
 

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -803,6 +803,90 @@ describe("runGuidedOnboarding", () => {
     expect(promptAuthChoiceGrouped).toHaveBeenCalledOnce();
   });
 
+  it("keeps a configured route when guarded discovery and replacement are skipped", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      issues: [],
+      config: {
+        agents: {
+          defaults: {
+            workspace: "/tmp/configured-workspace",
+            model: { primary: "openai/gpt-5.6" },
+          },
+        },
+        wizard: {
+          accessMode: "guarded",
+          securityAcknowledgedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    });
+    promptAuthChoiceGrouped.mockResolvedValueOnce("skip");
+    const prompter = createWizardPrompter(undefined, {
+      selectValues: ["guarded", "manual"],
+    });
+    const deps = {
+      ...setupDeps({ prompter }),
+      listManualOptions: vi.fn(async () => ({
+        manualProviders: [{ id: "openai-api-key", label: "OpenAI" }],
+        authOptions: [],
+        workspace: "/tmp/configured-workspace",
+        setupComplete: true,
+      })),
+    };
+
+    await runGuidedOnboarding({ acceptRisk: true }, makeRuntime(), deps);
+
+    expect(deps.applySetup).not.toHaveBeenCalled();
+    expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/configured-workspace");
+    const notes = JSON.stringify((prompter.note as ReturnType<typeof vi.fn>).mock.calls);
+    expect(notes).toContain("Keeping the working AI you already have.");
+    expect(notes).toContain("already set up");
+    expect(notes).not.toContain("Add AI later");
+  });
+
+  it("keeps a configured route when guarded setup has no replacement options", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      issues: [],
+      config: {
+        agents: {
+          defaults: {
+            workspace: "/tmp/configured-workspace",
+            model: { primary: "openai/gpt-5.6" },
+          },
+        },
+        wizard: {
+          accessMode: "guarded",
+          securityAcknowledgedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    });
+    const prompter = createWizardPrompter(undefined, {
+      selectValues: ["guarded", "manual"],
+    });
+    const deps = {
+      ...setupDeps({ prompter }),
+      listManualOptions: vi.fn(async () => ({
+        manualProviders: [],
+        authOptions: [],
+        workspace: "/tmp/configured-workspace",
+        setupComplete: true,
+      })),
+    };
+
+    await runGuidedOnboarding({ acceptRisk: true }, makeRuntime(), deps);
+
+    expect(promptAuthChoiceGrouped).not.toHaveBeenCalled();
+    expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/configured-workspace");
+    const notes = JSON.stringify((prompter.note as ReturnType<typeof vi.fn>).mock.calls);
+    expect(notes).toContain("Keeping the working AI you already have.");
+    expect(notes).not.toContain("No AI setup options are available");
+  });
+
   it("scans in guarded mode only after the look-around consent", async () => {
     const prompter = createWizardPrompter(undefined, { selectValues: ["guarded", "look"] });
     const deps = setupDeps({ prompter });

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -178,6 +178,13 @@ async function runManualStage(params: {
     ),
   }));
   if (detectedOptions.length === 0 && allowedChoices.size === 0) {
+    if (params.hasActiveRoute) {
+      await params.prompter.note(
+        t("wizard.guided.keepingCurrent"),
+        t("wizard.guided.aiAccessTitle"),
+      );
+      return null;
+    }
     await params.prompter.note(
       t("wizard.guided.noInferenceOptions"),
       t("wizard.guided.aiAccessTitle"),
@@ -586,6 +593,7 @@ async function runGuidedOnboardingFlow(
         t("wizard.guided.aiAccessTitle"),
       );
     }
+    const hasActiveRoute = detection?.setupComplete === true;
     const manualResult = await runManualStage({
       detection,
       autoAttemptedKinds,
@@ -594,14 +602,21 @@ async function runGuidedOnboardingFlow(
       runtime,
       prompter,
       activate,
+      hasActiveRoute,
     });
     if (!manualResult) {
-      return null;
+      if (!hasActiveRoute) {
+        return null;
+      }
+      resultLines = [];
+    } else {
+      resultLines = manualResult;
     }
-    resultLines = manualResult;
   }
 
-  await prompter.note(resultLines.join("\n"), t("wizard.guided.appliedTitle"));
+  if (resultLines.length > 0) {
+    await prompter.note(resultLines.join("\n"), t("wizard.guided.appliedTitle"));
+  }
   const persistedSnapshot = await readConfigFileSnapshot();
   const persistedConfig = persistedSnapshot.valid
     ? (persistedSnapshot.sourceConfig ?? persistedSnapshot.config)

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -593,7 +593,7 @@ async function runGuidedOnboardingFlow(
         t("wizard.guided.aiAccessTitle"),
       );
     }
-    const hasActiveRoute = detection?.setupComplete === true;
+    const hasActiveRoute = detection?.setupComplete ?? false;
     const manualResult = await runManualStage({
       detection,
       autoAttemptedKinds,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users rerunning guarded onboarding with an already configured AI route would be told to add AI later, and would never reach the hatch TUI, when they declined machine discovery and either skipped replacement setup or had no replacement choices. The manual stage returned `null` for both "keep the current route" and "continue without AI", and the caller treated both states as cancellation (`src/commands/onboard-guided.ts:596`).

## Why This Change Was Made

`listManualSetupInferenceOptions()` already owns the config-only classification and reports `setupComplete` when a default model is configured. The guided onboarding caller now carries that fact into the manual stage, preserves the existing route for both skip paths, and continues through the normal configured-install hatch handoff without rendering an empty applied summary.

## User Impact

Guarded users can decline discovery without losing the onboarding handoff for an AI route that is already configured. Fresh installs with no active route keep the existing cancellation and "add AI later" behavior.

## Real behavior proof

- **Behavior addressed:** Guarded onboarding preserves an already configured inference route when discovery is declined and no replacement route is selected or available.
- **Real environment tested:** Linux x86_64, Node 24.15.0, commit `dd618ca1c851` on branch `fix/guarded-onboarding-keep-configured-route`.
- **Exact steps or command run after this patch:** `node --import tsx /tmp/verify-guarded-route.mts` - writes an isolated configured-model state, executes the real guided onboarding entry point with guarded/manual selections and zero replacement choices, and records the hatch handoff.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live stdout):

  ```text
  PASS selections=guarded,manual keptRoute=true hatch=true
  ```

- **Observed result after fix:** The current route is retained, setup application is not invoked, and onboarding hands the configured workspace to the hatch TUI.
- **What was not tested:** A real provider turn and interactive terminal rendering were not exercised because the failure occurs before provider activation; the runtime proof uses the production onboarding flow with deterministic prompt and handoff adapters.

## Tests and validation

```text
$ node scripts/run-vitest.mjs src/commands/onboard-guided.test.ts
Test Files  1 passed (1)
Tests       29 passed (29)

$ git diff --check
EXIT=0
```

The regression test failed before the source fix because `launchHatchTui` had zero calls. Coverage now includes both an explicit replacement skip and a configured route with zero manual/auth choices.

Structured Codex autoreview was attempted with `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`, but the review transport returned HTTP 403 before a model response. The changed function, caller, config-only `setupComplete` producer, sibling active-route path, and adjacent tests were reviewed manually.

## Risk checklist

- User-visible behavior: Yes - configured guarded reruns now continue to the hatch instead of exiting as AI-less.
- Config/env/migration behavior: No - no config shape, default, persistence, or migration changes.
- Security/auth/secrets/network/tool execution: No - the patch only changes control flow after config-only route classification.
- Plugins/providers/channels/SDK: No - no provider activation contract or plugin surface changes.
- Highest-risk area: Distinguishing a deliberate AI-less skip from retaining a previously configured route.
- Mitigation: The existing `setupComplete` contract is used as the discriminator, with the existing active-route skip regression, the new empty-choice regression, and a direct runtime proof.

Closes: N/A (no existing issue)
