### PR TITLE
test(macos): anchor chat fixture timestamps to send-time events

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatHapticsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatHapticsTests.swift
@@ -22,11 +22,15 @@ private final class HapticRecorder: @unchecked Sendable {
 
 private final class HapticsTestTransport: @unchecked Sendable, OpenClawChatTransport {
     private let response: OpenClawChatSendResponse
-    private let historyMessages: [AnyCodable]
+    // History rows are built per fetch so fixtures can stamp timestamps at
+    // request time; every fetch in the send flow happens after the optimistic
+    // user echo exists, which keeps fixture rows ordered after the user turn
+    // regardless of how long the test was starved before sending.
+    private let historyMessages: @Sendable () -> [AnyCodable]
     private let stream: AsyncStream<OpenClawChatTransportEvent>
     private let continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation
 
-    init(status: String, historyMessages: [AnyCodable] = []) {
+    init(status: String, historyMessages: @escaping @Sendable () -> [AnyCodable] = { [] }) {
         self.response = OpenClawChatSendResponse(runId: "run-1", status: status)
         self.historyMessages = historyMessages
         var continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation!
@@ -38,7 +42,7 @@ private final class HapticsTestTransport: @unchecked Sendable, OpenClawChatTrans
         OpenClawChatHistoryPayload(
             sessionKey: sessionKey,
             sessionId: "session-1",
-            messages: self.historyMessages,
+            messages: self.historyMessages(),
             thinkingLevel: "off")
     }
 
@@ -65,7 +69,9 @@ private final class HapticsTestTransport: @unchecked Sendable, OpenClawChatTrans
     }
 }
 
-private func makeHapticsViewModel(status: String, historyMessages: [AnyCodable] = []) async -> (
+private func makeHapticsViewModel(
+    status: String,
+    historyMessages: @escaping @Sendable () -> [AnyCodable] = { [] }) async -> (
     HapticsTestTransport,
     OpenClawChatViewModel,
     HapticRecorder)
@@ -117,16 +123,20 @@ struct ChatHapticsTests {
 
     @Test(arguments: ["error", "aborted"])
     func `durable assistant failure fires run failed`(stopReason: String) async throws {
-        let error = AnyCodable([
-            "role": "assistant",
-            "content": [],
-            "timestamp": Date().timeIntervalSince1970 * 1000 + 1000,
-            "stopReason": stopReason,
-            "errorMessage": "provider failed",
-        ] as [String: Any])
-        let (_, viewModel, recorder) = await makeHapticsViewModel(
-            status: "started",
-            historyMessages: [error])
+        // The run-failed drain only fires for assistant rows timestamped at or
+        // after the optimistic user echo. Stamp the durable failure when history
+        // is fetched (always post-send) instead of at test start, where a >1s
+        // scheduling stall before send() left the row permanently "older" than
+        // the user turn and the wait timed out on loaded CI runners.
+        let (_, viewModel, recorder) = await makeHapticsViewModel(status: "started") {
+            [AnyCodable([
+                "role": "assistant",
+                "content": [],
+                "timestamp": Date().timeIntervalSince1970 * 1000,
+                "stopReason": stopReason,
+                "errorMessage": "provider failed",
+            ] as [String: Any])]
+        }
         await sendHapticsTestMessage(viewModel)
         try await waitUntil("run failed haptic") {
             recorder.events == [.messageSent, .runFailed]

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
@@ -500,7 +500,6 @@ struct ChatStreamReplayTests {
     }
 
     @Test func `reconnect mid-run converges via history refetch and drains pending run`() async throws {
-        let now = Date().timeIntervalSince1970 * 1000
         let harness = try await StreamReplayHarness.bootstrapped()
         let runId = try await harness.send("please finish")
 
@@ -509,17 +508,23 @@ struct ChatStreamReplayTests {
         // Stream stops here (no final, no lifecycle end). The gateway finished the
         // run while the client was away, so the next history fetch returns the
         // completed transcript keyed to this run.
+        // With no terminal event, the pending run drains only via the history
+        // poller, which requires the durable assistant row to be timestamped at
+        // or after the optimistic user echo. Anchor the transcript after the
+        // send instead of at test start, where slow bootstrap (>900ms on loaded
+        // CI runners) left the row "older" than the echo and the run never drained.
+        let reconnectNow = Date().timeIntervalSince1970 * 1000
         await harness.transport.setHistory(
             replayHistory(messages: [
                 replayRawMessage(
                     role: "user",
                     text: "please finish",
-                    timestamp: now + 100,
+                    timestamp: reconnectNow + 100,
                     idempotencyKey: "\(runId):user"),
                 replayRawMessage(
                     role: "assistant",
                     text: "Finished while you were away.",
-                    timestamp: now + 900,
+                    timestamp: reconnectNow + 900,
                     idempotencyKey: runId),
             ]))
         await MainActor.run { harness.vm.resumeFromForeground() }


### PR DESCRIPTION
## What Problem This Solves

Two macOS Swift Testing flakes failed the macos-swift lane on main (run 29573675642): `ChatHapticsTests` "durable assistant failure fires run failed" (both parameterized cases) and `ChatStreamReplayTests` "reconnect mid-run converges via history refetch" — all "Timeout waiting for" failures at ~17s.

## Why This Change Was Made

One shared mechanism, not two: fixture timestamps were anchored to wall clock at **test start**, raced against the optimistic user-echo timestamp captured later at **send time**. The only pending-run drain these fake transports have is `clearPendingRunIfAssistantMessagePresent` → `assistantHapticEvent(after:)`, which requires the assistant row's timestamp ≥ the echo timestamp. Under `swift test --parallel` all suites share the MainActor; a >1s starvation between fixture creation and `send()` leaves the fixture row permanently "older" than the echo, so the drain can never fire — both parameterized cases fail together, exactly the CI signature. (The reconnect test also can't drain via the foreground refetch: its scripted history has no `inFlightRun`, so only the timestamp comparison exists.)

Fix is event-ordered anchoring, no margins, no timeout changes:
- Haptics: the fake transport takes a history closure evaluated per `requestHistory`, stamping the failure row at fetch time — which is strictly after the echo append, so ordering holds by construction.
- Reconnect: the transcript anchors to a timestamp captured after the send completed.

## User Impact

None — test-only (mac app test fixtures).

## Evidence

- Deterministic repro: injecting a 1.5s / 1.2s stall before send reproduced both CI failures byte-for-byte; the fixes pass **with the stalls still injected** (proving immunity to scheduling delay), then stalls removed.
- Stress: 10/10 green runs of both tests; both full suites (10 tests) green.
- swiftformat --lint on both files: only a pre-existing docComments finding present at HEAD (Tests dirs aren't in CI lint lanes).
- Autoreview (codex/gpt-5.6-sol): clean, 0 findings, "patch is correct (0.94)".
