### PR TITLE
fix(zalo): trigger cleanup when abort signal already fired

### DIFF
--- a/extensions/zalo/src/channel.pre-aborted.integration.test.ts
+++ b/extensions/zalo/src/channel.pre-aborted.integration.test.ts
@@ -1,0 +1,113 @@
+// Zalo tests cover the configured gateway lifecycle through the real HTTP client.
+import { createServer, type Server } from "node:http";
+import {
+  createEmptyPluginRegistry,
+  createStartAccountContext,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveZaloAccount } from "./accounts.js";
+import { zaloPlugin } from "./channel.js";
+import { setZaloRuntime, type OpenClawConfig, type PluginRuntime } from "./runtime-api.js";
+
+const originalZaloApiUrl = process.env.ZALO_API_URL;
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback Zalo API address");
+  }
+  return `http://127.0.0.1:${String(address.port)}`;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function requireStartAccount() {
+  const startAccount = zaloPlugin.gateway?.startAccount;
+  if (!startAccount) {
+    throw new Error("expected Zalo gateway startAccount");
+  }
+  return startAccount;
+}
+
+describe("configured Zalo gateway with a pre-aborted lifecycle", () => {
+  let server: Server;
+  let apiMethods: string[];
+
+  beforeEach(async () => {
+    apiMethods = [];
+    server = createServer((request, response) => {
+      const method = request.url?.match(/\/bot[^/]+\/([^/?]+)/u)?.[1] ?? "unknown";
+      apiMethods.push(method);
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          result:
+            method === "getMe"
+              ? {
+                  id: "loopback-bot",
+                  account_name: "Loopback proof bot",
+                  account_type: "BOT",
+                  can_join_groups: false,
+                }
+              : { url: "" },
+        }),
+      );
+    });
+    process.env.ZALO_API_URL = await listen(server);
+    setZaloRuntime({} as PluginRuntime);
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  afterEach(async () => {
+    if (originalZaloApiUrl === undefined) {
+      delete process.env.ZALO_API_URL;
+    } else {
+      process.env.ZALO_API_URL = originalZaloApiUrl;
+    }
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    await close(server);
+  });
+
+  it.each([
+    { mode: "polling", channel: { botToken: "loopback-proof-token" } },
+    {
+      mode: "webhook",
+      channel: {
+        botToken: "loopback-proof-token",
+        webhookUrl: "https://example.invalid/hooks/zalo",
+        webhookSecret: "loopback-proof-secret",
+      },
+    },
+  ] as const)("performs only the account probe in $mode mode", async ({ channel }) => {
+    const cfg = { channels: { zalo: channel } } as OpenClawConfig;
+    const account = resolveZaloAccount({ cfg });
+    const abort = new AbortController();
+    abort.abort();
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    await requireStartAccount()(
+      createStartAccountContext({
+        account,
+        cfg,
+        abortSignal: abort.signal,
+      }),
+    );
+
+    expect(apiMethods).toEqual(["getMe"]);
+    expect(registry.httpRoutes).toHaveLength(0);
+  });
+});

--- a/extensions/zalo/src/channel.pre-aborted.integration.test.ts
+++ b/extensions/zalo/src/channel.pre-aborted.integration.test.ts
@@ -82,13 +82,13 @@ describe("configured Zalo gateway with a pre-aborted lifecycle", () => {
   });
 
   it.each([
-    { mode: "polling", channel: { botToken: "loopback-proof-token" } },
+    { mode: "polling", channel: { botToken: "test-bot-token" } },
     {
       mode: "webhook",
       channel: {
-        botToken: "loopback-proof-token",
+        botToken: "test-bot-token",
         webhookUrl: "https://example.invalid/hooks/zalo",
-        webhookSecret: "loopback-proof-secret",
+        webhookSecret: "test-webhook-secret",
       },
     },
   ] as const)("performs only the account probe in $mode mode", async ({ channel }) => {

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -252,6 +252,10 @@ describe("monitorZaloProvider lifecycle", () => {
     // early return works, this test completes. getUpdates should not be
     // called because we never entered polling.
     expect(getUpdatesMock).not.toHaveBeenCalled();
+    // getWebhookInfo should also be skipped — on main the polling path
+    // inspects the webhook before starting the loop, so a pre-aborted
+    // signal that misses the early return would hit getWebhookInfo first.
+    expect(getWebhookInfoMock).not.toHaveBeenCalled();
     // The early return logs provider init but skips the try/finally block,
     // so the "stopped" log from the finally block is not emitted.
   });

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -231,4 +231,49 @@ describe("monitorZaloProvider lifecycle", () => {
     expect(registry.httpRoutes).toHaveLength(0);
     expect(runtime.log).toHaveBeenCalledWith("[default] Zalo provider stopped mode=webhook");
   });
+
+  it("returns immediately without polling startup when abort signal is pre-aborted", async () => {
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const preAborted = new AbortController();
+    preAborted.abort();
+    const runtime = createRuntimeEnv();
+
+    // With a pre-aborted signal the function must return without ever
+    // entering the polling loop (getUpdates never called).
+    await monitorZaloProvider({
+      token: "test-token",
+      account: TEST_ACCOUNT,
+      config: TEST_CONFIG,
+      runtime,
+      abortSignal: preAborted.signal,
+    });
+
+    // getUpdatesMock is a never-resolving promise in polling mode; if the
+    // early return works, this test completes. getUpdates should not be
+    // called because we never entered polling.
+    expect(getUpdatesMock).not.toHaveBeenCalled();
+    // The early return logs provider init but skips the try/finally block,
+    // so the "stopped" log from the finally block is not emitted.
+  });
+
+  it("returns immediately without webhook registration when abort signal is pre-aborted", async () => {
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const preAborted = new AbortController();
+    preAborted.abort();
+    const runtime = createRuntimeEnv();
+
+    await monitorZaloProvider({
+      token: "test-token",
+      account: TEST_ACCOUNT,
+      config: TEST_CONFIG,
+      runtime,
+      abortSignal: preAborted.signal,
+      useWebhook: true,
+      webhookUrl: "https://example.com/hooks/zalo",
+      webhookSecret: "test-secret-min-8-chars",
+    });
+
+    // setWebhookMock should not be called — we returned before webhook setup.
+    expect(setWebhookMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -274,7 +274,7 @@ describe("monitorZaloProvider lifecycle", () => {
       abortSignal: preAborted.signal,
       useWebhook: true,
       webhookUrl: "https://example.com/hooks/zalo",
-      webhookSecret: "test-secret-min-8-chars",
+      webhookSecret: "test-webhook-secret",
     });
 
     // setWebhookMock should not be called — we returned before webhook setup.

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -856,7 +856,11 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
     }
   };
 
-  abortSignal.addEventListener("abort", stopOnAbort, { once: true });
+  if (abortSignal.aborted) {
+    stopOnAbort();
+  } else {
+    abortSignal.addEventListener("abort", stopOnAbort, { once: true });
+  }
 
   runtime.log?.(
     `[${account.accountId}] Zalo provider init mode=${mode} mediaMaxMb=${String(effectiveMediaMaxMb)}`,

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -857,10 +857,15 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
   };
 
   if (abortSignal.aborted) {
+    // The signal is already aborted — trigger cleanup in non-webhook mode
+    // and return before acquiring any resources (hosted-media routes,
+    // webhook registration, or polling). This avoids registering cleanup
+    // handlers after stop() has already set stopped=true, which would
+    // skip them in the finally block and leak plugin HTTP routes.
     stopOnAbort();
-  } else {
-    abortSignal.addEventListener("abort", stopOnAbort, { once: true });
+    return;
   }
+  abortSignal.addEventListener("abort", stopOnAbort, { once: true });
 
   runtime.log?.(
     `[${account.accountId}] Zalo provider init mode=${mode} mediaMaxMb=${String(effectiveMediaMaxMb)}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes a shutdown race in the Zalo channel provider. When the gateway stop `AbortSignal` was already aborted before `monitorZaloProvider` registered its listener, the abort event was not replayed and startup continued into polling or webhook resource acquisition.

## Why This Change Was Made

The monitor now checks `abortSignal.aborted` immediately before listener registration and before acquiring hosted-media routes, registering a webhook, or starting polling. The normal later-abort path remains unchanged.

The fix stays inside the Zalo plugin and adds no config, protocol, SDK, dependency, or compatibility surface.

## User Impact

Fast gateway stops and overlapping account lifecycle transitions no longer allow Zalo polling, webhook mutation, or local HTTP-route startup after shutdown has already won the race.

## Evidence

### Real behavior proof

The committed integration test exercises the complete production boundary:

`configured OpenClaw Zalo account` -> `zaloPlugin.gateway.startAccount` -> `startZaloGatewayAccount` -> real account probe -> `monitorZaloProvider`

It does not mock the Zalo API module, monitor, gateway runtime, config resolver, `fetch`, `AbortSignal`, or plugin HTTP-route registry. The production Zalo HTTP client connects over a real loopback TCP socket using its supported `ZALO_API_URL` override. The loopback endpoint returns normal Zalo-shaped responses and records every API method observed without exposing the configured token.

The same test was run against the PR base and the reviewed head:

| Revision | Result | API methods observed after configured gateway startup | Local routes after return |
| --- | --- | --- | --- |
| Base `db3213264a` | 0 passed, 2 failed | polling: `getMe`, `getWebhookInfo`; webhook: `getMe`, `setWebhook`, `deleteWebhook` | 0 |
| Head `14a96a5713` | 2 passed, 0 failed | polling: `getMe`; webhook: `getMe` | 0 |

`getMe` is the production gateway's account probe. On the fixed head, the already-aborted monitor performs no polling inspection, update polling, webhook registration/deletion, or local route registration after that probe.

Base failure excerpts:

```text
polling: expected [ 'getMe', 'getWebhookInfo' ] to deeply equal [ 'getMe' ]
webhook: expected [ 'getMe', 'setWebhook', 'deleteWebhook' ] to deeply equal [ 'getMe' ]
Test Files  1 failed (1)
Tests       2 failed (2)
```

Head result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```

Focused related validation on the final head:

```text
node scripts/run-vitest.mjs \
  extensions/zalo/src/channel.pre-aborted.integration.test.ts \
  extensions/zalo/src/monitor.lifecycle.test.ts \
  extensions/zalo/src/channel.startup.test.ts

Test Files  3 passed (3)
Tests       10 passed (10)
```

Targeted `oxfmt`, `oxlint`, and `git diff --check` pass. The standard pushed-head CI remains authoritative for full build, lint, and test-type gates.

Proof boundary: this is a real-process, real-socket integration against a deterministic loopback Zalo API endpoint, not a claim of testing the public Zalo service. That substitution is appropriate for this race because the asserted behavior is the absence and ordering of API/resource acquisition after a pre-aborted lifecycle; the test fails on the base by observing the exact unwanted production HTTP methods and passes on the fixed head with only the required account probe.
