### PR TITLE
fix(compaction): keep mirror usage from poisoning truncation

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -97,6 +97,20 @@ describe("calculateContextTokens", () => {
     ).toBe(927_907);
   });
 
+  it("normalizes OpenAI-style transcript usage without producing NaN", () => {
+    expect(
+      calculateContextTokens({
+        input: 0,
+        output: 0,
+        total: 45,
+        prompt_tokens: 40,
+        completion_tokens: 5,
+        total_tokens: 45,
+        cache: { read: 0, write: 0 },
+      } as unknown as Usage),
+    ).toBe(45);
+  });
+
   it("estimates the transcript instead of using aggregate billing when context is unavailable", () => {
     const estimate = estimateContextTokens([
       { role: "user", content: "hello", timestamp: 0 },
@@ -124,6 +138,51 @@ describe("calculateContextTokens", () => {
     expect(estimate.tokens).toBeGreaterThan(0);
     expect(estimate.usageTokens).toBe(0);
     expect(estimate.lastUsageIndex).toBeNull();
+  });
+
+  it("skips delivery-mirror usage and uses the previous real assistant snapshot", () => {
+    const estimate = estimateContextTokens([
+      { role: "user", content: "hello", timestamp: 0 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real answer" }],
+        api: "anthropic-messages",
+        provider: "anthropic",
+        model: "claude-fable-5",
+        usage: {
+          input: 20,
+          output: 10,
+          cacheRead: 3_000,
+          cacheWrite: 0,
+          totalTokens: 3_030,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "channel mirror" }],
+        api: "openclaw-transcript",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        usage: {
+          input: 0,
+          output: 0,
+          total: 0,
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 0,
+          cache: { read: 0, write: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        } as unknown as Usage,
+        stopReason: "stop",
+        timestamp: 2,
+      } as AssistantMessage,
+    ]);
+
+    expect(estimate.usageTokens).toBe(3_030);
+    expect(estimate.lastUsageIndex).toBe(1);
+    expect(estimate.tokens).toBeGreaterThan(3_030);
   });
 
   it("uses the previous exact snapshot and estimates only the unavailable tail", () => {
@@ -251,6 +310,77 @@ describe("session-entry compaction budgeting", () => {
         keepRecentTokens: 10_000,
       }),
     ).toEqual({ ok: true, value: undefined });
+  });
+});
+
+describe("prepareCompaction", () => {
+  it("keeps tokensBefore finite when delivery-mirror usage is the last assistant row", () => {
+    const entries: SessionTreeEntry[] = [
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: "2026-07-06T00:00:00.000Z",
+        message: { role: "user", content: "hello", timestamp: 0 },
+      },
+      {
+        type: "message",
+        id: "assistant-1",
+        parentId: "user-1",
+        timestamp: "2026-07-06T00:00:01.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "real answer" }],
+          api: "anthropic-messages",
+          provider: "anthropic",
+          model: "claude-fable-5",
+          usage: {
+            input: 20,
+            output: 10,
+            cacheRead: 3_000,
+            cacheWrite: 0,
+            totalTokens: 3_030,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: 1,
+        },
+      },
+      {
+        type: "message",
+        id: "mirror-1",
+        parentId: "assistant-1",
+        timestamp: "2026-07-06T00:00:02.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "channel mirror" }],
+          api: "openclaw-transcript",
+          provider: "openclaw",
+          model: "delivery-mirror",
+          usage: {
+            input: 0,
+            output: 0,
+            total: 0,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            cache: { read: 0, write: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          } as unknown as Usage,
+          stopReason: "stop",
+          timestamp: 2,
+        } as AssistantMessage,
+      },
+    ];
+
+    const result = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 0,
+      keepRecentTokens: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.ok ? Number.isFinite(result.value?.tokensBefore) : false).toBe(true);
+    expect(result.ok ? result.value?.tokensBefore : 0).toBeGreaterThan(3_030);
   });
 });
 

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -146,14 +146,91 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
   keepRecentTokens: 20000,
 };
 
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readTokenCount(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.min(Math.trunc(value), Number.MAX_SAFE_INTEGER);
+}
+
+function firstTokenCount(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const count = readTokenCount(value);
+    if (count !== undefined) {
+      return count;
+    }
+  }
+  return undefined;
+}
+
+function isTranscriptOnlyOpenClawAssistantMessage(msg: AgentMessage): boolean {
+  if (msg.role !== "assistant") {
+    return false;
+  }
+  const candidate = msg as {
+    provider?: unknown;
+    model?: unknown;
+    openclawDeliveryMirror?: unknown;
+  };
+  if (
+    candidate.provider === "openclaw" &&
+    (candidate.model === "delivery-mirror" || candidate.model === "gateway-injected")
+  ) {
+    return true;
+  }
+  const marker = readRecord(candidate.openclawDeliveryMirror);
+  return (
+    typeof marker?.kind === "string" &&
+    (marker.kind === "channel-final" ||
+      marker.kind === "channel-final-suppressed" ||
+      marker.kind === "message-tool-source-reply")
+  );
+}
+
 /** Calculate total context tokens from provider usage. */
 export function calculateContextTokens(usage: Usage): number {
   if (usage.contextUsage?.state === "available") {
-    return usage.contextUsage.totalTokens;
+    return readTokenCount(usage.contextUsage.totalTokens) ?? 0;
   }
-  return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+  const record = usage as unknown as Record<string, unknown>;
+  const cache = readRecord(record.cache);
+  const aggregateTotal = firstTokenCount(record.totalTokens, record.total_tokens, record.total);
+  const input =
+    firstTokenCount(
+      record.input,
+      record.inputTokens,
+      record.input_tokens,
+      record.promptTokens,
+      record.prompt_tokens,
+    ) ?? 0;
+  const output =
+    firstTokenCount(
+      record.output,
+      record.outputTokens,
+      record.output_tokens,
+      record.completionTokens,
+      record.completion_tokens,
+    ) ?? 0;
+  const cacheRead =
+    firstTokenCount(record.cacheRead, record.cache_read, cache?.read, cache?.cacheRead) ?? 0;
+  const cacheWrite =
+    firstTokenCount(record.cacheWrite, record.cache_write, cache?.write, cache?.cacheWrite) ?? 0;
+  const componentTotal = input + output + cacheRead + cacheWrite;
+  if (aggregateTotal !== undefined && aggregateTotal > 0) {
+    return aggregateTotal;
+  }
+  return componentTotal > 0 ? componentTotal : (aggregateTotal ?? 0);
 }
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {
+  if (isTranscriptOnlyOpenClawAssistantMessage(msg)) {
+    return undefined;
+  }
   if (msg.role === "assistant" && "usage" in msg) {
     const assistantMsg = msg;
     if (
@@ -195,7 +272,7 @@ export interface ContextUsageEstimate {
 
 function getLastAssistantUsageInfo(
   messages: AgentMessage[],
-): { usage: Usage; index: number } | undefined {
+): { usage: Usage; index: number; usageTokens: number } | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages.at(i);
     if (!message) {
@@ -203,7 +280,10 @@ function getLastAssistantUsageInfo(
     }
     const usage = getAssistantUsage(message);
     if (usage && usage.contextUsage?.state !== "unavailable") {
-      return { usage, index: i };
+      const usageTokens = calculateContextTokens(usage);
+      if (Number.isFinite(usageTokens) && usageTokens > 0) {
+        return { usage, index: i, usageTokens };
+      }
     }
   }
   return undefined;
@@ -226,7 +306,7 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
     };
   }
 
-  const usageTokens = calculateContextTokens(usageInfo.usage);
+  const usageTokens = usageInfo.usageTokens;
   let trailingTokens = 0;
   for (const message of messages.slice(usageInfo.index + 1)) {
     trailingTokens += estimateTokens(message);

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -413,6 +413,99 @@ describe("readTranscriptFileState", () => {
     expect(state.getLeafId()).toBe("compact-1");
   });
 
+  it("rejects compaction summaries whose tokensBefore serialized as null", async () => {
+    const root = await makeRoot("openclaw-transcript-state-null-compaction-tokens-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-07-06T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-07-06T00:00:01.000Z",
+          message: { role: "user", content: "old prompt" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-2",
+          parentId: "user-1",
+          timestamp: "2026-07-06T00:00:02.000Z",
+          message: { role: "user", content: "kept suffix" },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "user-2",
+          timestamp: "2026-07-06T00:00:03.000Z",
+          summary: "summary",
+          firstKeptEntryId: "user-2",
+          tokensBefore: null,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual(["user-1", "user-2"]);
+    expect(state.getLeafId()).toBe("user-2");
+    expect(state.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+  });
+
+  it("rejects compaction summaries whose tokensBefore field is omitted", async () => {
+    const root = await makeRoot("openclaw-transcript-state-missing-compaction-tokens-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-07-06T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-07-06T00:00:01.000Z",
+          message: { role: "user", content: "old prompt" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-2",
+          parentId: "user-1",
+          timestamp: "2026-07-06T00:00:02.000Z",
+          message: { role: "user", content: "kept suffix" },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "user-2",
+          timestamp: "2026-07-06T00:00:03.000Z",
+          summary: "summary",
+          firstKeptEntryId: "user-2",
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual(["user-1", "user-2"]);
+    expect(state.getLeafId()).toBe("user-2");
+    expect(state.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+  });
+
   it("skips JSON-valid non-object rows", async () => {
     const root = await makeRoot("openclaw-transcript-state-null-row-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -208,7 +208,10 @@ function isAgentMessage(value: unknown): boolean {
   }
 }
 
-function hasSessionEntryBase(entry: FileEntry): boolean {
+function hasSessionEntryBase(entry: unknown): boolean {
+  if (!isRecord(entry)) {
+    return false;
+  }
   const candidate = entry as {
     id?: unknown;
     parentId?: unknown;
@@ -223,9 +226,15 @@ function hasSessionEntryBase(entry: FileEntry): boolean {
   );
 }
 
-function isSessionEntry(entry: FileEntry): entry is SessionEntry {
+function isCanonicalCompactionTokensBefore(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isSessionEntry(entry: unknown): entry is SessionEntry {
   if (
+    !isRecord(entry) ||
     entry.type === "session" ||
+    typeof entry.type !== "string" ||
     !sessionEntryTypes.has(entry.type) ||
     !hasSessionEntryBase(entry)
   ) {
@@ -245,7 +254,7 @@ function isSessionEntry(entry: FileEntry): entry is SessionEntry {
       return (
         isString(candidate.firstKeptEntryId) &&
         typeof candidate.summary === "string" &&
-        typeof candidate.tokensBefore === "number"
+        isCanonicalCompactionTokensBefore(candidate.tokensBefore)
       );
     }
     case "custom":
@@ -494,7 +503,8 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
       }
       continue;
     }
-    if (!isSessionEntry(entry)) {
+    const sessionEntry = isSessionEntry(entry) ? entry : undefined;
+    if (!sessionEntry) {
       if (isString(id)) {
         rejectedIds.add(id);
         rejectedParentById.set(id, isString(rawParentId) ? rawParentId : null);
@@ -511,24 +521,24 @@ function readableSessionState(fileEntries: FileEntry[]): ReadableSessionState {
       }
       continue;
     }
-    if (entry.type === "label" && !acceptedIds.has(entry.targetId)) {
-      rejectedIds.add(entry.id);
-      rejectedParentById.set(entry.id, entry.parentId);
+    if (sessionEntry.type === "label" && !acceptedIds.has(sessionEntry.targetId)) {
+      rejectedIds.add(sessionEntry.id);
+      rejectedParentById.set(sessionEntry.id, sessionEntry.parentId);
       continue;
     }
-    if (acceptedIds.has(entry.id)) {
+    if (acceptedIds.has(sessionEntry.id)) {
       continue;
     }
     const hasSerializedParent = Object.hasOwn(rawRecord, "parentId");
     if (
       !hasSerializedParent ||
       (!isSessionTranscriptSideAppendEntry(rawRecord) &&
-        entry.parentId === effectiveAppendParentId &&
+        sessionEntry.parentId === effectiveAppendParentId &&
         effectiveLeafId !== effectiveAppendParentId)
     ) {
-      logicalParentsById.set(entry.id, effectiveLeafId);
+      logicalParentsById.set(sessionEntry.id, effectiveLeafId);
     }
-    const repaired = repairEntryLinks(entry);
+    const repaired = repairEntryLinks(sessionEntry);
     entries.push(repaired);
     acceptedIds.add(repaired.id);
     acceptedEntryById.set(repaired.id, repaired);

--- a/src/commands/doctor-session-transcripts.test.ts
+++ b/src/commands/doctor-session-transcripts.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readTranscriptFileState } from "../agents/embedded-agent-runner/transcript-file-state.js";
 import { SessionManager } from "../agents/sessions/session-manager.js";
 
 const note = vi.hoisted(() => vi.fn());
@@ -44,6 +45,7 @@ async function repairBrokenSessionTranscriptFile(params: {
       originalEntries: 0,
       activeEntries: 0,
       legacyOpenAICodexEntries: 0,
+      legacyNullCompactionTokensBeforeEntries: 0,
     };
   }
   if (!params.shouldRepair) {
@@ -606,6 +608,101 @@ describe("doctor session transcript repair", () => {
     const assistant = JSON.parse(expectDefined(lines[1], "lines[1] test invariant"));
     expect(assistant.message.provider).toBe("openai");
     expect(assistant.message.api).toBe("openai-chatgpt-responses");
+  });
+
+  it("rewrites null compaction tokensBefore only during doctor repair", async () => {
+    const filePath = await writeTranscript([
+      { type: "session", version: 3, id: "session-1", timestamp: "2026-07-06T00:00:00Z" },
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: "2026-07-06T00:00:01Z",
+        message: { role: "user", content: "old prompt" },
+      },
+      {
+        type: "message",
+        id: "user-2",
+        parentId: "user-1",
+        timestamp: "2026-07-06T00:00:02Z",
+        message: { role: "user", content: "kept suffix" },
+      },
+      {
+        type: "compaction",
+        id: "compact-1",
+        parentId: "user-2",
+        timestamp: "2026-07-06T00:00:03Z",
+        summary: "summary",
+        firstKeptEntryId: "user-2",
+        tokensBefore: null,
+      },
+    ]);
+
+    const preview = await repairBrokenSessionTranscriptFile({ filePath, shouldRepair: false });
+
+    expect(preview.broken).toBe(true);
+    expect(preview.repaired).toBe(false);
+    expect(preview.legacyNullCompactionTokensBeforeEntries).toBe(1);
+    expect(await fs.readFile(filePath, "utf-8")).toContain('"tokensBefore":null');
+
+    const result = await repairBrokenSessionTranscriptFile({ filePath, shouldRepair: true });
+
+    expect(result.broken).toBe(true);
+    expect(result.repaired).toBe(true);
+    expect(result.legacyNullCompactionTokensBeforeEntries).toBe(1);
+    if (!("backupPath" in result) || result.backupPath === undefined) {
+      throw new Error("expected transcript backup path");
+    }
+    await expect(fs.access(result.backupPath)).resolves.toBeUndefined();
+    const lines = (await fs.readFile(filePath, "utf-8")).trim().split(/\r?\n/);
+    const compaction = JSON.parse(expectDefined(lines[3], "lines[3] test invariant"));
+    expect(compaction).toMatchObject({ id: "compact-1", tokensBefore: 0 });
+
+    const reopened = await readTranscriptFileState(filePath);
+    expect(reopened.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary", tokensBefore: 0 },
+      { role: "user", content: "kept suffix" },
+    ]);
+  });
+
+  it("does not repair compaction rows whose tokensBefore field is omitted", async () => {
+    const filePath = await writeTranscript([
+      { type: "session", version: 3, id: "session-1", timestamp: "2026-07-06T00:00:00Z" },
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: "2026-07-06T00:00:01Z",
+        message: { role: "user", content: "old prompt" },
+      },
+      {
+        type: "message",
+        id: "user-2",
+        parentId: "user-1",
+        timestamp: "2026-07-06T00:00:02Z",
+        message: { role: "user", content: "kept suffix" },
+      },
+      {
+        type: "compaction",
+        id: "compact-1",
+        parentId: "user-2",
+        timestamp: "2026-07-06T00:00:03Z",
+        summary: "summary",
+        firstKeptEntryId: "user-2",
+      },
+    ]);
+
+    const result = await repairBrokenSessionTranscriptFile({ filePath, shouldRepair: true });
+
+    expect(result.broken).toBe(false);
+    expect(result.legacyNullCompactionTokensBeforeEntries).toBe(0);
+    expect(await fs.readFile(filePath, "utf-8")).not.toContain('"tokensBefore"');
+    const reopened = await readTranscriptFileState(filePath);
+    expect(reopened.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+    expect(reopened.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "old prompt" },
+      { role: "user", content: "kept suffix" },
+    ]);
   });
 
   it("rewrites shipped codex transcript provider metadata", async () => {

--- a/src/commands/doctor-session-transcripts.ts
+++ b/src/commands/doctor-session-transcripts.ts
@@ -38,6 +38,7 @@ type TranscriptRepairResult = {
   originalEntries: number;
   activeEntries: number;
   legacyOpenAICodexEntries: number;
+  legacyNullCompactionTokensBeforeEntries: number;
   backupPath?: string;
   reason?: string;
 };
@@ -110,6 +111,21 @@ function normalizeLegacyOpenAICodexTranscriptMetadata(entries: TranscriptEntry[]
       touched = true;
     }
     if (touched) {
+      changed += 1;
+    }
+  }
+  return changed;
+}
+
+function normalizeLegacyNullCompactionTokensBefore(entries: TranscriptEntry[]): number {
+  let changed = 0;
+  for (const entry of entries) {
+    if (
+      entry.type === "compaction" &&
+      Object.hasOwn(entry, "tokensBefore") &&
+      entry.tokensBefore === null
+    ) {
+      entry.tokensBefore = 0;
       changed += 1;
     }
   }
@@ -270,7 +286,7 @@ async function writeTranscriptEntries(params: {
   filePath: string;
   entries: TranscriptEntry[];
 }): Promise<string> {
-  const backupPath = `${params.filePath}.pre-doctor-openai-codex-repair-${new Date()
+  const backupPath = `${params.filePath}.pre-doctor-transcript-repair-${new Date()
     .toISOString()
     .replace(/[:.]/g, "-")}.bak`;
   await fs.copyFile(params.filePath, backupPath);
@@ -288,9 +304,14 @@ async function repairBrokenSessionTranscriptFile(params: {
     const raw = await fs.readFile(params.filePath, "utf-8");
     const entries = parseTranscriptEntries(raw);
     const legacyOpenAICodexEntries = normalizeLegacyOpenAICodexTranscriptMetadata(entries);
+    const legacyNullCompactionTokensBeforeEntries =
+      normalizeLegacyNullCompactionTokensBefore(entries);
     const activePath = selectActivePath(entries);
     if (!activePath) {
-      if (legacyOpenAICodexEntries > 0 && params.shouldRepair) {
+      if (
+        (legacyOpenAICodexEntries > 0 || legacyNullCompactionTokensBeforeEntries > 0) &&
+        params.shouldRepair
+      ) {
         const backupPath = await writeTranscriptEntries({ filePath: params.filePath, entries });
         return {
           filePath: params.filePath,
@@ -299,22 +320,28 @@ async function repairBrokenSessionTranscriptFile(params: {
           originalEntries: entries.length,
           activeEntries: 0,
           legacyOpenAICodexEntries,
+          legacyNullCompactionTokensBeforeEntries,
           backupPath,
           reason: "no active branch",
         };
       }
       return {
         filePath: params.filePath,
-        broken: legacyOpenAICodexEntries > 0,
+        broken: legacyOpenAICodexEntries > 0 || legacyNullCompactionTokensBeforeEntries > 0,
         repaired: false,
         originalEntries: entries.length,
         activeEntries: 0,
         legacyOpenAICodexEntries,
+        legacyNullCompactionTokensBeforeEntries,
         reason: "no active branch",
       };
     }
     const broken = hasBrokenPromptRewriteBranch(entries, activePath.entries);
-    if (!broken && legacyOpenAICodexEntries === 0) {
+    if (
+      !broken &&
+      legacyOpenAICodexEntries === 0 &&
+      legacyNullCompactionTokensBeforeEntries === 0
+    ) {
       return {
         filePath: params.filePath,
         broken: false,
@@ -322,6 +349,7 @@ async function repairBrokenSessionTranscriptFile(params: {
         originalEntries: entries.length,
         activeEntries: activePath.entries.length,
         legacyOpenAICodexEntries,
+        legacyNullCompactionTokensBeforeEntries,
       };
     }
     if (!params.shouldRepair) {
@@ -332,6 +360,7 @@ async function repairBrokenSessionTranscriptFile(params: {
         originalEntries: entries.length,
         activeEntries: activePath.entries.length,
         legacyOpenAICodexEntries,
+        legacyNullCompactionTokensBeforeEntries,
       };
     }
     const backupPath = broken
@@ -348,6 +377,7 @@ async function repairBrokenSessionTranscriptFile(params: {
       originalEntries: entries.length,
       activeEntries: activePath.entries.length,
       legacyOpenAICodexEntries,
+      legacyNullCompactionTokensBeforeEntries,
       backupPath,
     };
   } catch (err) {
@@ -358,6 +388,7 @@ async function repairBrokenSessionTranscriptFile(params: {
       originalEntries: 0,
       activeEntries: 0,
       legacyOpenAICodexEntries: 0,
+      legacyNullCompactionTokensBeforeEntries: 0,
       reason: String(err),
     };
   }
@@ -405,19 +436,29 @@ export async function detectSessionTranscriptHealthIssues(params?: {
 export function sessionTranscriptIssueToHealthFinding(
   issue: SessionTranscriptHealthIssue,
 ): HealthFinding {
-  const metadata =
+  const metadata = [
     issue.legacyOpenAICodexEntries > 0
-      ? ` ${issue.legacyOpenAICodexEntries} legacy OpenAI Codex metadata entr${
+      ? `${issue.legacyOpenAICodexEntries} legacy OpenAI Codex metadata entr${
           issue.legacyOpenAICodexEntries === 1 ? "y" : "ies"
         }`
-      : "";
+      : "",
+    issue.legacyNullCompactionTokensBeforeEntries > 0
+      ? `${issue.legacyNullCompactionTokensBeforeEntries} legacy null compaction token entr${
+          issue.legacyNullCompactionTokensBeforeEntries === 1 ? "y" : "ies"
+        }`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
   return {
     checkId: SESSION_TRANSCRIPTS_CHECK_ID,
     severity: "info",
-    message: `Session transcript has legacy branch or provider metadata that can be cleaned up.${metadata}`,
+    message: `Session transcript has legacy branch, provider metadata, or compaction telemetry that can be cleaned up.${
+      metadata ? ` ${metadata}` : ""
+    }`,
     path: issue.filePath,
     fixHint:
-      "To clean up the advisory artifact, run `openclaw doctor --fix` to rewrite affected transcripts to their active branch.",
+      "To clean up the advisory artifact, run `openclaw doctor --fix` to rewrite affected transcripts into their canonical form.",
   };
 }
 
@@ -470,7 +511,11 @@ export async function noteSessionTranscriptHealth(params?: {
           result.legacyOpenAICodexEntries > 0
             ? ` openai-codex=${result.legacyOpenAICodexEntries}`
             : "";
-        return `- ${shortenHomePath(result.filePath)} ${status} entries=${result.originalEntries}->${result.activeEntries + 1}${metadata}${backup}`;
+        const compactionTelemetry =
+          result.legacyNullCompactionTokensBeforeEntries > 0
+            ? ` compaction-null-tokens=${result.legacyNullCompactionTokensBeforeEntries}`
+            : "";
+        return `- ${shortenHomePath(result.filePath)} ${status} entries=${result.originalEntries}->${result.activeEntries + 1}${metadata}${compactionTelemetry}${backup}`;
       }),
     ];
     if (broken.length > 20) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running channel sessions could compact but fail to reclaim transcript history when a transcript-only `delivery-mirror` assistant row was the latest assistant entry. In that state, malformed mirror usage could poison `tokensBefore`, causing the compaction boundary to be dropped and the transcript to keep replaying old history.

Closes #100982

## Why This Change Was Made

The compaction estimator now ignores OpenClaw transcript-only assistant artifacts for last-assistant usage sampling and reads token usage through finite, provider-shape-tolerant counters. Normal transcript replay stays strict to canonical compaction records with numeric `tokensBefore`.

For already-written compaction rows whose explicit `tokensBefore` value serialized as `null`, the Doctor transcript repair path now detects and rewrites the durable JSONL to canonical `tokensBefore: 0`. Omitted `tokensBefore` and other malformed values remain invalid instead of being accepted during replay.

## User Impact

Safeguard compaction can keep using the real model assistant usage instead of a channel mirror row, so sessions no longer get wedged by mirror usage producing invalid `tokensBefore` telemetry. Existing transcripts with explicit `tokensBefore: null` compaction rows can be repaired with `openclaw doctor --fix`; normal runtime reads then consume the rewritten canonical row.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor-session-transcripts.test.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts packages/agent-core/src/harness/compaction/compaction.test.ts` -> 3 Vitest shards passed, 57 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` -> passed.
- `node_modules/.bin/oxfmt --check src/commands/doctor-session-transcripts.ts src/commands/doctor-session-transcripts.test.ts src/agents/embedded-agent-runner/transcript-file-state.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts packages/agent-core/src/harness/compaction/compaction.ts packages/agent-core/src/harness/compaction/compaction.test.ts` -> all matched files use the correct format.
- `git diff --check` -> no whitespace errors.
- Direct production-function proof is included below.

## Real behavior proof

**Behavior addressed:** Compaction token estimation skips transcript-only `delivery-mirror` usage, keeps `tokensBefore` finite, and moves explicit-null compaction telemetry repair into Doctor before strict transcript replay.

**Environment tested:** Linux source checkout, Node v22.22.0, pnpm 11.2.2.

**Steps run after the patch:** Ran the targeted regression tests, then ran a source-level proof script that imports the actual patched `prepareCompaction`, `detectSessionTranscriptHealthIssues`, `noteSessionTranscriptHealth`, and `readTranscriptFileState` functions. The proof uses a real assistant row followed by a `delivery-mirror` row carrying the OpenAI-style zero usage shape from the issue, plus JSONL files with explicit null and omitted compaction telemetry.

```bash
node scripts/run-vitest.mjs src/commands/doctor-session-transcripts.test.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts packages/agent-core/src/harness/compaction/compaction.test.ts
node --import tsx --no-warnings /tmp/openclaw-100982-proof.mjs
```

**Evidence after fix:** Targeted tests:

```text
[test] passed 3 Vitest shards in 67.48s
```

Production source-level proof output:

```text
prepareCompaction: {
  "ok": true,
  "tokensBefore": 3034,
  "finite": true
}

doctorReplay: {
  "issuesBefore": [
    {
      "file": "null.jsonl",
      "nullCompactionCount": 1
    }
  ],
  "nullBeforeEntries": [
    "user-1",
    "user-2"
  ],
  "nullAfterCompaction": {
    "type": "compaction",
    "id": "compact-null",
    "parentId": "user-2",
    "timestamp": "2026-07-06T00:00:03Z",
    "summary": "summary",
    "firstKeptEntryId": "user-2",
    "tokensBefore": 0
  },
  "nullRawContainsCanonicalZero": true,
  "omittedBeforeEntries": [
    "user-1",
    "user-2"
  ],
  "omittedAfterEntries": [
    "user-1",
    "user-2"
  ],
  "omittedRawContainsTokensBefore": false
}
```

**Observed result:** The production compaction path returns finite telemetry from the real assistant row instead of the mirror row. Doctor detects and rewrites explicit `tokensBefore: null` rows to durable `tokensBefore: 0`, after which strict replay accepts the compaction boundary; omitted `tokensBefore` remains unrepaired and absent from strict replay.

**Not tested:** A live long-running Telegram or gateway safeguard compaction loop with real channel delivery was not run.

## Impact Assessment

- Scope: agent-core compaction token estimation, embedded transcript JSONL replay, and Doctor session transcript repair.
- Downstream: existing callers continue receiving numeric `tokensBefore`; transcript-only assistant rows are ignored only as usage sources, not removed from transcript state by this change.
- Edge cases: non-finite, negative, missing, `null`, OpenAI-style, and nested cache usage fields are covered by normalization, strict replay rejection, Doctor repair, or fallback estimation as appropriate.
- Hard-coded values: no runtime configuration defaults were added or changed.
