### PR TITLE
fix(ci): bound npm resume GitHub lookups

### DIFF
--- a/scripts/openclaw-npm-resume-run.d.mts
+++ b/scripts/openclaw-npm-resume-run.d.mts
@@ -43,6 +43,22 @@ export function validateOpenClawNpmResumeRun(
   input: OpenClawNpmResumeValidationInput,
 ): OpenClawNpmResumeIdentity;
 
+export function runOpenClawNpmResumeGh(
+  args: string[],
+  params?: {
+    execFileSyncImpl?: (
+      command: string,
+      args: string[],
+      options: {
+        encoding: "utf8";
+        killSignal: "SIGKILL";
+        maxBuffer: number;
+        timeout: number;
+      },
+    ) => string;
+  },
+): string;
+
 export function resolveOpenClawNpmResumeRun(options: {
   repo: string;
   runId: string;

--- a/scripts/openclaw-npm-resume-run.mjs
+++ b/scripts/openclaw-npm-resume-run.mjs
@@ -5,6 +5,9 @@ import { fileURLToPath } from "node:url";
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const RELEASE_PUBLISH_REF_PATTERN = /^release-publish\/([a-f0-9]{12})-([1-9][0-9]*)$/u;
 const WORKFLOW_PATH = ".github/workflows/openclaw-npm-release.yml";
+// Resume checks run during release recovery, so keep enough headroom for GitHub
+// latency while preventing one stalled read from consuming the workflow budget.
+const GH_COMMAND_TIMEOUT_MS = 60_000;
 
 function fail(message) {
   throw new Error(message);
@@ -100,14 +103,17 @@ export function validateOpenClawNpmResumeRun({
   };
 }
 
-function defaultRunGh(args) {
-  return execFileSync("gh", args, {
+export function runOpenClawNpmResumeGh(args, params = {}) {
+  const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
+  return execFileSyncImpl("gh", args, {
     encoding: "utf8",
+    killSignal: "SIGKILL",
     maxBuffer: 32 * 1024 * 1024,
+    timeout: GH_COMMAND_TIMEOUT_MS,
   });
 }
 
-export function resolveOpenClawNpmResumeRun({ repo, runId, runGh = defaultRunGh }) {
+export function resolveOpenClawNpmResumeRun({ repo, runId, runGh = runOpenClawNpmResumeGh }) {
   if (!/^[1-9][0-9]*$/u.test(runId)) {
     fail("OpenClaw npm resume run id must be a positive integer.");
   }

--- a/test/scripts/openclaw-npm-resume-run.test.ts
+++ b/test/scripts/openclaw-npm-resume-run.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   resolveOpenClawNpmResumeRun,
+  runOpenClawNpmResumeGh,
   validateOpenClawNpmResumeRun,
 } from "../../scripts/openclaw-npm-resume-run.mjs";
 import type { OpenClawNpmResumeValidationInput } from "../../scripts/openclaw-npm-resume-run.mjs";
@@ -36,6 +37,40 @@ function fixture(
 }
 
 describe("openclaw npm resume run identity", () => {
+  it("bounds each GitHub lookup", () => {
+    const execFileSyncImpl = vi.fn(() => "result");
+
+    expect(
+      runOpenClawNpmResumeGh(["api", "repos/openclaw/openclaw/actions/runs/456"], {
+        execFileSyncImpl,
+      }),
+    ).toBe("result");
+    expect(execFileSyncImpl).toHaveBeenCalledWith(
+      "gh",
+      ["api", "repos/openclaw/openclaw/actions/runs/456"],
+      {
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        maxBuffer: 32 * 1024 * 1024,
+        timeout: 60_000,
+      },
+    );
+  });
+
+  it("propagates GitHub lookup timeouts", () => {
+    const timeoutError = Object.assign(new Error("spawnSync gh ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+
+    expect(() =>
+      runOpenClawNpmResumeGh(["api", "repos/openclaw/openclaw/actions/runs/456"], {
+        execFileSyncImpl: () => {
+          throw timeoutError;
+        },
+      }),
+    ).toThrow(timeoutError);
+  });
+
   it("accepts a successful run bound to a signed main-reachable tooling tag", () => {
     expect(validateOpenClawNpmResumeRun(fixture())).toEqual({
       tagObjectSha: TAG_OBJECT_SHA,


### PR DESCRIPTION
## What Problem This Solves

The npm release resume identity check performs six sequential `gh` network reads. Each read currently uses synchronous child execution without a timeout, so one stalled GitHub CLI request can block release recovery until the surrounding 120-minute workflow job expires.

## Why This Change Was Made

The script now routes its default GitHub calls through a caller-owned runner with a 60-second timeout and `SIGKILL`. This keeps the release-specific latency budget local, preserves the existing 32 MiB output allowance, covers all six lookups, and continues to fail closed when a lookup cannot complete.

The runner accepts the same narrow child-process injection pattern used by sibling release scripts, allowing the exact production options and error propagation to be tested without a slow timer-based test.

## User Impact

An npm publish resume no longer waits indefinitely on a stalled GitHub lookup. Healthy recovery behavior and identity validation are unchanged; a lookup that exceeds one minute now fails clearly so the release can be diagnosed or retried.

## Evidence

Exact head: `5ba1c19f49bc23eea421d2cb193c77b86d8c3ded`, based on `017217bae33e2c8fc272e94dedf87d53d2586ed2`.

- Node 24.15.0 focused test: `node scripts/run-vitest.mjs run test/scripts/openclaw-npm-resume-run.test.ts` - 14/14 passed.
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check origin/main...HEAD` passed.
- A live full resume lookup against successful release run `29562232032` completed and validated the signed tag/main identity in 10.94 seconds.
- Real stalled-process proof with the production timeout contract returned `{"code":"ETIMEDOUT","signal":"SIGKILL","elapsedBoundMs":54}`.
- Node 24.15.0's official `execFileSync` contract confirms that `timeout` bounds the child runtime, sends `killSignal`, waits for exit, and throws the underlying synchronous child result on timeout: https://nodejs.org/download/release/v24.15.0/docs/api/child_process.html#child_processexecfilesyncfile-args-options
- Fresh independent Codex adversarial review found no P1/P2 issues, judged this the best fix, and estimated 91% merge probability. The structured autoreview helper could not authenticate to its Codex endpoint (HTTP 401), so no helper report was substituted.

Remote Testbox proof was unavailable in this environment; the focused test used the repository's allowed Node 24 local fallback. The live GitHub path and real child timeout were both exercised separately.
