### PR TITLE
feat(linux): Quick Chat floating composer for the Tauri companion

### DIFF
--- a/apps/linux/src-tauri/permissions/quickchat.toml
+++ b/apps/linux/src-tauri/permissions/quickchat.toml
@@ -1,0 +1,10 @@
+[[permission]]
+identifier = "allow-quickchat"
+description = "Enables Quick Chat identity, send, hide, and dashboard commands."
+commands.allow = [
+  "quickchat_hide",
+  "quickchat_identity",
+  "quickchat_ready",
+  "quickchat_send",
+  "quickchat_show_dashboard",
+]

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod gateway;
 mod installer;
 mod notify;
 mod pending_approvals;
+mod quickchat;
 mod tray;
 mod updater;
 
@@ -19,6 +20,7 @@ use std::thread;
 use std::time::Duration;
 use tauri::{AppHandle, Manager, State, Url, WebviewWindow};
 use tauri_plugin_deep_link::DeepLinkExt;
+use tauri_plugin_global_shortcut::{Code, Modifiers};
 
 const CONNECTED_WATCH_INTERVAL: Duration = Duration::from_secs(15);
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(3);
@@ -277,7 +279,7 @@ impl DesktopState {
         self.inner.quitting.load(Ordering::SeqCst)
     }
 
-    fn resolve_cli(&self) -> Result<OpenClawCli, CliError> {
+    pub(crate) fn resolve_cli(&self) -> Result<OpenClawCli, CliError> {
         if let Some(cli) = self.inner.cli.lock().expect("CLI mutex poisoned").clone() {
             return Ok(cli);
         }
@@ -676,9 +678,15 @@ fn main() {
     let builder = if global_shortcuts_supported {
         builder.plugin(
             tauri_plugin_global_shortcut::Builder::new()
-                .with_handler(|app, _shortcut, event| {
+                .with_handler(|app, shortcut, event| {
                     if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                        tray::show_window(app);
+                        if shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::Space) {
+                            quickchat::toggle_quickchat(app);
+                        } else if shortcut
+                            .matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::KeyO)
+                        {
+                            tray::show_window(app);
+                        }
                     }
                 })
                 .build(),
@@ -693,7 +701,7 @@ fn main() {
         .plugin(tauri_plugin_process::init())
         .plugin(
             tauri_plugin_window_state::Builder::default()
-                .with_denylist(&["canvas"])
+                .with_denylist(&["canvas", quickchat::QUICKCHAT_LABEL])
                 .build(),
         );
     #[cfg(target_os = "linux")]
@@ -718,6 +726,7 @@ fn main() {
         }
 
         app.manage(discovery::GatewayDiscovery::default());
+        app.manage(quickchat::QuickChatState::default());
         app.manage(updater::UpdaterState::default());
         #[cfg(target_os = "linux")]
         match canvas::CanvasBridge::start(app.handle().clone()) {
@@ -739,6 +748,11 @@ fn main() {
         discovery::discover_gateways,
         install_cli,
         gateway_action,
+        quickchat::quickchat_hide,
+        quickchat::quickchat_identity,
+        quickchat::quickchat_ready,
+        quickchat::quickchat_send,
+        quickchat::quickchat_show_dashboard,
         updater::open_release_page,
         updater::relaunch,
         updater::updater_ready
@@ -752,6 +766,11 @@ fn main() {
         discovery::discover_gateways,
         install_cli,
         gateway_action,
+        quickchat::quickchat_hide,
+        quickchat::quickchat_identity,
+        quickchat::quickchat_ready,
+        quickchat::quickchat_send,
+        quickchat::quickchat_show_dashboard,
         updater::open_release_page,
         updater::relaunch,
         updater::updater_ready
@@ -759,6 +778,20 @@ fn main() {
 
     let app = builder
         .on_window_event(|window, event| {
+            if window.label() == quickchat::QUICKCHAT_LABEL {
+                match event {
+                    tauri::WindowEvent::Focused(false) => {
+                        quickchat::request_hide(window.app_handle());
+                        return;
+                    }
+                    tauri::WindowEvent::CloseRequested { api, .. } => {
+                        api.prevent_close();
+                        quickchat::request_hide(window.app_handle());
+                        return;
+                    }
+                    _ => {}
+                }
+            }
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 let state = window.app_handle().state::<DesktopState>();
                 if !state.is_quitting() {

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -1,0 +1,425 @@
+use crate::{notify, tray, DesktopState};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+use tauri::{
+    AppHandle, Emitter, Manager, PhysicalPosition, State, WebviewUrl, WebviewWindow,
+    WebviewWindowBuilder,
+};
+
+pub const QUICKCHAT_LABEL: &str = "quickchat";
+// Alt+Space is GNOME's window-menu grab; a second X11 grab for it always fails.
+pub const QUICKCHAT_SHORTCUT: &str = "CmdOrCtrl+Shift+Space";
+const QUICKCHAT_WIDTH: f64 = 640.0;
+const QUICKCHAT_HEIGHT: f64 = 92.0;
+const IDENTITY_CACHE_TTL: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Serialize)]
+pub struct QuickChatIdentity {
+    name: String,
+    emoji: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentSummary {
+    id: String,
+    name: Option<String>,
+    identity_name: Option<String>,
+    identity_emoji: Option<String>,
+    is_default: bool,
+}
+
+struct CachedIdentity {
+    fetched_at: Instant,
+    identity: QuickChatIdentity,
+}
+
+#[derive(Clone)]
+pub struct QuickChatState {
+    identity_cache: Arc<Mutex<Option<CachedIdentity>>>,
+    hide_requested: Arc<AtomicBool>,
+}
+
+impl Default for QuickChatState {
+    fn default() -> Self {
+        Self {
+            identity_cache: Arc::new(Mutex::new(None)),
+            hide_requested: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+impl QuickChatState {
+    fn identity(&self, desktop: &DesktopState) -> Result<QuickChatIdentity, String> {
+        if let Some(identity) = self
+            .identity_cache
+            .lock()
+            .map_err(|_| "Quick Chat identity cache is unavailable.".to_string())?
+            .as_ref()
+            .filter(|cached| cached.fetched_at.elapsed() < IDENTITY_CACHE_TTL)
+            .map(|cached| cached.identity.clone())
+        {
+            return Ok(identity);
+        }
+
+        let cli = desktop.resolve_cli().map_err(|error| error.to_string())?;
+        let (agents, output) = cli
+            .json::<Vec<AgentSummary>, _, _>(["agents", "list", "--json"])
+            .map_err(|error| error.to_string())?;
+        if !output.status.success() {
+            return Err(first_stderr_line(&output.stderr)
+                .unwrap_or_else(|| "Could not load the default agent identity.".to_string()));
+        }
+        let identity = default_identity(agents)?;
+        *self
+            .identity_cache
+            .lock()
+            .map_err(|_| "Quick Chat identity cache is unavailable.".to_string())? =
+            Some(CachedIdentity {
+                fetched_at: Instant::now(),
+                identity: identity.clone(),
+            });
+        Ok(identity)
+    }
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn default_identity(agents: Vec<AgentSummary>) -> Result<QuickChatIdentity, String> {
+    let agent = agents
+        .into_iter()
+        .find(|agent| agent.is_default)
+        .ok_or_else(|| "OpenClaw did not report a default agent.".to_string())?;
+    let name = non_empty(agent.identity_name)
+        .or_else(|| non_empty(agent.name))
+        .or_else(|| non_empty(Some(agent.id)))
+        .unwrap_or_else(|| "Agent".to_string());
+    Ok(QuickChatIdentity {
+        name,
+        emoji: non_empty(agent.identity_emoji),
+    })
+}
+
+fn first_stderr_line(stderr: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(stderr)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// Stages the message in an owner-only file: argv is world-readable via procfs, and the
+/// agent turn can keep running for minutes, so the text must never appear in `--message`.
+fn write_message_file(message: &str) -> Result<PathBuf, String> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| format!("Could not stage the message: {error}"))?
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "openclaw-quickchat-{}-{nanos}.txt",
+        std::process::id()
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .map_err(|error| format!("Could not stage the message: {error}"))?;
+    if let Err(error) = file.write_all(message.as_bytes()) {
+        // A partial write must not strand prompt text in the temp directory.
+        let _ = std::fs::remove_file(&path);
+        return Err(format!("Could not stage the message: {error}"));
+    }
+    Ok(path)
+}
+
+fn spawn_agent_turn(app: AppHandle, desktop: DesktopState, message: String) -> Result<(), String> {
+    let cli = desktop.resolve_cli().map_err(|error| error.to_string())?;
+    let message_file = write_message_file(&message)?;
+    let message_file_arg = message_file.to_string_lossy().into_owned();
+    let mut command = cli
+        .command([
+            "agent",
+            "--message-file",
+            message_file_arg.as_str(),
+            "--session-key",
+            "main",
+            "--json",
+        ])
+        .map_err(|error| {
+            let _ = std::fs::remove_file(&message_file);
+            error.to_string()
+        })?;
+    command.stdout(Stdio::null()).stderr(Stdio::piped());
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = std::fs::remove_file(&message_file);
+            return Err(format!("Failed to run OpenClaw CLI: {error}"));
+        }
+    };
+    thread::spawn(move || {
+        let outcome = child.wait_with_output();
+        let _ = std::fs::remove_file(&message_file);
+        match outcome {
+            Ok(output) if !output.status.success() => {
+                let body = first_stderr_line(&output.stderr)
+                    .unwrap_or_else(|| format!("OpenClaw agent exited with {}.", output.status));
+                notify::notify(&app, "Quick Chat message failed", &body);
+            }
+            Err(error) => notify::notify(
+                &app,
+                "Quick Chat message failed",
+                &format!("Could not monitor OpenClaw agent: {error}"),
+            ),
+            _ => {}
+        }
+    });
+    Ok(())
+}
+
+pub fn quickchat_position(
+    monitor_pos: (f64, f64),
+    monitor_size: (f64, f64),
+    window_size: (f64, f64),
+) -> (f64, f64) {
+    let max_x = monitor_pos.0 + (monitor_size.0 - window_size.0).max(0.0);
+    let max_y = monitor_pos.1 + (monitor_size.1 - window_size.1).max(0.0);
+    let x = monitor_pos.0 + (monitor_size.0 - window_size.0).max(0.0) / 2.0;
+    let y = monitor_pos.1 + monitor_size.1 * 0.22;
+    (x.clamp(monitor_pos.0, max_x), y.clamp(monitor_pos.1, max_y))
+}
+
+fn ensure_quickchat_window(app: &AppHandle) -> Result<WebviewWindow, String> {
+    if let Some(window) = app.get_webview_window(QUICKCHAT_LABEL) {
+        return Ok(window);
+    }
+    WebviewWindowBuilder::new(
+        app,
+        QUICKCHAT_LABEL,
+        WebviewUrl::App("quickchat.html".into()),
+    )
+    .title("Quick Chat")
+    .inner_size(QUICKCHAT_WIDTH, QUICKCHAT_HEIGHT)
+    .decorations(false)
+    .transparent(true)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .resizable(false)
+    .visible(false)
+    .build()
+    .map_err(|error| format!("Could not create Quick Chat window: {error}"))
+}
+
+fn position_quickchat(app: &AppHandle, window: &WebviewWindow) -> Result<(), String> {
+    let monitor = app
+        .cursor_position()
+        .ok()
+        .and_then(|cursor| app.monitor_from_point(cursor.x, cursor.y).ok().flatten())
+        .or_else(|| app.primary_monitor().ok().flatten())
+        .or_else(|| window.current_monitor().ok().flatten())
+        .ok_or_else(|| "Could not determine a monitor for Quick Chat.".to_string())?;
+    let work_area = monitor.work_area();
+    let window_size = window
+        .inner_size()
+        .map_err(|error| format!("Could not read Quick Chat size: {error}"))?;
+    let (x, y) = quickchat_position(
+        (work_area.position.x as f64, work_area.position.y as f64),
+        (work_area.size.width as f64, work_area.size.height as f64),
+        (window_size.width as f64, window_size.height as f64),
+    );
+    window
+        .set_position(PhysicalPosition::new(x.round() as i32, y.round() as i32))
+        .map_err(|error| format!("Could not position Quick Chat: {error}"))
+}
+
+pub fn request_hide(app: &AppHandle) {
+    app.state::<QuickChatState>()
+        .hide_requested
+        .store(true, Ordering::SeqCst);
+    let _ = app.emit_to(QUICKCHAT_LABEL, "quickchat:hide-requested", ());
+}
+
+pub fn toggle_quickchat(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window(QUICKCHAT_LABEL) {
+        if window.is_visible().unwrap_or(false) {
+            request_hide(app);
+            return;
+        }
+    }
+    if let Err(error) = show_quickchat(app) {
+        eprintln!("Quick Chat unavailable: {error}");
+    }
+}
+
+fn show_quickchat(app: &AppHandle) -> Result<(), String> {
+    let window = ensure_quickchat_window(app)?;
+    position_quickchat(app, &window)?;
+    app.state::<QuickChatState>()
+        .hide_requested
+        .store(false, Ordering::SeqCst);
+    window
+        .show()
+        .map_err(|error| format!("Could not show Quick Chat: {error}"))?;
+    if let Err(error) = window.set_focus() {
+        app.state::<QuickChatState>()
+            .hide_requested
+            .store(true, Ordering::SeqCst);
+        return match window.hide() {
+            Ok(()) => Err(format!("Could not focus Quick Chat: {error}")),
+            Err(hide_error) => match window.destroy() {
+                Ok(()) => Err(format!(
+                    "Could not focus Quick Chat: {error}; could not hide it again: {hide_error}"
+                )),
+                Err(destroy_error) => {
+                    let _ = window.emit("quickchat:shown", ());
+                    Err(format!(
+                        "Could not focus Quick Chat: {error}; could not hide it again: \
+                         {hide_error}; could not destroy it: {destroy_error}"
+                    ))
+                }
+            },
+        };
+    }
+    window
+        .emit("quickchat:shown", ())
+        .map_err(|error| format!("Could not activate Quick Chat: {error}"))
+}
+
+fn require_quickchat_window(window: &WebviewWindow) -> Result<(), String> {
+    if window.label() == QUICKCHAT_LABEL {
+        Ok(())
+    } else {
+        Err("Quick Chat command is available only to the Quick Chat window.".to_string())
+    }
+}
+
+#[tauri::command]
+pub async fn quickchat_identity(
+    window: WebviewWindow,
+    desktop: State<'_, DesktopState>,
+    state: State<'_, QuickChatState>,
+) -> Result<QuickChatIdentity, String> {
+    require_quickchat_window(&window)?;
+    let desktop = desktop.inner().clone();
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || state.identity(&desktop))
+        .await
+        .map_err(|error| format!("Quick Chat identity task failed: {error}"))?
+}
+
+#[tauri::command]
+pub async fn quickchat_send(
+    window: WebviewWindow,
+    app: AppHandle,
+    desktop: State<'_, DesktopState>,
+    message: String,
+) -> Result<(), String> {
+    require_quickchat_window(&window)?;
+    let message = message.trim().to_string();
+    if message.is_empty() {
+        return Err("Message cannot be empty.".to_string());
+    }
+    let desktop = desktop.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || spawn_agent_turn(app, desktop, message))
+        .await
+        .map_err(|error| format!("Quick Chat send task failed: {error}"))?
+}
+
+#[tauri::command]
+pub fn quickchat_hide(window: WebviewWindow) -> Result<(), String> {
+    require_quickchat_window(&window)?;
+    window
+        .app_handle()
+        .state::<QuickChatState>()
+        .hide_requested
+        .store(true, Ordering::SeqCst);
+    window
+        .hide()
+        .map_err(|error| format!("Could not hide Quick Chat: {error}"))
+}
+
+#[tauri::command]
+pub fn quickchat_ready(
+    window: WebviewWindow,
+    state: State<'_, QuickChatState>,
+) -> Result<bool, String> {
+    require_quickchat_window(&window)?;
+    Ok(!state.hide_requested.load(Ordering::SeqCst))
+}
+
+#[tauri::command]
+pub fn quickchat_show_dashboard(
+    window: WebviewWindow,
+    app: AppHandle,
+    desktop: State<'_, DesktopState>,
+) -> Result<(), String> {
+    require_quickchat_window(&window)?;
+    tray::open_dashboard(&app, desktop.inner());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_position(actual: (f64, f64), expected: (f64, f64)) {
+        assert!((actual.0 - expected.0).abs() < 1e-9);
+        assert!((actual.1 - expected.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn position_centers_window_at_twenty_two_percent_of_work_area() {
+        assert_position(
+            quickchat_position((0.0, 0.0), (1920.0, 1080.0), (640.0, 92.0)),
+            (640.0, 237.6),
+        );
+        assert_position(
+            quickchat_position((-1280.0, 40.0), (1280.0, 984.0), (640.0, 92.0)),
+            (-960.0, 256.48),
+        );
+    }
+
+    #[test]
+    fn position_stays_inside_small_work_area() {
+        assert_eq!(
+            quickchat_position((10.0, 20.0), (500.0, 80.0), (640.0, 92.0)),
+            (10.0, 20.0)
+        );
+    }
+
+    #[test]
+    fn identity_prefers_identity_fields_for_default_agent() {
+        let identity = default_identity(vec![
+            AgentSummary {
+                id: "other".to_string(),
+                name: Some("Other".to_string()),
+                identity_name: None,
+                identity_emoji: None,
+                is_default: false,
+            },
+            AgentSummary {
+                id: "main".to_string(),
+                name: Some("Configured".to_string()),
+                identity_name: Some("Molty".to_string()),
+                identity_emoji: Some("🦞".to_string()),
+                is_default: true,
+            },
+        ])
+        .expect("default identity");
+
+        assert_eq!(identity.name, "Molty");
+        assert_eq!(identity.emoji.as_deref(), Some("🦞"));
+    }
+}

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -1,4 +1,5 @@
 use crate::gateway::{GatewayAction, GatewaySnapshot};
+use crate::quickchat;
 use crate::DesktopState;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -10,6 +11,7 @@ use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
 const OPEN_ID: &str = "open-dashboard";
+const QUICKCHAT_ID: &str = "quickchat";
 const CHECK_UPDATES_ID: &str = "check-for-updates";
 const START_AT_LOGIN_ID: &str = "start-at-login";
 const GLOBAL_SHORTCUT_ID: &str = "global-shortcut";
@@ -25,6 +27,7 @@ pub struct TrayHandles {
     _tray: TrayIcon<tauri::Wry>,
     status: MenuItem<tauri::Wry>,
     status_line: Mutex<StatusLine>,
+    _quickchat: MenuItem<tauri::Wry>,
     open: MenuItem<tauri::Wry>,
     _check_updates: MenuItem<tauri::Wry>,
     _start_at_login: CheckMenuItem<tauri::Wry>,
@@ -128,6 +131,7 @@ pub fn build(
         false,
         None::<&str>,
     )?;
+    let quickchat = MenuItem::with_id(app, QUICKCHAT_ID, "Quick Chat", true, None::<&str>)?;
     let open = MenuItem::with_id(app, OPEN_ID, "Open Dashboard", true, None::<&str>)?;
     let check_updates = MenuItem::with_id(
         app,
@@ -182,6 +186,7 @@ pub fn build(
     let menu_builder = MenuBuilder::new(app).items(&[
         &status,
         &separator_one,
+        &quickchat,
         &open,
         &check_updates,
         &start_at_login,
@@ -236,6 +241,17 @@ pub fn build(
     #[cfg(target_os = "macos")]
     let tray_builder = tray_builder.icon_as_template(true);
     let tray = tray_builder.build(app)?;
+    if global_shortcuts_supported {
+        if let Err(error) = app
+            .global_shortcut()
+            .register(quickchat::QUICKCHAT_SHORTCUT)
+        {
+            eprintln!(
+                "Could not register Quick Chat shortcut {}: {error}",
+                quickchat::QUICKCHAT_SHORTCUT
+            );
+        }
+    }
     if let (Some(initial_state), Some(global_shortcut)) =
         (shortcut_initial_state, global_shortcut.as_ref())
     {
@@ -254,6 +270,7 @@ pub fn build(
             gateway: "Checking…".to_string(),
             pending_count: 0,
         }),
+        _quickchat: quickchat,
         open,
         _check_updates: check_updates,
         _start_at_login: start_at_login,
@@ -289,6 +306,7 @@ fn handle_menu(
             state.quit();
             app.exit(0);
         }
+        QUICKCHAT_ID => quickchat::toggle_quickchat(app),
         OPEN_ID => open_dashboard(app, state),
         CHECK_UPDATES_ID => {
             show_window(app);

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -65,6 +65,17 @@
           "local": true,
           "windows": ["canvas"],
           "permissions": ["allow-canvas-a2ui-action"]
+        },
+        {
+          "identifier": "quickchat",
+          "description": "Quick Chat can load the default agent, send a message, and receive window events.",
+          "local": true,
+          "windows": ["quickchat"],
+          "permissions": [
+            "allow-quickchat",
+            "core:event:allow-listen",
+            "core:event:allow-unlisten"
+          ]
         }
       ]
     }

--- a/apps/linux/ui/quickchat.css
+++ b/apps/linux/ui/quickchat.css
@@ -1,0 +1,174 @@
+:root {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #f7f7f8;
+  background: transparent;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: transparent;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px;
+}
+
+.composer {
+  width: 100%;
+  padding: 9px 11px;
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 9%);
+  border-radius: 16px;
+  opacity: 0;
+  background: rgb(28 28 30 / 94%);
+  box-shadow: 0 10px 36px rgb(0 0 0 / 34%);
+  transform: scale(0.97);
+  transition:
+    opacity 100ms ease-in,
+    transform 100ms ease-in;
+}
+
+body.shown .composer {
+  opacity: 1;
+  transform: scale(1);
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+
+.composer-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  min-height: 34px;
+}
+
+.agent-chip {
+  display: grid;
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 50%;
+  color: white;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  background: hsl(var(--agent-hue, 4) 58% 42%);
+}
+
+#message {
+  flex: 1;
+  min-width: 0;
+  height: 34px;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  color: #f7f7f8;
+  font: 400 14px/1.4 inherit;
+  caret-color: #ff6b6b;
+  background: transparent;
+}
+
+#message::placeholder {
+  color: #8e8e93;
+  opacity: 1;
+}
+
+.send {
+  display: grid;
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  color: #1c1c1e;
+  cursor: pointer;
+  background: #ff6b6b;
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+
+.send:hover:not(:disabled) {
+  transform: scale(1.05);
+}
+
+.send:disabled {
+  cursor: default;
+  opacity: 0.34;
+}
+
+.send.sending,
+.send.accepted {
+  opacity: 1;
+}
+
+.send-icon {
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.send.sending .send-icon {
+  width: 13px;
+  height: 13px;
+  border: 2px solid rgb(28 28 30 / 35%);
+  border-top-color: #1c1c1e;
+  border-radius: 50%;
+  animation: spin 700ms linear infinite;
+}
+
+.send.accepted .send-icon {
+  font-size: 16px;
+}
+
+.status {
+  max-height: 0;
+  margin: 0 0 0 38px;
+  overflow: hidden;
+  color: #ff7b7b;
+  font-size: 11px;
+  line-height: 16px;
+  opacity: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition:
+    max-height 120ms ease,
+    opacity 120ms ease;
+}
+
+.composer.has-error .status {
+  max-height: 16px;
+  opacity: 1;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/apps/linux/ui/quickchat.html
+++ b/apps/linux/ui/quickchat.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <title>Quick Chat</title>
+    <link rel="stylesheet" href="quickchat.css" />
+  </head>
+  <body>
+    <main id="composer" class="composer">
+      <div class="composer-row">
+        <span id="agent-chip" class="agent-chip" aria-hidden="true">A</span>
+        <input
+          id="message"
+          type="text"
+          placeholder="Message Agent"
+          aria-label="Quick Chat message"
+          autocomplete="off"
+        />
+        <button id="send" class="send" type="button" aria-label="Send message" disabled>
+          <span id="send-icon" class="send-icon" aria-hidden="true">↑</span>
+        </button>
+      </div>
+      <p id="status" class="status" role="alert"></p>
+    </main>
+    <script type="module" src="quickchat.js"></script>
+  </body>
+</html>

--- a/apps/linux/ui/quickchat.js
+++ b/apps/linux/ui/quickchat.js
@@ -1,0 +1,188 @@
+const tauri = window["__TAURI__"];
+const { invoke } = tauri.core;
+const { listen } = tauri.event;
+
+const elements = {
+  chip: document.querySelector("#agent-chip"),
+  composer: document.querySelector("#composer"),
+  input: document.querySelector("#message"),
+  send: document.querySelector("#send"),
+  sendIcon: document.querySelector("#send-icon"),
+  status: document.querySelector("#status"),
+};
+
+let sending = false;
+let accepted = false;
+let hiding = false;
+let hideTimer = null;
+let acceptedTimer = null;
+let visibilitySequence = 0;
+let sendError = "";
+
+function friendlyError(error) {
+  if (typeof error === "string") {
+    return error;
+  }
+  return error?.message || "Could not send the message.";
+}
+
+function setError(message = "") {
+  elements.status.textContent = message;
+  elements.composer.classList.toggle("has-error", Boolean(message));
+}
+
+function updateSendButton() {
+  const empty = !elements.input.value.trim();
+  elements.send.disabled = empty || sending || accepted;
+  elements.send.classList.toggle("sending", sending);
+  elements.send.classList.toggle("accepted", accepted);
+  elements.sendIcon.textContent = sending ? "" : accepted ? "✓" : "↑";
+  elements.input.readOnly = sending || accepted;
+}
+
+function nameHue(name) {
+  let hash = 0;
+  for (const character of name) {
+    hash = (hash * 31 + character.codePointAt(0)) >>> 0;
+  }
+  return hash % 360;
+}
+
+function renderIdentity(identity) {
+  const name = identity?.name?.trim() || "Agent";
+  const initial = [...name][0]?.toUpperCase() || "A";
+  elements.chip.textContent = identity?.emoji?.trim() || initial;
+  elements.chip.style.setProperty("--agent-hue", nameHue(name));
+  elements.input.placeholder = `Message ${name}`;
+}
+
+async function refreshIdentity() {
+  try {
+    renderIdentity(await invoke("quickchat_identity"));
+  } catch {
+    renderIdentity({ name: "Agent" });
+  }
+}
+
+async function requestHide(force = false) {
+  if ((accepted && !force) || hiding) {
+    return;
+  }
+  visibilitySequence += 1;
+  const hideSequence = visibilitySequence;
+  hiding = true;
+  document.body.classList.remove("shown");
+  window.clearTimeout(hideTimer);
+  hideTimer = window.setTimeout(async () => {
+    try {
+      await invoke("quickchat_hide");
+    } catch (error) {
+      if (visibilitySequence === hideSequence) {
+        sendError = friendlyError(error);
+        setError(sendError);
+        document.body.classList.add("shown");
+        elements.input.focus();
+      }
+    } finally {
+      if (visibilitySequence === hideSequence) {
+        hiding = false;
+      }
+    }
+  }, 100);
+}
+
+function reveal() {
+  window.clearTimeout(hideTimer);
+  if (accepted) {
+    window.clearTimeout(acceptedTimer);
+    acceptedTimer = null;
+    accepted = false;
+  }
+  hiding = false;
+  setError(sendError);
+  updateSendButton();
+  document.body.classList.remove("shown");
+  window.requestAnimationFrame(() => {
+    document.body.classList.add("shown");
+    elements.input.focus();
+  });
+  void refreshIdentity();
+}
+
+async function send(openDashboard) {
+  const message = elements.input.value.trim();
+  if (!message || sending || accepted) {
+    return;
+  }
+  sending = true;
+  sendError = "";
+  setError();
+  updateSendButton();
+  try {
+    await invoke("quickchat_send", { message });
+    sending = false;
+    accepted = true;
+    sendError = "";
+    elements.input.value = "";
+    updateSendButton();
+    if (openDashboard) {
+      void invoke("quickchat_show_dashboard");
+    }
+    acceptedTimer = window.setTimeout(() => {
+      accepted = false;
+      updateSendButton();
+      void requestHide(true);
+    }, 450);
+  } catch (error) {
+    sending = false;
+    sendError = friendlyError(error);
+    setError(sendError);
+    updateSendButton();
+    elements.input.focus();
+  }
+}
+
+elements.input.addEventListener("input", () => {
+  sendError = "";
+  setError();
+  updateSendButton();
+});
+elements.input.addEventListener("keydown", (event) => {
+  if (event.isComposing || event.keyCode === 229) {
+    return;
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    void requestHide();
+    return;
+  }
+  if (event.key === "Enter") {
+    event.preventDefault();
+    void send(event.ctrlKey);
+  }
+});
+elements.send.addEventListener("click", () => {
+  void send(false);
+});
+
+await listen("quickchat:shown", () => {
+  visibilitySequence += 1;
+  reveal();
+});
+await listen("quickchat:hide-requested", () => {
+  void requestHide();
+});
+
+const readySequence = visibilitySequence;
+try {
+  const shouldShow = await invoke("quickchat_ready");
+  if (visibilitySequence === readySequence) {
+    if (shouldShow) {
+      reveal();
+    } else {
+      void requestHide(true);
+    }
+  }
+} catch {
+  void requestHide(true);
+}

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -151,6 +151,7 @@ const rootEntries = [
   "apps/android/app/src/main/assets/katex/katex.min.js!",
   "apps/android/app/src/main/assets/katex/renderer.js!",
   "apps/linux/ui/main.js!",
+  "apps/linux/ui/quickchat.js!",
   "apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/CanvasA2UI/a2ui.bundle.js!",
   "scripts/qa/render-maturity-docs.ts!",
   bundledPluginFile("telegram", "src/audit.ts", "!"),

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5195,6 +5195,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /platforms/linux
 - Headings:
   - H2: Desktop companion
+  - H3: Quick Chat
   - H3: Canvas
   - H2: CLI and SSH alternative
   - H2: Node capabilities

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -49,6 +49,13 @@ The `Linux App` CI workflow uploads the same bundles as the
 manual runs. See `apps/linux/README.md` in the repository for Linux build
 dependencies and development commands.
 
+### Quick Chat
+
+Open Quick Chat with `Ctrl+Shift+Space` or the **Quick Chat** tray item. The
+shortcut is available on X11; on Wayland, use the tray item for now. Quick Chat
+sends the message through the OpenClaw CLI to the default agent's main session,
+then hides. Replies remain in the normal session; open the dashboard to read them.
+
 ### Canvas
 
 Linux Canvas uses two cooperating processes. `openclaw node run` remains the single Gateway node connection; the bundled `linux-canvas` plugin forwards `canvas.*` calls to the running desktop app over a user-only Unix socket. The app owns one on-demand WebView window, including the bundled A2UI renderer and action bridge back to the agent.


### PR DESCRIPTION
## What Problem This Solves

The Linux/Tauri companion has no quick way to message the agent — every interaction goes through the full dashboard. This is the cross-platform sibling of the macOS Quick Chat bar (#109720): a summonable floating composer that fires a message at the default agent's main session and gets out of the way.

## Why This Change Was Made

First deliberately minimal step, matching the shell's existing architecture (CLI delegation, static frontend, on-demand windows):

- **Window:** frameless, transparent, always-on-top `quickchat` webview created on demand (same pattern as the Canvas window), centered on the cursor's monitor with its top edge at ~22% of the work area, excluded from window-state restoration. CSS-driven fade+zoom in/out (140ms/100ms) with a JS↔Rust hide handshake; hides on Escape, focus loss, close-request, successful send, or toggle.
- **Entry points:** `Ctrl+Shift+Space` global shortcut on X11 (Alt+Space is GNOME's window-menu grab and can never be registered; the existing X11-only gate applies — the plugin's Linux backend doesn't support Wayland) and a **Quick Chat** tray item that works everywhere including Wayland. The existing `CmdOrCtrl+Shift+O` dashboard shortcut is untouched; the handler now dispatches by shortcut identity.
- **Send path:** a window-scoped `quickchat_send` command runs `openclaw agent --message-file <owner-only tmp> --session-key main --json` detached — the message is staged in a 0600 file and deleted after the turn because argv is world-readable through procfs and an agent turn can run for minutes. The bar shows the accepted state immediately; a failed turn surfaces as a desktop notification with the first stderr line. `Ctrl+Enter` additionally opens the dashboard.
- **Identity chip:** `quickchat_identity` resolves the default agent from `openclaw agents list --json` (60s cache) and renders emoji or a hue-hashed monogram with a "Message <Agent>" placeholder.
- **Security posture:** all five commands verify the calling window label; the new capability is scoped to the `quickchat` window with its own permission set; no permission strip on Linux (no TCC equivalent), and no accessibility/window-capture features in this first step by design.

## User Impact

Linux companion users get a keyboard-first composer for the main session. Replies stay in the normal session (dashboard). No changes to existing windows, shortcuts, or gateway behavior.

Release-note context: `feat(linux): Quick Chat floating composer — Ctrl+Shift+Space (X11) or tray item, sends to the main session via the CLI`.

## Evidence

- Structured autoreview (Codex `gpt-5.6-sol`, xhigh): three passes; accepted findings fixed (procfs argv exposure → `--message-file` with 0600 staging and cleanup incl. partial-write failure; GNOME-reserved Alt+Space default replaced; staged-file cleanup on every error path); final pass clean — "no accepted/actionable findings".
- CLI contracts verified against source: `agents list --json` emits `identityName`/`identityEmoji`/`isDefault` (src/commands/agents.commands.list.ts); `agent --message-file/--session-key` flags and bare-key default-agent resolution (src/cli/program/register.agent-turn.ts, src/agents/command/session.ts). `Shortcut::matches` verified in the vendored plugin's upstream source.
- Rust unit tests cover the placement math and default-identity selection.
- No Rust toolchain on the author host: the `linux-app` CI lane (`cargo fmt --check` + full Tauri bundle build on ubuntu) is the compile/build gate for this PR. Runtime verification on a real Linux desktop is a follow-up; the feature is additive and cannot affect existing shell behavior when unused.
