### PR TITLE
fix(agents): continuation-skip reinjects full workspace bootstrap for SQLite-backed sessions

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -5,10 +5,17 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  appendTranscriptEvent,
+  persistSessionTranscriptTurn,
+  upsertSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
+import {
   clearInternalHooks,
   registerInternalHook,
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -507,17 +514,104 @@ describe("hasCompletedBootstrapTurn", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    closeOpenClawAgentDatabasesForTest();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
+
+  async function makeSqliteTranscript(events: Array<Record<string, unknown>>): Promise<string> {
+    const agentId = "main";
+    const sessionId = `sqlite-${randomUUID()}`;
+    const sessionKey = `agent:${agentId}:${sessionId}`;
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionFile = formatSqliteSessionFileMarker({ agentId, sessionId, storePath });
+    await upsertSessionEntry(
+      { agentId, sessionKey, storePath },
+      { sessionId, sessionFile, updatedAt: Date.now() },
+    );
+    const scope = { agentId, sessionId, sessionKey, storePath };
+    for (const [index, event] of events.entries()) {
+      if (event.type === "message") {
+        // Message records must flow through the transcript-turn writer; raw
+        // event appends reject message rows to protect identity bookkeeping.
+        await persistSessionTranscriptTurn(scope, {
+          messages: [
+            {
+              eventId: `msg-${index}`,
+              parentId: null,
+              message: event.message as { role: string; content: string },
+            },
+          ],
+          touchSessionEntry: false,
+        });
+        continue;
+      }
+      await appendTranscriptEvent(scope, event);
+    }
+    return sessionFile;
+  }
 
   it("returns false when session file does not exist", async () => {
     expect(await hasCompletedBootstrapTurn(path.join(tmpDir, "missing.jsonl"))).toBe(false);
   });
 
-  it("returns false for SQLite transcript markers", async () => {
-    expect(
-      await hasCompletedBootstrapTurn("sqlite:main:session-1:/tmp/openclaw/sessions.json"),
-    ).toBe(false);
+  it("returns false for SQLite markers whose transcript has no bootstrap marker", async () => {
+    const sessionFile = await makeSqliteTranscript([
+      { type: "message", message: { role: "user", content: "hello" } },
+      { type: "message", message: { role: "assistant", content: "hi" } },
+    ]);
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
+  });
+
+  it("finds a full bootstrap marker in SQLite-backed transcripts", async () => {
+    const sessionFile = await makeSqliteTranscript([
+      { type: "message", message: { role: "assistant", content: "hi" } },
+      {
+        type: "custom",
+        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        data: { timestamp: 1 },
+      },
+    ]);
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
+  });
+
+  it("returns false when SQLite compaction happens after the bootstrap marker", async () => {
+    const sessionFile = await makeSqliteTranscript([
+      {
+        type: "custom",
+        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        data: { timestamp: 1 },
+      },
+      { type: "compaction", summary: "trimmed" },
+    ]);
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
+  });
+
+  it("returns true when a later SQLite bootstrap marker follows compaction", async () => {
+    const sessionFile = await makeSqliteTranscript([
+      {
+        type: "custom",
+        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        data: { timestamp: 1 },
+      },
+      { type: "compaction", summary: "trimmed" },
+      { type: "message", message: { role: "user", content: "new ask" } },
+      { type: "message", message: { role: "assistant", content: "new reply" } },
+      {
+        type: "custom",
+        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        data: { timestamp: 2 },
+      },
+    ]);
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
+  });
+
+  it("returns false for SQLite markers whose session store is missing", async () => {
+    const sessionFile = formatSqliteSessionFileMarker({
+      agentId: "main",
+      sessionId: "missing-session",
+      storePath: path.join(tmpDir, "missing-store", "sessions.json"),
+    });
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
   });
 
   it("returns false for empty session files", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -5,6 +5,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { loadTranscriptEvents } from "../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -69,10 +70,48 @@ export function resolveContextInjectionMode(
   return config?.agents?.defaults?.contextInjection ?? "always";
 }
 
+/**
+ * Scans transcript records newest-first for a full-bootstrap marker that has
+ * not been invalidated by a later compaction. Only the tail matters:
+ * compaction after the marker makes earlier bootstrap context unreliable for
+ * continuation prompts.
+ */
+function scanRecordsForCompletedBootstrapTurn(records: readonly unknown[]): boolean {
+  let compactedAfterLatestAssistant = false;
+  for (let i = records.length - 1; i >= 0; i--) {
+    const record = records[i] as
+      | {
+          type?: string;
+          customType?: string;
+          message?: { role?: string };
+        }
+      | null
+      | undefined;
+    if (record?.type === "compaction" || record?.type === "reset") {
+      compactedAfterLatestAssistant = true;
+      continue;
+    }
+    if (record?.type === "custom" && record.customType === FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE) {
+      return !compactedAfterLatestAssistant;
+    }
+  }
+  return false;
+}
+
 /** Checks whether the session transcript still has a valid full-bootstrap marker. */
 export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<boolean> {
-  if (parseSqliteSessionFileMarker(sessionFile)) {
-    return false;
+  const sqliteMarker = parseSqliteSessionFileMarker(sessionFile);
+  if (sqliteMarker) {
+    try {
+      const events = await loadTranscriptEvents({
+        agentId: sqliteMarker.agentId,
+        sessionId: sqliteMarker.sessionId,
+        storePath: sqliteMarker.storePath,
+      });
+      return scanRecordsForCompletedBootstrapTurn(events.slice(-CONTINUATION_SCAN_MAX_RECORDS));
+    } catch {
+      return false;
+    }
   }
   try {
     const stat = await fs.lstat(sessionFile);
@@ -101,43 +140,15 @@ export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<bo
       const records = text
         .split(/\r?\n/u)
         .filter((line) => line.trim().length > 0)
-        .slice(-CONTINUATION_SCAN_MAX_RECORDS);
-      let compactedAfterLatestAssistant = false;
-
-      for (let i = records.length - 1; i >= 0; i--) {
-        // Only the tail matters: compaction after the marker makes earlier
-        // bootstrap context unreliable for continuation prompts.
-        const line = records[i];
-        if (!line) {
-          continue;
-        }
-        let entry: unknown;
-        try {
-          entry = JSON.parse(line);
-        } catch {
-          continue;
-        }
-        const record = entry as
-          | {
-              type?: string;
-              customType?: string;
-              message?: { role?: string };
-            }
-          | null
-          | undefined;
-        if (record?.type === "compaction" || record?.type === "reset") {
-          compactedAfterLatestAssistant = true;
-          continue;
-        }
-        if (
-          record?.type === "custom" &&
-          record.customType === FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE
-        ) {
-          return !compactedAfterLatestAssistant;
-        }
-      }
-
-      return false;
+        .slice(-CONTINUATION_SCAN_MAX_RECORDS)
+        .flatMap((line) => {
+          try {
+            return [JSON.parse(line) as unknown];
+          } catch {
+            return [];
+          }
+        });
+      return scanRecordsForCompletedBootstrapTurn(records);
     } finally {
       await fh.close();
     }
@@ -178,7 +189,7 @@ function sanitizeBootstrapFiles(
     const pathValue = normalizeOptionalString(file.path) ?? "";
     if (!pathValue) {
       warn?.(
-        `skipping bootstrap file "${file.name}" — missing or invalid "path" field (hook may have used "filePath" instead)`,
+        `skipping bootstrap file "${file.name}" ??missing or invalid "path" field (hook may have used "filePath" instead)`,
       );
       continue;
     }


### PR DESCRIPTION
Related to #109656

AI-assisted: this change was implemented with Claude (Anthropic) doing the analysis and code under human direction and review. Workflow context: issue-driven fix; I traced the continuation gate (prepareEmbeddedAttemptBootstrap -> hasCompletedBootstrapTurn), wrote the failing SQLite tests first, then the fix. Follow-up framing check on 2026-07-19 was done with Cursor / Grok 4.5 against tagged releases and origin/main history. Live two-turn SQLite proof on 2026-07-21 used Cursor / Grok 4.5 with a local Mistral run (no Telegram/Vertex). Tip re-proof on `a37dc4208b` later the same day also used Cursor / Grok 4.5 + Mistral `--local`.

## What Problem This Solves

Fixes a current-main regression where agents configured with `contextInjection: "continuation-skip"` still get the full workspace bootstrap context reinjected on every turn, which breaks stable prompt prefixes and defeats prompt cache reads (same symptom as #109656).

Root cause on current code: after sessions and transcripts flipped to SQLite storage (#98236, first present in the v2026.7.2 betas), `hasCompletedBootstrapTurn` returned false for every `sqlite:` session-file marker. Live session files are always those markers now (`resolveAndPersistSessionFile` formats them that way), so the continuation gate never engages and the mode behaves like `always`.

## Scope honesty vs the original report

The issue author reproduced on v2026.5.27 and again on v2026.6.11. Both tags predate #98236 (`git merge-base --is-ancestor 0a8e3604ba v2026.6.11` / `v2026.5.27` / `v2026.7.1` are all false; the flip is contained in v2026.7.2-beta.1). On those releases, `hasCompletedBootstrapTurn` only scans JSONL transcript files. There is no `sqlite:` early-return and no SQLite-backed session-file marker in that code path.

So this PR's SQLite read fix is **not** an explanation of the pre-7.2 reproductions. It is the defect that makes the same symptom universal on current main / 7.2+. Closing #109656 solely on this change would over-claim. I am leaving the issue link as Related rather than Closes until someone confirms turn-2 skip (or identifies a separate pre-SQLite cause) on a pre-7.2 build or from the author's transcript evidence.

What still looks true from source:

1. Pre-#98236 JSONL scanner + marker write/read design are present on v2026.5.27 / v2026.6.11. I have not found a second definite bug in that JSONL scanner that would force reinjection when a valid `openclaw:bootstrap-context:full` marker is in the transcript tail.
2. On HEAD, the live path is SQLite-only for new sessions. The JSONL branch in `hasCompletedBootstrapTurn` remains for non-marker filesystem transcripts (tests / legacy paths) and is unchanged in behavior by this PR beyond sharing the scan helper.
3. The author's byte-identical `systemPrompt.chars` / `systemPrompt.hash` on turn 2 is real evidence that skip did not engage in those runs. Likely next checks for that era: whether the completion marker was actually appended to the JSONL transcript after turn 1, whether `contextInjection: "continuation-skip"` was the effective mode for that agent run, and whether `/context` / JSON `systemPrompt` is measuring the injected bootstrap set (not some other stable surface).

## Why This Change Was Made

The write side already persists the `openclaw:bootstrap-context:full` custom record into the SQLite transcript via `sessionManager.appendCustomEntry`, so only the read side was missing after the flip. `hasCompletedBootstrapTurn` now resolves `sqlite:` markers through `loadTranscriptEvents` and scans the bounded transcript tail with the same compaction-invalidation semantics as the JSONL path (a marker only counts if no compaction record follows it). The scan loop is shared between both paths. Any read failure still returns false, which falls back to full bootstrap injection, the safe direction.

## User Impact

`contextInjection: "continuation-skip"` works again on SQLite-backed sessions (all live sessions on current main). Continuation turns skip workspace bootstrap reinjection, so prompt prefixes stay stable and cacheable. Full-bootstrap turns, heartbeat runs, and post-compaction turns keep their current behavior. This does not by itself prove the pre-7.2 reports are fixed; those need separate confirmation.

## Evidence

### Unit (red then green)

Red first: with the new tests and the previous `hasCompletedBootstrapTurn` implementation checked out from main, the two positive SQLite tests fail.

```
$ git checkout origin/main -- src/agents/bootstrap-files.ts
$ npx vitest run src/agents/bootstrap-files.test.ts --project agents-core -t "SQLite"
- Expected
+ Received
- true
+ false
 > src/agents/bootstrap-files.test.ts:611:58
 Test Files  1 failed (1)
      Tests  2 failed | 3 passed | 39 skipped (44)
```

Green with the fix (Node 24.18.0, Windows 11):

```
$ npx vitest run src/agents/bootstrap-files.test.ts
 Test Files  2 failed (2)
      Tests  2 failed | 86 passed (88)
```

The 2 remaining failures are the pre-existing "returns false for symbolic links" test, which fails at test setup (`fs.symlink` EPERM) on Windows without symlink privileges; that test is untouched by this diff and fails identically at origin/main on this machine.

`pnpm check` (typecheck, oxlint, oxfmt, policy guards, import cycle check) exits 0, and `pnpm build` exits 0.

### Live two-turn SQLite session on tip `a37dc4208b` (2026-07-21 later re-proof)

Isolated `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH` with `agents.defaults.contextInjection: "continuation-skip"`. Empty workspace seeded by `ensureAgentWorkspace` (templates + pending `BOOTSTRAP.md`). Embedded runner via `openclaw agent --local --json` on tip `a37dc4208b`. Model: `mistral/mistral-small-latest`. Same session id `proof-109656-live5` across turns.

| Turn | projectContextChars | injectedWorkspaceFiles | hasCompletedBootstrapTurn | bootstrapPending |
| --- | ---: | ---: | --- | --- |
| 1 | 15752 | 7 (incl. BOOTSTRAP.md) | true after turn | true |
| 2 (after setup complete) | 0 | 0 | true | false |

Session marker shape (paths redacted): `sqlite:main:proof-109656-live5:.../sessions.json`

Turn 1:

```
reply: TURN1_OK
systemPrompt.chars: 34132
systemPrompt.hash: d9adc1b7fd98cad0070a2d09bff06c7cdc30b89639fc46b039df238ce392a3c2
systemPrompt.projectContextChars: 15752
injectedWorkspaceFiles: AGENTS/SOUL/TOOLS/IDENTITY/USER/HEARTBEAT/BOOTSTRAP
promptTokens: 29127
```

Between turns: deleted pending `BOOTSTRAP.md` and stamped `setupCompletedAt`. Pending bootstrap keeps `bootstrapMode: "full"` until setup is done; continuation-skip only engages once setup is complete and a marker already exists.

Turn 2:

```
reply: TURN2_OK
systemPrompt.chars: 17560
systemPrompt.hash: 35cb7cce6c0126a04dbf8860d34d0543e55829e2ac819d38186dab4d7e16440a
systemPrompt.projectContextChars: 0
injectedWorkspaceFiles: []
promptTokens: 25174
```

Harness note: an earlier tip re-run with custom stub workspace files did not keep BOOTSTRAP pending (`reconcileWorkspaceBootstrapCompletionState` treated the profile as configured and removed BOOTSTRAP before injection), so the marker was never written. The table above is the clean tip A/B after fixing the harness.

### Earlier live two-turn on fix commit `4b3d61cebb` (2026-07-21, Windows 11, Node v24.15.0)

Isolated `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH` with `agents.defaults.contextInjection: "continuation-skip"`. Embedded runner via `openclaw agent --local --json` on this PR head (`4b3d61cebb`). Model: `mistral/mistral-small-latest` (no Telegram / Vertex / gateway). Same `sessionKey` across turns.

Session file marker shape (paths redacted):

```
sqlite:main:64cf1fc5-ce2a-4829-8cd5-559947a1facb:<state>/agents/main/sessions/sessions.json
```

Turn 1 (workspace bootstrap still pending, so `bootstrapMode: "full"` records the completion marker):

```
finalAssistantVisibleText: TURN1_OK
systemPrompt.chars: 22997
systemPrompt.hash: 2cf33cb8d338a4f34aeff2cd414e91962bb23f09ed1cbb28f215c82c9af7ee84
systemPrompt.projectContextChars: 4879
injectedWorkspaceFiles: 7 (AGENTS/SOUL/TOOLS/IDENTITY/USER/HEARTBEAT/BOOTSTRAP)
promptTokens: 26685
```

Transcript after turn 1 contains `customType: "openclaw:bootstrap-context:full"` (seq 6).

Between turns, workspace setup was completed (removed pending `BOOTSTRAP.md` and stamped `setup_completed_at`). Pending bootstrap forces `bootstrapMode: "full"`, which intentionally keeps reinjection until setup is done; continuation-skip only engages once setup is complete and a marker already exists.

Turn 2 (same SQLite session, after setup complete):

```
finalAssistantVisibleText: TURN2_OK
systemPrompt.chars: 17303   (delta -5694)
systemPrompt.hash: 9ffa4ab22997203ef97a689e470292b83c430b93cd7c4457e1740ecf15f50d68
systemPrompt.projectContextChars: 0   (delta -4879)
injectedWorkspaceFiles: []   (0 files)
promptTokens: 25198
```

No additional `openclaw:bootstrap-context:full` marker was written on turn 2. Post-run probe with the same `sqlite:` marker:

```
hasCompletedBootstrapTurn => true
loadTranscriptEvents eventCount includes the turn-1 full-bootstrap custom record
```

Version / history checks for this framing (no fabrication):

- `#98236` = `0a8e3604ba` introduces `if (parseSqliteSessionFileMarker(sessionFile)) return false;` in `hasCompletedBootstrapTurn`
- that commit is first contained in `v2026.7.2-beta.1`, not in `v2026.5.27`, `v2026.6.11`, or `v2026.7.1`
- tagged `v2026.5.27` / `v2026.6.11` `bootstrap-files.ts` only has the JSONL `lstat` + tail scan path

