### PR TITLE
fix(sqlite): keep additive agent schema at version 11

### DIFF
--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -492,6 +492,37 @@ describe("openclaw agent database", () => {
     expect(registered?.sizeBytes).toBeGreaterThan(0);
   });
 
+  it("folds additive heartbeat storage into schema version 11", () => {
+    expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(11);
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = opened.path;
+    closeOpenClawAgentDatabasesForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const existingV11 = new DatabaseSync(databasePath);
+    existingV11.exec(`
+      DROP TABLE heartbeat_outcomes;
+      PRAGMA user_version = 11;
+      UPDATE schema_meta SET schema_version = 11 WHERE meta_key = 'primary';
+    `);
+    existingV11.close();
+
+    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    expect(
+      reopened.db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("heartbeat_outcomes"),
+    ).toEqual({ name: "heartbeat_outcomes" });
+    expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(11);
+    expect(
+      reopened.db
+        .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+        .get(),
+    ).toEqual({ schema_version: 11 });
+  });
+
   it("upgrades version 10 with agent state intact and adds lease storage", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -72,9 +72,8 @@ export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
  * per pathname, protected with private file modes, and registered in the shared
  * OpenClaw state database for discovery and maintenance.
  */
-// v12 = bounded per-session heartbeat outcome context.
-// v11 = agent-scoped runtime leases, durable delivery operations, and canonical
-// external conversation addresses.
+// v11 = agent-scoped runtime leases, durable delivery operations, canonical
+// external conversation addresses, and bounded per-session heartbeat outcome context.
 // v10 = materialized active transcript paths.
 // v9 = SQLite STRICT tables.
 // v8 added per-transcript session provenance. v7 added per-entry lifecycle status projection.
@@ -83,7 +82,7 @@ export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
 // The v4 session/transcript flip and main's v2 memory-identity
 // change is folded in structure-gated (migrateMemoryIndexSourcesIdentity), so
 // v2 main DBs and pre-merge v4 flip DBs both converge on this schema.
-export const OPENCLAW_AGENT_SCHEMA_VERSION = 12;
+export const OPENCLAW_AGENT_SCHEMA_VERSION = 11;
 const OPENCLAW_AGENT_DB_DIR_MODE = 0o700;
 const OPENCLAW_AGENT_DB_FILE_MODE = 0o600;
 const OPENCLAW_AGENT_DB_SLOW_OPEN_MS = 1_000;


### PR DESCRIPTION
Related: #95838

## What Problem This Solves

PR #95838 added the additive `heartbeat_outcomes` table but also advanced the per-agent SQLite schema marker from 11 to 12. That contradicted the deliberate version-11 consolidation and made a short-lived unreleased build rewrite existing v11 databases to v12.

## Why This Change Was Made

The heartbeat table uses `CREATE TABLE IF NOT EXISTS`, and the agent database owner executes the canonical schema on every open. It therefore fits the existing structure-gated version-11 schema without a new version marker.

This change folds the heartbeat table into the documented v11 surface and adds a regression test that starts from an existing v11 database without that table. Reopening creates the table while both `PRAGMA user_version` and `schema_meta.schema_version` remain 11.

The short-lived v12 marker was never shipped in a release. Any local database already opened by that main-only build should be backed up and have its two version markers corrected manually; steady-state runtime does not gain a downgrade shim.

## User Impact

Current-main operators remain on per-agent schema version 11 while retaining bounded heartbeat outcome storage. No table, column, or persisted heartbeat data is removed.

## Evidence

- Focused Linux Testbox: 41/41 agent-database tests passed: https://github.com/openclaw/openclaw/actions/runs/29582207277
- Targeted `oxfmt` and `oxlint` checks pass.
- Fresh autoreview reports no accepted/actionable findings.
