### PR TITLE
feat(macos): session detail parity — row actions, unread auto-clear, and subagent tree in native chat

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -705,6 +705,46 @@
       ]
     },
     {
+      "locale": "it",
+      "source": "Archive",
+      "translations": [
+        "Archivia",
+        "Archivio"
+      ]
+    },
+    {
+      "locale": "ko",
+      "source": "Archive",
+      "translations": [
+        "보관",
+        "아카이브"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Archive",
+      "translations": [
+        "Archiveer",
+        "Archiveren"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "Archive",
+      "translations": [
+        "Архив",
+        "Архивировать"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "Archive",
+      "translations": [
+        "Arkiv",
+        "Arkivera"
+      ]
+    },
+    {
       "locale": "fr",
       "source": "Asking OpenClaw",
       "translations": [
@@ -968,6 +1008,14 @@
       "translations": [
         "摄像头",
         "相机"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Cancel",
+      "translations": [
+        "Annuleer",
+        "Annuleren"
       ]
     },
     {
@@ -1495,14 +1543,6 @@
       ]
     },
     {
-      "locale": "zh-CN",
-      "source": "Connecting…",
-      "translations": [
-        "正在连接…",
-        "连接中…"
-      ]
-    },
-    {
       "locale": "zh-TW",
       "source": "Connecting…",
       "translations": [
@@ -1581,6 +1621,38 @@
       "translations": [
         "การควบคุม",
         "ควบคุม"
+      ]
+    },
+    {
+      "locale": "fa",
+      "source": "Copy Session Key",
+      "translations": [
+        "کپی کلید جلسه",
+        "کپی کلید نشست"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Copy Session Key",
+      "translations": [
+        "Kopieer sessiesleutel",
+        "Sessiesleutel kopiëren"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "Copy Session Key",
+      "translations": [
+        "Скопировать ключ сеанса",
+        "Скопировать ключ сессии"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Copy Session Key",
+      "translations": [
+        "Копіювати ключ сеансу",
+        "Копіювати ключ сесії"
       ]
     },
     {
@@ -1882,10 +1954,18 @@
       ]
     },
     {
+      "locale": "fa",
+      "source": "Delete Session",
+      "translations": [
+        "حذف جلسه",
+        "حذف نشست"
+      ]
+    },
+    {
       "locale": "hi",
       "source": "Delete Session",
       "translations": [
-        "सत्र हटाएं",
+        "सत्र हटाएँ",
         "सेशन हटाएँ"
       ]
     },
@@ -1895,14 +1975,6 @@
       "translations": [
         "Удалить сеанс",
         "Удалить сессию"
-      ]
-    },
-    {
-      "locale": "sv",
-      "source": "Delete Session",
-      "translations": [
-        "Radera session",
-        "Ta bort session"
       ]
     },
     {
@@ -2845,6 +2917,117 @@
       ]
     },
     {
+      "locale": "ar",
+      "source": "Fork",
+      "translations": [
+        "تشعيب",
+        "تفريع",
+        "تفرّع"
+      ]
+    },
+    {
+      "locale": "de",
+      "source": "Fork",
+      "translations": [
+        "Abzweigen",
+        "Fork"
+      ]
+    },
+    {
+      "locale": "fa",
+      "source": "Fork",
+      "translations": [
+        "Fork",
+        "انشعاب"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "Fork",
+      "translations": [
+        "Fork",
+        "फ़ोर्क करें"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "Fork",
+      "translations": [
+        "Buat Cabang",
+        "Fork"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "Fork",
+      "translations": [
+        "Crea fork",
+        "Duplica",
+        "Fork"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Fork",
+      "translations": [
+        "Afsplitsen",
+        "Fork",
+        "Splits af"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Fork",
+      "translations": [
+        "Fork",
+        "Rozgałęź",
+        "Utwórz odgałęzienie"
+      ]
+    },
+    {
+      "locale": "ru",
+      "source": "Fork",
+      "translations": [
+        "Ответвить",
+        "Создать ответвление",
+        "Форк"
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "Fork",
+      "translations": [
+        "แยกสาขา",
+        "แยกเซสชัน"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Fork",
+      "translations": [
+        "Відгалузити",
+        "Створити відгалуження",
+        "Форк"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "Fork",
+      "translations": [
+        "Phân nhánh",
+        "Tạo nhánh"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Fork",
+      "translations": [
+        "分叉",
+        "分支",
+        "创建分支"
+      ]
+    },
+    {
       "locale": "de",
       "source": "Gateway Auth Token",
       "translations": [
@@ -3000,8 +3183,16 @@
       "locale": "ar",
       "source": "Gateway connected",
       "translations": [
-        "تم اتصال Gateway",
-        "تم اتصال الـ Gateway"
+        "Gateway متصل",
+        "تم اتصال Gateway"
+      ]
+    },
+    {
+      "locale": "fa",
+      "source": "Gateway connected",
+      "translations": [
+        "Gateway متصل است",
+        "Gateway متصل شد"
       ]
     },
     {
@@ -3009,7 +3200,15 @@
       "source": "Gateway connected",
       "translations": [
         "Gateway に接続しました",
-        "Gateway接続済み"
+        "Gatewayに接続済み"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Gateway connected",
+      "translations": [
+        "Gateway połączony",
+        "Połączono z Gateway"
       ]
     },
     {
@@ -3018,14 +3217,6 @@
       "translations": [
         "Gateway подключен",
         "Gateway подключён"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Gateway connected",
-      "translations": [
-        "Gateway bağlandı",
-        "Gateway bağlı"
       ]
     },
     {
@@ -4279,6 +4470,54 @@
     },
     {
       "locale": "ar",
+      "source": "Mark Read",
+      "translations": [
+        "تحديد كمقروء",
+        "وضع علامة كمقروء"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "Mark Read",
+      "translations": [
+        "पठित चिह्नित करें",
+        "पढ़ा हुआ चिह्नित करें"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "Mark Read",
+      "translations": [
+        "Segna come letta",
+        "Segna come letto"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Mark Read",
+      "translations": [
+        "Markeer als gelezen",
+        "Markeren als gelezen"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Mark Read",
+      "translations": [
+        "Позначити прочитаним",
+        "Позначити як прочитане"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "Mark Read",
+      "translations": [
+        "Đánh dấu là đã đọc",
+        "Đánh dấu đã đọc"
+      ]
+    },
+    {
+      "locale": "ar",
       "source": "Message",
       "translations": [
         "Message",
@@ -4598,6 +4837,30 @@
       "translations": [
         "新建分组…",
         "新建组…"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "New Session",
+      "translations": [
+        "नया सत्र",
+        "नया सेशन"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "New Session",
+      "translations": [
+        "Нова сесія",
+        "Новий сеанс"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "New Session",
+      "translations": [
+        "Phiên Mới",
+        "Phiên mới"
       ]
     },
     {
@@ -6453,8 +6716,41 @@
     },
     {
       "locale": "es",
+      "source": "Rename",
+      "translations": [
+        "Cambiar nombre",
+        "Renombrar"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "Rename",
+      "translations": [
+        "Ganti Nama",
+        "Ubah Nama"
+      ]
+    },
+    {
+      "locale": "ko",
+      "source": "Rename",
+      "translations": [
+        "이름 바꾸기",
+        "이름 변경"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Rename",
+      "translations": [
+        "Hernoem",
+        "Hernoemen"
+      ]
+    },
+    {
+      "locale": "es",
       "source": "Rename Session",
       "translations": [
+        "Cambiar nombre de la sesión",
         "Cambiar nombre de sesión",
         "Renombrar sesión"
       ]
@@ -6476,6 +6772,14 @@
       ]
     },
     {
+      "locale": "id",
+      "source": "Rename Session",
+      "translations": [
+        "Ganti Nama Sesi",
+        "Ubah Nama Sesi"
+      ]
+    },
+    {
       "locale": "ko",
       "source": "Rename Session",
       "translations": [
@@ -6484,11 +6788,51 @@
       ]
     },
     {
+      "locale": "nl",
+      "source": "Rename Session",
+      "translations": [
+        "Hernoem sessie",
+        "Sessie hernoemen"
+      ]
+    },
+    {
       "locale": "ru",
       "source": "Rename Session",
       "translations": [
         "Переименовать сеанс",
         "Переименовать сессию"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Rename Session",
+      "translations": [
+        "Перейменувати сеанс",
+        "Перейменувати сесію"
+      ]
+    },
+    {
+      "locale": "es",
+      "source": "Rename…",
+      "translations": [
+        "Cambiar nombre…",
+        "Renombrar…"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "Rename…",
+      "translations": [
+        "Ganti nama…",
+        "Ubah nama…"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Rename…",
+      "translations": [
+        "Hernoemen…",
+        "Naam wijzigen…"
       ]
     },
     {
@@ -7181,19 +7525,11 @@
       ]
     },
     {
-      "locale": "hi",
+      "locale": "vi",
       "source": "Search sessions",
       "translations": [
-        "सत्र खोजें",
-        "सेशन खोजें"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "Search sessions",
-      "translations": [
-        "Пошук сеансів",
-        "Пошук сесій"
+        "Tìm kiếm phiên",
+        "Tìm phiên"
       ]
     },
     {
@@ -7305,7 +7641,16 @@
       "source": "Session name",
       "translations": [
         "Имя сессии",
-        "Название сеанса"
+        "Название сеанса",
+        "Название сессии"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Session name",
+      "translations": [
+        "Назва сеансу",
+        "Назва сесії"
       ]
     },
     {
@@ -8344,43 +8689,10 @@
       ]
     },
     {
-      "locale": "de",
-      "source": "Unarchive",
-      "translations": [
-        "Aus Archiv entfernen",
-        "Aus Archiv holen"
-      ]
-    },
-    {
-      "locale": "fa",
-      "source": "Unarchive",
-      "translations": [
-        "خارج کردن از بایگانی",
-        "خروج از بایگانی"
-      ]
-    },
-    {
-      "locale": "hi",
-      "source": "Unarchive",
-      "translations": [
-        "अनआर्काइव करें",
-        "संग्रह से हटाएं"
-      ]
-    },
-    {
-      "locale": "id",
-      "source": "Unarchive",
-      "translations": [
-        "Batalkan Pengarsipan",
-        "Batalkan arsip"
-      ]
-    },
-    {
       "locale": "it",
       "source": "Unarchive",
       "translations": [
         "Annulla archiviazione",
-        "Rimuovi dall'archivio",
         "Rimuovi dall’archivio"
       ]
     },
@@ -8390,14 +8702,6 @@
       "translations": [
         "アーカイブを解除",
         "アーカイブ解除"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Unarchive",
-      "translations": [
-        "Dearchiveren",
-        "Uit archief halen"
       ]
     },
     {
@@ -8414,22 +8718,6 @@
       "translations": [
         "Avarkivera",
         "Ta bort från arkiv"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Unarchive",
-      "translations": [
-        "ยกเลิกการเก็บถาวร",
-        "เลิกเก็บถาวร"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Unarchive",
-      "translations": [
-        "Arşivden Çıkar",
-        "Arşivden çıkar"
       ]
     },
     {
@@ -8519,6 +8807,14 @@
       "translations": [
         "Désépingler",
         "Détacher"
+      ]
+    },
+    {
+      "locale": "hi",
+      "source": "Unpin",
+      "translations": [
+        "अनपिन करें",
+        "पिन हटाएँ"
       ]
     },
     {

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36490,8 +36490,224 @@
       "id": "native.apple.7cd6fb01b9f5d14a"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 33,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Search sessions",
+      "surface": "apple",
+      "id": "native.apple.8ec708a3605a2cc3"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 38,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "No Sessions",
+      "surface": "apple",
+      "id": "native.apple.23b069b4e7f97039"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 39,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "No Results",
+      "surface": "apple",
+      "id": "native.apple.2d4ee298bdd1c05d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 49,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "New Session",
+      "surface": "apple",
+      "id": "native.apple.0058923f2ce8a3ec"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 51,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "New session",
+      "surface": "apple",
+      "id": "native.apple.66ba42960eb4135b"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 61,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Rename Session",
+      "surface": "apple",
+      "id": "native.apple.36753ef2f1ed4264"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 64,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Session name",
+      "surface": "apple",
+      "id": "native.apple.c9de0a1510ef475f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 65,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Rename",
+      "surface": "apple",
+      "id": "native.apple.6ec5a13c0e6c20d9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 71,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.4c76665d89af4bec"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 76,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Delete Session",
+      "surface": "apple",
+      "id": "native.apple.afb4e6c99c63a28d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 83,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "The session and its transcript are removed from the gateway.",
+      "surface": "apple",
+      "id": "native.apple.3d4ef32e42f136a4"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 105,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Delete “%@”?",
+      "surface": "apple",
+      "id": "native.apple.90bcad5f067b4be1"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 153,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Session running",
+      "surface": "apple",
+      "id": "native.apple.9a7dca238fba628d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 158,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Session failed",
+      "surface": "apple",
+      "id": "native.apple.fcfbfe5e97a95e9c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 167,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Unread",
+      "surface": "apple",
+      "id": "native.apple.ac85292b16a7465f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 177,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Rename…",
+      "surface": "apple",
+      "id": "native.apple.a174cb1027a9b881"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 183,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Pin",
+      "surface": "apple",
+      "id": "native.apple.134d6bf84d58fb38"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 183,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Unpin",
+      "surface": "apple",
+      "id": "native.apple.e7815cc4ba359513"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 189,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Fork",
+      "surface": "apple",
+      "id": "native.apple.83f9f2db7eef6a19"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 195,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Mark Read",
+      "surface": "apple",
+      "id": "native.apple.235614194dc19df2"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 195,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Mark Unread",
+      "surface": "apple",
+      "id": "native.apple.bc71f0d20b7f72a0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 206,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Archive",
+      "surface": "apple",
+      "id": "native.apple.c9e118f6aae18d97"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 206,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Restore",
+      "surface": "apple",
+      "id": "native.apple.10365a351a1b58b3"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 215,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Copy Session Key",
+      "surface": "apple",
+      "id": "native.apple.660f63319b89bd8e"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 224,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Delete Session…",
+      "surface": "apple",
+      "id": "native.apple.4aeb7c14c26dabac"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 254,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Gateway connected",
+      "surface": "apple",
+      "id": "native.apple.6a3425ea2811ff88"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 255,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
+      "source": "Connecting…",
+      "surface": "apple",
+      "id": "native.apple.e3958d1053259f1d"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 37,
+      "line": 67,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -36578,8 +36794,24 @@
       "id": "native.apple.b2435a79abf0c794"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 162,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Restore",
+      "surface": "apple",
+      "id": "native.apple.f0e9d8f69c1d9190"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 163,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Archive",
+      "surface": "apple",
+      "id": "native.apple.666ba6eb696e649f"
+    },
+    {
       "kind": "ui-modifier",
-      "line": 194,
+      "line": 197,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -36587,7 +36819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 227,
+      "line": 235,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename",
       "surface": "apple",
@@ -36595,7 +36827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 235,
+      "line": 243,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pin",
       "surface": "apple",
@@ -36603,27 +36835,35 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 235,
+      "line": 243,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unpin",
       "surface": "apple",
       "id": "native.apple.3c62aaf44e6ab4d4"
     },
     {
-      "kind": "conditional-branch",
-      "line": 244,
+      "kind": "ui-localized-call",
+      "line": 264,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Archive",
+      "source": "Fork",
       "surface": "apple",
-      "id": "native.apple.666ba6eb696e649f"
+      "id": "native.apple.6de479e9d780869a"
     },
     {
-      "kind": "conditional-branch",
-      "line": 244,
+      "kind": "ui-localized-call",
+      "line": 273,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Unarchive",
+      "source": "Mark Read",
       "surface": "apple",
-      "id": "native.apple.34b910911a05110e"
+      "id": "native.apple.1398a2f69867f22d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 274,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Mark Unread",
+      "surface": "apple",
+      "id": "native.apple.4f259c4409cfcc75"
     },
     {
       "kind": "conditional-branch",
@@ -36851,7 +37091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1002,
+      "line": 1027,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -36859,7 +37099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1060,
+      "line": 1085,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
@@ -36867,7 +37107,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 70,
+      "line": 73,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear this session's history?",
       "surface": "apple",
@@ -36875,7 +37115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 76,
+      "line": 79,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear History",
       "surface": "apple",
@@ -36883,15 +37123,47 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 81,
+      "line": 84,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "This resets the conversation for %@. The session key stays the same.",
       "surface": "apple",
       "id": "native.apple.6222c1b2e42e123e"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 90,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Rename Session",
+      "surface": "apple",
+      "id": "native.apple.a92e96bed98bd553"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 91,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Session name",
+      "surface": "apple",
+      "id": "native.apple.848e2388f3466f40"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 92,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Rename",
+      "surface": "apple",
+      "id": "native.apple.8d636ca6b4764418"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 97,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.32b4a79f1b889aa6"
+    },
+    {
       "kind": "ui-call",
-      "line": 124,
+      "line": 138,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -36899,7 +37171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 133,
+      "line": 147,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Sessions",
       "surface": "apple",
@@ -36907,7 +37179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 205,
+      "line": 231,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -36915,7 +37187,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 209,
+      "line": 235,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Thinking level",
       "surface": "apple",
@@ -36923,7 +37195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 225,
+      "line": 251,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -36931,7 +37203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 228,
+      "line": 254,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Recent",
       "surface": "apple",
@@ -36939,7 +37211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 231,
+      "line": 257,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Models",
       "surface": "apple",
@@ -36947,7 +37219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 235,
+      "line": 261,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Model",
       "surface": "apple",
@@ -36955,7 +37227,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 263,
+      "line": 281,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "New Session",
+      "surface": "apple",
+      "id": "native.apple.eb58552e43c8dde2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 289,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36963,151 +37243,79 @@
     },
     {
       "kind": "ui-call",
-      "line": 270,
+      "line": 296,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Sessions…",
       "surface": "apple",
       "id": "native.apple.2bcff4a8fa503739"
     },
     {
-      "kind": "ui-call",
-      "line": 285,
+      "kind": "ui-localized-call",
+      "line": 308,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Export Transcript…",
+      "source": "Rename Session…",
       "surface": "apple",
-      "id": "native.apple.9b2ad72143b931bf"
-    },
-    {
-      "kind": "ui-call",
-      "line": 297,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Show reasoning & tool activity",
-      "surface": "apple",
-      "id": "native.apple.3294ababd29c4457"
-    },
-    {
-      "kind": "ui-call",
-      "line": 314,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Clear History…",
-      "surface": "apple",
-      "id": "native.apple.4b24d792545e5086"
-    },
-    {
-      "kind": "ui-call",
-      "line": 317,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Session",
-      "surface": "apple",
-      "id": "native.apple.920fe8a7a33f9e92"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 320,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Session actions",
-      "surface": "apple",
-      "id": "native.apple.185a401f78328b0f"
+      "id": "native.apple.c36e008b051adb38"
     },
     {
       "kind": "ui-localized-call",
-      "line": 354,
+      "line": 316,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Session cost %@",
+      "source": "Fork Session",
       "surface": "apple",
-      "id": "native.apple.9f9dedf599b2619b"
+      "id": "native.apple.ea0ef95a159bffe0"
     },
     {
-      "kind": "ui-call",
-      "line": 360,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Compact Session",
-      "surface": "apple",
-      "id": "native.apple.f0a4720df5f5f403"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 408,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Search sessions",
-      "surface": "apple",
-      "id": "native.apple.0b9fc81ff2031799"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 412,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "No Results",
-      "surface": "apple",
-      "id": "native.apple.f10d5ccfd0530fec"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 412,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "No Sessions",
-      "surface": "apple",
-      "id": "native.apple.42b0ee4c8b3326b6"
-    },
-    {
-      "kind": "ui-call",
-      "line": 424,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "New Session",
-      "surface": "apple",
-      "id": "native.apple.eb58552e43c8dde2"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 426,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "New session",
-      "surface": "apple",
-      "id": "native.apple.247771e4350c006f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 447,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Delete Session",
-      "surface": "apple",
-      "id": "native.apple.d9a72d07e8d95d35"
-    },
-    {
-      "kind": "ui-call",
-      "line": 451,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "The session and its transcript are removed from the gateway.",
-      "surface": "apple",
-      "id": "native.apple.499537ec30a28ae0"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 502,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Unread",
-      "surface": "apple",
-      "id": "native.apple.1bd1b747fd161df5"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 512,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Pin",
-      "surface": "apple",
-      "id": "native.apple.a8a2f4b248663f97"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 512,
+      "kind": "ui-localized-call",
+      "line": 327,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Unpin",
       "surface": "apple",
       "id": "native.apple.8768f9ed198edc54"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 328,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Pin",
+      "surface": "apple",
+      "id": "native.apple.a8a2f4b248663f97"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 339,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Mark Read",
+      "surface": "apple",
+      "id": "native.apple.e53f1d7e094dc542"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 340,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Mark Unread",
+      "surface": "apple",
+      "id": "native.apple.99579b05ec001672"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 356,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Restore",
+      "surface": "apple",
+      "id": "native.apple.b39c58e213137cc8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 357,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Archive",
+      "surface": "apple",
+      "id": "native.apple.6f5686f621b44307"
+    },
+    {
       "kind": "ui-call",
-      "line": 519,
+      "line": 369,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Copy Session Key",
       "surface": "apple",
@@ -37115,27 +37323,59 @@
     },
     {
       "kind": "ui-call",
-      "line": 530,
+      "line": 375,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Delete Session…",
+      "source": "Export Transcript…",
       "surface": "apple",
-      "id": "native.apple.a994d072ab35cb35"
+      "id": "native.apple.9b2ad72143b931bf"
     },
     {
-      "kind": "conditional-branch",
-      "line": 550,
+      "kind": "ui-call",
+      "line": 387,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Connecting…",
+      "source": "Show reasoning & tool activity",
       "surface": "apple",
-      "id": "native.apple.22d5ce71e22a7f73"
+      "id": "native.apple.3294ababd29c4457"
     },
     {
-      "kind": "conditional-branch",
-      "line": 550,
+      "kind": "ui-call",
+      "line": 404,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Gateway connected",
+      "source": "Clear History…",
       "surface": "apple",
-      "id": "native.apple.8d0606ab1a2c0f44"
+      "id": "native.apple.4b24d792545e5086"
+    },
+    {
+      "kind": "ui-call",
+      "line": 407,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Session",
+      "surface": "apple",
+      "id": "native.apple.920fe8a7a33f9e92"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 410,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Session actions",
+      "surface": "apple",
+      "id": "native.apple.185a401f78328b0f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 444,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Session cost %@",
+      "surface": "apple",
+      "id": "native.apple.9f9dedf599b2619b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 450,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Compact Session",
+      "surface": "apple",
+      "id": "native.apple.f0a4720df5f5f403"
     },
     {
       "kind": "ui-call",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -22809,6 +22809,141 @@
       "translated": "المستخدم"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "البحث في الجلسات"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "لا توجد جلسات"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "لا توجد نتائج"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "جلسة جديدة"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "جلسة جديدة"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "إعادة تسمية الجلسة"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "اسم الجلسة"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "إعادة تسمية"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "إلغاء"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "حذف الجلسة"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "تتم إزالة الجلسة ونصها من Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "حذف «%@»؟"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "الجلسة قيد التشغيل"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "فشلت الجلسة"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "غير مقروء"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "إعادة تسمية…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "تثبيت"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "إلغاء التثبيت"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "تشعيب"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "تحديد كمقروء"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "وضع علامة كغير مقروء"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "أرشفة"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "استعادة"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "نسخ مفتاح الجلسة"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "حذف الجلسة…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway متصل"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "جارٍ الاتصال…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "مثبّت"
@@ -22864,6 +22999,16 @@
       "translated": "لم يتم العثور على جلسات"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "استعادة"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "أرشفة"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "مثبّت"
@@ -22884,14 +23029,19 @@
       "translated": "إلغاء التثبيت"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "أرشفة"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "تفرّع"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "إلغاء الأرشفة"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "وضع علامة كمقروء"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "وضع علامة كغير مقروء"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "سيؤدي هذا إلى إعادة تعيين المحادثة لـ %@. سيبقى مفتاح الجلسة كما هو."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "إعادة تسمية الجلسة"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "اسم الجلسة"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "إعادة تسمية"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "إلغاء"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "تصدير النص"
@@ -23099,6 +23269,11 @@
       "translated": "النموذج"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "جلسة جديدة"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "تحديث"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "الجلسات…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "إعادة تسمية الجلسة…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "تفرّع الجلسة"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "إلغاء التثبيت"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "تثبيت"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "وضع علامة كمقروء"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "وضع علامة كغير مقروء"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "استعادة"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "أرشفة"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "نسخ مفتاح الجلسة"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "ضغط الجلسة"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "البحث في الجلسات"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "لا توجد نتائج"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "لا توجد جلسات"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "جلسة جديدة"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "جلسة جديدة"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "حذف الجلسة"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "تتم إزالة الجلسة ونصها من الـ Gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "غير مقروء"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "تثبيت"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "إلغاء التثبيت"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "نسخ مفتاح الجلسة"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "حذف الجلسة…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "جارٍ الاتصال…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "تم اتصال الـ Gateway"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -22809,6 +22809,141 @@
       "translated": "Benutzer"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Sitzungen durchsuchen"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Keine Sitzungen"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Keine Ergebnisse"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Neue Sitzung"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Neue Sitzung"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Sitzung umbenennen"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Sitzungsname"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Umbenennen"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Abbrechen"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Sitzung löschen"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Die Sitzung und ihr Transkript werden vom Gateway entfernt."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "„%@“ löschen?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sitzung wird ausgeführt"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sitzung fehlgeschlagen"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Ungelesen"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Umbenennen…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Anheften"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Loslösen"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Abzweigen"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Als gelesen markieren"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Als ungelesen markieren"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Archivieren"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Wiederherstellen"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Sitzungsschlüssel kopieren"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Sitzung löschen…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway verbunden"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Verbindung wird hergestellt…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Angeheftet"
@@ -22864,6 +22999,16 @@
       "translated": "Keine Sitzungen gefunden"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Wiederherstellen"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Archivieren"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Angeheftet"
@@ -22884,14 +23029,19 @@
       "translated": "Lösen"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Archivieren"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Abzweigen"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Aus Archiv holen"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Als gelesen markieren"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Als ungelesen markieren"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Dadurch wird die Unterhaltung für %@ zurückgesetzt. Der Sitzungsschlüssel bleibt unverändert."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Sitzung umbenennen"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Sitzungsname"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Umbenennen"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Abbrechen"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Transkript exportieren"
@@ -23099,6 +23269,11 @@
       "translated": "Modell"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Neue Sitzung"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Aktualisieren"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sitzungen…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Sitzung umbenennen…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Sitzung abzweigen"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Loslösen"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Anpinnen"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Als gelesen markieren"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Als ungelesen markieren"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Wiederherstellen"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Archivieren"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Sitzungsschlüssel kopieren"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Sitzung komprimieren"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Sitzungen durchsuchen"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Keine Ergebnisse"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Keine Sitzungen"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Neue Sitzung"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Neue Sitzung"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Sitzung löschen"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Die Sitzung und ihr Transkript werden vom Gateway entfernt."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Ungelesen"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Anpinnen"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Loslösen"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Sitzungsschlüssel kopieren"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Sitzung löschen…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Verbinden…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway verbunden"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -22809,6 +22809,141 @@
       "translated": "Usuario"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Buscar sesiones"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "No hay sesiones"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "No hay resultados"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nueva sesión"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nueva sesión"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Cambiar nombre de la sesión"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nombre de la sesión"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Cambiar nombre"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Eliminar sesión"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "La sesión y su transcripción se eliminan del Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "¿Eliminar “%@”?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sesión en curso"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Error en la sesión"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "No leído"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Cambiar nombre…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Fijar"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Desfijar"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Bifurcar"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Marcar como leído"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Marcar como no leído"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Archivar"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Restaurar"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Copiar clave de sesión"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Eliminar sesión…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway conectado"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Conectando…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Fijado"
@@ -22864,6 +22999,16 @@
       "translated": "No se encontraron sesiones"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Restaurar"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Archivar"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Fijadas"
@@ -22884,14 +23029,19 @@
       "translated": "Dejar de fijar"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Archivar"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Bifurcar"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Desarchivar"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Marcar como leído"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Marcar como no leído"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Esto reinicia la conversación para %@. La clave de sesión permanece igual."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Renombrar sesión"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nombre de la sesión"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Renombrar"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Exportar transcripción"
@@ -23099,6 +23269,11 @@
       "translated": "Modelo"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nueva sesión"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Actualizar"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sesiones…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Renombrar sesión…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Bifurcar sesión"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Dejar de fijar"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Fijar"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Marcar como leído"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Marcar como no leído"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Restaurar"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Archivar"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Copiar clave de sesión"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Compactar sesión"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Buscar sesiones"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Sin resultados"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Sin sesiones"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nueva sesión"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Nueva sesión"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Eliminar sesión"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "La sesión y su transcripción se eliminan del gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "No leído"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Fijar"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Dejar de fijar"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Copiar clave de sesión"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Eliminar sesión…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Conectando…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway conectado"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -22809,6 +22809,141 @@
       "translated": "کاربر"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "جستجوی نشست‌ها"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "هیچ نشستی وجود ندارد"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "نتیجه‌ای یافت نشد"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "نشست جدید"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "نشست جدید"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "تغییر نام نشست"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "نام نشست"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "تغییر نام"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "لغو"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "حذف نشست"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "نشست و رونوشت آن از Gateway حذف می‌شوند."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "«%@» حذف شود؟"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "نشست در حال اجرا است"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "نشست ناموفق بود"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "خوانده‌نشده"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "تغییر نام…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "سنجاق کردن"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "برداشتن سنجاق"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "انشعاب"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "علامت‌گذاری به‌عنوان خوانده‌شده"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "علامت‌گذاری به‌عنوان خوانده‌نشده"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "بایگانی"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "بازیابی"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "کپی کلید نشست"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "حذف نشست…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway متصل است"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "در حال اتصال…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "سنجاق‌شده"
@@ -22864,6 +22999,16 @@
       "translated": "نشستی یافت نشد"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "بازیابی"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "بایگانی"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "سنجاق‌شده"
@@ -22884,14 +23029,19 @@
       "translated": "برداشتن سنجاق"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "بایگانی"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "انشعاب"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "خروج از بایگانی"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "علامت‌گذاری به‌عنوان خوانده‌شده"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "علامت‌گذاری به‌عنوان خوانده‌نشده"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "با این کار مکالمه برای %@ بازنشانی می‌شود. کلید نشست بدون تغییر باقی می‌ماند."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "تغییر نام نشست"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "نام نشست"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "تغییر نام"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "لغو"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "خروجی گرفتن رونوشت"
@@ -23099,6 +23269,11 @@
       "translated": "مدل"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "نشست جدید"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "بازخوانی"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "جلسه‌ها…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "تغییر نام نشست…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "انشعاب نشست"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "برداشتن سنجاق"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "سنجاق کردن"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "علامت‌گذاری به‌عنوان خوانده‌شده"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "علامت‌گذاری به‌عنوان خوانده‌نشده"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "بازیابی"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "بایگانی"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "کپی کلید جلسه"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "فشرده‌سازی نشست"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "جستجوی نشست‌ها"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "نتیجه‌ای نیست"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "نشستی نیست"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "نشست جدید"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "جلسه جدید"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "حذف جلسه"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "جلسه و رونوشت آن از Gateway حذف می‌شوند."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "خوانده‌نشده"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "سنجاق کردن"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "برداشتن سنجاق"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "کپی کلید جلسه"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "حذف جلسه…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "در حال اتصال…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway متصل شد"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -22809,6 +22809,141 @@
       "translated": "Utilisateur"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Rechercher des sessions"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Aucune session"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Aucun résultat"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nouvelle session"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nouvelle session"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Renommer la session"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nom de la session"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Renommer"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Annuler"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Supprimer la session"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "La session et sa transcription sont supprimées du Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Supprimer « %@ » ?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Session en cours"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Échec de la session"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Non lu"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Renommer…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Épingler"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Désépingler"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Dupliquer"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Marquer comme lu"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Marquer comme non lu"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Archiver"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Restaurer"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Copier la clé de session"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Supprimer la session…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway connecté"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Connexion…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Épinglé"
@@ -22864,6 +22999,16 @@
       "translated": "Aucune session trouvée"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Restaurer"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Archiver"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Épinglé"
@@ -22884,14 +23029,19 @@
       "translated": "Désépingler"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Archiver"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Dupliquer"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Désarchiver"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Marquer comme lu"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Marquer comme non lu"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Cette opération réinitialise la conversation pour %@. La clé de session reste la même."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Renommer la session"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nom de la session"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Renommer"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Annuler"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Exporter la transcription"
@@ -23099,6 +23269,11 @@
       "translated": "Modèle"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nouvelle session"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Actualiser"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sessions…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Renommer la session…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Dupliquer la session"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Désépingler"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Épingler"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Marquer comme lu"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Marquer comme non lu"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Restaurer"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Archiver"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Copier la clé de session"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Compacter la session"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Rechercher des sessions"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Aucun résultat"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Aucune session"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nouvelle session"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Nouvelle session"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Supprimer la session"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "La session et sa transcription sont supprimées du gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Non lu"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Épingler"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Désépingler"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Copier la clé de session"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Supprimer la session…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Connexion…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway connecté"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -22809,6 +22809,141 @@
       "translated": "उपयोगकर्ता"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "सत्र खोजें"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "कोई सत्र नहीं"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "कोई परिणाम नहीं"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "नया सत्र"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "नया सत्र"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "सत्र का नाम बदलें"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "सत्र का नाम"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "नाम बदलें"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "रद्द करें"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "सत्र हटाएँ"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "सत्र और उसकी ट्रांसक्रिप्ट Gateway से हटा दिए जाते हैं।"
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "“%@” को हटाएँ?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "सत्र चल रहा है"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "सत्र विफल रहा"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "अपठित"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "नाम बदलें…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "पिन करें"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "पिन हटाएँ"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "फ़ोर्क करें"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "पढ़ा हुआ चिह्नित करें"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "अपठित चिह्नित करें"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "संग्रहित करें"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "पुनर्स्थापित करें"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "सत्र कुंजी कॉपी करें"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "सत्र हटाएँ…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway कनेक्ट हो गया"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "कनेक्ट हो रहा है…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "पिन किया गया"
@@ -22864,6 +22999,16 @@
       "translated": "कोई सत्र नहीं मिला"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "पुनर्स्थापित करें"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "संग्रहित करें"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "पिन किया गया"
@@ -22884,14 +23029,19 @@
       "translated": "अनपिन करें"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "संग्रहित करें"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "फ़ोर्क करें"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "संग्रह से हटाएं"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "पठित चिह्नित करें"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "अपठित चिह्नित करें"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "यह %@ के लिए बातचीत रीसेट करता है। सेशन कुंजी वही रहती है।"
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "सत्र का नाम बदलें"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "सत्र का नाम"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "नाम बदलें"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "रद्द करें"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "ट्रांसक्रिप्ट निर्यात करें"
@@ -23099,6 +23269,11 @@
       "translated": "मॉडल"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "नया सेशन"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "रीफ़्रेश करें"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "सत्र…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "सत्र का नाम बदलें…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "सत्र को फ़ोर्क करें"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "अनपिन करें"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "पिन करें"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "पठित चिह्नित करें"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "अपठित चिह्नित करें"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "पुनर्स्थापित करें"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "संग्रहित करें"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "सत्र कुंजी कॉपी करें"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "सेशन कॉम्पैक्ट करें"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "सेशन खोजें"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "कोई परिणाम नहीं"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "कोई सेशन नहीं"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "नया सेशन"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "नया सत्र"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "सत्र हटाएं"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "सत्र और उसका ट्रांसक्रिप्ट Gateway से हटा दिए गए हैं।"
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "अपठित"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "पिन करें"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "अनपिन करें"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "सत्र कुंजी कॉपी करें"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "सत्र हटाएं…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "कनेक्ट हो रहा है…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway कनेक्ट हो गया"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -22809,6 +22809,141 @@
       "translated": "Pengguna"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Cari sesi"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Tidak Ada Sesi"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Tidak Ada Hasil"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Sesi Baru"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Sesi baru"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Ubah Nama Sesi"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nama sesi"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Ubah Nama"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Batal"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Hapus Sesi"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Sesi dan transkripnya dihapus dari gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Hapus “%@”?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sesi sedang berjalan"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sesi gagal"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Belum dibaca"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Ubah nama…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Sematkan"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Lepas Sematan"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Buat Cabang"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Tandai Sudah Dibaca"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Tandai Belum Dibaca"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Arsipkan"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Pulihkan"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Salin Kunci Sesi"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Hapus Sesi…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway terhubung"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Menghubungkan…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Disematkan"
@@ -22864,6 +22999,16 @@
       "translated": "Tidak ada sesi ditemukan"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Pulihkan"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Arsipkan"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Disematkan"
@@ -22884,14 +23029,19 @@
       "translated": "Lepas Sematan"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Arsipkan"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Fork"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Batalkan Pengarsipan"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Tandai Sudah Dibaca"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Tandai Belum Dibaca"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Tindakan ini mengatur ulang percakapan untuk %@. Kunci sesi tetap sama."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Ubah Nama Sesi"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nama sesi"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Ubah Nama"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Batal"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Ekspor Transkrip"
@@ -23099,6 +23269,11 @@
       "translated": "Model"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Sesi Baru"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Segarkan"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sesi…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Ubah Nama Sesi…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Fork Sesi"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Lepas sematan"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Sematkan"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Tandai Sudah Dibaca"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Tandai Belum Dibaca"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Pulihkan"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Arsip"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Salin Kunci Sesi"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Ringkas Sesi"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Cari sesi"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Tidak Ada Hasil"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Tidak Ada Sesi"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Sesi Baru"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Sesi baru"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Hapus Sesi"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Sesi dan transkripnya dihapus dari gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Belum dibaca"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Sematkan"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Lepas sematan"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Salin Kunci Sesi"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Hapus Sesi…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Menghubungkan…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway terhubung"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -22809,6 +22809,141 @@
       "translated": "Utente"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Cerca sessioni"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Nessuna sessione"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Nessun risultato"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nuova sessione"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nuova sessione"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Rinomina sessione"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nome della sessione"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Rinomina"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Annulla"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Elimina sessione"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "La sessione e la relativa trascrizione vengono rimosse dal Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Eliminare “%@”?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessione in corso"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sessione non riuscita"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Da leggere"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Rinomina…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Fissa"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Rimuovi"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Duplica"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Segna come letto"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Segna come non letta"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Archivia"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Ripristina"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Copia chiave sessione"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Elimina sessione…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway connesso"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Connessione…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Fissato"
@@ -22864,6 +22999,16 @@
       "translated": "Nessuna sessione trovata"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Ripristina"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Archivia"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Fissato"
@@ -22884,14 +23029,19 @@
       "translated": "Rimuovi"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Archivia"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Crea fork"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Rimuovi dall'archivio"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Segna come letta"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Segna come non letta"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Questa operazione reimposta la conversazione per %@. La chiave di sessione rimane invariata."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Rinomina sessione"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nome sessione"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Rinomina"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Annulla"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Esporta trascrizione"
@@ -23099,6 +23269,11 @@
       "translated": "Modello"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nuova sessione"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Aggiorna"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sessioni…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Rinomina sessione…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Crea fork della sessione"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Rimuovi fissaggio"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Fissa"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Segna come letta"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Segna come non letta"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Ripristina"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Archivio"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Copia chiave sessione"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Comprimi sessione"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Cerca sessioni"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Nessun risultato"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Nessuna sessione"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nuova sessione"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Nuova sessione"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Elimina sessione"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "La sessione e la relativa trascrizione vengono rimosse dal gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Non letto"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Fissa"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Rimuovi fissaggio"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Copia chiave sessione"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Elimina sessione…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Connessione in corso…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway connesso"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -22809,6 +22809,141 @@
       "translated": "ユーザー"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "セッションを検索"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "セッションがありません"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "結果がありません"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "新規セッション"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "新規セッション"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "セッション名を変更"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "セッション名"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "名前を変更"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "キャンセル"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "セッションを削除"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "セッションとそのトランスクリプトがGatewayから削除されます。"
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "「%@」を削除しますか？"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "セッションを実行中"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "セッションに失敗しました"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "未読"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "名前を変更…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "ピン留め"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "ピン留めを解除"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "フォーク"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "既読にする"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "未読にする"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "アーカイブ"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "復元"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "セッションキーをコピー"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "セッションを削除…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gatewayに接続済み"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "接続中…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "ピン留め済み"
@@ -22864,6 +22999,16 @@
       "translated": "セッションが見つかりません"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "復元"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "アーカイブ"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "ピン留め済み"
@@ -22884,14 +23029,19 @@
       "translated": "ピン留めを解除"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "アーカイブ"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "フォーク"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "アーカイブ解除"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "既読にする"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "未読にする"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "%@の会話がリセットされます。セッションキーは変更されません。"
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "セッション名を変更"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "セッション名"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "名前を変更"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "キャンセル"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "トランスクリプトをエクスポート"
@@ -23099,6 +23269,11 @@
       "translated": "モデル"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "新規セッション"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "更新"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "セッション…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "セッション名を変更…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "セッションをフォーク"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "ピン留めを解除"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "ピン留め"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "既読にする"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "未読にする"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "復元"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "アーカイブ"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "セッションキーをコピー"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "セッションを圧縮"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "セッションを検索"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "結果なし"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "セッションなし"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "新規セッション"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "新しいセッション"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "セッションを削除"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "セッションとそのトランスクリプトがGatewayから削除されます。"
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "未読"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "ピン留め"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "ピン留めを解除"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "セッションキーをコピー"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "セッションを削除…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "接続中…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway接続済み"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -22809,6 +22809,141 @@
       "translated": "사용자"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "세션 검색"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "세션 없음"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "결과 없음"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "새 세션"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "새 세션"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "세션 이름 변경"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "세션 이름"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "이름 변경"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "취소"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "세션 삭제"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "세션과 해당 대화 기록이 Gateway에서 삭제됩니다."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "“%@”을(를) 삭제하시겠습니까?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "세션 실행 중"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "세션 실패"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "읽지 않음"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "이름 변경…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "고정"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "고정 해제"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "포크"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "읽음으로 표시"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "읽지 않음으로 표시"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "보관"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "복원"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "세션 키 복사"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "세션 삭제…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway 연결됨"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "연결 중…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "고정됨"
@@ -22864,6 +22999,16 @@
       "translated": "세션을 찾을 수 없음"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "복원"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "보관"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "고정됨"
@@ -22884,14 +23029,19 @@
       "translated": "고정 해제"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "보관"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "포크"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "보관 해제"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "읽음으로 표시"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "읽지 않음으로 표시"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "%@의 대화가 초기화됩니다. 세션 키는 그대로 유지됩니다."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "세션 이름 변경"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "세션 이름"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "이름 변경"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "취소"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "기록 내보내기"
@@ -23099,6 +23269,11 @@
       "translated": "모델"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "새 세션"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "새로 고침"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "세션…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "세션 이름 변경…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "세션 포크"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "고정 해제"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "고정"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "읽음으로 표시"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "읽지 않음으로 표시"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "복원"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "아카이브"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "세션 키 복사"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "세션 압축"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "세션 검색"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "결과 없음"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "세션 없음"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "새 세션"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "새 세션"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "세션 삭제"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "세션과 대화 기록이 Gateway에서 제거됩니다."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "읽지 않음"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "고정"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "고정 해제"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "세션 키 복사"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "세션 삭제…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "연결 중…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway 연결됨"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -22809,6 +22809,141 @@
       "translated": "Gebruiker"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Sessies zoeken"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Geen sessies"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Geen resultaten"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nieuwe sessie"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nieuwe sessie"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Sessie hernoemen"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Sessienaam"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Hernoemen"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Annuleren"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Sessie verwijderen"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "De sessie en het transcript ervan worden uit de Gateway verwijderd."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "‘%@’ verwijderen?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessie actief"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sessie mislukt"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Ongelezen"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Hernoemen…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Vastmaken"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Losmaken"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Afsplitsen"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Markeren als gelezen"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Markeer als ongelezen"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Archiveer"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Herstel"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Kopieer sessiesleutel"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Verwijder sessie…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway verbonden"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Verbinden…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Vastgezet"
@@ -22864,6 +22999,16 @@
       "translated": "Geen sessies gevonden"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Herstel"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Archiveren"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Vastgezet"
@@ -22884,14 +23029,19 @@
       "translated": "Losmaken"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Archiveren"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Splits af"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Dearchiveren"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Markeer als gelezen"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Markeer als ongelezen"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Hiermee wordt het gesprek voor %@ gereset. De sessiesleutel blijft hetzelfde."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Hernoem sessie"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Sessienaam"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Hernoem"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Annuleer"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Transcript exporteren"
@@ -23099,6 +23269,11 @@
       "translated": "Model"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nieuwe sessie"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Vernieuwen"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sessies…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Hernoem sessie…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Splits sessie af"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Losmaken"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Vastmaken"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Markeer als gelezen"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Markeer als ongelezen"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Herstel"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Archiveer"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Sessiesleutel kopiëren"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Sessie comprimeren"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Sessies zoeken"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Geen resultaten"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Geen sessies"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nieuwe sessie"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Nieuwe sessie"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Sessie verwijderen"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "De sessie en het transcript worden van de gateway verwijderd."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Ongelezen"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Vastmaken"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Losmaken"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Sessiesleutel kopiëren"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Sessie verwijderen…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Verbinden…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway verbonden"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -22809,6 +22809,141 @@
       "translated": "Użytkownik"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Szukaj sesji"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Brak sesji"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Brak wyników"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nowa sesja"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nowa sesja"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Zmień nazwę sesji"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nazwa sesji"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Zmień nazwę"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Anuluj"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Usuń sesję"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Sesja i jej transkrypcja zostaną usunięte z Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Usunąć „%@”?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sesja jest uruchomiona"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sesja nie powiodła się"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Nieprzeczytane"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Zmień nazwę…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Przypnij"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Odepnij"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Rozgałęź"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Oznacz jako przeczytane"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Oznacz jako nieprzeczytane"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Archiwizuj"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Przywróć"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Kopiuj klucz sesji"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Usuń sesję…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Połączono z Gateway"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Łączenie…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Przypięte"
@@ -22864,6 +22999,16 @@
       "translated": "Nie znaleziono sesji"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Przywróć"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Archiwizuj"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Przypięte"
@@ -22884,14 +23029,19 @@
       "translated": "Odepnij"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Archiwizuj"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Utwórz odgałęzienie"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Przywróć z archiwum"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Oznacz jako przeczytane"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Oznacz jako nieprzeczytane"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Spowoduje to zresetowanie rozmowy dla %@. Klucz sesji pozostanie bez zmian."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Zmień nazwę sesji"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nazwa sesji"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Zmień nazwę"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Anuluj"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Eksportuj transkrypcję"
@@ -23099,6 +23269,11 @@
       "translated": "Model"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nowa sesja"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Odśwież"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sesje…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Zmień nazwę sesji…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Utwórz odgałęzienie sesji"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Odepnij"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Przypnij"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Oznacz jako przeczytane"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Oznacz jako nieprzeczytane"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Przywróć"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Archiwizuj"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Kopiuj klucz sesji"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Kompaktuj sesję"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Szukaj sesji"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Brak wyników"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Brak sesji"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nowa sesja"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Nowa sesja"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Usuń sesję"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Sesja i jej transkrypcja zostaną usunięte z gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Nieprzeczytane"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Przypnij"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Odepnij"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Kopiuj klucz sesji"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Usuń sesję…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Łączenie…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway połączony"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -22809,6 +22809,141 @@
       "translated": "Usuário"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Buscar sessões"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Nenhuma sessão"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Nenhum resultado"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nova sessão"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nova sessão"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Renomear sessão"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nome da sessão"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Renomear"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Excluir sessão"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "A sessão e sua transcrição são removidas do Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Excluir “%@”?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessão em execução"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Falha na sessão"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Não lida"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Renomear…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Fixar"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Desafixar"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Bifurcar"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Marcar como lida"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Marcar como não lida"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Arquivar"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Restaurar"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Copiar chave da sessão"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Excluir sessão…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway conectado"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Conectando…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Fixado"
@@ -22864,6 +22999,16 @@
       "translated": "Nenhuma sessão encontrada"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Restaurar"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Arquivar"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Fixada"
@@ -22884,14 +23029,19 @@
       "translated": "Desafixar"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Arquivar"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Bifurcar"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Desarquivar"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Marcar como lida"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Marcar como não lida"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Isso redefine a conversa para %@. A chave da sessão permanece a mesma."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Renomear sessão"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nome da sessão"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Renomear"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Exportar transcrição"
@@ -23099,6 +23269,11 @@
       "translated": "Modelo"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nova sessão"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Atualizar"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sessões…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Renomear sessão…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Bifurcar sessão"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Desafixar"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Fixar"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Marcar como lida"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Marcar como não lida"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Restaurar"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Arquivar"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Copiar chave da sessão"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Compactar sessão"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Buscar sessões"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Nenhum resultado"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Nenhuma sessão"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nova sessão"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Nova sessão"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Excluir sessão"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "A sessão e sua transcrição são removidas do gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Não lida"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Fixar"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Desafixar"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Copiar chave da sessão"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Excluir sessão…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Conectando…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway conectado"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -22809,6 +22809,141 @@
       "translated": "Пользователь"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Поиск сессий"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Нет сессий"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Нет результатов"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Новая сессия"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Новая сессия"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Переименовать сессию"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Название сессии"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Переименовать"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Отмена"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Удалить сессию"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Сессия и её расшифровка будут удалены из Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Удалить «%@»?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Сессия выполняется"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Сессия завершилась с ошибкой"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Непрочитанное"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Переименовать…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Закрепить"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Открепить"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Ответвить"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Отметить как прочитанное"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Отметить как непрочитанное"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Архивировать"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Восстановить"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Скопировать ключ сеанса"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Удалить сеанс…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway подключён"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Подключение…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Закреплено"
@@ -22864,6 +22999,16 @@
       "translated": "Сессии не найдены"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Восстановить"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Архивировать"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Закреплено"
@@ -22884,14 +23029,19 @@
       "translated": "Открепить"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Архивировать"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Создать ответвление"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Разархивировать"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Отметить как прочитанное"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Отметить как непрочитанное"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Это сбросит разговор для %@. Ключ сеанса останется прежним."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Переименовать сеанс"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Название сеанса"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Переименовать"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Отмена"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Экспорт транскрипта"
@@ -23099,6 +23269,11 @@
       "translated": "Модель"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Новая сессия"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Обновить"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Сеансы…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Переименовать сеанс…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Создать ответвление сеанса"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Открепить"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Закрепить"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Отметить как прочитанное"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Отметить как непрочитанное"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Восстановить"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Архив"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Скопировать ключ сессии"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Сжать сессию"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Поиск сессий"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Нет результатов"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Нет сессий"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Новая сессия"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Новая сессия"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Удалить сессию"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Сессия и её транскрипт удаляются из Gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Непрочитанные"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Закрепить"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Открепить"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Скопировать ключ сессии"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Удалить сессию…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Подключение…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway подключён"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -22809,6 +22809,141 @@
       "translated": "Användare"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Sök sessioner"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Inga sessioner"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Inga resultat"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Ny session"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Ny session"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Byt namn på session"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Sessionsnamn"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Byt namn"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Avbryt"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Radera session"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Sessionen och dess transkription tas bort från Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Radera ”%@”?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessionen körs"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sessionen misslyckades"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Oläst"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Byt namn…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Fäst"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Lossa"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Förgrena"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Markera som läst"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Markera som oläst"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Arkivera"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Återställ"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Kopiera sessionsnyckel"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Radera session…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway ansluten"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Ansluter…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Fäst"
@@ -22864,6 +22999,16 @@
       "translated": "Inga sessioner hittades"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Återställ"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Arkivera"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Fästa"
@@ -22884,14 +23029,19 @@
       "translated": "Lossa"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Arkivera"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Förgrena"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Avarkivera"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Markera som läst"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Markera som oläst"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Detta återställer konversationen för %@. Sessionsnyckeln förblir densamma."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Byt namn på session"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Sessionsnamn"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Byt namn"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Avbryt"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Exportera transkription"
@@ -23099,6 +23269,11 @@
       "translated": "Modell"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Ny session"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Uppdatera"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Sessioner…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Byt namn på session…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Förgrena session"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Lossa"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Fäst"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Markera som läst"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Markera som oläst"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Återställ"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Arkiv"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Kopiera sessionsnyckel"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Komprimera session"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Sök sessioner"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Inga resultat"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Inga sessioner"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Ny session"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Ny session"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Ta bort session"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Sessionen och dess transkript tas bort från gatewayen."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Oläst"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Fäst"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Lossa"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Kopiera sessionsnyckel"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Ta bort session…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Ansluter…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway ansluten"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -22809,6 +22809,141 @@
       "translated": "ผู้ใช้"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "ค้นหาเซสชัน"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "ไม่มีเซสชัน"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "ไม่พบผลลัพธ์"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "เซสชันใหม่"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "เซสชันใหม่"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "เปลี่ยนชื่อเซสชัน"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "ชื่อเซสชัน"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "เปลี่ยนชื่อ"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "ยกเลิก"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "ลบเซสชัน"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "เซสชันและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "ลบ “%@” หรือไม่?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "เซสชันกำลังทำงาน"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "เซสชันล้มเหลว"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "ยังไม่ได้อ่าน"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "เปลี่ยนชื่อ…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "ปักหมุด"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "เลิกปักหมุด"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "แยกเซสชัน"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "ทำเครื่องหมายว่าอ่านแล้ว"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "ทำเครื่องหมายว่ายังไม่ได้อ่าน"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "เก็บถาวร"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "กู้คืน"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "คัดลอกคีย์เซสชัน"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "ลบเซสชัน…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "เชื่อมต่อ Gateway แล้ว"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "กำลังเชื่อมต่อ…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "ปักหมุดแล้ว"
@@ -22864,6 +22999,16 @@
       "translated": "ไม่พบเซสชัน"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "กู้คืน"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "เก็บถาวร"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "ปักหมุดแล้ว"
@@ -22884,14 +23029,19 @@
       "translated": "เลิกปักหมุด"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "เก็บถาวร"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "แยกเซสชัน"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "เลิกเก็บถาวร"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "ทำเครื่องหมายว่าอ่านแล้ว"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "ทำเครื่องหมายว่ายังไม่ได้อ่าน"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "การดำเนินการนี้จะรีเซ็ตการสนทนาสำหรับ %@ โดยคีย์เซสชันจะยังคงเดิม"
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "เปลี่ยนชื่อเซสชัน"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "ชื่อเซสชัน"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "เปลี่ยนชื่อ"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "ยกเลิก"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "ส่งออกสำเนาบทสนทนา"
@@ -23099,6 +23269,11 @@
       "translated": "โมเดล"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "เซสชันใหม่"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "รีเฟรช"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "เซสชัน…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "เปลี่ยนชื่อเซสชัน…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "แยกเซสชัน"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "เลิกปักหมุด"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "ปักหมุด"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "ทำเครื่องหมายว่าอ่านแล้ว"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "ทำเครื่องหมายว่ายังไม่ได้อ่าน"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "กู้คืน"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "เก็บถาวร"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "คัดลอกคีย์เซสชัน"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "ย่อเซสชัน"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "ค้นหาเซสชัน"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "ไม่มีผลลัพธ์"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "ไม่มีเซสชัน"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "เซสชันใหม่"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "เซสชันใหม่"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "ลบเซสชัน"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "เซสชันและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "ยังไม่ได้อ่าน"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "ปักหมุด"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "เลิกปักหมุด"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "คัดลอกคีย์เซสชัน"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "ลบเซสชัน…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "กำลังเชื่อมต่อ…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "เชื่อมต่อ Gateway แล้ว"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -22809,6 +22809,141 @@
       "translated": "Kullanıcı"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Oturumlarda ara"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Oturum Yok"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Sonuç Yok"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Yeni Oturum"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Yeni oturum"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Oturumu Yeniden Adlandır"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Oturum adı"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Yeniden Adlandır"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "İptal"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Oturumu Sil"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Oturum ve dökümü Gateway'den kaldırılır."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "“%@” silinsin mi?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Oturum çalışıyor"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Oturum başarısız oldu"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Okunmamış"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Yeniden adlandır…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Sabitle"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Sabitlemeyi kaldır"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Çatalla"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Okundu Olarak İşaretle"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Okunmadı Olarak İşaretle"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Arşivle"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Geri Yükle"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Oturum Anahtarını Kopyala"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Oturumu Sil…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway bağlı"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Bağlanıyor…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Sabitlenmiş"
@@ -22864,6 +22999,16 @@
       "translated": "Oturum bulunamadı"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Geri Yükle"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Arşivle"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Sabitlenmiş"
@@ -22884,14 +23029,19 @@
       "translated": "Sabitlemeyi Kaldır"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Arşivle"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Çatalla"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Arşivden Çıkar"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Okundu Olarak İşaretle"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Okunmadı Olarak İşaretle"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Bu işlem, %@ için konuşmayı sıfırlar. Oturum anahtarı aynı kalır."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Oturumu Yeniden Adlandır"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Oturum adı"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Yeniden Adlandır"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "İptal"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Dökümü Dışa Aktar"
@@ -23099,6 +23269,11 @@
       "translated": "Model"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Yeni Oturum"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Yenile"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Oturumlar…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Oturumu Yeniden Adlandır…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Oturumu Çatalla"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Sabitlemeyi Kaldır"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Sabitle"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Okundu Olarak İşaretle"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Okunmadı Olarak İşaretle"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Geri Yükle"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Arşivle"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Oturum Anahtarını Kopyala"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Oturumu Sıkıştır"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Oturumlarda ara"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Sonuç Yok"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Oturum Yok"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Yeni Oturum"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Yeni oturum"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Oturumu Sil"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Oturum ve dökümü gateway'den kaldırılır."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Okunmamış"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Sabitle"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Sabitlemeyi Kaldır"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Oturum Anahtarını Kopyala"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Oturumu Sil…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Bağlanıyor…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway bağlandı"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -22809,6 +22809,141 @@
       "translated": "Користувач"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Пошук сеансів"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Немає сеансів"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Немає результатів"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Новий сеанс"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Новий сеанс"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Перейменувати сеанс"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Назва сеансу"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Перейменувати"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Скасувати"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Видалити сеанс"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Сеанс і його розшифровку буде видалено з Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Видалити «%@»?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Сеанс виконується"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Помилка сеансу"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Непрочитане"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Перейменувати…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Закріпити"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Відкріпити"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Відгалузити"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Позначити як прочитане"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Позначити непрочитаним"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Архівувати"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Відновити"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Копіювати ключ сесії"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Видалити сесію…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway підключено"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Підключення…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Закріплено"
@@ -22864,6 +22999,16 @@
       "translated": "Сеансів не знайдено"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Відновити"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Архівувати"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Закріплено"
@@ -22884,14 +23029,19 @@
       "translated": "Відкріпити"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Архівувати"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Створити відгалуження"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Розархівувати"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Позначити прочитаним"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Позначити непрочитаним"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Це скине розмову для %@. Ключ сеансу залишиться незмінним."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Перейменувати сесію"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Назва сесії"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Перейменувати"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Скасувати"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Експортувати стенограму"
@@ -23099,6 +23269,11 @@
       "translated": "Модель"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Нова сесія"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Оновити"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Сеанси…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Перейменувати сесію…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Створити відгалуження сесії"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Відкріпити"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Закріпити"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Позначити прочитаним"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Позначити непрочитаним"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Відновити"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Архівувати"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Копіювати ключ сеансу"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Стиснути сесію"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Пошук сесій"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Немає результатів"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Немає сесій"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Нова сесія"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Новий сеанс"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Видалити сеанс"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Сеанс і його транскрипт видаляються з gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Непрочитані"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Закріпити"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Відкріпити"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Копіювати ключ сеансу"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Видалити сеанс…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Підключення…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway підключено"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -22809,6 +22809,141 @@
       "translated": "Người dùng"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Tìm kiếm phiên"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Không có phiên nào"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "Không có kết quả"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Phiên mới"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Phiên mới"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Đổi tên phiên"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Tên phiên"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "Đổi tên"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "Hủy"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Xóa phiên"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Phiên và bản ghi của phiên sẽ bị xóa khỏi Gateway."
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "Xóa “%@”?"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Phiên đang chạy"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Phiên không thành công"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "Chưa đọc"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "Đổi tên…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "Ghim"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "Bỏ ghim"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "Phân nhánh"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "Đánh dấu đã đọc"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "Đánh dấu là chưa đọc"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "Lưu trữ"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "Khôi phục"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "Sao chép khóa phiên"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Xóa phiên…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway đã kết nối"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "Đang kết nối…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "Đã ghim"
@@ -22864,6 +22999,16 @@
       "translated": "Không tìm thấy phiên nào"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "Khôi phục"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "Lưu trữ"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "Đã ghim"
@@ -22884,14 +23029,19 @@
       "translated": "Bỏ ghim"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "Lưu trữ"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "Phân nhánh"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "Bỏ lưu trữ"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "Đánh dấu là đã đọc"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "Đánh dấu là chưa đọc"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "Thao tác này sẽ đặt lại cuộc trò chuyện cho %@. Khóa phiên vẫn giữ nguyên."
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Đổi tên phiên"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Tên phiên"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "Đổi tên"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "Hủy"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "Xuất Bản ghi"
@@ -23099,6 +23269,11 @@
       "translated": "Mô hình"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Phiên Mới"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "Làm mới"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "Phiên…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Đổi tên phiên…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Phân nhánh phiên"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "Bỏ ghim"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "Ghim"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "Đánh dấu là đã đọc"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "Đánh dấu là chưa đọc"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "Khôi phục"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "Lưu trữ"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "Sao chép khóa phiên"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "Thu gọn Phiên"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "Tìm phiên"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "Không có Kết quả"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "Không có Phiên"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Phiên Mới"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "Phiên mới"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "Xóa phiên"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Phiên và bản ghi của nó bị xóa khỏi gateway."
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "Chưa đọc"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "Ghim"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "Bỏ ghim"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "Sao chép khóa phiên"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "Xóa phiên…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "Đang kết nối…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway đã kết nối"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -22809,6 +22809,141 @@
       "translated": "用户"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "搜索会话"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "没有会话"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "没有结果"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "新建会话"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "新建会话"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "重命名会话"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "会话名称"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "重命名"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "删除会话"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "该会话及其转录内容将从 Gateway 中移除。"
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "删除“%@”？"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "会话正在运行"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "会话失败"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "未读"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "重命名…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "置顶"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "取消置顶"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "分支"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "标为已读"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "标为未读"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "归档"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "恢复"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "复制会话密钥"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "删除会话…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway 已连接"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "正在连接…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "已置顶"
@@ -22864,6 +22999,16 @@
       "translated": "未找到会话"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "恢复"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "归档"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "已置顶"
@@ -22884,14 +23029,19 @@
       "translated": "取消置顶"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "归档"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "创建分支"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "取消归档"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "标为已读"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "标为未读"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "这将重置与 %@ 的对话。会话密钥保持不变。"
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "重命名会话"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "会话名称"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "重命名"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "导出对话记录"
@@ -23099,6 +23269,11 @@
       "translated": "模型"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "新建会话"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "刷新"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "会话…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "重命名会话…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "为会话创建分支"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "取消置顶"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "置顶"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "标为已读"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "标为未读"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "恢复"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "归档"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "复制会话密钥"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "压缩会话"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "搜索会话"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "无结果"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "无会话"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "新建会话"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "新建会话"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "删除会话"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "会话及其转录记录已从 Gateway 中移除。"
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "未读"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "置顶"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "取消置顶"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "复制会话密钥"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "删除会话…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "连接中…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway 已连接"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -22809,6 +22809,141 @@
       "translated": "使用者"
     },
     {
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "搜尋工作階段"
+    },
+    {
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "沒有工作階段"
+    },
+    {
+      "id": "native.apple.2d4ee298bdd1c05d",
+      "source": "No Results",
+      "translated": "沒有結果"
+    },
+    {
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "新增工作階段"
+    },
+    {
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "新增工作階段"
+    },
+    {
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "重新命名工作階段"
+    },
+    {
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "工作階段名稱"
+    },
+    {
+      "id": "native.apple.6ec5a13c0e6c20d9",
+      "source": "Rename",
+      "translated": "重新命名"
+    },
+    {
+      "id": "native.apple.4c76665d89af4bec",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "刪除工作階段"
+    },
+    {
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "工作階段及其逐字記錄將從 Gateway 中移除。"
+    },
+    {
+      "id": "native.apple.90bcad5f067b4be1",
+      "source": "Delete “%@”?",
+      "translated": "刪除「%@」？"
+    },
+    {
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "工作階段執行中"
+    },
+    {
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "工作階段失敗"
+    },
+    {
+      "id": "native.apple.ac85292b16a7465f",
+      "source": "Unread",
+      "translated": "未讀"
+    },
+    {
+      "id": "native.apple.a174cb1027a9b881",
+      "source": "Rename…",
+      "translated": "重新命名…"
+    },
+    {
+      "id": "native.apple.134d6bf84d58fb38",
+      "source": "Pin",
+      "translated": "釘選"
+    },
+    {
+      "id": "native.apple.e7815cc4ba359513",
+      "source": "Unpin",
+      "translated": "取消釘選"
+    },
+    {
+      "id": "native.apple.83f9f2db7eef6a19",
+      "source": "Fork",
+      "translated": "分支"
+    },
+    {
+      "id": "native.apple.235614194dc19df2",
+      "source": "Mark Read",
+      "translated": "標示為已讀"
+    },
+    {
+      "id": "native.apple.bc71f0d20b7f72a0",
+      "source": "Mark Unread",
+      "translated": "標示為未讀"
+    },
+    {
+      "id": "native.apple.c9e118f6aae18d97",
+      "source": "Archive",
+      "translated": "封存"
+    },
+    {
+      "id": "native.apple.10365a351a1b58b3",
+      "source": "Restore",
+      "translated": "復原"
+    },
+    {
+      "id": "native.apple.660f63319b89bd8e",
+      "source": "Copy Session Key",
+      "translated": "複製工作階段金鑰"
+    },
+    {
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "刪除工作階段…"
+    },
+    {
+      "id": "native.apple.6a3425ea2811ff88",
+      "source": "Gateway connected",
+      "translated": "Gateway 已連線"
+    },
+    {
+      "id": "native.apple.e3958d1053259f1d",
+      "source": "Connecting…",
+      "translated": "連線中…"
+    },
+    {
       "id": "native.apple.63320b6d5138c0db",
       "source": "Pinned",
       "translated": "已釘選"
@@ -22864,6 +22999,16 @@
       "translated": "找不到工作階段"
     },
     {
+      "id": "native.apple.f0e9d8f69c1d9190",
+      "source": "Restore",
+      "translated": "復原"
+    },
+    {
+      "id": "native.apple.666ba6eb696e649f",
+      "source": "Archive",
+      "translated": "封存"
+    },
+    {
       "id": "native.apple.05cb1fecc5844b69",
       "source": "Pinned",
       "translated": "已釘選"
@@ -22884,14 +23029,19 @@
       "translated": "取消釘選"
     },
     {
-      "id": "native.apple.666ba6eb696e649f",
-      "source": "Archive",
-      "translated": "封存"
+      "id": "native.apple.6de479e9d780869a",
+      "source": "Fork",
+      "translated": "分支"
     },
     {
-      "id": "native.apple.34b910911a05110e",
-      "source": "Unarchive",
-      "translated": "取消封存"
+      "id": "native.apple.1398a2f69867f22d",
+      "source": "Mark Read",
+      "translated": "標示為已讀"
+    },
+    {
+      "id": "native.apple.4f259c4409cfcc75",
+      "source": "Mark Unread",
+      "translated": "標示為未讀"
     },
     {
       "id": "native.apple.c4e808a2ec8d49f5",
@@ -23059,6 +23209,26 @@
       "translated": "這會重設與 %@ 的對話。工作階段金鑰將維持不變。"
     },
     {
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "重新命名工作階段"
+    },
+    {
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "工作階段名稱"
+    },
+    {
+      "id": "native.apple.8d636ca6b4764418",
+      "source": "Rename",
+      "translated": "重新命名"
+    },
+    {
+      "id": "native.apple.32b4a79f1b889aa6",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
       "id": "native.apple.2ee7858b00a47c42",
       "source": "Export Transcript",
       "translated": "匯出對話紀錄"
@@ -23099,6 +23269,11 @@
       "translated": "模型"
     },
     {
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "新增工作階段"
+    },
+    {
       "id": "native.apple.5361129a24118af6",
       "source": "Refresh",
       "translated": "重新整理"
@@ -23107,6 +23282,51 @@
       "id": "native.apple.2bcff4a8fa503739",
       "source": "Sessions…",
       "translated": "工作階段…"
+    },
+    {
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "重新命名工作階段…"
+    },
+    {
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "分支工作階段"
+    },
+    {
+      "id": "native.apple.8768f9ed198edc54",
+      "source": "Unpin",
+      "translated": "取消釘選"
+    },
+    {
+      "id": "native.apple.a8a2f4b248663f97",
+      "source": "Pin",
+      "translated": "釘選"
+    },
+    {
+      "id": "native.apple.e53f1d7e094dc542",
+      "source": "Mark Read",
+      "translated": "標示為已讀"
+    },
+    {
+      "id": "native.apple.99579b05ec001672",
+      "source": "Mark Unread",
+      "translated": "標示為未讀"
+    },
+    {
+      "id": "native.apple.b39c58e213137cc8",
+      "source": "Restore",
+      "translated": "復原"
+    },
+    {
+      "id": "native.apple.6f5686f621b44307",
+      "source": "Archive",
+      "translated": "封存"
+    },
+    {
+      "id": "native.apple.27ddbe5e4643b60f",
+      "source": "Copy Session Key",
+      "translated": "複製工作階段金鑰"
     },
     {
       "id": "native.apple.9b2ad72143b931bf",
@@ -23142,76 +23362,6 @@
       "id": "native.apple.f0a4720df5f5f403",
       "source": "Compact Session",
       "translated": "精簡工作階段"
-    },
-    {
-      "id": "native.apple.0b9fc81ff2031799",
-      "source": "Search sessions",
-      "translated": "搜尋工作階段"
-    },
-    {
-      "id": "native.apple.f10d5ccfd0530fec",
-      "source": "No Results",
-      "translated": "沒有結果"
-    },
-    {
-      "id": "native.apple.42b0ee4c8b3326b6",
-      "source": "No Sessions",
-      "translated": "沒有工作階段"
-    },
-    {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "新增工作階段"
-    },
-    {
-      "id": "native.apple.247771e4350c006f",
-      "source": "New session",
-      "translated": "新工作階段"
-    },
-    {
-      "id": "native.apple.d9a72d07e8d95d35",
-      "source": "Delete Session",
-      "translated": "刪除工作階段"
-    },
-    {
-      "id": "native.apple.499537ec30a28ae0",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "工作階段及其記錄將從 gateway 移除。"
-    },
-    {
-      "id": "native.apple.1bd1b747fd161df5",
-      "source": "Unread",
-      "translated": "未讀"
-    },
-    {
-      "id": "native.apple.a8a2f4b248663f97",
-      "source": "Pin",
-      "translated": "釘選"
-    },
-    {
-      "id": "native.apple.8768f9ed198edc54",
-      "source": "Unpin",
-      "translated": "取消釘選"
-    },
-    {
-      "id": "native.apple.27ddbe5e4643b60f",
-      "source": "Copy Session Key",
-      "translated": "複製工作階段金鑰"
-    },
-    {
-      "id": "native.apple.a994d072ab35cb35",
-      "source": "Delete Session…",
-      "translated": "刪除工作階段…"
-    },
-    {
-      "id": "native.apple.22d5ce71e22a7f73",
-      "source": "Connecting…",
-      "translated": "連線中…"
-    },
-    {
-      "id": "native.apple.8d0606ab1a2c0f44",
-      "source": "Gateway connected",
-      "translated": "Gateway 已連線"
     },
     {
       "id": "native.apple.f74d150ce05205dd",

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -280,7 +280,7 @@
     <string name="native_2f9c977d4df31bfa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قراءة جهات الاتصال"</string>
     <string name="native_300574ec69847390" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مساحة تخزين المرفقات دون اتصال ممتلئة؛ احذف العناصر قيد الانتظار أولًا."</string>
     <string name="native_3043615848685c0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مرة واحدة"</string>
-    <string name="native_3064d79a295cefe4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعادة التسمية"</string>
+    <string name="native_3064d79a295cefe4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعادة تسمية"</string>
     <string name="native_308bdae31be27cbd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يتم العثور على قنوات."</string>
     <string name="native_30a64216eaeac5d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عرض الكل"</string>
     <string name="native_30d01a64f9a923c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جهاز جديد"</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -1358,7 +1358,7 @@
     <string name="native_edc519f75b9dc39f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Seleccionado en este teléfono"</string>
     <string name="native_eddc4738cc953030" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"unpin"</string>
     <string name="native_edeead3f1961f9b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Session History"</string>
-    <string name="native_ee3c716130546a45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dejar de fijar"</string>
+    <string name="native_ee3c716130546a45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Desfijar"</string>
     <string name="native_eed15187e1659f0f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usar este teléfono"</string>
     <string name="native_eef430d88d7f78d2" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No se pudieron cargar los detalles de ClawHub para %1$s."</string>
     <string name="native_ef363b97b21cbfd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Herramientas en ejecución"</string>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -280,7 +280,7 @@
     <string name="native_2f9c977d4df31bfa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Baca Kontak"</string>
     <string name="native_300574ec69847390" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Penyimpanan lampiran offline penuh; hapus item dalam antrean terlebih dahulu."</string>
     <string name="native_3043615848685c0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Satu kali"</string>
-    <string name="native_3064d79a295cefe4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ganti Nama"</string>
+    <string name="native_3064d79a295cefe4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ubah Nama"</string>
     <string name="native_308bdae31be27cbd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidak ada saluran yang ditemukan."</string>
     <string name="native_30a64216eaeac5d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lihat semua"</string>
     <string name="native_30d01a64f9a923c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Perangkat baru"</string>
@@ -822,7 +822,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mulai percakapan baru dan percakapan itu akan muncul di sini."</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Masalah koneksi"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sedang"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fork"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Buat Cabang"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aktifkan speaker"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Teks Peristiwa Sistem"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Urutkan: %1$s"</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -1358,7 +1358,7 @@
     <string name="native_edc519f75b9dc39f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Selezionato su questo telefono"</string>
     <string name="native_eddc4738cc953030" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"unpin"</string>
     <string name="native_edeead3f1961f9b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Session History"</string>
-    <string name="native_ee3c716130546a45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovi fissaggio"</string>
+    <string name="native_ee3c716130546a45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovi"</string>
     <string name="native_eed15187e1659f0f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usa questo telefono"</string>
     <string name="native_eef430d88d7f78d2" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile caricare i dettagli di ClawHub per %1$s."</string>
     <string name="native_ef363b97b21cbfd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Strumenti in esecuzione"</string>
@@ -1409,7 +1409,7 @@
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app bloccata dall\'inoltro."</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Azioni del messaggio"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tipo"</string>
-    <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovi dall\'archivio"</string>
+    <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Annulla archiviazione"</string>
     <string name="native_f584049cab5f523e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Transcripts"</string>
     <string name="native_f59b46c265d8d38f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sessioni recenti"</string>
     <string name="native_f5f0563199a5b403" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parole di attivazione"</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -280,7 +280,7 @@
     <string name="native_2f9c977d4df31bfa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"연락처 읽기"</string>
     <string name="native_300574ec69847390" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"오프라인 첨부 파일 저장 공간이 가득 찼습니다. 먼저 대기 중인 항목을 삭제하세요."</string>
     <string name="native_3043615848685c0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"한 번"</string>
-    <string name="native_3064d79a295cefe4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"이름 바꾸기"</string>
+    <string name="native_3064d79a295cefe4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"이름 변경"</string>
     <string name="native_308bdae31be27cbd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"채널을 찾을 수 없습니다."</string>
     <string name="native_30a64216eaeac5d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"모두 보기"</string>
     <string name="native_30d01a64f9a923c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"새 기기"</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -822,7 +822,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Start een nieuw gesprek en het verschijnt hier."</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verbindingsprobleem"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gemiddeld"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fork"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afsplitsen"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Luidspreker inschakelen"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeemgebeurtenistekst"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sortering: %1$s"</string>
@@ -1409,7 +1409,7 @@
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app is geblokkeerd voor doorsturen."</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Berichtacties"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Soort"</string>
-    <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dearchiveren"</string>
+    <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uit archief halen"</string>
     <string name="native_f584049cab5f523e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Transcripts"</string>
     <string name="native_f59b46c265d8d38f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recente sessies"</string>
     <string name="native_f5f0563199a5b403" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activeringswoorden"</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -822,7 +822,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มการสนทนาใหม่ แล้วจะแสดงที่นี่"</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัญหาการเชื่อมต่อ"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปานกลาง"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แยกสาขา"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แยกเซสชัน"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานลำโพง"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเหตุการณ์ระบบ"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จัดเรียง: %1$s"</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -1358,7 +1358,7 @@
     <string name="native_edc519f75b9dc39f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu telefonda seçildi"</string>
     <string name="native_eddc4738cc953030" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"unpin"</string>
     <string name="native_edeead3f1961f9b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Session History"</string>
-    <string name="native_ee3c716130546a45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sabitlemeyi Kaldır"</string>
+    <string name="native_ee3c716130546a45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sabitlemeyi kaldır"</string>
     <string name="native_eed15187e1659f0f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu telefonu kullan"</string>
     <string name="native_eef430d88d7f78d2" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s için ClawHub ayrıntıları yüklenemedi."</string>
     <string name="native_ef363b97b21cbfd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Araçlar çalışıyor"</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -811,7 +811,7 @@
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vận động"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thao tác cron không thành công."</string>
     <string name="native_8cb2bab2ce6a17b2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trên máy tính Gateway, chạy:"</string>
-    <string name="native_8cb650539ec84aa5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm phiên"</string>
+    <string name="native_8cb650539ec84aa5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm phiên"</string>
     <string name="native_8d0839802b4d6aca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Làm mới nhật ký"</string>
     <string name="native_8d20273207a2fe99" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw nodes approve %1$s"</string>
     <string name="native_8d57374bc09c8756" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tin nhắn thoại · %1$s"</string>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -822,7 +822,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始新的对话后，它会显示在这里。"</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接问题"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"中"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"分叉"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"创建分支"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"启用扬声器"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系统事件文本"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"排序：%1$s"</string>

--- a/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
@@ -1,0 +1,51 @@
+import Foundation
+import OpenClawChatUI
+
+extension MacGatewayChatTransport {
+    func acquireSessionMutationRouteLease() async -> OpenClawChatSessionMutationRouteLease? {
+        guard let serverLease = await GatewayConnection.shared.captureServerLease() else { return nil }
+        if let outboxGatewayID {
+            let currentGatewayID = await MainActor.run { MacChatTranscriptCache.currentGatewayID() }
+            guard currentGatewayID == outboxGatewayID else { return nil }
+        }
+        let transport = self
+        return OpenClawChatSessionMutationRouteLease { key, label, category, pinned, archived, unread in
+            let target = transport.sessionTarget(for: key)
+            let request = OpenClawChatGatewayRequests.patchSession(
+                sessionKey: target.sessionKey,
+                agentID: target.agentID,
+                label: label,
+                category: category,
+                pinned: pinned,
+                archived: archived,
+                unread: unread)
+            _ = try await GatewayConnection.shared.request(
+                method: request.method,
+                params: request.params,
+                timeoutMs: request.timeoutMs,
+                ifCurrentServerLease: serverLease)
+        }
+    }
+
+    func forkSession(parentKey: String) async throws -> String {
+        guard let serverLease = await GatewayConnection.shared.captureServerLease() else {
+            throw OpenClawChatTransportSendError.notDispatched
+        }
+        if let outboxGatewayID {
+            let currentGatewayID = await MainActor.run { MacChatTranscriptCache.currentGatewayID() }
+            guard currentGatewayID == outboxGatewayID else {
+                throw OpenClawChatTransportSendError.notDispatched
+            }
+        }
+        let target = self.sessionTarget(for: parentKey)
+        let request = OpenClawChatGatewayRequests.forkSession(
+            parentSessionKey: target.sessionKey,
+            agentID: target.agentID)
+        let data = try await GatewayConnection.shared.request(
+            method: request.method,
+            params: request.params,
+            timeoutMs: request.timeoutMs,
+            ifCurrentServerLease: serverLease)
+        return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: data).key
+    }
+}

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -59,7 +59,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
     typealias SessionTarget = OpenClawChatSessionTarget
 
-    private let outboxGatewayID: String?
+    let outboxGatewayID: String?
     private let routingIdentity: RoutingIdentity
 
     init(outboxGatewayID: String? = nil, defaultGlobalAgentID: String? = nil) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift
@@ -1,0 +1,265 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+@MainActor
+struct ChatSessionSidebar: View {
+    @Bindable var viewModel: OpenClawChatViewModel
+    @Binding var query: String
+    @State private var sessionPendingDeletion: OpenClawChatSessionEntry?
+    @State private var sessionPendingRename: OpenClawChatSessionEntry?
+    @State private var renameText = ""
+
+    var body: some View {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: self.viewModel.sessions,
+            currentSessionKey: self.viewModel.sessionKey,
+            mainSessionKey: self.viewModel.resolvedMainSessionKey,
+            activeAgentID: self.viewModel.activeAgentId,
+            query: self.query)
+        List(selection: self.selectionBinding) {
+            ForEach(sections) { section in
+                if let title = section.title {
+                    Section(title) { self.rows(section.nodes) }
+                } else {
+                    self.rows(section.nodes)
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .searchable(
+            text: self.$query,
+            placement: .sidebar,
+            prompt: String(localized: "Search sessions"))
+        .overlay {
+            if sections.isEmpty {
+                ContentUnavailableView(
+                    self.query.isEmpty
+                        ? String(localized: "No Sessions")
+                        : String(localized: "No Results"),
+                    systemImage: "bubble.left.and.bubble.right")
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) { self.connectionFooter }
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    Task { await self.viewModel.startNewSession() }
+                } label: {
+                    chatWindowActionLabel("New Session", systemImage: "square.and.pencil")
+                }
+                .help(String(localized: "New session"))
+            }
+        }
+        .task { self.viewModel.refreshSessions(limit: 200) }
+        .onChange(of: self.viewModel.healthOK) { previous, current in
+            if !previous, current {
+                self.viewModel.refreshSessions(limit: 200)
+            }
+        }
+        .alert(
+            String(localized: "Rename Session"),
+            isPresented: self.isPresentingRenameAlert)
+        {
+            TextField(String(localized: "Session name"), text: self.$renameText)
+            Button(String(localized: "Rename")) {
+                if let session = self.sessionPendingRename {
+                    self.viewModel.renameSession(key: session.key, label: self.renameText)
+                }
+                self.sessionPendingRename = nil
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {
+                self.sessionPendingRename = nil
+            }
+        }
+        .confirmationDialog(self.deleteDialogTitle, isPresented: self.isPresentingDeleteDialog) {
+                Button(String(localized: "Delete Session"), role: .destructive) {
+                    if let session = self.sessionPendingDeletion {
+                        self.viewModel.deleteSession(session.key)
+                    }
+                    self.sessionPendingDeletion = nil
+                }
+            } message: {
+                Text(String(localized: "The session and its transcript are removed from the gateway."))
+                    .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))
+            }
+    }
+
+    private var selectionBinding: Binding<String?> {
+        Binding(
+            get: {
+                ChatSessionSidebarModel.selectedSessionKey(
+                    sessions: self.viewModel.sessions,
+                    currentSessionKey: self.viewModel.sessionKey,
+                    mainSessionKey: self.viewModel.resolvedMainSessionKey,
+                    activeAgentID: self.viewModel.activeAgentId)
+            },
+            set: { next in
+                guard let next, next != self.viewModel.sessionKey else { return }
+                self.viewModel.switchSession(to: next)
+            })
+    }
+
+    private var deleteDialogTitle: String {
+        let name = self.sessionPendingDeletion.map(ChatSessionSidebarModel.displayName(for:)) ?? ""
+        return String(format: String(localized: "Delete “%@”?"), name)
+    }
+
+    private var isPresentingDeleteDialog: Binding<Bool> {
+        Binding(
+            get: { self.sessionPendingDeletion != nil },
+            set: { if !$0 { self.sessionPendingDeletion = nil } })
+    }
+
+    private var isPresentingRenameAlert: Binding<Bool> {
+        Binding(
+            get: { self.sessionPendingRename != nil },
+            set: { if !$0 { self.sessionPendingRename = nil } })
+    }
+
+    private func rows(_ nodes: [ChatSessionSidebarModel.Node]) -> some View {
+        OutlineGroup(nodes, children: \.outlineChildren) { node in
+            self.row(for: node)
+        }
+    }
+
+    private func row(for node: ChatSessionSidebarModel.Node) -> some View {
+        let session = node.session
+        return HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(ChatSessionSidebarModel.displayName(for: session))
+                    .font(OpenClawChatTypography.body(size: 13, weight: .medium, relativeTo: .body))
+                    .lineLimit(1)
+                if let subtitle = self.rowSubtitle(for: session) {
+                    Text(subtitle)
+                        .font(OpenClawChatTypography.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 0)
+            self.badges(for: node)
+        }
+        // The tag type must equal the List selection type (String?) exactly.
+        .tag(Optional(session.key))
+        .contextMenu { self.contextMenu(for: session) }
+    }
+
+    @ViewBuilder
+    private func badges(for node: ChatSessionSidebarModel.Node) -> some View {
+        if node.badges.runningCount > 0 {
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityLabel(String(localized: "Session running"))
+        }
+        if node.badges.failedCount > 0 {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(OpenClawChatTheme.warning)
+                .accessibilityLabel(String(localized: "Session failed"))
+        }
+        let isCurrentSession = self.viewModel.matchesCurrentSessionKey(
+            incoming: node.session.key,
+            current: self.viewModel.sessionKey)
+        if node.hasUnreadDescendant || (node.session.unread == true && !isCurrentSession) {
+            Circle()
+                .fill(.tint)
+                .frame(width: 7, height: 7)
+                .accessibilityLabel(String(localized: "Unread"))
+        }
+    }
+
+    @ViewBuilder
+    private func contextMenu(for session: OpenClawChatSessionEntry) -> some View {
+        Button {
+            self.renameText = session.label ?? session.displayName ?? ""
+            self.sessionPendingRename = session
+        } label: {
+            self.actionLabel(String(localized: "Rename…"), systemImage: "pencil")
+        }
+        Button {
+            self.viewModel.setSessionPinned(key: session.key, pinned: session.pinned != true)
+        } label: {
+            self.actionLabel(
+                session.pinned == true ? String(localized: "Unpin") : String(localized: "Pin"),
+                systemImage: session.pinned == true ? "pin.slash" : "pin")
+        }
+        Button {
+            Task { await self.viewModel.forkSession(key: session.key) }
+        } label: {
+            self.actionLabel(String(localized: "Fork"), systemImage: "arrow.triangle.branch")
+        }
+        Button {
+            self.viewModel.setSessionUnread(key: session.key, unread: session.unread != true)
+        } label: {
+            self.actionLabel(
+                session.unread == true ? String(localized: "Mark Read") : String(localized: "Mark Unread"),
+                systemImage: session.unread == true ? "envelope.open" : "envelope.badge")
+        }
+        if session.isArchived || ChatSessionSidebarModel.canArchiveSession(
+            session,
+            mainSessionKey: self.viewModel.resolvedMainSessionKey)
+        {
+            Button {
+                self.viewModel.setSessionArchived(key: session.key, archived: !session.isArchived)
+            } label: {
+                self.actionLabel(
+                    session.isArchived ? String(localized: "Restore") : String(localized: "Archive"),
+                    systemImage: session.isArchived ? "tray.and.arrow.up" : "archivebox")
+            }
+        }
+        Divider()
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(session.key, forType: .string)
+        } label: {
+            self.actionLabel(String(localized: "Copy Session Key"), systemImage: "doc.on.doc")
+        }
+        if ChatSessionSidebarModel.canDeleteSession(
+            key: session.key,
+            mainSessionKey: self.viewModel.resolvedMainSessionKey)
+        {
+            Button(role: .destructive) {
+                self.sessionPendingDeletion = session
+            } label: {
+                self.actionLabel(String(localized: "Delete Session…"), systemImage: "trash")
+            }
+        }
+    }
+
+    private func actionLabel(_ title: String, systemImage: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))
+    }
+
+    private func rowSubtitle(for session: OpenClawChatSessionEntry) -> String? {
+        var parts: [String] = []
+        if let branch = session.worktree?.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !branch.isEmpty
+        {
+            parts.append(branch)
+        }
+        if let updatedAt = session.updatedAt ?? session.lastActivityAt, updatedAt > 0 {
+            let date = Date(timeIntervalSince1970: updatedAt / 1000)
+            parts.append(date.formatted(.relative(presentation: .named)))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private var connectionFooter: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(self.viewModel.healthOK ? .green : .orange)
+                .frame(width: 7, height: 7)
+            Text(self.viewModel.healthOK
+                ? String(localized: "Gateway connected")
+                : String(localized: "Connecting…"))
+                .font(OpenClawChatTypography.caption)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+}
+#endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -3,10 +3,38 @@ import Foundation
 /// Pure grouping/filtering for the macOS sessions sidebar. Kept UI-free so the
 /// pin/search/ordering rules stay unit-testable.
 enum ChatSessionSidebarModel {
+    struct Badges: Equatable {
+        let runningCount: Int
+        let failedCount: Int
+        let hasUnread: Bool
+    }
+
+    struct Node: Identifiable, Equatable {
+        let session: OpenClawChatSessionEntry
+        let children: [Node]
+        let badges: Badges
+
+        var id: String {
+            self.session.key
+        }
+
+        var outlineChildren: [Node]? {
+            self.children.isEmpty ? nil : self.children
+        }
+
+        var hasUnreadDescendant: Bool {
+            self.children.contains { $0.badges.hasUnread }
+        }
+    }
+
     struct Section: Identifiable, Equatable {
         let id: String
         let title: String?
-        let sessions: [OpenClawChatSessionEntry]
+        let nodes: [Node]
+
+        var sessions: [OpenClawChatSessionEntry] {
+            self.nodes.map(\.session)
+        }
     }
 
     static func isHiddenInternalSession(_ key: String) -> Bool {
@@ -29,20 +57,114 @@ enum ChatSessionSidebarModel {
             mainSessionKey: mainSessionKey,
             activeAgentID: activeAgentID,
             query: query)
-        let pinned = visible.filter { $0.pinned == true }
-        let recent = visible.filter { $0.pinned != true }
+        // Pin state owns section placement. Cross-section parent links become
+        // roots so a child's own Pin/Unpin action always has visible effect.
+        let pinned = self.tree(from: visible.filter { $0.pinned == true })
+        let recent = self.tree(from: visible.filter { $0.pinned != true })
 
         var result: [Section] = []
         if !pinned.isEmpty {
-            result.append(Section(id: "pinned", title: "Pinned", sessions: pinned))
+            result.append(Section(id: "pinned", title: "Pinned", nodes: pinned))
         }
         if !recent.isEmpty {
             result.append(Section(
                 id: "recent",
                 title: pinned.isEmpty ? nil : "Recent",
-                sessions: recent))
+                nodes: recent))
         }
         return result
+    }
+
+    static func tree(from sessions: [OpenClawChatSessionEntry]) -> [Node] {
+        let hierarchyPresent = sessions.contains { session in
+            self.normalizedKey(session.spawnedBy) != nil ||
+                self.normalizedKey(session.parentSessionKey) != nil ||
+                session.childSessions != nil
+        }
+        guard hierarchyPresent else {
+            return sessions.map { self.node(session: $0, children: []) }
+        }
+
+        var entriesByKey: [String: OpenClawChatSessionEntry] = [:]
+        for session in sessions where entriesByKey[session.key] == nil {
+            entriesByKey[session.key] = session
+        }
+        var parentByChild: [String: String] = [:]
+        // The gateway child roster is freshness-filtered and omitted when
+        // empty. Persisted parent metadata can outlive that freshness window,
+        // so it is display metadata only and must not recreate stale edges.
+        for parent in sessions {
+            for childKey in parent.childSessions ?? [] where childKey != parent.key {
+                if entriesByKey[childKey] != nil, parentByChild[childKey] == nil {
+                    parentByChild[childKey] = parent.key
+                }
+            }
+        }
+
+        var orderByKey: [String: Int] = [:]
+        for (offset, session) in sessions.enumerated() where orderByKey[session.key] == nil {
+            orderByKey[session.key] = offset
+        }
+        for session in sessions {
+            var path: [String] = []
+            var indexByKey: [String: Int] = [:]
+            var cursor: String? = session.key
+            while let current = cursor, let parent = parentByChild[current] {
+                indexByKey[current] = path.count
+                path.append(current)
+                if let cycleStart = indexByKey[parent] {
+                    let cycle = path[cycleStart...]
+                    let root = cycle.min { (orderByKey[$0] ?? Int.max) < (orderByKey[$1] ?? Int.max) }
+                    if let root {
+                        parentByChild[root] = nil
+                    }
+                    break
+                }
+                cursor = parent
+            }
+        }
+
+        var childrenByParent: [String: [OpenClawChatSessionEntry]] = [:]
+        for session in sessions {
+            if let parentKey = parentByChild[session.key] {
+                childrenByParent[parentKey, default: []].append(session)
+            }
+        }
+
+        func build(_ session: OpenClawChatSessionEntry, ancestors: Set<String>) -> Node {
+            guard !ancestors.contains(session.key) else {
+                return Self.node(session: session, children: [])
+            }
+            var nextAncestors = ancestors
+            nextAncestors.insert(session.key)
+            let children = (childrenByParent[session.key] ?? []).map {
+                build($0, ancestors: nextAncestors)
+            }
+            return Self.node(session: session, children: children)
+        }
+
+        return sessions.compactMap { session in
+            guard parentByChild[session.key] == nil else { return nil }
+            return build(session, ancestors: [])
+        }
+    }
+
+    private static func node(session: OpenClawChatSessionEntry, children: [Node]) -> Node {
+        let status = session.status?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let isRunning = session.hasActiveRun == true || session.hasActiveSubagentRun == true || status == "running"
+        let hasFailed = status == "failed" || status == "timeout"
+        return Node(
+            session: session,
+            children: children,
+            badges: Badges(
+                runningCount: (isRunning ? 1 : 0) + children.reduce(0) { $0 + $1.badges.runningCount },
+                failedCount: (hasFailed ? 1 : 0) + children.reduce(0) { $0 + $1.badges.failedCount },
+                hasUnread: session.unread == true || children.contains { $0.badges.hasUnread }))
+    }
+
+    private static func normalizedKey(_ key: String?) -> String? {
+        let trimmed = key?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 
     static func displayName(for session: OpenClawChatSessionEntry) -> String {
@@ -60,6 +182,17 @@ enum ChatSessionSidebarModel {
         let normalized = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let normalizedMain = mainSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return normalized != "main" && normalized != "global" && normalized != normalizedMain
+    }
+
+    static func canArchiveSession(
+        _ session: OpenClawChatSessionEntry,
+        mainSessionKey: String) -> Bool
+    {
+        let status = session.status?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return self.canDeleteSession(key: session.key, mainSessionKey: mainSessionKey) &&
+            session.hasActiveRun != true &&
+            session.hasActiveSubagentRun != true &&
+            status != "running"
     }
 
     @MainActor

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionUnreadPatchGuard.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionUnreadPatchGuard.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+struct ChatSessionUnreadPatchGuard {
+    private var activeSessionKey = ""
+    private var requested = false
+    private var activeExplicitUnread: Bool?
+    private var confirmedUnreadByKey: [String: Bool] = [:]
+    private var pendingExplicitRevisions: [String: Int] = [:]
+    private var revisions: [String: Int] = [:]
+
+    mutating func observe(key: String, unread: Bool?) {
+        guard self.pendingExplicitRevisions[key] == nil,
+              !(key == self.activeSessionKey && self.activeExplicitUnread != nil)
+        else { return }
+        if let unread {
+            self.confirmedUnreadByKey[key] = unread
+        }
+        if key == self.activeSessionKey, unread == false {
+            self.requested = false
+        }
+    }
+
+    mutating func shouldPatch(key: String, unread: Bool?) -> Int? {
+        guard !key.isEmpty else { return nil }
+        self.activate(key: key)
+        if unread == false {
+            self.requested = false
+            return nil
+        }
+        guard unread == true, !self.requested else { return nil }
+        self.requested = true
+        return self.advanceRevision(key: key)
+    }
+
+    mutating func activate(key: String) {
+        guard key != self.activeSessionKey else { return }
+        self.activeSessionKey = key
+        self.requested = false
+        self.activeExplicitUnread = nil
+    }
+
+    mutating func beginExplicitPatch(key: String, unread: Bool, isActive: Bool) -> Int {
+        let revision = self.advanceRevision(key: key)
+        self.pendingExplicitRevisions[key] = revision
+        if isActive {
+            self.activeSessionKey = key
+            // The explicit action owns this activation. Only navigation opens
+            // the next episode; stale list snapshots cannot undo the action.
+            self.requested = true
+            self.activeExplicitUnread = unread
+        }
+        return revision
+    }
+
+    mutating func patchSucceeded(key: String, unread: Bool, revision: Int) -> Bool {
+        guard self.revisions[key] == revision else { return false }
+        if self.pendingExplicitRevisions[key] == revision {
+            self.pendingExplicitRevisions.removeValue(forKey: key)
+        }
+        self.confirmedUnreadByKey[key] = unread
+        return true
+    }
+
+    mutating func patchFailed(key: String, revision: Int) -> Bool {
+        guard self.revisions[key] == revision else { return false }
+        if self.pendingExplicitRevisions[key] == revision {
+            self.pendingExplicitRevisions.removeValue(forKey: key)
+        }
+        if key == self.activeSessionKey {
+            self.requested = false
+            self.activeExplicitUnread = nil
+        }
+        return true
+    }
+
+    func confirmedUnread(key: String) -> Bool? {
+        self.confirmedUnreadByKey[key]
+    }
+
+    private mutating func advanceRevision(key: String) -> Int {
+        let revision = self.revisions[key, default: 0] + 1
+        self.revisions[key] = revision
+        return revision
+    }
+}
+
+@MainActor
+final class ChatSessionUnreadMutationQueue {
+    private struct Tail {
+        let id: Int
+        let task: Task<Void, Never>
+    }
+
+    private var nextID = 0
+    private var tails: [String: Tail] = [:]
+
+    func reserve(
+        routeLease: Task<OpenClawChatSessionMutationRouteLease?, Never>,
+        queueKey: String,
+        routeKey: String,
+        unread: Bool) -> Task<Void, Error>
+    {
+        let previous = self.tails[queueKey]?.task
+        self.nextID += 1
+        let id = self.nextID
+        let operation = Task { @MainActor in
+            let resolvedRouteLease = await routeLease.value
+            await previous?.value
+            guard let resolvedRouteLease else {
+                throw OpenClawChatTransportSendError.notDispatched
+            }
+            try await resolvedRouteLease.patchSession(
+                key: routeKey,
+                label: nil,
+                category: nil,
+                pinned: nil,
+                archived: nil,
+                unread: unread)
+        }
+        let tail = Task { @MainActor in
+            _ = try? await operation.value
+        }
+        self.tails[queueKey] = Tail(id: id, task: tail)
+        Task { @MainActor in
+            await tail.value
+            if self.tails[queueKey]?.id == id {
+                self.tails.removeValue(forKey: queueKey)
+            }
+        }
+        return operation
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionUnreadPatchGuard.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionUnreadPatchGuard.swift
@@ -5,6 +5,7 @@ struct ChatSessionUnreadPatchGuard {
     private var requested = false
     private var activeExplicitUnread: Bool?
     private var confirmedUnreadByKey: [String: Bool] = [:]
+    private var pendingExplicitUnreadByKey: [String: Bool] = [:]
     private var pendingExplicitRevisions: [String: Int] = [:]
     private var revisions: [String: Int] = [:]
 
@@ -42,6 +43,7 @@ struct ChatSessionUnreadPatchGuard {
     mutating func beginExplicitPatch(key: String, unread: Bool, isActive: Bool) -> Int {
         let revision = self.advanceRevision(key: key)
         self.pendingExplicitRevisions[key] = revision
+        self.pendingExplicitUnreadByKey[key] = unread
         if isActive {
             self.activeSessionKey = key
             // The explicit action owns this activation. Only navigation opens
@@ -56,6 +58,7 @@ struct ChatSessionUnreadPatchGuard {
         guard self.revisions[key] == revision else { return false }
         if self.pendingExplicitRevisions[key] == revision {
             self.pendingExplicitRevisions.removeValue(forKey: key)
+            self.pendingExplicitUnreadByKey.removeValue(forKey: key)
         }
         self.confirmedUnreadByKey[key] = unread
         return true
@@ -65,6 +68,7 @@ struct ChatSessionUnreadPatchGuard {
         guard self.revisions[key] == revision else { return false }
         if self.pendingExplicitRevisions[key] == revision {
             self.pendingExplicitRevisions.removeValue(forKey: key)
+            self.pendingExplicitUnreadByKey.removeValue(forKey: key)
         }
         if key == self.activeSessionKey {
             self.requested = false
@@ -75,6 +79,14 @@ struct ChatSessionUnreadPatchGuard {
 
     func confirmedUnread(key: String) -> Bool? {
         self.confirmedUnreadByKey[key]
+    }
+
+    func localUnreadOverride(key: String) -> Bool? {
+        if let unread = self.pendingExplicitUnreadByKey[key] {
+            return unread
+        }
+        guard key == self.activeSessionKey else { return nil }
+        return self.activeExplicitUnread
     }
 
     private mutating func advanceRevision(key: String) -> Int {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -172,12 +172,6 @@ public struct OpenClawChatSessionWorktree: Codable, Sendable, Hashable {
     public let id: String?
     public let branch: String?
     public let repoRoot: String?
-
-    public init(id: String? = nil, branch: String? = nil, repoRoot: String? = nil) {
-        self.id = id
-        self.branch = branch
-        self.repoRoot = repoRoot
-    }
 }
 
 public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -168,6 +168,18 @@ public struct OpenClawChatSessionsDefaults: Codable, Sendable {
     }
 }
 
+public struct OpenClawChatSessionWorktree: Codable, Sendable, Hashable {
+    public let id: String?
+    public let branch: String?
+    public let repoRoot: String?
+
+    public init(id: String? = nil, branch: String? = nil, repoRoot: String? = nil) {
+        self.id = id
+        self.branch = branch
+        self.repoRoot = repoRoot
+    }
+}
+
 public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashable {
     public var id: String {
         self.key
@@ -189,8 +201,17 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
     public var space: String?
     public var updatedAt: Double?
     public var lastReadAt: Double?
+    public var lastInteractionAt: Double?
     public var lastActivityAt: Double?
     public var sessionId: String?
+
+    public var parentSessionKey: String?
+    public var spawnedBy: String?
+    public var childSessions: [String]?
+    public var status: String?
+    public var hasActiveRun: Bool?
+    public var hasActiveSubagentRun: Bool?
+    public var worktree: OpenClawChatSessionWorktree?
 
     public var systemSent: Bool?
     public var abortedLastRun: Bool?
@@ -241,7 +262,15 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         archivedAt: Double? = nil,
         unread: Bool? = nil,
         lastReadAt: Double? = nil,
-        lastActivityAt: Double? = nil)
+        lastInteractionAt: Double? = nil,
+        lastActivityAt: Double? = nil,
+        parentSessionKey: String? = nil,
+        spawnedBy: String? = nil,
+        childSessions: [String]? = nil,
+        status: String? = nil,
+        hasActiveRun: Bool? = nil,
+        hasActiveSubagentRun: Bool? = nil,
+        worktree: OpenClawChatSessionWorktree? = nil)
     {
         self.key = key
         self.kind = kind
@@ -259,8 +288,16 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         self.space = space
         self.updatedAt = updatedAt
         self.lastReadAt = lastReadAt
+        self.lastInteractionAt = lastInteractionAt
         self.lastActivityAt = lastActivityAt
         self.sessionId = sessionId
+        self.parentSessionKey = parentSessionKey
+        self.spawnedBy = spawnedBy
+        self.childSessions = childSessions
+        self.status = status
+        self.hasActiveRun = hasActiveRun
+        self.hasActiveSubagentRun = hasActiveSubagentRun
+        self.worktree = worktree
         self.systemSent = systemSent
         self.abortedLastRun = abortedLastRun
         self.thinkingLevel = thinkingLevel

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -158,7 +158,10 @@ struct ChatSessionsSheet: View {
     }
 
     private func sessionRow(_ session: OpenClawChatSessionEntry) -> some View {
-        Button {
+        let archiveActionTitle = LocalizedStringKey(session.isArchived
+            ? String(localized: "Restore")
+            : String(localized: "Archive"))
+        return Button {
             if session.isArchived {
                 // Archived sessions reject new sends; opening one restores it
                 // first and only switches on success so the composer never
@@ -209,15 +212,20 @@ struct ChatSessionsSheet: View {
             }
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            Button {
-                self.viewModel.setSessionArchived(key: session.key, archived: !session.isArchived)
-                self.refreshScopedSessionsSoon()
-            } label: {
-                self.actionLabel(
-                    session.isArchived ? "Unarchive" : "Archive",
-                    systemImage: session.isArchived ? "tray.and.arrow.up" : "archivebox")
+            if session.isArchived || ChatSessionSidebarModel.canArchiveSession(
+                session,
+                mainSessionKey: self.viewModel.resolvedMainSessionKey)
+            {
+                Button {
+                    self.viewModel.setSessionArchived(key: session.key, archived: !session.isArchived)
+                    self.refreshScopedSessionsSoon()
+                } label: {
+                    self.actionLabel(
+                        archiveActionTitle,
+                        systemImage: session.isArchived ? "tray.and.arrow.up" : "archivebox")
+                }
+                .tint(session.isArchived ? OpenClawChatTheme.accent : OpenClawChatTheme.danger)
             }
-            .tint(session.isArchived ? OpenClawChatTheme.accent : OpenClawChatTheme.danger)
         }
         .contextMenu {
             Button {
@@ -236,13 +244,35 @@ struct ChatSessionsSheet: View {
                         systemImage: session.isPinned ? "pin.slash" : "pin")
                 }
             }
+            if session.isArchived || ChatSessionSidebarModel.canArchiveSession(
+                session,
+                mainSessionKey: self.viewModel.resolvedMainSessionKey)
+            {
+                Button {
+                    self.viewModel.setSessionArchived(key: session.key, archived: !session.isArchived)
+                    self.refreshScopedSessionsSoon()
+                } label: {
+                    self.actionLabel(
+                        archiveActionTitle,
+                        systemImage: session.isArchived ? "tray.and.arrow.up" : "archivebox")
+                }
+            }
             Button {
-                self.viewModel.setSessionArchived(key: session.key, archived: !session.isArchived)
+                Task { await self.viewModel.forkSession(key: session.key) }
+            } label: {
+                self.actionLabel(
+                    LocalizedStringKey(String(localized: "Fork")),
+                    systemImage: "arrow.triangle.branch")
+            }
+            Button {
+                self.viewModel.setSessionUnread(key: session.key, unread: session.unread != true)
                 self.refreshScopedSessionsSoon()
             } label: {
                 self.actionLabel(
-                    session.isArchived ? "Unarchive" : "Archive",
-                    systemImage: session.isArchived ? "tray.and.arrow.up" : "archivebox")
+                    LocalizedStringKey(session.unread == true
+                        ? String(localized: "Mark Read")
+                        : String(localized: "Mark Unread")),
+                    systemImage: session.unread == true ? "envelope.open" : "envelope.badge")
             }
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -125,6 +125,35 @@ public struct OpenClawChatSessionSettingsRouteLease: Sendable {
     }
 }
 
+/// One physical gateway connection captured before a session mutation waits
+/// behind an earlier mutation for the same session.
+public struct OpenClawChatSessionMutationRouteLease: Sendable {
+    public typealias PatchSession = @Sendable (
+        _ key: String,
+        _ label: String??,
+        _ category: String??,
+        _ pinned: Bool?,
+        _ archived: Bool?,
+        _ unread: Bool?) async throws -> Void
+
+    private let patchSessionImpl: PatchSession
+
+    public init(patchSession: @escaping PatchSession) {
+        self.patchSessionImpl = patchSession
+    }
+
+    public func patchSession(
+        key: String,
+        label: String??,
+        category: String??,
+        pinned: Bool?,
+        archived: Bool?,
+        unread: Bool?) async throws
+    {
+        try await self.patchSessionImpl(key, label, category, pinned, archived, unread)
+    }
+}
+
 /// The transport rejected a send before it reached its request channel. This
 /// is the only failure class safe for automatic outbox retry.
 public enum OpenClawChatTransportSendError: Error, Sendable {
@@ -271,6 +300,7 @@ public protocol OpenClawChatTransport: Sendable {
         pinned: Bool?,
         archived: Bool?,
         unread: Bool?) async throws
+    func acquireSessionMutationRouteLease() async -> OpenClawChatSessionMutationRouteLease?
     func deleteSession(key: String) async throws
     func forkSession(parentKey: String) async throws -> String
     func setSessionModel(sessionKey: String, model: String?) async throws
@@ -340,6 +370,19 @@ extension OpenClawChatTransport {
                 sessionKey: sessionKey,
                 agentID: agentID,
                 patch: patch)
+        }
+    }
+
+    public func acquireSessionMutationRouteLease() async -> OpenClawChatSessionMutationRouteLease? {
+        let transport = self
+        return OpenClawChatSessionMutationRouteLease { key, label, category, pinned, archived, unread in
+            try await transport.patchSession(
+                key: key,
+                label: label,
+                category: category,
+                pinned: pinned,
+                archived: archived,
+                unread: unread)
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -67,17 +67,17 @@ extension OpenClawChatViewModel {
 
     public func renameSession(key: String, label: String) {
         let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        let nextLabel: String? = trimmed.isEmpty ? nil : trimmed
         let previous = self.sessions
         if let index = self.sessions.firstIndex(where: { $0.key == key }) {
-            self.sessions[index].label = trimmed
-            self.sessions[index].displayName = trimmed
+            self.sessions[index].label = nextLabel
+            self.sessions[index].displayName = nextLabel
         }
         Task {
             do {
                 try await self.transport.patchSession(
                     key: key,
-                    label: trimmed,
+                    label: .some(nextLabel),
                     category: nil,
                     pinned: nil,
                     archived: nil,
@@ -88,6 +88,66 @@ extension OpenClawChatViewModel {
                 self.errorText = error.localizedDescription
                 chatSessionActionsLogger.error(
                     "sessions.patch(label) failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    public func forkSession(key: String) async {
+        guard self.canCreateSessionForImmediateSwitch() else { return }
+        let initiatingSession = self.currentSessionSnapshot()
+        do {
+            let createdKey = try await self.transport.forkSession(parentKey: key)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !createdKey.isEmpty else { return }
+            guard self.isCurrentSession(initiatingSession), self.canCreateSessionForImmediateSwitch() else {
+                self.refreshSessions(limit: Self.sessionListFetchLimit)
+                return
+            }
+            self.switchSession(to: createdKey)
+        } catch {
+            self.errorText = error.localizedDescription
+            chatSessionActionsLogger.error(
+                "sessions.create(fork) failed \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    public func setSessionUnread(key: String, unread: Bool) {
+        let identityKey = self.sessionMutationIdentity(for: key)
+        let previousEntry = self.sessions.first(where: { $0.key == key })
+        let rollbackUnread = self.unreadPatchGuard.confirmedUnread(key: identityKey) ?? previousEntry?.unread
+        let revision = self.unreadPatchGuard.beginExplicitPatch(
+            key: identityKey,
+            unread: unread,
+            isActive: self.matchesCurrentSessionKey(incoming: key, current: self.sessionKey))
+        if let index = self.sessions.firstIndex(where: { $0.key == key }) {
+            self.sessions[index].unread = unread
+        }
+        let routeLease = Task { await self.transport.acquireSessionMutationRouteLease() }
+        let operation = self.unreadMutationQueue.reserve(
+            routeLease: routeLease,
+            queueKey: identityKey,
+            routeKey: key,
+            unread: unread)
+        Task {
+            do {
+                try await operation.value
+                guard self.unreadPatchGuard.patchSucceeded(
+                    key: identityKey,
+                    unread: unread,
+                    revision: revision)
+                else { return }
+                self.refreshSessions()
+            } catch {
+                guard self.unreadPatchGuard.patchFailed(key: identityKey, revision: revision) else { return }
+                if let index = self.sessions.firstIndex(where: { $0.key == key }),
+                   self.sessions[index].unread == unread
+                {
+                    self.sessions[index].unread = rollbackUnread
+                }
+                self.refreshSessions()
+                self.errorText = error.localizedDescription
+                chatSessionActionsLogger.error(
+                    "sessions.patch(unread) failed \(error.localizedDescription, privacy: .public)")
             }
         }
     }
@@ -134,7 +194,7 @@ extension OpenClawChatViewModel {
                     pinned: nil,
                     archived: true,
                     unread: nil)
-                if key == self.sessionKey {
+                if self.matchesCurrentSessionKey(incoming: key, current: self.sessionKey) {
                     // The archived session rejects new sends; move the user back
                     // to the main session instead of leaving a dead composer.
                     self.switchSession(to: self.resolvedMainSessionKey)
@@ -168,6 +228,40 @@ extension OpenClawChatViewModel {
             chatSessionActionsLogger.error(
                 "sessions.patch(archived=false) failed \(error.localizedDescription, privacy: .public)")
             return false
+        }
+    }
+
+    func markCurrentSessionReadAfterActivation(
+        _ session: SessionSnapshot,
+        fallbackEntry: OpenClawChatSessionEntry?) async
+    {
+        guard self.isCurrentSession(session), self.hasAppliedLiveHistory,
+              let entry = self.currentSessionEntry() ?? fallbackEntry,
+              let revision = self.unreadPatchGuard.shouldPatch(
+                  key: self.sessionMutationIdentity(for: entry.key, listedKey: entry.key),
+                  unread: entry.unread)
+        else { return }
+        let identityKey = self.sessionMutationIdentity(for: entry.key, listedKey: entry.key)
+        let routeLease = Task { await self.transport.acquireSessionMutationRouteLease() }
+        let operation = self.unreadMutationQueue.reserve(
+            routeLease: routeLease,
+            queueKey: identityKey,
+            routeKey: entry.key,
+            unread: false)
+        do {
+            try await operation.value
+            guard self.unreadPatchGuard.patchSucceeded(
+                key: identityKey,
+                unread: false,
+                revision: revision)
+            else { return }
+            if let index = self.sessions.firstIndex(where: { $0.key == entry.key }) {
+                self.sessions[index].unread = false
+            }
+        } catch {
+            guard self.unreadPatchGuard.patchFailed(key: identityKey, revision: revision) else { return }
+            chatSessionActionsLogger.error(
+                "sessions.patch(unread=false) failed \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -84,7 +84,7 @@ extension OpenClawChatViewModel {
                     unread: nil)
                 self.refreshSessions()
             } catch {
-                self.sessions = previous
+                self.sessions = self.applyingLocalUnreadOverrides(to: previous)
                 self.errorText = error.localizedDescription
                 chatSessionActionsLogger.error(
                     "sessions.patch(label) failed \(error.localizedDescription, privacy: .public)")
@@ -170,7 +170,7 @@ extension OpenClawChatViewModel {
                     unread: nil)
                 self.refreshSessions()
             } catch {
-                self.sessions = previous
+                self.sessions = self.applyingLocalUnreadOverrides(to: previous)
                 self.errorText = error.localizedDescription
                 chatSessionActionsLogger.error(
                     "sessions.patch(pinned) failed \(error.localizedDescription, privacy: .public)")
@@ -201,7 +201,7 @@ extension OpenClawChatViewModel {
                 }
                 self.refreshSessions()
             } catch {
-                self.sessions = previous
+                self.sessions = self.applyingLocalUnreadOverrides(to: previous)
                 self.errorText = error.localizedDescription
                 chatSessionActionsLogger.error(
                     "sessions.patch(archived) failed \(error.localizedDescription, privacy: .public)")

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -23,28 +23,6 @@ extension OpenClawChatViewModel {
         Task { await self.performCompact() }
     }
 
-    public func setSessionPinned(_ sessionKey: String, pinned: Bool) {
-        Task {
-            do {
-                try await self.transport.patchSession(
-                    key: sessionKey,
-                    label: nil,
-                    category: nil,
-                    pinned: pinned,
-                    archived: nil,
-                    unread: nil)
-            } catch {
-                self.errorText = error.localizedDescription
-                return
-            }
-            await self.fetchSessions(limit: nil, sessionSnapshot: self.currentSessionSnapshot())
-        }
-    }
-
-    /// One-shot session list fetch for search and archived browsing. Falls back
-    /// to locally filtering the cached active list when the gateway is
-    /// unreachable; archived rows exist only server-side, so archived mode
-    /// returns empty offline.
     public func fetchSessionList(search: String?, archived: Bool) async -> [OpenClawChatSessionEntry] {
         let normalizedSearch = search?.trimmingCharacters(in: .whitespacesAndNewlines)
         let query = normalizedSearch?.isEmpty == false ? normalizedSearch : nil

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -34,6 +34,20 @@ extension OpenClawChatViewModel {
             })
     }
 
+    /// Session mutations and their ordering use the routed gateway identity,
+    /// never a presentation alias such as `main`.
+    func sessionMutationIdentity(for key: String, listedKey: String? = nil) -> String {
+        let listedKey = listedKey ?? self.sessions.first(where: { $0.key == key })?.key ??
+            (self.matchesCurrentSessionKey(incoming: key, current: self.sessionKey)
+                ? self.currentSessionEntry()?.key
+                : nil)
+        return self.modelPatchTarget(
+            sessionKey: key,
+            canonicalSessionKey: listedKey,
+            agentID: OpenClawChatSessionKey.agentID(from: key) ?? self.activeAgentId,
+            sessionRoutingContract: nil).canonicalSessionKey
+    }
+
     func currentModelPatchTarget() -> ModelPatchTarget {
         let session = self.currentSessionSnapshot()
         return self.modelPatchTarget(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -48,6 +48,19 @@ extension OpenClawChatViewModel {
             sessionRoutingContract: nil).canonicalSessionKey
     }
 
+    func applyingLocalUnreadOverrides(
+        to sessions: [OpenClawChatSessionEntry]) -> [OpenClawChatSessionEntry]
+    {
+        sessions.map { session in
+            var session = session
+            let identityKey = self.sessionMutationIdentity(for: session.key, listedKey: session.key)
+            if let unread = self.unreadPatchGuard.localUnreadOverride(key: identityKey) {
+                session.unread = unread
+            }
+            return session
+        }
+    }
+
     func currentModelPatchTarget() -> ModelPatchTarget {
         let session = self.currentSessionSnapshot()
         return self.modelPatchTarget(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TranscriptCache.swift
@@ -62,7 +62,8 @@ extension OpenClawChatViewModel {
                 // A live sessions response (even an empty one) is authoritative;
                 // a slow cache read must never repaint over it.
                 guard self.sessions.isEmpty, !self.hasAppliedLiveSessions else { return }
-                self.sessions = OpenClawChatSessionListOrganizer.organize(cached)
+                self.sessions = self.applyingLocalUnreadOverrides(
+                    to: OpenClawChatSessionListOrganizer.organize(cached))
             }
         }
         guard messages.isEmpty, !hasAppliedLiveHistory else { return }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -953,7 +953,7 @@ extension OpenClawChatViewModel {
                     key: self.sessionMutationIdentity(for: session.key, listedKey: session.key),
                     unread: session.unread)
             }
-            self.sessions = organized
+            self.sessions = self.applyingLocalUnreadOverrides(to: organized)
             self.sessionDefaults = res.defaults
             if let overlappingRequestID = overlappingSuccessfulSettingsPatchRequestID,
                lastSuccessfulSettingsPatchRequestIDsByTarget[target] == overlappingRequestID

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -113,6 +113,9 @@ public final class OpenClawChatViewModel {
     /// one), a slow cache read must never paint stale rows over it.
     var hasAppliedLiveHistory = false
     var hasAppliedLiveSessions = false
+    @ObservationIgnored
+    var unreadPatchGuard = ChatSessionUnreadPatchGuard()
+    let unreadMutationQueue = ChatSessionUnreadMutationQueue()
     /// Internal for the outbox extension's flush path only.
     let transport: any OpenClawChatTransport
     let haptics: OpenClawChatHaptics
@@ -654,6 +657,15 @@ public final class OpenClawChatViewModel {
             !self.attachments.isEmpty
     }
 
+    func canCreateSessionForImmediateSwitch() -> Bool {
+        guard !self.blocksAttachmentOwnerChange else {
+            self.errorText = String(
+                localized: "Remove attachments or wait for delivery to resolve before starting a new chat.")
+            return false
+        }
+        return true
+    }
+
     var hasBlockingRunActivity: Bool {
         self.pendingRunCount > 0 || self.hasActiveSessionRunWithoutChatSnapshot
     }
@@ -731,6 +743,7 @@ extension OpenClawChatViewModel {
     private func startBootstrap(sessionKey requestedSessionKey: String? = nil) {
         let sessionKey = requestedSessionKey ?? self.sessionKey
         guard sessionKey == self.sessionKey else { return }
+        self.unreadPatchGuard.activate(key: self.sessionMutationIdentity(for: sessionKey))
         self.bootstrapGeneration &+= 1
         self.bootstrapTask?.cancel()
         self.isLoading = true
@@ -778,7 +791,14 @@ extension OpenClawChatViewModel {
                 sessionSnapshot: context.session,
                 refreshSessionsOnReconnect: false)
             guard self.isCurrentBootstrap(context) else { return }
+            // A sidebar-selected row can sit outside the bootstrap's 50-row refresh.
+            // Retain its unread metadata until activation acknowledgement finishes.
+            let activationEntry = self.currentSessionEntry()
             await self.fetchSessions(limit: 50, sessionSnapshot: context.session)
+            guard self.isCurrentBootstrap(context) else { return }
+            await self.markCurrentSessionReadAfterActivation(
+                context.session,
+                fallbackEntry: activationEntry)
             guard self.isCurrentBootstrap(context) else { return }
             await self.fetchModels(sessionSnapshot: context.session)
             guard self.isCurrentBootstrap(context) else { return }
@@ -928,6 +948,11 @@ extension OpenClawChatViewModel {
             }
             self.latestAppliedSessionsFetchRequestID = sessionsFetchRequestID
             let organized = OpenClawChatSessionListOrganizer.organize(res.sessions)
+            for session in organized {
+                self.unreadPatchGuard.observe(
+                    key: self.sessionMutationIdentity(for: session.key, listedKey: session.key),
+                    unread: session.unread)
+            }
             self.sessions = organized
             self.sessionDefaults = res.defaults
             if let overlappingRequestID = overlappingSuccessfulSettingsPatchRequestID,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -15,6 +15,9 @@ public struct OpenClawChatWindowShell: View {
     @State private var sessionQuery = ""
     @State private var isConfirmingClearHistory = false
     @State private var isPresentingSessions = false
+    @State private var isRenamingSession = false
+    @State private var renameSessionKey: String?
+    @State private var renameText = ""
     private let userAccent: Color?
     private let showsAssistantTrace: Bool
     private let emptyAssistantIntro: String?
@@ -84,7 +87,18 @@ public struct OpenClawChatWindowShell: View {
                 self.activeSessionTitle))
                 .font(OpenClawChatTypography.body)
         }
-        .sheet(isPresented: self.$isPresentingSessions) {
+        .alert(String(localized: "Rename Session"), isPresented: self.$isRenamingSession) {
+                TextField(String(localized: "Session name"), text: self.$renameText)
+                Button(String(localized: "Rename")) {
+                    guard let renameSessionKey else { return }
+                    self.viewModel.renameSession(key: renameSessionKey, label: self.renameText)
+                    self.renameSessionKey = nil
+                }
+                Button(String(localized: "Cancel"), role: .cancel) {
+                    self.renameSessionKey = nil
+                }
+            }
+            .sheet(isPresented: self.$isPresentingSessions) {
                 ChatSessionsSheet(viewModel: self.viewModel)
             }
             .onChange(of: self.viewModel.pendingRunCount) { previous, current in
@@ -141,11 +155,23 @@ public struct OpenClawChatWindowShell: View {
     }
 
     private var activeSessionTitle: String {
-        let entry = self.viewModel.sessions.first { $0.key == self.viewModel.sessionKey }
-        if let entry {
+        if let entry = self.activeSessionEntry {
             return ChatSessionSidebarModel.displayName(for: entry)
         }
         return ChatSessionSidebarModel.displayName(forKey: self.viewModel.sessionKey)
+    }
+
+    private var activeSessionEntry: OpenClawChatSessionEntry? {
+        self.viewModel.sessions.first { $0.key == self.viewModel.sessionKey } ??
+            self.viewModel.sessions.first {
+                self.viewModel.matchesCurrentSessionKey(
+                    incoming: $0.key,
+                    current: self.viewModel.sessionKey)
+            }
+    }
+
+    private var activeSessionKey: String {
+        self.activeSessionEntry?.key ?? self.viewModel.sessionKey
     }
 
     private var subtitle: String {
@@ -274,6 +300,70 @@ public struct OpenClawChatWindowShell: View {
             Divider()
 
             Button {
+                self.renameSessionKey = self.activeSessionKey
+                self.renameText = self.activeSessionEntry?.label ?? self.activeSessionTitle
+                self.isRenamingSession = true
+            } label: {
+                chatWindowActionLabel(
+                    LocalizedStringKey(String(localized: "Rename Session…")),
+                    systemImage: "pencil")
+            }
+
+            Button {
+                Task { await self.viewModel.forkSession(key: self.activeSessionKey) }
+            } label: {
+                chatWindowActionLabel(
+                    LocalizedStringKey(String(localized: "Fork Session")),
+                    systemImage: "arrow.triangle.branch")
+            }
+
+            Button {
+                self.viewModel.setSessionPinned(
+                    key: self.activeSessionKey,
+                    pinned: self.activeSessionEntry?.pinned != true)
+            } label: {
+                chatWindowActionLabel(
+                    LocalizedStringKey(self.activeSessionEntry?.pinned == true
+                        ? String(localized: "Unpin")
+                        : String(localized: "Pin")),
+                    systemImage: self.activeSessionEntry?.pinned == true ? "pin.slash" : "pin")
+            }
+
+            Button {
+                self.viewModel.setSessionUnread(
+                    key: self.activeSessionKey,
+                    unread: self.activeSessionEntry?.unread != true)
+            } label: {
+                chatWindowActionLabel(
+                    LocalizedStringKey(self.activeSessionEntry?.unread == true
+                        ? String(localized: "Mark Read")
+                        : String(localized: "Mark Unread")),
+                    systemImage: self.activeSessionEntry?.unread == true ? "envelope.open" : "envelope.badge")
+            }
+
+            if self.activeSessionEntry?.isArchived == true || self.activeSessionEntry.map({
+                ChatSessionSidebarModel.canArchiveSession(
+                    $0,
+                    mainSessionKey: self.viewModel.resolvedMainSessionKey)
+            }) == true {
+                Button {
+                    self.viewModel.setSessionArchived(
+                        key: self.activeSessionKey,
+                        archived: self.activeSessionEntry?.isArchived != true)
+                } label: {
+                    chatWindowActionLabel(
+                        LocalizedStringKey(self.activeSessionEntry?.isArchived == true
+                            ? String(localized: "Restore")
+                            : String(localized: "Archive")),
+                        systemImage: self.activeSessionEntry?.isArchived == true
+                            ? "tray.and.arrow.up"
+                            : "archivebox")
+                }
+            }
+
+            Divider()
+
+            Button {
                 self.copyToPasteboard(self.viewModel.sessionKey)
             } label: {
                 chatWindowActionLabel("Copy Session Key", systemImage: "doc.on.doc")
@@ -376,189 +466,7 @@ private struct ChatContextUsageMenu: View {
     }
 }
 
-@MainActor
-private struct ChatSessionSidebar: View {
-    @Bindable var viewModel: OpenClawChatViewModel
-    @Binding var query: String
-    @State private var sessionPendingDeletion: OpenClawChatSessionEntry?
-
-    var body: some View {
-        let sections = ChatSessionSidebarModel.sections(
-            sessions: self.viewModel.sessions,
-            currentSessionKey: self.viewModel.sessionKey,
-            mainSessionKey: self.viewModel.resolvedMainSessionKey,
-            activeAgentID: self.viewModel.activeAgentId,
-            query: self.query)
-        List(selection: self.selectionBinding) {
-            ForEach(sections) { section in
-                if let title = section.title {
-                    Section(title) {
-                        ForEach(section.sessions) { session in
-                            self.row(for: session)
-                        }
-                    }
-                } else {
-                    ForEach(section.sessions) { session in
-                        self.row(for: session)
-                    }
-                }
-            }
-        }
-        .listStyle(.sidebar)
-        .searchable(text: self.$query, placement: .sidebar, prompt: "Search sessions")
-        .overlay {
-            if sections.isEmpty {
-                ContentUnavailableView(
-                    self.query.isEmpty ? "No Sessions" : "No Results",
-                    systemImage: "bubble.left.and.bubble.right")
-            }
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            self.connectionFooter
-        }
-        .toolbar {
-            ToolbarItem {
-                Button {
-                    Task { await self.viewModel.startNewSession() }
-                } label: {
-                    chatWindowActionLabel("New Session", systemImage: "square.and.pencil")
-                }
-                .help("New session")
-            }
-        }
-        .task {
-            self.viewModel.refreshSessions(limit: 200)
-        }
-        .onChange(of: self.viewModel.healthOK) { previous, current in
-            if !previous, current {
-                self.viewModel.refreshSessions(limit: 200)
-            }
-        }
-        .confirmationDialog(
-            self.deleteDialogTitle,
-            isPresented: self.isPresentingDeleteDialog)
-        {
-            Button(role: .destructive) {
-                if let session = self.sessionPendingDeletion {
-                    self.viewModel.deleteSession(session.key)
-                }
-                self.sessionPendingDeletion = nil
-            } label: {
-                Text("Delete Session")
-                    .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))
-            }
-        } message: {
-            Text("The session and its transcript are removed from the gateway.")
-                .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))
-        }
-    }
-
-    private var deleteDialogTitle: String {
-        let name = self.sessionPendingDeletion.map(ChatSessionSidebarModel.displayName(for:)) ?? ""
-        return "Delete “\(name)”?"
-    }
-
-    private var isPresentingDeleteDialog: Binding<Bool> {
-        Binding(
-            get: { self.sessionPendingDeletion != nil },
-            set: { if !$0 { self.sessionPendingDeletion = nil } })
-    }
-
-    private var selectionBinding: Binding<String?> {
-        Binding(
-            get: {
-                ChatSessionSidebarModel.selectedSessionKey(
-                    sessions: self.viewModel.sessions,
-                    currentSessionKey: self.viewModel.sessionKey,
-                    mainSessionKey: self.viewModel.resolvedMainSessionKey,
-                    activeAgentID: self.viewModel.activeAgentId)
-            },
-            set: { next in
-                guard let next, next != self.viewModel.sessionKey else { return }
-                self.viewModel.switchSession(to: next)
-            })
-    }
-
-    private func row(for session: OpenClawChatSessionEntry) -> some View {
-        HStack(spacing: 6) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(ChatSessionSidebarModel.displayName(for: session))
-                    .font(OpenClawChatTypography.body(size: 13, weight: .medium, relativeTo: .body))
-                    .lineLimit(1)
-                if let subtitle = self.rowSubtitle(for: session) {
-                    Text(subtitle)
-                        .font(OpenClawChatTypography.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-
-            Spacer(minLength: 0)
-
-            if session.unread == true, session.key != self.viewModel.sessionKey {
-                Circle()
-                    .fill(.tint)
-                    .frame(width: 7, height: 7)
-                    .accessibilityLabel("Unread")
-            }
-        }
-        // The tag type must equal the List selection type (String?) exactly;
-        // a plain String tag silently breaks selection highlighting/clicks.
-        .tag(Optional(session.key))
-        .contextMenu {
-            Button {
-                self.viewModel.setSessionPinned(session.key, pinned: session.pinned != true)
-            } label: {
-                Text(session.pinned == true ? "Unpin" : "Pin")
-                    .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))
-            }
-            Button {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(session.key, forType: .string)
-            } label: {
-                Text("Copy Session Key")
-                    .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))
-            }
-            if ChatSessionSidebarModel.canDeleteSession(
-                key: session.key,
-                mainSessionKey: self.viewModel.resolvedMainSessionKey)
-            {
-                Divider()
-                Button(role: .destructive) {
-                    self.sessionPendingDeletion = session
-                } label: {
-                    Text("Delete Session…")
-                        .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))
-                }
-            }
-        }
-    }
-
-    private func rowSubtitle(for session: OpenClawChatSessionEntry) -> String? {
-        guard let updatedAt = session.updatedAt ?? session.lastActivityAt, updatedAt > 0 else {
-            return nil
-        }
-        let date = Date(timeIntervalSince1970: updatedAt / 1000)
-        return date.formatted(.relative(presentation: .named))
-    }
-
-    private var connectionFooter: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(self.viewModel.healthOK ? .green : .orange)
-                .frame(width: 7, height: 7)
-            Text(self.viewModel.healthOK ? "Gateway connected" : "Connecting…")
-                .font(OpenClawChatTypography.caption)
-                .foregroundStyle(.secondary)
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.bar)
-    }
-}
-
-private func chatWindowActionLabel(_ title: LocalizedStringKey, systemImage: String) -> some View {
+func chatWindowActionLabel(_ title: LocalizedStringKey, systemImage: String) -> some View {
     Label {
         Text(title)
             .font(OpenClawChatTypography.body(size: 13, weight: .regular, relativeTo: .body))

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
@@ -115,6 +115,34 @@ struct ChatGatewayRequestTests {
         #expect(create.params["worktree"]?.value as? Bool == true)
     }
 
+    @Test func `rename clear archive and fork use session mutation contracts`() {
+        let rename = OpenClawChatGatewayRequests.patchSession(
+            sessionKey: "agent:main:child",
+            agentID: nil,
+            label: .some(nil),
+            category: nil,
+            pinned: nil,
+            archived: nil,
+            unread: nil)
+        let archive = OpenClawChatGatewayRequests.patchSession(
+            sessionKey: "agent:main:child",
+            agentID: nil,
+            label: nil,
+            category: nil,
+            pinned: nil,
+            archived: true,
+            unread: nil)
+        let fork = OpenClawChatGatewayRequests.forkSession(
+            parentSessionKey: "agent:main:child",
+            agentID: nil)
+
+        #expect(rename.params["label"]?.value is NSNull)
+        #expect(archive.params["archived"]?.value as? Bool == true)
+        #expect(fork.method == "sessions.create")
+        #expect(fork.params["parentSessionKey"]?.value as? String == "agent:main:child")
+        #expect(fork.params["fork"]?.value as? Bool == true)
+    }
+
     @Test func `commands request selects session agent before fallback`() {
         let scoped = OpenClawChatGatewayRequests.commandsList(
             sessionKey: "agent:reviewer:main",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -210,10 +210,9 @@ struct ChatSessionSidebarModelTests {
         #expect(entry.hasActiveRun == true)
         #expect(entry.hasActiveSubagentRun == true)
         #expect(entry.lastInteractionAt == 1_700_000_000_000)
-        #expect(entry.worktree == OpenClawChatSessionWorktree(
-            id: "wt-1",
-            branch: "feature/chat",
-            repoRoot: "/repo"))
+        #expect(entry.worktree?.id == "wt-1")
+        #expect(entry.worktree?.branch == "feature/chat")
+        #expect(entry.worktree?.repoRoot == "/repo")
     }
 
     @Test func `tree nests children and bubbles run failure and unread badges`() {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -9,7 +9,14 @@ struct ChatSessionSidebarModelTests {
         displayName: String? = nil,
         updatedAt: Double? = nil,
         pinned: Bool? = nil,
-        archived: Bool? = nil) -> OpenClawChatSessionEntry
+        archived: Bool? = nil,
+        unread: Bool? = nil,
+        parentSessionKey: String? = nil,
+        spawnedBy: String? = nil,
+        childSessions: [String]? = nil,
+        status: String? = nil,
+        hasActiveRun: Bool? = nil,
+        hasActiveSubagentRun: Bool? = nil) -> OpenClawChatSessionEntry
     {
         OpenClawChatSessionEntry(
             key: key,
@@ -32,7 +39,14 @@ struct ChatSessionSidebarModelTests {
             model: nil,
             contextTokens: nil,
             pinned: pinned,
-            archived: archived)
+            archived: archived,
+            unread: unread,
+            parentSessionKey: parentSessionKey,
+            spawnedBy: spawnedBy,
+            childSessions: childSessions,
+            status: status,
+            hasActiveRun: hasActiveRun,
+            hasActiveSubagentRun: hasActiveSubagentRun)
     }
 
     @Test func `pinned sessions get their own section, rest sorted by recency`() {
@@ -59,6 +73,20 @@ struct ChatSessionSidebarModelTests {
 
         #expect(sections.count == 1)
         #expect(sections[0].title == nil)
+    }
+
+    @Test func `pinned descendants move to pinned section independently`() {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: [
+                self.entry(key: "parent", updatedAt: 200),
+                self.entry(key: "child", updatedAt: 100, pinned: true, parentSessionKey: "parent"),
+            ],
+            currentSessionKey: "parent",
+            query: "")
+
+        #expect(sections.map(\.id) == ["pinned", "recent"])
+        #expect(sections[0].nodes.map(\.id) == ["child"])
+        #expect(sections[1].nodes.map(\.id) == ["parent"])
     }
 
     @Test func `hides onboarding and archived sessions, keeps the active one`() {
@@ -156,5 +184,114 @@ struct ChatSessionSidebarModelTests {
         #expect(ChatSessionSidebarModel.canDeleteSession(
             key: "agent:other:global",
             mainSessionKey: mainKey))
+    }
+
+    @Test func `session list hierarchy fields decode with gateway spellings`() throws {
+        let data = try #require("""
+        {
+          "key": "agent:main:child",
+          "parentSessionKey": "agent:main:main",
+          "spawnedBy": "agent:main:controller",
+          "childSessions": ["agent:main:grandchild"],
+          "status": "running",
+          "hasActiveRun": true,
+          "hasActiveSubagentRun": true,
+          "lastInteractionAt": 1700000000000,
+          "worktree": {"id": "wt-1", "branch": "feature/chat", "repoRoot": "/repo"}
+        }
+        """.data(using: .utf8))
+
+        let entry = try JSONDecoder().decode(OpenClawChatSessionEntry.self, from: data)
+
+        #expect(entry.parentSessionKey == "agent:main:main")
+        #expect(entry.spawnedBy == "agent:main:controller")
+        #expect(entry.childSessions == ["agent:main:grandchild"])
+        #expect(entry.status == "running")
+        #expect(entry.hasActiveRun == true)
+        #expect(entry.hasActiveSubagentRun == true)
+        #expect(entry.lastInteractionAt == 1_700_000_000_000)
+        #expect(entry.worktree == OpenClawChatSessionWorktree(
+            id: "wt-1",
+            branch: "feature/chat",
+            repoRoot: "/repo"))
+    }
+
+    @Test func `tree nests children and bubbles run failure and unread badges`() {
+        let nodes = ChatSessionSidebarModel.tree(from: [
+            self.entry(key: "parent", childSessions: ["child"]),
+            self.entry(
+                key: "child",
+                spawnedBy: "parent",
+                childSessions: ["grandchild"],
+                status: "running"),
+            self.entry(key: "grandchild", unread: true, parentSessionKey: "child", status: "failed"),
+        ])
+
+        #expect(nodes.map(\.id) == ["parent"])
+        #expect(nodes[0].children.map(\.id) == ["child"])
+        #expect(nodes[0].children[0].children.map(\.id) == ["grandchild"])
+        #expect(nodes[0].badges == .init(runningCount: 1, failedCount: 1, hasUnread: true))
+        #expect(nodes[0].hasUnreadDescendant)
+    }
+
+    @Test func `tree breaks cycles without dropping or duplicating sessions`() {
+        let nodes = ChatSessionSidebarModel.tree(from: [
+            self.entry(key: "a", parentSessionKey: "b", childSessions: ["b"]),
+            self.entry(key: "b", parentSessionKey: "a", childSessions: ["a"]),
+        ])
+
+        func keys(_ nodes: [ChatSessionSidebarModel.Node]) -> [String] {
+            nodes.flatMap { [$0.id] + keys($0.children) }
+        }
+        #expect(keys(nodes) == ["a", "b"])
+    }
+
+    @Test func `omitted gateway child roster excludes stale persisted parent metadata`() {
+        let nodes = ChatSessionSidebarModel.tree(from: [
+            self.entry(key: "parent"),
+            self.entry(key: "stale-child", parentSessionKey: "parent"),
+        ])
+
+        #expect(nodes.map(\.id) == ["parent", "stale-child"])
+    }
+
+    @Test func `orphaned parents remain visible as roots`() {
+        let nodes = ChatSessionSidebarModel.tree(from: [
+            self.entry(key: "orphan", parentSessionKey: "missing"),
+            self.entry(key: "root"),
+        ])
+
+        #expect(nodes.map(\.id) == ["orphan", "root"])
+    }
+
+    @Test func `sessions without hierarchy data keep flat ordering`() {
+        let nodes = ChatSessionSidebarModel.tree(from: [
+            self.entry(key: "a"),
+            self.entry(key: "b"),
+        ])
+
+        #expect(nodes.map(\.id) == ["a", "b"])
+        #expect(nodes.filter { !$0.children.isEmpty }.isEmpty)
+    }
+
+    @Test func `main aliases cannot archive while ordinary sessions can`() {
+        #expect(!ChatSessionSidebarModel.canArchiveSession(
+            self.entry(key: "main"),
+            mainSessionKey: "agent:main:main"))
+        #expect(!ChatSessionSidebarModel.canArchiveSession(
+            self.entry(key: "global"),
+            mainSessionKey: "agent:main:main"))
+        #expect(!ChatSessionSidebarModel.canArchiveSession(
+            self.entry(key: "agent:main:main"),
+            mainSessionKey: "agent:main:main"))
+        #expect(ChatSessionSidebarModel.canArchiveSession(
+            self.entry(key: "agent:main:child"),
+            mainSessionKey: "agent:main:main"))
+        #expect(!ChatSessionSidebarModel.canArchiveSession(
+            self.entry(key: "agent:main:running", status: "running"),
+            mainSessionKey: "agent:main:main"))
+        #expect(!ChatSessionSidebarModel.canArchiveSession(
+            self.entry(key: "agent:main:active", hasActiveSubagentRun: true),
+            mainSessionKey: "agent:main:main"))
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClawChatUI
+
+private actor SessionActionTransportState {
+    var forkedParentKeys: [String] = []
+
+    func recordFork(_ key: String) {
+        self.forkedParentKeys.append(key)
+    }
+}
+
+private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTransport {
+    private let state = SessionActionTransportState()
+    private let forkDelay: Duration?
+
+    init(forkDelay: Duration? = nil) {
+        self.forkDelay = forkDelay
+    }
+
+    func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+        OpenClawChatHistoryPayload(
+            sessionKey: sessionKey,
+            sessionId: "session-\(sessionKey)",
+            messages: [],
+            thinkingLevel: "off")
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        throw NSError(domain: "SessionActionTransport", code: 1)
+    }
+
+    func forkSession(parentKey: String) async throws -> String {
+        await self.state.recordFork(parentKey)
+        if let forkDelay {
+            try await Task.sleep(for: forkDelay)
+        }
+        return "forked"
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        true
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func forkedParentKeys() async -> [String] {
+        await self.state.forkedParentKeys
+    }
+}
+
+@MainActor
+struct ChatViewModelSessionActionTests {
+    @Test func `fork does not mutate gateway while session switching is blocked`() async {
+        let transport = SessionActionTransport()
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.attachments = [OpenClawPendingAttachment(
+            url: nil,
+            data: Data([1]),
+            fileName: "draft.png",
+            mimeType: "image/png",
+            preview: nil)]
+
+        await viewModel.forkSession(key: "main")
+
+        let forkedKeys = await transport.forkedParentKeys()
+        #expect(forkedKeys.isEmpty)
+        #expect(viewModel.sessionKey == "main")
+        #expect(viewModel.errorText == String(
+            localized: "Remove attachments or wait for delivery to resolve before starting a new chat."))
+    }
+
+    @Test func `fork completion does not override newer navigation`() async throws {
+        let transport = SessionActionTransport(forkDelay: .milliseconds(50))
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+
+        let fork = Task { await viewModel.forkSession(key: "main") }
+        try await self.waitUntil { await transport.forkedParentKeys() == ["main"] }
+        viewModel.switchSession(to: "other")
+        await fork.value
+
+        #expect(viewModel.sessionKey == "other")
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @escaping @MainActor () async -> Bool) async throws
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("timed out waiting for session action condition")
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
@@ -1,0 +1,520 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClawChatUI
+
+private actor UnreadTestTransportState {
+    var historyCalls = 0
+    var listCalls = 0
+    var unreadPatchAttempts: [(String, Bool)] = []
+    var unreadPatchStarts = 0
+    var sessionOverride: [OpenClawChatSessionEntry]?
+    var historyFailuresRemaining: Int
+    var patchFailuresRemaining: Int
+
+    init(historyFailures: Int, patchFailures: Int) {
+        self.historyFailuresRemaining = historyFailures
+        self.patchFailuresRemaining = patchFailures
+    }
+}
+
+private actor UnreadMutationRecorder {
+    private(set) var events: [String] = []
+
+    func append(_ event: String) {
+        self.events.append(event)
+    }
+}
+
+private final class UnreadTestTransport: @unchecked Sendable, OpenClawChatTransport {
+    private let state: UnreadTestTransportState
+    private let sessions: [OpenClawChatSessionEntry]
+    private let respectsListLimit: Bool
+    private let patchDelay: Duration?
+
+    init(
+        sessions: [OpenClawChatSessionEntry],
+        historyFailures: Int = 0,
+        patchFailures: Int = 0,
+        respectsListLimit: Bool = false,
+        patchDelay: Duration? = nil)
+    {
+        self.sessions = sessions
+        self.respectsListLimit = respectsListLimit
+        self.patchDelay = patchDelay
+        self.state = UnreadTestTransportState(
+            historyFailures: historyFailures,
+            patchFailures: patchFailures)
+    }
+
+    func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+        await self.state.recordHistoryCall()
+        if await self.state.consumeHistoryFailure() {
+            throw NSError(domain: "UnreadTestTransport", code: 1)
+        }
+        return OpenClawChatHistoryPayload(
+            sessionKey: sessionKey,
+            sessionId: "session-\(sessionKey)",
+            messages: [],
+            thinkingLevel: "off")
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        throw NSError(domain: "UnreadTestTransport", code: 3)
+    }
+
+    func listSessions(
+        limit: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
+        await self.state.recordListCall()
+        let sessions = await self.state.sessionOverride ?? self.sessions
+        let listed = if self.respectsListLimit, let limit {
+            Array(sessions.prefix(limit))
+        } else {
+            sessions
+        }
+        return OpenClawChatSessionsListResponse(
+            ts: nil,
+            path: nil,
+            count: listed.count,
+            defaults: nil,
+            sessions: listed)
+    }
+
+    func patchSession(
+        key: String,
+        label _: String??,
+        category _: String??,
+        pinned _: Bool?,
+        archived _: Bool?,
+        unread: Bool?) async throws
+    {
+        guard let unread else { return }
+        await self.state.recordUnreadPatchStart()
+        if let patchDelay {
+            try await Task.sleep(for: patchDelay)
+        }
+        await self.state.recordUnreadPatch(key: key, unread: unread)
+        if await self.state.consumePatchFailure() {
+            throw NSError(domain: "UnreadTestTransport", code: 2)
+        }
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        true
+    }
+
+    func listModels() async throws -> [OpenClawChatModelChoice] {
+        []
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func unreadPatchAttempts() async -> [(String, Bool)] {
+        await self.state.unreadPatchAttempts
+    }
+
+    func historyCallCount() async -> Int {
+        await self.state.historyCalls
+    }
+
+    func unreadPatchStartCount() async -> Int {
+        await self.state.unreadPatchStarts
+    }
+
+    func listCallCount() async -> Int {
+        await self.state.listCalls
+    }
+
+    func setSessions(_ sessions: [OpenClawChatSessionEntry]) async {
+        await self.state.setSessions(sessions)
+    }
+}
+
+extension UnreadTestTransportState {
+    fileprivate func recordHistoryCall() {
+        self.historyCalls += 1
+    }
+
+    fileprivate func recordListCall() {
+        self.listCalls += 1
+    }
+
+    fileprivate func recordUnreadPatch(key: String, unread: Bool) {
+        self.unreadPatchAttempts.append((key, unread))
+    }
+
+    fileprivate func recordUnreadPatchStart() {
+        self.unreadPatchStarts += 1
+    }
+
+    fileprivate func consumeHistoryFailure() -> Bool {
+        guard self.historyFailuresRemaining > 0 else { return false }
+        self.historyFailuresRemaining -= 1
+        return true
+    }
+
+    fileprivate func consumePatchFailure() -> Bool {
+        guard self.patchFailuresRemaining > 0 else { return false }
+        self.patchFailuresRemaining -= 1
+        return true
+    }
+
+    fileprivate func setSessions(_ sessions: [OpenClawChatSessionEntry]) {
+        self.sessionOverride = sessions
+    }
+}
+
+@MainActor
+struct ChatViewModelUnreadTests {
+    @Test func `successful activation clears unread once`() async throws {
+        let transport = UnreadTestTransport(sessions: [self.entry(key: "a", unread: true)])
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+
+        viewModel.load()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        viewModel.refresh()
+        try await self.waitUntil { await transport.listCallCount() >= 2 && !viewModel.isLoading }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.0) == ["a"])
+        #expect(attempts.map(\.1) == [false])
+    }
+
+    @Test func `main alias refresh does not rearm unread clearing`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [self.entry(key: "agent:alpha:main", unread: true)])
+        let viewModel = self.viewModel(
+            sessionKey: "main",
+            activeAgentID: "alpha",
+            transport: transport)
+
+        viewModel.load()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        viewModel.refresh()
+        try await self.waitUntil { await transport.historyCallCount() >= 2 && !viewModel.isLoading }
+
+        #expect(await transport.unreadPatchAttempts().count == 1)
+    }
+
+    @Test func `cold main alias mark unread shares canonical activation identity`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [self.entry(key: "agent:alpha:main", unread: true)],
+            patchDelay: .milliseconds(50))
+        let viewModel = self.viewModel(
+            sessionKey: "main",
+            activeAgentID: "alpha",
+            transport: transport)
+
+        viewModel.setSessionUnread(key: "main", unread: true)
+        viewModel.load()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 && !viewModel.isLoading }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.0) == ["main"])
+        #expect(attempts.map(\.1) == [true])
+    }
+
+    @Test func `failed history does not clear unread`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [self.entry(key: "a", unread: true)],
+            historyFailures: 1)
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+
+        viewModel.load()
+        try await self.waitUntil { !viewModel.isLoading && viewModel.errorText != nil }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.isEmpty)
+    }
+
+    @Test func `failed unread patch retries on next activation`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [
+                self.entry(key: "a", unread: true),
+                self.entry(key: "b", unread: false),
+            ],
+            patchFailures: 1)
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+
+        viewModel.load()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        viewModel.switchSession(to: "b")
+        try await self.waitUntil { viewModel.sessionId == "session-b" }
+        viewModel.switchSession(to: "a")
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 2 }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.0) == ["a", "a"])
+        #expect(attempts.allSatisfy { !$0.1 })
+    }
+
+    @Test func `failed intermediate activation still rearms unread clearing`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [
+                self.entry(key: "a", unread: false),
+                self.entry(key: "b", unread: false),
+            ],
+            historyFailures: 1)
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+        viewModel.refreshSessions()
+        try await self.waitUntil { viewModel.sessions.count == 2 }
+
+        viewModel.setSessionUnread(key: "a", unread: true)
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        await transport.setSessions([
+            self.entry(key: "a", unread: true),
+            self.entry(key: "b", unread: false),
+        ])
+        viewModel.switchSession(to: "b")
+        try await self.waitUntil { viewModel.errorText != nil }
+        viewModel.switchSession(to: "a")
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 2 }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.0) == ["a", "a"])
+        #expect(attempts.map(\.1) == [true, false])
+    }
+
+    @Test func `explicit mark unread rearms automatic clearing`() async throws {
+        let transport = UnreadTestTransport(sessions: [
+            self.entry(key: "a", unread: true),
+            self.entry(key: "b", unread: false),
+        ])
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+
+        viewModel.load()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        viewModel.setSessionUnread(key: "a", unread: true)
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 2 }
+        viewModel.switchSession(to: "b")
+        try await self.waitUntil { viewModel.sessionId == "session-b" }
+        viewModel.switchSession(to: "a")
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 3 }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.1) == [false, true, false])
+    }
+
+    @Test func `marking background session unread does not consume its activation`() async throws {
+        let transport = UnreadTestTransport(sessions: [
+            self.entry(key: "a", unread: false),
+            self.entry(key: "b", unread: false),
+        ])
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+        viewModel.refreshSessions()
+        try await self.waitUntil { viewModel.sessions.count == 2 }
+
+        viewModel.setSessionUnread(key: "b", unread: true)
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        await transport.setSessions([
+            self.entry(key: "a", unread: false),
+            self.entry(key: "b", unread: true),
+        ])
+        viewModel.switchSession(to: "b")
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 2 }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.0) == ["b", "b"])
+        #expect(attempts.map(\.1) == [true, false])
+    }
+
+    @Test func `successful off-list mark read records read confirmation`() async throws {
+        let transport = UnreadTestTransport(sessions: [])
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+
+        viewModel.setSessionUnread(key: "hidden", unread: false)
+        try await self.waitUntil {
+            viewModel.unreadPatchGuard.confirmedUnread(key: "hidden") == false
+        }
+
+        #expect(viewModel.unreadPatchGuard.confirmedUnread(key: "hidden") == false)
+    }
+
+    @Test func `failed route lease preserves mutation queue ordering`() async throws {
+        let recorder = UnreadMutationRecorder()
+        let queue = ChatSessionUnreadMutationQueue()
+        let firstLease = OpenClawChatSessionMutationRouteLease { _, _, _, _, _, _ in
+            await recorder.append("first-start")
+            try await Task.sleep(for: .milliseconds(100))
+            await recorder.append("first-end")
+        }
+        let thirdLease = OpenClawChatSessionMutationRouteLease { _, _, _, _, _, _ in
+            await recorder.append("third")
+        }
+
+        let first = queue.reserve(
+            routeLease: Task<OpenClawChatSessionMutationRouteLease?, Never> { firstLease },
+            queueKey: "a",
+            routeKey: "a",
+            unread: false)
+        let second = queue.reserve(
+            routeLease: Task<OpenClawChatSessionMutationRouteLease?, Never> { nil },
+            queueKey: "a",
+            routeKey: "a",
+            unread: true)
+        let third = queue.reserve(
+            routeLease: Task<OpenClawChatSessionMutationRouteLease?, Never> { thirdLease },
+            queueKey: "a",
+            routeKey: "a",
+            unread: false)
+
+        try await first.value
+        await #expect(throws: OpenClawChatTransportSendError.self) {
+            try await second.value
+        }
+        try await third.value
+        #expect(await recorder.events == ["first-start", "first-end", "third"])
+    }
+
+    @Test func `activation clears selected session outside refresh page`() async throws {
+        let recent = (0..<50).map { index in
+            self.entry(key: "recent-\(index)", unread: false, updatedAt: Double(100 - index))
+        }
+        let selected = self.entry(key: "old", unread: true, updatedAt: 1)
+        let transport = UnreadTestTransport(
+            sessions: recent + [selected],
+            respectsListLimit: true)
+        let viewModel = self.viewModel(sessionKey: "old", transport: transport)
+
+        viewModel.refreshSessions(limit: 200)
+        try await self.waitUntil { viewModel.sessions.contains { $0.key == "old" } }
+        viewModel.load()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.0) == ["old"])
+        #expect(attempts.map(\.1) == [false])
+    }
+
+    @Test func `failed unread patch refreshes authoritative session state`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [
+                self.entry(key: "a", unread: true),
+                self.entry(key: "b", unread: false),
+            ],
+            patchFailures: 1,
+            patchDelay: .milliseconds(50))
+        let viewModel = self.viewModel(sessionKey: "b", transport: transport)
+        viewModel.refreshSessions()
+        try await self.waitUntil { viewModel.sessions.count == 2 }
+        await transport.setSessions([
+            self.entry(key: "a", unread: true),
+            self.entry(key: "b", unread: false, pinned: true),
+        ])
+
+        viewModel.setSessionUnread(key: "a", unread: false)
+        let otherIndex = try #require(viewModel.sessions.firstIndex(where: { $0.key == "b" }))
+        viewModel.sessions[otherIndex].pinned = true
+        try await self.waitUntil { viewModel.errorText != nil }
+        try await self.waitUntil { await transport.listCallCount() >= 2 }
+
+        #expect(viewModel.sessions.first(where: { $0.key == "a" })?.unread == true)
+        #expect(viewModel.sessions.first(where: { $0.key == "b" })?.pinned == true)
+    }
+
+    @Test func `mark unread wins over an older activation read`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [self.entry(key: "a", unread: true)],
+            patchDelay: .milliseconds(50))
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+
+        viewModel.load()
+        try await self.waitUntil { await transport.unreadPatchStartCount() == 1 }
+        viewModel.setSessionUnread(key: "a", unread: true)
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 2 }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.1) == [false, true])
+        #expect(viewModel.sessions.first(where: { $0.key == "a" })?.unread == true)
+    }
+
+    @Test func `stale list does not undo pending explicit unread`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [self.entry(key: "a", unread: false)],
+            patchDelay: .milliseconds(50))
+        let viewModel = self.viewModel(sessionKey: "a", transport: transport)
+        viewModel.refreshSessions()
+        try await self.waitUntil { viewModel.sessions.count == 1 }
+
+        viewModel.setSessionUnread(key: "a", unread: true)
+        viewModel.refreshSessions()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        await transport.setSessions([self.entry(key: "a", unread: true)])
+        viewModel.load()
+        try await self.waitUntil { !viewModel.isLoading && viewModel.sessionId == "session-a" }
+
+        let attempts = await transport.unreadPatchAttempts()
+        #expect(attempts.map(\.1) == [true])
+    }
+
+    private func viewModel(
+        sessionKey: String,
+        activeAgentID: String? = nil,
+        transport: UnreadTestTransport) -> OpenClawChatViewModel
+    {
+        let defaults = UserDefaults(suiteName: "ChatViewModelUnreadTests.\(UUID().uuidString)") ?? .standard
+        return OpenClawChatViewModel(
+            sessionKey: sessionKey,
+            transport: transport,
+            activeAgentId: activeAgentID,
+            modelPickerStore: ChatModelPickerStore(defaults: defaults))
+    }
+
+    private func entry(
+        key: String,
+        unread: Bool,
+        updatedAt: Double = 1,
+        lastInteractionAt: Double? = nil,
+        lastActivityAt: Double? = nil,
+        pinned: Bool? = nil) -> OpenClawChatSessionEntry
+    {
+        OpenClawChatSessionEntry(
+            key: key,
+            kind: nil,
+            displayName: nil,
+            surface: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: updatedAt,
+            sessionId: nil,
+            systemSent: nil,
+            abortedLastRun: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: nil,
+            modelProvider: nil,
+            model: nil,
+            contextTokens: nil,
+            pinned: pinned,
+            unread: unread,
+            lastInteractionAt: lastInteractionAt,
+            lastActivityAt: lastActivityAt)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @escaping @MainActor () async -> Bool) async throws
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("timed out waiting for unread test condition")
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
@@ -458,6 +458,41 @@ struct ChatViewModelUnreadTests {
         #expect(attempts.map(\.1) == [true])
     }
 
+    @Test func `pending explicit unread overlays stale list until fresh observation`() async throws {
+        let transport = UnreadTestTransport(
+            sessions: [
+                self.entry(key: "a", unread: false),
+                self.entry(key: "b", unread: false),
+            ],
+            patchDelay: .milliseconds(200))
+        let viewModel = self.viewModel(sessionKey: "b", transport: transport)
+        viewModel.refreshSessions()
+        try await self.waitUntil { viewModel.sessions.count == 2 }
+
+        viewModel.setSessionUnread(key: "a", unread: true)
+        try await self.waitUntil { await transport.unreadPatchStartCount() == 1 }
+        viewModel.refreshSessions()
+        try await self.waitUntil { await transport.listCallCount() >= 2 }
+
+        #expect(viewModel.sessions.first(where: { $0.key == "a" })?.unread == true)
+        #expect(viewModel.unreadPatchGuard.localUnreadOverride(key: "a") == true)
+
+        await transport.setSessions([
+            self.entry(key: "a", unread: true),
+            self.entry(key: "b", unread: false),
+        ])
+        let listCallCount = await transport.listCallCount()
+        try await self.waitUntil { await transport.unreadPatchAttempts().count == 1 }
+        try await self.waitUntil {
+            await transport.listCallCount() > listCallCount &&
+                viewModel.unreadPatchGuard.localUnreadOverride(key: "a") == nil
+        }
+
+        #expect(viewModel.unreadPatchGuard.localUnreadOverride(key: "a") == nil)
+        #expect(viewModel.unreadPatchGuard.confirmedUnread(key: "a") == true)
+        #expect(viewModel.sessions.first(where: { $0.key == "a" })?.unread == true)
+    }
+
     private func viewModel(
         sessionKey: String,
         activeAgentID: String? = nil,

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -9,8 +9,8 @@ The macOS menu bar app embeds the WebChat UI as a native SwiftUI view. It connec
 
 The full chat window is a native split view:
 
-- **Sessions sidebar**: searchable session list with pinned and recent sections, unread indicators, and context menus for pin/unpin, copy session key, and delete. A toolbar button (or Cmd-N) creates a real new session via `sessions.create`.
-- **Window toolbar**: context-usage ring (tokens and session cost, with a compact action), thinking-level picker, model picker, and a session actions menu. **Sessions…** (Shift-Cmd-S) opens the Active/Archived manager for gateway search, rename, pin, archive, and restore. The same menu can show or hide assistant reasoning and tool activity; this is on by default and remembered across launches.
+- **Sessions sidebar**: searchable session list with pinned and recent sections. Spawned child sessions nest beneath their parent when the Gateway provides hierarchy metadata; collapsed parents summarize running, failed, and unread descendants. Context menus support rename, pin, fork, read/unread, archive/restore, copy session key, and delete. A toolbar button (or Cmd-N) creates a real new session via `sessions.create`.
+- **Window toolbar**: context-usage ring (tokens and session cost, with a compact action), thinking-level picker, model picker, and a session actions menu. The menu can rename or fork the current session and update its pin, read, or archive state. **Sessions…** (Shift-Cmd-S) opens the Active/Archived manager for gateway search, rename, pin, archive, and restore. The same menu can show or hide assistant reasoning and tool activity; this is on by default and remembered across launches.
 - **Transcript and composer**: assistant messages render as plain text with an avatar, user messages as accent bubbles. Empty chats offer desktop starter prompts. Typing `/` opens slash-command autocomplete backed by `commands.list`, with arrow/Tab/Return/Escape keyboard navigation. Right-click a message to copy it, or use **Listen** for gateway TTS with a local speech fallback.
 - **Voice controls**: the composer can start or stop the existing macOS Talk Mode without replacing its menu-bar overlay. A separate microphone action records a voice note when Talk Mode does not own audio capture.
 
@@ -43,6 +43,7 @@ Quick Chat shows the main session's agent, sends directly to the main session, a
 - Data plane: Gateway WS methods `chat.history`, `chat.send`, `chat.abort`, `chat.inject`, and events `chat`, `agent`, `presence`, `tick`, `health`.
 - `chat.history` returns a display-normalized transcript: inline directive tags are stripped from visible text, plain-text tool-call XML payloads (`<tool_call>`, `<function_call>`, `<tool_calls>`, `<function_calls>`, including truncated blocks) and leaked model control tokens are stripped, pure silent-token assistant rows such as exact `NO_REPLY`/`no_reply` are omitted, and oversized rows can be replaced with a truncated placeholder.
 - Session: defaults to the primary session as above; the UI can switch between sessions.
+- Unread state: after a session activates and its live history loads successfully, the app clears that session's unread marker. Failed history loads do not clear it; a transient patch failure retries on the next activation.
 - Onboarding uses a dedicated session to keep first-run setup separate.
 - Offline cache: the app keeps a small read-only cache of recent chat sessions and transcripts per gateway (`~/Library/Application Support/OpenClaw/chat-cache.sqlite`): cold opens paint the last known transcript immediately and refresh once the Gateway responds, and recent chats stay browsable while disconnected (sending stays disabled until the connection is back).
 


### PR DESCRIPTION
## What Problem This Solves

The native macOS chat sidebar covers a fraction of the web chat's session management: rows only offer pin/copy/delete, opening a session never clears its unread marker, there is no rename or fork or archive outside the manager sheet, and subagent/child sessions render as a flat list with no run-state visibility.

## Why This Change Was Made

Round 2 of native/web chat alignment (follow-up to #109712), scoped to session details:

- Sidebar rows gain Rename…, Fork, Archive/Restore, Mark Read/Unread alongside Pin/Copy/Delete; the toolbar session menu gains "Rename Session…". Empty rename clears the custom label (explicit `label: null`).
- Opening a session now clears its unread marker exactly once per successful live activation, mirroring the web semantics: failed patches re-arm on the next activation, stale in-flight list snapshots cannot revert a just-clicked Mark Read/Unread (pending explicit mutations overlay list, cache-restore, and rollback assignments), and explicit actions use per-session FIFO ordering with canonical routed identities and route leases.
- The sidebar builds a cycle-safe session tree from `sessions.list` hierarchy metadata (`childSessions` authoritative; `parentSessionKey`/`spawnedBy` as metadata — field contract verified against `src/gateway/session-utils.types.ts`): children nest under parents with disclosure, and collapsed parents aggregate running/failed/unread descendant badges. Flat fallback when no hierarchy data is present.
- Archive is blocked for main/global aliases and sessions with active runs.
- Fork uses the existing `sessions.create` contract with `parentSessionKey` + `fork`. No new RPCs, settings, or protocol changes.

## User Impact

Everyday session management no longer requires the manager sheet or the web UI: rename, fork, archive, and read-state control live on the row; unread dots behave like the web; and subagent activity is visible at a glance with nesting and status badges.

## Evidence

- `swift build --package-path apps/shared/OpenClawKit --target OpenClawChatUI` and `swift build --package-path apps/macos --configuration release` — pass (re-verified after rebase onto landed main).
- `swift test --package-path apps/shared/OpenClawKit --parallel` — 885 tests pass; `swift test --package-path apps/macos --parallel` — 1304 pass.
- New coverage: sidebar tree construction (nesting, cycles, orphans, badge aggregation), unread guard episodes (14 tests) plus a stale-snapshot overlay regression, session action request encoding.
- Structured review: one accepted finding (stale list snapshots could visually revert pending explicit unread mutations) fixed with a guard-owned override applied at every sessions assignment site; follow-up review clean.
- `pnpm lint:swift`, `pnpm format:swift`, `pnpm native:i18n:check`, Apple/Android catalog tests — clean; new strings translated across all 21 locales.
