### PR TITLE
Bound ChatGPT websocket Blob frame reads

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -1164,4 +1164,3 @@ describe("parseSSEForTest", () => {
     expect(pullCount).toBeLessThanOrEqual(20);
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -438,6 +438,58 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.errorMessage).toContain("websocket connect failed");
   });
 
+  it("rejects oversized ChatGPT websocket Blob frames before materializing them", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("fetch should not run");
+    });
+    const arrayBuffer = vi.fn(async () => new ArrayBuffer(0));
+    const closeMock = vi.fn();
+    const oversizedFrame = {
+      size: 16 * 1024 * 1024 + 1,
+      arrayBuffer,
+    };
+    class OversizedBlobWebSocket {
+      private readonly listeners = new Map<string, (event: unknown) => void>();
+
+      send(): void {
+        queueMicrotask(() => {
+          this.listeners.get("message")?.({ data: oversizedFrame });
+        });
+      }
+      close = closeMock;
+      addEventListener(type: string, listener: (event: unknown) => void): void {
+        this.listeners.set(type, listener);
+        if (type === "open") {
+          queueMicrotask(() => listener({}));
+        }
+      }
+      removeEventListener(type: string): void {
+        this.listeners.delete(type);
+      }
+    }
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("WebSocket", OversizedBlobWebSocket);
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      sessionId: "session-oversized-blob",
+      transport: "websocket",
+    });
+
+    const result = await stream.result();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalledWith(1009, "message too big");
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain(
+      "WebSocket message too big: 16777217 bytes (limit: 16777216 bytes)",
+    );
+  });
   it("honors timeoutMs for explicit SSE transport requests", async () => {
     stubHangingFetch(5);
 
@@ -1112,3 +1164,4 @@ describe("parseSSEForTest", () => {
     expect(pullCount).toBeLessThanOrEqual(20);
   });
 });
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -1104,6 +1104,8 @@ async function connectWebSocket(
   });
 }
 
+type WebSocketReleaseOptions = { keep?: boolean; closeCode?: number; closeReason?: string };
+
 async function acquireWebSocket(
   url: string,
   headers: Headers,
@@ -1112,18 +1114,14 @@ async function acquireWebSocket(
 ): Promise<{
   socket: WebSocketLike;
   entry?: CachedWebSocketConnection;
-  release: (options?: { keep?: boolean }) => void;
+  release: (options?: WebSocketReleaseOptions) => void;
 }> {
   if (!sessionId) {
     const socket = await connectWebSocket(url, headers, signal);
     return {
       socket,
-      release: ({ keep } = {}) => {
-        if (keep === false) {
-          closeWebSocketSilently(socket);
-          return;
-        }
-        closeWebSocketSilently(socket);
+      release: ({ closeCode, closeReason } = {}) => {
+        closeWebSocketSilently(socket, closeCode, closeReason);
       },
     };
   }
@@ -1142,9 +1140,9 @@ async function acquireWebSocket(
       return {
         socket: cached.socket,
         entry: cached,
-        release: ({ keep } = {}) => {
+        release: ({ keep, closeCode, closeReason } = {}) => {
           if (!keep || !isWebSocketReusable(cached.socket)) {
-            closeWebSocketSilently(cached.socket);
+            closeWebSocketSilently(cached.socket, closeCode, closeReason);
             websocketSessionCache.delete(sessionId);
             return;
           }
@@ -1157,8 +1155,8 @@ async function acquireWebSocket(
       const socket = await connectWebSocket(url, headers, signal);
       return {
         socket,
-        release: () => {
-          closeWebSocketSilently(socket);
+        release: ({ closeCode, closeReason } = {}) => {
+          closeWebSocketSilently(socket, closeCode, closeReason);
         },
       };
     }
@@ -1174,9 +1172,9 @@ async function acquireWebSocket(
   return {
     socket,
     entry,
-    release: ({ keep } = {}) => {
+    release: ({ keep, closeCode, closeReason } = {}) => {
       if (!keep || !isWebSocketReusable(entry.socket)) {
-        closeWebSocketSilently(entry.socket);
+        closeWebSocketSilently(entry.socket, closeCode, closeReason);
         if (entry.idleTimer) {
           clearTimeout(entry.idleTimer);
         }
@@ -1243,7 +1241,19 @@ async function decodeWebSocketData(data: unknown): Promise<string | null> {
     return new TextDecoder().decode(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
   }
   if (data && typeof data === "object" && "arrayBuffer" in data) {
-    const blobLike = data as { arrayBuffer: () => Promise<ArrayBuffer> };
+    const blobLike = data as { arrayBuffer: () => Promise<ArrayBuffer>; size?: unknown };
+    if (
+      typeof blobLike.size === "number" &&
+      blobLike.size > OPENAI_CHATGPT_RESPONSES_SUCCESS_BODY_MAX_BYTES
+    ) {
+      throw new WebSocketCloseError(
+        `WebSocket message too big: ${blobLike.size} bytes (limit: ${OPENAI_CHATGPT_RESPONSES_SUCCESS_BODY_MAX_BYTES} bytes)`,
+        {
+          code: WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE,
+          reason: "message too big",
+        },
+      );
+    }
     const arrayBuffer = await blobLike.arrayBuffer();
     return new TextDecoder().decode(new Uint8Array(arrayBuffer));
   }
@@ -1253,6 +1263,7 @@ async function decodeWebSocketData(data: unknown): Promise<string | null> {
 async function* parseWebSocket(
   socket: WebSocketLike,
   signal?: AbortSignal,
+  onCloseError?: (error: WebSocketCloseError) => void,
 ): AsyncGenerator<Record<string, unknown>> {
   const queue: Record<string, unknown>[] = [];
   let pending: (() => void) | null = null;
@@ -1293,6 +1304,9 @@ async function* parseWebSocket(
         queue.push(parsed);
         wake();
       } catch (cause) {
+        if (cause instanceof WebSocketCloseError) {
+          onCloseError?.(cause);
+        }
         failed = new CodexProtocolError(
           `Invalid Codex WebSocket JSON: ${formatThrownValue(cause)}`,
           {
@@ -1463,6 +1477,7 @@ async function processWebSocketStream(
     options?.signal,
   );
   let keepConnection = true;
+  let closeError: WebSocketCloseError | undefined;
   const useCachedContext =
     options?.transport === "websocket-cached" || options?.transport === "auto";
   // ChatGPT Codex Responses rejects `store: true` ("Store must be set to false").
@@ -1477,7 +1492,11 @@ async function processWebSocketStream(
     socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
     await processResponsesStream(
       startWebSocketOutputOnFirstEvent(
-        mapCodexEvents(parseWebSocket(socket, options?.signal)),
+        mapCodexEvents(
+          parseWebSocket(socket, options?.signal, (error) => {
+            closeError = error;
+          }),
+        ),
         output,
         stream,
         onStart,
@@ -1520,7 +1539,11 @@ async function processWebSocketStream(
     keepConnection = false;
     throw error;
   } finally {
-    release({ keep: keepConnection });
+    release({
+      keep: keepConnection,
+      closeCode: closeError?.code,
+      closeReason: closeError?.reason,
+    });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

ChatGPT WebSocket responses accept string, ArrayBuffer, ArrayBufferView, and Blob-like frames. The Blob-like path previously called rrayBuffer() before checking any advertised frame size, so an oversized frame could force whole-frame materialization before the existing stream/body size caps had a chance to apply.

ClawSweeper also caught that the first bounded-read patch raised WebSocketCloseError(1009) but then released the socket through the normal close(1000, "done") path. That meant the runtime reported an error internally, but did not send the WebSocket message-too-big close code to the peer.

## Why This Change Was Made

packages/ai/src/providers/openai-chatgpt-responses.ts now checks Blob-like size before calling rrayBuffer(). Frames larger than the existing ChatGPT Responses success-body cap fail with the existing WebSocket message-too-big close code instead of allocating the full body.

The WebSocket parser now preserves close-code metadata from oversized frames and passes it into the socket release path, so oversized Blob-like frames close the socket with 1009 / "message too big" instead of the normal success close.

## User Impact

**Before:** A Blob-like WebSocket frame could be materialized in full even when it advertised a size above the provider's bounded response limit. After the initial patch, the stream failed but the socket still closed as a normal completion.

**After:** Oversized Blob-like WebSocket frames are rejected before rrayBuffer() is called, and the socket is closed with the WebSocket message-too-big code. Normal string, ArrayBuffer, typed-array, and Blob-like frames within the cap keep the same decode behavior.

## Evidence

**Current head:** $head  
**Base:** $base

**Scope:** 2 files.
- packages/ai/src/providers/openai-chatgpt-responses.ts: advertised Blob-like size guard before rrayBuffer(), plus close-code propagation through WebSocket release.
- packages/ai/src/providers/openai-chatgpt-responses.test.ts: focused oversized Blob-like frame regression asserting rrayBuffer() is not called and socket.close(1009, "message too big") is used.

### Current-head CI evidence

`	ext
Real behavior proof: pass on current head 187ac26b0a377d1eed7e0af82661dabeeb4f6943
`

Additional CI checks are running on the current head after the close-code follow-up. The PR should be re-reviewed after those checks finish green.

### Real WebSocket Blob proof from earlier head

The original runtime proof below was captured on cccd1055aa9159bca1337c095efd0511c6af57a9 for the Blob materialization guard. The current head keeps that guard and adds the close-code propagation/test requested by ClawSweeper.

`ash
$ node scripts/run-vitest.mjs packages/ai/src/providers/openai-chatgpt-responses.test.ts -t "rejects oversized" --reporter=verbose
✓ streamOpenAICodexResponses transport > rejects oversized ChatGPT websocket Blob frames before materializing them
`

`ash
$ node --import tsx pr109953-websocket-blob-proof.mjs
=== Test 1: Normal Blob frame ===
SMALL_BLOB_SIZE=81
SMALL_BLOB_DECODED={"type":"response.completed","response":{"id":"resp_small","status":"completed"}}
✓ Normal Blob frame decoded successfully

=== Test 2: Oversized Blob-like frame ===
OVERSIZED_REJECTED=true
OVERSIZED_ERROR=WebSocket message too big: 16777217 bytes (limit: 16777216 bytes)
OVERSIZED_ARRAY_BUFFER_CALLED=false
✓ Oversized Blob rejected before arrayBuffer() call

=== Test 3: Real WebSocket server/client (Node.js Buffer) ===
Note: Node.js ws library uses Buffer by default, not Blob.
The decodeWebSocketData function handles both Blob and ArrayBuffer/Buffer.
Server: Client connected
Client: Connected to server
Client: Sent binary data, length: 16
Server: Received message, type: Buffer
Server: Is Buffer? true
Server: Sent binary acknowledgment
Client: Received response, type: Buffer
Client: Response: {"type":"response.binary_ack","size":16}
✓ Real WebSocket binary frame exchange successful

=== All tests passed ===
Summary:
1. ✓ Normal Blob frames decode successfully
2. ✓ Oversized Blob frames are rejected before arrayBuffer() call
3. ✓ Real WebSocket server/client binary frame exchange works
`

### Notes

- The latest follow-up addresses ClawSweeper's close-code finding by preserving WebSocketCloseError metadata until socket release.
- No dependency, credential, or network-policy changes.

## Change Type / Scope / Security Impact

- Type: audit-fix / bounded response read
- Scope: ChatGPT Responses WebSocket Blob frame handling only
- Security: reduces memory exposure from oversized Blob-like WebSocket frames and closes oversized frames with the WebSocket message-too-big close code