### PR TITLE
fix(discord): release PluralKit 404 bodies

### DIFF
--- a/extensions/discord/src/pluralkit.test.ts
+++ b/extensions/discord/src/pluralkit.test.ts
@@ -59,13 +59,15 @@ describe("fetchPluralKitMessageInfo", () => {
   });
 
   it("returns null on 404", async () => {
-    const fetcher = vi.fn(async () => buildResponse({ status: 404 }));
+    const tracked = cancelTrackedResponse("missing", { status: 404 });
+    const fetcher = vi.fn(async () => tracked.response);
     const result = await fetchPluralKitMessageInfo({
       messageId: "missing",
       config: { enabled: true },
       fetcher: fetcher as unknown as typeof fetch,
     });
     expect(result).toBeNull();
+    expect(tracked.wasCanceled()).toBe(true);
   });
 
   it("returns payload and sends token when configured", async () => {

--- a/extensions/discord/src/pluralkit.ts
+++ b/extensions/discord/src/pluralkit.ts
@@ -65,6 +65,7 @@ export async function fetchPluralKitMessageInfo(params: {
       signal: timeout.signal,
     });
     if (res.status === 404) {
+      await res.body?.cancel().catch(() => undefined);
       return null;
     }
     if (!res.ok) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord PluralKit lookups could leave a 404 response body open when a webhook message had no PluralKit record.

## Why This Change Was Made

The missing-message path still returns `null`, but it now cancels any response body before leaving the PluralKit lookup. The existing bounded error-body path is unchanged.

## User Impact

Discord users with PluralKit enabled keep the same missing-message behavior while the plugin releases upstream response streams promptly.

## Evidence

- Production module boundary: `./node_modules/.bin/tsx proof-pluralkit-404.ts` imported the real PluralKit lookup module, exercised a 404 response with a stream body, and used a 200 JSON negative-control response to verify normal parsing still succeeds.
- `node scripts/run-vitest.mjs extensions/discord/src/pluralkit.test.ts -- -t "returns null on 404|bounds PluralKit API error bodies"`
- `node scripts/run-vitest.mjs extensions/discord/src/pluralkit.test.ts`

```text
$ ./node_modules/.bin/tsx proof-pluralkit-404.ts
missing-result=null
missing-body-canceled=true
found-member=member-1
```

<details>
<summary>proof-pluralkit-404.ts</summary>

```ts
import { fetchPluralKitMessageInfo } from "./extensions/discord/src/pluralkit.ts";

function cancelTrackedResponse(text: string, init: ResponseInit) {
  let canceled = false;
  const stream = new ReadableStream<Uint8Array>({
    start(controller) {
      controller.enqueue(new TextEncoder().encode(text));
    },
    cancel() {
      canceled = true;
    },
  });
  return {
    response: new Response(stream, init),
    wasCanceled: () => canceled,
  };
}

const missing = cancelTrackedResponse("missing", { status: 404 });
const missingResult = await fetchPluralKitMessageInfo({
  messageId: "missing-message",
  config: { enabled: true },
  fetcher: async () => missing.response,
});
console.log(`missing-result=${missingResult === null ? "null" : "unexpected"}`);
console.log(`missing-body-canceled=${missing.wasCanceled()}`);

const found = await fetchPluralKitMessageInfo({
  messageId: "found-message",
  config: { enabled: true },
  fetcher: async () =>
    new Response(
      JSON.stringify({
        id: "found-message",
        member: { id: "member-1", name: "Member" },
        system: { id: "system-1", name: "System" },
      }),
      {
        status: 200,
        headers: { "content-type": "application/json" },
      },
    ),
});
console.log(`found-member=${found?.member?.id ?? "missing"}`);
```

</details>

AI-assisted: built with Codex
