### PR TITLE
fix(sandbox): bound sandbox seed bootstrap file reads

### DIFF
--- a/src/agents/sandbox/workspace.test.ts
+++ b/src/agents/sandbox/workspace.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../workspace-bootstrap-read.js";
 import { DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME } from "../workspace.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
@@ -79,16 +80,14 @@ describe("ensureSandboxWorkspace", () => {
   });
 
   it("skips an oversized seed file but still seeds the others", async () => {
-    // 2 MiB limit mirrors SANDBOX_SEED_FILE_MAX_BYTES in the source module.
     // An unbounded read would copy the oversized file through; the bound skips it.
-    const limit = 2 * 1024 * 1024;
     const root = await makeTempRoot();
     const seed = path.join(root, "seed");
     const sandbox = path.join(root, "sandbox");
     await fs.mkdir(seed, { recursive: true });
     await fs.writeFile(
       path.join(seed, DEFAULT_AGENTS_FILENAME),
-      `## Startup\n\n` + "x".repeat(limit),
+      `## Startup\n\n` + "x".repeat(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES),
       "utf-8",
     );
     await fs.writeFile(path.join(seed, DEFAULT_TOOLS_FILENAME), "seeded-tools", "utf-8");
@@ -103,14 +102,13 @@ describe("ensureSandboxWorkspace", () => {
     );
   });
 
-  it("seeds a bootstrap file just under the byte read limit", async () => {
-    const limit = 2 * 1024 * 1024;
+  it("seeds a bootstrap file at the byte read limit", async () => {
     const root = await makeTempRoot();
     const seed = path.join(root, "seed");
     const sandbox = path.join(root, "sandbox");
     await fs.mkdir(seed, { recursive: true });
     const content = "## Startup\n\nDo startup things.\n";
-    const padding = "x".repeat(limit - content.length - 1);
+    const padding = "x".repeat(MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES - content.length);
     await fs.writeFile(path.join(seed, DEFAULT_AGENTS_FILENAME), content + padding, "utf-8");
 
     await ensureSandboxWorkspace(sandbox, seed, true);

--- a/src/agents/sandbox/workspace.test.ts
+++ b/src/agents/sandbox/workspace.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { DEFAULT_AGENTS_FILENAME } from "../workspace.js";
+import { DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME } from "../workspace.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
 const tempRoots: string[] = [];
@@ -76,5 +76,46 @@ describe("ensureSandboxWorkspace", () => {
     await expect(fs.readFile(path.join(sandbox, DEFAULT_AGENTS_FILENAME), "utf-8")).rejects.toThrow(
       "no such file",
     );
+  });
+
+  it("skips an oversized seed file but still seeds the others", async () => {
+    // 2 MiB limit mirrors SANDBOX_SEED_FILE_MAX_BYTES in the source module.
+    // An unbounded read would copy the oversized file through; the bound skips it.
+    const limit = 2 * 1024 * 1024;
+    const root = await makeTempRoot();
+    const seed = path.join(root, "seed");
+    const sandbox = path.join(root, "sandbox");
+    await fs.mkdir(seed, { recursive: true });
+    await fs.writeFile(
+      path.join(seed, DEFAULT_AGENTS_FILENAME),
+      `## Startup\n\n` + "x".repeat(limit),
+      "utf-8",
+    );
+    await fs.writeFile(path.join(seed, DEFAULT_TOOLS_FILENAME), "seeded-tools", "utf-8");
+
+    await ensureSandboxWorkspace(sandbox, seed, true);
+
+    await expect(fs.readFile(path.join(sandbox, DEFAULT_AGENTS_FILENAME), "utf-8")).rejects.toThrow(
+      "no such file",
+    );
+    await expect(fs.readFile(path.join(sandbox, DEFAULT_TOOLS_FILENAME), "utf-8")).resolves.toBe(
+      "seeded-tools",
+    );
+  });
+
+  it("seeds a bootstrap file just under the byte read limit", async () => {
+    const limit = 2 * 1024 * 1024;
+    const root = await makeTempRoot();
+    const seed = path.join(root, "seed");
+    const sandbox = path.join(root, "sandbox");
+    await fs.mkdir(seed, { recursive: true });
+    const content = "## Startup\n\nDo startup things.\n";
+    const padding = "x".repeat(limit - content.length - 1);
+    await fs.writeFile(path.join(seed, DEFAULT_AGENTS_FILENAME), content + padding, "utf-8");
+
+    await ensureSandboxWorkspace(sandbox, seed, true);
+
+    const seeded = await fs.readFile(path.join(sandbox, DEFAULT_AGENTS_FILENAME), "utf-8");
+    expect(seeded).toContain("Do startup things");
   });
 });

--- a/src/agents/sandbox/workspace.ts
+++ b/src/agents/sandbox/workspace.ts
@@ -8,9 +8,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OptionalBootstrapFileName } from "../../config/types.agent-defaults.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
-import { readFileDescriptorBoundedSync } from "../../infra/file-descriptor-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveUserPath } from "../../utils.js";
+import {
+  MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+  readWorkspaceBootstrapFile,
+} from "../workspace-bootstrap-read.js";
 import {
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
@@ -23,12 +26,6 @@ import {
 } from "../workspace.js";
 
 const log = createSubsystemLogger("sandbox-workspace");
-
-// Sandbox seed files (AGENTS.md / SOUL.md / TOOLS.md / ...) are bootstrap metadata.
-// Bound the pinned seed read so an oversized or misconfigured seed path cannot trigger
-// an unbounded read at sandbox-creation time. Aligns with the 2 MiB workspace bootstrap
-// file limit used by other workspace reads.
-const SANDBOX_SEED_FILE_MAX_BYTES = 2 * 1024 * 1024;
 
 export async function ensureSandboxWorkspace(
   workspaceDir: string,
@@ -64,15 +61,12 @@ export async function ensureSandboxWorkspace(
             continue;
           }
           try {
-            const content = readFileDescriptorBoundedSync(
-              opened.fd,
-              SANDBOX_SEED_FILE_MAX_BYTES,
-            ).toString("utf-8");
+            const content = await readWorkspaceBootstrapFile(opened.fd);
             await fs.writeFile(dest, content, { encoding: "utf-8", flag: "wx" });
           } catch (err) {
             if (err instanceof RangeError) {
               log.warn(
-                `Ignoring oversized sandbox seed file ${src}: file exceeds the ${SANDBOX_SEED_FILE_MAX_BYTES}-byte limit`,
+                `Ignoring oversized sandbox seed file ${src}: file exceeds the ${MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES}-byte limit`,
               );
             }
             // ignore missing or oversized seed file

--- a/src/agents/sandbox/workspace.ts
+++ b/src/agents/sandbox/workspace.ts
@@ -8,6 +8,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OptionalBootstrapFileName } from "../../config/types.agent-defaults.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
+import { readFileDescriptorBoundedSync } from "../../infra/file-descriptor-read.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveUserPath } from "../../utils.js";
 import {
   DEFAULT_AGENTS_FILENAME,
@@ -19,6 +21,14 @@ import {
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
 } from "../workspace.js";
+
+const log = createSubsystemLogger("sandbox-workspace");
+
+// Sandbox seed files (AGENTS.md / SOUL.md / TOOLS.md / ...) are bootstrap metadata.
+// Bound the pinned seed read so an oversized or misconfigured seed path cannot trigger
+// an unbounded read at sandbox-creation time. Aligns with the 2 MiB workspace bootstrap
+// file limit used by other workspace reads.
+const SANDBOX_SEED_FILE_MAX_BYTES = 2 * 1024 * 1024;
 
 export async function ensureSandboxWorkspace(
   workspaceDir: string,
@@ -54,8 +64,18 @@ export async function ensureSandboxWorkspace(
             continue;
           }
           try {
-            const content = syncFs.readFileSync(opened.fd, "utf-8");
+            const content = readFileDescriptorBoundedSync(
+              opened.fd,
+              SANDBOX_SEED_FILE_MAX_BYTES,
+            ).toString("utf-8");
             await fs.writeFile(dest, content, { encoding: "utf-8", flag: "wx" });
+          } catch (err) {
+            if (err instanceof RangeError) {
+              log.warn(
+                `Ignoring oversized sandbox seed file ${src}: file exceeds the ${SANDBOX_SEED_FILE_MAX_BYTES}-byte limit`,
+              );
+            }
+            // ignore missing or oversized seed file
           } finally {
             syncFs.closeSync(opened.fd);
           }

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1004,28 +1004,25 @@ describe("loadWorkspaceBootstrapFiles", () => {
       content: "# AGENTS.md\n\nkeep me\n",
     });
 
+    // The bounded fd reader consumes the descriptor via fs.read; inject the
+    // transient failure at that seam.
     const originalRead = syncFs.read.bind(syncFs);
     let readCalls = 0;
     let threwTransient = false;
-    const readSpy = vi.spyOn(syncFs, "read").mockImplementation(((
-      fd: number,
-      buffer: Buffer,
-      offset: number,
-      length: number,
-      position: number | null,
-      callback: (error: NodeJS.ErrnoException | null, bytesRead: number, buffer: Buffer) => void,
-    ) => {
+    const readSpy = vi.spyOn(syncFs, "read").mockImplementation(((...args: unknown[]) => {
       readCalls += 1;
       if (!threwTransient) {
         threwTransient = true;
-        const error = Object.assign(new Error("Unknown system error -11: read"), {
-          code: "EAGAIN",
-          errno: -11,
-        });
-        queueMicrotask(() => callback(error, 0, buffer));
+        const callback = args.at(-1) as (error: Error) => void;
+        callback(
+          Object.assign(new Error("Unknown system error -11: read"), {
+            code: "EAGAIN",
+            errno: -11,
+          }),
+        );
         return;
       }
-      return originalRead(fd, buffer, offset, length, position, callback);
+      (originalRead as (...forwarded: unknown[]) => void)(...args);
     }) as typeof syncFs.read);
 
     try {
@@ -1050,19 +1047,14 @@ describe("loadWorkspaceBootstrapFiles", () => {
       content: "# AGENTS.md\n",
     });
 
-    const readSpy = vi.spyOn(syncFs, "read").mockImplementation(((
-      _fd: number,
-      buffer: Buffer,
-      _offset: number,
-      _length: number,
-      _position: number | null,
-      callback: (error: NodeJS.ErrnoException | null, bytesRead: number, buffer: Buffer) => void,
-    ) => {
-      const error = Object.assign(new Error("Unknown system error -11: read"), {
-        code: "EAGAIN",
-        errno: -11,
-      });
-      queueMicrotask(() => callback(error, 0, buffer));
+    const readSpy = vi.spyOn(syncFs, "read").mockImplementation(((...args: unknown[]) => {
+      const callback = args.at(-1) as (error: Error) => void;
+      callback(
+        Object.assign(new Error("Unknown system error -11: read"), {
+          code: "EAGAIN",
+          errno: -11,
+        }),
+      );
     }) as typeof syncFs.read);
 
     try {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1004,30 +1004,36 @@ describe("loadWorkspaceBootstrapFiles", () => {
       content: "# AGENTS.md\n\nkeep me\n",
     });
 
-    const originalReadFileSync = syncFs.readFileSync.bind(syncFs);
-    let readFileSyncCalls = 0;
+    const originalRead = syncFs.read.bind(syncFs);
+    let readCalls = 0;
     let threwTransient = false;
-    const readSpy = vi.spyOn(syncFs, "readFileSync").mockImplementation(((
-      target: unknown,
-      options: unknown,
+    const readSpy = vi.spyOn(syncFs, "read").mockImplementation(((
+      fd: number,
+      buffer: Buffer,
+      offset: number,
+      length: number,
+      position: number | null,
+      callback: (error: NodeJS.ErrnoException | null, bytesRead: number, buffer: Buffer) => void,
     ) => {
-      readFileSyncCalls += 1;
+      readCalls += 1;
       if (!threwTransient) {
         threwTransient = true;
-        throw Object.assign(new Error("Unknown system error -11: read"), {
+        const error = Object.assign(new Error("Unknown system error -11: read"), {
           code: "EAGAIN",
           errno: -11,
         });
+        queueMicrotask(() => callback(error, 0, buffer));
+        return;
       }
-      return originalReadFileSync(target as never, options as never);
-    }) as typeof syncFs.readFileSync);
+      return originalRead(fd, buffer, offset, length, position, callback);
+    }) as typeof syncFs.read);
 
     try {
       const files = await loadWorkspaceBootstrapFiles(tempDir);
       expect(threwTransient).toBe(true);
       // The retry re-opens and reads again, so the failed first read is followed
       // by at least one more successful read.
-      expect(readFileSyncCalls).toBeGreaterThanOrEqual(2);
+      expect(readCalls).toBeGreaterThanOrEqual(2);
       const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
       expect(agents?.missing).toBe(false);
       expect(agents?.content).toContain("keep me");
@@ -1044,12 +1050,20 @@ describe("loadWorkspaceBootstrapFiles", () => {
       content: "# AGENTS.md\n",
     });
 
-    const readSpy = vi.spyOn(syncFs, "readFileSync").mockImplementation((() => {
-      throw Object.assign(new Error("Unknown system error -11: read"), {
+    const readSpy = vi.spyOn(syncFs, "read").mockImplementation(((
+      _fd: number,
+      buffer: Buffer,
+      _offset: number,
+      _length: number,
+      _position: number | null,
+      callback: (error: NodeJS.ErrnoException | null, bytesRead: number, buffer: Buffer) => void,
+    ) => {
+      const error = Object.assign(new Error("Unknown system error -11: read"), {
         code: "EAGAIN",
         errno: -11,
       });
-    }) as typeof syncFs.readFileSync);
+      queueMicrotask(() => callback(error, 0, buffer));
+    }) as typeof syncFs.read);
 
     try {
       // Unlike the template check, this reader returns an io failure (not a


### PR DESCRIPTION
## What Problem This Solves

`ensureSandboxWorkspace` seeds a fresh sandbox workspace by copying each bootstrap file (AGENTS.md / SOUL.md / TOOLS.md / IDENTITY.md / USER.md / BOOTSTRAP.md / HEARTBEAT.md) from a user-configured seed path (`seedFrom`) into the new workspace. After the root-boundary `openRootFile` validates the path, it read the whole file with an unbounded `readFileSync(opened.fd, "utf-8")`. The seed path comes from user config, so a misconfigured or oversized seed file forced an unbounded memory allocation at sandbox-creation time.

This is a direct sibling of #101472 (bound hook manifest/HOOK.md reads, same `readFileDescriptorBoundedSync` helper) and #109945 (bound AGENTS.md read in post-compaction context): root-boundary-validated workspace metadata reads should be bounded so an oversized file cannot trigger an unbounded read.

## Evidence

- Replaced `syncFs.readFileSync(opened.fd, "utf-8")` with `readFileDescriptorBoundedSync(opened.fd, SANDBOX_SEED_FILE_MAX_BYTES).toString("utf-8")` - the same shared helper adopted by #101472 (`src/infra/file-descriptor-read.ts`) - with a 2 MiB limit aligned to `MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES` (2 MiB) used by the other workspace bootstrap reads in `src/agents/workspace.ts`.
- On overflow the loop catches `RangeError`, emits a `sandbox-workspace` subsystem warning naming the seed path and limit, and skips just that one seed file via `continue` semantics (the existing outer `catch` already swallowed missing-seed errors per-file), so other seed files still seed normally. `closeSync(opened.fd)` runs in `finally` regardless.
- Added two tests in `src/agents/sandbox/workspace.test.ts`:
  - `skips an oversized seed file but still seeds the others` - a >2 MiB `AGENTS.md` seed is skipped (not copied), while a normal `TOOLS.md` seed alongside it is still copied. An unbounded read would have copied the oversized file through, so this asserts the bound triggers and isolation holds.
  - `seeds a bootstrap file just under the byte read limit` - a file 1 byte under the limit is still copied, proving the bound is not too aggressive for legitimate seed files.
- Local prechecks green: `vitest run src/agents/sandbox/workspace.test.ts` -> 6 passed, 4 skipped; `oxlint` clean; `tsgo:core:test` exit 0.
