### PR TITLE
fix(gateway): reconcile restartPending when channel restart backoff rejects

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -880,6 +880,30 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
 
+  it("reconciles restartPending when the restart backoff rejects without a manual stop", async () => {
+    // When the abort signal races the backoff sleep, sleepWithAbort rejects.
+    // The empty catch used to swallow this silently, leaving restartPending
+    // true forever with no restart in flight. The fix reconciles the state.
+    // See issue #109659.
+    const startAccount = vi.fn(async () => {});
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    // Make the first backoff sleep reject (simulates abort racing the sleep).
+    hoisted.sleepWithAbort.mockRejectedValueOnce(new Error("aborted"));
+
+    await manager.startChannels();
+    await vi.advanceTimersByTimeAsync(200);
+
+    // The backoff sleep was called and rejected.
+    expect(hoisted.sleepWithAbort).toHaveBeenCalled();
+    // startAccount was called only once — the channel never restarted.
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    // restartPending must be reconciled to false — no restart is in flight.
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.restartPending).toBe(false);
+  });
+
   it("does not auto-restart a channel task exit marked as terminal disconnect", async () => {
     const startAccount = vi.fn(
       async ({

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -959,8 +959,19 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   preserveRestartAttempts: true,
                   preserveManualStop: true,
                 });
-              } catch {
-                // abort or startup failure — next crash will retry
+              } catch (error) {
+                // The restart sleep rejected (abort raced the backoff) or
+                // startChannelInternal threw.  Either way the restart chain
+                // has exited and no further attempt will happen from this
+                // branch — the next channel crash starts a fresh chain.
+                // Reconcile restartPending so runtime state does not
+                // advertise a restart that will never arrive.
+                log.error?.(`[${id}] auto-restart aborted: ${formatErrorMessage(error)}`);
+                setRuntime(channelId, id, {
+                  accountId: id,
+                  restartPending: false,
+                  reconnectAttempts: restart.attempts,
+                });
               } finally {
                 pendingAutoRestarts.delete(rKey);
               }


### PR DESCRIPTION
Closes #109659

## What Problem This Solves

Fixes an issue where a channel whose provider closes the connection can get permanently stuck with no restart, no log line, and no error — while `/health` and the Docker healthcheck both stay green. In production this caused two multi-hour outages (~34h and ~21h) on a Zalo channel, both ended only by manual `docker restart`.

## Why This Change Was Made

The channel auto-restart path in `src/gateway/server-channels.ts` schedules a backoff sleep via `sleepWithAbort(retry.delayMs, retry.signal)` before restarting the channel. When the run's abort signal fires during the backoff window, `sleepWithAbort` rejects. The empty `catch {}` at line 824 silently swallowed this rejection, causing three problems:

1. `startChannelInternal` was never called — the channel never came back
2. No error was logged — the failure was invisible (green health checks, no diagnostics)
3. `restartPending: true` (set at line 806) was never cleared — runtime state permanently lied about a restart that would never arrive

The fix replaces the empty `catch {}` with `catch (error)` that:
- **Logs the rejection** so a lost restart is diagnosable (`log.error?.(...)`)
- **Reconciles `restartPending: false`** so runtime state no longer advertises a restart that will never arrive

The fix is intentionally **design-neutral** — it does not change abort signal ownership, restart policy, or retry counts. Either policy (retry again or give up loudly) satisfies the reconciliation, as long as a terminal exit clears the state it advertised. The abort-ownership decision (whether a restart-scoped signal distinct from the run-scoped one is needed) is a maintainer call per the issue.

## User Impact

Operators will no longer see channels silently stuck with `restartPending: true` behind green health checks after an abort/backoff race. When a restart is lost, the error is now logged and the runtime state is reconciled, making the failure visible and the channel eligible for recovery on the next crash.

## Evidence

- **Issue #109659** provides a source-level reproduction with three dated production incidents (two stuck for 34h and 21h, one recovered in 7s), plus a detailed analysis of the empty-catch defect.
- **ClawSweeper review** confirmed the bug is source-reproducible and the defect is bounded to the shared channel restart lifecycle.
- **Commenter @JOY** provided a drop-in test case that reproduces the bug on current main: the test confirms `restartPending` stays `true` forever when the backoff rejects without a manual stop (48 existing tests pass, the new test fails on unpatched code).
- **After fix**: 50 tests pass (49 existing + 1 new regression test), including the new `reconciles restartPending when the restart backoff rejects without a manual stop`.

### Test output

```
RUN  v4.1.10

 ✓  gateway-server  ../../src/gateway/server-channels.test.ts (50 tests) 219ms

 Test Files  1 passed (1)
      Tests  50 passed (50)
   Duration  19.07s
```

### Changed files

- `src/gateway/server-channels.ts` — replaced empty `catch {}` with `catch (error)` that logs and reconciles `restartPending`
- `src/gateway/server-channels.test.ts` — added regression test verifying `restartPending` is cleared when the backoff rejects without a manual stop