### PR TITLE
fix(qqbot): avoid memory spikes from oversized client secret files

### DIFF
--- a/extensions/qqbot/src/bridge/config.ts
+++ b/extensions/qqbot/src/bridge/config.ts
@@ -1,7 +1,7 @@
 // Qqbot helper module supports config behavior.
-import fs from "node:fs";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { coerceSecretRef, normalizeSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { getPlatformAdapter } from "../engine/adapter/index.js";
 import {
@@ -135,8 +135,17 @@ export function resolveQQBotAccount(
     secretSource = "config";
   } else if (accountConfig.clientSecretFile) {
     try {
-      clientSecret = fs.readFileSync(accountConfig.clientSecretFile, "utf8").trim();
-      secretSource = "file";
+      const fileSecret = tryReadSecretFileSync(
+        accountConfig.clientSecretFile,
+        "QQ Bot client secret",
+        // Existing clientSecretFile paths may be symlinks or hardlinks. Keep
+        // that contract while gaining the shared credential size limit.
+        { rejectHardlinks: false },
+      );
+      if (fileSecret) {
+        clientSecret = fileSecret;
+        secretSource = "file";
+      }
     } catch {
       secretSource = "none";
     }

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -1,6 +1,5 @@
 // Qqbot tests cover config plugin behavior.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -8,7 +7,8 @@ import {
   validateJsonSchemaValue,
 } from "openclaw/plugin-sdk/json-schema-runtime";
 import { DEFAULT_SECRET_FILE_MAX_BYTES } from "openclaw/plugin-sdk/secret-file-runtime";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { qqbotSetupAdapterShared } from "./bridge/config-shared.js";
 import {
   DEFAULT_ACCOUNT_ID,
@@ -26,6 +26,8 @@ function requireRuntimeSchema() {
   return runtimeSchema;
 }
 import { makeQqbotDefaultAccountConfig, makeQqbotSecretRefConfig } from "./qqbot-test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function requireQQBotSetup() {
   if (!qqbotSetupPlugin.setup) {
@@ -244,26 +246,22 @@ describe("qqbot config", () => {
   });
 
   it("rejects oversized client secret files", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-client-secret-"));
+    const tempDir = tempDirs.make("qqbot-client-secret-");
     const secretFile = path.join(tempDir, "secret");
     fs.writeFileSync(secretFile, "x".repeat(DEFAULT_SECRET_FILE_MAX_BYTES + 1));
 
-    try {
-      const resolved = resolveQQBotAccount({
-        channels: { qqbot: { appId: "123456", clientSecretFile: secretFile } },
-      } as OpenClawConfig);
+    const resolved = resolveQQBotAccount({
+      channels: { qqbot: { appId: "123456", clientSecretFile: secretFile } },
+    } as OpenClawConfig);
 
-      expect(resolved.clientSecret).toBe("");
-      expect(resolved.secretSource).toBe("none");
-    } finally {
-      fs.rmSync(tempDir, { force: true, recursive: true });
-    }
+    expect(resolved.clientSecret).toBe("");
+    expect(resolved.secretSource).toBe("none");
   });
 
   it.runIf(process.platform !== "win32").each(["symlink", "hardlink"] as const)(
     "continues to resolve client secret files through a %s",
     (linkType) => {
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-client-secret-link-"));
+      const tempDir = tempDirs.make("qqbot-client-secret-link-");
       const targetFile = path.join(tempDir, "secret-target");
       const linkedFile = path.join(tempDir, "secret-link");
       fs.writeFileSync(targetFile, " fixture-secret\n");
@@ -273,16 +271,12 @@ describe("qqbot config", () => {
         fs.linkSync(targetFile, linkedFile);
       }
 
-      try {
-        const resolved = resolveQQBotAccount({
-          channels: { qqbot: { appId: "123456", clientSecretFile: linkedFile } },
-        } as OpenClawConfig);
+      const resolved = resolveQQBotAccount({
+        channels: { qqbot: { appId: "123456", clientSecretFile: linkedFile } },
+      } as OpenClawConfig);
 
-        expect(resolved.clientSecret).toBe("fixture-secret");
-        expect(resolved.secretSource).toBe("file");
-      } finally {
-        fs.rmSync(tempDir, { force: true, recursive: true });
-      }
+      expect(resolved.clientSecret).toBe("fixture-secret");
+      expect(resolved.secretSource).toBe("file");
     },
   );
 

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -7,6 +7,7 @@ import {
   type JsonSchemaObject,
   validateJsonSchemaValue,
 } from "openclaw/plugin-sdk/json-schema-runtime";
+import { DEFAULT_SECRET_FILE_MAX_BYTES } from "openclaw/plugin-sdk/secret-file-runtime";
 import { describe, expect, it } from "vitest";
 import { qqbotSetupAdapterShared } from "./bridge/config-shared.js";
 import {
@@ -245,7 +246,7 @@ describe("qqbot config", () => {
   it("rejects oversized client secret files", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-client-secret-"));
     const secretFile = path.join(tempDir, "secret");
-    fs.writeFileSync(secretFile, "x".repeat(16 * 1024 + 1));
+    fs.writeFileSync(secretFile, "x".repeat(DEFAULT_SECRET_FILE_MAX_BYTES + 1));
 
     try {
       const resolved = resolveQQBotAccount({

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -1,5 +1,7 @@
 // Qqbot tests cover config plugin behavior.
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   type JsonSchemaObject,
@@ -239,6 +241,49 @@ describe("qqbot config", () => {
     expect(resolved.clientSecret).toBe("secret-value");
     expect(resolved.name).toBe("Bot Two");
   });
+
+  it("rejects oversized client secret files", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-client-secret-"));
+    const secretFile = path.join(tempDir, "secret");
+    fs.writeFileSync(secretFile, "x".repeat(16 * 1024 + 1));
+
+    try {
+      const resolved = resolveQQBotAccount({
+        channels: { qqbot: { appId: "123456", clientSecretFile: secretFile } },
+      } as OpenClawConfig);
+
+      expect(resolved.clientSecret).toBe("");
+      expect(resolved.secretSource).toBe("none");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it.runIf(process.platform !== "win32").each(["symlink", "hardlink"] as const)(
+    "continues to resolve client secret files through a %s",
+    (linkType) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-client-secret-link-"));
+      const targetFile = path.join(tempDir, "secret-target");
+      const linkedFile = path.join(tempDir, "secret-link");
+      fs.writeFileSync(targetFile, " fixture-secret\n");
+      if (linkType === "symlink") {
+        fs.symlinkSync(targetFile, linkedFile);
+      } else {
+        fs.linkSync(targetFile, linkedFile);
+      }
+
+      try {
+        const resolved = resolveQQBotAccount({
+          channels: { qqbot: { appId: "123456", clientSecretFile: linkedFile } },
+        } as OpenClawConfig);
+
+        expect(resolved.clientSecret).toBe("fixture-secret");
+        expect(resolved.secretSource).toBe("file");
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("resolves env SecretRefs on runtime resolution", () => {
     const cfg = makeQqbotSecretRefConfig();

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -1,5 +1,6 @@
 // Qqbot tests cover config plugin behavior.
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -7,8 +8,7 @@ import {
   validateJsonSchemaValue,
 } from "openclaw/plugin-sdk/json-schema-runtime";
 import { DEFAULT_SECRET_FILE_MAX_BYTES } from "openclaw/plugin-sdk/secret-file-runtime";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { describe, expect, it } from "vitest";
 import { qqbotSetupAdapterShared } from "./bridge/config-shared.js";
 import {
   DEFAULT_ACCOUNT_ID,
@@ -26,8 +26,6 @@ function requireRuntimeSchema() {
   return runtimeSchema;
 }
 import { makeQqbotDefaultAccountConfig, makeQqbotSecretRefConfig } from "./qqbot-test-support.js";
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function requireQQBotSetup() {
   if (!qqbotSetupPlugin.setup) {
@@ -246,37 +244,43 @@ describe("qqbot config", () => {
   });
 
   it("rejects oversized client secret files", () => {
-    const tempDir = tempDirs.make("qqbot-client-secret-");
-    const secretFile = path.join(tempDir, "secret");
-    fs.writeFileSync(secretFile, "x".repeat(DEFAULT_SECRET_FILE_MAX_BYTES + 1));
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-client-secret-"));
+    try {
+      const secretFile = path.join(tempDir, "secret");
+      fs.writeFileSync(secretFile, "x".repeat(DEFAULT_SECRET_FILE_MAX_BYTES + 1));
+      const resolved = resolveQQBotAccount({
+        channels: { qqbot: { appId: "123456", clientSecretFile: secretFile } },
+      } as OpenClawConfig);
 
-    const resolved = resolveQQBotAccount({
-      channels: { qqbot: { appId: "123456", clientSecretFile: secretFile } },
-    } as OpenClawConfig);
-
-    expect(resolved.clientSecret).toBe("");
-    expect(resolved.secretSource).toBe("none");
+      expect(resolved.clientSecret).toBe("");
+      expect(resolved.secretSource).toBe("none");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
   });
 
   it.runIf(process.platform !== "win32").each(["symlink", "hardlink"] as const)(
     "continues to resolve client secret files through a %s",
     (linkType) => {
-      const tempDir = tempDirs.make("qqbot-client-secret-link-");
-      const targetFile = path.join(tempDir, "secret-target");
-      const linkedFile = path.join(tempDir, "secret-link");
-      fs.writeFileSync(targetFile, " fixture-secret\n");
-      if (linkType === "symlink") {
-        fs.symlinkSync(targetFile, linkedFile);
-      } else {
-        fs.linkSync(targetFile, linkedFile);
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-client-secret-link-"));
+      try {
+        const targetFile = path.join(tempDir, "secret-target");
+        const linkedFile = path.join(tempDir, "secret-link");
+        fs.writeFileSync(targetFile, " fixture-secret\n");
+        if (linkType === "symlink") {
+          fs.symlinkSync(targetFile, linkedFile);
+        } else {
+          fs.linkSync(targetFile, linkedFile);
+        }
+        const resolved = resolveQQBotAccount({
+          channels: { qqbot: { appId: "123456", clientSecretFile: linkedFile } },
+        } as OpenClawConfig);
+
+        expect(resolved.clientSecret).toBe("fixture-secret");
+        expect(resolved.secretSource).toBe("file");
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
       }
-
-      const resolved = resolveQQBotAccount({
-        channels: { qqbot: { appId: "123456", clientSecretFile: linkedFile } },
-      } as OpenClawConfig);
-
-      expect(resolved.clientSecret).toBe("fixture-secret");
-      expect(resolved.secretSource).toBe("file");
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QQ Bot operators using `clientSecretFile` could have an arbitrarily large file loaded in full during account resolution. A mistaken credential path pointing to a large file could therefore consume excessive memory before the bot connects.

## Why This Change Was Made

QQ Bot account resolution now uses OpenClaw's existing pinned secret-file reader and its 16 KiB credential limit. The plugin-local change preserves the existing missing/empty-file fallback and existing symlink/hardlink layouts; it does not change configuration shape or the QQ network path.

AI-assisted: yes. I inspected the complete resolver, its runtime/setup callers, adjacent tests, sibling plugin consumers, and installed `@openclaw/fs-safe@0.4.1` source, types, and secret-file documentation before making the change.

## User Impact

QQ Bot operators can continue using normal file-backed client secrets while oversized credential files are rejected before their contents are retained in the resolved account.

## Evidence

**Real-machine production-path proof:** Linux `6.8.0-134-generic` x86_64, Node `v24.18.0`. The harness imported QQ Bot's production bootstrap and `resolveQQBotAccount`, then exercised real regular, symlinked, and hardlinked files on disk; no resolver or filesystem mock was used.

The exact harness used on both revisions was:

```bash
node --import tsx --input-type=module <<'NODE'
import { linkSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";
import path from "node:path";
await import("./extensions/qqbot/src/bridge/bootstrap.ts");
const { resolveQQBotAccount } = await import("./extensions/qqbot/src/bridge/config.ts");
const dir = mkdtempSync(path.join(tmpdir(), "qqbot-secret-proof-"));
try {
  const oversized = path.join(dir, "oversized"), normal = path.join(dir, "normal");
  const symlink = path.join(dir, "symlink"), hardlink = path.join(dir, "hardlink");
  writeFileSync(oversized, "x".repeat(20 * 1024));
  writeFileSync(normal, " fixture-secret\n");
  symlinkSync(normal, symlink); linkSync(normal, hardlink);
  const summarize = (file) => {
    const account = resolveQQBotAccount({ channels: { qqbot: { appId: "fixture-app", clientSecretFile: file } } });
    return { secretSource: account.secretSource, secretChars: account.clientSecret.length };
  };
  console.log(JSON.stringify({ inputBytes: 20 * 1024, oversized: summarize(oversized), negativeControls: { normal: summarize(normal), symlink: summarize(symlink), hardlink: summarize(hardlink) } }));
} finally { rmSync(dir, { recursive: true, force: true }); }
NODE
```

**Before:** On `upstream/main` at `cbaf1123550572466a9aeac9275a290fae267dc6`, the production resolver retained all 20 KiB. The resolver blob remained unchanged through the latest base `2c43e867870dd610e510882017d787a8aa67b944` (`231624bd4327e0cabd3b24a6046c186c02da4006` on both revisions).

```text
{"inputBytes":20480,"oversized":{"secretSource":"file","secretChars":20480},"negativeControls":{"normal":{"secretSource":"file","secretChars":14},"symlink":{"secretSource":"file","secretChars":14},"hardlink":{"secretSource":"file","secretChars":14}}}
```

**Premise:** Installed `@openclaw/fs-safe@0.4.1` defines `DEFAULT_SECRET_FILE_MAX_BYTES = 16 * 1024`, checks file size before its pinned descriptor read, trims the result, and throws on oversized input. `openclaw/plugin-sdk/secret-file-runtime` is the public plugin re-export. Passing `rejectHardlinks: false` preserves QQ Bot's prior hardlink behavior; symlinks remain accepted by the helper's default.

**After / negative control:** On commit `7d9c747917a5d05d375bd921fc0bbe4057b24b71`, the same production path rejected the 20 KiB file while a normal file and the existing symlink/hardlink layouts still resolved.

```text
{"inputBytes":20480,"oversized":{"secretSource":"none","secretChars":0},"negativeControls":{"normal":{"secretSource":"file","secretChars":14},"symlink":{"secretSource":"file","secretChars":14},"hardlink":{"secretSource":"file","secretChars":14}}}
```

**Focused validation:**

```bash
node scripts/run-vitest.mjs extensions/qqbot/src/config.test.ts
```

```text
Test Files  1 passed (1)
Tests       23 passed (23)
```

Targeted `oxfmt --check`, targeted `oxlint`, and `git diff --check` also passed. Wide validation is left to fork CI because this external-contributor workflow prohibits the repository's maintainer-only remote test infrastructure.

Not tested against a live QQ account because the changed behavior is entirely in local credential-file resolution before the QQ connection and request paths, which are unchanged.
