### PR TITLE
chore(plugin-sdk): refresh generated API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a630c0cbe46727a2dbfdfff05ac195c74d6cabe80eb36a95ceda85186768999f  plugin-sdk-api-baseline.json
-fcc48ec840e97e8159da2e02434430a4f39baa1984c89f98506b7252fcf352b8  plugin-sdk-api-baseline.jsonl
+148fa180c89f7d4797c59b1d1779b51a25cf7123e874e64cce99024bd1cd771e  plugin-sdk-api-baseline.json
+ba44e7b8e6f7e6a50f3e8de5fe792199ce779c5eedb09928e8a6220e15316829  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the changed-surface gate fails on current main after the meeting-runtime public signature changed.

## Why This Change Was Made

Refreshes the generated Plugin SDK API baseline hashes for the already-merged `recoverMeetingBrowserTab` signature. No source or API behavior changes here.

## User Impact

No user-visible impact. Plugin SDK baseline validation reflects the current public surface again.

## Evidence

- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — passed
- `git diff --check` — passed
- Generated JSONL comparison: one declaration change, `recoverMeetingBrowserTab` in `openclaw/plugin-sdk/meeting-runtime`
