### PR TITLE
fix(telegram): time out incomplete Mini App auth bodies

### DIFF
--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import net from "node:net";
 import { Readable } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { BOOTSTRAP_HANDOFF_OPERATOR_SCOPES } from "openclaw/plugin-sdk/device-bootstrap";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -166,7 +167,7 @@ describe("registerTelegramMiniAppRoutes", () => {
     expect(issueDeviceBootstrapToken).toHaveBeenCalledWith({
       profile: {
         roles: ["operator"],
-        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+        scopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
         purpose: "control-ui",
       },
     });
@@ -265,7 +266,9 @@ describe("registerTelegramMiniAppRoutes", () => {
       });
     });
     try {
-      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
       const address = server.address();
       if (!address || typeof address === "string") {
         throw new Error("expected TCP server address");
@@ -292,7 +295,7 @@ describe("registerTelegramMiniAppRoutes", () => {
           );
         });
         socket.on("data", (chunk) => {
-          raw += chunk;
+          raw += typeof chunk === "string" ? chunk : chunk.toString("utf8");
         });
         socket.on("error", reject);
         socket.on("close", () => {
@@ -305,9 +308,15 @@ describe("registerTelegramMiniAppRoutes", () => {
       expect(response).toContain("Connection: close");
       expect(response).toContain("Request body timeout");
     } finally {
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      );
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
     }
   });
 });

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -29,6 +29,20 @@ vi.mock("./url.js", async (importOriginal) => ({
   resolveTelegramMiniAppUrls,
 }));
 
+vi.mock("openclaw/plugin-sdk/webhook-ingress", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/webhook-ingress")>();
+  return {
+    ...actual,
+    WEBHOOK_BODY_READ_DEFAULTS: {
+      ...actual.WEBHOOK_BODY_READ_DEFAULTS,
+      preAuth: {
+        ...actual.WEBHOOK_BODY_READ_DEFAULTS.preAuth,
+        timeoutMs: 1,
+      },
+    },
+  };
+});
+
 const { registerTelegramMiniAppRoutes } = await import("./routes.js");
 
 const BOT_TOKEN = "fixture";
@@ -240,5 +254,40 @@ describe("registerTelegramMiniAppRoutes", () => {
 
     expect(last?.statusCode).toBe(429);
     expect(last?.body).toBe("Too many requests");
+  });
+
+  it("times out incomplete Mini App auth request bodies", async () => {
+    const route = createRoute(config());
+    const req = new Readable({
+      read() {
+        // Keep the body open until the route's body timeout settles the request.
+      },
+    }) as IncomingMessage;
+    req.method = "POST";
+    req.url = "/__openclaw_tg_miniapp/auth";
+    req.headers = { "content-type": "application/json" };
+    Object.defineProperty(req, "socket", {
+      value: { remoteAddress: "203.0.113.50" },
+    });
+    const res = new MockResponse() as ServerResponse & MockResponse;
+    const handled = route.handler(req, res);
+    void handled.catch(() => undefined);
+    let guard: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const settled = await Promise.race([
+        handled.then(() => true),
+        new Promise<false>((resolve) => {
+          guard = setTimeout(() => resolve(false), 100);
+        }),
+      ]);
+
+      expect(settled).toBe(true);
+      expect(res.statusCode).toBe(408);
+      expect(res.body).toBe("Request body timeout");
+    } finally {
+      clearTimeout(guard);
+      req.destroy();
+    }
   });
 });

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -270,13 +270,12 @@ describe("registerTelegramMiniAppRoutes", () => {
       value: { remoteAddress: "203.0.113.50" },
     });
     const res = new MockResponse() as ServerResponse & MockResponse;
-    const handled = route.handler(req, res);
-    void handled.catch(() => undefined);
+    const handled = Promise.resolve(route.handler(req, res)).catch(() => undefined);
     let guard: ReturnType<typeof setTimeout> | undefined;
 
     try {
       const settled = await Promise.race([
-        handled.then(() => true),
+        handled.then(() => true as const),
         new Promise<false>((resolve) => {
           guard = setTimeout(() => resolve(false), 100);
         }),

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import net from "node:net";
 import { Readable } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
@@ -256,37 +257,57 @@ describe("registerTelegramMiniAppRoutes", () => {
     expect(last?.body).toBe("Too many requests");
   });
 
-  it("times out incomplete Mini App auth request bodies", async () => {
+  it("returns 408 and closes the socket for incomplete Mini App auth bodies", async () => {
     const route = createRoute(config());
-    const req = new Readable({
-      read() {
-        // Keep the body open until the route's body timeout settles the request.
-      },
-    }) as IncomingMessage;
-    req.method = "POST";
-    req.url = "/__openclaw_tg_miniapp/auth";
-    req.headers = { "content-type": "application/json" };
-    Object.defineProperty(req, "socket", {
-      value: { remoteAddress: "203.0.113.50" },
+    const server = createServer((req, res) => {
+      void Promise.resolve(route.handler(req, res)).catch(() => {
+        res.destroy();
+      });
     });
-    const res = new MockResponse() as ServerResponse & MockResponse;
-    const handled = Promise.resolve(route.handler(req, res)).catch(() => undefined);
-    let guard: ReturnType<typeof setTimeout> | undefined;
-
     try {
-      const settled = await Promise.race([
-        handled.then(() => true as const),
-        new Promise<false>((resolve) => {
-          guard = setTimeout(() => resolve(false), 100);
-        }),
-      ]);
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP server address");
+      }
+      const response = await new Promise<string>((resolve, reject) => {
+        const socket = net.createConnection({ host: "127.0.0.1", port: address.port });
+        let raw = "";
+        const timeout = setTimeout(() => {
+          socket.destroy();
+          reject(new Error("timed out waiting for server to close the partial request"));
+        }, 500);
+        socket.setEncoding("utf8");
+        socket.on("connect", () => {
+          socket.write(
+            [
+              "POST /__openclaw_tg_miniapp/auth HTTP/1.1",
+              "Host: 127.0.0.1",
+              "Content-Type: application/json",
+              "Content-Length: 64",
+              "Connection: keep-alive",
+              "",
+              '{"initData":"partial',
+            ].join("\r\n"),
+          );
+        });
+        socket.on("data", (chunk) => {
+          raw += chunk;
+        });
+        socket.on("error", reject);
+        socket.on("close", () => {
+          clearTimeout(timeout);
+          resolve(raw);
+        });
+      });
 
-      expect(settled).toBe(true);
-      expect(res.statusCode).toBe(408);
-      expect(res.body).toBe("Request body timeout");
+      expect(response).toContain("HTTP/1.1 408 Request Timeout");
+      expect(response).toContain("Connection: close");
+      expect(response).toContain("Request body timeout");
     } finally {
-      clearTimeout(guard);
-      req.destroy();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
     }
   });
 });

--- a/extensions/telegram/src/miniapp/routes.ts
+++ b/extensions/telegram/src/miniapp/routes.ts
@@ -8,12 +8,8 @@ import {
   issueDeviceBootstrapToken,
 } from "openclaw/plugin-sdk/device-bootstrap";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import {
-  isRequestBodyLimitError,
-  readRequestBodyWithLimit,
-  requestBodyErrorToText,
-  WEBHOOK_BODY_READ_DEFAULTS,
-} from "openclaw/plugin-sdk/webhook-ingress";
+import { WEBHOOK_BODY_READ_DEFAULTS } from "openclaw/plugin-sdk/webhook-ingress";
+import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import { resolveTelegramAccount } from "../accounts.js";
 import { validateTelegramMiniAppInitData } from "./init-data.js";
 import { isTelegramMiniAppOwner } from "./owner.js";
@@ -91,20 +87,11 @@ async function handleAuth(
     return;
   }
 
-  let body: Awaited<ReturnType<typeof readJsonBody>>;
-  try {
-    body = await readJsonBody(req);
-  } catch (error) {
-    if (isRequestBodyLimitError(error, "PAYLOAD_TOO_LARGE")) {
-      sendText(res, 413, requestBodyErrorToText(error.code));
-      return;
-    }
-    if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
-      sendText(res, 408, requestBodyErrorToText(error.code));
-      return;
-    }
-    throw error;
+  const bodyResult = await readJsonBodyOrReject(req, res);
+  if (!bodyResult.ok) {
+    return;
   }
+  const body = bodyResult.value;
   if (!body) {
     sendText(res, 401, TELEGRAM_MINIAPP_EXPIRED_MESSAGE);
     return;
@@ -154,27 +141,64 @@ function currentConfig(api: OpenClawPluginApi): OpenClawConfig {
   return (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
 }
 
-async function readJsonBody(
+async function readJsonBodyOrReject(
   req: IncomingMessage,
-): Promise<{ initData: string; accountId?: string } | null> {
-  const raw = await readRequestBodyWithLimit(req, {
+  res: ServerResponse,
+): Promise<{ ok: true; value: { initData: string; accountId?: string } | null } | { ok: false }> {
+  const shouldKeepAlive = res.shouldKeepAlive;
+  // The guard ends its error response before destroying the incomplete request.
+  // Predeclare that close on the wire, then restore keep-alive after a complete read.
+  res.shouldKeepAlive = false;
+  const guard = installRequestBodyLimitGuard(req, res, {
     maxBytes: MAX_BODY_BYTES,
     timeoutMs: WEBHOOK_BODY_READ_DEFAULTS.preAuth.timeoutMs,
+    responseFormat: "text",
   });
+  if (guard.isTripped()) {
+    return { ok: false };
+  }
+
+  let raw: string;
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    raw = Buffer.concat(chunks).toString("utf8");
+  } catch (error) {
+    // The guard must flush its HTTP error before destroying the incomplete body.
+    // Swallow only that expected stream abort; other read failures still surface.
+    if (guard.isTripped()) {
+      return { ok: false };
+    }
+    throw error;
+  } finally {
+    guard.dispose();
+    if (!guard.isTripped()) {
+      res.shouldKeepAlive = shouldKeepAlive;
+    }
+  }
+  if (guard.isTripped()) {
+    return { ok: false };
+  }
+
   try {
     const parsed = JSON.parse(raw) as {
       initData?: unknown;
       accountId?: unknown;
     };
     if (typeof parsed.initData !== "string") {
-      return null;
+      return { ok: true, value: null };
     }
     return {
-      initData: parsed.initData,
-      ...(typeof parsed.accountId === "string" ? { accountId: parsed.accountId } : {}),
+      ok: true,
+      value: {
+        initData: parsed.initData,
+        ...(typeof parsed.accountId === "string" ? { accountId: parsed.accountId } : {}),
+      },
     };
   } catch {
-    return null;
+    return { ok: true, value: null };
   }
 }
 

--- a/extensions/telegram/src/miniapp/routes.ts
+++ b/extensions/telegram/src/miniapp/routes.ts
@@ -8,6 +8,12 @@ import {
   issueDeviceBootstrapToken,
 } from "openclaw/plugin-sdk/device-bootstrap";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+  WEBHOOK_BODY_READ_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-ingress";
 import { resolveTelegramAccount } from "../accounts.js";
 import { validateTelegramMiniAppInitData } from "./init-data.js";
 import { isTelegramMiniAppOwner } from "./owner.js";
@@ -85,10 +91,19 @@ async function handleAuth(
     return;
   }
 
-  const body = await readJsonBody(req);
-  if (body === "too-large") {
-    sendText(res, 413, "Payload too large");
-    return;
+  let body: Awaited<ReturnType<typeof readJsonBody>>;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    if (isRequestBodyLimitError(error, "PAYLOAD_TOO_LARGE")) {
+      sendText(res, 413, requestBodyErrorToText(error.code));
+      return;
+    }
+    if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
+      sendText(res, 408, requestBodyErrorToText(error.code));
+      return;
+    }
+    throw error;
   }
   if (!body) {
     sendText(res, 401, TELEGRAM_MINIAPP_EXPIRED_MESSAGE);
@@ -141,19 +156,13 @@ function currentConfig(api: OpenClawPluginApi): OpenClawConfig {
 
 async function readJsonBody(
   req: IncomingMessage,
-): Promise<{ initData: string; accountId?: string } | "too-large" | null> {
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of req) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += buffer.length;
-    if (total > MAX_BODY_BYTES) {
-      return "too-large";
-    }
-    chunks.push(buffer);
-  }
+): Promise<{ initData: string; accountId?: string } | null> {
+  const raw = await readRequestBodyWithLimit(req, {
+    maxBytes: MAX_BODY_BYTES,
+    timeoutMs: WEBHOOK_BODY_READ_DEFAULTS.preAuth.timeoutMs,
+  });
   try {
-    const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+    const parsed = JSON.parse(raw) as {
       initData?: unknown;
       accountId?: unknown;
     };


### PR DESCRIPTION
## What Problem This Solves

The Telegram Mini App auth endpoint (`/__openclaw_tg_miniapp/auth`) had no bounded body-read lifecycle. An unauthenticated client could send an incomplete body and hold request-processing resources open.

The first version of this PR bounded the read, but real socket proof exposed a protocol bug: `readRequestBodyWithLimit` destroyed the request before the route could flush its intended HTTP 408. The client saw a silent close with zero response bytes.

## Why This Change Was Made

The route now uses the shared request-body guard, which owns the required response-before-destroy ordering for size and timeout failures. During the guarded read it also predeclares `Connection: close`, so the wire response agrees with the socket lifecycle; complete requests restore their original keep-alive state.

The regression test now uses a real `node:http` server plus a raw TCP client. It deliberately leaves a declared request body incomplete and asserts all three externally observable guarantees:

- `HTTP/1.1 408 Request Timeout`
- `Connection: close` with `Request body timeout`
- the client socket actually closes

## User Impact

Unauthenticated slow-body requests against the Mini App auth route are bounded by the shared 5-second pre-auth timeout. Clients receive a usable 408 response, the connection is closed, and normal complete requests retain keep-alive behavior.

## Evidence

### Focused regression test — exact head `70ed5884bb7d9b39af0e447e719732e73c8a916c`

```text
$ node scripts/run-vitest.mjs extensions/telegram/src/miniapp/routes.test.ts

Test Files  1 passed (1)
     Tests  7 passed (7)
[test] passed 1 Vitest shard in 13.97s
```

The timeout case is a real HTTP/TCP test, not a mocked `ServerResponse` or synthetic `Readable` assertion.

### Live Gateway A/B socket proof

Proof setup was isolated and credential-free: loopback-only Gateway, temporary state, Control UI disabled, gateway auth disabled only inside the isolated proof instance, and no Telegram token. The production Gateway plugin loader reported the proof plugin as loaded; that plugin only registers `registerTelegramMiniAppRoutes` built from the stated PR head. The request declared `Content-Length: 64`, sent only a partial JSON prefix, and deliberately kept its write side open.

Before the response-ordering fix (`b684f7ffff60ac26add071d7e3c5edf46a2cdff4`):

```text
connected=true request=partial-post writeSideOpen=true
elapsedMs=5043 end=true close=true error=none
rawResponseBegin
<no response bytes>
rawResponseEnd
```

After the fix (`70ed5884bb7d9b39af0e447e719732e73c8a916c`):

```http
connected=true request=partial-post writeSideOpen=true
elapsedMs=5041 end=true close=true error=none
rawResponseBegin
HTTP/1.1 408 Request Timeout
Content-Type: text/plain; charset=utf-8
Connection: close
Content-Length: 20

Request body timeout
rawResponseEnd
```

Immediate post-timeout liveness probe against the same Gateway process:

```text
postTimeoutProbeStatus=200 contentType=text/html; charset=utf-8 bytes=2373
listener=127.0.0.1
```

This proves the incomplete client no longer remains open, receives the bounded 408 response, and does not destabilize the Gateway.

### Static hygiene

```text
oxfmt --check: passed (2 files)
git diff --check: passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) and updated with live Gateway proof.
