### PR TITLE
fix(signal): drain accepted inbound events on stop

### DIFF
--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -201,7 +201,7 @@ describe("monitorSignalProvider tool results", () => {
     expect(sendMock).toHaveBeenCalledWith("+15550001111", "accepted reply", expect.anything());
   });
 
-  it("does not dispatch a buffered inbound message after the monitor stops", async () => {
+  it("drains a buffered inbound message accepted before the monitor stops", async () => {
     vi.useFakeTimers();
     const abortController = new AbortController();
     setSignalToolResultTestConfig({
@@ -210,7 +210,7 @@ describe("monitorSignalProvider tool results", () => {
     });
     replyMock.mockResolvedValue({ text: "late reply" });
     streamMock.mockImplementation(async ({ onEvent }) => {
-      onEvent({
+      await onEvent({
         event: "receive",
         data: JSON.stringify({
           envelope: {
@@ -230,10 +230,9 @@ describe("monitorSignalProvider tool results", () => {
         baseUrl: "http://127.0.0.1:8080",
         abortSignal: abortController.signal,
       });
-      await vi.advanceTimersByTimeAsync(10);
 
-      expect(replyMock).not.toHaveBeenCalled();
-      expect(sendMock).not.toHaveBeenCalled();
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(sendMock).toHaveBeenCalledWith("+15550001111", "late reply", expect.anything());
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -719,10 +719,10 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     }
     throw err;
   } finally {
-    await ingressMonitor?.stop();
-    // Daemon attachment finishes before monitor tasks start. Keep teardown open until both the
-    // child has exited and already-started reply work has drained.
+    // Abort can force accepted debounced ingress work to run its first flush.
+    // Keep the drain alive until already-started reply tasks settle.
     await Promise.all([daemonLifecycle.stop(), monitorTaskRunner.waitForIdle()]);
+    await ingressMonitor?.stop();
     opts.abortSignal?.removeEventListener("abort", onAbort);
   }
 }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -218,6 +218,36 @@ async function finalizeSignalStatusReaction(params: {
 
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
+  const acceptedFlushEntries = new WeakSet<SignalInboundEntry>();
+  const acceptedFlushCountsByKey = new Map<string, number>();
+
+  const markAcceptedFlushEntry = (entry: SignalInboundEntry): string | null => {
+    const key = resolveSignalInboundDebounceKey(deps.accountId, entry);
+    if (!key) {
+      return null;
+    }
+    acceptedFlushEntries.add(entry);
+    acceptedFlushCountsByKey.set(key, (acceptedFlushCountsByKey.get(key) ?? 0) + 1);
+    return key;
+  };
+
+  const completeAcceptedFlushEntries = (entries: SignalInboundEntry[]) => {
+    for (const entry of entries) {
+      if (!acceptedFlushEntries.delete(entry)) {
+        continue;
+      }
+      const key = resolveSignalInboundDebounceKey(deps.accountId, entry);
+      if (!key) {
+        continue;
+      }
+      const nextCount = (acceptedFlushCountsByKey.get(key) ?? 0) - 1;
+      if (nextCount > 0) {
+        acceptedFlushCountsByKey.set(key, nextCount);
+      } else {
+        acceptedFlushCountsByKey.delete(key);
+      }
+    }
+  };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
     const fromLabel = formatInboundFromLabel({
@@ -794,9 +824,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
 
   const flushDebouncedSignalInboundEntries = async (entries: SignalInboundEntry[]) => {
     // enqueue() awaits inline and overflow flushes, but not timer-backed work.
-    // Drain tracked inline work on shutdown; stop delayed work with no owner.
+    // Drain tracked accepted work on shutdown; stop delayed work with no owner.
     const hasActiveEnqueue = entries.some((entry) => activeEnqueueEntries.has(entry));
-    if (!hasActiveEnqueue && deps.abortSignal?.aborted) {
+    const hasAcceptedFlush = entries.some((entry) => acceptedFlushEntries.has(entry));
+    if (!hasActiveEnqueue && !hasAcceptedFlush && deps.abortSignal?.aborted) {
       return;
     }
     try {
@@ -826,9 +857,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
   };
   const pendingInboundRegistry = createSignalPendingInboundRegistry(deps.accountId);
-  const flushNormalSignalInboundEntries = pendingInboundRegistry.completeAfter(
-    flushDebouncedSignalInboundEntries,
-  );
+  const flushNormalSignalInboundEntries = async (entries: SignalInboundEntry[]) => {
+    try {
+      await flushDebouncedSignalInboundEntries(entries);
+    } finally {
+      completeAcceptedFlushEntries(entries);
+      pendingInboundRegistry.complete(entries);
+    }
+  };
 
   const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
@@ -842,7 +878,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       }),
     onFlush: flushNormalSignalInboundEntries,
     onError: reportSignalInboundFlushError,
-    onCancel: pendingInboundRegistry.complete,
+    onCancel: (entries) => {
+      completeAcceptedFlushEntries(entries);
+      pendingInboundRegistry.complete(entries);
+    },
   });
   const { debouncer: controlDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
@@ -854,6 +893,25 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     onFlush: flushDebouncedSignalInboundEntries,
     onError: reportSignalInboundFlushError,
   });
+  const flushAcceptedDebounceKeys = async () => {
+    const keys = [...acceptedFlushCountsByKey.keys()];
+    await Promise.all(keys.map((key) => debouncer.flushKey(key)));
+  };
+  const flushAcceptedDebounceKeysOnAbort = () => {
+    if (acceptedFlushCountsByKey.size === 0) {
+      return;
+    }
+    // Durable ingress already accepted these rows. Force the first debounce flush
+    // during teardown; retry backoff remains abortable inside retrySignalInboundFlush.
+    if (deps.runTrackedTask) {
+      deps.runTrackedTask(flushAcceptedDebounceKeys);
+      return;
+    }
+    void flushAcceptedDebounceKeys().catch((err: unknown) => {
+      deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
+    });
+  };
+  deps.abortSignal?.addEventListener("abort", flushAcceptedDebounceKeysOnAbort, { once: true });
 
   async function handleReactionOnlyInbound(params: {
     envelope: SignalEnvelope;
@@ -1389,12 +1447,19 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const inboundLane = resolveSignalControlLaneKey(deps.accountId, entry)
       ? controlDebouncer
       : debouncer;
+    let acceptedFlushKey: string | null = null;
     if (inboundLane === debouncer) {
       pendingInboundRegistry.track(entry);
+      if (turnAdoptionLifecycle) {
+        acceptedFlushKey = markAcceptedFlushEntry(entry);
+      }
     }
     activeEnqueueEntries.add(entry);
     try {
       await inboundLane.enqueue(entry);
+      if (acceptedFlushKey && deps.abortSignal?.aborted) {
+        await debouncer.flushKey(acceptedFlushKey);
+      }
     } finally {
       activeEnqueueEntries.delete(entry);
     }


### PR DESCRIPTION
## Summary
- Keep Signal durable-ingress debounce entries marked as accepted until their first flush or cancel completes.
- Force accepted debounced Signal entries to flush when the monitor aborts, while retaining abort cancellation for reply-session conflict retry backoff.
- Keep the Signal ingress drain alive until already-started monitor tasks finish so adoption can tombstone accepted claims before teardown.

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope
- [ ] Gateway
- [ ] Skills
- [ ] Auth
- [ ] Memory
- [ ] Integrations
- [ ] API
- [ ] UI/UX
- [ ] CI
- [x] Signal plugin

## What Problem This Solves
Fixes an issue where Signal users could lose an inbound message that signal-cli had already accepted when the monitor stopped before the configured inbound debounce timer fired.

Closes #103881

## Why This Change Was Made
Signal now tracks durable-ingress-owned debounce entries separately from inline enqueue work, and monitor abort forces those accepted debounce keys through their first flush. Retry waits after a reply-session initialization conflict still observe the monitor abort signal and cancel instead of continuing stale retries.

## User Impact
Signal messages accepted just before shutdown or reconnect teardown are delivered once instead of being skipped by the initial debounce abort check. Shutdown still avoids unowned delayed work and still cancels retry backoff after the first accepted attempt.

## Real behavior proof

**Behavior addressed:** A Signal inbound event accepted before monitor shutdown completes its initial debounced flush instead of being skipped when the monitor aborts.
**Environment tested:** Linux, Node v24.16.0, pnpm v11.2.2, local source checkout.
**Steps run after the patch:** Ran the Signal monitor regression test that accepts a debounced inbound event, aborts the monitor before the debounce window elapses, and asserts the reply is delivered once; also ran the reply-session retry cancellation and durable ingress lifecycle suites.
**Evidence after fix:**

```text
$ node scripts/run-vitest.mjs extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts extensions/signal/src/signal-ingress.test.ts
[test] starting test/vitest/vitest.extension-signal.config.ts

 Test Files  5 passed (5)
      Tests  61 passed (61)
   Duration  30.41s

[test] passed 1 Vitest shard in 36.19s
```

**Observed result:** The buffered accepted-before-stop Signal monitor test now observes one reply delivery; the retry-conflict suite still confirms pending retry backoff is canceled after monitor stop.
**Not tested:** Live signal-cli daemon/SSE traffic against a real Signal account.

## Root Cause
- Root cause: Signal only treated entries as shutdown-drainable while `enqueue()` was actively awaited. Timer-backed debounce work had already returned from `enqueue()`, so monitor abort could reach the initial flush before dispatch and skip an accepted durable event.
- Missing guardrail: The existing stop coverage only proved inline accepted work drained and retry backoff canceled; it did not cover a durable, debounced event accepted before stop but flushed after abort.

## Regression Test Plan
- Updated the Signal monitor stop regression to cover a buffered inbound message accepted before stop.
- Re-ran the issue's focused monitor tool-result shard plus durable ingress and reply-session conflict retry suites.

## Impact Assessment
- Scope: Signal monitor/event handler only; no config, schema, or public API surface changes.
- Downstream: Normal Signal debounce entries with durable ingress lifecycle are affected; control-lane immediate commands and unowned delayed work keep their existing behavior.
- Edge cases: Covers abort before the timer fires and abort racing immediately after enqueue returns.
- Hard-coded values: None introduced.

## Security Impact
- New permissions? No
- Secrets handling changed? No
- New network calls? No

## Verification
- `pnpm format extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor.ts extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts` passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor.ts extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts` passed.
- `git diff --check` passed.
- `node scripts/run-vitest.mjs extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts extensions/signal/src/signal-ingress.test.ts` passed: 5 files, 61 tests.
- `node scripts/check-changed.mjs -- <changed files>` could not run because the local crabbox wrapper selected for Blacksmith delegation failed its basic sanity check.
