### PR TITLE
refactor(mcp): reuse plugin cache primitives

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime-config.ts
+++ b/src/agents/agent-bundle-mcp-runtime-config.ts
@@ -4,6 +4,7 @@ import { resolveRuntimeConfigCacheKey } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { PluginLruCache } from "../plugins/plugin-cache-primitives.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { assignSafeServerNames } from "./agent-bundle-mcp-names.js";
@@ -20,25 +21,25 @@ type PreparedSessionMcpConfig = {
 };
 type SessionMcpConfigDiscoveryCacheEntry = {
   loaded: LoadedMcpConfig;
-  preparedByVariant: Map<string, PreparedSessionMcpConfig>;
+  preparedByVariant: PluginLruCache<PreparedSessionMcpConfig>;
 };
 
 const SESSION_MCP_CONFIG_DISCOVERY_CACHE_KEY = Symbol.for(
-  "openclaw.sessionMcpConfigDiscoveryCache",
+  "openclaw.sessionMcpConfigDiscoveryCache.pluginLru.v1",
 );
 const SESSION_MCP_CONFIG_DISCOVERY_CACHE_LIMIT = 128;
 const SESSION_MCP_PREPARED_CONFIG_VARIANT_LIMIT = 64;
 const EMPTY_OPENCLAW_CONFIG: OpenClawConfig = {};
 
 type SessionMcpConfigDiscoveryCacheState = {
-  entries: Map<string, SessionMcpConfigDiscoveryCacheEntry>;
+  entries: PluginLruCache<SessionMcpConfigDiscoveryCacheEntry>;
   manifestRegistryIds: WeakMap<object, number>;
   nextManifestRegistryId: number;
 };
 
 function getSessionMcpConfigDiscoveryCacheState(): SessionMcpConfigDiscoveryCacheState {
   return resolveGlobalSingleton(SESSION_MCP_CONFIG_DISCOVERY_CACHE_KEY, () => ({
-    entries: new Map(),
+    entries: new PluginLruCache(SESSION_MCP_CONFIG_DISCOVERY_CACHE_LIMIT),
     manifestRegistryIds: new WeakMap(),
     nextManifestRegistryId: 1,
   }));
@@ -75,28 +76,6 @@ function buildSessionMcpConfigDiscoveryCacheKey(params: {
   });
 }
 
-function trimSessionMcpConfigDiscoveryCache(state: SessionMcpConfigDiscoveryCacheState): void {
-  while (state.entries.size > SESSION_MCP_CONFIG_DISCOVERY_CACHE_LIMIT) {
-    const oldest = state.entries.keys().next().value;
-    if (typeof oldest !== "string") {
-      return;
-    }
-    state.entries.delete(oldest);
-  }
-}
-
-function trimPreparedConfigVariants(
-  preparedByVariant: Map<string, PreparedSessionMcpConfig>,
-): void {
-  while (preparedByVariant.size > SESSION_MCP_PREPARED_CONFIG_VARIANT_LIMIT) {
-    const oldest = preparedByVariant.keys().next().value;
-    if (typeof oldest !== "string") {
-      return;
-    }
-    preparedByVariant.delete(oldest);
-  }
-}
-
 function clonePreparedSessionMcpConfig(
   prepared: PreparedSessionMcpConfig,
 ): PreparedSessionMcpConfig {
@@ -114,9 +93,6 @@ function loadCachedEmbeddedAgentMcpConfig(params: {
   const key = buildSessionMcpConfigDiscoveryCacheKey(params);
   const cached = state.entries.get(key);
   if (cached) {
-    // LRU order bounds long-lived processes that observe many config revisions.
-    state.entries.delete(key);
-    state.entries.set(key, cached);
     return cached;
   }
   // Bundle manifests and their MCP JSON are process-stable metadata. Keep the
@@ -125,7 +101,9 @@ function loadCachedEmbeddedAgentMcpConfig(params: {
   const discovered = structuredClone(loadEmbeddedAgentMcpConfig(params));
   const loaded = {
     loaded: discovered,
-    preparedByVariant: new Map(),
+    preparedByVariant: new PluginLruCache<PreparedSessionMcpConfig>(
+      SESSION_MCP_PREPARED_CONFIG_VARIANT_LIMIT,
+    ),
   };
   // Diagnostics can represent transient filesystem or manifest failures. Keep
   // those results session-owned so the next run retries discovery.
@@ -133,7 +111,6 @@ function loadCachedEmbeddedAgentMcpConfig(params: {
     return loaded;
   }
   state.entries.set(key, loaded);
-  trimSessionMcpConfigDiscoveryCache(state);
   return loaded;
 }
 
@@ -248,8 +225,6 @@ export function loadSessionMcpConfig(params: {
   });
   const prepared = discovery.preparedByVariant.get(variantKey);
   if (prepared) {
-    discovery.preparedByVariant.delete(variantKey);
-    discovery.preparedByVariant.set(variantKey, prepared);
     return clonePreparedSessionMcpConfig(prepared);
   }
   const mcpServers = filterMcpServers(discovery.loaded.mcpServers, {
@@ -271,7 +246,6 @@ export function loadSessionMcpConfig(params: {
     }),
   };
   discovery.preparedByVariant.set(variantKey, result);
-  trimPreparedConfigVariants(discovery.preparedByVariant);
   return clonePreparedSessionMcpConfig(result);
 }
 


### PR DESCRIPTION
## Summary

- Replace the two hand-rolled MCP discovery/preparation LRU maps from #79882 with the existing lifecycle-owned `PluginLruCache` primitive.
- Delete duplicate promotion and eviction loops.
- Version the process-global singleton key so a module reload cannot reuse the former Map-backed state shape.
- Net change: 26 lines deleted.

## What Problem This Solves

The new MCP discovery cache duplicated the repository's canonical plugin metadata LRU implementation. Keeping two eviction implementations increased lifecycle and mixed-module reload risk for no product benefit.

## Change Type (select all)

- [ ] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Follow-up to #79882.
- [ ] This PR fixes a bug or regression.

## Evidence

- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime-config.test.ts src/agents/agent-bundle-mcp-runtime.test.ts src/plugins/plugin-cache-primitives.test.ts`
  - MCP: 81 tests passed.
  - Plugin cache primitive: 10 tests passed.
- `git diff --check` passed.
- Mandatory autoreview converged clean after versioning the singleton key for mixed-module reload safety.
- Hosted changed gate: https://github.com/openclaw/openclaw/actions/runs/29583900631
  - Change-specific formatting and structural guards passed.
  - The only failure was the Plugin SDK API baseline already reproducible byte-for-byte on exact clean `origin/main` and its parent: generated `42bdede4.../2c8cf57e...`, tracked `5bab8bc9.../c5f6cd4c...`.

## Root Cause

The initial performance fix needed bounded process caches and implemented the Map bookkeeping locally instead of adopting `PluginLruCache`, which already owns promotion, capacity normalization, and oldest-entry eviction for stable plugin metadata.

## Regression Test Plan

- Existing MCP discovery reuse, invalidation, failure retry, and mutation-isolation tests.
- Existing `PluginLruCache` hit promotion, capacity, and eviction tests.

## Notes for reviewers

- Behavior-neutral; no config, API, persistence, or runtime pooling changes.
- No changelog required.
