### PR TITLE
fix(cli): setup rejects invalid gateway ports

### DIFF
--- a/src/cli/gateway-port-option.test.ts
+++ b/src/cli/gateway-port-option.test.ts
@@ -8,12 +8,11 @@ describe("parseGatewayPortOption", () => {
     expect(parseGatewayPortOption(65_535)).toBe(65_535);
   });
 
-  it("treats absent values as no override", () => {
+  it("treats an absent value as no override", () => {
     expect(parseGatewayPortOption(undefined)).toBeUndefined();
-    expect(parseGatewayPortOption("")).toBeUndefined();
   });
 
-  it.each(["0", "65536", "1e4", "18789ms"])("rejects invalid port value %s", (value) => {
+  it.each(["", "0", "65536", "1e4", "18789ms"])("rejects invalid port value %j", (value) => {
     expect(() => parseGatewayPortOption(value)).toThrow(
       "--port must be an integer between 1 and 65535.",
     );

--- a/src/cli/gateway-port-option.ts
+++ b/src/cli/gateway-port-option.ts
@@ -14,10 +14,6 @@ export function parseGatewayPortOption(raw: unknown, flagName = "--port"): numbe
       : typeof raw === "number" || typeof raw === "bigint"
         ? String(raw)
         : "";
-  if (!value) {
-    return undefined;
-  }
-
   const parsed = parseStrictPositiveInteger(value);
   if (parsed === undefined || parsed > MAX_TCP_PORT) {
     throw new Error(`${flagName} must be an integer between 1 and ${MAX_TCP_PORT}.`);

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -96,19 +96,25 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardOptions(2).installDaemon).toBe(false);
   });
 
-  it("parses numeric gateway port and drops invalid values", async () => {
+  it("parses an explicit gateway port and leaves an omitted port unset", async () => {
     await runCli(["onboard", "--gateway-port", "18789"]);
     expect(setupWizardOptions(0).gatewayPort).toBe(18789);
 
-    await runCli(["onboard", "--gateway-port", "nope"]);
+    await runCli(["onboard"]);
     expect(setupWizardOptions(1).gatewayPort).toBeUndefined();
-
-    await runCli(["onboard", "--gateway-port", "18789x"]);
-    expect(setupWizardOptions(2).gatewayPort).toBeUndefined();
-
-    await runCli(["onboard", "--gateway-port", "99999"]);
-    expect(setupWizardOptions(3).gatewayPort).toBeUndefined();
   });
+
+  it.each(["", "nope", "1.5", "99999"])(
+    "rejects invalid gateway port %j before running onboarding",
+    async (value) => {
+      await expect(runCli(["onboard", "--gateway-port", value])).rejects.toThrow(
+        "--gateway-port must be an integer between 1 and 65535.",
+      );
+
+      expect(setupWizardCommandMock).not.toHaveBeenCalled();
+      expect(mocks.runSystemAgentWithInference).not.toHaveBeenCalled();
+    },
+  );
 
   it("forwards --reset-scope to setup wizard options", async () => {
     await runCli(["onboard", "--reset", "--reset-scope", "full"]);

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -18,6 +18,7 @@ import type {
 import { resolveProviderOnboardAuthFlags } from "../../plugins/provider-auth-choices.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatCliCommand } from "../command-format.js";
+import { parseGatewayPortOption } from "../gateway-port-option.js";
 import { parsePort } from "../shared/parse-port.js";
 
 export function resolveInstallDaemonFlag(command: Command): boolean | undefined {
@@ -204,7 +205,9 @@ export function registerOnboardCommand(program: Command): void {
   registerOnboardAuthOptions(command);
 
   command
-    .option("--gateway-port <port>", "Gateway port")
+    .option("--gateway-port <port>", "Gateway port", (value) =>
+      parseGatewayPortOption(value, "--gateway-port"),
+    )
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
     .option("--gateway-auth <mode>", "Gateway auth: token|password")
     .option("--gateway-token <token>", "Gateway token (token auth)")

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -161,8 +161,23 @@ describe("registerSetupCommand", () => {
 
     expect(setupWizardCommandMock).toHaveBeenCalledWith(lastWizardOptions(), runtime);
     expect(lastWizardOptions()?.workspace).toBe("/tmp/ws");
+    expect(lastWizardOptions()?.gatewayPort).toBeUndefined();
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
+
+  it.each(["", "nope", "1.5", "99999"])(
+    "rejects invalid gateway port %j before routing setup",
+    async (value) => {
+      await expect(runCli(["setup", "--gateway-port", value])).rejects.toThrow(
+        "--gateway-port must be an integer between 1 and 65535.",
+      );
+
+      expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+      expect(setupCommandMock).not.toHaveBeenCalled();
+      expect(setupWizardCommandMock).not.toHaveBeenCalled();
+      expect(runSystemAgentMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("runs baseline setup command when --baseline is set", async () => {
     await runCli(["setup", "--baseline", "--workspace", "/tmp/ws"]);

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -14,6 +14,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
 import { isUnconfiguredConfigSource } from "../fresh-install-config.js";
+import { parseGatewayPortOption } from "../gateway-port-option.js";
 import { parsePort } from "../shared/parse-port.js";
 import {
   pickOnboardAuthOptionValues,
@@ -188,7 +189,9 @@ export function registerSetupCommand(program: Command): void {
   registerOnboardAuthOptions(command);
 
   command
-    .option("--gateway-port <port>", "Gateway port")
+    .option("--gateway-port <port>", "Gateway port", (value) =>
+      parseGatewayPortOption(value, "--gateway-port"),
+    )
     .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
     .option("--gateway-auth <mode>", "Gateway auth: token|password")
     .option("--gateway-token <token>", "Gateway token (token auth)")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw onboard` or `openclaw setup` with an explicitly invalid `--gateway-port` value could silently continue without applying that value. Automation could appear successful while OpenClaw used a different port.

## Why This Change Was Made

Parse `--gateway-port` at the CLI option boundary with the shared strict TCP port parser. Omitted values remain unset, while empty, non-integer, decimal, and out-of-range values stop before setup handlers or config writes.

## User Impact

Setup and onboarding now fail immediately with a clear error for invalid explicit gateway ports instead of silently dropping the option.

## Evidence

- `node scripts/run-vitest.mjs src/cli/gateway-port-option.test.ts src/cli/program/register.onboard.test.ts src/cli/program/register.setup.test.ts` — 51 passed.
- `node scripts/run-vitest.mjs src/commands/onboard.test.ts` — 20 passed.
- Real CLI smoke exits 1 with `--gateway-port must be an integer between 1 and 65535.`
- Targeted oxlint and `git diff origin/main --check` passed.
- Fresh autoreview completed; its only note was rejected after checking the existing undefined/null guard and the passing parser test.
- AI-assisted; I reviewed the diff and understand the behavior.
