### PR TITLE
fix(voice-call): ngrok tunnels no longer survive cleanup

### DIFF
--- a/extensions/voice-call/src/tunnel.process.test.ts
+++ b/extensions/voice-call/src/tunnel.process.test.ts
@@ -1,0 +1,96 @@
+// Voice Call process tests exercise real tunnel child shutdown behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { startTunnel } from "./tunnel.js";
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPid(pidPath: string): Promise<number> {
+  let pid = Number.NaN;
+  await expect
+    .poll(
+      async () => {
+        try {
+          pid = Number.parseInt(await fs.readFile(pidPath, "utf8"), 10);
+          return Number.isInteger(pid) && pid > 0;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 2_000, interval: 20 },
+    )
+    .toBe(true);
+  return pid;
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  try {
+    await expect.poll(() => isProcessAlive(pid), { timeout: timeoutMs, interval: 20 }).toBe(false);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(process.platform === "win32")("voice-call tunnel child shutdown", () => {
+  it("force-kills ngrok when it ignores graceful shutdown", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ngrok-stop-"));
+    const pidPath = path.join(tempDir, "ngrok.pid");
+    const ngrokPath = path.join(tempDir, "ngrok");
+    const previousPath = process.env.PATH;
+    const previousPidPath = process.env.OPENCLAW_NGROK_PID_FILE;
+    let childPid: number | undefined;
+
+    await fs.writeFile(
+      ngrokPath,
+      [
+        "#!/usr/bin/env node",
+        'const fs = require("node:fs");',
+        'process.on("SIGTERM", () => {});',
+        "fs.writeFileSync(process.env.OPENCLAW_NGROK_PID_FILE, String(process.pid));",
+        'process.stdout.write(JSON.stringify({ msg: "started tunnel", url: "https://bounded.ngrok.test" }) + "\\n");',
+        "setInterval(() => {}, 1000);",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${tempDir}${path.delimiter}${previousPath ?? ""}`;
+    process.env.OPENCLAW_NGROK_PID_FILE = pidPath;
+
+    try {
+      const tunnel = await startTunnel({
+        provider: "ngrok",
+        port: 3334,
+        path: "/voice/webhook",
+      });
+      if (!tunnel) {
+        throw new Error("Expected ngrok tunnel to start");
+      }
+      childPid = await readPid(pidPath);
+
+      await tunnel.stop();
+
+      expect(await waitForProcessExit(childPid, 1_000)).toBe(true);
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousPidPath === undefined) {
+        delete process.env.OPENCLAW_NGROK_PID_FILE;
+      } else {
+        process.env.OPENCLAW_NGROK_PID_FILE = previousPidPath;
+      }
+      if (childPid && isProcessAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+        await waitForProcessExit(childPid, 1_000);
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/voice-call/src/tunnel.process.test.ts
+++ b/extensions/voice-call/src/tunnel.process.test.ts
@@ -93,4 +93,72 @@ describe.skipIf(process.platform === "win32")("voice-call tunnel child shutdown"
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("force-kills ngrok before rejecting a startup timeout", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ngrok-timeout-"));
+    const pidPath = path.join(tempDir, "ngrok.pid");
+    const signalPath = path.join(tempDir, "ngrok.signal");
+    const ngrokPath = path.join(tempDir, "ngrok");
+    const previousPath = process.env.PATH;
+    const previousPidPath = process.env.OPENCLAW_NGROK_PID_FILE;
+    const previousSignalPath = process.env.OPENCLAW_NGROK_SIGNAL_FILE;
+    let childPid: number | undefined;
+
+    await fs.writeFile(
+      ngrokPath,
+      [
+        "#!/usr/bin/env node",
+        'const fs = require("node:fs");',
+        'process.on("SIGTERM", () => fs.writeFileSync(process.env.OPENCLAW_NGROK_SIGNAL_FILE, "SIGTERM"));',
+        "fs.writeFileSync(process.env.OPENCLAW_NGROK_PID_FILE, String(process.pid));",
+        "setInterval(() => {}, 1000);",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${tempDir}${path.delimiter}${previousPath ?? ""}`;
+    process.env.OPENCLAW_NGROK_PID_FILE = pidPath;
+    process.env.OPENCLAW_NGROK_SIGNAL_FILE = signalPath;
+
+    try {
+      const result = startTunnel({
+        provider: "ngrok",
+        port: 3334,
+        path: "/voice/webhook",
+      });
+      childPid = await readPid(pidPath);
+
+      await expect(result).rejects.toThrow("ngrok startup timed out (30s)");
+
+      await expect
+        .poll(
+          async () => {
+            try {
+              return await fs.readFile(signalPath, "utf8");
+            } catch {
+              return "";
+            }
+          },
+          { timeout: 1_000, interval: 20 },
+        )
+        .toBe("SIGTERM");
+      expect(await waitForProcessExit(childPid, 1_000)).toBe(true);
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousPidPath === undefined) {
+        delete process.env.OPENCLAW_NGROK_PID_FILE;
+      } else {
+        process.env.OPENCLAW_NGROK_PID_FILE = previousPidPath;
+      }
+      if (previousSignalPath === undefined) {
+        delete process.env.OPENCLAW_NGROK_SIGNAL_FILE;
+      } else {
+        process.env.OPENCLAW_NGROK_SIGNAL_FILE = previousSignalPath;
+      }
+      if (childPid && isProcessAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+        await waitForProcessExit(childPid, 1_000);
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  }, 40_000);
 });

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -12,10 +12,13 @@ class FakeChildProcess extends EventEmitter {
   readonly stdout = new PassThrough();
   readonly stderr = new PassThrough();
   killedWith: NodeJS.Signals | null = null;
+  closeOnKill = true;
 
   kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
     this.killedWith = signal;
-    queueMicrotask(() => this.emit("close", null));
+    if (this.closeOnKill) {
+      queueMicrotask(() => this.emit("close", null));
+    }
     return true;
   }
 
@@ -168,6 +171,25 @@ describe("voice-call tunnels", () => {
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
+  });
+
+  it("bounds ngrok stop even when forced termination never emits close", async () => {
+    vi.useFakeTimers();
+    try {
+      const proc = nextProcess();
+      proc.closeOnKill = false;
+      const result = startNgrokTunnel({ port: 3334, path: "/voice/webhook" });
+      emitNgrokUrl(proc, "https://stuck.ngrok.io");
+      const tunnel = await result;
+
+      const stop = tunnel.stop();
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      await expect(stop).resolves.toBeUndefined();
+      expect(proc.killedWith).toBe("SIGKILL");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("parses complete ngrok log lines before bounding the incomplete tail", async () => {

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -12,11 +12,14 @@ class FakeChildProcess extends EventEmitter {
   readonly stdout = new PassThrough();
   readonly stderr = new PassThrough();
   killedWith: NodeJS.Signals | null = null;
+  readonly killSignals: NodeJS.Signals[] = [];
+  readonly ignoredSignals = new Set<NodeJS.Signals>();
   closeOnKill = true;
 
   kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
     this.killedWith = signal;
-    if (this.closeOnKill) {
+    this.killSignals.push(signal);
+    if (this.closeOnKill && !this.ignoredSignals.has(signal)) {
       queueMicrotask(() => this.emit("close", null));
     }
     return true;
@@ -187,6 +190,25 @@ describe("voice-call tunnels", () => {
 
       await expect(stop).resolves.toBeUndefined();
       expect(proc.killedWith).toBe("SIGKILL");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("force-kills ngrok before rejecting a startup timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const proc = nextProcess();
+      proc.ignoredSignals.add("SIGTERM");
+      const result = startNgrokTunnel({ port: 3334, path: "/voice/webhook" });
+      const rejection = expect(result).rejects.toThrow("ngrok startup timed out (30s)");
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(proc.killSignals).toEqual(["SIGTERM"]);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await rejection;
+      expect(proc.killSignals).toEqual(["SIGTERM", "SIGKILL"]);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -164,6 +164,9 @@ async function startNgrokTunnel(config: {
                   res();
                 };
                 proc.once("close", finish);
+                // Give ngrok a graceful window before forcing termination. The final bounded
+                // close wait avoids returning before SIGKILL normally reaps the child without
+                // letting an unobservable close event hang runtime cleanup forever.
                 const forceKillTimer = setTimeout(() => {
                   if (!closed) {
                     proc.kill("SIGKILL");

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -16,6 +16,47 @@ const TUNNEL_COMMAND_OUTPUT_MAX_BYTES = 16_384;
 const NGROK_STOP_GRACE_MS = 2_000;
 const NGROK_FORCE_KILL_WAIT_MS = 1_000;
 
+async function terminateNgrokProcess(
+  proc: Pick<ChildProcessWithoutNullStreams, "kill" | "once" | "off">,
+  isClosed: () => boolean,
+): Promise<void> {
+  if (isClosed()) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    let finished = false;
+    let forceKillWaitTimer: ReturnType<typeof setTimeout> | undefined;
+    const finish = () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+      }
+      if (forceKillWaitTimer) {
+        clearTimeout(forceKillWaitTimer);
+      }
+      proc.off("close", finish);
+      resolve();
+    };
+    proc.once("close", finish);
+    // Give ngrok a graceful window before forcing termination. The final bounded
+    // close wait avoids returning before SIGKILL normally reaps the child without
+    // letting an unobservable close event hang cleanup forever.
+    const forceKillTimer = setTimeout(() => {
+      forceKillWaitTimer = setTimeout(finish, NGROK_FORCE_KILL_WAIT_MS);
+      if (!isClosed()) {
+        proc.kill("SIGKILL");
+      }
+    }, NGROK_STOP_GRACE_MS);
+    proc.kill("SIGTERM");
+    if (isClosed()) {
+      finish();
+    }
+  });
+}
+
 function listenForChildStreamErrors(
   proc: Pick<ChildProcessWithoutNullStreams, "stdout" | "stderr">,
   onError: (stream: "stdout" | "stderr", error: Error) => void,
@@ -99,8 +140,9 @@ async function startNgrokTunnel(config: {
     const timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true;
-        proc.kill("SIGTERM");
-        reject(new Error("ngrok startup timed out (30s)"));
+        void terminateNgrokProcess(proc, () => closed).then(() => {
+          reject(new Error("ngrok startup timed out (30s)"));
+        });
       }
     }, 30000);
 
@@ -143,41 +185,7 @@ async function startNgrokTunnel(config: {
             publicUrl: fullUrl,
             provider: "ngrok",
             stop: async () => {
-              if (closed) {
-                return;
-              }
-              await new Promise<void>((res) => {
-                let finished = false;
-                let forceKillWaitTimer: ReturnType<typeof setTimeout> | undefined;
-                const finish = () => {
-                  if (finished) {
-                    return;
-                  }
-                  finished = true;
-                  if (forceKillTimer) {
-                    clearTimeout(forceKillTimer);
-                  }
-                  if (forceKillWaitTimer) {
-                    clearTimeout(forceKillWaitTimer);
-                  }
-                  proc.off("close", finish);
-                  res();
-                };
-                proc.once("close", finish);
-                // Give ngrok a graceful window before forcing termination. The final bounded
-                // close wait avoids returning before SIGKILL normally reaps the child without
-                // letting an unobservable close event hang runtime cleanup forever.
-                const forceKillTimer = setTimeout(() => {
-                  if (!closed) {
-                    proc.kill("SIGKILL");
-                  }
-                  forceKillWaitTimer = setTimeout(finish, NGROK_FORCE_KILL_WAIT_MS);
-                }, NGROK_STOP_GRACE_MS);
-                proc.kill("SIGTERM");
-                if (closed) {
-                  finish();
-                }
-              });
+              await terminateNgrokProcess(proc, () => closed);
             },
           });
         }

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -13,6 +13,8 @@ const NGROK_LOG_BUFFER_MAX_CHARS = 16_384;
 const NGROK_ERROR_MARKER = "ERR_NGROK";
 const NGROK_STDERR_TAIL_MAX_CHARS = NGROK_ERROR_MARKER.length - 1;
 const TUNNEL_COMMAND_OUTPUT_MAX_BYTES = 16_384;
+const NGROK_STOP_GRACE_MS = 2_000;
+const NGROK_FORCE_KILL_WAIT_MS = 1_000;
 
 function listenForChildStreamErrors(
   proc: Pick<ChildProcessWithoutNullStreams, "stdout" | "stderr">,
@@ -146,21 +148,28 @@ async function startNgrokTunnel(config: {
               }
               await new Promise<void>((res) => {
                 let finished = false;
+                let forceKillWaitTimer: ReturnType<typeof setTimeout> | undefined;
                 const finish = () => {
                   if (finished) {
                     return;
                   }
                   finished = true;
-                  clearTimeout(fallback);
+                  if (forceKillTimer) {
+                    clearTimeout(forceKillTimer);
+                  }
+                  if (forceKillWaitTimer) {
+                    clearTimeout(forceKillWaitTimer);
+                  }
                   proc.off("close", finish);
                   res();
                 };
-                if (closed) {
-                  res();
-                  return;
-                }
                 proc.once("close", finish);
-                const fallback = setTimeout(finish, 2000);
+                const forceKillTimer = setTimeout(() => {
+                  if (!closed) {
+                    proc.kill("SIGKILL");
+                  }
+                  forceKillWaitTimer = setTimeout(finish, NGROK_FORCE_KILL_WAIT_MS);
+                }, NGROK_STOP_GRACE_MS);
                 proc.kill("SIGTERM");
                 if (closed) {
                   finish();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where voice-call could release ngrok process ownership while the process was still running when it ignored `SIGTERM`. This affected both normal runtime cleanup and the 30-second startup-timeout path, where a surviving process could keep an external tunnel active after stop completed or startup failed.

## Why This Change Was Made

A module-local ngrok termination helper now waits two seconds for graceful termination, escalates to `SIGKILL`, and waits for the child `close` event. A final one-second fallback keeps ownership release bounded even if close is never observable. Both successful stop and startup timeout use the helper; the change adds no configuration or API surface.

## User Impact

Voice-call no longer leaves a SIGTERM-resistant ngrok tunnel behind after either runtime shutdown or startup failure. Both paths retain finite upper bounds, so an unresponsive child cannot make cleanup wait forever.

## Evidence

- Current-main reproductions: a real executable named `ngrok` ignored `SIGTERM`; the old `stop()` returned with its PID still alive, and the old startup-timeout path rejected with its PID still alive one second later.
- Standalone production-path proof: `startTunnel` spawned a real ngrok-named child; the child was alive before cleanup, recorded `SIGTERM`, and was dead when `stop()` returned after about 2.0 seconds.
- Standalone startup-timeout proof: a real ngrok-named child emitted no recognized URL, ignored `SIGTERM`, and was dead before `startTunnel` rejected after about 32.0 seconds.
- `pnpm exec vitest run --config test/vitest/vitest.extension-voice-call.config.ts extensions/voice-call/src/tunnel.test.ts extensions/voice-call/src/tunnel.process.test.ts` — 2 files passed, 21 tests passed.
- `pnpm exec oxlint extensions/voice-call/src/tunnel.ts extensions/voice-call/src/tunnel.test.ts extensions/voice-call/src/tunnel.process.test.ts` — passed.
- `pnpm exec oxfmt --check extensions/voice-call/src/tunnel.ts extensions/voice-call/src/tunnel.test.ts extensions/voice-call/src/tunnel.process.test.ts` — passed.
- Fresh same-problem scan found no equivalent open PR. #109416 changes ngrok startup-timer bookkeeping but does not add bounded signal escalation or child reaping.
- The live proof does not contact the ngrok service or use credentials; a real OS child reproduces the targeted SIGTERM-resistant shutdown behavior. Broader extension TypeScript/check-changed coverage remains with hosted CI.
