### PR TITLE
fix(proxy): make debug CA generation recoverable

### DIFF
--- a/src/proxy-capture/ca.test.ts
+++ b/src/proxy-capture/ca.test.ts
@@ -1,0 +1,209 @@
+// Proxy capture CA tests cover bounded and recoverable certificate generation.
+import { mkdir, readdir, readFile, stat, utimes, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+
+const { resolveSystemBinMock, runExecMock } = vi.hoisted(() => ({
+  resolveSystemBinMock: vi.fn(),
+  runExecMock: vi.fn(),
+}));
+
+vi.mock("../infra/resolve-system-bin.js", () => ({ resolveSystemBin: resolveSystemBinMock }));
+vi.mock("../process/exec.js", () => ({ runExec: runExecMock }));
+
+import { ensureDebugProxyCa } from "./ca.js";
+
+const tempDirs = createTrackedTempDirs();
+
+function argAfter(args: string[], flag: string): string {
+  const index = args.indexOf(flag);
+  expect(index).toBeGreaterThanOrEqual(0);
+  const value = args[index + 1];
+  expect(value).toBeDefined();
+  return value as string;
+}
+
+function mockSuccessfulGeneration() {
+  runExecMock.mockImplementation(async (_command: string, args: string[]) => {
+    await writeFile(argAfter(args, "-keyout"), "generated key\n", "utf8");
+    await writeFile(argAfter(args, "-out"), "generated cert\n", "utf8");
+    return { stdout: "", stderr: "" };
+  });
+}
+
+async function sortedDirEntries(dir: string): Promise<string[]> {
+  return (await readdir(dir)).sort();
+}
+
+beforeEach(() => {
+  resolveSystemBinMock.mockReturnValue("/usr/bin/openssl");
+  runExecMock.mockReset();
+});
+
+afterEach(async () => {
+  await tempDirs.cleanup();
+});
+
+describe("ensureDebugProxyCa", () => {
+  it("reuses an existing CA pair without invoking OpenSSL", async () => {
+    const certDir = await tempDirs.make("openclaw-proxy-ca-");
+    const certPath = path.join(certDir, "root-ca.pem");
+    const keyPath = path.join(certDir, "root-ca-key.pem");
+    await writeFile(certPath, "existing cert\n", "utf8");
+    await writeFile(keyPath, "existing key\n", "utf8");
+
+    await expect(ensureDebugProxyCa(certDir)).resolves.toEqual({ certPath, keyPath });
+
+    expect(runExecMock).not.toHaveBeenCalled();
+  });
+
+  it("generates into temporary files before promoting the reusable CA pair", async () => {
+    const certDir = await tempDirs.make("openclaw-proxy-ca-");
+    const certPath = path.join(certDir, "root-ca.pem");
+    const keyPath = path.join(certDir, "root-ca-key.pem");
+    mockSuccessfulGeneration();
+
+    await expect(ensureDebugProxyCa(certDir)).resolves.toEqual({ certPath, keyPath });
+
+    expect(await readFile(certPath, "utf8")).toBe("generated cert\n");
+    expect(await readFile(keyPath, "utf8")).toBe("generated key\n");
+    await expect(sortedDirEntries(certDir)).resolves.toEqual(["root-ca-key.pem", "root-ca.pem"]);
+
+    const [command, args, options] = runExecMock.mock.calls[0] as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(command).toBe("/usr/bin/openssl");
+    expect(options).toEqual({ logOutput: false, timeoutMs: 30_000 });
+    expect(argAfter(args, "-keyout").startsWith(`${keyPath}.tmp-`)).toBe(true);
+    expect(argAfter(args, "-out").startsWith(`${certPath}.tmp-`)).toBe(true);
+    expect(args).not.toContain(keyPath);
+    expect(args).not.toContain(certPath);
+  });
+
+  it("cleans partial CA output after a generation failure so a retry can regenerate", async () => {
+    const certDir = await tempDirs.make("openclaw-proxy-ca-");
+    const certPath = path.join(certDir, "root-ca.pem");
+    const keyPath = path.join(certDir, "root-ca-key.pem");
+    await writeFile(certPath, "stale partial cert\n", "utf8");
+    runExecMock
+      .mockImplementationOnce(async (_command: string, args: string[]) => {
+        await writeFile(argAfter(args, "-keyout"), "partial key\n", "utf8");
+        await writeFile(argAfter(args, "-out"), "partial cert\n", "utf8");
+        throw new Error("openssl timed out");
+      })
+      .mockImplementationOnce(async (_command: string, args: string[]) => {
+        await writeFile(argAfter(args, "-keyout"), "retry key\n", "utf8");
+        await writeFile(argAfter(args, "-out"), "retry cert\n", "utf8");
+        return { stdout: "", stderr: "" };
+      });
+
+    await expect(ensureDebugProxyCa(certDir)).rejects.toThrow("openssl timed out");
+    await expect(sortedDirEntries(certDir)).resolves.toEqual([]);
+
+    await expect(ensureDebugProxyCa(certDir)).resolves.toEqual({ certPath, keyPath });
+    await expect(readFile(certPath, "utf8")).resolves.toBe("retry cert\n");
+    await expect(readFile(keyPath, "utf8")).resolves.toBe("retry key\n");
+  });
+
+  it("does not recursively remove existing directories at CA output paths", async () => {
+    const certDir = await tempDirs.make("openclaw-proxy-ca-");
+    const certPath = path.join(certDir, "root-ca.pem");
+    const nestedPath = path.join(certPath, "keep.txt");
+    await mkdir(certPath);
+    await writeFile(nestedPath, "user data\n", "utf8");
+    runExecMock.mockRejectedValueOnce(new Error("openssl failed"));
+
+    await expect(ensureDebugProxyCa(certDir)).rejects.toThrow("openssl failed");
+
+    expect((await stat(certPath)).isDirectory()).toBe(true);
+    await expect(readFile(nestedPath, "utf8")).resolves.toBe("user data\n");
+  });
+
+  it("reclaims abandoned lock tokens before regenerating", async () => {
+    const certDir = await tempDirs.make("openclaw-proxy-ca-");
+    const certPath = path.join(certDir, "root-ca.pem");
+    const keyPath = path.join(certDir, "root-ca-key.pem");
+    const lockDir = path.join(certDir, ".root-ca-generation.lock");
+    const lockTokenPath = path.join(lockDir, "abandoned.lock");
+    const nowMs = Date.parse("2026-07-17T00:00:00.000Z");
+    await mkdir(lockDir);
+    await writeFile(lockTokenPath, String(nowMs - 40_000), "utf8");
+    await utimes(lockTokenPath, new Date(nowMs - 40_000), new Date(nowMs - 40_000));
+    mockSuccessfulGeneration();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs);
+    try {
+      await expect(ensureDebugProxyCa(certDir)).resolves.toEqual({ certPath, keyPath });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await expect(readFile(certPath, "utf8")).resolves.toBe("generated cert\n");
+    await expect(readFile(keyPath, "utf8")).resolves.toBe("generated key\n");
+    await expect(sortedDirEntries(certDir)).resolves.toEqual(["root-ca-key.pem", "root-ca.pem"]);
+  });
+
+  it("times out instead of reclaiming active lock tokens across processes", async () => {
+    const certDir = await tempDirs.make("openclaw-proxy-ca-");
+    const lockDir = path.join(certDir, ".root-ca-generation.lock");
+    const lockTokenPath = path.join(lockDir, "active.lock");
+    const nowMs = Date.parse("2026-07-17T00:00:00.000Z");
+    await mkdir(lockDir);
+    await writeFile(lockTokenPath, String(nowMs), "utf8");
+
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs);
+    try {
+      const generation = ensureDebugProxyCa(certDir);
+      await vi.advanceTimersByTimeAsync(35_100);
+
+      await expect(generation).rejects.toThrow(
+        "timed out waiting for debug proxy CA generation lock",
+      );
+      expect(runExecMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("serializes concurrent generation for a shared cert directory", async () => {
+    const certDir = await tempDirs.make("openclaw-proxy-ca-");
+    const certPath = path.join(certDir, "root-ca.pem");
+    const keyPath = path.join(certDir, "root-ca-key.pem");
+    let markStarted!: () => void;
+    let finishGeneration!: () => void;
+    const generationStarted = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const generationMayFinish = new Promise<void>((resolve) => {
+      finishGeneration = resolve;
+    });
+    runExecMock.mockImplementationOnce(async (_command: string, args: string[]) => {
+      markStarted();
+      await generationMayFinish;
+      await writeFile(argAfter(args, "-keyout"), "shared key\n", "utf8");
+      await writeFile(argAfter(args, "-out"), "shared cert\n", "utf8");
+      return { stdout: "", stderr: "" };
+    });
+
+    const first = ensureDebugProxyCa(certDir);
+    await generationStarted;
+    const second = ensureDebugProxyCa(certDir);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+
+    finishGeneration();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { certPath, keyPath },
+      { certPath, keyPath },
+    ]);
+    expect(runExecMock).toHaveBeenCalledTimes(1);
+    await expect(sortedDirEntries(certDir)).resolves.toEqual(["root-ca-key.pem", "root-ca.pem"]);
+  });
+});

--- a/src/proxy-capture/ca.ts
+++ b/src/proxy-capture/ca.ts
@@ -1,8 +1,15 @@
 // Proxy capture CA helpers create and inspect local capture CA certificates.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { resolveSystemBin } from "../infra/resolve-system-bin.js";
 import { runExec } from "../process/exec.js";
+
+const DEBUG_PROXY_CA_GENERATION_TIMEOUT_MS = 30_000;
+const DEBUG_PROXY_CA_LOCK_WAIT_MS = DEBUG_PROXY_CA_GENERATION_TIMEOUT_MS + 5_000;
+const DEBUG_PROXY_CA_LOCK_POLL_MS = 50;
+const DEBUG_PROXY_CA_LOCK_TOKEN_SUFFIX = ".lock";
 
 // Ensure a short-lived root CA for local MITM debug proxy runs. Existing certs
 // are reused within the cert dir so repeated starts do not prompt regeneration.
@@ -13,32 +20,191 @@ export async function ensureDebugProxyCa(certDir: string): Promise<{
   fs.mkdirSync(certDir, { recursive: true });
   const certPath = path.join(certDir, "root-ca.pem");
   const keyPath = path.join(certDir, "root-ca-key.pem");
-  if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
+  if (debugProxyCaPairExists(certPath, keyPath)) {
     return { certPath, keyPath };
   }
-  const openssl = resolveSystemBin("openssl");
-  if (!openssl) {
-    throw new Error("openssl is required to generate debug proxy certificates");
+  const releaseLock = await acquireDebugProxyCaGenerationLock(certDir);
+  try {
+    if (debugProxyCaPairExists(certPath, keyPath)) {
+      return { certPath, keyPath };
+    }
+    cleanupDebugProxyCaFiles(certPath, keyPath);
+    const openssl = resolveSystemBin("openssl");
+    if (!openssl) {
+      throw new Error("openssl is required to generate debug proxy certificates");
+    }
+    const tempSuffix = `.tmp-${process.pid}-${randomUUID()}`;
+    const tempKeyPath = `${keyPath}${tempSuffix}`;
+    const tempCertPath = `${certPath}${tempSuffix}`;
+    try {
+      // OpenSSL writes the key and cert independently. Keep those writes off the
+      // reusable paths so a killed process cannot publish a partial CA pair.
+      await runExec(
+        openssl,
+        [
+          "req",
+          "-x509",
+          "-newkey",
+          "rsa:2048",
+          "-sha256",
+          "-days",
+          "7",
+          "-nodes",
+          "-keyout",
+          tempKeyPath,
+          "-out",
+          tempCertPath,
+          "-subj",
+          "/CN=OpenClaw Debug Proxy",
+        ],
+        { logOutput: false, timeoutMs: DEBUG_PROXY_CA_GENERATION_TIMEOUT_MS },
+      );
+      fs.renameSync(tempKeyPath, keyPath);
+      fs.renameSync(tempCertPath, certPath);
+    } catch (err) {
+      cleanupDebugProxyCaFiles(certPath, keyPath, tempCertPath, tempKeyPath);
+      throw err;
+    }
+    return { certPath, keyPath };
+  } finally {
+    releaseLock();
   }
-  await runExec(
-    openssl,
-    [
-      "req",
-      "-x509",
-      "-newkey",
-      "rsa:2048",
-      "-sha256",
-      "-days",
-      "7",
-      "-nodes",
-      "-keyout",
-      keyPath,
-      "-out",
-      certPath,
-      "-subj",
-      "/CN=OpenClaw Debug Proxy",
-    ],
-    { logOutput: false },
+}
+
+function debugProxyCaPairExists(certPath: string, keyPath: string): boolean {
+  return fs.existsSync(certPath) && fs.existsSync(keyPath);
+}
+
+async function acquireDebugProxyCaGenerationLock(certDir: string): Promise<() => void> {
+  const lockDir = path.join(certDir, ".root-ca-generation.lock");
+  const deadline = Date.now() + DEBUG_PROXY_CA_LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir);
+      const lockTokenPath = path.join(
+        lockDir,
+        `${process.pid}-${randomUUID()}${DEBUG_PROXY_CA_LOCK_TOKEN_SUFFIX}`,
+      );
+      try {
+        fs.writeFileSync(lockTokenPath, String(Date.now()), { flag: "wx" });
+      } catch (err) {
+        releaseDebugProxyCaGenerationLock(lockDir, lockTokenPath);
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          continue;
+        }
+        throw err;
+      }
+      return () => releaseDebugProxyCaGenerationLock(lockDir, lockTokenPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+    }
+    if (reclaimAbandonedDebugProxyCaLock(lockDir)) {
+      continue;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("timed out waiting for debug proxy CA generation lock");
+    }
+    await delay(DEBUG_PROXY_CA_LOCK_POLL_MS);
+  }
+}
+
+function reclaimAbandonedDebugProxyCaLock(lockDir: string): boolean {
+  const now = Date.now();
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(lockDir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
+    }
+    return false;
+  }
+
+  const tokenEntries = entries.filter(
+    (entry) => entry.isFile() && entry.name.endsWith(DEBUG_PROXY_CA_LOCK_TOKEN_SUFFIX),
   );
-  return { certPath, keyPath };
+  if (tokenEntries.length === 0) {
+    if (entries.length > 0) {
+      return false;
+    }
+    return reclaimEmptyAbandonedDebugProxyCaLockDir(lockDir, now);
+  }
+  if (tokenEntries.length !== entries.length) {
+    return false;
+  }
+
+  const tokenPaths = tokenEntries.map((entry) => path.join(lockDir, entry.name));
+  for (const tokenPath of tokenPaths) {
+    try {
+      const stat = fs.statSync(tokenPath);
+      if (now - stat.mtimeMs < DEBUG_PROXY_CA_LOCK_WAIT_MS) {
+        return false;
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      return false;
+    }
+  }
+
+  let removedToken = false;
+  for (const tokenPath of tokenPaths) {
+    try {
+      fs.unlinkSync(tokenPath);
+      removedToken = true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        return false;
+      }
+    }
+  }
+  if (!removedToken) {
+    return true;
+  }
+  return removeEmptyDebugProxyCaLockDir(lockDir);
+}
+
+function reclaimEmptyAbandonedDebugProxyCaLockDir(lockDir: string, now: number): boolean {
+  try {
+    const stat = fs.statSync(lockDir);
+    if (now - stat.mtimeMs < DEBUG_PROXY_CA_LOCK_WAIT_MS) {
+      return false;
+    }
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ENOENT";
+  }
+  return removeEmptyDebugProxyCaLockDir(lockDir);
+}
+
+function releaseDebugProxyCaGenerationLock(lockDir: string, lockTokenPath: string): void {
+  try {
+    fs.unlinkSync(lockTokenPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      return;
+    }
+  }
+  removeEmptyDebugProxyCaLockDir(lockDir);
+}
+
+function removeEmptyDebugProxyCaLockDir(lockDir: string): boolean {
+  try {
+    fs.rmdirSync(lockDir);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ENOENT";
+  }
+}
+
+function cleanupDebugProxyCaFiles(...files: string[]): void {
+  for (const file of files) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // Best effort cleanup preserves the original OpenSSL error path.
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Make debug proxy CA generation publish only complete key/cert pairs by writing OpenSSL output to unique temporary files before promotion.
- Serialize shared cert-dir generation with a bounded lock and reclaim abandoned lock tokens safely.
- Clean failed generation output without recursively deleting user-controlled CA output paths.

Refs #109106.

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope
- [ ] Gateway
- [ ] Skills
- [ ] Auth
- [ ] Memory
- [ ] Integrations
- [ ] API
- [ ] UI/UX
- [ ] CI
- [x] Proxy capture

## Verification
- `env PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs src/proxy-capture/ca.test.ts` -> passed 1 Vitest shard.
- `env PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs src/proxy-capture/proxy-server.test.ts src/proxy-capture/proxy-server.managed-proxy.test.ts` -> passed 2 Vitest shards, 11 tests.
- `env PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH ./node_modules/.bin/oxfmt --check src/proxy-capture/ca.ts src/proxy-capture/ca.test.ts` -> all matched files use the correct format.
- `git diff --check` -> passed.

## Real behavior proof

**Behavior addressed:** A stale partial `root-ca.pem` no longer gets reused, and a successful debug proxy CA generation leaves only a complete reusable `root-ca.pem` / `root-ca-key.pem` pair.

**Environment tested:** Linux workspace, Node 24.16.0, OpenSSL resolved through the production `ensureDebugProxyCa` path.

**Steps run after the patch:** Called the actual patched `ensureDebugProxyCa` source via `node --import tsx`, starting with a temp cert directory that contained only a stale partial `root-ca.pem`, then called it again to verify reuse.

**Evidence after fix:**

```text
{
  "before": [
    "root-ca.pem"
  ],
  "caPair": {
    "certBasename": "root-ca.pem",
    "keyBasename": "root-ca-key.pem",
    "elapsedMs": 205,
    "subject": "CN=OpenClaw Debug Proxy",
    "validTo": "Jul 24 10:54:52 2026 GMT",
    "keyType": "rsa"
  },
  "after": [
    "root-ca-key.pem",
    "root-ca.pem"
  ],
  "tempOrLockFilesAfterGeneration": [],
  "reusedSamePaths": true,
  "afterReuse": [
    "root-ca-key.pem",
    "root-ca.pem"
  ]
}
```

**Observed result:** The production function replaced the partial cert-only state with a valid RSA key/cert pair, left no temporary or lock files behind, and reused the same paths on the next call.

**Not tested:** A live macOS System Keychain trust operation from `scripts/proxy-install-ca.mjs`; the CA generation path it calls was exercised directly.

## Root Cause
- Root cause: OpenSSL wrote key and certificate outputs directly to the reusable paths, so a timeout or killed child could leave one canonical file behind.
- Missing guardrail: There was no generation lock, no temporary promotion boundary, and no regression coverage for partial output retry.

## Regression Test Plan
- Added `src/proxy-capture/ca.test.ts` for reuse, temp-file promotion, retry after failed generation, abandoned lock recovery, active lock waiting, non-recursive cleanup, and same-directory concurrent calls.
- The focused test is the smallest reliable guardrail because `ensureDebugProxyCa` is the shared production entry point used by the proxy CLI, proxy server, and CA installer.

## User-visible / Behavior Changes
Debug proxy startup and CA installation can recover from interrupted CA generation instead of reusing incomplete CA files or requiring manual cleanup of partial outputs.

## Security Impact
- New permissions? No.
- Secrets handling changed? No.
- New network calls? No.
- CA output cleanup now avoids recursively deleting directories at user-configurable output paths.
