### PR TITLE
fix(msteams): release failed Graph collection bodies

### DIFF
--- a/extensions/msteams/src/attachments.graph.test.ts
+++ b/extensions/msteams/src/attachments.graph.test.ts
@@ -148,6 +148,27 @@ const createJsonResponse = (payload: unknown, status = 200) =>
   new Response(JSON.stringify(payload), { status });
 const createGraphCollectionResponse = (value: unknown[]) => createJsonResponse({ value });
 const createNotFoundResponse = () => new Response("not found", { status: 404 });
+function cancelTrackedResponse(
+  text: string,
+  init: ResponseInit,
+): {
+  response: Response;
+  wasCanceled: () => boolean;
+} {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, init),
+    wasCanceled: () => canceled,
+  };
+}
 const createRedirectResponse = (location: string, status = 302) =>
   new Response(null, { status, headers: { location } });
 const asFetchFn = (fetchFn: unknown): FetchFn => fetchFn as FetchFn;
@@ -323,6 +344,32 @@ describe("msteams graph attachments", () => {
   });
 
   it.each<GraphMediaSuccessCase>(GRAPH_MEDIA_SUCCESS_CASES)("$label", runGraphMediaSuccessCase);
+
+  it("cancels non-OK Graph collection bodies before returning empty hosted content", async () => {
+    const tracked = cancelTrackedResponse("missing hosted contents", { status: 404 });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = resolveRequestUrl(input);
+      if (url === DEFAULT_MESSAGE_URL) {
+        return createJsonResponse({ attachments: [] });
+      }
+      if (url === `${DEFAULT_MESSAGE_URL}/hostedContents`) {
+        return tracked.response;
+      }
+      return createNotFoundResponse();
+    });
+
+    const media = await downloadMSTeamsGraphMedia({
+      messageUrl: DEFAULT_MESSAGE_URL,
+      tokenProvider: createTokenProvider(),
+      maxBytes: DEFAULT_MAX_BYTES,
+      fetchFn: asFetchFn(fetchMock),
+      resolveFn: resolvePublicHost,
+    });
+
+    expect(media.media).toEqual([]);
+    expect(media.hostedStatus).toBe(404);
+    expect(tracked.wasCanceled()).toBe(true);
+  });
 
   it("does not forward Authorization for SharePoint redirects outside auth allowlist", async () => {
     const tokenProvider = createTokenProvider("top-secret-token");

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -120,6 +120,7 @@ async function fetchGraphCollection(params: {
   try {
     const status = response.status;
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       return { status, items: [] };
     }
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MS Teams Graph hosted-content collection lookups could leave a non-OK response body open while falling back to an empty media result.

## Why This Change Was Made

The Graph collection fallback behavior is unchanged: non-OK collection responses still produce an empty item list with the observed status. The fallback branch now cancels any response body before returning.

## User Impact

MS Teams media handling keeps skipping unavailable hosted-content collections while releasing failed Graph collection response streams promptly.

## Evidence

- Native-network production boundary: a temporary Vitest proof harness imported the real `downloadMSTeamsGraphMedia` entrypoint and used Node's native `fetch` against `https://graph.microsoft.com`. DNS was pinned to a contemporaneously resolved public Microsoft Graph address because this runner uses an RFC 2544 fake-IP proxy; the HTTP responses and bodies were not mocked.
- The harness used an intentionally invalid redacted bearer value, observed real `401` responses from both the message and `/hostedContents` endpoints through Undici diagnostics, and counted the production fallback's `ReadableStream.cancel()` call.
- `node scripts/run-vitest.mjs extensions/msteams/src/attachments.graph.test.ts -- -t "cancels non-OK Graph collection bodies"`
- `node scripts/run-vitest.mjs extensions/msteams/src/attachments.graph.test.ts`

```text
$ pnpm vitest run extensions/msteams/src/proof-native-fetch.test.ts --reporter=verbose
transport: native fetch to graph.microsoft.com
responses:
  - GET /v1.0/chats/[proof]/messages/[proof] -> 401, body present
  - GET /v1.0/chats/[proof]/messages/[proof]/hostedContents -> 401, body present
cancelCalls: 1
mediaCount: 0
hostedStatus: 401
Test Files  1 passed (1)
Tests       1 passed (1)
```

<details>
<summary>Native-fetch proof method</summary>

```ts
import { channel } from "node:diagnostics_channel";
import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
import { downloadMSTeamsGraphMedia } from "./extensions/msteams/src/attachments/graph.ts";

const responses = [];
let cancelCalls = 0;
const originalCancel = ReadableStream.prototype.cancel;
ReadableStream.prototype.cancel = function (...args) {
  cancelCalls += 1;
  return originalCancel.apply(this, args);
};

// The runner resolves public hosts into an RFC 2544 proxy range. Pin only DNS
// validation to a public Graph address resolved immediately before the run.
const dnsPin = mockPinnedHostnameResolution(["[current public Graph IPv4]"]);
const responseChannel = channel("undici:request:headers");
responseChannel.subscribe((event) => {
  responses.push({
    url: `${event.request.origin}${event.request.path}`,
    status: event.response.statusCode,
  });
});

const result = await downloadMSTeamsGraphMedia({
  messageUrl:
    "https://graph.microsoft.com/v1.0/chats/openclaw-proof/messages/openclaw-proof",
  tokenProvider: { getAccessToken: async () => "[redacted invalid proof token]" },
  maxBytes: 1024,
});

console.log({ responses, cancelCalls, mediaCount: result.media.length });
```

</details>

AI-assisted: built with Codex
