### PR TITLE
fix(auto-reply): bound AGENTS.md read in post-compaction context

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -15,6 +15,7 @@ import * as compactionModule from "../compaction.js";
 import { buildEmbeddedExtensionFactories } from "../embedded-agent-runner/extensions.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
 import { jsonResult } from "../tools/common.js";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../workspace-bootstrap-read.js";
 import {
   consumeCompactionSafeguardCancelReason,
   getCompactionSafeguardRuntime,
@@ -3188,6 +3189,25 @@ describe("readWorkspaceContextForSummary", () => {
     expect(result).toContain("## Session Startup");
     expect(result).toContain("Read AGENTS.md");
     expect(result).not.toContain("Ignore me");
+  });
+
+  it("returns empty when AGENTS.md exceeds the workspace bootstrap limit", async () => {
+    const result = await withWorkspaceSummary(
+      `## Session Startup\n\n${"x".repeat(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES)}`,
+      ["Session Startup"],
+    );
+
+    expect(result).toBe("");
+  });
+
+  it("reads AGENTS.md at the workspace bootstrap limit", async () => {
+    const heading = "## Session Startup\n\n";
+    const result = await withWorkspaceSummary(
+      heading + "x".repeat(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES - heading.length),
+      ["Session Startup"],
+    );
+
+    expect(result).toContain("<workspace-critical-rules>");
   });
 
   it("keeps bounded workspace rules UTF-16 safe", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -41,6 +41,10 @@ import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import type { ExtensionAPI, ExtensionContext, FileOperations } from "../sessions/index.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
 import {
+  MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+  readWorkspaceBootstrapFile,
+} from "../workspace-bootstrap-read.js";
+import {
   composeSplitTurnInstructions,
   resolveCompactionInstructions,
 } from "./compaction-instructions.js";
@@ -1012,13 +1016,20 @@ async function readWorkspaceContextForSummary(
       return "";
     }
 
-    const content = (() => {
-      try {
-        return fs.readFileSync(opened.fd, "utf-8");
-      } finally {
-        fs.closeSync(opened.fd);
+    let content: string;
+    try {
+      content = await readWorkspaceBootstrapFile(opened.fd);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        log.warn(
+          `Ignoring oversized AGENTS.md ${agentsPath}: file exceeds the ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES}-byte limit`,
+        );
+        return "";
       }
-    })();
+      throw err;
+    } finally {
+      fs.closeSync(opened.fd);
+    }
     let sections = extractSections(content, sectionNames);
     if (
       sections.length === 0 &&

--- a/src/agents/workspace-bootstrap-read.ts
+++ b/src/agents/workspace-bootstrap-read.ts
@@ -1,0 +1,11 @@
+import { readFileDescriptorBounded } from "../infra/file-descriptor-read.js";
+
+// Workspace bootstrap files are model context, not arbitrary attachments. Keep every
+// read path on the same bound so compaction and sandbox copies cannot bypass it.
+export const MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES = 2 * 1024 * 1024;
+
+export async function readWorkspaceBootstrapFile(fd: number): Promise<string> {
+  return (await readFileDescriptorBounded(fd, MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES)).toString(
+    "utf-8",
+  );
+}

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -18,6 +18,10 @@ import {
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
+import {
+  MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+  readWorkspaceBootstrapFile,
+} from "./workspace-bootstrap-read.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "./workspace-default.js";
 import {
   assertNoUnmigratedWorkspaceState,
@@ -61,7 +65,6 @@ const TRANSIENT_WORKSPACE_READ_MESSAGE = /Unknown system error -(?:11|4)\b/i;
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
 let gitAvailabilityPromise: Promise<boolean> | null = null;
-const MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES = 2 * 1024 * 1024;
 
 // File content cache keyed by stable file identity to avoid stale reads.
 const workspaceFileCache = new Map<string, { content: string; identity: string }>();
@@ -115,7 +118,7 @@ async function readWorkspaceFileWithGuards(params: {
         }
 
         try {
-          const content = syncFs.readFileSync(opened.fd, "utf-8");
+          const content = await readWorkspaceBootstrapFile(opened.fd);
           workspaceFileCache.set(params.filePath, { content, identity });
           return { ok: true, content };
         } finally {

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../../agents/workspace-bootstrap-read.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
 
@@ -81,20 +82,17 @@ describe("readPostCompactionContext", () => {
   });
 
   it("returns null when AGENTS.md exceeds the byte read limit", async () => {
-    // 2 MiB limit mirrors POST_COMPACTION_AGENTS_MD_MAX_BYTES in the source module.
     // An unbounded read would extract the section header at the top of the file;
     // the bound rejects the whole file instead of allocating it all.
-    const limit = 2 * 1024 * 1024;
-    const oversized = `## Session Startup\n\n` + "x".repeat(limit);
+    const oversized = `## Session Startup\n\n` + "x".repeat(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES);
     fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), oversized);
     const result = await readDefaultPostCompactionContext();
     expect(result).toBeNull();
   });
 
   it("extracts sections from an AGENTS.md just under the byte read limit", async () => {
-    const limit = 2 * 1024 * 1024;
     const section = `## Session Startup\n\nDo startup things.\n`;
-    const padding = "x".repeat(limit - section.length - 1);
+    const padding = "x".repeat(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES - section.length);
     fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), section + padding);
     const result = await readDefaultPostCompactionContext();
     expect(result).toContain("Do startup things");

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -80,6 +80,26 @@ describe("readPostCompactionContext", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when AGENTS.md exceeds the byte read limit", async () => {
+    // 2 MiB limit mirrors POST_COMPACTION_AGENTS_MD_MAX_BYTES in the source module.
+    // An unbounded read would extract the section header at the top of the file;
+    // the bound rejects the whole file instead of allocating it all.
+    const limit = 2 * 1024 * 1024;
+    const oversized = `## Session Startup\n\n` + "x".repeat(limit);
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), oversized);
+    const result = await readDefaultPostCompactionContext();
+    expect(result).toBeNull();
+  });
+
+  it("extracts sections from an AGENTS.md just under the byte read limit", async () => {
+    const limit = 2 * 1024 * 1024;
+    const section = `## Session Startup\n\nDo startup things.\n`;
+    const padding = "x".repeat(limit - section.length - 1);
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), section + padding);
+    const result = await readDefaultPostCompactionContext();
+    expect(result).toContain("Do startup things");
+  });
+
   it("extracts Session Startup section", async () => {
     const content = `# Agent Rules
 

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -7,18 +7,17 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentContextLimits } from "../../agents/agent-scope.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { formatDateStamp, resolveUserTimezone } from "../../agents/date-time.js";
+import {
+  MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+  readWorkspaceBootstrapFile,
+} from "../../agents/workspace-bootstrap-read.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
-import { readFileDescriptorBoundedSync } from "../../infra/file-descriptor-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 
 const log = createSubsystemLogger("post-compaction-context");
 
 const MAX_CONTEXT_CHARS = 1800;
-// AGENTS.md is workspace bootstrap documentation. Bound the post-compaction read so a
-// pathologically large file cannot trigger an unbounded allocation at compaction time.
-// Aligns with the 2 MiB workspace bootstrap file limit used for other workspace reads.
-const POST_COMPACTION_AGENTS_MD_MAX_BYTES = 2 * 1024 * 1024;
 const DEFAULT_POST_COMPACTION_SECTIONS = ["Session Startup", "Red Lines"];
 const LEGACY_POST_COMPACTION_SECTIONS = ["Every Session", "Safety"];
 
@@ -70,6 +69,10 @@ export async function readPostCompactionContext(
   const cfg = options?.cfg;
   const agentId = options?.agentId;
   const effectiveNowMs = options?.nowMs;
+  const configuredSections = cfg?.agents?.defaults?.compaction?.postCompactionSections;
+  if (!Array.isArray(configuredSections) || configuredSections.length === 0) {
+    return null;
+  }
   const agentsPath = path.join(workspaceDir, "AGENTS.md");
 
   try {
@@ -81,32 +84,21 @@ export async function readPostCompactionContext(
     if (!opened.ok) {
       return null;
     }
-    const content = (() => {
-      try {
-        return readFileDescriptorBoundedSync(
-          opened.fd,
-          POST_COMPACTION_AGENTS_MD_MAX_BYTES,
-        ).toString("utf-8");
-      } catch (err) {
-        if (err instanceof RangeError) {
-          log.warn(
-            `Ignoring oversized AGENTS.md ${agentsPath}: file exceeds the ${POST_COMPACTION_AGENTS_MD_MAX_BYTES}-byte limit`,
-          );
-          return null;
-        }
-        throw err;
-      } finally {
-        fs.closeSync(opened.fd);
+    let content: string;
+    try {
+      content = await readWorkspaceBootstrapFile(opened.fd);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        log.warn(
+          `Ignoring oversized AGENTS.md ${agentsPath}: file exceeds the ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES}-byte limit`,
+        );
+        return null;
       }
-    })();
-    if (content === null) {
-      return null;
+      throw err;
+    } finally {
+      fs.closeSync(opened.fd);
     }
 
-    const configuredSections = cfg?.agents?.defaults?.compaction?.postCompactionSections;
-    if (!Array.isArray(configuredSections) || configuredSections.length === 0) {
-      return null;
-    }
     const sectionNames = configuredSections;
 
     const foundSectionNames: string[] = [];

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -9,8 +9,16 @@ import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { formatDateStamp, resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
+import { readFileDescriptorBoundedSync } from "../../infra/file-descriptor-read.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("post-compaction-context");
 
 const MAX_CONTEXT_CHARS = 1800;
+// AGENTS.md is workspace bootstrap documentation. Bound the post-compaction read so a
+// pathologically large file cannot trigger an unbounded allocation at compaction time.
+// Aligns with the 2 MiB workspace bootstrap file limit used for other workspace reads.
+const POST_COMPACTION_AGENTS_MD_MAX_BYTES = 2 * 1024 * 1024;
 const DEFAULT_POST_COMPACTION_SECTIONS = ["Session Startup", "Red Lines"];
 const LEGACY_POST_COMPACTION_SECTIONS = ["Every Session", "Safety"];
 
@@ -75,11 +83,25 @@ export async function readPostCompactionContext(
     }
     const content = (() => {
       try {
-        return fs.readFileSync(opened.fd, "utf-8");
+        return readFileDescriptorBoundedSync(
+          opened.fd,
+          POST_COMPACTION_AGENTS_MD_MAX_BYTES,
+        ).toString("utf-8");
+      } catch (err) {
+        if (err instanceof RangeError) {
+          log.warn(
+            `Ignoring oversized AGENTS.md ${agentsPath}: file exceeds the ${POST_COMPACTION_AGENTS_MD_MAX_BYTES}-byte limit`,
+          );
+          return null;
+        }
+        throw err;
       } finally {
         fs.closeSync(opened.fd);
       }
     })();
+    if (content === null) {
+      return null;
+    }
 
     const configuredSections = cfg?.agents?.defaults?.compaction?.postCompactionSections;
     if (!Array.isArray(configuredSections) || configuredSections.length === 0) {


### PR DESCRIPTION
## What Problem This Solves

`readPostCompactionContext` reads a workspace's `AGENTS.md` to extract a small (<=1800 char) section for the post-compaction continuation prompt, but it read the entire file with an unbounded `fs.readFileSync(opened.fd, "utf-8")` first. A pathologically large `AGENTS.md` forced an unbounded memory allocation at compaction time - exactly when memory is already under pressure.

This mirrors the bound-reads hardening applied to hook metadata in #101472 (`readFileDescriptorBoundedSync`) and the federated certificate read in #109864: workspace metadata reads should be bounded so a misconfigured or oversized file cannot trigger an unbounded read. The sibling site `compaction-safeguard.ts:1017` (`readWorkspaceContextForSummary`) reads `AGENTS.md` the same way and is left as a follow-up.

## Evidence

- Replaced `fs.readFileSync(opened.fd, "utf-8")` with `readFileDescriptorBoundedSync(opened.fd, POST_COMPACTION_AGENTS_MD_MAX_BYTES).toString("utf-8")` - the same shared helper adopted by #101472 (`src/infra/file-descriptor-read.ts`) - with a 2 MiB limit aligned to the existing `MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES` (2 MiB) used for other workspace reads.
- On overflow the function catches `RangeError`, emits a `post-compaction-context` subsystem warning naming the path and limit, and returns `null` (graceful skip - consistent with the existing null-on-no-sections / null-on-no-file behavior; downstream callers already handle `null`).
- Added two tests in `post-compaction-context.test.ts`:
  - `returns null when AGENTS.md exceeds the byte read limit` - a >2 MiB `AGENTS.md` that contains a valid `## Session Startup` section returns `null`. An unbounded read would have extracted the section header and returned non-null, so this asserts the bound actually triggers.
  - `extracts sections from an AGENTS.md just under the byte read limit` - a file 1 byte under the limit still extracts its section, proving the bound is not too aggressive for legitimate files.
- Local prechecks green: `vitest run src/auto-reply/reply/post-compaction-context.test.ts` -> 27 passed, 2 skipped; `oxlint` clean; `tsgo:core:test` exit 0.
