### PR TITLE
fix(msteams): avoid memory spikes from oversized certificate files

### DIFF
--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -10,9 +10,13 @@ vi.mock("node:fs", async (importOriginal) => {
     ...actual,
     openSync: vi.fn(() => 42),
     readSync: vi.fn(
-      (_fd: number, buffer: Buffer, _offset: number, _length: number, _position: number) => {
+      (
+        _fd: number,
+        buffer: Buffer,
+        opts?: { offset?: number; length?: number; position?: number | null },
+      ) => {
         const content = "-----BEGIN RSA PRIVATE KEY-----\nfake-key\n-----END RSA PRIVATE KEY-----";
-        return buffer.write(content, 0, buffer.length, "utf-8");
+        return buffer.write(content, 0, opts?.length ?? buffer.length, "utf-8");
       },
     ),
     closeSync: vi.fn(),
@@ -87,8 +91,8 @@ describe("createMSTeamsApp", () => {
   });
 
   it("rejects oversized certificate files before reading them", async () => {
-    vi.mocked(fs.readSync).mockImplementationOnce((_fd, _buffer, _offset, length, _position) => {
-      return length; // maxBytes + 1 — triggers the oversized rejection
+    vi.mocked(fs.readSync).mockImplementationOnce((_fd, _buffer, opts) => {
+      return opts?.length ?? 0; // buffer length = maxBytes + 1 — triggers the oversized rejection
     });
 
     const creds: MSTeamsFederatedCredentials = {

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -8,10 +8,14 @@ vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
     ...actual,
-    statSync: vi.fn(() => ({ size: 1024 }) as fs.Stats),
-    readFileSync: vi.fn(
-      () => "-----BEGIN RSA PRIVATE KEY-----\nfake-key\n-----END RSA PRIVATE KEY-----",
+    openSync: vi.fn(() => 42),
+    readSync: vi.fn(
+      (_fd: number, buffer: Buffer, _offset: number, _length: number, _position: number) => {
+        const content = "-----BEGIN RSA PRIVATE KEY-----\nfake-key\n-----END RSA PRIVATE KEY-----";
+        return buffer.write(content, 0, buffer.length, "utf-8");
+      },
     ),
+    closeSync: vi.fn(),
   };
 });
 
@@ -77,13 +81,15 @@ describe("createMSTeamsApp", () => {
 
     const app = await createMSTeamsApp(creds);
     expect(app).toBeDefined();
-    expect(fs.statSync).toHaveBeenCalledWith("/path/to/cert.pem");
-    expect(fs.readFileSync).toHaveBeenCalledWith("/path/to/cert.pem", "utf-8");
+    expect(fs.openSync).toHaveBeenCalledWith("/path/to/cert.pem", "r");
+    expect(fs.readSync).toHaveBeenCalled();
+    expect(fs.closeSync).toHaveBeenCalled();
   });
 
   it("rejects oversized certificate files before reading them", async () => {
-    vi.mocked(fs.readFileSync).mockClear();
-    vi.mocked(fs.statSync).mockReturnValueOnce({ size: 64 * 1024 + 1 } as fs.Stats);
+    vi.mocked(fs.readSync).mockImplementationOnce((_fd, _buffer, _offset, length, _position) => {
+      return length; // maxBytes + 1 — triggers the oversized rejection
+    });
 
     const creds: MSTeamsFederatedCredentials = {
       type: "federated",
@@ -93,11 +99,10 @@ describe("createMSTeamsApp", () => {
     };
 
     await expect(createMSTeamsApp(creds)).rejects.toThrow("certificate file exceeds 65536 bytes");
-    expect(fs.readFileSync).not.toHaveBeenCalled();
   });
 
   it("throws when certificate file is missing", async () => {
-    vi.mocked(fs.readFileSync).mockImplementation(() => {
+    vi.mocked(fs.openSync).mockImplementationOnce(() => {
       throw new Error("ENOENT: no such file");
     });
 

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -8,6 +8,7 @@ vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
     ...actual,
+    statSync: vi.fn(() => ({ size: 1024 }) as fs.Stats),
     readFileSync: vi.fn(
       () => "-----BEGIN RSA PRIVATE KEY-----\nfake-key\n-----END RSA PRIVATE KEY-----",
     ),
@@ -76,7 +77,23 @@ describe("createMSTeamsApp", () => {
 
     const app = await createMSTeamsApp(creds);
     expect(app).toBeDefined();
+    expect(fs.statSync).toHaveBeenCalledWith("/path/to/cert.pem");
     expect(fs.readFileSync).toHaveBeenCalledWith("/path/to/cert.pem", "utf-8");
+  });
+
+  it("rejects oversized certificate files before reading them", async () => {
+    vi.mocked(fs.readFileSync).mockClear();
+    vi.mocked(fs.statSync).mockReturnValueOnce({ size: 64 * 1024 + 1 } as fs.Stats);
+
+    const creds: MSTeamsFederatedCredentials = {
+      type: "federated",
+      appId: "test-app-id",
+      tenantId: "test-tenant",
+      certificatePath: "/path/to/oversized-cert.pem",
+    };
+
+    await expect(createMSTeamsApp(creds)).rejects.toThrow("certificate file exceeds 65536 bytes");
+    expect(fs.readFileSync).not.toHaveBeenCalled();
   });
 
   it("throws when certificate file is missing", async () => {

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -176,6 +176,7 @@ type AzureIdentityModule = {
 };
 
 const AZURE_IDENTITY_MODULE = "@azure/identity";
+const MAX_MSTEAMS_CERTIFICATE_FILE_BYTES = 64 * 1024;
 
 const loadAzureIdentity = createLazyRuntimeModule(
   () => import(AZURE_IDENTITY_MODULE) as Promise<AzureIdentityModule>,
@@ -319,6 +320,10 @@ function createFederatedApp(
 
   let privateKey: string;
   try {
+    const certificateSize = fs.statSync(creds.certificatePath).size;
+    if (certificateSize > MAX_MSTEAMS_CERTIFICATE_FILE_BYTES) {
+      throw new Error(`certificate file exceeds ${MAX_MSTEAMS_CERTIFICATE_FILE_BYTES} bytes`);
+    }
     privateKey = fs.readFileSync(creds.certificatePath, "utf-8");
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -191,7 +191,7 @@ function readBoundedFileSync(path: string, maxBytes: number): string {
     // Allocate one extra byte so we can detect overflow — if readSync fills
     // the buffer the file is larger than maxBytes.
     const buffer = Buffer.alloc(maxBytes + 1);
-    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    const bytesRead = fs.readSync(fd, buffer, { offset: 0, length: buffer.length, position: 0 });
     if (bytesRead > maxBytes) {
       throw new Error(`certificate file exceeds ${maxBytes} bytes`);
     }

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -178,6 +178,31 @@ type AzureIdentityModule = {
 const AZURE_IDENTITY_MODULE = "@azure/identity";
 const MAX_MSTEAMS_CERTIFICATE_FILE_BYTES = 64 * 1024;
 
+/**
+ * Read at most {@link maxBytes} from one opened file descriptor and close it
+ * in a finally block. The single-handle bounded read prevents a TOCTOU race
+ * where a separate stat + read would let the file grow or be replaced between
+ * the two calls.
+ */
+function readBoundedFileSync(path: string, maxBytes: number): string {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(path, "r");
+    // Allocate one extra byte so we can detect overflow — if readSync fills
+    // the buffer the file is larger than maxBytes.
+    const buffer = Buffer.alloc(maxBytes + 1);
+    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    if (bytesRead > maxBytes) {
+      throw new Error(`certificate file exceeds ${maxBytes} bytes`);
+    }
+    return buffer.toString("utf-8", 0, bytesRead);
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
+  }
+}
+
 const loadAzureIdentity = createLazyRuntimeModule(
   () => import(AZURE_IDENTITY_MODULE) as Promise<AzureIdentityModule>,
 );
@@ -320,11 +345,7 @@ function createFederatedApp(
 
   let privateKey: string;
   try {
-    const certificateSize = fs.statSync(creds.certificatePath).size;
-    if (certificateSize > MAX_MSTEAMS_CERTIFICATE_FILE_BYTES) {
-      throw new Error(`certificate file exceeds ${MAX_MSTEAMS_CERTIFICATE_FILE_BYTES} bytes`);
-    }
-    privateKey = fs.readFileSync(creds.certificatePath, "utf-8");
+    privateKey = readBoundedFileSync(creds.certificatePath, MAX_MSTEAMS_CERTIFICATE_FILE_BYTES);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`Failed to read certificate file at '${creds.certificatePath}': ${msg}`, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Microsoft Teams operators using certificate-based federated authentication could have an arbitrarily large file loaded into memory when the channel, probe, Graph helper, or outbound sender initialized. A mistaken `certificatePath` could therefore cause a large memory spike before any Azure request was made.

## Why This Change Was Made

Certificate authentication now opens the certificate file once and reads at most 64 KiB plus one byte through a single file descriptor, with guaranteed cleanup in a `finally` block. This replaces a `statSync` + `readFileSync` pair that had a TOCTOU race — the file could be replaced or grow between the two calls, bypassing the size check. The risk is bounded to certificate-based Microsoft Teams authentication; client-secret and managed-identity flows are unchanged.

The 64 KiB limit itself remains a maintainer decision — Azure Identity does not publish a certificate-size maximum, so the right compatibility boundary for existing certificate bundles needs owner intent.

AI-assisted: yes. I inspected the production loader and all callers, adjacent tests, the Microsoft Teams authentication docs, and the installed `@azure/identity@4.13.1` certificate types and implementation.

## User Impact

Microsoft Teams operators get a bounded certificate file read instead of loading an oversized certificate into the OpenClaw process. Normal certificate files continue to initialize as before.

## Evidence

**Real-machine production-path proof:** Linux `6.8.0-134-generic` x86_64, Node `v24.18.0`. The harness directly imported the production `loadMSTeamsSdkWithAuth` export and used real files on disk; no filesystem or SDK mock was used. The regular PEM was run first to warm the lazily loaded Teams SDK, so the oversized-file RSS delta isolates the file read.

The same harness was run from a detached latest-main checkout and from the fix checkout:

```bash
proof_dir=$(mktemp -d)
truncate -s 20971520 "$proof_dir/oversized.pem"
printf '%s\n' \
  '-----BEGIN RSA PRIVATE KEY-----' \
  'fake-key' \
  '-----END RSA PRIVATE KEY-----' > "$proof_dir/regular.pem"

MSTEAMS_PROOF_DIR="$proof_dir" node --import tsx --input-type=module -e '
import { loadMSTeamsSdkWithAuth } from "./extensions/msteams/src/sdk.ts";
const base = process.env.MSTEAMS_PROOF_DIR;
for (const name of ["regular.pem", "oversized.pem"]) {
  const path = `${base}/${name}`;
  const before = process.memoryUsage().rss;
  try {
    const { app } = await loadMSTeamsSdkWithAuth({
      type: "federated",
      appId: "proof-app",
      tenantId: "proof-tenant",
      certificatePath: path,
    });
    console.log(JSON.stringify({
      name,
      outcome: "accepted",
      appCreated: Boolean(app),
      rssDelta: process.memoryUsage().rss - before,
    }));
  } catch (error) {
    console.log(JSON.stringify({
      name,
      outcome: "rejected",
      error: error instanceof Error ? error.message : String(error),
      rssDelta: process.memoryUsage().rss - before,
    }));
  }
}
'
```

**Before / negative control:** On latest `upstream/main` at `b319493a529c8961f20fea03455b35023defef44`, the regular PEM initialized successfully. The 20 MiB file was also accepted and added about 21.2 MiB RSS after SDK warmup, demonstrating the RED condition.

```text
{"name":"regular.pem","outcome":"accepted","appCreated":true,"rssDelta":64724992}
{"name":"oversized.pem","outcome":"accepted","appCreated":true,"rssDelta":21204992}
```

**Premise:** `extensions/msteams/src/token.ts` resolves the operator-controlled `certificatePath`, and `probe.ts`, `graph.ts`, `send-context.ts`, and `monitor.ts` all reach `loadMSTeamsSdkWithAuth`. Installed `@azure/identity@4.13.1` declares `{ certificate: string }` in `dist/esm/credentials/clientCertificateCredentialModels.d.ts`; its implementation consumes that string in `dist/esm/credentials/clientCertificateCredential.js`. Therefore the OpenClaw loader owns the file read and can reject an oversized input before passing certificate contents to Azure Identity.

**After:** On the fix branch, the same production path rejected the 20 MiB file via a single-handle bounded `readSync` before reading the full contents, with zero post-warmup RSS growth. The regular PEM negative control still initialized successfully.

```text
{"name":"regular.pem","outcome":"accepted","appCreated":true,"rssDelta":75599872}
{"name":"oversized.pem","outcome":"rejected","error":"Failed to read certificate file at '<tmp>/oversized.pem': certificate file exceeds 65536 bytes","rssDelta":0}
```

**TOCTOU hardening:** The original implementation used `statSync` + `readFileSync` — a separate check and read that could race if the file was replaced or grew between calls. The current fix uses `openSync` + `readSync` + `closeSync` on one file descriptor, allocating `maxBytes + 1` and rejecting overflow, with guaranteed descriptor cleanup in a `finally` block.

**Focused validation:**

```bash
node scripts/run-vitest.mjs extensions/msteams/src/sdk.test.ts
```

```text
Test Files  1 passed (1)
Tests       19 passed (19)
```

Targeted oxfmt, targeted oxlint, the Microsoft Teams tsgo project, and `git diff --check` also passed.

Not tested against a live Entra tenant or Teams delivery because the changed behavior is entirely in the local pre-network certificate file read; Azure token acquisition and Teams transport are unchanged. Fork CI remains the wide validation path.
