### PR TITLE
refactor(discord): adopt shared realtime voice session harness

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -4,7 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
 import type {
   RealtimeVoiceAgentControlResult,
-  RealtimeVoiceForcedConsultCoordinator,
+  RealtimeVoiceSessionHarness,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelType } from "../internal/discord.js";
@@ -264,6 +264,26 @@ vi.mock("openclaw/plugin-sdk/realtime-voice", async () => {
   return {
     ...actual,
     createRealtimeVoiceBridgeSession: createRealtimeVoiceBridgeSessionMock,
+    createRealtimeVoiceSessionHarness: (
+      params: Parameters<typeof actual.createRealtimeVoiceSessionHarness>[0],
+    ) => {
+      const harness = actual.createRealtimeVoiceSessionHarness(params);
+      return {
+        ...harness,
+        createBridge: (bridgeParams: Parameters<typeof harness.createBridge>[0]) =>
+          createRealtimeVoiceBridgeSessionMock(bridgeParams),
+        flushOutput: (flush: () => void) => flush(),
+        handleBargeIn: (
+          options: Parameters<typeof harness.handleBargeIn>[0],
+          fallbackFlush: () => void,
+        ) => {
+          realtimeSessionMock.handleBargeIn(options);
+          // The mock provider never clears audio, so exercise the harness fallback directly.
+          // Discord passes a no-op for normal truncation and a real clear for forced paths.
+          fallbackFlush();
+        },
+      };
+    },
     controlRealtimeVoiceAgentRun: controlRealtimeVoiceAgentRunMock,
     resolveConfiguredRealtimeVoiceProvider: resolveConfiguredRealtimeVoiceProviderMock,
   };
@@ -5084,14 +5104,14 @@ describe("DiscordVoiceManager", () => {
       realtime?: unknown;
     };
     const realtime = entry.realtime as {
-      forcedConsults: RealtimeVoiceForcedConsultCoordinator;
+      harness: RealtimeVoiceSessionHarness;
     };
-    const cancelled = realtime.forcedConsults.prepare("cancelled question");
+    const cancelled = realtime.harness.forcedConsults.prepare("cancelled question");
     if (!cancelled) {
       throw new Error("expected forced consult handle");
     }
-    realtime.forcedConsults.markStarted(cancelled);
-    realtime.forcedConsults.markCancelled(cancelled);
+    realtime.harness.forcedConsults.markStarted(cancelled);
+    realtime.harness.forcedConsults.markCancelled(cancelled);
     const bridgeParams = lastRealtimeBridgeParams() as
       | {
           onToolCall?: (

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -10,10 +10,7 @@ import {
   buildRealtimeVoiceAgentConsultPolicyInstructions,
   classifySkippableRealtimeVoiceConsultTranscript,
   controlRealtimeVoiceAgentRun,
-  createRealtimeVoiceAgentTalkbackQueue,
-  createRealtimeVoiceBridgeSession,
-  createRealtimeVoiceForcedConsultCoordinator,
-  createRealtimeVoiceOutputActivityTracker,
+  createRealtimeVoiceSessionHarness,
   createRealtimeVoiceTurnContextTracker,
   matchRealtimeVoiceActivationName,
   matchRealtimeVoiceConsultQuestions,
@@ -27,15 +24,13 @@ import {
   resolveRealtimeVoiceAgentConsultTools,
   resolveRealtimeVoiceAgentConsultToolsAllow,
   type RealtimeVoiceBridgeEvent,
-  type RealtimeVoiceAgentTalkbackQueue,
   type RealtimeVoiceAgentConsultToolPolicy,
   type RealtimeVoiceAgentControlResult,
   type RealtimeVoiceBridgeSession,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceToolCallEvent,
-  type RealtimeVoiceForcedConsultCoordinator,
   type RealtimeVoiceForcedConsultHandle,
-  type RealtimeVoiceOutputActivityTracker,
+  type RealtimeVoiceSessionHarness,
   type RealtimeVoiceTurnContextHandle,
   type RealtimeVoiceTurnContextTracker,
   type RealtimeVoiceActivationNameTranscriptResult,
@@ -93,6 +88,7 @@ const DISCORD_REALTIME_DUPLICATE_ERROR_SUPPRESS_MS = 60_000;
 const DISCORD_REALTIME_CONTROL_SPEECH_DEDUPE_MS = 5_000;
 const DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS = 1_500;
 const DISCORD_REALTIME_WAKE_ACKS = ["Yeah.", "Mm-hmm.", "Got it.", "One sec."];
+const discordRealtimeTalkPayload = () => ({});
 const REALTIME_PCM16_BYTES_PER_SAMPLE = 2;
 const DISCORD_RAW_PCM_FRAME_BYTES = 3_840;
 const DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES = 25;
@@ -318,29 +314,16 @@ function normalizeControlSpeechText(text: string): string {
   return text.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
-function matchesPendingAgentProxyQuestion(
-  consultMessage: string | undefined,
-  question: string | undefined,
-): boolean {
-  return matchRealtimeVoiceConsultQuestions(consultMessage, question);
-}
-
 export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   private bridge: RealtimeVoiceBridgeSession | null = null;
   private outputStream: PassThrough | null = null;
-  private readonly talkback: RealtimeVoiceAgentTalkbackQueue;
+  private readonly harness: RealtimeVoiceSessionHarness<AgentProxyConsultState>;
   private stopped = false;
   private consultToolPolicy: RealtimeVoiceAgentConsultToolPolicy = "safe-read-only";
   private consultToolsAllow: string[] | undefined;
   private consultPolicy: "auto" | "always" = "auto";
   private wakeNamePolicy: DiscordRealtimeWakeNamePolicy = "never";
   private wakeNames: string[] = [];
-  private readonly forcedConsults: RealtimeVoiceForcedConsultCoordinator<AgentProxyConsultState> =
-    createRealtimeVoiceForcedConsultCoordinator<AgentProxyConsultState>({
-      limit: DISCORD_REALTIME_RECENT_AGENT_PROXY_CONSULT_LIMIT,
-      nativeDedupeMs: DISCORD_REALTIME_RECENT_AGENT_PROXY_CONSULT_TTL_MS,
-      questionsMatch: matchesPendingAgentProxyQuestion,
-    });
   private readonly speakerTurns: RealtimeVoiceTurnContextTracker<
     DiscordRealtimeSpeakerContext,
     PendingSpeakerTurnStats
@@ -351,8 +334,6 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       deferUntilAudio: true,
     },
   );
-  private readonly outputActivity: RealtimeVoiceOutputActivityTracker =
-    createRealtimeVoiceOutputActivityTracker();
   private outputPlaybackWatchdog: ReturnType<typeof setTimeout> | undefined;
   private outputPacedBuffer: Buffer = Buffer.alloc(0);
   private realtimeProviderId: string | undefined;
@@ -394,28 +375,48 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       runAgentTurn: (params: VoiceRealtimeAgentTurnParams) => Promise<string>;
     },
   ) {
-    this.talkback = createRealtimeVoiceAgentTalkbackQueue({
-      debounceMs: this.realtimeConfig?.debounceMs ?? DISCORD_REALTIME_TALKBACK_DEBOUNCE_MS,
-      isStopped: () => this.stopped,
-      logger,
-      logPrefix: "[discord] realtime agent",
-      responseStyle: "Brief, natural spoken answer for a Discord voice channel.",
-      fallbackText: DISCORD_REALTIME_FALLBACK_TEXT,
-      consult: async ({ question, responseStyle, metadata }) => {
-        const context = isDiscordRealtimeSpeakerContext(metadata) ? metadata : undefined;
-        return {
-          text: await this.runAgentTurn({
-            context,
-            message: formatVoiceIngressPrompt(
-              [question, responseStyle ? `Spoken style: ${responseStyle}` : undefined]
-                .filter(Boolean)
-                .join("\n\n"),
-              context?.speakerLabel ?? "Discord voice speaker",
-            ),
-          }),
-        };
+    this.harness = createRealtimeVoiceSessionHarness<AgentProxyConsultState>({
+      talk: {
+        sessionId: `discord:${this.params.entry.voiceSessionKey}:realtime`,
+        mode: "realtime",
+        transport: "gateway-relay",
+        brain: "agent-consult",
       },
-      deliver: (text) => this.enqueueExactSpeechMessage(text),
+      talkPayloads: {
+        turnStarted: discordRealtimeTalkPayload,
+        turnEnded: discordRealtimeTalkPayload,
+        inputAudioDelta: discordRealtimeTalkPayload,
+        outputAudioStarted: discordRealtimeTalkPayload,
+        outputAudioDelta: discordRealtimeTalkPayload,
+        outputAudioDone: discordRealtimeTalkPayload,
+      },
+      talkback: {
+        debounceMs: this.realtimeConfig?.debounceMs ?? DISCORD_REALTIME_TALKBACK_DEBOUNCE_MS,
+        logger,
+        logPrefix: "[discord] realtime agent",
+        responseStyle: "Brief, natural spoken answer for a Discord voice channel.",
+        fallbackText: DISCORD_REALTIME_FALLBACK_TEXT,
+        consult: async ({ question, responseStyle, metadata }) => {
+          const context = isDiscordRealtimeSpeakerContext(metadata) ? metadata : undefined;
+          return {
+            text: await this.runAgentTurn({
+              context,
+              message: formatVoiceIngressPrompt(
+                [question, responseStyle ? `Spoken style: ${responseStyle}` : undefined]
+                  .filter(Boolean)
+                  .join("\n\n"),
+                context?.speakerLabel ?? "Discord voice speaker",
+              ),
+            }),
+          };
+        },
+        deliver: (text) => this.enqueueExactSpeechMessage(text),
+      },
+      forcedConsults: {
+        limit: DISCORD_REALTIME_RECENT_AGENT_PROXY_CONSULT_LIMIT,
+        nativeDedupeMs: DISCORD_REALTIME_RECENT_AGENT_PROXY_CONSULT_TTL_MS,
+        questionsMatch: matchRealtimeVoiceConsultQuestions,
+      },
     });
   }
 
@@ -470,7 +471,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       toolPolicy,
       consultPolicy,
     });
-    this.bridge = createRealtimeVoiceBridgeSession({
+    this.bridge = this.harness.createBridge({
       provider: resolved.provider,
       cfg: this.params.cfg,
       providerConfig: resolved.providerConfig,
@@ -485,7 +486,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       audioSink: {
         isOpen: () => !this.stopped,
         sendAudio: (audio) => this.sendOutputAudio(audio),
-        clearAudio: () => this.clearOutputAudio("provider-clear-audio"),
+        clearAudio: () =>
+          this.harness.flushOutput(() => this.clearOutputAudio("provider-clear-audio")),
       },
       onTranscript: (role, text, isFinal) => {
         if (isFinal && text.trim()) {
@@ -563,8 +565,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   close(): void {
     this.stopped = true;
     this.flushSuppressedRealtimeErrors();
-    this.talkback.close();
-    this.forcedConsults.clear();
+    this.harness.close();
     this.speakerTurns.clear();
     this.queuedExactSpeechMessages = [];
     this.exactSpeechResponseActive = false;
@@ -675,14 +676,16 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const outputActive = this.hasInterruptibleOutputAudio();
     if (!outputActive) {
       logger.info(
-        `discord voice: realtime barge-in ignored reason=${reason} outputActive=false guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} playbackChunks=${this.outputAudioChunks()}`,
+        `discord voice: realtime barge-in ignored reason=${reason} outputActive=false guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} playbackChunks=${this.harness.outputActivity.snapshot().chunks}`,
       );
       return;
     }
     logger.info(
-      `discord voice: realtime barge-in requested reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.outputAudioChunks()}`,
+      `discord voice: realtime barge-in requested reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.harness.outputActivity.snapshot().chunks}`,
     );
-    this.bridge?.handleBargeIn({ audioPlaybackActive: true });
+    // Provider owns barge-in truncation. If audio is below minBargeInAudioEndMs,
+    // shipped behavior leaves local playback intact, so the fallback must not clear it.
+    this.harness.handleBargeIn({ audioPlaybackActive: true }, () => {});
   }
 
   isBargeInEnabled(): boolean {
@@ -697,8 +700,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private hasInterruptibleOutputAudio(): boolean {
-    this.syncOutputAudioTimestamp();
-    return this.outputActivity.isInterruptible(this.isOutputStreamActive());
+    this.bridge?.setMediaTimestamp(this.outputAudioMs());
+    const streamActive = Boolean(this.outputStream && !this.outputStream.destroyed);
+    return this.harness.outputActivity.isInterruptible(streamActive);
   }
 
   private get realtimeConfig(): DiscordRealtimeVoiceConfig {
@@ -718,8 +722,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (discordPcm.length === 0) {
       return;
     }
-    this.syncOutputAudioTimestamp();
-    if (this.outputActivity.snapshot().streamEnding) {
+    this.bridge?.setMediaTimestamp(this.outputAudioMs());
+    if (this.harness.outputActivity.snapshot().streamEnding) {
       logVoiceVerbose(
         `realtime output audio ignored after stream ending: guild ${this.params.entry.guildId} channel ${this.params.entry.channelId}`,
       );
@@ -729,7 +733,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (this.exactSpeechResponseActive) {
       this.exactSpeechAudioStarted = true;
     }
-    this.outputActivity.markAudio({
+    this.harness.outputActivity.markAudio({
       audioMs: pcm16MonoDurationMs(
         realtimePcm24kMono,
         REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz,
@@ -747,11 +751,11 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const stream = new PassThrough({ highWaterMark: DISCORD_RAW_PCM_FRAME_BYTES * 128 });
     this.outputStream = stream;
     this.outputPacedBuffer = Buffer.alloc(0);
-    this.outputActivity.markStreamOpened();
+    this.harness.outputActivity.markStreamOpened();
     stream.once("close", () => {
       // After playback starts this PCM stream can close before Discord consumes
       // the Opus resource; idle/watchdog owns active playback cleanup.
-      if (this.outputActivity.snapshot().playbackStarted) {
+      if (this.harness.outputActivity.snapshot().playbackStarted) {
         return;
       }
       this.handleOutputStreamClosed(stream, "stream-close");
@@ -766,7 +770,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.logOutputAudioStopped(reason);
     this.clearOutputPlaybackWatchdog();
     this.outputStream = null;
-    this.resetOutputAudioStats();
+    this.outputPacedBuffer = Buffer.alloc(0);
+    this.harness.outputActivity.reset();
     // The Opus resource can close without Discord emitting player idle. This
     // close path releases queued exact speech, so clear the old watchdog before
     // the next response owns exact-speech state.
@@ -774,7 +779,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private queueOutputAudio(stream: PassThrough, discordPcm: Buffer): void {
-    if (this.outputActivity.snapshot().playbackStarted) {
+    if (this.harness.outputActivity.snapshot().playbackStarted) {
       stream.write(discordPcm);
       return;
     }
@@ -791,7 +796,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private startOutputPlayback(stream: PassThrough): void {
-    if (this.outputActivity.snapshot().playbackStarted || stream.destroyed) {
+    if (this.harness.outputActivity.snapshot().playbackStarted || stream.destroyed) {
       return;
     }
     const voiceSdk = loadDiscordVoiceSdk();
@@ -820,7 +825,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       inputType: voiceSdk.StreamType.Opus,
     });
     this.params.entry.player.play(resource);
-    this.outputActivity.markPlaybackStarted();
+    this.harness.outputActivity.markPlaybackStarted();
     const realtimeConfig = this.realtimeConfig;
     logger.info(
       `discord voice: realtime audio playback started guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} mode=${this.params.mode} model=${realtimeConfig?.model ?? "provider-default"} voice=${realtimeConfig?.voice ?? "provider-default"}`,
@@ -838,7 +843,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.logOutputAudioStopped(reason);
     this.outputStream = null;
     this.outputPacedBuffer = Buffer.alloc(0);
-    this.resetOutputAudioStats();
+    this.harness.outputActivity.reset();
     stream?.end();
     stream?.destroy();
   }
@@ -848,12 +853,12 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     { playBuffered = true }: { playBuffered?: boolean } = {},
   ): void {
     const stream = this.outputStream;
-    if (!stream || stream.destroyed || this.outputActivity.snapshot().streamEnding) {
+    if (!stream || stream.destroyed || this.harness.outputActivity.snapshot().streamEnding) {
       return;
     }
-    this.outputActivity.markStreamEnding();
+    this.harness.outputActivity.markStreamEnding();
     logger.info(
-      `discord voice: realtime audio playback finishing reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${this.outputAudioMs()} chunks=${this.outputAudioChunks()}`,
+      `discord voice: realtime audio playback finishing reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${this.outputAudioMs()} chunks=${this.harness.outputActivity.snapshot().chunks}`,
     );
     if (playBuffered) {
       this.startOutputPlayback(stream);
@@ -869,7 +874,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
 
   private scheduleOutputPlaybackWatchdog(reason: string, stream: PassThrough): void {
     this.clearOutputPlaybackWatchdog();
-    const timeoutMs = this.outputActivity.playbackWatchdogDelayMs({
+    const timeoutMs = this.harness.outputActivity.playbackWatchdogDelayMs({
       marginMs: DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS,
     });
     if (timeoutMs === undefined) {
@@ -885,7 +890,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         return;
       }
       logger.warn(
-        `discord voice: realtime audio playback watchdog fired reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${this.outputAudioMs()} elapsedMs=${this.outputActivity.elapsedPlaybackMs()}`,
+        `discord voice: realtime audio playback watchdog fired reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${this.outputAudioMs()} elapsedMs=${this.harness.outputActivity.elapsedPlaybackMs()}`,
       );
       this.clearOutputAudio("playback-watchdog");
       this.completeExactSpeechResponse("playback-watchdog");
@@ -949,8 +954,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     }
     this.queuedExactSpeechMessages = [];
     this.completeExactSpeechResponse("active-run-control", { drain: false });
-    this.bridge?.handleBargeIn?.({ audioPlaybackActive: true, force: true });
-    this.clearOutputAudio("active-run-control");
+    this.harness.handleBargeIn({ audioPlaybackActive: true, force: true }, () =>
+      this.clearOutputAudio("active-run-control"),
+    );
     this.lastControlSpeech = {
       normalizedText: normalizeControlSpeechText(trimmed),
       sentAt: Date.now(),
@@ -978,8 +984,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     logger.info(
       `discord voice: realtime duplicate active-run control speech suppressed guild=${this.params.entry.guildId} channel=${this.params.entry.channelId}`,
     );
-    this.bridge?.handleBargeIn?.({ audioPlaybackActive: true, force: true });
-    this.clearOutputAudio("duplicate-active-run-control");
+    this.harness.handleBargeIn({ audioPlaybackActive: true, force: true }, () =>
+      this.clearOutputAudio("duplicate-active-run-control"),
+    );
   }
 
   private completeExactSpeechResponse(reason: string, options?: { drain?: boolean }): void {
@@ -1014,12 +1021,12 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private logOutputAudioStopped(reason: string): void {
-    const activity = this.outputActivity.snapshot();
+    const activity = this.harness.outputActivity.snapshot();
     const audioMs = Math.floor(activity.audioMs);
     const chunks = activity.chunks;
     const discordBytes = activity.sinkAudioBytes;
     const realtimeBytes = activity.sourceAudioBytes;
-    const elapsedMs = this.outputActivity.elapsedPlaybackMs();
+    const elapsedMs = this.harness.outputActivity.elapsedPlaybackMs();
     if (this.outputStream || chunks > 0 || audioMs > 0) {
       logger.info(
         `discord voice: realtime audio playback stopped reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${audioMs} elapsedMs=${elapsedMs} chunks=${chunks} discordBytes=${discordBytes} realtimeBytes=${realtimeBytes}`,
@@ -1027,29 +1034,14 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     }
   }
 
-  private resetOutputAudioStats(): void {
-    this.outputPacedBuffer = Buffer.alloc(0);
-    this.outputActivity.reset();
-  }
-
-  private syncOutputAudioTimestamp(): void {
-    this.bridge?.setMediaTimestamp(this.outputAudioMs());
-  }
-
   private outputAudioMs(): number {
-    return Math.floor(this.outputActivity.snapshot().audioMs);
-  }
-
-  private outputAudioChunks(): number {
-    return this.outputActivity.snapshot().chunks;
-  }
-
-  private isOutputStreamActive(): boolean {
-    return Boolean(this.outputStream && !this.outputStream.destroyed);
+    return Math.floor(this.harness.outputActivity.snapshot().audioMs);
   }
 
   private isOutputAudioActive(): boolean {
-    return this.outputActivity.isActive(this.isOutputStreamActive());
+    return this.harness.outputActivity.isActive(
+      Boolean(this.outputStream && !this.outputStream.destroyed),
+    );
   }
 
   private logSpeakerTurnClosed(turn: PendingSpeakerTurn): void {
@@ -1127,10 +1119,10 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     logger.info(
       `discord voice: realtime consult requested call=${callId || "unknown"} voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId} question=${formatVoiceLogPreview(consultMessage)}`,
     );
-    const nativeConsult = this.forcedConsults.recordNativeConsult(event.args, callId);
+    const nativeConsult = this.harness.forcedConsults.recordNativeConsult(event.args, callId);
     if (
       nativeConsult.kind === "already_delivered" &&
-      this.forcedConsults.isCancelled(nativeConsult.handle)
+      this.harness.forcedConsults.isCancelled(nativeConsult.handle)
     ) {
       await this.submitTerminalRealtimeToolResult(callId, session, {
         status: "cancelled",
@@ -1140,7 +1132,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     }
     const pendingConsult = nativeConsult.kind === "pending" ? nativeConsult.handle : undefined;
     if (pendingConsult) {
-      this.forcedConsults.rememberQuestion(pendingConsult, consultMessage);
+      this.harness.forcedConsults.rememberQuestion(pendingConsult, consultMessage);
     }
     let context = pendingConsult?.context?.speaker;
     let recent = pendingConsult;
@@ -1296,7 +1288,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     });
     if (control?.handled) {
       if (pendingForcedConsult) {
-        this.forcedConsults.remove(pendingForcedConsult);
+        this.harness.forcedConsults.remove(pendingForcedConsult);
       }
       this.logAgentControlResult(control.result);
       if (control.speakText) {
@@ -1314,7 +1306,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       }
       return;
     }
-    this.talkback.enqueue(
+    this.harness.talkback?.enqueue(
       acceptedText,
       forcedSpeakerContext ?? this.consumePendingSpeakerContext(),
     );
@@ -1445,13 +1437,13 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       logger.warn("discord voice: realtime forced agent consult has no speaker context");
       return undefined;
     }
-    return this.forcedConsults.prepare(question, {
+    return this.harness.forcedConsults.prepare(question, {
       context: { speaker: context },
     });
   }
 
   private schedulePreparedForcedAgentProxyConsult(pending: AgentProxyConsultHandle): void {
-    this.forcedConsults.schedule(
+    this.harness.forcedConsults.schedule(
       pending,
       DISCORD_REALTIME_FORCED_CONSULT_FALLBACK_DELAY_MS,
       (handle) => void this.runForcedAgentProxyConsult(handle),
@@ -1459,16 +1451,16 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private async runForcedAgentProxyConsult(pending: AgentProxyConsultHandle): Promise<void> {
-    this.forcedConsults.markStarted(pending);
+    this.harness.forcedConsults.markStarted(pending);
     const state = pending.context;
     if (!state) {
-      this.forcedConsults.markCancelled(pending);
+      this.harness.forcedConsults.markCancelled(pending);
       return;
     }
     const context = state.speaker;
     const { question } = pending;
     if (this.stopped) {
-      this.forcedConsults.markCancelled(pending);
+      this.harness.forcedConsults.markCancelled(pending);
       return;
     }
     const startedAt = Date.now();
@@ -1480,7 +1472,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     );
     if (this.hasInterruptibleOutputAudio()) {
       logger.info(
-        `discord voice: realtime forced agent consult preserving active playback guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.outputAudioChunks()}`,
+        `discord voice: realtime forced agent consult preserving active playback guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.harness.outputActivity.snapshot().chunks}`,
       );
     }
     state.handledByForcedPlayback = true;
@@ -1580,7 +1572,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     context: DiscordRealtimeSpeakerContext,
     options: { id?: string; started?: boolean } = {},
   ): AgentProxyConsultHandle {
-    const handle = this.forcedConsults.prepare(question, {
+    const handle = this.harness.forcedConsults.prepare(question, {
       context: { speaker: context },
       ...(options.id ? { id: options.id } : {}),
     });
@@ -1588,7 +1580,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       throw new Error("Discord realtime consult context requires a non-empty question");
     }
     if (options.started) {
-      this.forcedConsults.markStarted(handle);
+      this.harness.forcedConsults.markStarted(handle);
     }
     return handle;
   }
@@ -1601,23 +1593,23 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (!state) {
       return;
     }
-    this.forcedConsults.markStarted(recent);
+    this.harness.forcedConsults.markStarted(recent);
     state.promise = promise;
     void promise
       .then((text) => {
         state.result = { status: "fulfilled", text };
-        this.forcedConsults.markDelivered(recent);
+        this.harness.forcedConsults.markDelivered(recent);
       })
       .catch((error: unknown) => {
         state.result = { status: "rejected", error: formatErrorMessage(error) };
-        this.forcedConsults.markDelivered(recent);
+        this.harness.forcedConsults.markDelivered(recent);
       });
   }
 
   private findRecentAgentProxyConsultContext(
     consultMessage: string,
   ): AgentProxyConsultHandle | undefined {
-    return this.forcedConsults.findRecent(consultMessage);
+    return this.harness.forcedConsults.findRecent(consultMessage);
   }
 
   private async submitTerminalRealtimeToolResult(


### PR DESCRIPTION
## What Problem This Solves

Discord voice was the last consumer still hand-wiring the realtime session plumbing that #109497 consolidated into `createRealtimeVoiceSessionHarness` — its own talk-session controller, talkback queue, forced-consult coordinator, and output-activity tracker constructions, plus bespoke barge-in/output-clear coupling.

## Why This Change Was Made

Completes the four-site harness consolidation (google-meet and voice-call adopted in #109497). `DiscordRealtimeVoiceSession` now builds its session state through the harness: bridge creation via `harness.createBridge` (final-transcript and bridge-event capture included), talkback and forced-consult coordination via harness members, output-activity/playback bookkeeping via `harness.outputActivity`, and all barge-in paths via `harness.handleBargeIn` with per-path flush callbacks. Discord-specific behavior stays put: speaker attribution, wake-name policy, Opus conversion and preroll, exact-speech queue, player lifecycle, DAVE recovery.

Barge-in semantics preserved exactly: the normal barge-in path passes a no-op fallback flush — provider-side truncation owns it, and shipped behavior deliberately leaves local playback intact below `minBargeInAudioEndMs` (contract comment added at the call site); forced control-speech barge-ins keep their explicit output clears as the fallback.

## User Impact

None intended — Discord voice sessions behave identically; the shared harness is now the single owner of realtime session wiring across all voice surfaces.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/voice src/talk`: green (full voice + talk suites; e2e mock updated to exercise the harness-backed bridge and fallback paths).
- Autoreview (Codex gpt-5.6-sol, xhigh): clean — "consistently migrates ... while preserving the existing talkback, forced-consult, output-activity, playback, and barge-in behavior."
- Net −8 LOC in the adapter; the payoff is single ownership of the wiring invariants, not line count.
