### PR TITLE
fix(raft): time out incomplete wake bodies

### DIFF
--- a/extensions/raft/src/gateway.test.ts
+++ b/extensions/raft/src/gateway.test.ts
@@ -420,7 +420,9 @@ describe("Raft wake gateway", () => {
       ]);
       expect(closed).toBe(true);
       expect(run).not.toHaveBeenCalled();
-      expect(ctx.log?.warn).toHaveBeenCalledWith(expect.stringContaining("timed out"));
+      expect(ctx.log?.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Request body timeout"),
+      );
     } finally {
       socket.destroy();
       controller.abort();

--- a/extensions/raft/src/gateway.test.ts
+++ b/extensions/raft/src/gateway.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
+import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
@@ -372,6 +373,59 @@ describe("Raft wake gateway", () => {
 
     controller.abort();
     await start;
+  });
+
+  it("closes authenticated wake requests whose bodies never finish", async () => {
+    const { ctx, controller, run, wakeDedupe } = createContext();
+    Object.defineProperty(ctx, "abortSignal", { value: controller.signal });
+    const bridge = new FakeBridge();
+    let endpoint: string | undefined;
+    let token: string | undefined;
+    const start = startRaftGatewayAccount(ctx, {
+      spawnBridge: (params) => {
+        endpoint = params.endpoint;
+        token = params.token;
+        return bridge;
+      },
+      wakeBodyTimeoutMs: 50,
+      wakeDedupe,
+    });
+
+    const wakeEndpoint = new URL(await waitFor(() => endpoint));
+    const bridgeToken = await waitFor(() => token);
+    const socket = connect(Number(wakeEndpoint.port), wakeEndpoint.hostname);
+    try {
+      await new Promise<void>((resolve) => {
+        socket.once("connect", resolve);
+      });
+      socket.write(
+        [
+          `POST ${wakeEndpoint.pathname} HTTP/1.1`,
+          `Host: ${wakeEndpoint.host}`,
+          `x-raft-bridge-token: ${bridgeToken}`,
+          "Content-Type: application/json",
+          "Content-Length: 128",
+          "",
+          '{"eventId":"unfinished',
+        ].join("\r\n"),
+      );
+
+      const closed = await Promise.race([
+        new Promise<true>((resolve) => {
+          socket.once("close", () => resolve(true));
+        }),
+        new Promise<false>((resolve) => {
+          setTimeout(() => resolve(false), 500);
+        }),
+      ]);
+      expect(closed).toBe(true);
+      expect(run).not.toHaveBeenCalled();
+      expect(ctx.log?.warn).toHaveBeenCalledWith(expect.stringContaining("timed out"));
+    } finally {
+      socket.destroy();
+      controller.abort();
+      await start;
+    }
   });
 
   it("keeps a failed delivery eligible for a bridge retry", async () => {

--- a/extensions/raft/src/gateway.test.ts
+++ b/extensions/raft/src/gateway.test.ts
@@ -141,6 +141,54 @@ async function waitFor<T>(getValue: () => T | undefined): Promise<T> {
   throw new Error("Timed out waiting for value.");
 }
 
+async function sendPartialWakeRequest(params: {
+  endpoint: URL;
+  token: string;
+  contentLength: number;
+  bodyPrefix: string;
+}): Promise<string> {
+  const socket = connect(Number(params.endpoint.port), params.endpoint.hostname);
+  let response = "";
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", resolve);
+      socket.once("error", reject);
+    });
+    socket.setEncoding("utf8");
+    const closed = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("Timed out waiting for the Raft wake socket to close."));
+      }, 500);
+      socket.on("data", (chunk: string) => {
+        response += chunk;
+      });
+      socket.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      socket.once("close", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+    socket.write(
+      [
+        `POST ${params.endpoint.pathname} HTTP/1.1`,
+        `Host: ${params.endpoint.host}`,
+        `x-raft-bridge-token: ${params.token}`,
+        "Content-Type: application/json",
+        `Content-Length: ${params.contentLength}`,
+        "",
+        params.bodyPrefix,
+      ].join("\r\n"),
+    );
+    await closed;
+    return response;
+  } finally {
+    socket.destroy();
+  }
+}
+
 afterEach(() => {
   resetPluginStateStoreForTests();
   for (const dir of tempDirs) {
@@ -375,6 +423,38 @@ describe("Raft wake gateway", () => {
     await start;
   });
 
+  it("returns 413 and closes declared-oversized incomplete wake requests", async () => {
+    const { ctx, controller, run, wakeDedupe } = createContext();
+    Object.defineProperty(ctx, "abortSignal", { value: controller.signal });
+    const bridge = new FakeBridge();
+    let endpoint: string | undefined;
+    let token: string | undefined;
+    const start = startRaftGatewayAccount(ctx, {
+      spawnBridge: (params) => {
+        endpoint = params.endpoint;
+        token = params.token;
+        return bridge;
+      },
+      wakeDedupe,
+    });
+
+    try {
+      const response = await sendPartialWakeRequest({
+        endpoint: new URL(await waitFor(() => endpoint)),
+        token: await waitFor(() => token),
+        contentLength: 17 * 1024,
+        bodyPrefix: '{"eventId":"unfinished',
+      });
+      expect(response).toContain("HTTP/1.1 413 Payload Too Large");
+      expect(response.toLowerCase()).toContain("connection: close");
+      expect(response).toContain('"error":"Wake payload exceeds the 16 KiB limit."');
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      controller.abort();
+      await start;
+    }
+  });
+
   it("closes authenticated wake requests whose bodies never finish", async () => {
     const { ctx, controller, run, wakeDedupe } = createContext();
     Object.defineProperty(ctx, "abortSignal", { value: controller.signal });
@@ -393,36 +473,16 @@ describe("Raft wake gateway", () => {
 
     const wakeEndpoint = new URL(await waitFor(() => endpoint));
     const bridgeToken = await waitFor(() => token);
-    const socket = connect(Number(wakeEndpoint.port), wakeEndpoint.hostname);
     try {
-      await new Promise<void>((resolve) => {
-        socket.once("connect", resolve);
+      await sendPartialWakeRequest({
+        endpoint: wakeEndpoint,
+        token: bridgeToken,
+        contentLength: 128,
+        bodyPrefix: '{"eventId":"unfinished',
       });
-      socket.write(
-        [
-          `POST ${wakeEndpoint.pathname} HTTP/1.1`,
-          `Host: ${wakeEndpoint.host}`,
-          `x-raft-bridge-token: ${bridgeToken}`,
-          "Content-Type: application/json",
-          "Content-Length: 128",
-          "",
-          '{"eventId":"unfinished',
-        ].join("\r\n"),
-      );
-
-      const closed = await Promise.race([
-        new Promise<true>((resolve) => {
-          socket.once("close", () => resolve(true));
-        }),
-        new Promise<false>((resolve) => {
-          setTimeout(() => resolve(false), 500);
-        }),
-      ]);
-      expect(closed).toBe(true);
       expect(run).not.toHaveBeenCalled();
       expect(ctx.log?.warn).toHaveBeenCalledWith(expect.stringContaining("Request body timeout"));
     } finally {
-      socket.destroy();
       controller.abort();
       await start;
     }

--- a/extensions/raft/src/gateway.test.ts
+++ b/extensions/raft/src/gateway.test.ts
@@ -420,9 +420,7 @@ describe("Raft wake gateway", () => {
       ]);
       expect(closed).toBe(true);
       expect(run).not.toHaveBeenCalled();
-      expect(ctx.log?.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Request body timeout"),
-      );
+      expect(ctx.log?.warn).toHaveBeenCalledWith(expect.stringContaining("Request body timeout"));
     } finally {
       socket.destroy();
       controller.abort();

--- a/extensions/raft/src/gateway.ts
+++ b/extensions/raft/src/gateway.ts
@@ -9,7 +9,12 @@ import { keepHttpServerTaskAlive, waitUntilAbort } from "openclaw/plugin-sdk/cha
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
-import { WEBHOOK_BODY_READ_DEFAULTS } from "openclaw/plugin-sdk/webhook-ingress";
+import {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+  WEBHOOK_BODY_READ_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-ingress";
 import { RAFT_CHANNEL_ID, type ResolvedRaftAccount } from "./accounts.js";
 import { dispatchRaftWake } from "./inbound.js";
 
@@ -128,41 +133,35 @@ async function readWakePayload(
   request: IncomingMessage,
   timeoutMs: number,
 ): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  let bytes = 0;
-  let tooLarge = false;
-  let timedOut = false;
-  // A stalled bridge write must not pin this authenticated handler indefinitely.
-  // Destroying the partial request also closes the unusable connection.
-  const timer = setTimeout(() => {
-    timedOut = true;
-    request.destroy();
-  }, timeoutMs);
-  timer.unref();
+  // Reject declared oversized payloads before the shared reader destroys the
+  // underlying socket, so the caller can still write a proper HTTP response.
+  const contentLengthHeader = request.headers["content-length"];
+  if (typeof contentLengthHeader === "string") {
+    const contentLength = Number(contentLengthHeader);
+    if (Number.isFinite(contentLength) && contentLength > MAX_WAKE_BODY_BYTES) {
+      throw new WakeRequestError(413, "Wake payload exceeds the 16 KiB limit.");
+    }
+  }
+
+  // Route body reads through the shared Plugin SDK request-body reader so
+  // timeout, size enforcement, destruction, and typed error classification
+  // stay on the centrally hardened path used by sibling channel webhooks.
+  let raw: string;
   try {
-    for await (const chunk of request) {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      bytes += buffer.length;
-      if (bytes > MAX_WAKE_BODY_BYTES) {
-        tooLarge = true;
-        continue;
-      }
-      chunks.push(buffer);
-    }
+    raw = await readRequestBodyWithLimit(request, {
+      maxBytes: MAX_WAKE_BODY_BYTES,
+      timeoutMs,
+    });
   } catch (error) {
-    if (!timedOut) {
-      throw error;
+    if (isRequestBodyLimitError(error, "PAYLOAD_TOO_LARGE")) {
+      throw new WakeRequestError(413, requestBodyErrorToText(error.code));
     }
-  } finally {
-    clearTimeout(timer);
+    if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
+      throw new WakeRequestError(408, requestBodyErrorToText(error.code));
+    }
+    throw error;
   }
-  if (timedOut) {
-    throw new WakeRequestError(408, "Wake payload body timed out.");
-  }
-  if (tooLarge) {
-    throw new WakeRequestError(413, "Wake payload exceeds the 16 KiB limit.");
-  }
-  const text = Buffer.concat(chunks).toString("utf8").trim();
+  const text = raw.trim();
   if (!text) {
     return {};
   }

--- a/extensions/raft/src/gateway.ts
+++ b/extensions/raft/src/gateway.ts
@@ -82,6 +82,7 @@ class WakeRequestError extends Error {
   constructor(
     readonly statusCode: number,
     message: string,
+    readonly closeConnection = false,
   ) {
     super(message);
   }
@@ -139,7 +140,7 @@ async function readWakePayload(
   if (typeof contentLengthHeader === "string") {
     const contentLength = Number(contentLengthHeader);
     if (Number.isFinite(contentLength) && contentLength > MAX_WAKE_BODY_BYTES) {
-      throw new WakeRequestError(413, "Wake payload exceeds the 16 KiB limit.");
+      throw new WakeRequestError(413, "Wake payload exceeds the 16 KiB limit.", true);
     }
   }
 
@@ -212,12 +213,28 @@ function resolveWakeDedupeKey(payload: Record<string, unknown>): string | undefi
   return eventId ? hashWakeEventId(`id:${eventId}`) : undefined;
 }
 
-function sendJson(response: ServerResponse, statusCode: number, body: Record<string, unknown>) {
+function sendJson(
+  response: ServerResponse,
+  statusCode: number,
+  body: Record<string, unknown>,
+  closeConnection = false,
+) {
+  if (closeConnection) {
+    response.shouldKeepAlive = false;
+  }
   response.writeHead(statusCode, {
     "content-type": "application/json; charset=utf-8",
     "cache-control": "no-store",
+    ...(closeConnection ? { connection: "close" } : {}),
   });
-  response.end(JSON.stringify(body));
+  const payload = JSON.stringify(body);
+  if (closeConnection) {
+    // The rejected body remains unread, so close immediately after flushing the
+    // error response; otherwise the client can retain this authenticated socket.
+    response.end(payload, () => response.destroy());
+    return;
+  }
+  response.end(payload);
 }
 
 function closeServer(server: Server, sockets: Set<Socket>) {
@@ -362,9 +379,10 @@ export async function startRaftGatewayAccount(
     })().catch((error: unknown) => {
       const statusCode = error instanceof WakeRequestError ? error.statusCode : 500;
       const message = error instanceof WakeRequestError ? error.message : "Internal server error.";
+      const closeConnection = error instanceof WakeRequestError && error.closeConnection;
       ctx.log?.warn?.(`Raft wake request rejected: ${message}`);
       if (!response.headersSent) {
-        sendJson(response, statusCode, { error: message });
+        sendJson(response, statusCode, { error: message }, closeConnection);
       } else {
         response.destroy();
       }

--- a/extensions/raft/src/gateway.ts
+++ b/extensions/raft/src/gateway.ts
@@ -9,6 +9,7 @@ import { keepHttpServerTaskAlive, waitUntilAbort } from "openclaw/plugin-sdk/cha
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import { WEBHOOK_BODY_READ_DEFAULTS } from "openclaw/plugin-sdk/webhook-ingress";
 import { RAFT_CHANNEL_ID, type ResolvedRaftAccount } from "./accounts.js";
 import { dispatchRaftWake } from "./inbound.js";
 
@@ -68,6 +69,7 @@ type RaftWakeReplayGuard = ReturnType<typeof createRaftWakeReplayGuard>;
 type RaftGatewayDeps = {
   createToken?: () => string;
   spawnBridge?: (params: { profile: string; endpoint: string; token: string }) => RaftBridgeProcess;
+  wakeBodyTimeoutMs?: number;
   wakeDedupe?: RaftWakeReplayGuard;
 };
 
@@ -122,18 +124,40 @@ function hasMatchingToken(request: IncomingMessage, expected: string): boolean {
   return safeEqualSecret(value, expected);
 }
 
-async function readWakePayload(request: IncomingMessage): Promise<Record<string, unknown>> {
+async function readWakePayload(
+  request: IncomingMessage,
+  timeoutMs: number,
+): Promise<Record<string, unknown>> {
   const chunks: Buffer[] = [];
   let bytes = 0;
   let tooLarge = false;
-  for await (const chunk of request) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    bytes += buffer.length;
-    if (bytes > MAX_WAKE_BODY_BYTES) {
-      tooLarge = true;
-      continue;
+  let timedOut = false;
+  // A stalled bridge write must not pin this authenticated handler indefinitely.
+  // Destroying the partial request also closes the unusable connection.
+  const timer = setTimeout(() => {
+    timedOut = true;
+    request.destroy();
+  }, timeoutMs);
+  timer.unref();
+  try {
+    for await (const chunk of request) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bytes += buffer.length;
+      if (bytes > MAX_WAKE_BODY_BYTES) {
+        tooLarge = true;
+        continue;
+      }
+      chunks.push(buffer);
     }
-    chunks.push(buffer);
+  } catch (error) {
+    if (!timedOut) {
+      throw error;
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+  if (timedOut) {
+    throw new WakeRequestError(408, "Wake payload body timed out.");
   }
   if (tooLarge) {
     throw new WakeRequestError(413, "Wake payload exceeds the 16 KiB limit.");
@@ -290,7 +314,10 @@ export async function startRaftGatewayAccount(
         return;
       }
 
-      const payload = await readWakePayload(request);
+      const payload = await readWakePayload(
+        request,
+        deps.wakeBodyTimeoutMs ?? WEBHOOK_BODY_READ_DEFAULTS.postAuth.timeoutMs,
+      );
       if (containsMessageContent(payload)) {
         throw new WakeRequestError(400, "Wake payload must not include message content.");
       }


### PR DESCRIPTION
## What Problem This Solves

The token-authenticated Raft `/wake` endpoint capped bodies at 16 KiB, but an authenticated client could declare a body, send only a prefix, and keep the request handler and socket resident indefinitely.

The first revision routed body consumption through the shared Plugin SDK `readRequestBodyWithLimit` timeout path. Review then identified a second lifecycle gap: the early `Content-Length` rejection preserved a useful HTTP 413 response, but bypassed the shared reader's socket destruction and left an incomplete oversized connection reusable.

This revision keeps the shared reader and makes the early 413 path deterministic: it sends `Connection: close`, disables keep-alive, flushes the JSON error, then destroys the response socket. Neither incomplete-body variant reaches wake dispatch.

## Implementation

- Use `WEBHOOK_BODY_READ_DEFAULTS.postAuth.timeoutMs` and the shared `readRequestBodyWithLimit` implementation for authenticated body reads.
- Map shared `PAYLOAD_TOO_LARGE` and `REQUEST_BODY_TIMEOUT` errors to Raft HTTP errors.
- Preserve an explicit 413 for a declared oversized body, while marking that error as connection-closing.
- Flush the 413 JSON response with `Connection: close`, then destroy the socket because the rejected request body remains unread.
- Add a reusable raw-TCP regression helper and cover both incomplete request variants.

## Evidence

Exact tested head: `4cb8dd5b64`.

Focused repository test:

```text
$ node scripts/run-vitest.mjs extensions/raft/src/gateway.test.ts

Test Files  1 passed (1)
     Tests  8 passed (8)
  Duration  7.14s
[test] passed 1 Vitest shard in 14.35s
```

The new raw-TCP regression sends an authenticated request with `Content-Length: 17408`, writes only a JSON prefix, and leaves the client write side open. It observes `HTTP/1.1 413 Payload Too Large`, `Connection: close`, the bounded-body error JSON, a closed socket within 500 ms, and zero wake dispatches. The existing timeout regression performs the normal-sized incomplete variant and also observes closure with zero dispatches.

Non-Vitest source-run proof against the same head directly imported `extensions/raft/src/gateway.ts`, started the real `startRaftGatewayAccount` HTTP server, and drove both requests over raw TCP. The bridge child lifecycle was stubbed only to expose the loopback endpoint; request parsing, authentication, timeout, response, and socket teardown all ran through production source. Tokens were redacted by omission.

```json
{
  "normalIncomplete": {
    "closed": true,
    "elapsedMs": 162,
    "responseBytes": 0,
    "timeoutLogged": true
  },
  "declaredOversizedIncomplete": {
    "closed": true,
    "elapsedMs": 3,
    "status": "HTTP/1.1 413 Payload Too Large",
    "connectionClose": true,
    "limitMessage": true
  },
  "dispatchRuntimeAccesses": 0
}
```

Additional local gates:

```text
$ oxfmt --check extensions/raft/src/gateway.ts extensions/raft/src/gateway.test.ts
All matched files use the correct format.

$ oxlint extensions/raft/src/gateway.ts extensions/raft/src/gateway.test.ts
(exit 0)

$ git diff --check
(exit 0)
```

The external Raft CLI binary itself was not installed for this proof; the changed OpenClaw ingress server and both socket lifecycle paths were exercised directly from source.

Generated with Claude Code and repaired with Codex.
