### PR TITLE
fix(discord): cap decoded voice captures

### DIFF
--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -97,15 +97,17 @@ describe("discord voice opus codec", () => {
     const packets = await packetsPromise;
     const onError = vi.fn();
 
-    await decodeOpusStream(Readable.from(packets), {
+    const decoded = await decodeOpusStream(Readable.from(packets), {
       onError,
       onVerbose: vi.fn(),
       onWarn: vi.fn(),
     });
 
+    expect(decoded).toHaveLength(960 * 2 * 2);
+    expect(decoded.length).toBeLessThanOrEqual(4096);
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining("decoded audio exceeds"),
+        message: expect.stringContaining("decoded audio exceeds 4096 bytes"),
       }),
     );
   });

--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -10,6 +10,7 @@ vi.mock("node:child_process", async (importOriginal) => ({
 }));
 vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
+  MAX_AUDIO_BYTES: 4096,
   resolveFfmpegBin: () => "ffmpeg",
 }));
 
@@ -87,6 +88,26 @@ describe("discord voice opus codec", () => {
     const packets = await packetsPromise;
 
     expect(packets).toHaveLength(1);
+  });
+
+  it("stops decoding when buffered PCM exceeds the shared audio limit", async () => {
+    const encoder = createDiscordOpusEncodeStream();
+    const packetsPromise = collectBuffers(encoder);
+    encoder.end(Buffer.alloc(960 * 2 * 2 * 2));
+    const packets = await packetsPromise;
+    const onError = vi.fn();
+
+    await decodeOpusStream(Readable.from(packets), {
+      onError,
+      onVerbose: vi.fn(),
+      onWarn: vi.fn(),
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("decoded audio exceeds"),
+      }),
+    );
   });
 
   it("surfaces chunk decode stream failures to callers", async () => {

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -10,7 +10,7 @@ import {
   type OpusDecoderHandle as LibopusDecoder,
   type OpusEncoderHandle as LibopusEncoder,
 } from "libopus-wasm";
-import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
+import { MAX_AUDIO_BYTES, resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 import { resamplePcm } from "openclaw/plugin-sdk/realtime-voice";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -273,6 +273,7 @@ export async function decodeOpusStream(
   }
   params.onVerbose(`opus decoder: ${selected.name}`);
   const chunks: Buffer[] = [];
+  let decodedBytes = 0;
   try {
     for await (const chunk of stream) {
       if (!chunk || !(chunk instanceof Buffer) || chunk.length === 0) {
@@ -280,6 +281,13 @@ export async function decodeOpusStream(
       }
       const decoded = await selected.decoder.decode(chunk);
       if (decoded && decoded.length > 0) {
+        // Speaking-end is transport-driven; cap decoded media so a missing end event
+        // cannot grow a voice capture without bound.
+        const nextDecodedBytes = decodedBytes + decoded.length;
+        if (nextDecodedBytes > MAX_AUDIO_BYTES) {
+          throw new Error("Discord voice decoded audio exceeds " + MAX_AUDIO_BYTES + " bytes");
+        }
+        decodedBytes = nextDecodedBytes;
         chunks.push(Buffer.from(decoded));
       }
     }

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -6157,6 +6157,76 @@ describe("DiscordVoiceManager", () => {
     expect(stream.destroy).toHaveBeenCalledTimes(1);
   });
 
+  it("cleans up capped captures and accepts the same speaker's next capture", async () => {
+    const connection = createConnectionMock();
+    joinVoiceChannelMock.mockReturnValueOnce(connection);
+    decodeOpusStreamMock
+      .mockImplementationOnce(
+        async (
+          _stream: Readable,
+          params: {
+            onError: (err: unknown) => void;
+          },
+        ) => {
+          params.onError(new Error("Discord voice decoded audio exceeds 16777216 bytes"));
+          return Buffer.alloc(0);
+        },
+      )
+      .mockResolvedValueOnce(Buffer.alloc(192_000));
+    const manager = createManager({
+      groupPolicy: "open",
+      allowFrom: ["discord:u-speaker"],
+      voice: { enabled: true, mode: "stt-tts" },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager) as {
+      capture: {
+        activeSpeakers: Set<string>;
+        activeCaptureStreams: Map<string, unknown>;
+      };
+      processingQueue: Promise<void>;
+    };
+    const cappedStream = {
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+      destroyed: false,
+      async *[Symbol.asyncIterator]() {},
+    };
+    const recoveryStream = {
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+      destroyed: false,
+      async *[Symbol.asyncIterator]() {},
+    };
+    connection.receiver.subscribe
+      .mockReturnValueOnce(cappedStream)
+      .mockReturnValueOnce(recoveryStream);
+    const handleSpeakingStart = (
+      manager as unknown as {
+        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
+      }
+    ).handleSpeakingStart.bind(manager);
+
+    await handleSpeakingStart(entry, "u-speaker");
+
+    expect(cappedStream.destroy).toHaveBeenCalledTimes(1);
+    expect(entry.capture.activeSpeakers.has("u-speaker")).toBe(false);
+    expect(entry.capture.activeCaptureStreams.has("u-speaker")).toBe(false);
+    expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+
+    await handleSpeakingStart(entry, "u-speaker");
+    await entry.processingQueue;
+
+    expect(connection.receiver.subscribe).toHaveBeenCalledTimes(2);
+    expect(recoveryStream.destroy).toHaveBeenCalledTimes(1);
+    expect(entry.capture.activeSpeakers.has("u-speaker")).toBe(false);
+    expect(entry.capture.activeCaptureStreams.has("u-speaker")).toBe(false);
+    expect(transcribeAudioFileMock).toHaveBeenCalledTimes(1);
+  });
+
   it("processes partial non-realtime audio after abort-like stream endings", async () => {
     const connection = createConnectionMock();
     joinVoiceChannelMock.mockReturnValueOnce(connection);


### PR DESCRIPTION
## What Problem This Solves

Discord batch voice capture subscribes with `EndBehaviorType.Manual`, so a missing speaking-end event can leave the Opus receive stream open indefinitely. `decodeOpusStream` retained every decoded PCM chunk until the stream ended, allowing one capture to grow without a memory bound.

## Implementation

- Count decoded PCM bytes before retaining each decoded chunk.
- Stop decoding before retained PCM would exceed the existing shared `MAX_AUDIO_BYTES` policy; no new configuration or compatibility path is introduced.
- Preserve the existing decoder error path and `finally` cleanup. The voice manager then removes the active capture and destroys the Discord receive stream.
- Strengthen the production-codec regression test to prove the returned PCM remains within the cap.
- Add manager lifecycle coverage proving a capped capture is destroyed and removed, then the same speaker can complete a normal capture in the same voice session.

## Evidence

Exact head: `a0eead453b8932f925dda49c98c6c8122b677b18`.

- Production-codec boundary: `audio.test.ts` generates real Opus packets with `libopus-wasm`, crosses a test-only 4096-byte shared limit, asserts the retained PCM is exactly one 3840-byte frame, and verifies the bounded error reports the 4096-byte limit.
- Capture cleanup: `manager.e2e.test.ts` drives the production `handleSpeakingStart` lifecycle, verifies the capped stream is destroyed, and verifies both active-capture registries are empty.
- Same-session recovery: the lifecycle test starts a second capture for the same speaker on the same manager/session, verifies a second receiver subscription, successful transcription, stream destruction, and clean registries afterward.
- Dependency contract: `@discordjs/voice@0.19.2` defines Manual receive streams as destroy-only and removes the receiver subscription on stream close; `libopus-wasm@0.2.0` returns decoded PCM arrays and exposes idempotent decoder `free()` cleanup. The production manager and decoder `finally` blocks satisfy both contracts.
- Exact-head [CI run 29649523788](https://github.com/openclaw/openclaw/actions/runs/29649523788) passed all 7 large and 17 small Node test shards, build artifacts, lint, production and test types, dependency checks, plugin/channel contracts, architecture boundaries, and `openclaw/ci-gate`.
- The previously failing [Real behavior proof gate](https://github.com/openclaw/openclaw/actions/runs/29649541901) passes on the exact head after adding the required authored problem and evidence sections.
- Static hygiene before push: `git diff --cached --check` passed.

No Discord credentials, tokens, guild IDs, channel IDs, or user content are included in this evidence.
