### PR TITLE
fix(onboarding): stop recommending tools setup cannot activate

### DIFF
--- a/scripts/lib/recommended-tool-installs.json
+++ b/scripts/lib/recommended-tool-installs.json
@@ -27,41 +27,6 @@
       "hint": "OpenAI's coding agent CLI",
       "website": "https://developers.openai.com/codex/cli/",
       "icon": "https://github.com/openai.png"
-    },
-    {
-      "id": "pi",
-      "label": "Pi",
-      "hint": "Open-source coding agent",
-      "website": "https://pi.dev/",
-      "icon": "https://cdn.simpleicons.org/pi"
-    },
-    {
-      "id": "opencode",
-      "label": "OpenCode",
-      "hint": "Open-source coding agent",
-      "website": "https://opencode.ai/docs/",
-      "icon": "https://cdn.simpleicons.org/opencode"
-    },
-    {
-      "id": "gemini-cli",
-      "label": "Gemini CLI",
-      "hint": "Google's coding agent CLI",
-      "website": "https://geminicli.com/docs/get-started/installation/",
-      "icon": "https://cdn.simpleicons.org/googlegemini"
-    },
-    {
-      "id": "kimi-code",
-      "label": "Kimi Code",
-      "hint": "Moonshot's coding agent CLI",
-      "website": "https://www.kimi.com/code",
-      "icon": "https://cdn.simpleicons.org/kimi"
-    },
-    {
-      "id": "grok-build",
-      "label": "Grok Build",
-      "hint": "xAI's coding agent CLI",
-      "website": "https://x.ai/cli",
-      "icon": "https://github.com/xai-org.png"
     }
   ]
 }

--- a/scripts/lib/recommended-tool-installs.json
+++ b/scripts/lib/recommended-tool-installs.json
@@ -30,45 +30,6 @@
       "hint": "OpenAI's coding agent CLI",
       "website": "https://developers.openai.com/codex/cli/",
       "icon": "https://github.com/openai.png"
-    },
-    {
-      "id": "pi",
-      "label": "Pi",
-      "hint": "Open-source coding agent",
-      "website": "https://pi.dev/",
-      "icon": "https://cdn.simpleicons.org/pi"
-    },
-    {
-      "id": "opencode",
-      "brandId": "opencode",
-      "label": "OpenCode",
-      "hint": "Open-source coding agent",
-      "website": "https://opencode.ai/docs/",
-      "icon": "https://cdn.simpleicons.org/opencode"
-    },
-    {
-      "id": "gemini-cli",
-      "brandId": "gemini",
-      "label": "Gemini CLI",
-      "hint": "Google's coding agent CLI",
-      "website": "https://geminicli.com/docs/get-started/installation/",
-      "icon": "https://cdn.simpleicons.org/googlegemini"
-    },
-    {
-      "id": "kimi-code",
-      "brandId": "kimi",
-      "label": "Kimi Code",
-      "hint": "Moonshot's coding agent CLI",
-      "website": "https://www.kimi.com/code",
-      "icon": "https://cdn.simpleicons.org/kimi"
-    },
-    {
-      "id": "grok-build",
-      "brandId": "grok",
-      "label": "Grok Build",
-      "hint": "xAI's coding agent CLI",
-      "website": "https://x.ai/cli",
-      "icon": "https://github.com/xai-org.png"
     }
   ]
 }

--- a/src/plugins/recommended-tool-installs.test.ts
+++ b/src/plugins/recommended-tool-installs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { listRecommendedToolInstalls } from "./recommended-tool-installs.js";
 
 describe("recommended tool installs", () => {
-  it("loads the complete bundled catalog with unique HTTPS metadata", () => {
+  it("loads only tools that guided setup can turn into an inference route", () => {
     const installs = listRecommendedToolInstalls();
 
     expect(installs.map((entry) => entry.id)).toEqual([
@@ -10,11 +10,6 @@ describe("recommended tool installs", () => {
       "lmstudio",
       "claude-code",
       "codex-cli",
-      "pi",
-      "opencode",
-      "gemini-cli",
-      "kimi-code",
-      "grok-build",
     ]);
     expect(new Set(installs.map((entry) => entry.id)).size).toBe(installs.length);
     for (const entry of installs) {

--- a/src/plugins/recommended-tool-installs.test.ts
+++ b/src/plugins/recommended-tool-installs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { listRecommendedToolInstalls } from "./recommended-tool-installs.js";
 
 describe("recommended tool installs", () => {
-  it("loads the complete bundled catalog with unique HTTPS metadata", () => {
+  it("loads guided-setup-compatible installs with their current brand metadata", () => {
     const installs = listRecommendedToolInstalls();
 
     expect(installs.map((entry) => entry.id)).toEqual([
@@ -10,11 +10,6 @@ describe("recommended tool installs", () => {
       "lmstudio",
       "claude-code",
       "codex-cli",
-      "pi",
-      "opencode",
-      "gemini-cli",
-      "kimi-code",
-      "grok-build",
     ]);
     expect(new Set(installs.map((entry) => entry.id)).size).toBe(installs.length);
     expect(
@@ -25,10 +20,6 @@ describe("recommended tool installs", () => {
       ollama: "ollama",
       "claude-code": "claude",
       "codex-cli": "openai",
-      opencode: "opencode",
-      "gemini-cli": "gemini",
-      "kimi-code": "kimi",
-      "grok-build": "grok",
     });
     for (const entry of installs) {
       expect(entry.label).not.toBe("");

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -380,7 +380,12 @@ describe("detectSetupInference", () => {
     });
     expect(detection.candidates[1]).toMatchObject({ kind: "codex-cli", recommended: false });
     expect(detection.setupComplete).toBe(false);
-    expect(detection.recommendedInstalls).toHaveLength(9);
+    expect(detection.recommendedInstalls.map((entry) => entry.id)).toEqual([
+      "ollama",
+      "lmstudio",
+      "claude-code",
+      "codex-cli",
+    ]);
     expect(detection.workspace.length).toBeGreaterThan(0);
     expect(resolveManifestProviderAuthChoices).toHaveBeenCalledWith(
       expect.objectContaining({ includeWorkspacePlugins: false }),

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -689,7 +689,12 @@ describe("detectSetupInference", () => {
       recommended: false,
     });
     expect(detection.setupComplete).toBe(false);
-    expect(detection.recommendedInstalls).toHaveLength(9);
+    expect(detection.recommendedInstalls.map((install) => install.id)).toEqual([
+      "ollama",
+      "lmstudio",
+      "claude-code",
+      "codex-cli",
+    ]);
     expect(detection.workspace.length).toBeGreaterThan(0);
     expect(resolveManifestProviderAuthChoices).toHaveBeenCalledWith(
       expect.objectContaining({ includeWorkspacePlugins: false }),


### PR DESCRIPTION
## What Problem This Solves

First-run CLI, Control UI, and macOS onboarding tell operators to install Pi, OpenCode, Gemini CLI, Kimi Code, or Grok Build and then check again even though none of those standalone CLI installations can become a verified guided-setup inference candidate. Installing the suggested tool therefore leaves operators in the same empty state.

## Why This Change Was Made

The bundled presentation catalog is the shared producer for guided CLI setup, the Control UI, macOS onboarding, and isolated detection workers. Remove the five unsupported recommendations at that owner boundary while preserving the four routes setup can actually detect and activate: Ollama, LM Studio, Claude Code, and Codex CLI.

The rewritten change preserves the current `brandId` values for Ollama, Claude Code, and Codex CLI. Those identities were added after the original contributor branch was created and are required for local provider artwork in current Control UI and macOS clients. A downstream runtime filter would duplicate the setup detector's existing eligibility policy and leave other consumers inconsistent.

Direct upstream Codex contract independently checked by both maintainers in upstream checkout revision `3b67b03a3f6b0590589fb85d2be26d0eb58ac159`: `codex-rs/cli/src/main.rs:512-542,1134-1183` defines the app-server and its default stdio transport; `codex-rs/cli/src/login.rs:434-483` owns login-status results; `codex-rs/login/src/auth/storage.rs:38-48,405-445` defines keyring/file credential ownership; `codex-rs/app-server-protocol/src/protocol/common.rs:1219-1224` and `codex-rs/app-server/src/request_processors/account_processor.rs:1028-1047` implement `account/read`. This independently verifies the retained Codex CLI card corresponds to a real existing setup route without changing authentication behavior.

## User Impact

Fresh operators see only four install suggestions that the guided setup detector can turn into a usable inference route. Pi, OpenCode, Gemini, Kimi, and xAI remain supported through their existing dedicated provider, OAuth, or ACP flows; this change only removes misleading standalone-install recommendations.

Before: nine recommendation cards, including five tools that setup cannot activate.

![Before: onboarding recommends five unsupported standalone tool installs](https://github.com/user-attachments/assets/68869887-53d2-44df-9115-f2d0f5a1e0e6)

After: four usable recommendations with their existing local provider icons preserved.

![After: onboarding recommends Ollama, LM Studio, Claude Code, and Codex CLI](https://github.com/user-attachments/assets/75526515-0a49-462c-816b-bbf60faab438)

## Evidence

The existing catalog regression was first changed on unmodified current-main production code and failed because all five unsupported tools remained present. After removing them from the canonical JSON catalog, the same regression and the detector, icon-allowlist owner, and guided CLI siblings pass:

```text
node scripts/run-vitest.mjs src/plugins/recommended-tool-installs.test.ts src/system-agent/setup-inference.test.ts src/plugins/management-service.test.ts src/commands/onboard-guided.test.ts

Test Files  4 passed (4)
Tests       196 passed (196)
```

Real Chromium rendered the current-source Control UI twice against the repository's mocked Gateway, with `openclaw.setup.detect` returning the actual production catalog each time. The before run displayed nine cards; the after run displayed exactly `ollama,lmstudio,claude-code,codex-cli`, and existing Ollama, Claude, and Codex local brand icons remained visible. Each page made one actual setup-detection Gateway request. Screenshots above were captured from those running browser sessions and inspected for sensitive content.

```text
node scripts/check-changed.mjs -- scripts/lib/recommended-tool-installs.json src/plugins/recommended-tool-installs.test.ts src/system-agent/setup-inference.test.ts
git diff --check
```

The workstation's stale shared dependencies prevent its local core-test typecheck from running, and an attempted clean remote check timed out while synchronizing its workspace. Exact-head hosted CI must provide the clean-dependency typecheck evidence before this change can land.

Production catalog: +0/-39 lines. Tests: +7/-11 lines. No config, migration, provider, authentication, protocol, or dependency behavior changed.

Separate follow-ups: `src/node-host/node-worker-supervisor.ts` has an unrelated deferred-success lifecycle race where a container worker can briefly be classified as interrupted before its completed result is observed; its unchanged regression passed four independent local runs. `test/scripts/managed-child-process.test.ts` also has a pre-existing descendant-readiness timing race previously addressed by #125441; its unchanged failing case passed six independent local runs. Track both lifecycle ownership repairs separately from this onboarding change.

Original proposal and contributor credit: @zhanxingxin1998.
