### PR TITLE
fix(plugin-sdk): guard provider catalog live URL parsing against malformed responses

### DIFF
--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -699,4 +699,109 @@ describe("provider-catalog-live-runtime", () => {
     expect(recovered.models.map((model) => model.id)).toEqual(["model-b"]);
     expect(fetchGuardMock).toHaveBeenCalledTimes(2);
   });
+
+  it("gracefully ignores a malformed absolute next URL instead of crashing", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response(
+        JSON.stringify({
+          data: [{ id: "model-a", object: "model" }],
+          // Space in hostname makes this a genuinely invalid absolute URL that
+          // throws TypeError from `new URL()`. Relative URLs like "?page=2" never
+          // throw and are handled by the existing pagination path.
+          next: "http://exa mple.com/models?page=2",
+          has_more: false,
+        }),
+      ),
+      finalUrl: "https://provider.example.test/v1/models",
+      release,
+    }));
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a"]);
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gracefully ignores a malformed nested links.next URL", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response(
+        JSON.stringify({
+          data: [{ id: "model-a", object: "model" }],
+          links: { next: "http://exa mple.com/models?page=2" },
+          has_more: false,
+        }),
+      ),
+      finalUrl: "https://provider.example.test/v1/models",
+      release,
+    }));
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a"]);
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets safe replay headers when final URL is unparseable", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response(
+        JSON.stringify({
+          data: [{ id: "model-a", object: "model" }],
+        }),
+      ),
+      // An unparseable finalUrl should trigger safe replay headers (conservative
+      // cross-origin assumption), not crash.
+      finalUrl: "http://exa mple.com/models",
+      release,
+    }));
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a"]);
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports incomplete pagination instead of crashing on malformed next URL with has_more", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response(
+        JSON.stringify({
+          data: [{ id: "model-a", object: "model" }],
+          next: "http://exa mple.com/models?page=2",
+          has_more: true,
+        }),
+      ),
+      finalUrl: "https://provider.example.test/v1/models",
+      release,
+    }));
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).rejects.toThrow(
+      "provider model discovery did not include a supported next page before the catalog completed",
+    );
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -700,15 +700,13 @@ describe("provider-catalog-live-runtime", () => {
     expect(fetchGuardMock).toHaveBeenCalledTimes(2);
   });
 
-  it("gracefully ignores a malformed absolute next URL instead of crashing", async () => {
+  it("reports incomplete pagination on malformed absolute next URL with no usable fallback", async () => {
     const release = vi.fn(async () => undefined);
     const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
       response: new Response(
         JSON.stringify({
           data: [{ id: "model-a", object: "model" }],
-          // Space in hostname makes this a genuinely invalid absolute URL that
-          // throws TypeError from `new URL()`. Relative URLs like "?page=2" never
-          // throw and are handled by the existing pagination path.
+          // Space in hostname makes this a genuinely invalid absolute URL.
           next: "http://exa mple.com/models?page=2",
           has_more: false,
         }),
@@ -717,18 +715,24 @@ describe("provider-catalog-live-runtime", () => {
       release,
     }));
 
+    // The provider explicitly advertised a next page via the `next` field but
+    // the URL is malformed and there is no cursor fallback. The controlled
+    // incomplete-pagination error prevents silently returning a truncated
+    // catalog.
     await expect(
       fetchLiveProviderModelIds({
         providerId: "provider",
         endpoint: "https://provider.example.test/v1/models",
         fetchGuard: fetchGuardMock,
       }),
-    ).resolves.toEqual(["model-a"]);
+    ).rejects.toThrow(
+      "provider model discovery did not include a supported next page before the catalog completed",
+    );
 
     expect(fetchGuardMock).toHaveBeenCalledTimes(1);
   });
 
-  it("gracefully ignores a malformed nested links.next URL", async () => {
+  it("reports incomplete pagination on malformed nested links.next URL", async () => {
     const release = vi.fn(async () => undefined);
     const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
       response: new Response(
@@ -748,9 +752,50 @@ describe("provider-catalog-live-runtime", () => {
         endpoint: "https://provider.example.test/v1/models",
         fetchGuard: fetchGuardMock,
       }),
-    ).resolves.toEqual(["model-a"]);
+    ).rejects.toThrow(
+      "provider model discovery did not include a supported next page before the catalog completed",
+    );
 
     expect(fetchGuardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers malformed next URL via cursor fallback", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            data: [{ id: "model-a", object: "model" }],
+            next: "http://exa mple.com/models?page=2",
+            next_cursor: "cursor-2",
+            has_more: true,
+          }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models",
+        release,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({ data: [{ id: "model-b", object: "model" }], has_more: false }),
+        ),
+        finalUrl: "https://provider.example.test/v1/models?after=cursor-2",
+        release,
+      });
+
+    // The malformed next URL is ignored; cursor-based pagination takes over.
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).resolves.toEqual(["model-a", "model-b"]);
+
+    expect(fetchGuardMock).toHaveBeenCalledTimes(2);
+    expect(fetchGuardMock.mock.calls[1]?.[0].url).toBe(
+      "https://provider.example.test/v1/models?after=cursor-2",
+    );
   });
 
   it("sets safe replay headers when final URL is unparseable", async () => {

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -212,22 +212,33 @@ function bodyAdvertisesMoreLiveModelCatalogPages(body: unknown): boolean {
   );
 }
 
+function tryParseUrl(url: string, base?: string): URL | undefined {
+  try {
+    return new URL(url, base);
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveLiveModelCatalogNextPage(
   currentUrl: string,
   body: unknown,
 ): LiveModelCatalogNextPageResolution {
   const rawNextUrl = readLiveModelCatalogNextUrl(body);
   if (rawNextUrl) {
-    const nextUrl = new URL(rawNextUrl, currentUrl);
-    if (nextUrl.origin === new URL(currentUrl).origin) {
+    const currentParsed = tryParseUrl(currentUrl);
+    const nextUrl = tryParseUrl(rawNextUrl, currentUrl);
+    if (nextUrl && currentParsed && nextUrl.origin === currentParsed.origin) {
       return { status: "next", url: nextUrl.toString() };
     }
   }
   const cursor = readLiveModelCatalogCursor(body);
   if (cursor) {
-    const nextUrl = new URL(currentUrl);
-    nextUrl.searchParams.set(cursor.name, cursor.value);
-    return { status: "next", url: nextUrl.toString() };
+    const nextUrl = tryParseUrl(currentUrl);
+    if (nextUrl) {
+      nextUrl.searchParams.set(cursor.name, cursor.value);
+      return { status: "next", url: nextUrl.toString() };
+    }
   }
   return bodyAdvertisesMoreLiveModelCatalogPages(body)
     ? { status: "incomplete" }
@@ -302,7 +313,14 @@ export async function fetchLiveProviderModelRows(
       safeReplayHeaders,
     });
     rows.push(...result.rows);
-    if (safeReplayHeaders || new URL(result.finalUrl).origin !== new URL(requestedPageUrl).origin) {
+    const finalParsed = tryParseUrl(result.finalUrl);
+    const requestedParsed = tryParseUrl(requestedPageUrl);
+    if (
+      safeReplayHeaders ||
+      !finalParsed ||
+      !requestedParsed ||
+      finalParsed.origin !== requestedParsed.origin
+    ) {
       safeReplayHeaders = new Headers(
         retainSafeHeadersForCrossOriginRedirect(result.requestHeaders),
       );

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -231,6 +231,20 @@ function resolveLiveModelCatalogNextPage(
     if (nextUrl && currentParsed && nextUrl.origin === currentParsed.origin) {
       return { status: "next", url: nextUrl.toString() };
     }
+    // The provider advertised a next URL but it is malformed or cross-origin.
+    // Attempt cursor-based pagination as a fallback before giving up.
+    const cursor = readLiveModelCatalogCursor(body);
+    if (cursor) {
+      const cursorUrl = tryParseUrl(currentUrl);
+      if (cursorUrl) {
+        cursorUrl.searchParams.set(cursor.name, cursor.value);
+        return { status: "next", url: cursorUrl.toString() };
+      }
+    }
+    // No usable fallback: the provider explicitly advertised a next page we
+    // cannot follow. Return incomplete so the caller surfaces a controlled
+    // error instead of silently returning a truncated catalog.
+    return { status: "incomplete" };
   }
   const cursor = readLiveModelCatalogCursor(body);
   if (cursor) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `fetchLiveProviderModelRows` / `fetchLiveProviderModelIds` would crash with an uncaught `TypeError` when a provider model catalog API returns a genuinely malformed absolute URL in its `next` / `links.next` pagination field, or when the guarded fetch reports an unparseable redirect target (`finalUrl`).

## Why This Change Was Made

`resolveLiveModelCatalogNextPage` and `fetchLiveProviderModelRows` each called `new URL()` on external API response data without try/catch. The fix introduces a `tryParseUrl` helper that returns `undefined` on parse failures, matching the defensive pattern already used by `withoutMatrixStateAfterSyncParam` in the Matrix transport (#109759).

When a provider-advertised next URL is malformed or cross-origin, the fix attempts cursor-based pagination as a fallback, then returns the controlled `incomplete` result when no fallback remains — preventing silent catalog truncation.

## User Impact

Provider live model discovery survives misbehaving catalog APIs without crashing; a malformed pagination URL surfaces a controlled incomplete-pagination error instead of an uncaught TypeError or a silently truncated catalog.

## Evidence

**Before (upstream main — TypeError crash through real guarded fetch):**

```json
{"ok":false,"error":"TypeError: Invalid URL","label":"before-fix"}
```

**After (this branch — controlled incomplete-pagination error through real guarded fetch):**

```json
{"ok":false,"error":"Error: proof model discovery did not include a supported next page before the catalog completed","label":"after-fix"}
```

The harness drives the real exported `fetchLiveProviderModelIds` through a loopback HTTP server using the production `fetchWithSsrFGuard` and `ssrfPolicyFromHttpBaseUrlAllowedHostname`. The malformed `next` URL contains a space in the hostname (`http://exa mple.com/p2`), which is a genuinely invalid absolute URL that triggers the native `new URL()` parse failure.

**Focused tests (24 passed):**

```
$ node scripts/run-vitest.mjs run src/plugin-sdk/provider-catalog-live-runtime.test.ts
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

New tests cover: malformed absolute `next` URL (incomplete-pagination error), malformed nested `links.next` URL, cursor fallback recovery from malformed URL, unparseable `finalUrl` (cross-origin replay header fallback), and malformed `next` with `has_more: true`.

**What was not tested:** Live provider catalog APIs returning malformed pagination URLs; the loopback harness proves the defensive parsing guard on the real exported function through the production guarded-HTTP stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
