### PR TITLE
fix(bedrock): avoid replaying partial thinking signatures

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -52,6 +52,15 @@ async function* streamEvents(events: unknown[]) {
   }
 }
 
+function thinkingBlocks(message: { content?: unknown[] }) {
+  return (message.content ?? []).filter(
+    (block): block is { type: "thinking"; thinking?: string; thinkingSignature?: string } =>
+      Boolean(block) &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "thinking",
+  );
+}
+
 async function captureClientRegion(
   model: Parameters<typeof streamBedrock>[0],
   options: Parameters<typeof streamBedrock>[2] = {},
@@ -214,6 +223,157 @@ describe("Bedrock reasoning replay", () => {
     );
 
     expect(messages).toEqual([]);
+  });
+});
+
+describe("Bedrock reasoning stream ingest", () => {
+  const model = () =>
+    bedrockModel({
+      id: "us.anthropic.claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    });
+
+  it("commits streamed reasoning signatures only after the content block stops", async () => {
+    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { text: "step by step" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { signature: "chunk1" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { signature: "chunk2" } },
+          },
+        },
+        { contentBlockStop: { contentBlockIndex: 0 } },
+        { messageStop: { stopReason: BedrockStopReason.END_TURN } },
+      ]),
+    } as never);
+
+    const result = await streamBedrock(model(), {
+      messages: [{ role: "user", content: "Think.", timestamp: 0 }],
+    } as never).result();
+
+    expect(thinkingBlocks(result)).toEqual([
+      { type: "thinking", thinking: "step by step", thinkingSignature: "chunk1chunk2" },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "the stream ends before contentBlockStop",
+      events: [
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { text: "partial reasoning" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { signature: "partial-signature" } },
+          },
+        },
+      ],
+      stopReason: "stop",
+    },
+    {
+      name: "the provider errors before contentBlockStop",
+      events: [
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { text: "partial reasoning" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { signature: "partial-signature" } },
+          },
+        },
+        {
+          validationException: Object.assign(new Error("Invalid signature in thinking block"), {
+            name: "ValidationException",
+          }),
+        },
+      ],
+      stopReason: "error",
+    },
+  ])("does not persist signature deltas when $name", async ({ events, stopReason }) => {
+    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents(events),
+    } as never);
+
+    const result = await streamBedrock(model(), {
+      messages: [{ role: "user", content: "Think.", timestamp: 0 }],
+    } as never).result();
+
+    expect(result.stopReason).toBe(stopReason);
+    expect(thinkingBlocks(result)).toEqual([
+      { type: "thinking", thinking: "partial reasoning", thinkingSignature: "" },
+    ]);
+  });
+
+  it("commits only stopped signatures across interleaved thinking blocks", async () => {
+    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { text: "first" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 1,
+            delta: { reasoningContent: { text: "second" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 1,
+            delta: { reasoningContent: { signature: "complete-second" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { reasoningContent: { signature: "partial-first" } },
+          },
+        },
+        { contentBlockStop: { contentBlockIndex: 1 } },
+      ]),
+    } as never);
+
+    const result = await streamBedrock(model(), {
+      messages: [{ role: "user", content: "Think.", timestamp: 0 }],
+    } as never).result();
+
+    expect(thinkingBlocks(result)).toEqual([
+      { type: "thinking", thinking: "first", thinkingSignature: "" },
+      { type: "thinking", thinking: "second", thinkingSignature: "complete-second" },
+    ]);
   });
 });
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -75,6 +75,14 @@ import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";
 type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
 type BedrockEventSink = { push(event: AssistantMessageEvent): void };
 
+function clearStreamingScratch(blocks: Array<TextContent | ThinkingContent | ToolCall>): void {
+  for (const block of blocks) {
+    delete (block as Block).index;
+    // partialJson is only a streaming scratch buffer; never persist it.
+    delete (block as Block).partialJson;
+  }
+}
+
 function usesClaudeFable5BedrockContract(model: Model<"bedrock-converse-stream">): boolean {
   return resolveClaudeFable5ModelIdentity(model) !== undefined;
 }
@@ -280,6 +288,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
       }
 
       let sawMessageStop = false;
+      // Bedrock emits reasoning signature bytes before the content-block
+      // lifecycle proves they are complete. Keep partial bytes out of the
+      // replay-visible output until contentBlockStop commits them.
+      const pendingThinkingSignatures = new Map<number, string>();
       for await (const item of response.stream!) {
         if (item.messageStart) {
           if (item.messageStart.role !== ConversationRole.ASSISTANT) {
@@ -291,9 +303,21 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
         } else if (item.contentBlockStart) {
           handleContentBlockStart(item.contentBlockStart, blocks, output, eventSink);
         } else if (item.contentBlockDelta) {
-          handleContentBlockDelta(item.contentBlockDelta, blocks, output, eventSink);
+          handleContentBlockDelta(
+            item.contentBlockDelta,
+            blocks,
+            output,
+            eventSink,
+            pendingThinkingSignatures,
+          );
         } else if (item.contentBlockStop) {
-          handleContentBlockStop(item.contentBlockStop, blocks, output, eventSink);
+          handleContentBlockStop(
+            item.contentBlockStop,
+            blocks,
+            output,
+            eventSink,
+            pendingThinkingSignatures,
+          );
         } else if (item.messageStop) {
           sawMessageStop = true;
           if ((item.messageStop.stopReason as string | undefined) === "refusal") {
@@ -336,14 +360,11 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
       }
 
       refusalBuffer?.flush();
+      clearStreamingScratch(output.content);
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();
     } catch (error) {
-      for (const block of output.content) {
-        delete (block as Block).index;
-        // partialJson is only a streaming scratch buffer; never persist it.
-        delete (block as Block).partialJson;
-      }
+      clearStreamingScratch(output.content);
       if (refusalBuffer) {
         refusalBuffer.discard();
         output.content = [];
@@ -499,6 +520,7 @@ function handleContentBlockDelta(
   blocks: Block[],
   output: AssistantMessage,
   stream: BedrockEventSink,
+  pendingThinkingSignatures: Map<number, string>,
 ): void {
   const contentBlockIndex = event.contentBlockIndex!;
   const delta = event.delta;
@@ -555,8 +577,16 @@ function handleContentBlockDelta(
         });
       }
       if (delta.reasoningContent.signature) {
-        thinkingBlock.thinkingSignature =
-          (thinkingBlock.thinkingSignature || "") + delta.reasoningContent.signature;
+        const pendingSignature = pendingThinkingSignatures.get(contentBlockIndex);
+        if (pendingSignature === undefined) {
+          thinkingBlock.thinkingSignature = "";
+          pendingThinkingSignatures.set(contentBlockIndex, delta.reasoningContent.signature);
+        } else {
+          pendingThinkingSignatures.set(
+            contentBlockIndex,
+            pendingSignature + delta.reasoningContent.signature,
+          );
+        }
       }
     }
   }
@@ -582,8 +612,15 @@ function handleContentBlockStop(
   blocks: Block[],
   output: AssistantMessage,
   stream: BedrockEventSink,
+  pendingThinkingSignatures: Map<number, string>,
 ): void {
-  const index = blocks.findIndex((b) => b.index === event.contentBlockIndex);
+  const contentBlockIndex = event.contentBlockIndex;
+  const pendingSignature =
+    contentBlockIndex === undefined ? undefined : pendingThinkingSignatures.get(contentBlockIndex);
+  if (contentBlockIndex !== undefined) {
+    pendingThinkingSignatures.delete(contentBlockIndex);
+  }
+  const index = blocks.findIndex((b) => b.index === contentBlockIndex);
   const block = blocks[index];
   if (!block) {
     return;
@@ -595,6 +632,9 @@ function handleContentBlockStop(
       stream.push({ type: "text_end", contentIndex: index, content: block.text, partial: output });
       break;
     case "thinking":
+      if (pendingSignature !== undefined) {
+        block.thinkingSignature = pendingSignature;
+      }
       stream.push({
         type: "thinking_end",
         contentIndex: index,


### PR DESCRIPTION
Refs #109881

This PR partially addresses #109881 by preventing newly interrupted Bedrock thinking streams from persisting incomplete signatures. It intentionally does not close the broader issue because live full-signature rejection handling and recovery for already-poisoned sessions remain separate work.

## What Problem This Solves

Partially addresses an issue where users running Amazon Bedrock Claude 4+ or newer models with extended thinking could persist a partial streamed thinking signature if the Bedrock Converse stream ended or failed before the reasoning content block completed. That partial signature could later be replayed and rejected by Bedrock as an invalid thinking signature, leaving the session unable to continue until reset.

## Why This Change Was Made

Bedrock reasoning signature deltas are opaque and only safe to replay once the corresponding `contentBlockStop` arrives. The Bedrock stream runtime now stages signature deltas by content block index, clears the replay-visible signature while staging, and commits the staged signature only at `contentBlockStop`. It also strips transient streaming indexes from successful partial results so interrupted output cannot leak runtime-only bookkeeping into transcript content.

Existing invalid-thinking replay recovery remains responsible for sessions already poisoned by older output; this change prevents new Bedrock streams from persisting incomplete signature bytes in the first place.

## User Impact

Bedrock Claude sessions that hit an interrupted or failed thinking stream are less likely to poison future replay state. Completed thinking signatures are preserved byte-for-byte for normal Bedrock replay, while incomplete signatures are left blank and are not sent back as native signed reasoning.

## Evidence

Targeted regression test:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs extensions/amazon-bedrock/stream.runtime.test.ts

Test Files  1 passed (1)
Tests  48 passed (48)
```

Expanded plugin test suite:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs extensions/amazon-bedrock

Test Files  9 passed (9)
Tests  171 passed (171)
```

Formatter and whitespace sanity:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH pnpm format extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts
git diff --check
```

Attempted broader changed-code gate:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/check-changed.mjs -- extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts
```

This delegated to the remote changed-code runner but could not run because the local runner binary failed its basic sanity check:

```text
[crabbox] selected binary failed basic --version/--help sanity checks
```

## Real behavior proof

**Behavior addressed:** Bedrock Converse reasoning signature deltas are no longer persisted into replay-visible thinking blocks until the matching `contentBlockStop` has arrived.

**Environment tested:** Linux source checkout, Node 24.16.0, local `@aws-sdk/client-bedrock-runtime@3.1078.0`, patched `extensions/amazon-bedrock/stream.runtime.ts` imported directly through `node --import tsx`.

**Steps run after the patch:** Called the actual patched `streamBedrock` production function with an interleaved Bedrock reasoning stream where block 0 receives a signature delta but never stops, while block 1 receives a signature delta and stops.

**Evidence after fix:** Command and output from the patched source path:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node --import tsx --no-warnings --input-type=module <<'NODE_PROOF'
import { BedrockRuntimeClient, ConversationRole } from '@aws-sdk/client-bedrock-runtime';
import { streamBedrock } from './extensions/amazon-bedrock/stream.runtime.ts';

BedrockRuntimeClient.prototype.send = async () => ({
  $metadata: { httpStatusCode: 200 },
  stream: (async function* () {
    yield { messageStart: { role: ConversationRole.ASSISTANT } };
    yield { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'first' } } } };
    yield { contentBlockDelta: { contentBlockIndex: 1, delta: { reasoningContent: { text: 'second' } } } };
    yield { contentBlockDelta: { contentBlockIndex: 1, delta: { reasoningContent: { signature: 'complete-second' } } } };
    yield { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { signature: 'partial-first' } } } };
    yield { contentBlockStop: { contentBlockIndex: 1 } };
  })(),
});

const model = {
  api: 'bedrock-converse-stream',
  provider: 'amazon-bedrock',
  id: 'us.anthropic.claude-opus-4-8',
  name: 'Claude Opus 4.8',
  baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
  reasoning: true,
  input: ['text'],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 1000000,
  maxTokens: 128000,
};
const result = await streamBedrock(model, {
  messages: [{ role: 'user', content: 'Think.', timestamp: 0 }],
}).result();
console.log(JSON.stringify(result.content, null, 2));
NODE_PROOF

[
  {
    "type": "thinking",
    "thinking": "first",
    "thinkingSignature": ""
  },
  {
    "type": "thinking",
    "thinking": "second",
    "thinkingSignature": "complete-second"
  }
]
```

**Observed result after the fix:** The first block received `partial-first` but did not stop, so its persisted `thinkingSignature` stayed empty. The second block stopped and retained `complete-second`, proving completed signatures are still replayable while partial signatures are withheld.

**Not tested:** A live AWS Bedrock request with real Claude credentials was not run. The existing session-level invalid-thinking replay recovery was not re-tested here because this patch targets the Bedrock transport's creation-time signature persistence path.

