### PR TITLE
fix: route bindings return the wrong agent when route identifiers contain separators

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -134,18 +134,6 @@ describe("resolveAgentRoute", () => {
     expect(route.mainSessionKey).toBe("agent:main:work");
   });
 
-  test("allows a channel route to require a stronger direct-message scope", () => {
-    const route = resolveRoute({
-      cfg: { session: { dmScope: "main" } },
-      channel: "zalouser",
-      peer: { kind: "direct", id: "321" },
-      dmScope: "per-channel-peer",
-    });
-
-    expect(route.sessionKey).toBe("agent:main:zalouser:direct:321");
-    expect(route.dmScope).toBe("per-channel-peer");
-  });
-
   test.each([
     { dmScope: "per-peer" as const, expected: "agent:main:direct:+15551234567" },
     {
@@ -1205,6 +1193,151 @@ describe("wildcard peer bindings (peer.id=*)", () => {
     expect(route.agentId).toBe("grp");
     expect(route.matchedBy).toBe("binding.peer.wildcard");
   });
+
+  test("does not reuse a cached route when peer and guild fields contain cache separators", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "whole-peer" }, { id: "guild-room" }] },
+      bindings: [
+        {
+          agentId: "whole-peer",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "group", id: "room\t-\tguild-1" },
+          },
+        },
+        {
+          agentId: "guild-room",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "group", id: "room" },
+            guildId: "guild-1",
+          },
+        },
+      ],
+    };
+
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "default",
+        peer: { kind: "group", id: "room\t-\tguild-1" },
+      }),
+      { agentId: "whole-peer", matchedBy: "binding.peer" },
+    );
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "default",
+        guildId: "guild-1",
+        peer: { kind: "group", id: "room" },
+      }),
+      { agentId: "guild-room", matchedBy: "binding.peer" },
+    );
+  });
+
+  test("does not reuse a cached route when role IDs contain cache separators", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "comma-role" }, { id: "suffix-role" }] },
+      bindings: [
+        {
+          agentId: "comma-role",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            guildId: "guild-1",
+            roles: ["a,b"],
+          },
+        },
+        {
+          agentId: "suffix-role",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            guildId: "guild-1",
+            roles: ["b,c"],
+          },
+        },
+      ],
+    };
+
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "default",
+        guildId: "guild-1",
+        memberRoleIds: ["a,b", "c"],
+      }),
+      { agentId: "comma-role", matchedBy: "binding.guild+roles" },
+    );
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "default",
+        guildId: "guild-1",
+        memberRoleIds: ["a", "b,c"],
+      }),
+      { agentId: "suffix-role", matchedBy: "binding.guild+roles" },
+    );
+  });
+
+  // Regression: the old hyphen-concatenated cache key used "|| \"-\"" as a
+  // sentinel for omitted optional fields. An absent guildId/teamId and the
+  // literal value "-" produced the same cache entry, so a binding for one
+  // could resolve through a cached route meant for the other.
+  test("does not reuse a cached route when guildId is omitted versus the literal hyphen string", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "no-guild" }, { id: "hyphen-guild" }] },
+      bindings: [
+        {
+          agentId: "no-guild",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "group", id: "room-A" },
+          },
+        },
+        {
+          agentId: "hyphen-guild",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "group", id: "room-B" },
+            guildId: "-",
+          },
+        },
+      ],
+    };
+
+    // Populate the cache with the absent-guildId route first.
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "default",
+        peer: { kind: "group", id: "room-A" },
+      }),
+      { agentId: "no-guild", matchedBy: "binding.peer" },
+    );
+    // The literal "-" guildId must resolve to its own binding — the
+    // cached route for no-guildId with peer "room-A" must not collide
+    // with the cache entry for guildId="-" + peer "room-B".
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "default",
+        peer: { kind: "group", id: "room-B" },
+        guildId: "-",
+      }),
+      { agentId: "hyphen-guild", matchedBy: "binding.peer" },
+    );
+  });
 });
 
 describe("binding evaluation cache scalability", () => {
@@ -1289,4 +1422,3 @@ describe("binding evaluation cache scalability", () => {
     expect(defaultRoute.matchedBy).toBe("default");
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -134,6 +134,18 @@ describe("resolveAgentRoute", () => {
     expect(route.mainSessionKey).toBe("agent:main:work");
   });
 
+  test("allows a channel route to require a stronger direct-message scope", () => {
+    const route = resolveAgentRoute({
+      cfg: { session: { dmScope: "main" } },
+      channel: "zalouser",
+      peer: { kind: "direct", id: "321" },
+      dmScope: "per-channel-peer",
+    });
+
+    expect(route.sessionKey).toBe("agent:main:zalouser:direct:321");
+    expect(route.dmScope).toBe("per-channel-peer");
+  });
+
   test.each([
     { dmScope: "per-peer" as const, expected: "agent:main:direct:+15551234567" },
     {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1205,7 +1205,9 @@ describe("wildcard peer bindings (peer.id=*)", () => {
     expect(route.agentId).toBe("grp");
     expect(route.matchedBy).toBe("binding.peer.wildcard");
   });
+});
 
+describe("resolved route cache keys", () => {
   test("does not reuse a cached route when peer and guild fields contain cache separators", () => {
     const cfg: OpenClawConfig = {
       agents: { list: [{ id: "whole-peer" }, { id: "guild-room" }] },
@@ -1298,56 +1300,39 @@ describe("wildcard peer bindings (peer.id=*)", () => {
     );
   });
 
-  // Regression: the old hyphen-concatenated cache key used "|| \"-\"" as a
-  // sentinel for omitted optional fields. An absent guildId/teamId and the
-  // literal value "-" produced the same cache entry, so a binding for one
-  // could resolve through a cached route meant for the other.
   test("does not reuse a cached route when guildId is omitted versus the literal hyphen string", () => {
     const cfg: OpenClawConfig = {
-      agents: { list: [{ id: "no-guild" }, { id: "hyphen-guild" }] },
+      agents: { list: [{ id: "main", default: true }, { id: "hyphen-guild" }] },
       bindings: [
-        {
-          agentId: "no-guild",
-          match: {
-            channel: "discord",
-            accountId: "default",
-            peer: { kind: "group", id: "room-A" },
-          },
-        },
         {
           agentId: "hyphen-guild",
           match: {
             channel: "discord",
             accountId: "default",
-            peer: { kind: "group", id: "room-B" },
             guildId: "-",
           },
         },
       ],
     };
 
-    // Populate the cache with the absent-guildId route first.
     expectResolvedRoute(
       resolveAgentRoute({
         cfg,
         channel: "discord",
         accountId: "default",
-        peer: { kind: "group", id: "room-A" },
+        peer: { kind: "group", id: "room" },
       }),
-      { agentId: "no-guild", matchedBy: "binding.peer" },
+      { agentId: "main", matchedBy: "default" },
     );
-    // The literal "-" guildId must resolve to its own binding — the
-    // cached route for no-guildId with peer "room-A" must not collide
-    // with the cache entry for guildId="-" + peer "room-B".
     expectResolvedRoute(
       resolveAgentRoute({
         cfg,
         channel: "discord",
         accountId: "default",
-        peer: { kind: "group", id: "room-B" },
+        peer: { kind: "group", id: "room" },
         guildId: "-",
       }),
-      { agentId: "hyphen-guild", matchedBy: "binding.peer" },
+      { agentId: "hyphen-guild", matchedBy: "binding.guild" },
     );
   });
 });
@@ -1434,3 +1419,4 @@ describe("binding evaluation cache scalability", () => {
     expect(defaultRoute.matchedBy).toBe("default");
   });
 });
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -31,11 +31,12 @@ export type RoutePeer = {
   id: string;
 };
 
-type ResolveAgentRouteInput = {
+export type ResolveAgentRouteInput = {
   cfg: OpenClawConfig;
   channel: string;
   accountId?: string | null;
   peer?: RoutePeer | null;
+  dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
   /** Parent peer for threads — used for binding inheritance when peer doesn't match directly. */
   parentPeer?: RoutePeer | null;
   guildId?: string | null;
@@ -619,7 +620,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
-  const dmScope = input.cfg.session?.dmScope ?? "main";
+  const dmScope = input.dmScope ?? input.cfg.session?.dmScope ?? "main";
   const identityLinks = input.cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -817,3 +817,4 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   return choose(resolveDefaultAgentId(input.cfg), "default");
 }
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -548,10 +548,6 @@ function formatRouteCachePeer(peer: RoutePeer | null): string {
   return `${peer.kind}:${peer.id}`;
 }
 
-function formatRoleIdsCacheKey(roleIds: string[]): string[] {
-  return roleIds.toSorted();
-}
-
 function buildResolvedRouteCacheKey(params: {
   channel: string;
   accountId: string;
@@ -569,7 +565,7 @@ function buildResolvedRouteCacheKey(params: {
     formatRouteCachePeer(params.parentPeer),
     params.guildId ?? null,
     params.teamId ?? null,
-    formatRoleIdsCacheKey(params.memberRoleIds),
+    params.memberRoleIds.toSorted(),
     params.dmScope,
   ]);
 }

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -31,12 +31,11 @@ export type RoutePeer = {
   id: string;
 };
 
-export type ResolveAgentRouteInput = {
+type ResolveAgentRouteInput = {
   cfg: OpenClawConfig;
   channel: string;
   accountId?: string | null;
   peer?: RoutePeer | null;
-  dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
   /** Parent peer for threads — used for binding inheritance when peer doesn't match directly. */
   parentPeer?: RoutePeer | null;
   guildId?: string | null;
@@ -548,20 +547,8 @@ function formatRouteCachePeer(peer: RoutePeer | null): string {
   return `${peer.kind}:${peer.id}`;
 }
 
-function formatRoleIdsCacheKey(roleIds: string[]): string {
-  const count = roleIds.length;
-  if (count === 0) {
-    return "-";
-  }
-  if (count === 1) {
-    return roleIds[0] ?? "-";
-  }
-  if (count === 2) {
-    const first = roleIds[0] ?? "";
-    const second = roleIds[1] ?? "";
-    return first <= second ? `${first},${second}` : `${second},${first}`;
-  }
-  return roleIds.toSorted().join(",");
+function formatRoleIdsCacheKey(roleIds: string[]): string[] {
+  return roleIds.toSorted();
 }
 
 function buildResolvedRouteCacheKey(params: {
@@ -574,7 +561,16 @@ function buildResolvedRouteCacheKey(params: {
   memberRoleIds: string[];
   dmScope: string;
 }): string {
-  return `${params.channel}\t${params.accountId}\t${formatRouteCachePeer(params.peer)}\t${formatRouteCachePeer(params.parentPeer)}\t${params.guildId || "-"}\t${params.teamId || "-"}\t${formatRoleIdsCacheKey(params.memberRoleIds)}\t${params.dmScope}`;
+  return JSON.stringify([
+    params.channel,
+    params.accountId,
+    formatRouteCachePeer(params.peer),
+    formatRouteCachePeer(params.parentPeer),
+    params.guildId ?? null,
+    params.teamId ?? null,
+    formatRoleIdsCacheKey(params.memberRoleIds),
+    params.dmScope,
+  ]);
 }
 
 function hasGuildConstraint(match: NormalizedBindingMatch): boolean {
@@ -623,7 +619,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
-  const dmScope = input.dmScope ?? input.cfg.session?.dmScope ?? "main";
+  const dmScope = input.cfg.session?.dmScope ?? "main";
   const identityLinks = input.cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer
@@ -820,4 +816,3 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   return choose(resolveDefaultAgentId(input.cfg), "default");
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Route bindings cache resolved agents by a route-context key. The prior key joined channel, account, peer, guild, team, role, and direct-message scope fields with tab/comma delimiters, so distinct contexts containing those separators could collide and return the wrong cached agent. Omitted optional identifiers also shared the old hyphen sentinel with a literal hyphen identifier.

## Why This Change Was Made

The route-cache key is now a JSON-serialized tuple, so each field has an unambiguous boundary. Optional guild and team IDs retain their normalized value while the serialized tuple keeps empty and literal-hyphen values distinct. The maintainer review also corrected the absent-versus-hyphen regression to hold every other key field constant.

## User Impact

Routing contexts whose peer, guild, team, or role identifiers contain separators no longer risk reusing a route resolved for another context. Binding precedence, matching, and fallback behavior are unchanged.

## Evidence

- src/routing/resolve-route.test.ts has targeted resolver regressions for tab-bearing peer/guild ambiguity, comma-bearing role-list ambiguity, and absent versus literal-hyphen guild IDs.
- node scripts/run-vitest.mjs src/routing/resolve-route.test.ts reached 58 passing assertions after rebase; the local wrapper then hung in cleanup, so exact-head hosted CI/Testbox remains the merge gate.
- Final maintainer AutoReview reported no accepted/actionable findings.

Release note: fixes rare wrong-agent route-cache reuse for separator-bearing identifiers. Credit: @YangManBOBO.
