### PR TITLE
fix(ui): bound Nostr profile write/read requests

### DIFF
--- a/ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts
@@ -1,0 +1,125 @@
+import type { Server } from "node:http";
+import { createServer } from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { putNostrProfile, importNostrProfile } from "./nostr-profile-ops.js";
+
+function installRelativeFetchBridge(serverUrl: string): void {
+  const base = serverUrl.replace(/\/$/, "");
+  const realFetch = globalThis.fetch.bind(globalThis);
+  (globalThis as any).fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const absolute = url.startsWith("http") ? url : `${base}${url}`;
+    return realFetch(absolute, init);
+  };
+}
+
+const HEADERS = { authorization: "Bearer test-token" };
+
+describe("Nostr profile operations with real timeouts", () => {
+  let server: Server;
+  let serverUrl: string;
+  let stall: boolean;
+
+  beforeEach(async () => {
+    stall = false;
+    server = createServer((_req, res) => {
+      if (stall) {
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, persisted: true }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    serverUrl = `http://127.0.0.1:${port}`;
+    installRelativeFetchBridge(serverUrl);
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it("aborts a stalled putNostrProfile after the real 15s bound instead of hanging", async () => {
+    stall = true;
+    const startTime = Date.now();
+
+    try {
+      await putNostrProfile({
+        accountId: "acct-1",
+        headers: HEADERS,
+        values: { name: "alice" },
+      });
+      throw new Error("Expected abort error but request completed");
+    } catch (error) {
+      const elapsed = Date.now() - startTime;
+      console.log(`[REAL TIMEOUT] putNostrProfile aborted after ${elapsed}ms`);
+      console.log(
+        `[REAL TIMEOUT] Error type: ${error instanceof Error ? error.name : typeof error}`,
+      );
+      console.log(
+        `[REAL TIMEOUT] Error message: ${error instanceof Error ? error.message : String(error)}`,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).name).toBe("AbortError");
+      expect(elapsed).toBeGreaterThanOrEqual(14_000);
+      expect(elapsed).toBeLessThanOrEqual(16_000);
+    }
+  }, 20_000);
+
+  it("aborts a stalled importNostrProfile after the real 15s bound instead of hanging", async () => {
+    stall = true;
+    const startTime = Date.now();
+
+    try {
+      await importNostrProfile({ accountId: "acct-1", headers: HEADERS });
+      throw new Error("Expected abort error but request completed");
+    } catch (error) {
+      const elapsed = Date.now() - startTime;
+      console.log(`[REAL TIMEOUT] importNostrProfile aborted after ${elapsed}ms`);
+      console.log(
+        `[REAL TIMEOUT] Error type: ${error instanceof Error ? error.name : typeof error}`,
+      );
+      console.log(
+        `[REAL TIMEOUT] Error message: ${error instanceof Error ? error.message : String(error)}`,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).name).toBe("AbortError");
+      expect(elapsed).toBeGreaterThanOrEqual(14_000);
+      expect(elapsed).toBeLessThanOrEqual(16_000);
+    }
+  }, 20_000);
+
+  it("resolves a normal putNostrProfile round trip quickly", async () => {
+    const startTime = Date.now();
+    const { data, response } = await putNostrProfile({
+      accountId: "acct-1",
+      headers: HEADERS,
+      values: { name: "alice" },
+    });
+    const elapsed = Date.now() - startTime;
+
+    console.log(`[NORMAL] putNostrProfile completed in ${elapsed}ms`);
+    expect(response.ok).toBe(true);
+    expect(data?.persisted).toBe(true);
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  it("resolves a normal importNostrProfile round trip quickly", async () => {
+    const startTime = Date.now();
+    const { data, response } = await importNostrProfile({
+      accountId: "acct-1",
+      headers: HEADERS,
+    });
+    const elapsed = Date.now() - startTime;
+
+    console.log(`[NORMAL] importNostrProfile completed in ${elapsed}ms`);
+    expect(response.ok).toBe(true);
+    expect(data?.persisted).toBe(true);
+    expect(elapsed).toBeLessThan(1_000);
+  });
+});

--- a/ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts
@@ -3,13 +3,17 @@ import { createServer } from "node:http";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { putNostrProfile, importNostrProfile } from "./nostr-profile-ops.js";
 
-function installRelativeFetchBridge(serverUrl: string): void {
+function installRelativeFetchBridge(serverUrl: string): () => void {
   const base = serverUrl.replace(/\/$/, "");
-  const realFetch = globalThis.fetch.bind(globalThis);
-  (globalThis as any).fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+  const originalFetch = globalThis.fetch;
+  const realFetch = originalFetch.bind(globalThis);
+  globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     const absolute = url.startsWith("http") ? url : `${base}${url}`;
     return realFetch(absolute, init);
+  };
+  return () => {
+    globalThis.fetch = originalFetch;
   };
 }
 
@@ -19,6 +23,7 @@ describe("Nostr profile operations with real timeouts", () => {
   let server: Server;
   let serverUrl: string;
   let stall: boolean;
+  let restoreFetch: () => void;
 
   beforeEach(async () => {
     stall = false;
@@ -35,10 +40,11 @@ describe("Nostr profile operations with real timeouts", () => {
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : 0;
     serverUrl = `http://127.0.0.1:${port}`;
-    installRelativeFetchBridge(serverUrl);
+    restoreFetch = installRelativeFetchBridge(serverUrl);
   });
 
   afterEach(() => {
+    restoreFetch();
     server.close();
   });
 

--- a/ui/src/pages/channels/nostr-profile-ops.test.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.test.ts
@@ -101,7 +101,9 @@ describe("Nostr profile operations", () => {
     const headersOnlyServer = createServer((_req, res) => {
       res.writeHead(200, { "content-type": "application/json" });
     });
-    await new Promise<void>((resolve) => headersOnlyServer.listen(0, resolve));
+    await new Promise<void>((resolve) => {
+      headersOnlyServer.listen(0, resolve);
+    });
     const address = headersOnlyServer.address();
     const port = typeof address === "object" && address ? address.port : 0;
     const headersOnlyServerUrl = `http://127.0.0.1:${port}`;
@@ -121,7 +123,9 @@ describe("Nostr profile operations", () => {
     const headersOnlyServer = createServer((_req, res) => {
       res.writeHead(200, { "content-type": "application/json" });
     });
-    await new Promise<void>((resolve) => headersOnlyServer.listen(0, resolve));
+    await new Promise<void>((resolve) => {
+      headersOnlyServer.listen(0, resolve);
+    });
     const address = headersOnlyServer.address();
     const port = typeof address === "object" && address ? address.port : 0;
     const headersOnlyServerUrl = `http://127.0.0.1:${port}`;

--- a/ui/src/pages/channels/nostr-profile-ops.test.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.test.ts
@@ -1,0 +1,135 @@
+import type { Server } from "node:http";
+import { createServer } from "node:http";
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { putNostrProfile, importNostrProfile } from "./nostr-profile-ops.js";
+
+function installRelativeFetchBridge(serverUrl: string): void {
+  const base = serverUrl.replace(/\/$/, "");
+  const realFetch = globalThis.fetch.bind(globalThis);
+  vi.stubGlobal("fetch", (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const absolute = url.startsWith("http") ? url : `${base}${url}`;
+    return realFetch(absolute, init);
+  });
+}
+
+const HEADERS = { authorization: "Bearer test-token" };
+
+describe("Nostr profile operations", () => {
+  let server: Server;
+  let serverUrl: string;
+  let stall: boolean;
+
+  let onUnhandled: (reason: unknown) => void;
+
+  beforeEach(async () => {
+    stall = false;
+    onUnhandled = (reason: unknown) => {
+      if (reason instanceof Error && reason.name === "AbortError") {
+        return;
+      }
+      process.emit("uncaughtExceptionMonitor", reason as Error);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    server = createServer((_req, res) => {
+      if (stall) {
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, persisted: true }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    serverUrl = `http://127.0.0.1:${port}`;
+    installRelativeFetchBridge(serverUrl);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", onUnhandled);
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    server.close();
+  });
+
+  it("aborts a stalled putNostrProfile after the bound instead of hanging", async () => {
+    stall = true;
+    const call = putNostrProfile({
+      accountId: "acct-1",
+      headers: HEADERS,
+      values: { name: "alice" },
+    });
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(call).rejects.toThrow();
+  });
+
+  it("aborts a stalled importNostrProfile after the bound instead of hanging", async () => {
+    stall = true;
+    const call = importNostrProfile({ accountId: "acct-1", headers: HEADERS });
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(call).rejects.toThrow();
+  });
+
+  it("still resolves a normal putNostrProfile round trip", async () => {
+    vi.useRealTimers();
+    const { data, response } = await putNostrProfile({
+      accountId: "acct-1",
+      headers: HEADERS,
+      values: { name: "alice" },
+    });
+    expect(response.ok).toBe(true);
+    expect(data?.persisted).toBe(true);
+    vi.useFakeTimers();
+  });
+
+  it("still resolves a normal importNostrProfile round trip", async () => {
+    vi.useRealTimers();
+    const { data, response } = await importNostrProfile({
+      accountId: "acct-1",
+      headers: HEADERS,
+    });
+    expect(response.ok).toBe(true);
+    expect(data?.persisted).toBe(true);
+    vi.useFakeTimers();
+  });
+
+  it("aborts putNostrProfile when headers received but body stalls", async () => {
+    const headersOnlyServer = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+    });
+    await new Promise<void>((resolve) => headersOnlyServer.listen(0, resolve));
+    const address = headersOnlyServer.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const headersOnlyServerUrl = `http://127.0.0.1:${port}`;
+    installRelativeFetchBridge(headersOnlyServerUrl);
+
+    const call = putNostrProfile({
+      accountId: "acct-1",
+      headers: HEADERS,
+      values: { name: "alice" },
+    });
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(call).rejects.toThrow();
+    headersOnlyServer.close();
+  });
+
+  it("aborts importNostrProfile when headers received but body stalls", async () => {
+    const headersOnlyServer = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+    });
+    await new Promise<void>((resolve) => headersOnlyServer.listen(0, resolve));
+    const address = headersOnlyServer.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const headersOnlyServerUrl = `http://127.0.0.1:${port}`;
+    installRelativeFetchBridge(headersOnlyServerUrl);
+
+    const call = importNostrProfile({ accountId: "acct-1", headers: HEADERS });
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(call).rejects.toThrow();
+    headersOnlyServer.close();
+  });
+});

--- a/ui/src/pages/channels/nostr-profile-ops.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.ts
@@ -28,46 +28,62 @@ function buildNostrProfileUrl(accountId: string, suffix = ""): string {
   return `/api/channels/nostr/${encodeURIComponent(accountId)}/profile${suffix}`;
 }
 
+const NOSTR_PROFILE_FETCH_TIMEOUT_MS = 15_000;
+
 export async function putNostrProfile(params: {
   accountId: string;
   headers: Record<string, string>;
   values: NostrProfile;
 }) {
-  const response = await fetch(buildNostrProfileUrl(params.accountId), {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      ...params.headers,
-    },
-    body: JSON.stringify(params.values),
-  });
-  const data = (await response.json().catch(() => null)) as {
-    ok?: boolean;
-    error?: string;
-    details?: unknown;
-    persisted?: boolean;
-  } | null;
-  return { data, response };
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), NOSTR_PROFILE_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(buildNostrProfileUrl(params.accountId), {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        ...params.headers,
+      },
+      body: JSON.stringify(params.values),
+      signal: controller.signal,
+    });
+    const data = (await response.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+      details?: unknown;
+      persisted?: boolean;
+    } | null;
+    return { data, response };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function importNostrProfile(params: {
   accountId: string;
   headers: Record<string, string>;
 }) {
-  const response = await fetch(buildNostrProfileUrl(params.accountId, "/import"), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...params.headers,
-    },
-    body: JSON.stringify({ autoMerge: true }),
-  });
-  const data = (await response.json().catch(() => null)) as {
-    ok?: boolean;
-    error?: string;
-    imported?: NostrProfile;
-    merged?: NostrProfile;
-    saved?: boolean;
-  } | null;
-  return { data, response };
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), NOSTR_PROFILE_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(buildNostrProfileUrl(params.accountId, "/import"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...params.headers,
+      },
+      body: JSON.stringify({ autoMerge: true }),
+      signal: controller.signal,
+    });
+    const data = (await response.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+      imported?: NostrProfile;
+      merged?: NostrProfile;
+      saved?: boolean;
+    } | null;
+    return { data, response };
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/ui/src/pages/channels/nostr-profile-ops.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.ts
@@ -81,6 +81,7 @@ export async function importNostrProfile(params: {
       imported?: NostrProfile;
       merged?: NostrProfile;
       saved?: boolean;
+      persisted?: boolean;
     } | null;
     return { data, response };
   } finally {


### PR DESCRIPTION
## What Problem This Solves

The `putNostrProfile` and `importNostrProfile` helpers in `ui/src/pages/channels/nostr-profile-ops.ts` issue `fetch` requests to the gateway/relay Nostr profile endpoint **without any timeout or abort signal**. A stalled or unreachable endpoint hangs the channels page indefinitely while it awaits the response.

This mirrors the same class of unbounded-network-operation fixes (e.g. `fix(ci)`, `fix(docker)`, `fix(doctor)` "bound X" PRs): an unterminated request with no `AbortSignal` can block the UI forever.

## Why This Change Was Made

Add an `AbortController` + `setTimeout` watchdog (`NOSTR_PROFILE_FETCH_TIMEOUT_MS = 15_000`) to both fetches, following the existing Control UI convention used by `browser-client.ts`, `custom-theme.ts`, and `agent-select.ts`. The timeout is cleared in `finally` so no timer leaks.

## User Impact

The channels Nostr profile publish/import actions now fail fast instead of hanging when the relay is slow or down.

## Evidence

### Real behavior proof

**Behavior or issue addressed:** Nostr profile publish/import (`putNostrProfile`, `importNostrProfile`) hang the channels page forever when the gateway/relay endpoint never responds, because the fetch has no abort signal.

**Real environment tested:** macOS 15, Node v24.18.0, vitest 4.1.10, local HTTP server (`node:http`) bound to 127.0.0.1:0. **Real wall-clock time** is used (not fake timers) to prove actual timeout behavior.

**Exact commands run:**
```bash
# Fake-timer regression tests (fast CI feedback)
node scripts/run-vitest.mjs ui/src/pages/channels/nostr-profile-ops.test.ts

# Real-timeout behavior proof (actual wall-clock validation)
node scripts/run-vitest.mjs ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts --reporter=verbose

# Type-suppression inventory (repo-wide guard that previously failed on this branch)
node scripts/run-vitest.mjs test/scripts/type-suppression-inventory.test.ts
```

**Terminal output showing real timeout behavior:**
```
$ node -v
v24.18.0

$ node scripts/run-vitest.mjs ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts --reporter=verbose

 RUN  v4.1.10 /Users/maomaoplanet/workspace/openclaw-worktrees/pr-110009

stdout | ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > aborts a stalled putNostrProfile after the real 15s bound instead of hanging
[REAL TIMEOUT] putNostrProfile aborted after 15016ms
[REAL TIMEOUT] Error type: AbortError
[REAL TIMEOUT] Error message: This operation was aborted

 ✓ |ui| ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > aborts a stalled putNostrProfile after the real 15s bound instead of hanging 15013ms
stdout | ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > aborts a stalled importNostrProfile after the real 15s bound instead of hanging
[REAL TIMEOUT] importNostrProfile aborted after 15006ms
[REAL TIMEOUT] Error type: AbortError
[REAL TIMEOUT] Error message: This operation was aborted

stdout | ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > resolves a normal putNostrProfile round trip quickly
[NORMAL] putNostrProfile completed in 15ms

stdout | ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > resolves a normal importNostrProfile round trip quickly
[NORMAL] importNostrProfile completed in 4ms

 ✓ |ui| ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > aborts a stalled importNostrProfile after the real 15s bound instead of hanging 15006ms
 ✓ |ui| ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > resolves a normal putNostrProfile round trip quickly 17ms
 ✓ |ui| ui/src/pages/channels/nostr-profile-ops.real-timeout.test.ts > Nostr profile operations with real timeouts > resolves a normal importNostrProfile round trip quickly 5ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  06:24:29
   Duration  30.36s (transform 19ms, setup 11ms, import 12ms, tests 30.04s, environment 240ms)
```

**Terminal output showing regression suite (fake timers) and type-suppression guard:**
```
$ node scripts/run-vitest.mjs ui/src/pages/channels/nostr-profile-ops.test.ts
 ✓ |ui| ui/src/pages/channels/nostr-profile-ops.test.ts (6 tests) 25ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  621ms (transform 43ms, setup 31ms, import 7ms, tests 25ms, environment 486ms)

$ node scripts/run-vitest.mjs test/scripts/type-suppression-inventory.test.ts
 ✓ keeps unchecked any casts at zero and negative type assertions explicit  2545ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  2.84s (transform 98ms, setup 29ms, import 177ms, tests 2.55s, environment 0ms)
```

**Observed result after fix:**
- Stalled `putNostrProfile` aborts after exactly **15,016ms** (within the 15s bound) and raises `AbortError`
- Stalled `importNostrProfile` aborts after exactly **15,006ms** (within the 15s bound) and raises `AbortError`
- Normal `putNostrProfile` requests complete in **15ms** (fast, no timeout)
- Normal `importNostrProfile` requests complete in **4ms** (fast, no timeout)
- All timeout tests pass with real wall-clock time, proving the abort mechanism works correctly
- Error type is correctly `AbortError` with message "This operation was aborted"

**What was tested:**
- Real wall-clock timeout behavior (not fake timers) against a deliberately stalled local HTTP server
- Normal operation round trips complete in milliseconds
- AbortError is correctly raised and can be caught/handled by UI code
- Timeout mechanism works for both publish and import operations
- Both quick-regression tests (fake timers) and real-behavior tests (real timers) pass
- The real-timeout suite saves the original `globalThis.fetch` before installing its relative-URL bridge and restores it in `afterEach`, so no bridge leaks into later tests; both Nostr suites were rerun after this teardown repair (results above)
- The repo-wide type-suppression inventory passes (`as-any` count stays at 0); the fetch bridge assigns `globalThis.fetch` through the standard typed signature
- No persistent data-model change: the diff only touches the two Nostr profile helpers and their test files; nothing is serialized, stored, or migrated

**Key difference from prior evidence:** This uses actual wall-clock time to demonstrate the timeout mechanism, providing real runtime behavior proof that the UI will fail fast after 15 seconds instead of hanging indefinitely. The tests prove the error is recoverable (AbortError can be caught and handled).
