### PR TITLE
fix: prevent connection retention on guarded redirect failures

### DIFF
--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -16,7 +16,7 @@ function redirectResponse(location: string): Response {
     ok: false,
     status: 302,
     headers: makeFetchHeaders({ location }),
-    body: { cancel: vi.fn() },
+    body: { cancel: vi.fn().mockResolvedValue(undefined) },
   } as unknown as Response;
 }
 

--- a/src/infra/net/fetch-guard.integration.test.ts
+++ b/src/infra/net/fetch-guard.integration.test.ts
@@ -1,0 +1,108 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { fetchWithSsrFGuard } from "./fetch-guard.js";
+
+const REJECTION_TIMEOUT_MS = 1_000;
+const SOCKET_RELEASE_TIMEOUT_MS = 1_000;
+
+type RedirectScenario = {
+  path: string;
+  location?: string;
+  maxRedirects?: number;
+  expectedError: RegExp;
+};
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function close(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function expectRejectedRedirectToReleaseDispatcher(
+  scenario: RedirectScenario,
+): Promise<void> {
+  const sockets = new Set<Socket>();
+  const server = createServer((_request, response) => {
+    response.writeHead(302, {
+      "content-type": "text/plain",
+      ...(scenario.location ? { location: scenario.location } : {}),
+    });
+    // Keep the redirect body open so rejection must cancel it before the
+    // dispatcher can release its connection promptly.
+    response.write("pending redirect body");
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  await listen(server);
+
+  try {
+    const address = server.address() as AddressInfo;
+    const origin = `http://127.0.0.1:${address.port}`;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        expect(
+          fetchWithSsrFGuard({
+            url: `${origin}${scenario.path}`,
+            policy: { allowedOrigins: [origin] },
+            ...(scenario.maxRedirects === undefined
+              ? {}
+              : { maxRedirects: scenario.maxRedirects }),
+          }),
+        ).rejects.toThrow(scenario.expectedError),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("redirect rejection did not complete promptly")),
+            REJECTION_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+
+    await vi.waitFor(() => expect(sockets.size).toBe(0), {
+      timeout: SOCKET_RELEASE_TIMEOUT_MS,
+    });
+  } finally {
+    await close(server, sockets);
+  }
+}
+
+describe("fetchWithSsrFGuard real redirect cleanup", () => {
+  it.each<RedirectScenario>([
+    {
+      path: "/missing-location",
+      expectedError: /Redirect missing location header/u,
+    },
+    {
+      path: "/loop",
+      location: "/loop",
+      expectedError: /Redirect loop detected/u,
+    },
+    {
+      path: "/limit",
+      location: "/next",
+      maxRedirects: 0,
+      expectedError: /Too many redirects/u,
+    },
+  ])("rejects $path promptly and releases the Undici connection", async (scenario) => {
+    await expectRejectedRedirectToReleaseDispatcher(scenario);
+  });
+});

--- a/src/infra/net/fetch-guard.integration.test.ts
+++ b/src/infra/net/fetch-guard.integration.test.ts
@@ -27,7 +27,9 @@ async function close(server: Server, sockets: Set<Socket>): Promise<void> {
   for (const socket of sockets) {
     socket.destroy();
   }
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
 }
 
 async function expectRejectedRedirectToReleaseDispatcher(

--- a/src/infra/net/fetch-guard.integration.test.ts
+++ b/src/infra/net/fetch-guard.integration.test.ts
@@ -61,9 +61,7 @@ async function expectRejectedRedirectToReleaseDispatcher(
           fetchWithSsrFGuard({
             url: `${origin}${scenario.path}`,
             policy: { allowedOrigins: [origin] },
-            ...(scenario.maxRedirects === undefined
-              ? {}
-              : { maxRedirects: scenario.maxRedirects }),
+            ...(scenario.maxRedirects === undefined ? {} : { maxRedirects: scenario.maxRedirects }),
           }),
         ).rejects.toThrow(scenario.expectedError),
         new Promise<never>((_resolve, reject) => {

--- a/src/infra/net/fetch-guard.integration.test.ts
+++ b/src/infra/net/fetch-guard.integration.test.ts
@@ -11,7 +11,43 @@ type RedirectScenario = {
   location?: string;
   maxRedirects?: number;
   expectedError: RegExp;
+  /** Expected body.cancel() calls before rejection (loop/limit cancel each hop). */
+  expectedCancelCount: number;
 };
+
+const REDIRECT_SCENARIOS: RedirectScenario[] = [
+  {
+    path: "/missing-location",
+    expectedError: /Redirect missing location header/u,
+    expectedCancelCount: 1,
+  },
+  {
+    // Location resolves to the same URL as the request, so the second visit key
+    // collides immediately after one hop (one body cancel, then loop error).
+    path: "/loop",
+    location: "/loop",
+    expectedError: /Redirect loop detected/u,
+    expectedCancelCount: 1,
+  },
+  {
+    path: "/limit",
+    location: "/next",
+    maxRedirects: 0,
+    expectedError: /Too many redirects/u,
+    expectedCancelCount: 1,
+  },
+];
+
+function createTrackedOpenBody(onCancel: () => void): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start() {
+      // Leave the body open so rejection must cancel rather than drain it.
+    },
+    cancel() {
+      onCancel();
+    },
+  });
+}
 
 async function listen(server: Server): Promise<void> {
   await new Promise<void>((resolve, reject) => {
@@ -32,6 +68,69 @@ async function close(server: Server, sockets: Set<Socket>): Promise<void> {
   });
 }
 
+async function raceRejection(run: () => Promise<unknown>, expectedError: RegExp): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      expect(run()).rejects.toThrow(expectedError),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("redirect rejection did not complete promptly")),
+          REJECTION_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Instrumented body proof: fails if cancel is not invoked. Socket teardown alone
+ * cannot pass this harness because the open body never drains without cancel.
+ */
+async function expectRejectedRedirectCancelsBody(scenario: RedirectScenario): Promise<void> {
+  let cancelCount = 0;
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const parsed = new URL(url);
+    const location =
+      scenario.location === undefined ? undefined : new URL(scenario.location, parsed).toString();
+    return new Response(
+      createTrackedOpenBody(() => {
+        cancelCount += 1;
+      }),
+      {
+        status: 302,
+        headers: {
+          "content-type": "text/plain",
+          ...(location ? { location } : {}),
+        },
+      },
+    );
+  });
+
+  await raceRejection(
+    () =>
+      fetchWithSsrFGuard({
+        // Mocked fetch stays hermetic (no DNS) while still exercising redirect
+        // rejection and body cancel counting.
+        url: `https://public.example${scenario.path}`,
+        fetchImpl,
+        ...(scenario.maxRedirects === undefined ? {} : { maxRedirects: scenario.maxRedirects }),
+      }),
+    scenario.expectedError,
+  );
+
+  expect(cancelCount).toBe(scenario.expectedCancelCount);
+}
+
+/**
+ * Real Undici + loopback server: prompt rejection and connection release under a
+ * body left open on the wire. Supplemental to the cancel-count harness above.
+ */
 async function expectRejectedRedirectToReleaseDispatcher(
   scenario: RedirectScenario,
 ): Promise<void> {
@@ -41,8 +140,8 @@ async function expectRejectedRedirectToReleaseDispatcher(
       "content-type": "text/plain",
       ...(scenario.location ? { location: scenario.location } : {}),
     });
-    // Keep the redirect body open so rejection must cancel it before the
-    // dispatcher can release its connection promptly.
+    // Keep the redirect body open so rejection must abandon the stream before
+    // the client connection can return to idle promptly.
     response.write("pending redirect body");
   });
   server.on("connection", (socket) => {
@@ -54,28 +153,15 @@ async function expectRejectedRedirectToReleaseDispatcher(
   try {
     const address = server.address() as AddressInfo;
     const origin = `http://127.0.0.1:${address.port}`;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        expect(
-          fetchWithSsrFGuard({
-            url: `${origin}${scenario.path}`,
-            policy: { allowedOrigins: [origin] },
-            ...(scenario.maxRedirects === undefined ? {} : { maxRedirects: scenario.maxRedirects }),
-          }),
-        ).rejects.toThrow(scenario.expectedError),
-        new Promise<never>((_resolve, reject) => {
-          timer = setTimeout(
-            () => reject(new Error("redirect rejection did not complete promptly")),
-            REJECTION_TIMEOUT_MS,
-          );
+    await raceRejection(
+      () =>
+        fetchWithSsrFGuard({
+          url: `${origin}${scenario.path}`,
+          policy: { allowedOrigins: [origin] },
+          ...(scenario.maxRedirects === undefined ? {} : { maxRedirects: scenario.maxRedirects }),
         }),
-      ]);
-    } finally {
-      if (timer) {
-        clearTimeout(timer);
-      }
-    }
+      scenario.expectedError,
+    );
 
     await vi.waitFor(() => expect(sockets.size).toBe(0), {
       timeout: SOCKET_RELEASE_TIMEOUT_MS,
@@ -86,23 +172,17 @@ async function expectRejectedRedirectToReleaseDispatcher(
 }
 
 describe("fetchWithSsrFGuard real redirect cleanup", () => {
-  it.each<RedirectScenario>([
-    {
-      path: "/missing-location",
-      expectedError: /Redirect missing location header/u,
+  it.each(REDIRECT_SCENARIOS)(
+    "cancels the open redirect body for $path (instrumented)",
+    async (scenario) => {
+      await expectRejectedRedirectCancelsBody(scenario);
     },
-    {
-      path: "/loop",
-      location: "/loop",
-      expectedError: /Redirect loop detected/u,
+  );
+
+  it.each(REDIRECT_SCENARIOS)(
+    "rejects $path promptly and releases the Undici connection",
+    async (scenario) => {
+      await expectRejectedRedirectToReleaseDispatcher(scenario);
     },
-    {
-      path: "/limit",
-      location: "/next",
-      maxRedirects: 0,
-      expectedError: /Too many redirects/u,
-    },
-  ])("rejects $path promptly and releases the Undici connection", async (scenario) => {
-    await expectRejectedRedirectToReleaseDispatcher(scenario);
-  });
+  );
 });

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1459,6 +1459,25 @@ describe("fetchWithSsrFGuard hardening", () => {
     },
   );
 
+  it("does not stall when redirect body cancel never settles", async () => {
+    const response = new Response("redirect body", { status: 302 });
+    const cancel = vi
+      .spyOn(response.body!, "cancel")
+      .mockImplementation(() => new Promise<void>(() => {}));
+    const startedAt = Date.now();
+
+    await expectRedirectFailure({
+      url: "https://public.example/start",
+      responses: [response],
+      expectedError: /missing location header/i,
+      lookupFn: createPublicLookup(),
+    });
+
+    expect(cancel).toHaveBeenCalledOnce();
+    // Bound is 100ms; allow generous headroom without masking a hang.
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
   it("rejects redirect loops that return to the original URL", async () => {
     await expectRedirectFailure({
       url: "https://public.example/start",

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1389,6 +1389,76 @@ describe("fetchWithSsrFGuard hardening", () => {
     });
   });
 
+  it.each([
+    {
+      name: "missing location header",
+      location: undefined,
+      expectedError: /missing location header/i,
+    },
+    {
+      name: "invalid location header",
+      location: "http://[invalid",
+      expectedError: /invalid url/i,
+    },
+  ])("cancels rejected redirect bodies for $name", async ({ location, expectedError }) => {
+    const response = new Response("redirect body", {
+      status: 302,
+      ...(location ? { headers: { location } } : {}),
+    });
+    const cancel = vi.spyOn(response.body!, "cancel");
+
+    await expectRedirectFailure({
+      url: "https://public.example/start",
+      responses: [response],
+      expectedError,
+      lookupFn: createPublicLookup(),
+    });
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "redirect loop",
+      firstLocation: "https://public.example/next",
+      secondLocation: "https://public.example/next",
+      expectedError: /redirect loop/i,
+      maxRedirects: undefined,
+    },
+    {
+      name: "redirect limit",
+      firstLocation: "https://public.example/one",
+      secondLocation: "https://public.example/two",
+      expectedError: /too many redirects/i,
+      maxRedirects: 1,
+    },
+  ])(
+    "cancels every redirect body when rejecting a $name",
+    async ({ firstLocation, secondLocation, expectedError, maxRedirects }) => {
+      const firstResponse = new Response("first redirect body", {
+        status: 302,
+        headers: { location: firstLocation },
+      });
+      const secondResponse = new Response("second redirect body", {
+        status: 302,
+        headers: { location: secondLocation },
+      });
+      const firstCancel = vi.spyOn(firstResponse.body!, "cancel");
+      const secondCancel = vi.spyOn(secondResponse.body!, "cancel");
+
+      await expectRedirectFailure({
+        url: "https://public.example/start",
+        responses: [firstResponse, secondResponse],
+        expectedError,
+        lookupFn: createPublicLookup(),
+        maxRedirects,
+      });
+
+      expect(firstCancel).toHaveBeenCalledOnce();
+      expect(secondCancel).toHaveBeenCalledOnce();
+    },
+  );
+
   it("rejects redirect loops that return to the original URL", async () => {
     await expectRedirectFailure({
       url: "https://public.example/start",

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -663,6 +663,7 @@ async function fetchWithSsrFGuardInternal(
       });
 
       if (isRedirectStatus(response.status)) {
+        await response.body?.cancel().catch(() => undefined);
         const location = response.headers.get("location");
         if (!location) {
           await release(dispatcher);
@@ -698,7 +699,6 @@ async function fetchWithSsrFGuardInternal(
           throw new Error("Redirect loop detected");
         }
         visited.add(nextVisitKey);
-        void response.body?.cancel();
         await closeDispatcher(dispatcher);
         currentUrl = nextUrl;
         continue;

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -122,6 +122,39 @@ type GuardedFetchPresetOptions = Omit<
 
 const DEFAULT_MAX_REDIRECTS = 3;
 const OPENCLAW_DEBUG_PROXY_ENABLED = "OPENCLAW_DEBUG_PROXY_ENABLED";
+// Match dispatcher close bound so redirect cleanup cannot hang forever when a
+// custom or faulty stream returns a never-settling cancel() promise.
+const REDIRECT_BODY_CANCEL_TIMEOUT_MS = 100;
+
+/**
+ * Start canceling a redirect response body, but never block redirect rejection
+ * or hop handling on a cancel() that never settles. Errors are non-fatal: the
+ * caller still runs release/closeDispatcher for connection cleanup.
+ */
+async function cancelRedirectResponseBody(
+  body: ReadableStream<Uint8Array> | null | undefined,
+): Promise<void> {
+  if (!body) {
+    return;
+  }
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve(body.cancel()).catch(() => undefined),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(() => {
+          timeout = undefined;
+          resolve();
+        }, REDIRECT_BODY_CANCEL_TIMEOUT_MS);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 async function runAbortablePreflight<T>(run: () => Promise<T>, signal?: AbortSignal): Promise<T> {
   if (!signal) {
@@ -663,7 +696,9 @@ async function fetchWithSsrFGuardInternal(
       });
 
       if (isRedirectStatus(response.status)) {
-        await response.body?.cancel().catch(() => undefined);
+        // Cancel before validating the hop so rejected redirects release the
+        // body promptly; bound so never-settling cancel cannot stall release.
+        await cancelRedirectResponseBody(response.body);
         const location = response.headers.get("location");
         if (!location) {
           await release(dispatcher);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where guarded HTTP redirects could leave an unread response body attached to the dispatcher when the redirect was rejected because of a missing or invalid `Location`, a loop, or the redirect limit. Repeated failures could delay connection reuse and retain transport resources.

## Why This Change Was Made

Cancel every redirect response body before validating or following the next hop, while preserving existing redirect, authorization, and dispatcher cleanup behavior.

Cancellation is **bounded** (100ms `Promise.race` against `body.cancel()`) so a never-settling `cancel()` cannot stall guarded fetch before `release()` / `closeDispatcher()`. Cancellation failures and timeouts remain non-fatal; dispatcher cleanup still runs.

## User Impact

Guarded fetch callers cleanly release redirect responses on all rejection paths without risking an indefinite hang on a faulty stream cancel, improving reliability under repeated malformed or looping redirects without changing accepted redirect behavior.

## Evidence

### Behavior
- Before: rejected redirects omitted explicit body cancellation (or used fire-and-forget `void cancel()` only on followed hops).
- After: every redirect status runs `cancelRedirectResponseBody` first (bounded), then validates location / limit / loop and releases the dispatcher.

### Standalone real-behavior proof (outside Vitest harness)
Redacted terminal transcript from a non-test Node runner against head `ddf2df66c7fa620b4f7c1f7a1bfcd5760967de12`. Ephemeral loopback server leaves the redirect body open; `fetchWithSsrFGuard` must reject promptly and release sockets.

```text
openclaw-fetch-guard-standalone-proof
{"headHint":"ddf2df66c7fa620b4f7c1f7a1bfcd5760967de12","worktree":"<local-checkout>","node":"v26.5.0","note":"loopback only; no credentials; response bodies left open on server"}
{"scenario":"missing-location","origin":"http://127.0.0.1:<ephemeral>","path":"/missing-location","rejected":true,"error":"Redirect missing location header (302)","rejectMs":58,"socketReleaseMs":11,"socketsOpenAfter":0}
{"scenario":"redirect-loop","origin":"http://127.0.0.1:<ephemeral>","path":"/loop","rejected":true,"error":"Redirect loop detected","rejectMs":2,"socketReleaseMs":0,"socketsOpenAfter":0}
{"scenario":"redirect-limit","origin":"http://127.0.0.1:<ephemeral>","path":"/limit","rejected":true,"error":"Too many redirects (limit: 0)","rejectMs":2,"socketReleaseMs":0,"socketsOpenAfter":0}
{"result":"ok","scenarios":3,"summary":"all rejected redirects completed promptly and released loopback sockets while bodies stayed open"}
```

Command shape (no secrets): `node --import tsx/esm standalone-proof.mts` loading `src/infra/net/fetch-guard.ts` from this PR head. Loopback only.

### Regression coverage
- Unit cancel spies: missing-location, invalid-location, loop, and limit paths.
- Unit never-settling `cancel()`: rejection still completes within the bound.
- Instrumented integration: open `ReadableStream` bodies with cancel counters — fails if cancel is not called.
- Real Undici + ephemeral loopback integration tests (same three scenarios).

### CI on head `ddf2df66c7fa620b4f7c1f7a1bfcd5760967de12`
- [fetch-guard unit + integration shard](https://github.com/openclaw/openclaw/actions/runs/29597665692/job/87942128754): `fetch-guard.ssrf.test.ts` 103/103; `fetch-guard.integration.test.ts` 6/6.
- [check-lint](https://github.com/openclaw/openclaw/actions/runs/29597665692/job/87942128347): oxlint + oxfmt clean.
- [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/29597665692/job/87943289021): passed.

### ClawSweeper findings addressed
1. Bounded cancel — `cancelRedirectResponseBody` races cancel with 100ms timeout.
2. Cancel-specific proof — instrumented open-stream harness asserts exact cancel counts.
3. Standalone runtime transcript — above (this section).

### Dependency
- Undici: response bodies must be consumed or canceled for connection reuse: https://github.com/nodejs/undici#garbage-collection

### Privacy
- Secretless fork CI + ephemeral loopback only. No credentials, private endpoints, or agent transcripts. Standalone log redacts ephemeral ports.

AI-assisted; I reviewed the diff and understand the behavior.

