### PR TITLE
fix(nostr): send receipts report the relay event id

### DIFF
--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -49,7 +49,7 @@ function installOutboundRuntime(convertMarkdownTables = vi.fn((text: string) => 
 }
 
 async function startOutboundAccount(accountId?: string) {
-  const sendDm = vi.fn(async () => {});
+  const sendDm = vi.fn(async () => "a".repeat(64));
   const bus = {
     sendDm,
     close: vi.fn(),
@@ -136,6 +136,24 @@ describe("nostr outbound cfg threading", () => {
       accountId: "work",
     });
     expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "hello");
+
+    await cleanup.stop();
+  });
+
+  it("returns the relay-confirmed event id in the delivery receipt", async () => {
+    installOutboundRuntime();
+    const { cleanup, sendDm } = await startOutboundAccount();
+    const eventId = "b".repeat(64);
+    sendDm.mockResolvedValueOnce(eventId);
+
+    const result = await nostrOutboundAdapter.sendText({
+      cfg: createCfg() as OpenClawConfig,
+      to: "NPUB123",
+      text: "hello",
+      accountId: "default",
+    });
+
+    expect(result.messageId).toBe(eventId);
 
     await cleanup.stop();
   });

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -323,10 +323,10 @@ export const nostrOutboundAdapter: NostrOutboundAdapter = {
     });
     const message = core.channel.text.convertMarkdownTables(text ?? "", tableMode);
     const normalizedTo = normalizePubkey(to);
-    await bus.sendDm(normalizedTo, message);
+    const eventId = await bus.sendDm(normalizedTo, message);
     return attachChannelToResult("nostr", {
       to: normalizedTo,
-      messageId: `nostr-${Date.now()}`,
+      messageId: eventId,
     });
   },
 };

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -144,7 +144,7 @@ export interface NostrBusHandle {
   /** Get the bot's public key */
   publicKey: string;
   /** Send a DM to a pubkey */
-  sendDm: (toPubkey: string, text: string) => Promise<void>;
+  sendDm: (toPubkey: string, text: string) => Promise<string>;
   /** Get current metrics snapshot */
   getMetrics: () => MetricsSnapshot;
   /** Publish a profile (kind:0) to all relays */
@@ -643,8 +643,8 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
   });
 
   // Public sendDm function
-  const sendDm = async (toPubkey: string, text: string): Promise<void> => {
-    await sendEncryptedDm(
+  const sendDm = async (toPubkey: string, text: string): Promise<string> => {
+    return await sendEncryptedDm(
       pool,
       sk,
       toPubkey,
@@ -744,7 +744,7 @@ async function sendEncryptedDm(
   healthTracker: RelayHealthTracker,
   onError?: (error: Error, context: string) => void,
   replyToEventId?: string,
-): Promise<void> {
+): Promise<string> {
   const ciphertext = encrypt(sk, toPubkey, text);
   // NIP-04 uses an e tag to keep a reply attached to its verified inbound event.
   const tags = [["p", toPubkey]];
@@ -788,7 +788,7 @@ async function sendEncryptedDm(
       cb?.recordSuccess();
       healthTracker.recordSuccess(relay, latency);
 
-      return; // Success - exit early
+      return reply.id;
     } catch (err) {
       lastError = err as Error;
       const latency = Date.now() - startTime;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Nostr users sending a DM through OpenClaw received a synthetic timestamp-based message ID instead of the Nostr event ID accepted by the relay. That made delivery receipts impossible to correlate with the event stored on the Nostr network.

## Why This Change Was Made

The Nostr bus now returns the finalized event ID after a relay acknowledges the publish, and the outbound adapter uses that ID in the delivery receipt. The change is limited to the existing Nostr DM send path and its regression test; relay selection, retry behavior, and protocol payloads are unchanged.

## User Impact

Successful Nostr DM sends now report the real 64-character event ID, so users and downstream tooling can match an OpenClaw receipt to the event observed on a relay.

## Evidence

- Regression test first failed on `origin/main`: the adapter returned `nostr-<timestamp>` instead of the relay event ID (1 failed, 3 passed).
- Public relay before/after proof using the real `openclaw gateway call send` path, temporary random Nostr keys, and `wss://nos.lol`:
  - Before: OpenClaw returned `nostr-1784291329214`, while a receiving client subscribed to the public relay and decrypted event `eec9c242dc3d9f62034a1e8789f06ce5cc076d3b0a2f8512a0beeb6f5812fbd9`.
  - After: OpenClaw returned `b9238d764986b3b03f29faf4f1382896853ae9bfdf6b69231431ecf7850c8ada`, exactly matching the event received and decrypted from the public relay.
  - No real user account or message data was used.
- `pnpm test:extension nostr extensions/nostr/src/channel.outbound.test.ts`: 4 passed.
- `pnpm test:extension nostr` on supported Node 24.15.0: 14 files, 212 tests passed.
- Local changed-lane check on supported Node 24.15.0: formatting, API baseline, plugin boundaries, extension typechecks/lint, and runtime guards passed.
- `codex review --base origin/main`: no findings; focused related tests run by the reviewer passed 26/26.
- Source-checkout incremental build succeeded (`OpenClaw 2026.7.2`). An earlier full-build attempt was terminated by local resource pressure; it was not treated as product validation. The rebased commit has the same stable patch ID as the live-proven commit.
