### PR TITLE
fix(gateway): reject malformed LAN route metrics

### DIFF
--- a/src/infra/advertised-lan-host.test.ts
+++ b/src/infra/advertised-lan-host.test.ts
@@ -77,6 +77,31 @@ describe("advertised LAN host", () => {
     );
   });
 
+  it("does not truncate malformed Windows route metrics", async () => {
+    const runner = createRouteRunner(
+      JSON.stringify([
+        { InterfaceAlias: "Ethernet", RouteMetric: "1abc", InterfaceMetric: 1 },
+        { InterfaceAlias: "Ethernet 3", RouteMetric: 0.5, InterfaceMetric: 0 },
+        { InterfaceAlias: "Ethernet 4", RouteMetric: null, InterfaceMetric: "" },
+        { InterfaceAlias: "Ethernet 2", RouteMetric: "10", InterfaceMetric: "1" },
+      ]),
+    );
+
+    await expect(
+      resolveAdvertisedLanHost({
+        platform: "win32",
+        runCommandWithTimeout: runner,
+        networkInterfaces: () =>
+          ({
+            Ethernet: [ipv4("10.37.129.4")],
+            "Ethernet 2": [ipv4("10.211.55.3")],
+            "Ethernet 3": [ipv4("192.168.1.20")],
+            "Ethernet 4": [ipv4("192.168.2.20")],
+          }) as NetworkInterfacesSnapshot,
+      }),
+    ).resolves.toBe("10.211.55.3");
+  });
+
   it("falls back to interface order when Linux route hints do not match", async () => {
     await expect(
       resolveAdvertisedLanHost({

--- a/src/infra/advertised-lan-host.ts
+++ b/src/infra/advertised-lan-host.ts
@@ -60,15 +60,19 @@ function normalizeInterfaceName(name: unknown): string {
   return typeof name === "string" ? name.trim().toLowerCase() : "";
 }
 
-function normalizeMetric(value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
+function normalizeMetric(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
   }
-  if (typeof value === "string" && value.trim()) {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) ? parsed : 0;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!/^\d+$/u.test(trimmed)) {
+      return null;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    return Number.isSafeInteger(parsed) ? parsed : null;
   }
-  return 0;
+  return null;
 }
 
 function listAdvertisedLanHostCandidates(
@@ -131,6 +135,9 @@ function parseWindowsDefaultRouteHints(stdout: string): AdvertisedLanRouteHint[]
     if (interfaceName) {
       const routeMetric = normalizeMetric(route.RouteMetric);
       const interfaceMetric = normalizeMetric(route.InterfaceMetric);
+      if (routeMetric === null || interfaceMetric === null) {
+        continue;
+      }
       rankedRows.push({
         interfaceName,
         effectiveMetric: routeMetric + interfaceMetric,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows gateway LAN address advertisement could pick the wrong interface when route probing returned malformed route metrics such as partial numeric strings, fractional values, blank fields, or null metric values.

## Why This Change Was Made

Windows default-route metric parsing now accepts only non-negative safe integer metrics, whether PowerShell emits them as JSON numbers or decimal strings. Rows with malformed required metrics are skipped before ranking instead of being truncated or treated as artificially low priority.

Related independent bug-family PRs: this is a sibling of https://github.com/openclaw/openclaw/pull/109962 in the strict external numeric-token parsing wave. The PRs are independent, based on `upstream/main`, and have no merge dependency.

## User Impact

Gateway users on Windows are less likely to receive a LAN control URL for the wrong network interface when route probe output is malformed or partially corrupted.

## Evidence

Head: `a6271ea75584294ec0f9cae98b837b1b476c2f50`

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' | Select-Object -Property InterfaceAlias,InterfaceIndex,NextHop,RouteMetric,InterfaceMetric,DestinationPrefix | ConvertTo-Json -Compress"` passed on Windows and returned the live default-route JSON shape with `RouteMetric` and `InterfaceMetric` fields.
- `node --import tsx --input-type=module -` passed a Windows PowerShell-backed proof: the production `Get-NetRoute ... ConvertTo-Json -Compress` command emitted representative rows with `RouteMetric:"1abc"`, `RouteMetric:0.5`, `RouteMetric:null` plus blank `InterfaceMetric`, and a valid `Ethernet 2` row with `RouteMetric:"10"` and `InterfaceMetric:"1"`; `resolveAdvertisedLanHost({ platform: "win32" })` selected `10.211.55.3`, proving malformed metric rows were skipped instead of truncated or treated as zero.
- `node scripts/run-vitest.mjs src/infra/advertised-lan-host.test.ts` passed: 1 file, 7 tests.
- `.\node_modules\.bin\oxlint.cmd src\infra\advertised-lan-host.ts src\infra\advertised-lan-host.test.ts` passed.
- `git diff --check upstream/main...HEAD` passed.