### PR TITLE
fix(nostr): relay connection failures no longer report successful publishes

### DIFF
--- a/extensions/nostr/src/nostr-bus.outbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.outbound.test.ts
@@ -7,22 +7,14 @@ const GOOD_RELAY = "wss://good-relay.example";
 const RECIPIENT_PUBKEY = "b".repeat(64);
 
 const mocks = vi.hoisted(() => ({
-  ensureRelay: vi.fn(),
   poolPublish: vi.fn(),
-  relayPublish: vi.fn(),
   close: vi.fn(),
 }));
 
 vi.mock("nostr-tools", () => {
   class MockSimplePool {
-    maxWaitForConnection = 3000;
-
     subscribeMany() {
       return { close: vi.fn() };
-    }
-
-    ensureRelay(relay: string, options?: { connectionTimeout?: number }) {
-      return mocks.ensureRelay(relay, options);
     }
 
     publish(relays: string[]) {
@@ -65,12 +57,6 @@ vi.mock("./nostr-profile.js", () => ({
 
 describe("Nostr outbound relay failover", () => {
   beforeEach(() => {
-    mocks.ensureRelay.mockReset().mockImplementation(async (relay: string) => {
-      if (relay === BAD_RELAY) {
-        throw new Error("connection failed");
-      }
-      return { publish: mocks.relayPublish };
-    });
     mocks.poolPublish
       .mockReset()
       .mockImplementation((relays: string[]) => [
@@ -78,7 +64,6 @@ describe("Nostr outbound relay failover", () => {
           relays[0] === BAD_RELAY ? "connection failure: connection failed" : "saved",
         ),
       ]);
-    mocks.relayPublish.mockReset().mockResolvedValue("saved");
     mocks.close.mockReset();
   });
 
@@ -92,19 +77,14 @@ describe("Nostr outbound relay failover", () => {
 
     await bus.sendDm(RECIPIENT_PUBKEY, "hello");
 
-    expect(mocks.ensureRelay).toHaveBeenNthCalledWith(1, BAD_RELAY, {
-      connectionTimeout: 3000,
-    });
-    expect(mocks.ensureRelay).toHaveBeenNthCalledWith(2, GOOD_RELAY, {
-      connectionTimeout: 3000,
-    });
-    expect(mocks.relayPublish).toHaveBeenCalledTimes(1);
-
+    expect(mocks.poolPublish.mock.calls.map(([relays]) => relays)).toEqual([
+      [BAD_RELAY],
+      [GOOD_RELAY],
+    ]);
     bus.close();
   });
 
   it("preserves string connection failures when every relay fails", async () => {
-    mocks.ensureRelay.mockRejectedValue("connection failed");
     const onError = vi.fn();
     const bus = await startNostrBus({
       privateKey: "1".repeat(64),

--- a/extensions/nostr/src/nostr-bus.outbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.outbound.test.ts
@@ -1,0 +1,124 @@
+// Nostr tests cover outbound relay failover behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { startNostrBus } from "./nostr-bus.js";
+
+const BAD_RELAY = "wss://bad-relay.example";
+const GOOD_RELAY = "wss://good-relay.example";
+const RECIPIENT_PUBKEY = "b".repeat(64);
+
+const mocks = vi.hoisted(() => ({
+  ensureRelay: vi.fn(),
+  poolPublish: vi.fn(),
+  relayPublish: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock("nostr-tools", () => {
+  class MockSimplePool {
+    maxWaitForConnection = 3000;
+
+    subscribeMany() {
+      return { close: vi.fn() };
+    }
+
+    ensureRelay(relay: string, options?: { connectionTimeout?: number }) {
+      return mocks.ensureRelay(relay, options);
+    }
+
+    publish(relays: string[]) {
+      return mocks.poolPublish(relays);
+    }
+
+    close(relays: string[]) {
+      mocks.close(relays);
+    }
+  }
+
+  return {
+    SimplePool: MockSimplePool,
+    finalizeEvent: vi.fn((event: unknown) => event),
+    getPublicKey: vi.fn(() => "a".repeat(64)),
+    verifyEvent: vi.fn(() => true),
+    nip19: {
+      decode: vi.fn(),
+      npubEncode: vi.fn(),
+    },
+  };
+});
+
+vi.mock("nostr-tools/nip04", () => ({
+  decrypt: vi.fn(),
+  encrypt: vi.fn(() => "ciphertext"),
+}));
+
+vi.mock("./nostr-state-store.js", () => ({
+  readNostrBusState: vi.fn(async () => null),
+  writeNostrBusState: vi.fn(async () => {}),
+  computeSinceTimestamp: vi.fn(() => 0),
+  readNostrProfileState: vi.fn(async () => null),
+  writeNostrProfileState: vi.fn(async () => {}),
+}));
+
+vi.mock("./nostr-profile.js", () => ({
+  publishProfile: vi.fn(),
+}));
+
+describe("Nostr outbound relay failover", () => {
+  beforeEach(() => {
+    mocks.ensureRelay.mockReset().mockImplementation(async (relay: string) => {
+      if (relay === BAD_RELAY) {
+        throw new Error("connection failed");
+      }
+      return { publish: mocks.relayPublish };
+    });
+    mocks.poolPublish
+      .mockReset()
+      .mockImplementation((relays: string[]) => [
+        Promise.resolve(
+          relays[0] === BAD_RELAY ? "connection failure: connection failed" : "saved",
+        ),
+      ]);
+    mocks.relayPublish.mockReset().mockResolvedValue("saved");
+    mocks.close.mockReset();
+  });
+
+  it("tries the next relay when the first relay cannot connect", async () => {
+    const bus = await startNostrBus({
+      privateKey: "1".repeat(64),
+      relays: [BAD_RELAY, GOOD_RELAY],
+      onMessage: vi.fn(async () => {}),
+      onMetric: () => {},
+    });
+
+    await bus.sendDm(RECIPIENT_PUBKEY, "hello");
+
+    expect(mocks.ensureRelay).toHaveBeenNthCalledWith(1, BAD_RELAY, {
+      connectionTimeout: 3000,
+    });
+    expect(mocks.ensureRelay).toHaveBeenNthCalledWith(2, GOOD_RELAY, {
+      connectionTimeout: 3000,
+    });
+    expect(mocks.relayPublish).toHaveBeenCalledTimes(1);
+
+    bus.close();
+  });
+
+  it("preserves string connection failures when every relay fails", async () => {
+    mocks.ensureRelay.mockRejectedValue("connection failed");
+    const onError = vi.fn();
+    const bus = await startNostrBus({
+      privateKey: "1".repeat(64),
+      relays: [BAD_RELAY],
+      onMessage: vi.fn(async () => {}),
+      onError,
+      onMetric: () => {},
+    });
+
+    await expect(bus.sendDm(RECIPIENT_PUBKEY, "hello")).rejects.toThrow(
+      "Failed to publish to any relay: connection failed",
+    );
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), `publish to ${BAD_RELAY}`);
+
+    bus.close();
+  });
+});

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -23,6 +23,7 @@ import {
   readNostrProfileState,
   writeNostrProfileState,
 } from "./nostr-state-store.js";
+import { publishNostrEventToRelay } from "./relay-publish.js";
 import { createSeenTracker, type SeenTracker } from "./seen-tracker.js";
 
 // ============================================================================
@@ -769,12 +770,7 @@ async function sendEncryptedDm(
 
     const startTime = Date.now();
     try {
-      const publishPromises = pool.publish([relay], reply);
-      if (publishPromises.length === 0) {
-        throw new Error(`Failed to create publish promise for relay ${relay}`);
-      }
-      const publishPromise = publishPromises[0];
-      await publishPromise;
+      await publishNostrEventToRelay(pool, relay, reply);
       const latency = Date.now() - startTime;
 
       // Record success
@@ -783,7 +779,7 @@ async function sendEncryptedDm(
 
       return; // Success - exit early
     } catch (err) {
-      lastError = err as Error;
+      lastError = err instanceof Error ? err : new Error(String(err));
       const latency = Date.now() - startTime;
 
       // Record failure

--- a/extensions/nostr/src/nostr-profile.test.ts
+++ b/extensions/nostr/src/nostr-profile.test.ts
@@ -11,10 +11,12 @@ const TEST_PUBKEY = getPublicKey(TEST_HEX_PRIVATE_KEY_BYTES);
 async function publishTestProfile(profile: NostrProfile, lastPublishedAt?: number): Promise<Event> {
   let publishedEvent: Event | undefined;
   const pool = {
-    publish: vi.fn((_relays: string[], event: Event) => {
-      publishedEvent = event;
-      return [Promise.resolve()];
-    }),
+    ensureRelay: vi.fn(async () => ({
+      publish: vi.fn(async (event: Event) => {
+        publishedEvent = event;
+        return "saved";
+      }),
+    })),
   } as unknown as SimplePool;
 
   await publishProfile(
@@ -292,7 +294,9 @@ describe("publishProfile", () => {
 
   function createFakePool(publishResult: unknown): SimplePool {
     return {
-      publish: vi.fn(() => [publishResult]),
+      ensureRelay: vi.fn(async () => ({
+        publish: vi.fn(() => publishResult),
+      })),
     } as unknown as SimplePool;
   }
 
@@ -310,6 +314,26 @@ describe("publishProfile", () => {
 
     expect(result.successes).toEqual(["wss://relay.example"]);
     expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports relay connection failures instead of successful publishes", async () => {
+    const profile: NostrProfile = { name: "test" };
+    const pool = {
+      ensureRelay: vi.fn(async () => {
+        throw new Error("connection failed");
+      }),
+      publish: vi.fn(() => [Promise.resolve("connection failure: connection failed")]),
+    } as unknown as SimplePool;
+
+    const result = await publishProfile(
+      pool,
+      TEST_HEX_PRIVATE_KEY_BYTES,
+      ["wss://relay.example"],
+      profile,
+    );
+
+    expect(result.successes).toEqual([]);
+    expect(result.failures).toEqual([{ relay: "wss://relay.example", error: "connection failed" }]);
   });
 
   it("clears the per-relay timeout timer after a publish timeout", async () => {

--- a/extensions/nostr/src/nostr-profile.test.ts
+++ b/extensions/nostr/src/nostr-profile.test.ts
@@ -11,12 +11,10 @@ const TEST_PUBKEY = getPublicKey(TEST_HEX_PRIVATE_KEY_BYTES);
 async function publishTestProfile(profile: NostrProfile, lastPublishedAt?: number): Promise<Event> {
   let publishedEvent: Event | undefined;
   const pool = {
-    ensureRelay: vi.fn(async () => ({
-      publish: vi.fn(async (event: Event) => {
-        publishedEvent = event;
-        return "saved";
-      }),
-    })),
+    publish: vi.fn((_relays: string[], event: Event) => {
+      publishedEvent = event;
+      return [Promise.resolve("saved")];
+    }),
   } as unknown as SimplePool;
 
   await publishProfile(
@@ -294,16 +292,14 @@ describe("publishProfile", () => {
 
   function createFakePool(publishResult: unknown): SimplePool {
     return {
-      ensureRelay: vi.fn(async () => ({
-        publish: vi.fn(() => publishResult),
-      })),
+      publish: vi.fn(() => [publishResult]),
     } as unknown as SimplePool;
   }
 
   it("clears the per-relay timeout timer after a successful publish", async () => {
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
     const profile: NostrProfile = { name: "test" };
-    const pool = createFakePool(Promise.resolve());
+    const pool = createFakePool(Promise.resolve("saved"));
 
     const result = await publishProfile(
       pool,
@@ -319,9 +315,6 @@ describe("publishProfile", () => {
   it("reports relay connection failures instead of successful publishes", async () => {
     const profile: NostrProfile = { name: "test" };
     const pool = {
-      ensureRelay: vi.fn(async () => {
-        throw new Error("connection failed");
-      }),
       publish: vi.fn(() => [Promise.resolve("connection failure: connection failed")]),
     } as unknown as SimplePool;
 
@@ -359,7 +352,7 @@ describe("publishProfile", () => {
     vi.spyOn(globalThis, "setTimeout").mockClear();
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
     const profile: NostrProfile = { name: "test" };
-    const pool = createFakePool(Promise.resolve());
+    const pool = createFakePool(Promise.resolve("saved"));
 
     await publishProfile(
       pool,

--- a/extensions/nostr/src/nostr-profile.ts
+++ b/extensions/nostr/src/nostr-profile.ts
@@ -9,6 +9,7 @@ import { finalizeEvent, SimplePool, type Event } from "nostr-tools";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { NostrProfile } from "./config-schema.js";
 import { profileToContent } from "./nostr-profile-core.js";
+import { publishNostrEventToRelay } from "./relay-publish.js";
 
 // ============================================================================
 // Types
@@ -97,7 +98,7 @@ async function publishProfileEvent(
         timer = setTimeout(() => reject(new Error("timeout")), RELAY_PUBLISH_TIMEOUT_MS);
       });
 
-      await Promise.race([...pool.publish([relay], event), timeoutPromise]);
+      await Promise.race([publishNostrEventToRelay(pool, relay, event), timeoutPromise]);
 
       successes.push(relay);
     } catch (err) {

--- a/extensions/nostr/src/relay-publish.ts
+++ b/extensions/nostr/src/relay-publish.ts
@@ -1,6 +1,8 @@
 // Nostr relay publishing keeps connection and publish failures rejectable.
 import type { Event, SimplePool } from "nostr-tools";
 
+const CONNECTION_FAILURE_PREFIX = "connection failure: ";
+
 export async function publishNostrEventToRelay(
   pool: SimplePool,
   relay: string,
@@ -8,8 +10,13 @@ export async function publishNostrEventToRelay(
 ): Promise<string> {
   // SimplePool.publish resolves connection failures as strings, which makes failed
   // relays look successful to callers and prevents sequential failover.
-  const connection = await pool.ensureRelay(relay, {
-    connectionTimeout: pool.maxWaitForConnection,
-  });
-  return await connection.publish(event);
+  const publishPromise = pool.publish([relay], event)[0];
+  if (!publishPromise) {
+    throw new Error(`Failed to create publish promise for relay ${relay}`);
+  }
+  const result = await publishPromise;
+  if (result.startsWith(CONNECTION_FAILURE_PREFIX)) {
+    throw new Error(result.slice(CONNECTION_FAILURE_PREFIX.length));
+  }
+  return result;
 }

--- a/extensions/nostr/src/relay-publish.ts
+++ b/extensions/nostr/src/relay-publish.ts
@@ -1,0 +1,15 @@
+// Nostr relay publishing keeps connection and publish failures rejectable.
+import type { Event, SimplePool } from "nostr-tools";
+
+export async function publishNostrEventToRelay(
+  pool: SimplePool,
+  relay: string,
+  event: Event,
+): Promise<string> {
+  // SimplePool.publish resolves connection failures as strings, which makes failed
+  // relays look successful to callers and prevents sequential failover.
+  const connection = await pool.ensureRelay(relay, {
+    connectionTimeout: pool.maxWaitForConnection,
+  });
+  return await connection.publish(event);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending Nostr DMs through multiple configured relays could receive a successful send result when the first relay could not connect, even though the message never reached a healthy relay. The same connection failure could also be counted as a successful profile publish.

## Why This Change Was Made

Keep publishing through `SimplePool.publish()` so its connection timeout, write admission, connection callbacks, relay tracking, and authentication retry behavior remain intact. The shared helper only converts nostr-tools' fulfilled `connection failure: ...` marker back into an error, allowing the existing DM failover and profile failure accounting to work as intended. Non-Error relay rejections are normalized before reporting them.

## User Impact

Nostr DMs now continue to the next configured relay after a connection failure, while profile publishing reports unreachable relays as failures instead of successes. If every relay fails, callers receive the actual connection error rather than an undefined message.

## Evidence

- Test-first regressions reproduced the false-success behavior, missing connection timeout, and lost string error before the fix.
- `pnpm test:extension nostr`: 15 files, 214 tests passed.
- Focused outbound/profile tests: 2 files, 24 tests passed.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test`: passed.
- Touched-file oxlint, oxfmt check, and `git diff --check`: passed.
- Live third-party proof used fresh temporary Nostr keys and `openclaw gateway call send` with an unreachable first relay and public `wss://relay.nostr.net` as the healthy relay. A control event was written and queried back before each run. No persistent credentials or message contents are included.

Redacted before-fix output from current main:

```json
{
  "relays": ["wss://relay.invalid", "wss://relay.nostr.net"],
  "relayControlDelivered": true,
  "cliExitCode": 0,
  "cliReportedSuccess": true,
  "deliveredOnHealthyRelay": false,
  "decryptedPayloadMatched": false
}
```

Redacted after-fix terminal output:

```text
$ openclaw gateway call send ... <temporary token, recipient, payload, and idempotency key redacted>
{
  "messageId": "<redacted>",
  "channel": "nostr"
}

2026-07-17T21:52:55.592+08:00 [nostr] [default] Nostr error (publish to wss://relay.invalid): connection failed
```

The same live verifier then queried and decrypted the event from the healthy public relay:

```json
{
  "relayControlDelivered": true,
  "firstRelayFailureObserved": true,
  "cliExitCode": 0,
  "cliReportedSuccess": true,
  "deliveredOnHealthyRelay": true,
  "decryptedPayloadMatched": true
}
```
