### PR TITLE
chore: repair plugin release validation expectations

### DIFF
--- a/extensions/teams-meetings/src/transports/chrome.test.ts
+++ b/extensions/teams-meetings/src/transports/chrome.test.ts
@@ -1,5 +1,5 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTeamsMeetingsConfig } from "../config.js";
 
 const engineMocks = vi.hoisted(() => ({
@@ -76,7 +76,12 @@ function browserResult(params: Record<string, unknown>, state: { tabOpen: boolea
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
   engineMocks.startAgent.mockRejectedValue(new Error("realtime startup failed"));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("Microsoft Teams meeting Chrome startup cleanup", () => {

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -58,6 +58,7 @@ const EXPECTED_BUNDLED_STARTUP_PLUGIN_IDS = [
   "policy",
   "reef",
   "talk-voice",
+  "teams-meetings",
   "thread-ownership",
   "voice-call",
   "webhooks",


### PR DESCRIPTION
## What Problem This Solves

Resolves plugin release-validation failures after Teams Meetings became an eagerly started bundled plugin and its macOS-only audio guard began running in Linux CI.

## Why This Change Was Made

Updates the explicit bundled-plugin contract and makes the Chrome cleanup test exercise its intended macOS path on every CI platform. Production behavior is unchanged.

## User Impact

No user-visible change. Release and prerelease validation can exercise the intended plugin contracts again.

## Evidence

- Failing bundled-plugin job: https://github.com/openclaw/openclaw/actions/runs/29583418232/job/87894493600
- Failing Teams Meetings job: https://github.com/openclaw/openclaw/actions/runs/29583418232/job/87894493846
- `pnpm vitest run src/plugins/bundled-plugin-metadata.test.ts extensions/teams-meetings/src/transports/chrome.test.ts` — 38 passed
- Autoreview: clean, no accepted/actionable findings
