### PR TITLE
fix: keep memory SecretRef failures agent-scoped

### DIFF
--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -301,7 +301,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
   });
 
   it("honors remote overrides when creating the provider", async () => {
-    resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "gh_remote_token" });
+    resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "test-token-placeholder" });
     mockDiscoveryResponse({
       ok: true,
       json: buildModelsResponse([
@@ -320,7 +320,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
 
     expect(resolveFirstGithubTokenMock).toHaveBeenCalled();
     expect(firstCopilotApiTokenRequest().env).toBe(process.env);
-    expect(firstCopilotApiTokenRequest().githubToken).toBe("gh_remote_token");
+    expect(firstCopilotApiTokenRequest().githubToken).toBe("test-token-placeholder");
 
     const discoveryCall = firstDiscoveryRequest();
     expect(discoveryCall.url).toBe("https://proxy.example/v1/models");

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -128,11 +128,11 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
   beforeEach(() => {
     resolveConfiguredSecretInputStringMock.mockResolvedValue({});
     resolveFirstGithubTokenMock.mockResolvedValue({
-      githubToken: "gh_test_token_123",
+      githubToken: "test-token-placeholder",
       hasProfile: false,
     });
     resolveCopilotApiTokenMock.mockResolvedValue({
-      token: "copilot_test_token_abc",
+      token: "test-token-placeholder",
       expiresAt: Date.now() + 3_600_000,
       source: "test",
       baseUrl: TEST_BASE_URL,
@@ -168,7 +168,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
 
     expect(result.provider?.model).toBe("text-embedding-3-small");
-    expect(firstCopilotApiTokenRequest().githubToken).toBe("gh_test_token_123");
+    expect(firstCopilotApiTokenRequest().githubToken).toBe("test-token-placeholder");
   });
 
   it("matches embedding-capable models when supported_endpoints is missing or malformed", async () => {

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -301,7 +301,6 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
   });
 
   it("honors remote overrides when creating the provider", async () => {
-    resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "test-token-placeholder" });
     mockDiscoveryResponse({
       ok: true,
       json: buildModelsResponse([
@@ -318,7 +317,8 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
       },
     } as never);
 
-    expect(resolveFirstGithubTokenMock).toHaveBeenCalled();
+    expect(resolveFirstGithubTokenMock).not.toHaveBeenCalled();
+    expect(resolveConfiguredSecretInputStringMock).not.toHaveBeenCalled();
     expect(firstCopilotApiTokenRequest().env).toBe(process.env);
     expect(firstCopilotApiTokenRequest().githubToken).toBe("test-token-placeholder");
 
@@ -326,6 +326,23 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     expect(discoveryCall.url).toBe("https://proxy.example/v1/models");
     expect(discoveryCall.init.headers["Accept-Encoding"]).toBe("identity");
     expect(discoveryCall.init.headers["X-Proxy-Token"]).toBe("test-token-placeholder");
+  });
+
+  it("rejects an unresolved remote ref without falling back to another profile", async () => {
+    await expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.create({
+        ...defaultCreateOptions(),
+        remote: {
+          apiKey: { source: "env", provider: "default", id: "MISSING_TEST_VALUE" },
+        },
+      } as never),
+    ).rejects.toMatchObject({
+      name: "UnresolvedSecretInputError",
+      path: "agents.*.memorySearch.remote.apiKey",
+    });
+    expect(resolveFirstGithubTokenMock).not.toHaveBeenCalled();
+    expect(resolveCopilotApiTokenMock).not.toHaveBeenCalled();
+    expect(resolveConfiguredSecretInputStringMock).not.toHaveBeenCalled();
   });
 
   it("includes provider, baseUrl, and model in runtime cache data", async () => {

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -15,7 +15,7 @@ vi.mock("openclaw/plugin-sdk/secret-input-runtime", () => ({
 }));
 
 vi.mock("./token.js", () => ({
-  DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",
+  DEFAULT_COPILOT_API_BASE_URL: "https://example.test",
   resolveCopilotApiToken: resolveCopilotApiTokenMock,
 }));
 
@@ -33,7 +33,7 @@ afterAll(() => {
   vi.resetModules();
 });
 
-const TEST_BASE_URL = "https://api.githubcopilot.test";
+const TEST_BASE_URL = "https://example.test";
 
 function shouldContinueAutoSelection(error: Error): boolean {
   const shouldContinue = githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection;

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -312,9 +312,9 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     await githubCopilotMemoryEmbeddingProviderAdapter.create({
       ...defaultCreateOptions(),
       remote: {
-        apiKey: "ignored-at-runtime",
+        apiKey: "test-token-placeholder",
         baseUrl: "https://proxy.example/v1",
-        headers: { "X-Proxy-Token": "proxy" },
+        headers: { "X-Proxy-Token": "test-token-placeholder" },
       },
     } as never);
 
@@ -325,7 +325,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     const discoveryCall = firstDiscoveryRequest();
     expect(discoveryCall.url).toBe("https://proxy.example/v1/models");
     expect(discoveryCall.init.headers["Accept-Encoding"]).toBe("identity");
-    expect(discoveryCall.init.headers["X-Proxy-Token"]).toBe("proxy");
+    expect(discoveryCall.init.headers["X-Proxy-Token"]).toBe("test-token-placeholder");
   });
 
   it("includes provider, baseUrl, and model in runtime cache data", async () => {

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -11,7 +11,7 @@ import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
-import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveFirstGithubToken } from "./auth.js";
 import { resolveGithubCopilotDomain } from "./domain.js";
@@ -283,18 +283,19 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
   allowExplicitWhenConfiguredAuto: true,
   shouldContinueAutoSelection: (err: unknown) => isCopilotSetupError(err),
   create: async (options) => {
-    const explicitValue = await resolveConfiguredSecretInputString({
-      config: options.config,
-      env: process.env,
+    const explicitValue = normalizeResolvedSecretInputString({
       value: options.remote?.apiKey,
       path: "agents.*.memorySearch.remote.apiKey",
     });
-    const profile = await resolveFirstGithubToken({
-      agentDir: options.agentDir,
-      config: options.config,
-      env: process.env,
-    });
-    const value = explicitValue.value || profile.githubToken;
+    const value = explicitValue
+      ? explicitValue
+      : (
+          await resolveFirstGithubToken({
+            agentDir: options.agentDir,
+            config: options.config,
+            env: process.env,
+          })
+        ).githubToken;
     if (!value) {
       throw new Error("No GitHub token available for Copilot embedding provider");
     }
@@ -329,7 +330,7 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
       baseUrl,
       env: process.env,
       fetchImpl: fetch,
-      githubToken,
+      githubToken: value,
       githubDomain,
       headers: options.remote?.headers,
       model,

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -289,12 +289,12 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
       value: options.remote?.apiKey,
       path: "agents.*.memorySearch.remote.apiKey",
     });
-    const { githubToken: profileValue } = await resolveFirstGithubToken({
+    const profile = await resolveFirstGithubToken({
       agentDir: options.agentDir,
       config: options.config,
       env: process.env,
     });
-    const value = explicitValue.value || profileValue;
+    const value = explicitValue.value || profile.githubToken;
     if (!value) {
       throw new Error("No GitHub token available for Copilot embedding provider");
     }

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -283,19 +283,19 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
   allowExplicitWhenConfiguredAuto: true,
   shouldContinueAutoSelection: (err: unknown) => isCopilotSetupError(err),
   create: async (options) => {
-    const remoteGithubToken = await resolveConfiguredSecretInputString({
+    const explicitValue = await resolveConfiguredSecretInputString({
       config: options.config,
       env: process.env,
       value: options.remote?.apiKey,
       path: "agents.*.memorySearch.remote.apiKey",
     });
-    const { githubToken: profileGithubToken } = await resolveFirstGithubToken({
+    const { githubToken: profileValue } = await resolveFirstGithubToken({
       agentDir: options.agentDir,
       config: options.config,
       env: process.env,
     });
-    const githubToken = remoteGithubToken.value || profileGithubToken;
-    if (!githubToken) {
+    const value = explicitValue.value || profileValue;
+    if (!value) {
       throw new Error("No GitHub token available for Copilot embedding provider");
     }
 
@@ -304,7 +304,7 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
       config: options.config,
     });
     const { token: copilotToken, baseUrl: resolvedBaseUrl } = await resolveCopilotApiToken({
-      githubToken,
+      githubToken: value,
       env: process.env,
       githubDomain,
     });

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -12,6 +12,11 @@ import {
   clearMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider,
 } from "../plugins/memory-embedding-providers.js";
+import {
+  SecretSurfaceUnavailableError,
+  setActiveDegradedSecretOwners,
+} from "../secrets/runtime-degraded-state.js";
+import { runtimeMemorySecretOwnerId } from "../secrets/runtime-memory-secret-owner.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { resolveMemorySearchConfig, resolveMemorySearchSyncConfig } from "./memory-search.js";
@@ -87,6 +92,7 @@ describe("memory search config", () => {
   });
 
   afterEach(() => {
+    setActiveDegradedSecretOwners([]);
     clearMemoryEmbeddingProviders();
     restoreRegisteredEmbeddingProviders(registeredEmbeddingProvidersSnapshot);
   });
@@ -186,6 +192,27 @@ describe("memory search config", () => {
     });
     const resolved = resolveMemorySearchConfig(cfg, "main");
     expect(resolved).toBeNull();
+  });
+
+  it("throws the typed unavailable error only for the degraded agent owner", () => {
+    const cfg = asConfig({
+      agents: {
+        list: [{ id: "cold" }, { id: "healthy" }],
+      },
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: runtimeMemorySecretOwnerId("cold"),
+        state: "unavailable",
+        paths: ["agents.defaults.memorySearch.remote.apiKey"],
+        refKeys: ["env:default:MISSING_MEMORY_KEY"],
+        reason: "secret reference was not found",
+      },
+    ]);
+
+    expect(() => resolveMemorySearchConfig(cfg, "cold")).toThrow(SecretSurfaceUnavailableError);
+    expect(resolveMemorySearchConfig(cfg, "healthy")?.enabled).toBe(true);
   });
 
   it("returns null sync config when disabled", () => {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -22,6 +22,8 @@ import {
 } from "../memory-host-sdk/multimodal.js";
 import { getEmbeddingProvider } from "../plugins/embedding-provider-runtime.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
+import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js";
+import { runtimeMemorySecretOwnerId } from "../secrets/runtime-memory-secret-owner.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { clampInt, clampNumber } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
@@ -481,6 +483,7 @@ export function resolveMemorySearchConfig(
   if (!resolved.enabled) {
     return null;
   }
+  assertSecretOwnerAvailable("capability", runtimeMemorySecretOwnerId(agentId));
   const isFtsOnly = normalizeProviderId(resolved.provider) === "none";
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider = isFtsOnly

--- a/src/gateway/server-startup-memory.test.ts
+++ b/src/gateway/server-startup-memory.test.ts
@@ -4,9 +4,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { MemoryQmdUpdateConfig } from "../config/types.memory.js";
+import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 
-const { getMemorySearchManagerMock } = vi.hoisted(() => ({
+const { getMemorySearchManagerMock, resolveMemorySearchConfigMock } = vi.hoisted(() => ({
   getMemorySearchManagerMock: vi.fn(),
+  resolveMemorySearchConfigMock: vi.fn(),
 }));
 
 vi.mock("../plugins/memory-runtime.js", () => ({
@@ -23,12 +25,7 @@ vi.mock("../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../agents/memory-search.js", () => ({
-  resolveMemorySearchConfig: (cfg: OpenClawConfig, agentId: string) => {
-    const agent = cfg.agents?.list?.find((entry) => entry.id === agentId);
-    const enabled =
-      agent?.memorySearch?.enabled ?? cfg.agents?.defaults?.memorySearch?.enabled ?? true;
-    return enabled ? {} : null;
-  },
+  resolveMemorySearchConfig: resolveMemorySearchConfigMock,
 }));
 
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
@@ -105,6 +102,13 @@ function expectBootSyncCompleted(
 describe("startGatewayMemoryBackend", () => {
   beforeEach(() => {
     getMemorySearchManagerMock.mockClear();
+    resolveMemorySearchConfigMock.mockReset();
+    resolveMemorySearchConfigMock.mockImplementation((cfg: OpenClawConfig, agentId: string) => {
+      const agent = cfg.agents?.list?.find((entry) => entry.id === agentId);
+      const enabled =
+        agent?.memorySearch?.enabled ?? cfg.agents?.defaults?.memorySearch?.enabled ?? true;
+      return enabled ? {} : null;
+    });
   });
 
   it("skips initialization when memory backend is not qmd", async () => {
@@ -190,6 +194,37 @@ describe("startGatewayMemoryBackend", () => {
       'qmd memory startup initialization failed for agent "main": qmd missing',
     );
     expectBootSyncCompleted(log, 1, '"ops"');
+  });
+
+  it("skips an unavailable memory owner and initializes healthy agents", async () => {
+    const cfg = createQmdConfig(
+      {
+        defaults: { memorySearch: { enabled: true } },
+        list: [{ id: "cold", default: true }, { id: "healthy" }],
+      },
+      { startup: "immediate", interval: "0s", embedInterval: "0s" },
+    );
+    resolveMemorySearchConfigMock.mockImplementation((_cfg: OpenClawConfig, agentId: string) => {
+      if (agentId === "cold") {
+        throw new SecretSurfaceUnavailableError({
+          ownerKind: "capability",
+          ownerId: "memory-provider:cold",
+          state: "unavailable",
+          paths: ["agents.defaults.memorySearch.remote.apiKey"],
+          refKeys: ["env:default:MISSING_MEMORY_KEY"],
+          reason: "secret reference was not found",
+        });
+      }
+      return {};
+    });
+
+    const log = await startQmdBackendWithManager(cfg);
+
+    expectQmdManagerRequests(cfg, ["healthy"]);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('memory startup unavailable for agent "cold"'),
+    );
+    expectBootSyncCompleted(log, 1, '"healthy"');
   });
 
   it("skips agents with memory search disabled", async () => {

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -9,6 +9,7 @@ import {
 } from "../memory-host-sdk/host/backend-config.js";
 import { getActiveMemorySearchManager } from "../plugins/memory-runtime.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 
 /** True when qmd memory config opts into Gateway startup manager work. */
 function shouldRunQmdStartupManager(qmd: ResolvedQmdConfig): boolean {
@@ -57,7 +58,17 @@ export async function startGatewayMemoryBackend(params: {
   const initializedAgentIds: string[] = [];
   const deferredAgentIds: string[] = [];
   for (const agentId of agentIds) {
-    if (!resolveMemorySearchConfig(params.cfg, agentId)) {
+    try {
+      if (!resolveMemorySearchConfig(params.cfg, agentId)) {
+        continue;
+      }
+    } catch (error) {
+      if (!(error instanceof SecretSurfaceUnavailableError)) {
+        throw error;
+      }
+      // One isolated provider must not prevent healthy agents from completing
+      // Gateway-owned boot sync and background manager initialization.
+      params.log.warn(`memory startup unavailable for agent "${agentId}": ${error.message}`);
       continue;
     }
     const resolved = resolveMemoryBackendConfig({ cfg: params.cfg, agentId });

--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { getRuntimeAuthProfileStoreSnapshot } from "../agents/auth-profiles/runtime-snapshots.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
+import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAuthProfileSecretOwnerId } from "../secrets/runtime-auth-profile-owner.js";
@@ -98,6 +99,51 @@ describe("Gateway startup SecretRef owner isolation", () => {
         );
       },
     );
+  });
+
+  it("reaches /readyz with a cold memory provider and rejects only that owner", async () => {
+    await withEnvAsync({ MISSING_MEMORY_KEY: undefined }, async () => {
+      await writeConfig({
+        ...baseConfig(),
+        agents: {
+          defaults: {
+            memorySearch: {
+              remote: {
+                apiKey: { source: "env", provider: "default", id: "MISSING_MEMORY_KEY" },
+              },
+            },
+          },
+        },
+      });
+
+      const port = await getFreePort();
+      server = await startGatewayServer(port, { auth: { mode: "none" } });
+      const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+
+      expect(ready.status).toBe(200);
+      const active = getActiveSecretsRuntimeSnapshot();
+      expect(active?.degradedOwners).toMatchObject([
+        {
+          ownerKind: "capability",
+          ownerId: "memory-provider:main",
+          state: "unavailable",
+        },
+      ]);
+      if (!active) {
+        throw new Error("Expected active secrets runtime snapshot");
+      }
+      let thrown: unknown;
+      try {
+        resolveMemorySearchConfig(active.config, "main");
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toMatchObject({
+        code: "SECRET_SURFACE_UNAVAILABLE",
+        ownerKind: "capability",
+        ownerId: "memory-provider:main",
+      });
+    });
   });
 
   it("isolates TTS during a successful Gateway-auth SecretRef preflight", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -3,7 +3,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import type { AddressInfo, Socket } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
-import { withEnvAsync } from "../test-utils/env.js";
+import { UnresolvedSecretInputError } from "../config/types.secrets.js";
 import type { EmbeddingProviderCreateOptions } from "./embedding-providers.js";
 import { getRegisteredEmbeddingProvider } from "./embedding-providers.js";
 import { openAICompatibleEmbeddingProviderAdapter } from "./openai-compatible-embedding-provider.js";
@@ -578,122 +578,42 @@ describe("openai-compatible generic embedding provider", () => {
     expect(server.getBodyBytesSent()).toBeLessThan(server.getPlannedBodyBytes() / 2);
   });
 
-  it("resolves env SecretRef API keys on the memory search secret surface", async () => {
-    const value = "test-token-placeholder";
-    const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_EMBEDDING_API_KEY";
-    const server = await startEmbeddingServer({ token: value });
-
-    await withEnvAsync({ [envVar]: value }, async () => {
-      const { provider } = await createOpenAICompatibleEmbeddingProvider(
+  it("rejects unresolved API-key refs instead of re-resolving runtime config", async () => {
+    const server = await startEmbeddingServer();
+    await expect(
+      createOpenAICompatibleEmbeddingProvider(
         createOptions({
           model: "text-embedding-bge-m3",
           remote: {
             baseUrl: server.baseUrl,
-            apiKey: { source: "env", provider: "default", id: envVar },
+            apiKey: { source: "env", provider: "default", id: "MISSING_TEST_VALUE" },
           },
         }),
-      );
-
-      await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
-      expect(server.requests[0]?.headers.authorization).toBe(`Bearer ${value}`);
-    });
+      ),
+    ).rejects.toBeInstanceOf(UnresolvedSecretInputError);
+    expect(server.requests).toHaveLength(0);
   });
 
-  it("enforces configured env SecretRef allowlists for API keys", async () => {
-    const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_BLOCKED_API_KEY";
+  it("rejects unresolved header refs instead of re-resolving runtime config", async () => {
     const server = await startEmbeddingServer();
-
-    await withEnvAsync({ [envVar]: "test-token-placeholder" }, async () => {
-      await expect(
-        createOpenAICompatibleEmbeddingProvider(
-          createOptions({
-            config: {
-              secrets: {
-                providers: {
-                  default: { source: "env", allowlist: ["OPENCLAW_ALLOWED_ONLY"] },
-                },
-              },
-            } as EmbeddingProviderCreateOptions["config"],
-            model: "text-embedding-bge-m3",
-            remote: {
-              baseUrl: server.baseUrl,
-              apiKey: { source: "env", provider: "default", id: envVar },
-            },
-          }),
-        ),
-      ).rejects.toThrow("SecretRef is unresolved");
-      expect(server.requests).toHaveLength(0);
-    });
-  });
-
-  it("enforces configured env SecretRef allowlists for custom headers", async () => {
-    const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_BLOCKED_HEADER";
-    const server = await startEmbeddingServer();
-
-    await withEnvAsync({ [envVar]: "blocked-header" }, async () => {
-      await expect(
-        createOpenAICompatibleEmbeddingProvider(
-          createOptions({
-            config: {
-              secrets: {
-                providers: {
-                  default: { source: "env", allowlist: ["OPENCLAW_ALLOWED_ONLY"] },
-                },
-              },
-            } as EmbeddingProviderCreateOptions["config"],
-            model: "text-embedding-bge-m3",
-            remote: {
-              baseUrl: server.baseUrl,
-              headers: {
-                "x-tenant-token": {
-                  source: "env",
-                  provider: "default",
-                  id: envVar,
-                } as unknown as string,
-              },
-            },
-          }),
-        ),
-      ).rejects.toThrow("SecretRef is unresolved");
-      expect(server.requests).toHaveLength(0);
-    });
-  });
-
-  it("resolves env-template API key strings before treating them as inline secrets", async () => {
-    const value = "test-token-placeholder";
-    const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_EMBEDDING_TEMPLATE_KEY";
-    const ref = `\${${envVar}}`;
-    const server = await startEmbeddingServer({ token: value });
-
-    await withEnvAsync({ [envVar]: value }, async () => {
-      const { provider } = await createOpenAICompatibleEmbeddingProvider(
+    await expect(
+      createOpenAICompatibleEmbeddingProvider(
         createOptions({
           model: "text-embedding-bge-m3",
-          remote: { baseUrl: server.baseUrl, apiKey: ref },
+          remote: {
+            baseUrl: server.baseUrl,
+            headers: {
+              "x-tenant-value": {
+                source: "env",
+                provider: "default",
+                id: "MISSING_TEST_VALUE",
+              } as unknown as string,
+            },
+          },
         }),
-      );
-
-      await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
-      expect(server.requests[0]?.headers.authorization).toBe(`Bearer ${value}`);
-    });
-  });
-
-  it("does not treat missing env-template API key strings as inline secrets", async () => {
-    const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_EMBEDDING_MISSING_TEMPLATE_KEY";
-    const ref = `\${${envVar}}`;
-    const server = await startEmbeddingServer();
-
-    await withEnvAsync({ [envVar]: undefined }, async () => {
-      await expect(
-        createOpenAICompatibleEmbeddingProvider(
-          createOptions({
-            model: "text-embedding-bge-m3",
-            remote: { baseUrl: server.baseUrl, apiKey: ref },
-          }),
-        ),
-      ).rejects.toThrow(`SecretRef is unresolved (env:default:${envVar})`);
-      expect(server.requests).toHaveLength(0);
-    });
+      ),
+    ).rejects.toBeInstanceOf(UnresolvedSecretInputError);
+    expect(server.requests).toHaveLength(0);
   });
 
   it("reads connection settings from configured explicit OpenAI-compatible providers", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -579,11 +579,11 @@ describe("openai-compatible generic embedding provider", () => {
   });
 
   it("resolves env SecretRef API keys on the memory search secret surface", async () => {
-    const token = "env-secret-token";
+    const value = "test-token-placeholder";
     const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_EMBEDDING_API_KEY";
-    const server = await startEmbeddingServer({ token });
+    const server = await startEmbeddingServer({ token: value });
 
-    await withEnvAsync({ [envVar]: token }, async () => {
+    await withEnvAsync({ [envVar]: value }, async () => {
       const { provider } = await createOpenAICompatibleEmbeddingProvider(
         createOptions({
           model: "text-embedding-bge-m3",
@@ -595,7 +595,7 @@ describe("openai-compatible generic embedding provider", () => {
       );
 
       await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
-      expect(server.requests[0]?.headers.authorization).toBe(`Bearer ${token}`);
+      expect(server.requests[0]?.headers.authorization).toBe(`Bearer ${value}`);
     });
   });
 
@@ -603,7 +603,7 @@ describe("openai-compatible generic embedding provider", () => {
     const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_BLOCKED_API_KEY";
     const server = await startEmbeddingServer();
 
-    await withEnvAsync({ [envVar]: "blocked-token" }, async () => {
+    await withEnvAsync({ [envVar]: "test-token-placeholder" }, async () => {
       await expect(
         createOpenAICompatibleEmbeddingProvider(
           createOptions({
@@ -660,28 +660,27 @@ describe("openai-compatible generic embedding provider", () => {
   });
 
   it("resolves env-template API key strings before treating them as inline secrets", async () => {
-    const token = "env-template-token";
+    const value = "test-token-placeholder";
     const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_EMBEDDING_TEMPLATE_KEY";
-    const server = await startEmbeddingServer({ token });
+    const ref = `\${${envVar}}`;
+    const server = await startEmbeddingServer({ token: value });
 
-    await withEnvAsync({ [envVar]: token }, async () => {
+    await withEnvAsync({ [envVar]: value }, async () => {
       const { provider } = await createOpenAICompatibleEmbeddingProvider(
         createOptions({
           model: "text-embedding-bge-m3",
-          remote: {
-            baseUrl: server.baseUrl,
-            apiKey: `\${${envVar}}`,
-          },
+          remote: { baseUrl: server.baseUrl, apiKey: ref },
         }),
       );
 
       await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
-      expect(server.requests[0]?.headers.authorization).toBe(`Bearer ${token}`);
+      expect(server.requests[0]?.headers.authorization).toBe(`Bearer ${value}`);
     });
   });
 
   it("does not treat missing env-template API key strings as inline secrets", async () => {
     const envVar = "OPENCLAW_TEST_OPENAI_COMPATIBLE_EMBEDDING_MISSING_TEMPLATE_KEY";
+    const ref = `\${${envVar}}`;
     const server = await startEmbeddingServer();
 
     await withEnvAsync({ [envVar]: undefined }, async () => {
@@ -689,10 +688,7 @@ describe("openai-compatible generic embedding provider", () => {
         createOpenAICompatibleEmbeddingProvider(
           createOptions({
             model: "text-embedding-bge-m3",
-            remote: {
-              baseUrl: server.baseUrl,
-              apiKey: `\${${envVar}}`,
-            },
+            remote: { baseUrl: server.baseUrl, apiKey: ref },
           }),
         ),
       ).rejects.toThrow(`SecretRef is unresolved (env:default:${envVar})`);

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -7,8 +7,7 @@ import type {
   ConfiguredProviderLocalServiceTarget,
 } from "../agents/provider-local-service.js";
 import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
-import { normalizeSecretInputString } from "../config/types.secrets.js";
-import { resolveConfiguredSecretInputString } from "../gateway/resolve-configured-secret-input-string.js";
+import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import { readResponseTextPrefix } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { ssrfPolicyFromHttpBaseUrlAllowedHostname, type SsrFPolicy } from "../infra/net/ssrf.js";
@@ -144,11 +143,10 @@ function normalizeHeaderName(name: string): string {
   return name.trim().toLowerCase();
 }
 
-async function buildHeaders(params: {
-  config: EmbeddingProviderCreateOptions["config"];
+function buildHeaders(params: {
   apiKey: string | undefined;
   extra: Record<string, unknown> | undefined;
-}): Promise<Record<string, string>> {
+}): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/json",
     "content-type": "application/json",
@@ -158,8 +156,7 @@ async function buildHeaders(params: {
     if (!normalizedName || normalizedName === "authorization") {
       continue;
     }
-    const value = await resolveSecretString({
-      config: params.config,
+    const value = resolveSecretString({
       value: rawValue,
       path: `models.providers.*.headers.${normalizedName}`,
     });
@@ -191,30 +188,15 @@ function sanitizeCacheHeaders(headers: Record<string, string>): Record<string, s
   return Object.keys(safeHeaders).length > 0 ? safeHeaders : undefined;
 }
 
-async function resolveSecretString(params: {
-  config: EmbeddingProviderCreateOptions["config"];
-  value: unknown;
-  path: string;
-}): Promise<string | undefined> {
-  const resolved = await resolveConfiguredSecretInputString({
-    config: params.config,
-    env: process.env,
+function resolveSecretString(params: { value: unknown; path: string }): string | undefined {
+  return normalizeResolvedSecretInputString({
     value: params.value,
     path: params.path,
-    unresolvedReasonStyle: "detailed",
   });
-  if (resolved.unresolvedRefReason) {
-    throw new Error(resolved.unresolvedRefReason);
-  }
-  return normalizeSecretInputString(resolved.value);
 }
 
-async function resolveRemoteApiKey(
-  config: EmbeddingProviderCreateOptions["config"],
-  value: unknown,
-): Promise<string | undefined> {
-  return await resolveSecretString({
-    config,
+function resolveRemoteApiKey(value: unknown): string | undefined {
+  return resolveSecretString({
     value,
     path: "agents.*.memorySearch.remote.apiKey",
   });
@@ -400,16 +382,14 @@ async function createOpenAICompatibleEmbeddingClient(
   const remoteBaseUrl = normalizeOptionalString(options.remote?.baseUrl);
   const baseUrl = normalizeBaseUrl(remoteBaseUrl ?? configuredProvider?.baseUrl);
   const model = normalizeModel(options.model, options.provider);
-  const apiKey = await resolveRemoteApiKey(
-    options.config,
+  const value = resolveRemoteApiKey(
     chooseSecretInputOverride(options.remote?.apiKey, configuredProvider?.apiKey),
   );
   const inputType = normalizeOptionalInputType(options.inputType);
   const queryInputType = normalizeOptionalInputType(options.queryInputType);
   const documentInputType = normalizeOptionalInputType(options.documentInputType);
-  const headers = await buildHeaders({
-    config: options.config,
-    apiKey,
+  const headers = buildHeaders({
+    apiKey: value,
     extra: {
       ...configuredProvider?.headers,
       ...options.remote?.headers,

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -7,10 +7,9 @@ import {
   resolveEffectiveMediaEntryCapabilities,
 } from "../media-understanding/entry-capabilities.js";
 import { buildMediaUnderstandingCapabilityRegistry } from "../media-understanding/provider-capability-registry.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { collectAgentMemorySearchAssignments } from "./runtime-config-collectors-memory.js";
 import { collectTtsApiKeyAssignments } from "./runtime-config-collectors-tts.js";
 import { evaluateGatewayAuthSurfaceStates } from "./runtime-gateway-auth-surfaces.js";
-import { runtimeMemorySecretOwnerId } from "./runtime-memory-secret-owner.js";
 import {
   collectSecretInputAssignment,
   collectRuntimeSecretInputAssignment,
@@ -124,135 +123,6 @@ function collectSkillAssignments(params: {
       },
       apply: (value) => {
         entry.apiKey = value;
-      },
-    });
-  }
-}
-
-function collectAgentMemorySearchAssignments(params: {
-  config: OpenClawConfig;
-  defaults: SecretDefaults | undefined;
-  context: ResolverContext;
-}): void {
-  const agents = params.config.agents as Record<string, unknown> | undefined;
-  if (!isRecord(agents)) {
-    return;
-  }
-  const defaultsConfig = isRecord(agents.defaults) ? agents.defaults : undefined;
-  const defaultsMemorySearch = isRecord(defaultsConfig?.memorySearch)
-    ? defaultsConfig.memorySearch
-    : undefined;
-  const list = Array.isArray(agents.list) ? agents.list : [];
-  const defaultRemote = isRecord(defaultsMemorySearch?.remote)
-    ? defaultsMemorySearch.remote
-    : undefined;
-  const defaultHeaders = isRecord(defaultRemote?.headers) ? defaultRemote.headers : undefined;
-  let defaultApiKeyAssignmentCollected = false;
-  const collectedDefaultHeaderKeys = new Set<string>();
-  const collectForAgent = (rawAgent: Record<string, unknown> | undefined, index?: number) => {
-    const memorySearch = isRecord(rawAgent?.memorySearch) ? rawAgent.memorySearch : undefined;
-    const remote = isRecord(memorySearch?.remote) ? memorySearch.remote : undefined;
-    const agentId = normalizeAgentId(
-      typeof rawAgent?.id === "string" ? rawAgent.id : DEFAULT_AGENT_ID,
-    );
-    const active =
-      rawAgent?.enabled !== false &&
-      (memorySearch?.enabled ?? defaultsMemorySearch?.enabled ?? true) !== false;
-    const owner = {
-      ownerKind: "capability",
-      ownerId: runtimeMemorySecretOwnerId(agentId),
-      requiredForGateway: false,
-      disposition: "isolate",
-    } satisfies SecretAssignmentOwner;
-
-    const hasApiKeyOverride = Boolean(remote && Object.hasOwn(remote, "apiKey"));
-    const apiKeyTarget = hasApiKeyOverride ? remote : defaultRemote;
-    if (apiKeyTarget && Object.hasOwn(apiKeyTarget, "apiKey")) {
-      collectRuntimeSecretInputAssignment({
-        value: apiKeyTarget.apiKey,
-        path: hasApiKeyOverride
-          ? `agents.list.${index}.memorySearch.remote.apiKey`
-          : "agents.defaults.memorySearch.remote.apiKey",
-        expected: "string",
-        defaults: params.defaults,
-        context: params.context,
-        active,
-        inactiveReason: "agent or memorySearch override is disabled.",
-        owner,
-        apply: (value) => {
-          apiKeyTarget.apiKey = value;
-        },
-      });
-      if (!hasApiKeyOverride && active) {
-        defaultApiKeyAssignmentCollected = true;
-      }
-    }
-
-    const overrideHeaders = isRecord(remote?.headers) ? remote.headers : undefined;
-    const headerTarget = overrideHeaders ?? defaultHeaders;
-    if (!headerTarget) {
-      return;
-    }
-    for (const [headerKey, headerValue] of Object.entries(headerTarget)) {
-      collectRuntimeSecretInputAssignment({
-        value: headerValue,
-        path: overrideHeaders
-          ? `agents.list.${index}.memorySearch.remote.headers.${headerKey}`
-          : `agents.defaults.memorySearch.remote.headers.${headerKey}`,
-        expected: "string",
-        defaults: params.defaults,
-        context: params.context,
-        active,
-        inactiveReason: "agent or memorySearch override is disabled.",
-        owner,
-        apply: (value) => {
-          headerTarget[headerKey] = value;
-        },
-      });
-      if (!overrideHeaders && active) {
-        collectedDefaultHeaderKeys.add(headerKey);
-      }
-    }
-  };
-
-  if (list.length === 0) {
-    collectForAgent(undefined);
-  } else {
-    list.forEach((rawAgent, index) => {
-      if (isRecord(rawAgent)) {
-        collectForAgent(rawAgent, index);
-      }
-    });
-  }
-
-  if (defaultRemote && !defaultApiKeyAssignmentCollected) {
-    collectRuntimeSecretInputAssignment({
-      value: defaultRemote.apiKey,
-      path: "agents.defaults.memorySearch.remote.apiKey",
-      expected: "string",
-      defaults: params.defaults,
-      context: params.context,
-      active: false,
-      inactiveReason: "no enabled agent inherits this memorySearch remote api key.",
-      apply: (value) => {
-        defaultRemote.apiKey = value;
-      },
-    });
-  }
-  for (const [headerKey, headerValue] of Object.entries(defaultHeaders ?? {})) {
-    if (collectedDefaultHeaderKeys.has(headerKey)) {
-      continue;
-    }
-    collectRuntimeSecretInputAssignment({
-      value: headerValue,
-      path: `agents.defaults.memorySearch.remote.headers.${headerKey}`,
-      expected: "string",
-      defaults: params.defaults,
-      context: params.context,
-      active: false,
-      inactiveReason: "no enabled agent inherits this memorySearch remote header.",
-      apply: (value) => {
-        defaultHeaders![headerKey] = value;
       },
     });
   }
@@ -745,7 +615,6 @@ function collectSandboxSshAssignments(params: {
   }
 }
 
-/** Collects SecretRef assignments from core-owned config surfaces. */
 /** Collects SecretRef assignments from core non-plugin config surfaces. */
 export function collectCoreConfigAssignments(params: {
   config: OpenClawConfig;

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -7,8 +7,10 @@ import {
   resolveEffectiveMediaEntryCapabilities,
 } from "../media-understanding/entry-capabilities.js";
 import { buildMediaUnderstandingCapabilityRegistry } from "../media-understanding/provider-capability-registry.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import { collectTtsApiKeyAssignments } from "./runtime-config-collectors-tts.js";
 import { evaluateGatewayAuthSurfaceStates } from "./runtime-gateway-auth-surfaces.js";
+import { runtimeMemorySecretOwnerId } from "./runtime-memory-secret-owner.js";
 import {
   collectSecretInputAssignment,
   collectRuntimeSecretInputAssignment,
@@ -140,76 +142,120 @@ function collectAgentMemorySearchAssignments(params: {
   const defaultsMemorySearch = isRecord(defaultsConfig?.memorySearch)
     ? defaultsConfig.memorySearch
     : undefined;
-  const defaultsEnabled = defaultsMemorySearch?.enabled !== false;
-
   const list = Array.isArray(agents.list) ? agents.list : [];
-  let hasEnabledAgentWithoutOverride = false;
-  for (const rawAgent of list) {
-    if (!isRecord(rawAgent)) {
-      continue;
+  const defaultRemote = isRecord(defaultsMemorySearch?.remote)
+    ? defaultsMemorySearch.remote
+    : undefined;
+  const defaultHeaders = isRecord(defaultRemote?.headers) ? defaultRemote.headers : undefined;
+  let defaultApiKeyAssignmentCollected = false;
+  const collectedDefaultHeaderKeys = new Set<string>();
+  const collectForAgent = (rawAgent: Record<string, unknown> | undefined, index?: number) => {
+    const memorySearch = isRecord(rawAgent?.memorySearch) ? rawAgent.memorySearch : undefined;
+    const remote = isRecord(memorySearch?.remote) ? memorySearch.remote : undefined;
+    const agentId = normalizeAgentId(
+      typeof rawAgent?.id === "string" ? rawAgent.id : DEFAULT_AGENT_ID,
+    );
+    const active =
+      rawAgent?.enabled !== false &&
+      (memorySearch?.enabled ?? defaultsMemorySearch?.enabled ?? true) !== false;
+    const owner = {
+      ownerKind: "capability",
+      ownerId: runtimeMemorySecretOwnerId(agentId),
+      requiredForGateway: false,
+      disposition: "isolate",
+    } satisfies SecretAssignmentOwner;
+
+    const hasApiKeyOverride = Boolean(remote && Object.hasOwn(remote, "apiKey"));
+    const apiKeyTarget = hasApiKeyOverride ? remote : defaultRemote;
+    if (apiKeyTarget && Object.hasOwn(apiKeyTarget, "apiKey")) {
+      collectRuntimeSecretInputAssignment({
+        value: apiKeyTarget.apiKey,
+        path: hasApiKeyOverride
+          ? `agents.list.${index}.memorySearch.remote.apiKey`
+          : "agents.defaults.memorySearch.remote.apiKey",
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active,
+        inactiveReason: "agent or memorySearch override is disabled.",
+        owner,
+        apply: (value) => {
+          apiKeyTarget.apiKey = value;
+        },
+      });
+      if (!hasApiKeyOverride && active) {
+        defaultApiKeyAssignmentCollected = true;
+      }
     }
-    if (rawAgent.enabled === false) {
-      continue;
+
+    const overrideHeaders = isRecord(remote?.headers) ? remote.headers : undefined;
+    const headerTarget = overrideHeaders ?? defaultHeaders;
+    if (!headerTarget) {
+      return;
     }
-    const memorySearch = isRecord(rawAgent.memorySearch) ? rawAgent.memorySearch : undefined;
-    if (memorySearch?.enabled === false) {
-      continue;
+    for (const [headerKey, headerValue] of Object.entries(headerTarget)) {
+      collectRuntimeSecretInputAssignment({
+        value: headerValue,
+        path: overrideHeaders
+          ? `agents.list.${index}.memorySearch.remote.headers.${headerKey}`
+          : `agents.defaults.memorySearch.remote.headers.${headerKey}`,
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active,
+        inactiveReason: "agent or memorySearch override is disabled.",
+        owner,
+        apply: (value) => {
+          headerTarget[headerKey] = value;
+        },
+      });
+      if (!overrideHeaders && active) {
+        collectedDefaultHeaderKeys.add(headerKey);
+      }
     }
-    if (!memorySearch || !Object.hasOwn(memorySearch, "remote")) {
-      hasEnabledAgentWithoutOverride = true;
-      continue;
-    }
-    const remote = isRecord(memorySearch.remote) ? memorySearch.remote : undefined;
-    if (!remote || !Object.hasOwn(remote, "apiKey")) {
-      hasEnabledAgentWithoutOverride = true;
-      continue;
-    }
+  };
+
+  if (list.length === 0) {
+    collectForAgent(undefined);
+  } else {
+    list.forEach((rawAgent, index) => {
+      if (isRecord(rawAgent)) {
+        collectForAgent(rawAgent, index);
+      }
+    });
   }
 
-  if (defaultsMemorySearch && isRecord(defaultsMemorySearch.remote)) {
-    const remote = defaultsMemorySearch.remote;
-    collectSecretInputAssignment({
-      value: remote.apiKey,
+  if (defaultRemote && !defaultApiKeyAssignmentCollected) {
+    collectRuntimeSecretInputAssignment({
+      value: defaultRemote.apiKey,
       path: "agents.defaults.memorySearch.remote.apiKey",
       expected: "string",
       defaults: params.defaults,
       context: params.context,
-      active: defaultsEnabled && (hasEnabledAgentWithoutOverride || list.length === 0),
-      inactiveReason: hasEnabledAgentWithoutOverride
-        ? undefined
-        : "all enabled agents override memorySearch.remote.apiKey.",
+      active: false,
+      inactiveReason: "no enabled agent inherits this memorySearch remote api key.",
       apply: (value) => {
-        remote.apiKey = value;
+        defaultRemote.apiKey = value;
       },
     });
   }
-
-  list.forEach((rawAgent, index) => {
-    if (!isRecord(rawAgent)) {
-      return;
+  for (const [headerKey, headerValue] of Object.entries(defaultHeaders ?? {})) {
+    if (collectedDefaultHeaderKeys.has(headerKey)) {
+      continue;
     }
-    const memorySearch = isRecord(rawAgent.memorySearch) ? rawAgent.memorySearch : undefined;
-    if (!memorySearch) {
-      return;
-    }
-    const remote = isRecord(memorySearch.remote) ? memorySearch.remote : undefined;
-    if (!remote || !Object.hasOwn(remote, "apiKey")) {
-      return;
-    }
-    const enabled = rawAgent.enabled !== false && memorySearch.enabled !== false;
-    collectSecretInputAssignment({
-      value: remote.apiKey,
-      path: `agents.list.${index}.memorySearch.remote.apiKey`,
+    collectRuntimeSecretInputAssignment({
+      value: headerValue,
+      path: `agents.defaults.memorySearch.remote.headers.${headerKey}`,
       expected: "string",
       defaults: params.defaults,
       context: params.context,
-      active: enabled,
-      inactiveReason: "agent or memorySearch override is disabled.",
+      active: false,
+      inactiveReason: "no enabled agent inherits this memorySearch remote header.",
       apply: (value) => {
-        remote.apiKey = value;
+        defaultHeaders![headerKey] = value;
       },
     });
-  });
+  }
 }
 
 function collectTalkAssignments(params: {

--- a/src/secrets/runtime-config-collectors-memory.ts
+++ b/src/secrets/runtime-config-collectors-memory.ts
@@ -1,0 +1,141 @@
+/** Collects per-agent memory search secret refs from runtime config. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { runtimeMemorySecretOwnerId } from "./runtime-memory-secret-owner.js";
+import {
+  collectRuntimeSecretInputAssignment,
+  type ResolverContext,
+  type SecretAssignmentOwner,
+  type SecretDefaults,
+} from "./runtime-shared.js";
+import { isRecord } from "./shared.js";
+
+/** Collects memory-search SecretRefs once for every agent that can inherit them. */
+export function collectAgentMemorySearchAssignments(params: {
+  config: OpenClawConfig;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+}): void {
+  const agents = params.config.agents as Record<string, unknown> | undefined;
+  if (!isRecord(agents)) {
+    return;
+  }
+  const defaultsConfig = isRecord(agents.defaults) ? agents.defaults : undefined;
+  const defaultsMemorySearch = isRecord(defaultsConfig?.memorySearch)
+    ? defaultsConfig.memorySearch
+    : undefined;
+  const list = Array.isArray(agents.list) ? agents.list : [];
+  const defaultRemote = isRecord(defaultsMemorySearch?.remote)
+    ? defaultsMemorySearch.remote
+    : undefined;
+  const defaultHeaders = isRecord(defaultRemote?.headers) ? defaultRemote.headers : undefined;
+  let defaultApiKeyAssignmentCollected = false;
+  const collectedDefaultHeaderKeys = new Set<string>();
+  const collectForAgent = (rawAgent: Record<string, unknown> | undefined, index?: number) => {
+    const memorySearch = isRecord(rawAgent?.memorySearch) ? rawAgent.memorySearch : undefined;
+    const remote = isRecord(memorySearch?.remote) ? memorySearch.remote : undefined;
+    const agentId = normalizeAgentId(
+      typeof rawAgent?.id === "string" ? rawAgent.id : DEFAULT_AGENT_ID,
+    );
+    const active =
+      rawAgent?.enabled !== false &&
+      (memorySearch?.enabled ?? defaultsMemorySearch?.enabled ?? true) !== false;
+    const owner = {
+      ownerKind: "capability",
+      ownerId: runtimeMemorySecretOwnerId(agentId),
+      requiredForGateway: false,
+      disposition: "isolate",
+    } satisfies SecretAssignmentOwner;
+
+    const hasApiKeyOverride = Boolean(remote && Object.hasOwn(remote, "apiKey"));
+    const apiKeyTarget = hasApiKeyOverride ? remote : defaultRemote;
+    if (apiKeyTarget && Object.hasOwn(apiKeyTarget, "apiKey")) {
+      collectRuntimeSecretInputAssignment({
+        value: apiKeyTarget.apiKey,
+        path: hasApiKeyOverride
+          ? `agents.list.${index}.memorySearch.remote.apiKey`
+          : "agents.defaults.memorySearch.remote.apiKey",
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active,
+        inactiveReason: "agent or memorySearch override is disabled.",
+        owner,
+        apply: (value) => {
+          apiKeyTarget.apiKey = value;
+        },
+      });
+      if (!hasApiKeyOverride && active) {
+        defaultApiKeyAssignmentCollected = true;
+      }
+    }
+
+    const overrideHeaders = isRecord(remote?.headers) ? remote.headers : undefined;
+    const headerTarget = overrideHeaders ?? defaultHeaders;
+    if (!headerTarget) {
+      return;
+    }
+    for (const [headerKey, headerValue] of Object.entries(headerTarget)) {
+      collectRuntimeSecretInputAssignment({
+        value: headerValue,
+        path: overrideHeaders
+          ? `agents.list.${index}.memorySearch.remote.headers.${headerKey}`
+          : `agents.defaults.memorySearch.remote.headers.${headerKey}`,
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active,
+        inactiveReason: "agent or memorySearch override is disabled.",
+        owner,
+        apply: (value) => {
+          headerTarget[headerKey] = value;
+        },
+      });
+      if (!overrideHeaders && active) {
+        collectedDefaultHeaderKeys.add(headerKey);
+      }
+    }
+  };
+
+  if (list.length === 0) {
+    collectForAgent(undefined);
+  } else {
+    list.forEach((rawAgent, index) => {
+      if (isRecord(rawAgent)) {
+        collectForAgent(rawAgent, index);
+      }
+    });
+  }
+
+  if (defaultRemote && !defaultApiKeyAssignmentCollected) {
+    collectRuntimeSecretInputAssignment({
+      value: defaultRemote.apiKey,
+      path: "agents.defaults.memorySearch.remote.apiKey",
+      expected: "string",
+      defaults: params.defaults,
+      context: params.context,
+      active: false,
+      inactiveReason: "no enabled agent inherits this memorySearch remote api key.",
+      apply: (value) => {
+        defaultRemote.apiKey = value;
+      },
+    });
+  }
+  for (const [headerKey, headerValue] of Object.entries(defaultHeaders ?? {})) {
+    if (collectedDefaultHeaderKeys.has(headerKey)) {
+      continue;
+    }
+    collectRuntimeSecretInputAssignment({
+      value: headerValue,
+      path: `agents.defaults.memorySearch.remote.headers.${headerKey}`,
+      expected: "string",
+      defaults: params.defaults,
+      context: params.context,
+      active: false,
+      inactiveReason: "no enabled agent inherits this memorySearch remote header.",
+      apply: (value) => {
+        defaultHeaders![headerKey] = value;
+      },
+    });
+  }
+}

--- a/src/secrets/runtime-memory-secret-owner.ts
+++ b/src/secrets/runtime-memory-secret-owner.ts
@@ -1,0 +1,6 @@
+import { normalizeAgentId } from "../routing/session-key.js";
+
+/** Runtime owner for one agent's configured memory embedding provider. */
+export function runtimeMemorySecretOwnerId(agentId: string): string {
+  return `memory-provider:${normalizeAgentId(agentId)}`;
+}

--- a/src/secrets/runtime-provider-and-media-surfaces.test.ts
+++ b/src/secrets/runtime-provider-and-media-surfaces.test.ts
@@ -547,4 +547,53 @@ describe("secrets runtime provider and media surfaces", () => {
       "agents.defaults.memorySearch.remote.apiKey",
     );
   });
+
+  it("isolates an inherited memory ref to its exact agent owner", async () => {
+    const missingRef = envTokenRef("MISSING_TEST_VALUE");
+    const healthyValue = "test-token-placeholder";
+    const healthyRef = envTokenRef("HEALTHY_TEST_VALUE");
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        agents: {
+          defaults: {
+            memorySearch: {
+              remote: {
+                apiKey: missingRef,
+                headers: { "X-Memory-Value": missingRef },
+              },
+            },
+          },
+          list: [
+            { id: "cold", default: true },
+            {
+              id: "healthy",
+              memorySearch: {
+                remote: { apiKey: healthyRef, headers: { "X-Memory-Value": healthyRef } },
+              },
+            },
+          ],
+        },
+      }),
+      env: { HEALTHY_TEST_VALUE: healthyValue },
+      agentDirs: ["/tmp/openclaw-agent-cold", "/tmp/openclaw-agent-healthy"],
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+      allowUnavailableSecretOwners: true,
+    });
+
+    expect(snapshot.config.agents?.list?.[1]?.memorySearch?.remote?.apiKey).toBe(healthyValue);
+    expect(snapshot.config.agents?.list?.[1]?.memorySearch?.remote?.headers).toEqual({
+      "X-Memory-Value": healthyValue,
+    });
+    expect(snapshot.degradedOwners).toMatchObject([
+      {
+        ownerKind: "capability",
+        ownerId: "memory-provider:cold",
+        state: "unavailable",
+        paths: [
+          "agents.defaults.memorySearch.remote.apiKey",
+          "agents.defaults.memorySearch.remote.headers.X-Memory-Value",
+        ],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Related: #101265

## What Problem This Solves

Fixes an issue where one agent's unresolved memory-search SecretRef could block Gateway startup or leak into embedding-provider fallback and re-resolution paths.

## Why This Change Was Made

Memory API keys and headers now resolve under agent-specific capability owners. A broken owner stays cold while healthy agents and Gateway startup continue. OpenAI-compatible and GitHub Copilot embedding adapters consume prepared literals only; an explicit unavailable Copilot value no longer falls back to another profile. Memory assignment collection lives in its own focused module so the core collector remains within the repository size limit.

AI-assisted implementation. Maintainer-reviewed and understood.

## User Impact

Operators can keep the Gateway and unrelated agents available when one agent's memory provider credential is unavailable. Explicit memory credentials fail closed at their owning agent instead of being re-resolved or replaced from another profile.

## Evidence

- `node scripts/run-vitest.mjs src/secrets/runtime-provider-and-media-surfaces.test.ts src/agents/memory-search.test.ts src/plugins/openai-compatible-embedding-provider.test.ts extensions/github-copilot/embeddings.test.ts src/gateway/server-startup-memory.test.ts src/gateway/server-startup-secret-owner-isolation.test.ts` — 106 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- <13 touched files>` — full hosted Blacksmith Testbox gate passed in 24m58s: https://github.com/openclaw/openclaw/actions/runs/29582855130
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean after fixing its accepted remote-header preflight finding; the final extraction review was also clean at 0.99 confidence.
