### PR TITLE
fix(ci): bound docs-agent git fetch operations with timeout

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -62,7 +62,7 @@ jobs:
           fi
 
           for attempt in 1 2 3 4 5; do
-            if git fetch --no-tags origin main; then
+            if timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin main; then
               break
             fi
             if [ "$attempt" = "5" ]; then
@@ -230,7 +230,7 @@ jobs:
           git commit --no-verify -m "docs: refresh documentation"
 
           for attempt in 1 2 3 4 5; do
-            if ! git fetch --no-tags origin "${TARGET_BRANCH}"; then
+            if ! timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "${TARGET_BRANCH}"; then
               echo "Fetch attempt ${attempt} failed; retrying."
               sleep $((attempt * 2))
               continue


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the docs-agent workflow could remain stuck in either of its two `git fetch` steps until the job timeout when the Git transport stalls. This blocks automated documentation refresh and wastes runner time.

## Why This Change Was Made

Both `git fetch` commands (main fetch at L65 and target-branch fetch at L233) now run through the repository's bounded process pattern: a 120-second deadline, followed by a 10-second termination grace period. This matches the pattern already applied to Mantis Crabbox workflows in #108940 (commit 16c2bbb) and the npm-release workflow in #109176. All doc-generation logic, PR creation, and non-network operations are unchanged.

## User Impact

Maintainers get prompt, actionable fetch failures instead of losing a docs-agent runner for the full job timeout before documentation refresh begins.

## Evidence

- Regression: `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts --run --testNamePattern="bounds docs-agent git fetch"` ??1 passed.

- Controlled runtime proof extracted each production workflow step, scaled the production deadline to one second, and injected a Git transport that stalls until `TERM`. Every step returned 124 in about 1.03 seconds, the Git fixture observed `TERM`, and none reached the five-second outer watchdog. The identical pattern was proven for Mantis Crabbox workflows in #108940.

- `pnpm exec oxfmt --check` passed for the changed file; `git diff --check` passed.

- The complete test suite was also attempted: all tests passed, while unrelated environment-dependent cases were skipped. The affected focused regression is green.