### PR TITLE
fix(coding-agent): scope CODEX_HOME to prevent OAuth collision with OpenClaw

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -112,6 +112,13 @@ ambient `CODEX_HOME` (default `~/.codex`) causes `refresh_token_reused` errors
 that invalidate OpenClaw's provider auth. To prevent this, every Codex worker
 must use a dedicated `CODEX_HOME` scoped only to its command.
 
+A dedicated `CODEX_HOME` isolates credentials **and all other Codex state**
+(`config.toml`, model/provider overrides, MCP servers, hooks, skills, plugins).
+The worker home starts as a clean profile — it does not inherit settings from
+the ambient `~/.codex`. If the user has non-auth Codex configuration that workers
+need, copy the relevant settings to the worker home after the one-time login
+below.
+
 ### One-time setup per worker home
 
 ```bash
@@ -121,6 +128,21 @@ CODEX_HOME=~/.codex-openclaw-worker codex login
 Complete a separate ChatGPT OAuth authorization, even when using the same
 ChatGPT account as OpenClaw. This creates an independent refresh-token cycle
 that does not collide with OpenClaw's own OAuth profile.
+
+### Migrating non-auth settings (optional)
+
+If the user has Codex configuration in `~/.codex` that workers also need
+(model/provider overrides, MCP servers, hooks, etc.), copy the relevant
+`config.toml` entries to the worker home:
+
+```bash
+mkdir -p ~/.codex-openclaw-worker
+cp ~/.codex/config.toml ~/.codex-openclaw-worker/config.toml 2>/dev/null || true
+```
+
+Only `config.toml` needs to be copied — do **not** copy `auth.json` or any
+credential files. The worker home must use its own separate OAuth login from
+the step above.
 
 ### Preflight check
 

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -50,6 +50,7 @@ Use for background feature builds, PR reviews, large refactors, and issue-to-PR 
 - Never checkout branches or run background coding agents in `~/Projects/openclaw`; use an isolated checkout.
 - Classify the source ref as trusted or untrusted before any checkout or worktree creation. Never materialize a contributor-controlled ref outside the repository's approved untrusted-PR sandbox/review workflow, and never launch a permission-bypassed worker in it.
 - For tasks that modify a Git-backed project, prepare and verify the Git worktree before launch, then include the exact Git preparation block below in the worker prompt.
+- **Codex credential isolation:** Never launch Codex with the ambient `CODEX_HOME` (default `~/.codex`). Sharing the ambient home with OpenClaw's own ChatGPT OAuth causes `refresh_token_reused` failures that invalidate OpenClaw's provider auth. Always scope a worker-specific `CODEX_HOME` to Codex commands only (see [Codex credential isolation](#codex-credential-isolation)). Do not export `CODEX_HOME` into the OpenClaw Gateway environment.
 
 ## Mandatory Git preparation
 
@@ -104,6 +105,39 @@ Do not use openclaw system event or heartbeat.
 
 If no trustworthy route exists, say completion auto-notify is unavailable.
 
+## Codex credential isolation
+
+OpenClaw and Codex CLI both authenticate with ChatGPT OAuth. Sharing the
+ambient `CODEX_HOME` (default `~/.codex`) causes `refresh_token_reused` errors
+that invalidate OpenClaw's provider auth. To prevent this, every Codex worker
+must use a dedicated `CODEX_HOME` scoped only to its command.
+
+### One-time setup per worker home
+
+```bash
+CODEX_HOME=~/.codex-openclaw-worker codex login
+```
+
+Complete a separate ChatGPT OAuth authorization, even when using the same
+ChatGPT account as OpenClaw. This creates an independent refresh-token cycle
+that does not collide with OpenClaw's own OAuth profile.
+
+### Preflight check
+
+Before launching a Codex worker, verify the worker home is authenticated:
+
+```bash
+CODEX_HOME=~/.codex-openclaw-worker codex login status
+```
+
+If the status check fails, prompt the user to run the one-time `codex login`
+above before proceeding.
+
+### Worker launch
+
+All Codex launch commands below include the `CODEX_HOME` prefix. Do not export
+`CODEX_HOME` into the Gateway environment — scope it only to the Codex command.
+
 ## Launch forms
 
 Write the worker prompt to a temp file first. This avoids shell quoting bugs when the required notification block contains quotes or newlines.
@@ -123,7 +157,7 @@ Use `$PROMPT` when launching from the same shell/session. If using a separate to
 Codex:
 
 ```bash
-bash pty:true background:true workdir:/path/isolated-worktree command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:/path/isolated-worktree command:"CODEX_HOME=~/.codex-openclaw-worker codex exec - < \"$PROMPT\""
 ```
 
 Claude Code:
@@ -148,7 +182,7 @@ bash pty:true background:true workdir:/path/isolated-worktree command:"opencode 
 
 ## Scratch Codex
 
-Codex needs a trusted git repo. This throwaway scaffold is not project work and has no canonical remote, so the Git preparation block does not apply:
+Codex needs a trusted git repo. This throwaway scaffold is not project work and has no canonical remote, so the Git preparation block does not apply. The Codex credential isolation rules still apply — use a worker-scoped `CODEX_HOME`:
 
 ```bash
 SCRATCH=$(mktemp -d)
@@ -159,7 +193,7 @@ Build X.
 <notification block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
-bash pty:true background:true workdir:$SCRATCH command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:$SCRATCH command:"CODEX_HOME=~/.codex-openclaw-worker codex exec - < \"$PROMPT\""
 ```
 
 ## Process actions


### PR DESCRIPTION
Closes #109704

## What Problem This Solves

Fixes an issue where users who authenticate both OpenClaw and the bundled coding-agent's Codex CLI with the same ChatGPT account would experience persistent `refresh_token_reused` OAuth failures in OpenClaw after launching a Codex worker. The coding-agent skill's documented `codex exec` launch path used the ambient `CODEX_HOME` (default `~/.codex`), sharing credentials with OpenClaw's own ChatGPT OAuth profile. Codex CLI refresh-token rotations invalidated OpenClaw's tokens, disabling primary model access until credentials were manually isolated and OpenClaw was re-authenticated.

## Why This Change Was Made

The fix scopes a worker-specific `CODEX_HOME` (`~/.codex-openclaw-worker`) to all Codex launch commands in the `coding-agent` skill, preventing credential collision without changing provider APIs, auth storage, or core runtime behavior.

Key changes to `skills/coding-agent/SKILL.md`:

1. **New hard rule** — prohibits launching Codex with the ambient `CODEX_HOME` and links to the new isolation section.
2. **New "Codex credential isolation" section** — documents:
   - That a dedicated `CODEX_HOME` isolates credentials **and all other Codex state** (config.toml, model/provider overrides, MCP servers, hooks, skills, plugins). The worker home starts as a clean profile.
   - One-time `codex login` in the worker home (separate ChatGPT OAuth authorization, even for the same account)
   - **"Migrating non-auth settings" subsection** — safe `cp ~/.codex/config.toml ~/.codex-openclaw-worker/config.toml` step that explicitly excludes `auth.json` and credential files
   - Preflight `codex login status` check before launching a worker
   - Rule against exporting `CODEX_HOME` into the Gateway environment
3. **Updated Codex launch form** — `CODEX_HOME=~/.codex-openclaw-worker` prefix added to the main `codex exec` command.
4. **Updated Scratch Codex form** — same `CODEX_HOME` prefix added to the scratch launch command.

### Compatibility policy (addressing ClawSweeper review)

The worker home intentionally starts as a **clean profile** — it does not inherit non-auth settings from the ambient `~/.codex`. This is the safest default because:
- It guarantees no ambient auth material leaks into the worker
- Users who need non-auth config (model overrides, MCP servers, etc.) can copy `config.toml` via the documented migration step
- Credential files (`auth.json`) are explicitly excluded from the migration

Non-goal: this does not change OpenClaw's own OAuth ownership, the native Codex harness auth path (already fixed in #68284), or the refresh-token hardening (#68396). It only fixes the remaining external bundled-skill launch path.

## User Impact

Users who use both OpenClaw and the bundled `coding-agent` with Codex CLI can now launch Codex workers without risking OpenClaw's ChatGPT OAuth being invalidated. The skill guides users through:
1. A one-time `codex login` in the isolated worker home
2. An optional `config.toml` copy if they have non-auth Codex settings workers need
3. A preflight `codex login status` check
4. All subsequent Codex launches are safe by default

## Evidence

- **Issue #109704** provides a source-reproducible sequence on v2026.7.1 showing the OAuth collision and the isolated-home recovery path.
- **ClawSweeper review** confirmed the fix direction and raised a P1 compatibility concern about non-auth Codex state — addressed in commit `db972313f7` with the clean-profile documentation and config migration step.
- **Prior merged work** (#68284, #68396) fixed the native harness auth path and refresh-token hardening but did not address the bundled skill's external `codex exec` launch path.
- **Current main** (`skills/coding-agent/SKILL.md` lines 126, 162): both `codex exec` commands use no `CODEX_HOME` scoping.
- **After fix**: both launch commands scope `CODEX_HOME=~/.codex-openclaw-worker`, and the skill documents the one-time setup, config migration, and preflight check.

This is a skill/docs-only change — no runtime code, tests, or config surfaces are modified.