### PR TITLE
fix(mcp): avoid memory spikes from oversized client TLS files

### DIFF
--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { parseErrorResponse } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 /**
@@ -182,6 +185,54 @@ describe("MCP HTTP fetch helpers", () => {
       getDispatcherConnectOptions(fetchCalls[1]?.init)?.["rejectUnauthorized"],
     ).toBeUndefined();
   });
+
+  it("loads bounded client certificate and key files", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-mcp-tls-"));
+    const clientCert = path.join(root, "client.crt");
+    const clientKey = path.join(root, "client.key");
+    fs.writeFileSync(clientCert, "client-certificate\n", "utf8");
+    fs.writeFileSync(clientKey, "client-key\n", "utf8");
+
+    try {
+      const fetch = buildMcpHttpFetch({
+        clientCert,
+        clientKey,
+        resourceUrl: "https://mcp.example.com/mcp",
+      });
+
+      await fetch("https://mcp.example.com/token");
+
+      expect(getDispatcherConnectOptions(fetchCalls[0]?.init)).toMatchObject({
+        cert: "client-certificate",
+        key: "client-key",
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["clientCert", "clientKey"] as const)(
+    "rejects oversized %s files before dispatch",
+    async (field) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-mcp-tls-"));
+      const oversized = path.join(root, field);
+      fs.writeFileSync(oversized, "x".repeat(64 * 1024 + 1), "utf8");
+
+      try {
+        const fetch = buildMcpHttpFetch({
+          [field]: oversized,
+          resourceUrl: "https://mcp.example.com/mcp",
+        });
+
+        await expect(fetch("https://mcp.example.com/token")).rejects.toThrow(
+          `exceeds ${64 * 1024} bytes`,
+        );
+        expect(fetchCalls).toHaveLength(0);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("uses configured env proxy for ordinary MCP HTTP requests", async () => {
     vi.stubEnv("https_proxy", "http://proxy.example:8080");

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -3,7 +3,6 @@
  * Adds SSRF protection, scoped TLS/client-cert dispatchers, response cleanup,
  * and same-origin header handling around the MCP SDK fetch contract.
  */
-import fs from "node:fs";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { wrapGuardedBodyStream } from "../infra/net/guarded-body-stream.js";
@@ -12,6 +11,7 @@ import {
   type PinnedDispatcherPolicy,
 } from "../infra/net/ssrf.js";
 import { loadUndiciRuntimeDeps } from "../infra/net/undici-runtime.js";
+import { readSecretFileSync } from "../infra/secret-file.js";
 
 /** Default MCP HTTP fetch backed by lazy-loaded undici runtime deps. */
 const fetchWithUndici: FetchLike = async (url, init) =>
@@ -26,6 +26,14 @@ const fetchWithUndiciGuard = async (
 ): Promise<Response> => await fetchWithUndici(input instanceof Request ? input.url : input, init);
 
 const MCP_HTTP_MAX_REDIRECTS = 20;
+const MCP_CLIENT_TLS_FILE_MAX_BYTES = 64 * 1024;
+
+function readMcpClientTlsFile(filePath: string, label: string): string {
+  return readSecretFileSync(filePath, label, {
+    maxBytes: MCP_CLIENT_TLS_FILE_MAX_BYTES,
+    rejectHardlinks: false,
+  });
+}
 
 function resolveFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
   if (input instanceof Request) {
@@ -114,8 +122,12 @@ export function buildMcpHttpFetch(params: {
     }
     customConnect ??= {
       ...(params.sslVerify === false ? { rejectUnauthorized: false } : {}),
-      ...(params.clientCert ? { cert: fs.readFileSync(params.clientCert, "utf-8") } : {}),
-      ...(params.clientKey ? { key: fs.readFileSync(params.clientKey, "utf-8") } : {}),
+      ...(params.clientCert
+        ? { cert: readMcpClientTlsFile(params.clientCert, "MCP client certificate") }
+        : {}),
+      ...(params.clientKey
+        ? { key: readMcpClientTlsFile(params.clientKey, "MCP client key") }
+        : {}),
     };
     return { mode: "direct", connect: customConnect };
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MCP operators using `clientCert` or `clientKey` could have an arbitrarily large file loaded in full when OpenClaw prepared an HTTP mTLS connection. A mistaken path to a large file could therefore cause a memory spike before the MCP request was sent.

## Why This Change Was Made

MCP HTTP connections now load both client TLS files through OpenClaw's existing pinned secret-file reader with a 64 KiB limit. This keeps the current config shape and preserves symlink and hardlink layouts, but intentionally rejects certificate or key files larger than 64 KiB before dispatch.

AI-assisted: yes. I inspected the complete fetch wrapper, both production callers, MCP config normalization, adjacent tests, the Undici/Node TLS string contract, and installed `@openclaw/fs-safe@0.4.1` source and types. Per the task constraint, I performed the final review manually without invoking an agent review skill.

## User Impact

MCP operators can continue using ordinary PEM client certificates and keys, while oversized TLS files now fail with a clear size error before OpenClaw opens the network connection or retains the full contents.

## Evidence

**Real-machine production-path proof:** Linux `6.8.0-134-generic` x86_64, Node `v24.18.0`, OpenSSL `3.0.13`. The harness generated a real CA, server certificate, and client certificate, started a real localhost HTTPS server requiring a CA-signed client certificate, and called the production `buildMcpHttpFetch`. No filesystem, TLS, fetch, dispatcher, or server mock was used.

The fixture and three proof runs used these commands:

```bash
proof_dir=$(mktemp -d /tmp/openclaw-mcp-mtls.XXXXXX)
openssl req -x509 -newkey rsa:2048 -nodes -keyout "$proof_dir/ca.key" -out "$proof_dir/ca.crt" -days 1 -subj '/CN=OpenClaw MCP Proof CA'
openssl req -newkey rsa:2048 -nodes -keyout "$proof_dir/server.key" -out "$proof_dir/server.csr" -subj '/CN=127.0.0.1'
openssl x509 -req -in "$proof_dir/server.csr" -CA "$proof_dir/ca.crt" -CAkey "$proof_dir/ca.key" -CAcreateserial -out "$proof_dir/server.crt" -days 1
openssl req -newkey rsa:2048 -nodes -keyout "$proof_dir/client.key" -out "$proof_dir/client.csr" -subj '/CN=OpenClaw MCP Client'
openssl x509 -req -in "$proof_dir/client.csr" -CA "$proof_dir/ca.crt" -CAkey "$proof_dir/ca.key" -CAcreateserial -out "$proof_dir/client.crt" -days 1

node --import tsx /tmp/openclaw-mcp-mtls-proof.mjs /tmp/openclaw-mcp-before "$proof_dir" oversized
node --import tsx /tmp/openclaw-mcp-mtls-proof.mjs . "$proof_dir" oversized
node --import tsx /tmp/openclaw-mcp-mtls-proof.mjs . "$proof_dir" regular
```

The proof harness imported `src/agents/mcp-http-fetch.ts`, appended newline-valid PEM whitespace to create the oversized certificate, and invoked the returned fetch against this real mTLS server:

```js
const server = https.createServer({
  key: fs.readFileSync(path.join(fixtureRoot, "server.key")),
  cert: fs.readFileSync(path.join(fixtureRoot, "server.crt")),
  ca: fs.readFileSync(path.join(fixtureRoot, "ca.crt")),
  requestCert: true,
  rejectUnauthorized: true,
}, (_request, response) => {
  serverRequests += 1;
  response.end("mcp-ok");
});

const fetch = buildMcpHttpFetch({
  sslVerify: false,
  clientCert,
  clientKey: path.join(fixtureRoot, "client.key"),
  resourceUrl,
});
const response = await fetch(resourceUrl);
```

**Before / negative control:** On latest `upstream/main` at `71c1d612a6f728f36beb07b2fbf236835f6c9247`, a 72,701-byte client certificate was loaded and used successfully. The real server received one authenticated request and returned HTTP 200.

```text
{"mode":"oversized","certBytes":72701,"status":200,"body":"mcp-ok","serverRequests":1}
```

**Premise:** `clientCert` and `clientKey` flow from MCP config through `mcp-transport.ts` and `mcp-auth-profile.ts` to this wrapper without an upstream size check. Installed `@openclaw/fs-safe@0.4.1` checks a regular file's size before its pinned descriptor read and throws an `FsSafeError` on overflow. Its default accepts symlinks, and `rejectHardlinks: false` preserves the previous MCP hardlink behavior. Node's TLS types accept `string` certificate and key material; the live handshake above proves the resulting strings reach the real TLS stack.

**After:** On commit `6b6ee3cd107a1aff1110094661c0e93802c14f84`, the same 72,701-byte certificate was rejected at the 65,536-byte boundary before dispatch. The real server received zero requests.

```text
{"mode":"oversized","certBytes":72701,"error":"MCP client certificate file at /tmp/openclaw-mcp-mtls.4Z3pcU/client-oversized.crt exceeds 65536 bytes.","serverRequests":0}
```

**Negative control after the fix:** The same production path with the regular 1,021-byte client certificate still completed the mTLS handshake and returned HTTP 200.

```text
{"mode":"regular","certBytes":1021,"status":200,"body":"mcp-ok","serverRequests":1}
```

**Focused validation:** after rebasing onto the SHA above:

```bash
node scripts/run-vitest.mjs src/agents/mcp-http-fetch.test.ts
```

```text
Test Files  1 passed (1)
Tests       20 passed (20)
```

Targeted `oxfmt`, targeted `oxlint`, and `git diff --check` also passed. The repository lint wrapper was unable to enter its target lint stage because latest main's plugin-SDK boundary generation currently reports unrelated `packages/net-policy/src/ip.ts` type errors; wide validation is left to fork CI because this external-contributor workflow does not use maintainer-only remote test infrastructure.

Not tested against an external MCP service because the changed behavior is the local cert/key read before dispatch; the real localhost mTLS server exercised the same production fetch, Undici dispatcher, Node TLS handshake, client-certificate authentication, and response path.
