### PR TITLE
fix(group): keep group id display truncation UTF-16 safe

### DIFF
--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -1,7 +1,7 @@
 // Session group tests cover grouping and lookup of related sessions.
 import { describe, expect, it } from "vitest";
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { buildGroupDisplayTitle, resolveGroupSessionKey } from "./group.js";
+import { buildGroupDisplayTitle, resolveGroupSessionKey, shortenGroupId } from "./group.js";
 
 describe("resolveGroupSessionKey", () => {
   it("preserves Signal group ids from the originating target", () => {
@@ -63,6 +63,21 @@ describe("resolveGroupSessionKey", () => {
   });
 });
 
+function hasOrphanedSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) {
+        return true;
+      }
+      i++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("buildGroupDisplayTitle", () => {
   it("prefers the native channel name with optional space prefix", () => {
     expect(buildGroupDisplayTitle({ groupChannel: "general" })).toBe("#general");
@@ -77,5 +92,67 @@ describe("buildGroupDisplayTitle", () => {
     expect(buildGroupDisplayTitle({ space: "Acme" })).toBe("Acme");
     expect(buildGroupDisplayTitle({})).toBeUndefined();
     expect(buildGroupDisplayTitle({ subject: "  " })).toBeUndefined();
+  });
+});
+
+describe("shortenGroupId", () => {
+  it("truncates long ASCII strings to prefix...suffix", () => {
+    expect(shortenGroupId("abcdefghijklmnop")).toBe("abcdef...mnop");
+  });
+
+  it("handles emoji at suffix boundary without orphaned surrogates", () => {
+    // Bug: old code used trimmed.slice(-4) which can split a surrogate pair.
+    // With the 4-UTF-16-unit suffix, the 😱 at positions 10-11 doesn't fit
+    // (start=-4 lands at index 11 = low surrogate → adjusted to 12 → "klm").
+    const input = "abcdefghij" + String.fromCodePoint(0x1f631) + "klm";
+    const result = shortenGroupId(input);
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+    expect(result).toBe("abcdef...klm");
+  });
+
+  it("preserves emoji at suffix edge when it fits in 4 UTF-16 units", () => {
+    // Regression: suffix uses sliceUtf16Safe(input, -4) to take the last
+    // 4 UTF-16 code units without splitting surrogates. "😱ab" is exactly 4
+    // UTF-16 units (high surr + low surr + a + b) and fits correctly.
+    const asciiInput = "0123456789xyabcd";
+    expect(shortenGroupId(asciiInput)).toBe("012345...abcd");
+    const emojiInput = "0123456789xy😱ab";
+    const result = shortenGroupId(emojiInput);
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+    expect(result).toBe("012345...😱ab");
+  });
+
+  it("handles emoji at prefix boundary", () => {
+    const input = "abcde" + String.fromCodePoint(0x1f631) + "fghijklmnopqrst";
+    const result = shortenGroupId(input);
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+  });
+
+  it("produces no orphaned surrogates with multiple emoji", () => {
+    const emoji = String.fromCodePoint(0x1f631);
+    const input = emoji.repeat(10);
+    const result = shortenGroupId(input);
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+  });
+
+  it("stays within the 13-UTF-16-unit budget with all-emoji input", () => {
+    // All-emoji input exercises the suffix budget: each emoji = 2 UTF-16 units.
+    // Prefix takes 6 UTF-16 units (3 emoji), suffix takes 4 UTF-16 units (2 emoji),
+    // "..." adds 3. Total display = 3 + 3 + 2 = 8 code points, 13 UTF-16 units.
+    const emoji = String.fromCodePoint(0x1f631);
+    const input = emoji.repeat(10);
+    const result = shortenGroupId(input);
+
+    // No orphaned surrogates in output
+    expect(hasOrphanedSurrogate(result)).toBe(false);
+    // Total UTF-16 length stays within the original budget of 13
+    expect(result.length).toBeLessThanOrEqual(13);
+    // Shows 3 prefix emoji + "..." + 2 suffix emoji
+    expect(result).toBe(`${emoji.repeat(3)}...${emoji.repeat(2)}`);
+  });
+
+  it("returns short strings unchanged", () => {
+    expect(shortenGroupId("short")).toBe("short");
+    expect(shortenGroupId("")).toBe("");
   });
 });

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeHyphenSlug } from "@openclaw/normalization-core/string-normalization";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { listChannelPlugins } from "../../channels/plugins/registry.js";
 import { normalizeSessionPeerId } from "../../sessions/session-key-utils.js";
@@ -69,7 +70,7 @@ function resolveOriginatingGroupTargetId(params: {
   return null;
 }
 
-function shortenGroupId(value?: string) {
+export function shortenGroupId(value?: string) {
   const trimmed = normalizeOptionalString(value) ?? "";
   if (!trimmed) {
     return "";
@@ -77,7 +78,7 @@ function shortenGroupId(value?: string) {
   if (trimmed.length <= 14) {
     return trimmed;
   }
-  return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
+  return `${truncateUtf16Safe(trimmed, 6)}...${sliceUtf16Safe(trimmed, -4)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #109993

## What Problem This Solves

**Problem**: `shortenGroupId` in `src/config/sessions/group.ts` uses `String.prototype.slice()` which operates on UTF-16 code units. When a surrogate pair (e.g. emoji like 🚀 🎉) straddles the truncation boundary, `.slice()` produces orphan surrogates that render as garbled text in the UI.

**Root Cause**: `trimmed.slice(0, 6)` and `trimmed.slice(-4)` can cut through the middle of a surrogate pair. For example, when a high surrogate lands at code-unit position 5 (the last position of the prefix), `slice(0, 6)` returns the high surrogate without its matching low surrogate. Same issue for the suffix.

**Solution**: Replace `.slice(0, 6)` with `truncateUtf16Safe(trimmed, 6)` and `.slice(-4)` with `sliceUtf16Safe(trimmed, -4)` from `@openclaw/normalization-core/utf16-slice`. These helpers detect surrogate pair boundaries and adjust the cut position to keep pairs whole. Also exported `shortenGroupId` for direct testing.

## Evidence

**Real environment tested**: Linux 6.17.0-35-generic / Node.js v25.9.0 / tsx v4.22.4

**Exact steps or command run after this patch**:
```bash
npx tsx scripts/evidence-shortenGroupId.mts
```

The script directly imports `shortenGroupId` from `src/config/sessions/group.ts` and compares its output against the old `String.prototype.slice` implementation across 10 test cases covering ASCII, CJK, emoji, and mixed scripts.

**After-fix evidence**:
```
HEAD: 5849a2c6c06a7232dda76fe13a1bd0d8161195a6

====================================================================================================
  shortenGroupId -- OLD (String.prototype.slice) vs NEW (UTF-16 safe)
====================================================================================================

  #  Test case                       OLD result                  NEW result                  Status
  ────────────────────────────────────────────────────────────────────────────────────────────────

   1  ASCII, <=14 chars -- no trunc     C0123456789abc              C0123456789abc              OK
   2  ASCII, >14 chars                  C01234...bcde               C01234...bcde               OK
   3  slice(0,6) hits pair mid          abcde\uD83C...lmno          abcde...lmno                <<< OLD HAS ORPHAN SURROGATE
   4  slice(-4) hits pair mid           abcdef...\uDF89nop          abcdef...nop                <<< OLD HAS ORPHAN SURROGATE
   5  both ends hit pairs               abcde\uD83C...wxyz          abcde...wxyz                <<< OLD HAS ORPHAN SURROGATE
   6  CJK channel name                  项目-Alpha-长期讨论群               项目-Alpha-长期讨论群               OK
   7  emoji-rich group                  abcde\uD83D...pqrs          abcde...pqrs                <<< OLD HAS ORPHAN SURROGATE
   8  slack-like channel id             slack:...EFGH               slack:...EFGH               OK
   9  pair at slice(0,6) edge           abcde\uD83C...wxyz          abcde...wxyz                <<< OLD HAS ORPHAN SURROGATE
  10  pair at slice(-4) edge            abcdef...\uDF89opq          abcdef...opq                <<< OLD HAS ORPHAN SURROGATE
  ────────────────────────────────────────────────────────────────────────────────────────────────

Summary: 6 cases had orphan surrogates in OLD path. 4 cases pass (NEW has 0 orphans).
All NEW results are UTF-16 safe -- no broken surrogate pairs.
```

**Observed result after the fix**: The new `shortenGroupId` produces valid UTF-16 output in all 10 test cases. 6 out of 10 cases produced orphan surrogates (shown as `\uD83C`, `\uD83D`, `\uDF89`) under the old `.slice()` implementation -- the fix eliminates all of them.

**What was not tested**: Full Gateway runtime with real session-group display data. The change is scoped to one pure function and does not affect networking, external services, or any runtime behavior beyond the string truncation path.

## Tests and validation

All existing unit tests pass. The existing `@openclaw/normalization-core/utf16-slice` unit tests already cover the surrogate-safe helpers.

The `src/config/sessions/group.test.ts` file has 13 tests covering `shortenGroupId`, `buildGroupDisplayTitle`, and `resolveGroupSessionKey`. All 13 pass with the fix applied:

```
 ✓ src/config/sessions/group.test.ts > resolveGroupSessionKey > preserves Signal group ids from the originating target
 ✓ src/config/sessions/group.test.ts > resolveGroupSessionKey > keeps non-Signal group ids lowercase
 ✓ src/config/sessions/group.test.ts > resolveGroupSessionKey > preserves empty opaque segments in originating group ids
 ✓ src/config/sessions/group.test.ts > resolveGroupSessionKey > rejects empty structural group-route segments
 ✓ src/config/sessions/group.test.ts > buildGroupDisplayTitle > prefers the native channel name with optional space prefix
 ✓ src/config/sessions/group.test.ts > buildGroupDisplayTitle > falls back to the chat subject, then the space, then undefined
 ✓ src/config/sessions/group.test.ts > shortenGroupId > truncates long ASCII strings to prefix...suffix
 ✓ src/config/sessions/group.test.ts > shortenGroupId > handles emoji at suffix boundary without orphaned surrogates
 ✓ src/config/sessions/group.test.ts > shortenGroupId > preserves emoji at suffix edge when it fits in 4 UTF-16 units
 ✓ src/config/sessions/group.test.ts > shortenGroupId > handles emoji at prefix boundary
 ✓ src/config/sessions/group.test.ts > shortenGroupId > produces no orphaned surrogates with multiple emoji
 ✓ src/config/sessions/group.test.ts > shortenGroupId > stays within the 13-UTF-16-unit budget with all-emoji input
 ✓ src/config/sessions/group.test.ts > shortenGroupId > returns short strings unchanged
```

The evidence script (`scripts/evidence-shortenGroupId.mts`) validates the `shortenGroupId` end-to-end integration against both old and new implementations.

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation
- [ ] Breaking changes (if any) are documented in Summary