### PR TITLE
fix(nextcloud-talk): avoid crashes when webhook port is already in use

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.lifecycle.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.lifecycle.test.ts
@@ -1,0 +1,32 @@
+// Nextcloud Talk tests cover webhook server lifecycle behavior.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { createNextcloudTalkWebhookServer } from "./monitor.js";
+
+describe("createNextcloudTalkWebhookServer lifecycle", () => {
+  it("rejects when the configured webhook port is already in use", async () => {
+    const occupiedServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+      occupiedServer.once("error", reject);
+      occupiedServer.listen(0, "127.0.0.1", resolve);
+    });
+    const address = occupiedServer.address() as AddressInfo;
+    const webhook = createNextcloudTalkWebhookServer({
+      host: "127.0.0.1",
+      port: address.port,
+      path: "/nextcloud-talk-webhook",
+      secret: "nextcloud-secret", // pragma: allowlist secret
+      onMessage: async () => {},
+    });
+
+    try {
+      await expect(webhook.start()).rejects.toMatchObject({ code: "EADDRINUSE" });
+    } finally {
+      webhook.stop();
+      await new Promise<void>((resolve, reject) => {
+        occupiedServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -342,8 +342,20 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
   });
 
   const start = (): Promise<void> => {
-    return new Promise((resolve) => {
-      server.listen(port, host, () => resolve());
+    return new Promise((resolve, reject) => {
+      // Startup has one terminal event; remove the other listener so stale startup
+      // state cannot consume a later runtime error or resolve after rejection.
+      const onListenError = (error: Error) => {
+        server.off("listening", onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        server.off("error", onListenError);
+        resolve();
+      };
+      server.once("error", onListenError);
+      server.once("listening", onListening);
+      server.listen(port, host);
     });
   };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators starting the Nextcloud Talk webhook on an occupied port would have the OpenClaw process crash with an unhandled `EADDRINUSE` error while startup remained unresolved.

## Why This Change Was Made

The Nextcloud Talk webhook now subscribes to both startup outcomes before calling `listen()`, rejects the existing startup promise on bind failure, and removes the opposite one-shot listener after either terminal event. The change is limited to webhook startup error propagation; it does not add retries, fallback ports, configuration, or SDK surface.

## User Impact

Operators now receive the real webhook bind error through the existing provider startup path instead of losing the process to an unhandled server event, so port conflicts can be diagnosed and corrected normally.

## Evidence

**Real-machine before / premise / after / negative control**

Environment: Linux x86_64, Node v24.18.0. The same exported production function was run on a real localhost TCP stack from a detached latest-main worktree and the fixed worktree. A real `node:http` server first acquired an operating-system-assigned port, then the Nextcloud Talk production server attempted to bind the same address and port. No server, event, or `listen()` API was mocked.

```bash
node --import tsx --input-type=module -e '
import { createServer } from "node:http";
import { createNextcloudTalkWebhookServer } from "./extensions/nextcloud-talk/src/monitor.ts";
const occupied = createServer();
await new Promise((resolve, reject) => {
  occupied.once("error", reject);
  occupied.listen(0, "127.0.0.1", resolve);
});
const address = occupied.address();
const webhook = createNextcloudTalkWebhookServer({
  host: "127.0.0.1",
  port: address.port,
  path: "/nextcloud-talk-webhook",
  secret: "proof-secret",
  onMessage: async () => {},
});
const timeout = setTimeout(() => {
  console.error("TIMEOUT: start() did not settle after EADDRINUSE");
  process.exit(2);
}, 2000);
try {
  await webhook.start();
  console.error("UNEXPECTED: conflicting server started");
  process.exitCode = 3;
} catch (error) {
  console.log("REJECTED: code=" + error.code + " message=" + error.message);
} finally {
  clearTimeout(timeout);
  webhook.stop();
  occupied.close();
}
'
```

Negative control / before (`upstream/main` at `017217bae33e685d987e9b7804b64e75916d10ec`):

```text
node:events:487
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use 127.0.0.1:41445
Emitted 'error' event on Server instance at:
  code: 'EADDRINUSE',
  syscall: 'listen',
  address: '127.0.0.1',
  port: 41445

Node.js v24.18.0
exit_code=1
```

The real bind error bypasses the unresolved startup promise and terminates the process as an unhandled EventEmitter error.

Premise: Node documents that a successful `server.listen()` emits `listening`, while listen failures emit the server `error` event; it identifies `EADDRINUSE` as the common result when another server already owns the requested port: https://nodejs.org/api/net.html#event-error and https://nodejs.org/api/net.html#serverlisten. The existing Nextcloud Talk runtime already awaits the returned startup promise, so rejecting that owner is sufficient and avoids inventing retry or fallback policy.

After (`07fd65356c7684e1407ec1ebce5237416bd58bfc`):

```text
REJECTED: code=EADDRINUSE message=listen EADDRINUSE: address already in use 127.0.0.1:39405
exit_code=0
```

The same production path now settles through the existing promise with the original errno, and the process remains alive. The regression test uses the same negative control: it occupies a real ephemeral localhost port, calls `createNextcloudTalkWebhookServer().start()`, and requires rejection with `code: "EADDRINUSE"`.

Focused validation:

```text
node scripts/run-vitest.mjs extensions/nextcloud-talk/src/monitor.lifecycle.test.ts extensions/nextcloud-talk/src/monitor.replay.test.ts
Test Files  2 passed (2)
Tests       11 passed (11)

./node_modules/.bin/oxfmt --check extensions/nextcloud-talk/src/monitor.ts extensions/nextcloud-talk/src/monitor.lifecycle.test.ts
All matched files use the correct format.

./node_modules/.bin/oxlint extensions/nextcloud-talk/src/monitor.ts extensions/nextcloud-talk/src/monitor.lifecycle.test.ts
exit 0

git diff --check upstream/main...HEAD
exit 0
```

Full build and full typecheck were not run locally; fork GitHub Actions are expected to cover the wider repository gates. A direct linked-worktree typecheck could not resolve unbuilt self-referenced `openclaw/plugin-sdk/*` declaration artifacts, so no product code was changed to accommodate that local setup limitation. No external Nextcloud instance was exercised because the failure occurs before any webhook traffic or Nextcloud API call; the affected production bind path itself was exercised against the real OS TCP stack.

**AI-assisted:** Yes. I reviewed the complete webhook server module, its runtime caller, harness and adjacent tests, the gateway sibling implementation, the Node server error contract, collision searches, and the real-machine evidence.
