### PR TITLE
fix(acp): defer session snapshot update after newSession/resumeSession result

### DIFF
--- a/src/acp/translator.session-lifecycle.ts
+++ b/src/acp/translator.session-lifecycle.ts
@@ -84,11 +84,31 @@ export class AcpTranslatorSessionLifecycle {
     await this.sessionUpdates.startLedgerSession(session, { complete: true, reset: true });
     this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);
     const sessionSnapshot = await this.sessionState.getSnapshot(session.sessionKey);
+    // Pre-fetch available commands BEFORE arming the snapshot delivery timer.
+    // The lazy command-module import yields to the event loop; if that yield
+    // happens after the snapshot's setTimeout(0) is armed, the snapshot
+    // notification can overtake the session/new RPC response. Resolving
+    // commands first ensures no async yield occurs between arming the timer
+    // and returning the result.
+    const availableCommands = await this.sessionUpdates.prepareAvailableCommands();
+    // Defer notification delivery past the RPC response boundary so the client
+    // receives session/new result before session_info_update. The guard fences
+    // the deferred callback by the captured session instance: after close the
+    // store removes this object, and a resume with the same ID creates a new
+    // one, so the stale callback is suppressed instead of leaking.
+    const deliveryGuard = () => this.sessionStore.getSession(session.sessionId) === session;
     await this.sessionState.sendSnapshotUpdate(session, sessionSnapshot, {
       includeControls: false,
       record: true,
+      deferDelivery: true,
+      deliveryGuard,
     });
-    await this.sessionUpdates.sendAvailableCommands(session, { record: true });
+    await this.sessionUpdates.sendAvailableCommands(session, {
+      record: true,
+      deferDelivery: true,
+      deliveryGuard,
+      availableCommands,
+    });
     const { configOptions, modes } = sessionSnapshot;
     return {
       sessionId: session.sessionId,
@@ -244,11 +264,26 @@ export class AcpTranslatorSessionLifecycle {
     });
     await this.sessionUpdates.startLedgerSession(session, { complete: false });
     this.log(`resumeSession: ${session.sessionId} -> ${session.sessionKey}`);
+    // Pre-fetch commands before arming the snapshot timer (same invariant
+    // as newSession: the lazy import yield must not let the snapshot timer
+    // fire before the handler returns).
+    const availableCommands = await this.sessionUpdates.prepareAvailableCommands();
+    // Same deferred-delivery contract as newSession: the resume result must
+    // reach the client before session_info_update. Guard by the captured
+    // session instance to suppress stale callbacks after close-then-resume.
+    const deliveryGuard = () => this.sessionStore.getSession(session.sessionId) === session;
     await this.sessionState.sendSnapshotUpdate(session, sessionSnapshot, {
       includeControls: false,
       record: false,
+      deferDelivery: true,
+      deliveryGuard,
     });
-    await this.sessionUpdates.sendAvailableCommands(session, { record: false });
+    await this.sessionUpdates.sendAvailableCommands(session, {
+      record: false,
+      deferDelivery: true,
+      deliveryGuard,
+      availableCommands,
+    });
     const { configOptions, modes } = sessionSnapshot;
     return { configOptions, modes };
   }

--- a/src/acp/translator.session-ordering.command-yield.test.ts
+++ b/src/acp/translator.session-ordering.command-yield.test.ts
@@ -1,0 +1,52 @@
+/** Tests that a yielding command-module import cannot let the snapshot timer
+ * fire before the lifecycle RPC result is returned.
+ *
+ * The real getAvailableCommandsForAcp uses a lazy dynamic import that yields to
+ * the macrotask queue on first call. If commands are resolved AFTER arming the
+ * snapshot delivery timer, that yield lets the timer fire and send
+ * session_info_update before the session/new or session/resume response. This
+ * test injects a yielding stub to prove the pre-fetch fix holds. */
+import { createInMemorySessionStore } from "@openclaw/acp-core/session";
+import { describe, expect, it, vi } from "vitest";
+import { createNewSessionRequest, expectSessionUpdate } from "./translator.bridge-test-helpers.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+// Yield to the macrotask queue before returning, simulating the lazy
+// command-module dynamic-import yield that triggers the ordering race.
+vi.mock("./commands.js", () => ({
+  getAvailableCommands: async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    return [];
+  },
+}));
+
+async function flushTimers() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+describe("acp session ordering with delayed command discovery", () => {
+  it("newSession does not send session_info_update while command discovery yields", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection["__sessionUpdateMock"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(), {
+      sessionStore,
+    });
+
+    const result = await agent.newSession(createNewSessionRequest());
+
+    // The RPC result is available before any notification is delivered, even
+    // though command discovery yielded to the macrotask queue. Without the
+    // pre-fetch fix, the snapshot timer would fire during the yield.
+    expect(result.sessionId).toEqual(expect.any(String));
+    expect(sessionUpdate).not.toHaveBeenCalled();
+
+    await flushTimers();
+    expectSessionUpdate(sessionUpdate, result.sessionId, "session_info_update");
+  });
+});

--- a/src/acp/translator.session-ordering.test.ts
+++ b/src/acp/translator.session-ordering.test.ts
@@ -1,0 +1,195 @@
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+/** Tests deferred notification delivery ordering and close-then-resume identity guard. */
+import { createInMemorySessionStore } from "@openclaw/acp-core/session";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import type { AcpEventLedger } from "./event-ledger.js";
+import { createNewSessionRequest, expectSessionUpdate } from "./translator.bridge-test-helpers.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { AcpTranslatorSessionUpdates } from "./translator.session-updates.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+vi.mock("./commands.js", () => ({
+  getAvailableCommands: () => [],
+}));
+
+function createResumeSessionRequest(sessionId: string, cwd = "/tmp") {
+  return {
+    sessionId,
+    cwd,
+    mcpServers: [],
+    _meta: {},
+  } as never;
+}
+
+async function flushTimers() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+/** Gateway mock that returns a resumable session for sessions.list searches. */
+function createResumableGateway(): GatewayClient {
+  const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === "sessions.list") {
+      return {
+        ts: Date.now(),
+        path: "/tmp/sessions.json",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: typeof params?.search === "string" ? params.search : "agent:main:resumable",
+            label: "resumable",
+            displayName: "Resumable",
+            kind: "direct",
+            updatedAt: 1_710_000_000_000,
+            thinkingLevel: "adaptive",
+            modelProvider: "openai",
+            model: "gpt-5.4",
+          },
+        ],
+      };
+    }
+    return { ok: true };
+  }) as GatewayClient["request"];
+  return createAcpGateway(request);
+}
+
+describe("acp session notification ordering", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("newSession: response precedes session_info_update notification", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection["__sessionUpdateMock"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(), {
+      sessionStore,
+    });
+
+    const result = await agent.newSession(createNewSessionRequest());
+
+    expect(result.sessionId).toEqual(expect.any(String));
+    expect(sessionUpdate).not.toHaveBeenCalled();
+
+    await flushTimers();
+    expectSessionUpdate(sessionUpdate, result.sessionId, "session_info_update");
+    expectSessionUpdate(sessionUpdate, result.sessionId, "available_commands_update");
+  });
+
+  it("resumeSession: response precedes session_info_update notification", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection["__sessionUpdateMock"];
+    const agent = new AcpGatewayAgent(connection, createResumableGateway(), {
+      sessionStore,
+    });
+
+    const result = await agent.resumeSession(createResumeSessionRequest("agent:main:resumable"));
+
+    expect(result.modes).toBeDefined();
+    expect(sessionUpdate).not.toHaveBeenCalled();
+
+    await flushTimers();
+    expectSessionUpdate(sessionUpdate, "agent:main:resumable", "session_info_update");
+  });
+
+  it("newSession suppresses deferred notifications when closeSession runs before the timer fires", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection["__sessionUpdateMock"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(), {
+      sessionStore,
+    });
+
+    const result = await agent.newSession(createNewSessionRequest());
+    await agent.closeSession({ sessionId: result.sessionId } as never);
+
+    await flushTimers();
+    expect(sessionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("resumeSession suppresses deferred notifications when closeSession runs before the timer fires", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection["__sessionUpdateMock"];
+    const agent = new AcpGatewayAgent(connection, createResumableGateway(), {
+      sessionStore,
+    });
+
+    await agent.resumeSession(createResumeSessionRequest("agent:main:resumable"));
+    await agent.closeSession({ sessionId: "agent:main:resumable" } as never);
+
+    await flushTimers();
+    expect(sessionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not leak stale notifications from a closed session into a resumed session with the same ID", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection["__sessionUpdateMock"];
+    const agent = new AcpGatewayAgent(connection, createResumableGateway(), {
+      sessionStore,
+    });
+
+    // Resume arms a deferred callback, then close removes the session instance.
+    await agent.resumeSession(createResumeSessionRequest("agent:main:resumable"));
+    await agent.closeSession({ sessionId: "agent:main:resumable" } as never);
+
+    // Resume again with the same ID before the timer fires. The old callback's
+    // deliveryGuard compares against the captured (now-deleted) session instance
+    // and must suppress delivery; the new session's own callbacks deliver later.
+    await agent.resumeSession(createResumeSessionRequest("agent:main:resumable"));
+
+    await flushTimers();
+    // Exactly one session_info_update (from the new lifecycle), not two.
+    const infoUpdates = vi
+      .mocked(sessionUpdate)
+      .mock.calls.filter(
+        ([call]) =>
+          (call as { update: { sessionUpdate: string } }).update.sessionUpdate ===
+          "session_info_update",
+      );
+    expect(infoUpdates.length).toBe(1);
+  });
+});
+
+describe("acp session command discovery failure", () => {
+  it("emit with deferDelivery propagates command discovery failure to the caller", async () => {
+    // Unit-level proof: sendAvailableCommands awaits getAvailableCommands inside
+    // emit before deferring delivery, so a discovery failure rejects the caller's
+    // promise (newSession/resumeSession) rather than being swallowed.
+    const failingCommands = vi.fn(async () => {
+      throw new Error("command discovery unavailable");
+    });
+    const updates = new AcpTranslatorSessionUpdates({
+      connection: {
+        sessionUpdate: vi.fn(async () => {}),
+      } as Pick<AgentSideConnection, "sessionUpdate">,
+      eventLedger: createLedger(),
+      getAvailableCommands: failingCommands,
+      log: () => {},
+    });
+
+    await expect(
+      updates.sendAvailableCommands(
+        { sessionId: "session-1", sessionKey: "agent:main:session-1" },
+        { record: true, deferDelivery: true, deliveryGuard: () => true },
+      ),
+    ).rejects.toThrow(/command discovery unavailable/);
+  });
+});
+
+function createLedger(): AcpEventLedger {
+  return {
+    startSession: vi.fn(async () => {}),
+    recordUserPrompt: vi.fn(async () => {}),
+    recordUpdate: vi.fn(async () => {}),
+    markIncomplete: vi.fn(async () => {}),
+    readReplay: vi.fn(async () => ({ complete: true, events: [] })),
+    readReplayBySessionId: vi.fn(async () => ({ complete: true, events: [] })),
+    readReplayBySessionKey: vi.fn(async () => ({ complete: true, events: [] })),
+  };
+}

--- a/src/acp/translator.session-ordering.transport-proof.test.ts
+++ b/src/acp/translator.session-ordering.transport-proof.test.ts
@@ -1,0 +1,90 @@
+import { PassThrough, Readable, Writable } from "node:stream";
+import {
+  AgentSideConnection,
+  ClientSideConnection,
+  PROTOCOL_VERSION,
+  ndJsonStream,
+} from "@agentclientprotocol/sdk";
+/** Boundary-level transport proof: uses real ACP SDK transport
+ * (AgentSideConnection + ClientSideConnection + ndJsonStream over PassThrough
+ * streams) with a mock Gateway to prove the JSON-RPC response reaches the wire
+ * before any session/update notification. */
+import { createInMemorySessionStore } from "@openclaw/acp-core/session";
+import { describe, expect, it, vi } from "vitest";
+import { AcpGatewayAgent } from "./translator.js";
+import { createAcpGateway } from "./translator.test-helpers.js";
+
+vi.mock("./commands.js", () => ({
+  getAvailableCommands: () => [],
+}));
+
+describe("acp session ordering transport proof", () => {
+  it("newSession response precedes session/update notification over real ACP transport", async () => {
+    const agentToClient = new PassThrough();
+    const clientToAgent = new PassThrough();
+
+    const agentStream = ndJsonStream(
+      Writable.toWeb(agentToClient),
+      Readable.toWeb(clientToAgent) as ReadableStream<Uint8Array>,
+    );
+    const clientStream = ndJsonStream(
+      Writable.toWeb(clientToAgent),
+      Readable.toWeb(agentToClient) as ReadableStream<Uint8Array>,
+    );
+
+    const sessionStore = createInMemorySessionStore();
+    let agent: AcpGatewayAgent;
+    const connection = new AgentSideConnection(
+      ((conn: AgentSideConnection) => {
+        agent = new AcpGatewayAgent(conn, createAcpGateway(), { sessionStore });
+        agent.start();
+        return agent;
+      }) as () => AcpGatewayAgent,
+      agentStream,
+    );
+    void connection;
+
+    const events: string[] = [];
+    const client = new ClientSideConnection(
+      () => ({
+        sessionUpdate: async () => {
+          events.push("notification");
+        },
+        requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+      }),
+      clientStream,
+    );
+
+    await client.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+      },
+      clientInfo: { name: "transport-proof-client", version: "1.0.0" },
+    });
+
+    await client.newSession({
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: {},
+    });
+    events.push("response");
+
+    // The response must arrive before any notification.
+    expect(events[0]).toBe("response");
+
+    // Allow deferred notifications to fire.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+
+    expect(events).toContain("notification");
+    expect(events.indexOf("response")).toBeLessThan(events.indexOf("notification"));
+
+    // Clean up.
+    agent!.shutdown();
+    agentToClient.destroy();
+    clientToAgent.destroy();
+  });
+});

--- a/src/acp/translator.session-state.ts
+++ b/src/acp/translator.session-state.ts
@@ -82,8 +82,18 @@ export class AcpTranslatorSessionState {
   async sendSnapshotUpdate(
     session: { sessionId: string; sessionKey: string; ledgerSessionId?: string },
     sessionSnapshot: SessionSnapshot,
-    options: { includeControls: boolean; record: boolean; runId?: string },
+    options: {
+      includeControls: boolean;
+      record: boolean;
+      runId?: string;
+      deferDelivery?: boolean;
+      deliveryGuard?: () => boolean;
+    },
   ): Promise<void> {
+    const deliveryOptions = {
+      ...(options.deferDelivery ? { deferDelivery: true } : {}),
+      ...(options.deliveryGuard ? { deliveryGuard: options.deliveryGuard } : {}),
+    };
     if (options.includeControls) {
       await this.sessionUpdates.emit({
         sessionId: session.sessionId,
@@ -91,6 +101,7 @@ export class AcpTranslatorSessionState {
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
         runId: options.runId,
         record: options.record,
+        ...deliveryOptions,
         update: {
           sessionUpdate: "current_mode_update",
           currentModeId: sessionSnapshot.modes.currentModeId,
@@ -102,6 +113,7 @@ export class AcpTranslatorSessionState {
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
         runId: options.runId,
         record: options.record,
+        ...deliveryOptions,
         update: {
           sessionUpdate: "config_option_update",
           configOptions: sessionSnapshot.configOptions,
@@ -115,6 +127,7 @@ export class AcpTranslatorSessionState {
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
         runId: options.runId,
         record: options.record,
+        ...deliveryOptions,
         update: {
           sessionUpdate: "session_info_update",
           ...sessionSnapshot.metadata,
@@ -128,6 +141,7 @@ export class AcpTranslatorSessionState {
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
         runId: options.runId,
         record: options.record,
+        ...deliveryOptions,
         update: {
           sessionUpdate: "usage_update",
           used: sessionSnapshot.usage.used,

--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -43,6 +43,14 @@ export class AcpTranslatorSessionUpdates {
     this.stopped = true;
   }
 
+  /** Pre-fetches available commands so callers can resolve them before arming
+  deferred delivery timers. The lazy command-module import yields to the
+  event loop; if that yield happens after a snapshot timer is armed, the
+  snapshot notification can overtake the RPC response. */
+  prepareAvailableCommands(): Promise<AvailableCommand[]> {
+    return this.options.getAvailableCommands();
+  }
+
   async startLedgerSession(
     session: AcpTranslatorLedgerSessionRef,
     options: { complete: boolean; reset?: boolean },
@@ -139,8 +147,44 @@ export class AcpTranslatorSessionUpdates {
     update: SessionUpdate;
     record?: boolean;
     waitForDelivery?: boolean;
+    // Defer only the wire delivery past the current synchronous return so the
+    // caller's JSON-RPC result reaches the client before this notification.
+    // The ledger write is still awaited before emit resolves, so follow-up
+    // reads see the recorded update immediately. The guard fences the deferred
+    // callback against a close-then-resume-same-ID race: if the captured
+    // session instance no longer matches the store's current instance, the
+    // notification is suppressed instead of leaking into a new lifecycle.
+    deferDelivery?: boolean;
+    deliveryGuard?: () => boolean;
   }): Promise<void> {
     if (this.stopped) {
+      return;
+    }
+    if (params.deferDelivery) {
+      const recording =
+        params.record && params.sessionKey
+          ? this.recordLedgerUpdate({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
+              ...(params.runId ? { runId: params.runId } : {}),
+              update: params.update,
+            })
+          : undefined;
+      await recording;
+      const guard = params.deliveryGuard;
+      setTimeout(() => {
+        if (this.stopped || (guard && !guard())) {
+          return;
+        }
+        void this.options.connection
+          .sessionUpdate({ sessionId: params.sessionId, update: params.update })
+          .catch((err: unknown) => {
+            this.options.log(
+              `session update delivery failed for ${params.sessionId}: ${String(err)}`,
+            );
+          });
+      }, 0);
       return;
     }
     const delivery = this.options.connection.sessionUpdate({
@@ -169,16 +213,25 @@ export class AcpTranslatorSessionUpdates {
 
   async sendAvailableCommands(
     session: AcpTranslatorSessionRef,
-    options: { record: boolean },
+    options: {
+      record: boolean;
+      deferDelivery?: boolean;
+      deliveryGuard?: () => boolean;
+      availableCommands?: AvailableCommand[];
+    },
   ): Promise<void> {
+    const availableCommands =
+      options.availableCommands ?? (await this.options.getAvailableCommands());
     await this.emit({
       sessionId: session.sessionId,
       sessionKey: session.sessionKey,
       ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
       record: options.record,
+      deferDelivery: options.deferDelivery,
+      ...(options.deliveryGuard ? { deliveryGuard: options.deliveryGuard } : {}),
       update: {
         sessionUpdate: "available_commands_update",
-        availableCommands: await this.options.getAvailableCommands(),
+        availableCommands,
       },
     });
   }


### PR DESCRIPTION
## What Problem This Solves

ACP clients could receive `session_info_update` and `available_commands_update` notifications before the `session/new` or `session/resume` JSON-RPC response, causing the client to observe incomplete session state on the wire. The deferred notifications could also fire after `session/close` completed, sending stale notifications for sessions the client had already closed.

Root causes:
1. `newSession` and `resumeSession` in `translator.session-lifecycle.ts` awaited snapshot and command delivery before returning the RPC result, so the notification could reach the wire before the response.
2. Even with deferred delivery via `setTimeout(0)`, the snapshot timer was armed before command discovery completed. The lazy command-module dynamic import yields to the event loop; during that yield, the snapshot timer could fire and deliver `session_info_update` before the handler returned.
3. The prior `hasSession`-based guard was not identity-safe: after close, a client could resume the same session ID before the timer fired, and the old callback would pass the guard and emit its stale snapshot into the replacement lifecycle.

This is a reimplementation of PR #109973 on the refactored session lifecycle owner (PR #120941 split `translator.ts` into `session-lifecycle` / `session-state` / `session-updates` modules).

Related to #109973

## Why This Change Was Made

`setTimeout(0)` defers initial lifecycle notification delivery past the synchronous handler return and response serialization, establishing a deterministic event-loop boundary that guarantees the JSON-RPC result reaches the wire before any notification. The ledger write is still awaited before `emit` resolves, so follow-up reads see the recorded update immediately.

Available commands are pre-fetched via `prepareAvailableCommands()` BEFORE arming the snapshot delivery timer, so the lazy command-module import yield cannot let the snapshot timer fire while the handler is still pending.

A captured-session identity guard at the top of each deferred callback skips stale notifications when `closeSession` has removed the session instance, closing the close-then-resume-same-ID race window.

Command-discovery failures propagate naturally: `prepareAvailableCommands()` awaits `getAvailableCommands` before any timer is armed, so a discovery error rejects the `newSession`/`resumeSession` promise rather than being swallowed.

Changes:
1. **`src/acp/translator.session-updates.ts`** — `emit()` gains `deferDelivery` and `deliveryGuard` options. When `deferDelivery` is set, the ledger record is awaited first, then wire delivery is scheduled via `setTimeout(0)` with the guard checked before sending. New `prepareAvailableCommands()` method exposes the command provider for pre-fetching. `sendAvailableCommands` accepts an optional `availableCommands` parameter to skip internal re-fetch.
2. **`src/acp/translator.session-state.ts`** — `sendSnapshotUpdate` accepts and forwards `deferDelivery` / `deliveryGuard` to each underlying `emit` call.
3. **`src/acp/translator.session-lifecycle.ts`** — `newSession` and `resumeSession` pre-fetch commands before arming the snapshot timer, then pass `deferDelivery: true` with a `deliveryGuard` that compares the captured session object reference against the store's current instance.
4. **`src/acp/translator.session-ordering.test.ts`** — 6 regression tests: ordering, close-before-timer suppression, close-then-resume-same-ID identity guard, command-discovery failure propagation.
5. **`src/acp/translator.session-ordering.command-yield.test.ts`** — Proves that a yielding command-module import (simulated via `setTimeout(0)` inside `getAvailableCommands`) cannot let the snapshot timer fire before the RPC result.
6. **`src/acp/translator.session-ordering.transport-proof.test.ts`** — Boundary-level proof using real ACP SDK transport (`AgentSideConnection` + `ClientSideConnection` + `ndJsonStream` over `PassThrough` streams) with a mock Gateway. Asserts the `session/new` response arrives before any `session/update` notification over the real wire.

## User Impact

ACP clients can now rely on receiving the `session/new` and `session/resume` JSON-RPC result before any `session/update` notification over the wire, and will no longer receive stale notifications for sessions they have already closed. No user-visible API or response shape changes.

## Evidence

### Changed files

- `src/acp/translator.session-updates.ts` — `emit()` defer path + `prepareAvailableCommands()` + `sendAvailableCommands` with `availableCommands` option
- `src/acp/translator.session-state.ts` — `sendSnapshotUpdate` forwards `deferDelivery` / `deliveryGuard`
- `src/acp/translator.session-lifecycle.ts` — `newSession`/`resumeSession` pre-fetch commands, then defer delivery with captured-session guard
- `src/acp/translator.session-ordering.test.ts` — 6 ordering/regression tests
- `src/acp/translator.session-ordering.command-yield.test.ts` — delayed command-discovery ordering proof
- `src/acp/translator.session-ordering.transport-proof.test.ts` — real ACP transport ordering proof

### Test results

```console
$ git diff --stat HEAD~1 HEAD
 src/acp/translator.session-lifecycle.ts                     | 37 +++-
 src/acp/translator.session-ordering.command-yield.test.ts   |  60 +++++
 src/acp/translator.session-ordering.test.ts                 | 205 +++++++++++++++++
 src/acp/translator.session-ordering.transport-proof.test.ts |  99 ++++++++
 src/acp/translator.session-state.ts                         |  16 +-
 src/acp/translator.session-updates.ts                       |  56 +++-
 6 files changed, 467 insertions(+), 6 deletions(-)

$ node scripts/run-vitest.mjs src/acp/translator.session-ordering.test.ts src/acp/translator.session-ordering.command-yield.test.ts src/acp/translator.session-ordering.transport-proof.test.ts src/acp/translator.session-updates.test.ts src/acp/translator.session-setup.test.ts src/acp/translator.session-snapshot.test.ts

 ✓ |unit-fast-isolated| src/acp/translator.session-snapshot.test.ts (2 tests) 22ms
 ✓ |unit-fast-isolated| src/acp/translator.session-setup.test.ts (6 tests) 29ms

 Test Files  2 passed (2)
      Tests  8 passed (8)

 ✓ |acp| src/acp/translator.session-updates.test.ts (4 tests) 150ms
 ✓ |acp| src/acp/translator.session-ordering.test.ts (6 tests) 25ms
 ✓ |acp| src/acp/translator.session-ordering.transport-proof.test.ts (1 test) 88ms
      ✓ newSession response precedes session/update notification over real ACP transport
 ✓ |acp| src/acp/translator.session-ordering.command-yield.test.ts (1 test) 6ms
      ✓ newSession does not send session_info_update while command discovery yields

 Test Files  4 passed (4)
      Tests  12 passed (12)
```

```console
$ node_modules/.bin/oxlint src/acp/translator.session-updates.ts src/acp/translator.session-state.ts src/acp/translator.session-lifecycle.ts src/acp/translator.session-ordering.test.ts src/acp/translator.session-ordering.command-yield.test.ts src/acp/translator.session-ordering.transport-proof.test.ts
Found 0 warnings and 0 errors.
Finished in 17ms on 6 files with 212 rules using 8 threads.

$ node_modules/.bin/oxfmt --check src/acp/translator.session-updates.ts src/acp/translator.session-state.ts src/acp/translator.session-lifecycle.ts src/acp/translator.session-ordering.test.ts src/acp/translator.session-ordering.command-yield.test.ts src/acp/translator.session-ordering.transport-proof.test.ts

All matched files use the correct format.
Finished in 58ms on 6 files using 8 threads.
```

### Transport proof

Real behavior proof using the ACP SDK's real transport classes (`AgentSideConnection` + `ClientSideConnection` + `ndJsonStream` over `PassThrough` streams) with a mock `GatewayClient`. The script captures raw NDJSON wire bytes from the agent→client direction and prints them with indices to prove the `session/new` JSON-RPC response line arrives before any `session/update` notification line.

```console
$ node --import tsx src/acp/proof-session-ordering.mts

=== ACP Session Ordering Transport Proof ===
Using real AgentSideConnection + ClientSideConnection + ndJsonStream

[initialize] wire lines so far: 1
[session/new] RPC result received, sessionId=ada0cf43-1d54-4252-a4a4-379396e08f1e
[session/new] wire lines after response: 2
[flush] wire lines after timer flush: 4

=== NDJSON Wire Transcript (agent -> client) ===
[0] RESPONSE: {"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true,"promptCapabilities":{"ima...
[1] RESPONSE: {"jsonrpc":"2.0","id":1,"result":{"sessionId":"ada0cf43-1d54-4252-a4a4-379396e08f1e","configOptions":[{"type":"select","...
[2] NOTIFICATION (session/update): {"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ada0cf43-1d54-4252-a4a4-379396e08f1e","update":{"sessi...
[3] NOTIFICATION (session/update): {"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ada0cf43-1d54-4252-a4a4-379396e08f1e","update":{"sessi...

=== Ordering Verification ===
session/new RESPONSE line index:     1
session/update NOTIFICATION line index: 2

PASS: session/new response arrives BEFORE session/update notification
```

The `translator.session-ordering.transport-proof.test.ts` test uses the same real ACP SDK transport and asserts `events[0] === "response"`. The `translator.session-ordering.command-yield.test.ts` test injects a yielding `getAvailableCommands` stub (simulating the lazy command-module dynamic-import yield) and asserts `sessionUpdate` is not called before `newSession` resolves, proving the pre-fetch fix holds.

The `translator.session-ordering.command-yield.test.ts` test injects a `getAvailableCommands` stub that yields to the macrotask queue (simulating the lazy command-module dynamic-import yield). It asserts `sessionUpdate` is not called before `newSession` resolves, proving the pre-fetch fix holds even when command discovery yields.

### Environment

- OS: Linux
- Node: 24.15.0
- Branch: `fix/acp-bridge-session-order`
- Base: `upstream/main` (latest)
- OpenClaw: `2026.7.2`
