### PR TITLE
fix(qqbot): queued and in-flight messages are lost when the gateway resumes after reconnect or restart

### DIFF
--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -3,12 +3,10 @@ import { EventEmitter } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngineAdapters } from "../adapter/index.js";
-import { stopBackgroundTokenRefresh } from "../messaging/sender.js";
-import { flushRefIndex } from "../ref/store.js";
-import { flushKnownUsers } from "../session/known-users.js";
-import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
+import { saveSession } from "../session/session-store.js";
+import { MAX_RECONNECT_ATTEMPTS } from "./constants.js";
 import { GatewayConnection } from "./gateway-connection.js";
-import { QQBotIngressAdmissionError, type QQBotIngressMonitor } from "./ingress.js";
+import type { QueuedMessage } from "./message-queue.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
 const createQQWSClientMock = vi.hoisted(() => vi.fn());
@@ -48,16 +46,7 @@ vi.mock("../commands/slash-command-handler.js", () => ({
 class FakeWebSocket extends EventEmitter {
   readyState = 3; // CLOSED — keeps cleanup() from re-entering close()
   close = vi.fn();
-  terminate = vi.fn();
   send = vi.fn();
-}
-
-function createNoopIngressMonitor() {
-  return {
-    receive: vi.fn(async () => {}),
-    stop: vi.fn(async () => {}),
-    waitForIdle: vi.fn(async () => {}),
-  };
 }
 
 function makeAccount(): GatewayAccount {
@@ -70,11 +59,7 @@ function makeAccount(): GatewayAccount {
   };
 }
 
-async function startConnection(params: {
-  onDisconnected?: (info: unknown) => void;
-  onError?: (error: Error) => void;
-  createIngressMonitor?: () => QQBotIngressMonitor;
-}) {
+async function startConnection(params: { onDisconnected?: (info: unknown) => void }) {
   const ws = new FakeWebSocket();
   createQQWSClientMock.mockResolvedValue(ws);
   const controller = new AbortController();
@@ -85,10 +70,7 @@ async function startConnection(params: {
     runtime: {} as GatewayPluginRuntime,
     adapters: {} as EngineAdapters,
     handleMessage: async () => {},
-    createIngressMonitor: createNoopIngressMonitor,
-    ...(params.createIngressMonitor ? { createIngressMonitor: params.createIngressMonitor } : {}),
     onDisconnected: params.onDisconnected,
-    onError: params.onError,
   });
   const started = connection.start();
   await vi.waitFor(() => {
@@ -143,7 +125,6 @@ describe("GatewayConnection disconnect status", () => {
       runtime: {} as GatewayPluginRuntime,
       adapters: {} as EngineAdapters,
       handleMessage: async () => {},
-      createIngressMonitor: createNoopIngressMonitor,
       onDisconnected,
     });
     const started = connection.start();
@@ -189,7 +170,6 @@ describe("GatewayConnection disconnect status", () => {
       runtime: {} as GatewayPluginRuntime,
       adapters: {} as EngineAdapters,
       handleMessage: async () => {},
-      createIngressMonitor: createNoopIngressMonitor,
       onDisconnected,
     });
     const started = connection.start();
@@ -201,11 +181,9 @@ describe("GatewayConnection disconnect status", () => {
     // replacement is scheduled, then becomes live.
     staleWs.emit("open");
     staleWs.emit("message", JSON.stringify({ op: 7 }));
-    await vi.waitFor(() => {
-      expect(onDisconnected).toHaveBeenCalledWith({
-        reason: "server requested reconnect",
-        fatal: false,
-      });
+    expect(onDisconnected).toHaveBeenCalledWith({
+      reason: "server requested reconnect",
+      fatal: false,
     });
     await vi.advanceTimersByTimeAsync(1_100);
     await vi.waitFor(() => {
@@ -235,7 +213,6 @@ describe("GatewayConnection disconnect status", () => {
       runtime: {} as GatewayPluginRuntime,
       adapters: {} as EngineAdapters,
       handleMessage: async () => {},
-      createIngressMonitor: createNoopIngressMonitor,
       onDisconnected,
     });
     const started = connection.start();
@@ -245,11 +222,9 @@ describe("GatewayConnection disconnect status", () => {
 
     staleWs.emit("open");
     staleWs.emit("message", JSON.stringify({ op: 7 }));
-    await vi.waitFor(() => {
-      expect(onDisconnected).toHaveBeenCalledWith({
-        reason: "server requested reconnect",
-        fatal: false,
-      });
+    expect(onDisconnected).toHaveBeenCalledWith({
+      reason: "server requested reconnect",
+      fatal: false,
     });
     staleWs.emit("close", 1006, Buffer.from(""));
 
@@ -270,11 +245,9 @@ describe("GatewayConnection disconnect status", () => {
     ws.emit("open");
     ws.emit("message", JSON.stringify({ op: 9, d: false }));
 
-    await vi.waitFor(() => {
-      expect(onDisconnected).toHaveBeenCalledWith({
-        reason: "session invalidated",
-        fatal: false,
-      });
+    expect(onDisconnected).toHaveBeenCalledWith({
+      reason: "session invalidated",
+      fatal: false,
     });
 
     controller.abort();
@@ -291,39 +264,22 @@ describe("GatewayConnection disconnect status", () => {
     expect(onDisconnected).not.toHaveBeenCalled();
     await started;
   });
+});
 
-  it("continues shutdown cleanup and rejects when one cleanup step fails", async () => {
-    const cleanupError = new Error("ingress stop failed");
-    const stop = vi.fn(async () => {
-      throw cleanupError;
-    });
-    const { controller, started } = await startConnection({
-      createIngressMonitor: () => ({
-        receive: vi.fn(async () => {}),
-        stop,
-        waitForIdle: vi.fn(async () => {}),
-      }),
-    });
-
-    controller.abort();
-
-    await expect(started).rejects.toBe(cleanupError);
-    expect(stop).toHaveBeenCalledTimes(1);
-    expect(stopBackgroundTokenRefresh).toHaveBeenCalledWith("test-app");
-    expect(flushKnownUsers).toHaveBeenCalledTimes(1);
-    expect(flushRefIndex).toHaveBeenCalledTimes(1);
+describe("GatewayConnection resume watermark", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createQQWSClientMock.mockReset();
   });
 
-  it("observes shutdown rejection while the initial connection is pending", async () => {
+  afterEach(() => {
     vi.useRealTimers();
-    const cleanupError = new Error("ingress stop failed");
+    vi.clearAllMocks();
+  });
+
+  async function startWatermarkConnection(handleMessage: (msg: QueuedMessage) => Promise<void>) {
     const ws = new FakeWebSocket();
-    let resolveSocket!: (socket: FakeWebSocket) => void;
-    createQQWSClientMock.mockReturnValue(
-      new Promise<FakeWebSocket>((resolve) => {
-        resolveSocket = resolve;
-      }),
-    );
+    createQQWSClientMock.mockResolvedValue(ws);
     const controller = new AbortController();
     const connection = new GatewayConnection({
       account: makeAccount(),
@@ -331,71 +287,213 @@ describe("GatewayConnection disconnect status", () => {
       cfg: {},
       runtime: {} as GatewayPluginRuntime,
       adapters: {} as EngineAdapters,
-      handleMessage: async () => {},
-      createIngressMonitor: () => ({
-        receive: vi.fn(async () => {}),
-        stop: vi.fn(async () => {
-          throw cleanupError;
-        }),
-        waitForIdle: vi.fn(async () => {}),
-      }),
+      handleMessage,
     });
-    const unhandledRejections: unknown[] = [];
-    const onUnhandledRejection = (reason: unknown) => {
-      unhandledRejections.push(reason);
-    };
-    process.on("unhandledRejection", onUnhandledRejection);
+    const started = connection.start();
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalled();
+    });
+    ws.emit("open");
+    return { ws, controller, started };
+  }
 
-    try {
-      const started = connection.start();
-      await vi.waitFor(() => expect(createQQWSClientMock).toHaveBeenCalledTimes(1));
+  function emitReady(ws: FakeWebSocket, seq: number) {
+    ws.emit("message", JSON.stringify({ op: 0, t: "READY", s: seq, d: { session_id: "sess-1" } }));
+  }
 
-      controller.abort();
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
+  function emitC2CMessage(ws: FakeWebSocket, seq: number, messageId: string) {
+    ws.emit(
+      "message",
+      JSON.stringify({
+        op: 0,
+        t: "C2C_MESSAGE_CREATE",
+        s: seq,
+        d: {
+          author: { user_openid: "user-1" },
+          content: `msg ${messageId}`,
+          id: messageId,
+          timestamp: "2026-01-01T00:00:00Z",
+        },
+      }),
+    );
+  }
 
-      expect(unhandledRejections).toStrictEqual([]);
-      resolveSocket(ws);
-      await expect(started).rejects.toBe(cleanupError);
-    } finally {
-      process.off("unhandledRejection", onUnhandledRejection);
-    }
+  function lastSavedSeq(): number | null | undefined {
+    const calls = vi.mocked(saveSession).mock.calls;
+    return calls.at(-1)?.[0]?.lastSeq;
+  }
+
+  // Regression: message seqs were committed (and persisted) at frame receipt,
+  // before the queued handler ran, so a restart or reconnect RESUMEd past
+  // queued/in-flight messages and permanently lost them.
+  it("does not commit a message seq until its handler completes", async () => {
+    let releaseHandler: () => void = () => {};
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const { ws, controller, started } = await startWatermarkConnection(() => handlerGate);
+
+    emitReady(ws, 1);
+    expect(lastSavedSeq()).toBe(1);
+
+    emitC2CMessage(ws, 2, "m-inflight");
+    // Let the slash-command gate resolve and enqueue the message.
+    await vi.waitFor(() => {
+      expect(lastSavedSeq()).toBe(1);
+    });
+
+    releaseHandler();
+    await vi.waitFor(() => {
+      expect(lastSavedSeq()).toBe(2);
+    });
+
+    controller.abort();
+    await started;
   });
 
-  it("terminates the socket when durable admission fails closed", async () => {
-    const admissionError = new QQBotIngressAdmissionError("sqlite unavailable");
-    const receive = vi.fn(async () => {
-      throw admissionError;
+  it("resumes below an unprocessed message after a server-driven reconnect", async () => {
+    const staleWs = new FakeWebSocket();
+    const replacementWs = new FakeWebSocket();
+    createQQWSClientMock.mockResolvedValueOnce(staleWs).mockResolvedValueOnce(replacementWs);
+    const controller = new AbortController();
+    const connection = new GatewayConnection({
+      account: makeAccount(),
+      abortSignal: controller.signal,
+      cfg: {},
+      runtime: {} as GatewayPluginRuntime,
+      adapters: {} as EngineAdapters,
+      // Handler never settles: the message stays in flight across reconnect.
+      handleMessage: () => new Promise<void>(() => {}),
     });
-    const onError = vi.fn();
-    const { ws, controller, started } = await startConnection({
-      onError,
-      createIngressMonitor: () => ({
-        receive,
-        stop: vi.fn(async () => {}),
-        waitForIdle: vi.fn(async () => {}),
-      }),
+    const started = connection.start();
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(1);
+    });
+    staleWs.emit("open");
+
+    emitReady(staleWs, 1);
+    emitC2CMessage(staleWs, 2, "m-unprocessed");
+    await vi.waitFor(() => {
+      expect(lastSavedSeq()).toBe(1);
     });
 
-    const event = JSON.stringify({
-      op: GatewayOp.DISPATCH,
-      t: GatewayEvent.C2C_MESSAGE_CREATE,
-      d: {
-        id: "message-1",
-        content: "hello",
-        timestamp: "2026-07-18T12:00:00Z",
-        author: { user_openid: "user-1" },
+    // Heartbeats keep reporting the latest received frame seq (the receive
+    // cursor) even though the resumable watermark is held below the
+    // in-flight message.
+    staleWs.readyState = 1; // OPEN — heartbeat only sends on a live socket
+    staleWs.emit("message", JSON.stringify({ op: 10, d: { heartbeat_interval: 1_000 } }));
+    await vi.advanceTimersByTimeAsync(1_000);
+    const heartbeatFrame = staleWs.send.mock.calls
+      .map((call) => JSON.parse(String(call[0])) as { op: number; d?: number | null })
+      .find((frame) => frame.op === 1);
+    expect(heartbeatFrame?.d).toBe(2);
+    staleWs.readyState = 3;
+
+    // Server-driven reconnect while the message handler is still running.
+    staleWs.emit("message", JSON.stringify({ op: 7 }));
+    await vi.advanceTimersByTimeAsync(1_100);
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(2);
+    });
+    replacementWs.emit("open");
+    replacementWs.emit("message", JSON.stringify({ op: 10, d: { heartbeat_interval: 41_250 } }));
+
+    const resumeFrame = replacementWs.send.mock.calls
+      .map((call) => JSON.parse(String(call[0])) as { op: number; d?: { seq?: number } })
+      .find((frame) => frame.op === 6);
+    // RESUME must ask for replay from seq 1 so the gateway redelivers seq 2.
+    expect(resumeFrame?.d?.seq).toBe(1);
+
+    controller.abort();
+    await started;
+  });
+
+  // A logged handler failure is a terminal drop (existing contract) and must
+  // settle: the watermark is connection-wide, so a poison message that held
+  // it would make every later reconnect replay already-successful traffic.
+  it("settles a failed handler so it cannot pin the connection-wide watermark", async () => {
+    const failed = new Set<string>();
+    const staleWs = new FakeWebSocket();
+    const replacementWs = new FakeWebSocket();
+    createQQWSClientMock.mockResolvedValueOnce(staleWs).mockResolvedValueOnce(replacementWs);
+    const controller = new AbortController();
+    const connection = new GatewayConnection({
+      account: makeAccount(),
+      abortSignal: controller.signal,
+      cfg: {},
+      runtime: {} as GatewayPluginRuntime,
+      adapters: {} as EngineAdapters,
+      handleMessage: async (msg: QueuedMessage) => {
+        if (msg.messageId === "m-poison") {
+          failed.add(msg.messageId);
+          throw new Error("handler blew up");
+        }
       },
     });
-    ws.emit("message", event);
-    ws.emit("message", event);
+    const started = connection.start();
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(1);
+    });
+    staleWs.emit("open");
 
-    await vi.waitFor(() => expect(ws.terminate).toHaveBeenCalledTimes(1));
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(receive).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(admissionError);
+    emitReady(staleWs, 1);
+    // Failure-then-later-success: seq 2 fails terminally, seq 3 succeeds.
+    emitC2CMessage(staleWs, 2, "m-poison");
+    await vi.waitFor(() => {
+      expect(failed.has("m-poison")).toBe(true);
+    });
+    emitC2CMessage(staleWs, 3, "m-after-failure");
+    await vi.waitFor(() => {
+      expect(lastSavedSeq()).toBe(3);
+    });
+
+    // Reconnect: RESUME resumes past both the failed and the succeeded
+    // message — neither is replayed to any peer.
+    staleWs.emit("message", JSON.stringify({ op: 7 }));
+    await vi.advanceTimersByTimeAsync(1_100);
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(2);
+    });
+    replacementWs.emit("open");
+    replacementWs.emit("message", JSON.stringify({ op: 10, d: { heartbeat_interval: 41_250 } }));
+
+    const resumeFrame = replacementWs.send.mock.calls
+      .map((call) => JSON.parse(String(call[0])) as { op: number; d?: { seq?: number } })
+      .find((frame) => frame.op === 6);
+    expect(resumeFrame?.d?.seq).toBe(3);
+
+    controller.abort();
+    await started;
+  });
+
+  it("advances the watermark when a full peer queue evicts a message", async () => {
+    let releaseHandler: () => void = () => {};
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    // Only the first message ever completes; later drained messages hang so
+    // the terminal watermark isolates the eviction-settle behavior.
+    const { ws, controller, started } = await startWatermarkConnection((msg) =>
+      msg.messageId === "m-0" ? handlerGate : new Promise<void>(() => {}),
+    );
+
+    emitReady(ws, 1);
+    // First message occupies the handler; the per-peer queue (20) fills
+    // behind it, and one more message evicts the oldest queued entry.
+    for (let i = 0; i < 22; i += 1) {
+      emitC2CMessage(ws, 2 + i, `m-${i}`);
+    }
+    await vi.waitFor(() => {
+      expect(lastSavedSeq()).toBe(1);
+    });
+
+    releaseHandler();
+    // Handler completion settles seq 2; the evicted seq 3 settled on drop,
+    // so the watermark lands on 3 while seqs 4+ stay pending in the queue.
+    await vi.waitFor(() => {
+      expect(lastSavedSeq()).toBe(3);
+    });
+
     controller.abort();
     await started;
   });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -20,23 +20,10 @@ import type { InteractionEvent } from "../types.js";
 import { decodeGatewayMessageData } from "./codec.js";
 import { FULL_INTENTS, RATE_LIMIT_DELAY, GatewayOp } from "./constants.js";
 import { dispatchEvent } from "./event-dispatcher.js";
-import { createQQBotIngressEffectOnce } from "./ingress-effects.js";
-import { isQQBotTurnEventType } from "./ingress-envelope.js";
-import {
-  createQQBotIngressMonitor,
-  QQBotIngressAdmissionError,
-  type QQBotIngressDispatchResult,
-  type QQBotIngressMonitor,
-} from "./ingress.js";
 import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
 import { ReconnectState } from "./reconnect.js";
-import type {
-  GatewayAccount,
-  EngineLogger,
-  GatewayPluginRuntime,
-  QQBotIngressLifecycle,
-  WSPayload,
-} from "./types.js";
+import { SeqWatermark } from "./seq-watermark.js";
+import type { GatewayAccount, EngineLogger, GatewayPluginRuntime, WSPayload } from "./types.js";
 import { createQQWSClient } from "./ws-client.js";
 
 interface GatewayConnectionContext {
@@ -52,7 +39,6 @@ interface GatewayConnectionContext {
   onDisconnected?: (info: { reason?: string; fatal?: boolean }) => void;
   handleMessage: (event: QueuedMessage) => Promise<void>;
   onInteraction?: (event: InteractionEvent) => void;
-  createIngressMonitor?: typeof createQQBotIngressMonitor;
 }
 
 export class GatewayConnection {
@@ -60,18 +46,15 @@ export class GatewayConnection {
   private currentWs: WebSocket | null = null;
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
   private sessionId: string | null = null;
-  private lastSeq: number | null = null;
+  // Resumable seq lives behind a watermark: message frames commit only after
+  // their queued handler settles, so RESUME replays anything still in flight.
+  private readonly seqWatermark = new SeqWatermark();
   private isConnecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private shouldRefreshToken = false;
-  private ingress: QQBotIngressMonitor | undefined;
-  private socketMessageTail: Promise<void> = Promise.resolve();
-  private shutdownTask: Promise<void> | undefined;
-  private readonly failedIngressSockets = new WeakSet<WebSocket>();
 
   private readonly reconnect: ReconnectState;
   private readonly msgQueue;
-  private readonly ingressEffectOnce;
   private readonly ctx: GatewayConnectionContext;
 
   constructor(ctx: GatewayConnectionContext) {
@@ -81,45 +64,21 @@ export class GatewayConnection {
       accountId: ctx.account.accountId,
       log: ctx.log,
       isAborted: () => this.isAborted,
+      onMessageSettled: (msg) => this.settleMessage(msg),
     });
-    this.ingressEffectOnce = createQQBotIngressEffectOnce({
-      accountId: ctx.account.accountId,
-      log: ctx.log,
-    });
+  }
+
+  private get lastSeq(): number | null {
+    return this.seqWatermark.value();
   }
 
   async start(): Promise<void> {
     this.restoreSession();
-    this.msgQueue.startProcessor(this.ctx.handleMessage);
-    const slashCtx = this.createSlashCommandContext();
-    const createIngressMonitor = this.ctx.createIngressMonitor ?? createQQBotIngressMonitor;
-    this.ingress = createIngressMonitor({
-      accountId: this.ctx.account.accountId,
-      runtime: this.ctx.runtime,
-      log: this.ctx.log,
-      dispatch: (message, lifecycle, eventId) =>
-        this.dispatchIngressMessage(message, lifecycle, eventId, slashCtx),
+    this.registerAbortHandler();
+    await this.connect();
+    return new Promise<void>((resolve) => {
+      this.ctx.abortSignal.addEventListener("abort", () => resolve());
     });
-    const stopped = new Promise<void>((resolve, reject) => {
-      const stop = () => void this.shutdown().then(resolve, reject);
-      if (this.ctx.abortSignal.aborted) {
-        stop();
-        return;
-      }
-      this.ctx.abortSignal.addEventListener("abort", stop, { once: true });
-    });
-    // Observe shutdown immediately: abort can reject while the initial connection is still pending.
-    const stoppedResult = stopped.then(
-      () => ({ ok: true as const }),
-      (error: unknown) => ({ ok: false as const, error }),
-    );
-    if (!this.isAborted) {
-      await this.connect();
-    }
-    const result = await stoppedResult;
-    if (!result.ok) {
-      throw result.error;
-    }
   }
 
   private restoreSession(): void {
@@ -127,9 +86,25 @@ export class GatewayConnection {
     const saved = loadSession(account.accountId, account.appId);
     if (saved) {
       this.sessionId = saved.sessionId;
-      this.lastSeq = saved.lastSeq;
+      this.seqWatermark.reset(saved.lastSeq);
       log?.info(`Restored session: sessionId=${this.sessionId}, lastSeq=${this.lastSeq}`);
     }
+  }
+
+  /**
+   * Commit a message's seq once its handler finished or the message was
+   * intentionally dropped. Merged group turns settle every source seq.
+   */
+  private settleMessage(msg: QueuedMessage): void {
+    for (const source of msg.merge?.messages ?? []) {
+      if (source.gatewaySeq !== undefined) {
+        this.seqWatermark.settle(source.gatewaySeq);
+      }
+    }
+    if (msg.gatewaySeq !== undefined) {
+      this.seqWatermark.settle(msg.gatewaySeq);
+    }
+    this.saveCurrentSession();
   }
 
   private saveCurrentSession(): void {
@@ -148,98 +123,19 @@ export class GatewayConnection {
     });
   }
 
-  private shutdown(): Promise<void> {
-    this.shutdownTask ??= (async () => {
-      const { account } = this.ctx;
-      const errors: unknown[] = [];
-      const runCleanup = async (
-        label: string,
-        cleanup: () => void | Promise<void>,
-      ): Promise<void> => {
-        try {
-          await cleanup();
-        } catch (error) {
-          errors.push(error);
-          this.ctx.log?.error(`QQBot gateway shutdown ${label} failed: ${String(error)}`);
-        }
-      };
+  private registerAbortHandler(): void {
+    const { account, abortSignal, log: _log } = this.ctx;
+    abortSignal.addEventListener("abort", () => {
       this.isAborted = true;
       if (this.reconnectTimer) {
         clearTimeout(this.reconnectTimer);
         this.reconnectTimer = null;
       }
-      await runCleanup("socket cleanup", () => this.cleanup());
-      await runCleanup("ingress stop", () => this.ingress?.stop());
-      await runCleanup("socket drain", () => this.socketMessageTail);
-      await runCleanup("message queue stop", () => this.msgQueue.stop());
-      await runCleanup("token refresh stop", () => stopBackgroundTokenRefresh(account.appId));
-      await runCleanup("known-user flush", () => flushKnownUsers());
-      await runCleanup("reference-index flush", () => flushRefIndex());
-      if (errors.length === 1) {
-        throw errors[0];
-      }
-      if (errors.length > 1) {
-        throw new AggregateError(errors, "QQBot gateway shutdown failed.");
-      }
-    })();
-    return this.shutdownTask;
-  }
-
-  private createSlashCommandContext(): SlashCommandHandlerContext {
-    const { account, cfg, log, adapters } = this.ctx;
-    return {
-      account,
-      cfg,
-      log,
-      getMessagePeerId: (msg) => this.msgQueue.getMessagePeerId(msg),
-      getQueueSnapshot: (peerId) => this.msgQueue.getSnapshot(peerId),
-      resolveCommandAuthorized: (params) =>
-        adapters.access.resolveSlashCommandAuthorization({
-          cfg,
-          accountId: account.accountId,
-          ...params,
-        }),
-    };
-  }
-
-  private async dispatchIngressMessage(
-    msg: QueuedMessage,
-    lifecycle: QQBotIngressLifecycle,
-    eventId: string,
-    slashCtx: SlashCommandHandlerContext,
-  ): Promise<QQBotIngressDispatchResult> {
-    if (this.isAborted || lifecycle.abortSignal.aborted) {
-      return {
-        kind: "failed-retryable",
-        error:
-          lifecycle.abortSignal.reason ?? this.ctx.abortSignal.reason ?? new Error("QQBot stopped"),
-      };
-    }
-    msg.turnAdoptionLifecycle = lifecycle;
-    // Fleet at-least-once contract: a pre-tombstone crash can replay slash commands.
-    // Non-idempotent handlers opt into createIngressEffectOnce through this dispatch context.
-    const result = await trySlashCommand(msg, slashCtx, {
-      eventId,
-      effectOnce: this.ingressEffectOnce,
+      this.cleanup();
+      stopBackgroundTokenRefresh(account.appId);
+      flushKnownUsers();
+      flushRefIndex();
     });
-    if (result === "handled") {
-      return { kind: "completed" };
-    }
-    if (this.isAborted || lifecycle.abortSignal.aborted) {
-      return {
-        kind: "failed-retryable",
-        error:
-          lifecycle.abortSignal.reason ?? this.ctx.abortSignal.reason ?? new Error("QQBot stopped"),
-      };
-    }
-    if (result === "urgent") {
-      const peerId = this.msgQueue.getMessagePeerId(msg);
-      this.msgQueue.clearUserQueue(peerId);
-      this.msgQueue.executeImmediate(msg);
-    } else {
-      this.msgQueue.enqueue(msg);
-    }
-    return { kind: "deferred" };
   }
 
   private cleanup(): void {
@@ -308,33 +204,130 @@ export class GatewayConnection {
       });
       this.currentWs = ws;
 
+      const slashCtx: SlashCommandHandlerContext = {
+        account,
+        cfg: this.ctx.cfg,
+        log,
+        getMessagePeerId: (msg) => this.msgQueue.getMessagePeerId(msg),
+        getQueueSnapshot: (peerId) => this.msgQueue.getSnapshot(peerId),
+        resolveCommandAuthorized: (params) =>
+          this.ctx.adapters.access.resolveSlashCommandAuthorization({
+            cfg: this.ctx.cfg,
+            accountId: account.accountId,
+            ...params,
+          }),
+      };
+
+      const trySlashCommandOrEnqueue = async (msg: QueuedMessage): Promise<void> => {
+        const result = await trySlashCommand(msg, slashCtx);
+        if (result === "enqueue") {
+          this.msgQueue.enqueue(msg);
+        } else if (result === "urgent") {
+          const peerId = this.msgQueue.getMessagePeerId(msg);
+          this.msgQueue.clearUserQueue(peerId);
+          this.msgQueue.executeImmediate(msg);
+        } else {
+          // "handled" — command executed to completion, nothing to queue.
+          this.settleMessage(msg);
+        }
+      };
+
       // ---- WebSocket: open ----
       ws.on("open", () => {
         log?.info(`WebSocket connected`);
         this.isConnecting = false;
         this.reconnect.onConnected();
+        this.msgQueue.startProcessor(this.ctx.handleMessage);
         startBackgroundTokenRefresh(account.appId, account.clientSecret, { log });
       });
 
       // ---- WebSocket: message ----
       ws.on("message", (data) => {
-        this.socketMessageTail = this.socketMessageTail
-          .then(() => this.handleSocketMessage(ws, data, accessToken))
-          .catch((error: unknown) => {
-            const message = error instanceof Error ? error.message : String(error);
-            if (error instanceof QQBotIngressAdmissionError) {
-              log?.error(`Durable ingress failed; terminating gateway socket: ${message}`);
-              this.ctx.onError?.(error);
-              if (this.currentWs === ws) {
-                // Fence callbacks already queued behind the failed append before
-                // terminate emits close and starts the reconnect path.
-                this.failedIngressSockets.add(ws);
-                ws.terminate();
+        try {
+          const rawData = decodeGatewayMessageData(data);
+          const payload = JSON.parse(rawData) as WSPayload;
+          const { op, d, s, t } = payload;
+
+          // Message-event seqs are registered (committed only after the
+          // handler settles); every other frame's seq commits immediately.
+          // Committing message seqs at receipt would let RESUME skip queued
+          // or in-flight messages after a restart or handler failure.
+          let messageSeqRegistered = false;
+
+          switch (op) {
+            case GatewayOp.HELLO:
+              this.handleHello(ws, d, accessToken);
+              break;
+
+            case GatewayOp.DISPATCH: {
+              log?.debug?.(`Dispatch event: t=${t}, d=${JSON.stringify(d)}`);
+              const result = dispatchEvent(t ?? "", d, account.accountId, log);
+              if (result.action === "message" && s) {
+                result.msg.gatewaySeq = s;
+                this.seqWatermark.register(s);
+                messageSeqRegistered = true;
               }
-              return;
+              if (result.action === "ready") {
+                this.sessionId = result.sessionId;
+                this.saveCurrentSession();
+                this.ctx.onReady?.(result.data);
+              } else if (result.action === "resumed") {
+                (this.ctx.onResumed ?? this.ctx.onReady)?.(result.data);
+                this.saveCurrentSession();
+              } else if (result.action === "interaction") {
+                this.ctx.onInteraction?.(result.event);
+              } else if (result.action === "message") {
+                const msg = result.msg;
+                void trySlashCommandOrEnqueue(msg).catch((err: unknown) => {
+                  // Keep the seq pending so RESUME replays the message the
+                  // slash-command gate failed to route.
+                  log?.error(
+                    `Message routing error for ${msg.messageId}: ${err instanceof Error ? err.message : String(err)}`,
+                  );
+                });
+              }
+              break;
             }
-            log?.error(`Message parse error: ${message}`);
-          });
+
+            case GatewayOp.HEARTBEAT_ACK:
+              break;
+
+            case GatewayOp.RECONNECT:
+              this.ctx.onDisconnected?.({
+                reason: "server requested reconnect",
+                fatal: false,
+              });
+              this.cleanup();
+              this.scheduleReconnect();
+              break;
+
+            case GatewayOp.INVALID_SESSION: {
+              const canResume = d as boolean;
+              this.ctx.onDisconnected?.({
+                reason: canResume ? "session resume rejected" : "session invalidated",
+                fatal: false,
+              });
+              if (!canResume) {
+                this.sessionId = null;
+                this.seqWatermark.reset(null);
+                clearSession(account.accountId);
+                this.shouldRefreshToken = true;
+              }
+              this.cleanup();
+              this.scheduleReconnect(3000);
+              break;
+            }
+          }
+
+          if (s) {
+            if (!messageSeqRegistered) {
+              this.seqWatermark.observe(s);
+            }
+            this.saveCurrentSession();
+          }
+        } catch (err) {
+          log?.error(`Message parse error: ${err instanceof Error ? err.message : String(err)}`);
+        }
       });
 
       // ---- WebSocket: close ----
@@ -364,84 +357,6 @@ export class GatewayConnection {
       } else {
         this.scheduleReconnect();
       }
-    }
-  }
-
-  private async handleSocketMessage(
-    ws: WebSocket,
-    data: unknown,
-    accessToken: string,
-  ): Promise<void> {
-    if (this.isAborted || this.currentWs !== ws || this.failedIngressSockets.has(ws)) {
-      return;
-    }
-    const rawData = decodeGatewayMessageData(data);
-    const payload = JSON.parse(rawData) as WSPayload;
-    const { op, d, s, t } = payload;
-    let saveAfterDispatch = false;
-
-    switch (op) {
-      case GatewayOp.HELLO:
-        this.handleHello(ws, d, accessToken);
-        break;
-
-      case GatewayOp.DISPATCH: {
-        this.ctx.log?.debug?.(`Dispatch event: t=${t}, d=${JSON.stringify(d)}`);
-        if (isQQBotTurnEventType(t)) {
-          if (!this.ingress) {
-            throw new Error("QQBot ingress monitor is unavailable.");
-          }
-          // Resume sequence advances only after the raw turn is durable.
-          await this.ingress.receive(rawData);
-        } else {
-          const result = dispatchEvent(t ?? "", d, this.ctx.account.accountId, this.ctx.log);
-          if (result.action === "ready") {
-            this.sessionId = result.sessionId;
-            saveAfterDispatch = true;
-            this.ctx.onReady?.(result.data);
-          } else if (result.action === "resumed") {
-            (this.ctx.onResumed ?? this.ctx.onReady)?.(result.data);
-            saveAfterDispatch = true;
-          } else if (result.action === "interaction") {
-            this.ctx.onInteraction?.(result.event);
-          }
-        }
-        break;
-      }
-
-      case GatewayOp.HEARTBEAT_ACK:
-        break;
-
-      case GatewayOp.RECONNECT:
-        this.ctx.onDisconnected?.({ reason: "server requested reconnect", fatal: false });
-        this.cleanup();
-        this.scheduleReconnect();
-        break;
-
-      case GatewayOp.INVALID_SESSION: {
-        const canResume = d as boolean;
-        this.ctx.onDisconnected?.({
-          reason: canResume ? "session resume rejected" : "session invalidated",
-          fatal: false,
-        });
-        if (!canResume) {
-          this.sessionId = null;
-          this.lastSeq = null;
-          clearSession(this.ctx.account.accountId);
-          this.shouldRefreshToken = true;
-        }
-        this.cleanup();
-        this.scheduleReconnect(3000);
-        break;
-      }
-    }
-
-    if (typeof s === "number") {
-      this.lastSeq = s;
-      saveAfterDispatch = true;
-    }
-    if (saveAfterDispatch) {
-      this.saveCurrentSession();
     }
   }
 
@@ -478,7 +393,11 @@ export class GatewayConnection {
     }
     this.heartbeatInterval = setInterval(() => {
       if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ op: GatewayOp.HEARTBEAT, d: this.lastSeq }));
+        // Heartbeats report the latest received frame seq (receive cursor);
+        // only RESUME and persistence use the settlement watermark. Sending
+        // the watermark here would look like the client fell behind while a
+        // handler is still running and provoke reconnect/replay churn.
+        ws.send(JSON.stringify({ op: GatewayOp.HEARTBEAT, d: this.seqWatermark.latest() }));
       }
     }, interval);
   }
@@ -489,7 +408,7 @@ export class GatewayConnection {
 
     if (action.clearSession) {
       this.sessionId = null;
-      this.lastSeq = null;
+      this.seqWatermark.reset(null);
       clearSession(account.accountId);
     }
     if (action.refreshToken) {

--- a/extensions/qqbot/src/engine/gateway/message-queue.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue.ts
@@ -2,9 +2,6 @@
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatErrorMessage } from "../utils/format.js";
-import { isQQBotAuthenticationFailure } from "./ingress-errors.js";
-import { buildQQBotMergedIngressLifecycle } from "./message-queue-ingress.js";
-import type { QQBotIngressLifecycle } from "./types.js";
 
 const DEFAULT_GLOBAL_QUEUE_SIZE = 1000;
 const DEFAULT_PER_PEER_QUEUE_SIZE = 20;
@@ -48,6 +45,8 @@ export interface QueuedMessage {
   refMsgIdx?: string;
   msgIdx?: string;
   msgType?: number;
+  /** Gateway frame seq; commits to the RESUME watermark when the message settles. */
+  gatewaySeq?: number;
   msgElements?: Array<{
     msg_idx?: string;
     content?: string;
@@ -66,7 +65,6 @@ export interface QueuedMessage {
   mentions?: QueuedMention[];
   messageScene?: { source?: string; ext?: string[] };
   merge?: QueuedMergeInfo;
-  turnAdoptionLifecycle?: QQBotIngressLifecycle;
 }
 
 export function isMergedTurn(msg: QueuedMessage): msg is QueuedMessage & {
@@ -83,6 +81,14 @@ interface MessageQueueContext {
     debug?: (msg: string, meta?: Record<string, unknown>) => void;
   };
   isAborted: () => boolean;
+  /**
+   * Fired when a message reaches a terminal state: handled, dropped after a
+   * logged handler failure (the existing failure contract), or intentionally
+   * discarded (queue-full eviction, urgent queue clear). Every terminal state
+   * settles so the connection-wide RESUME watermark only stays behind
+   * messages that are genuinely still queued or in flight.
+   */
+  onMessageSettled?: (msg: QueuedMessage) => void;
   groupQueueSize?: number;
   peerQueueSize?: number;
   globalQueueSize?: number;
@@ -103,7 +109,6 @@ interface MessageQueue {
   getMessagePeerId: (msg: QueuedMessage) => string;
   clearUserQueue: (peerId: string) => number;
   executeImmediate: (msg: QueuedMessage) => void;
-  stop: () => Promise<void>;
 }
 
 function isGroupPeer(peerId: string): boolean {
@@ -196,7 +201,6 @@ function mergeGroupMessages(batch: QueuedMessage[]): QueuedMessage {
     mentions: mergedMentions.length > 0 ? mergedMentions : undefined,
     messageScene: last.messageScene,
     merge: { count: batch.length, messages: batch },
-    turnAdoptionLifecycle: buildQQBotMergedIngressLifecycle(batch),
   };
 }
 
@@ -209,35 +213,8 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
 
   const userQueues = new Map<string, QueuedMessage[]>();
   const activeUsers = new Set<string>();
-  const activeTasks = new Set<Promise<void>>();
-  const ingressSettlements = new Set<Promise<void>>();
   let handleMessageFnRef: ((msg: QueuedMessage) => Promise<void>) | null = null;
   let totalEnqueued = 0;
-  let stopped = false;
-
-  const trackIngressSettlement = (
-    msg: QueuedMessage,
-    kind: "completed" | "abandoned",
-  ): Promise<void> => {
-    const lifecycle = msg.turnAdoptionLifecycle;
-    if (!lifecycle) {
-      return Promise.resolve();
-    }
-    const settlement = Promise.resolve(
-      kind === "completed" ? lifecycle.onAdopted() : lifecycle.onAbandoned(),
-    )
-      .catch((error: unknown) => {
-        log?.error(`Ingress ${kind} settlement failed: ${formatErrorMessage(error)}`);
-      })
-      .finally(() => ingressSettlements.delete(settlement));
-    ingressSettlements.add(settlement);
-    return settlement;
-  };
-
-  const trackTask = (task: Promise<void>): void => {
-    activeTasks.add(task);
-    void task.finally(() => activeTasks.delete(task));
-  };
 
   const getMessagePeerId = (msg: QueuedMessage): string => {
     if (msg.type === "guild") {
@@ -260,18 +237,16 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
   };
 
   const processOne = async (msg: QueuedMessage, peerId: string, label: string): Promise<void> => {
-    if (msg.turnAdoptionLifecycle?.abortSignal.aborted) {
-      await trackIngressSettlement(msg, "abandoned");
-      return;
-    }
     try {
       await handleMessageFnRef!(msg);
     } catch (err) {
-      const permanentFailure = isQQBotAuthenticationFailure(err);
-      // Deferred lifecycles cannot return errors to the drain. Permanent auth failures must
-      // tombstone here because releasing them would replay a turn that cannot succeed.
-      await trackIngressSettlement(msg, permanentFailure ? "completed" : "abandoned");
+      // A logged handler failure is a terminal drop (existing contract). It
+      // must settle too: the watermark is connection-wide, so holding it here
+      // would make every later reconnect replay already-successful traffic
+      // for unrelated peers behind one poison message.
       log?.error(`${label} error for ${peerId}: ${formatErrorMessage(err)}`);
+    } finally {
+      ctx.onMessageSettled?.(msg);
     }
   };
 
@@ -337,36 +312,20 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
       }
     } finally {
       activeUsers.delete(peerId);
-      if (stopped || ctx.isAborted()) {
-        const abandoned = queue.splice(0);
-        totalEnqueued = Math.max(0, totalEnqueued - abandoned.length);
-        for (const msg of abandoned) {
-          void trackIngressSettlement(msg, "abandoned");
-        }
-        userQueues.delete(peerId);
-      } else if (queue.length === 0) {
-        userQueues.delete(peerId);
-      }
+      userQueues.delete(peerId);
 
       for (const [waitingPeerId, waitingQueue] of userQueues) {
-        if (stopped || ctx.isAborted()) {
-          break;
-        }
         if (activeUsers.size >= maxConcurrentUsers) {
           break;
         }
         if (waitingQueue.length > 0 && !activeUsers.has(waitingPeerId)) {
-          trackTask(drainUserQueue(waitingPeerId));
+          void drainUserQueue(waitingPeerId);
         }
       }
     }
   };
 
   const enqueue = (msg: QueuedMessage): void => {
-    if (stopped) {
-      void trackIngressSettlement(msg, "abandoned");
-      return;
-    }
     const peerId = getMessagePeerId(msg);
     const isGroup = isGroupPeer(peerId);
 
@@ -379,10 +338,12 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
     const maxSize = isGroup ? groupQueueSize : peerQueueSize;
     if (queue.length >= maxSize) {
       const dropped = evictOne(queue, isGroup);
-      if (dropped) {
-        void trackIngressSettlement(dropped, "abandoned");
-      }
       totalEnqueued = Math.max(0, totalEnqueued - 1);
+      if (dropped) {
+        // Intentional drop is a terminal state; settle so the RESUME
+        // watermark does not wedge behind a message we chose to discard.
+        ctx.onMessageSettled?.(dropped);
+      }
       if (isGroup && dropped?.senderIsBot) {
         log?.info(`Queue full for ${peerId}, dropping bot message ${dropped.messageId}`, {
           accountId: ctx.accountId,
@@ -413,7 +374,7 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
       `Message enqueued for ${peerId}, user queue: ${queue.length}, active users: ${activeUsers.size}`,
     );
 
-    trackTask(drainUserQueue(peerId));
+    void drainUserQueue(peerId);
   };
 
   const startProcessor = (handleMessageFn: (msg: QueuedMessage) => Promise<void>): void => {
@@ -443,32 +404,24 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
       return 0;
     }
     const droppedCount = queue.length;
-    const dropped = queue.splice(0);
-    totalEnqueued = Math.max(0, totalEnqueued - droppedCount);
-    for (const msg of dropped) {
-      // Urgent commands intentionally supersede buffered work.
-      void trackIngressSettlement(msg, "completed");
+    // Cleared messages are intentionally discarded; settle each one so the
+    // RESUME watermark advances past them.
+    for (const dropped of queue) {
+      ctx.onMessageSettled?.(dropped);
     }
+    queue.length = 0;
+    totalEnqueued = Math.max(0, totalEnqueued - droppedCount);
     return droppedCount;
   };
 
   const executeImmediate = (msg: QueuedMessage): void => {
     if (handleMessageFnRef) {
-      trackTask(processOne(msg, getMessagePeerId(msg), "Immediate execution"));
+      handleMessageFnRef(msg)
+        .catch((err: unknown) => {
+          log?.error(`Immediate execution error: ${formatErrorMessage(err)}`);
+        })
+        .finally(() => ctx.onMessageSettled?.(msg));
     }
-  };
-
-  const stop = async (): Promise<void> => {
-    stopped = true;
-    for (const queue of userQueues.values()) {
-      for (const msg of queue.splice(0)) {
-        void trackIngressSettlement(msg, "abandoned");
-      }
-    }
-    userQueues.clear();
-    totalEnqueued = 0;
-    await Promise.allSettled(activeTasks);
-    await Promise.allSettled(ingressSettlements);
   };
 
   return {
@@ -478,6 +431,5 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
     getMessagePeerId,
     clearUserQueue,
     executeImmediate,
-    stop,
   };
 }

--- a/extensions/qqbot/src/engine/gateway/seq-watermark.test.ts
+++ b/extensions/qqbot/src/engine/gateway/seq-watermark.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { SeqWatermark } from "./seq-watermark.js";
+
+describe("SeqWatermark", () => {
+  it("starts empty and accepts a restored seed", () => {
+    const w = new SeqWatermark();
+    expect(w.value()).toBeNull();
+    w.reset(41);
+    expect(w.value()).toBe(41);
+    w.reset(null);
+    expect(w.value()).toBeNull();
+  });
+
+  it("commits observed non-message seqs immediately", () => {
+    const w = new SeqWatermark();
+    w.observe(1);
+    w.observe(2);
+    expect(w.value()).toBe(2);
+    // Out-of-order duplicates never move the watermark backwards.
+    w.observe(1);
+    expect(w.value()).toBe(2);
+  });
+
+  it("holds the watermark below an unsettled message seq", () => {
+    const w = new SeqWatermark();
+    w.observe(1);
+    w.register(2);
+    expect(w.value()).toBe(1);
+    w.settle(2);
+    expect(w.value()).toBe(2);
+  });
+
+  // Regression: committing message seqs at frame receipt let RESUME skip
+  // queued/in-flight messages after a restart or handler failure.
+  it("keeps replaying the oldest unsettled message even when later frames arrive", () => {
+    const w = new SeqWatermark();
+    w.register(2);
+    w.observe(3);
+    w.register(4);
+    w.settle(4);
+    // Seq 2 is still in flight: RESUME must ask for replay from seq 1.
+    expect(w.value()).toBe(1);
+    w.settle(2);
+    expect(w.value()).toBe(4);
+  });
+
+  it("settling out of order advances to the highest fully-settled seq", () => {
+    const w = new SeqWatermark();
+    w.register(10);
+    w.register(11);
+    w.register(12);
+    w.settle(11);
+    expect(w.value()).toBe(9);
+    w.settle(10);
+    expect(w.value()).toBe(11);
+    w.settle(12);
+    expect(w.value()).toBe(12);
+  });
+
+  it("ignores settles for seqs that were never registered", () => {
+    const w = new SeqWatermark();
+    w.observe(5);
+    w.settle(99);
+    expect(w.value()).toBe(5);
+  });
+
+  it("keeps the heartbeat receive cursor at the latest seq while messages are pending", () => {
+    const w = new SeqWatermark();
+    w.observe(1);
+    w.register(2);
+    w.observe(3);
+    // Heartbeats report the receive cursor; RESUME uses the watermark.
+    expect(w.latest()).toBe(3);
+    expect(w.value()).toBe(1);
+    w.settle(2);
+    expect(w.latest()).toBe(3);
+    expect(w.value()).toBe(3);
+    w.reset(null);
+    expect(w.latest()).toBeNull();
+  });
+
+  it("clears pending seqs on reset so a new session starts clean", () => {
+    const w = new SeqWatermark();
+    w.register(7);
+    w.reset(null);
+    expect(w.value()).toBeNull();
+    w.observe(1);
+    expect(w.value()).toBe(1);
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/seq-watermark.ts
+++ b/extensions/qqbot/src/engine/gateway/seq-watermark.ts
@@ -1,0 +1,65 @@
+/**
+ * RESUME seq watermark — tracks in-flight message seqs so reconnect resume
+ * never skips messages that were received but not yet fully processed.
+ *
+ * The QQ gateway replays only events with seq greater than the RESUME seq.
+ * Committing a message frame's seq before its queued handler finishes turns
+ * a restart, reconnect, or handler failure into permanent message loss.
+ * The watermark therefore advances past a message seq only after that
+ * message settles (handled successfully or intentionally dropped); frames
+ * without queued work (HELLO acks, READY, interactions) commit immediately.
+ */
+export class SeqWatermark {
+  private highestObserved: number | null = null;
+  private pending = new Set<number>();
+
+  /** Reset to a restored seq (or null when the session is discarded). */
+  reset(seed: number | null): void {
+    this.highestObserved = seed;
+    this.pending.clear();
+  }
+
+  /** Record a frame whose seq may commit immediately (no queued work). */
+  observe(seq: number): void {
+    if (this.highestObserved === null || seq > this.highestObserved) {
+      this.highestObserved = seq;
+    }
+  }
+
+  /** Record a message frame whose seq must wait for its handler to settle. */
+  register(seq: number): void {
+    this.pending.add(seq);
+    this.observe(seq);
+  }
+
+  /** Mark a registered message as settled (handled or intentionally dropped). */
+  settle(seq: number): void {
+    this.pending.delete(seq);
+  }
+
+  /**
+   * Latest received frame seq, regardless of settlement. Heartbeats report
+   * this receive cursor; using the resumable watermark there would make the
+   * client look behind while a handler is still running.
+   */
+  latest(): number | null {
+    return this.highestObserved;
+  }
+
+  /**
+   * Resumable seq: the highest observed seq once nothing older is pending,
+   * otherwise just below the oldest unsettled message so RESUME replays it.
+   */
+  value(): number | null {
+    if (this.pending.size === 0) {
+      return this.highestObserved;
+    }
+    let oldestPending: number | null = null;
+    for (const seq of this.pending) {
+      if (oldestPending === null || seq < oldestPending) {
+        oldestPending = seq;
+      }
+    }
+    return oldestPending === null ? this.highestObserved : oldestPending - 1;
+  }
+}


### PR DESCRIPTION
Closes #109996

## What Problem This Solves

Fixes an issue where QQ Bot users' messages would silently vanish — no reply, no error — whenever the gateway connection dropped, the server requested a reconnect, or the gateway process restarted while their message was still queued or being processed.

The QQ gateway replays only events with `seq` greater than the RESUME seq, but the channel committed (and persisted to the SQLite session store) each frame's seq at receipt, before the queued handler ran. Any message in flight or in the in-memory per-peer queue at disconnect/restart time was skipped by the resume replay and permanently lost. Handler failures had the same outcome: the message was logged-and-dropped locally while the already-advanced seq defeated the protocol's replay. This is the same defect family as the ClickClack reconnect-cursor race fixed in #108577, with the added severity that the premature cursor is persisted across process restarts (5-minute resume window).

## Why This Change Was Made

Message-frame seqs now commit to the RESUME watermark only when the message settles. A new `SeqWatermark` tracks in-flight message seqs: the resumable value stays just below the oldest unsettled message, so RESUME replays anything still queued, in flight, or failed; frames without queued work (READY, RESUMED, interactions, acks) commit immediately, exactly as before. Settling covers every terminal state: handler completed, handler failed with a logged drop (the existing failure contract), or intentional discard (queue-full eviction, urgent queue clear). Failed handlers settle deliberately: the watermark is connection-wide and the queue keeps processing later messages after a failure, so holding the cursor behind one poison message would replay already-successful traffic for unrelated peers on every reconnect. The watermark therefore stays behind only messages that are genuinely still queued or in flight — exactly the restart/reconnect loss window this PR closes. The previously fire-and-forget message dispatch also gets a rejection handler so routing failures are logged and left pending for replay. Heartbeats intentionally do NOT use the watermark: they report the latest received frame seq (receive cursor) so the client never looks behind while a handler is running; only RESUME and persisted session state use the settlement watermark.

Delivery semantics move from at-most-once (silent loss) to at-least-once across reconnects: a crash after a handler completes but before the throttled session save can redeliver an already-handled message. That matches the durable-before-ack convention used by the Telegram/WhatsApp/Slack/Signal channels.

## User Impact

QQ Bot messages received while an agent turn is running — or queued behind one — now survive reconnects, server-driven RECONNECTs, and gateway restarts within the resume window: the gateway replays them and the bot answers. Previously they disappeared with no trace. No config, protocol, or persisted-state shape changes.

## Evidence

### Live behavior proof (real GatewayConnection, real `ws` client, protocol-compatible local gateway)

Driver: the production `GatewayConnection` (real websocket client, real reconnect/backoff, real event dispatcher and per-peer message queue) connected to a local WebSocket server implementing the QQ gateway protocol: HELLO → IDENTIFY → READY(s=1), and RESUME → replay events with `seq > resume seq`. A message event `s=2` is delivered while its handler is still running, then the server drops the socket.

Before (current `main`) — the client resumes at the already-committed seq and the message is lost:

```
[server] IDENTIFY received — sending READY (s=1)
[proof] delivering message event seq=2 (handler will hang in flight)
[client] handler invoked for m-inflight (call #1)
[server] dropping the client connection (transient network failure)
[client] WebSocket closed: 1006
[server] RESUME received with seq=2 — replaying 0 event(s) with seq>2
[proof] FINAL: resumeSeq=2 handledAfterReplay=(none)
```

After (this patch) — the client resumes below the unprocessed message, the server replays it, and it is handled:

```
[server] RESUME received with seq=1 — replaying 1 event(s) with seq>1
[client] handler invoked for m-inflight (call #2)
[client] handler COMPLETED for m-inflight
[proof] FINAL: resumeSeq=1 handledAfterReplay=m-inflight
```

### Regression coverage

- `seq-watermark.test.ts` (new): commit/register/settle semantics, out-of-order settles, replay boundary, session reset.
- `gateway-connection.test.ts` (4 new integration tests): message seq is not committed until the handler completes; with a message in flight, heartbeats report the latest received seq (2) while reconnect RESUME asks for replay below the unprocessed message (1); a failed handler settles and a failure-then-later-success reconnect resumes past both (no cross-peer replay amplification); queue-full eviction settles so the watermark cannot wedge.
- Against unfixed `main`, all 4 new integration tests fail (RESUME seq advances past the in-flight message); the 7 pre-existing disconnect-status tests pass unchanged in both states.
- `node scripts/run-vitest.mjs` on `seq-watermark.test.ts` + `gateway-connection.test.ts` + `message-queue.test.ts` → 26 passed.
- Pre-existing `outbound-dispatch.test.ts` failures on this machine reproduce identically without this change (unrelated outbound media-path surface).
- Scoped `oxlint`, `oxfmt`, and `git diff --check` pass on the five changed files.

### Sibling-surface context

The receive-path audit that found this also checked the other channels for the same premature-cursor family: Telegram's default isolated ingress advances its offset only after durable spooling, WhatsApp journals inbound before ack, Slack and Signal are durable-before-ack, and iMessage clamps its catchup cursor below failed rows — qqbot was the remaining gateway-resume surface committing before processing.



