### PR TITLE
fix(reef): discovered conversation turns bind correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Reef discovered conversation turns:** persist exact outbound route and origin metadata together when lazily binding trusted directory peers, and surface required binding failures instead of silently treating them as best-effort mirror writes. Fixes #110018.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Reef discovered conversation turns:** persist exact outbound route and origin metadata together when lazily binding trusted directory peers, and surface required binding failures instead of silently treating them as best-effort mirror writes. Fixes #110018.
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/src/config/sessions/conversation-identity.test.ts
+++ b/src/config/sessions/conversation-identity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildConversationIdentity,
   conversationIdentityFromMsgContext,
   conversationIdentityFromSessionEntry,
 } from "./conversation-identity.js";
@@ -99,6 +100,70 @@ describe("conversation identity", () => {
     expect(identity?.conversationRef).not.toBe(
       conversationIdentityFromSessionEntry(directEntry("peer-a"))?.conversationRef,
     );
+  });
+
+  it("keeps a paired canonical outbound peer separate from its delivery alias", () => {
+    const identity = conversationIdentityFromSessionEntry({
+      sessionId: "session-main",
+      updatedAt: 100,
+      chatType: "direct",
+      deliveryContext: {
+        channel: "discord",
+        accountId: "default",
+        to: "user:delivery-alias-456",
+      },
+      origin: {
+        provider: "discord",
+        accountId: "default",
+        chatType: "direct",
+        from: "discord:canonical-peer-123",
+        to: "user:delivery-alias-456",
+        nativeDirectUserId: "canonical-peer-123",
+      },
+    });
+
+    expect(identity).toMatchObject({
+      channel: "discord",
+      deliveryTarget: "user:delivery-alias-456",
+      nativeDirectUserId: "canonical-peer-123",
+      peerId: "canonical-peer-123",
+    });
+    expect(identity?.conversationRef).toBe(
+      buildConversationIdentity({
+        channel: "discord",
+        accountId: "default",
+        kind: "direct",
+        peerId: "canonical-peer-123",
+        deliveryTarget: "user:delivery-alias-456",
+      })?.conversationRef,
+    );
+  });
+
+  it("keeps a group bound to its room instead of the paired origin sender", () => {
+    const identity = conversationIdentityFromSessionEntry({
+      sessionId: "session-group",
+      updatedAt: 100,
+      chatType: "group",
+      deliveryContext: {
+        channel: "discord",
+        accountId: "default",
+        to: "channel:ops-room",
+      },
+      origin: {
+        provider: "discord",
+        accountId: "default",
+        chatType: "group",
+        from: "discord:user:participant-123",
+        to: "channel:ops-room",
+        nativeChannelId: "ops-room",
+      },
+    });
+
+    expect(identity).toMatchObject({
+      deliveryTarget: "channel:ops-room",
+      nativeChannelId: "ops-room",
+      peerId: "ops-room",
+    });
   });
 
   it("keeps fallback origin targets paired with their origin channel", () => {

--- a/src/config/sessions/conversation-identity.ts
+++ b/src/config/sessions/conversation-identity.ts
@@ -56,6 +56,35 @@ function normalizeKind(value: unknown): ConversationKind {
   return "direct";
 }
 
+function resolvePairedOriginPeerId(params: {
+  entry: SessionEntry;
+  deliveryContext?: DeliveryContext;
+  deliveryTarget: string;
+  kind: ConversationKind;
+}): string | undefined {
+  if (params.kind !== "direct") {
+    return undefined;
+  }
+  const origin = params.entry.origin;
+  const originFrom = normalizeText(origin?.from);
+  const originTo = normalizeText(origin?.to);
+  const originChannel = normalizeText(origin?.provider)?.toLowerCase();
+  const deliveryChannel = normalizeText(params.deliveryContext?.channel)?.toLowerCase();
+  if (
+    !originFrom ||
+    originTo !== params.deliveryTarget ||
+    !originChannel ||
+    originChannel !== deliveryChannel ||
+    normalizeChatType(origin?.chatType) !== params.kind ||
+    (normalizeAccountId(origin?.accountId) ?? "default") !==
+      (normalizeAccountId(params.deliveryContext?.accountId) ?? "default") ||
+    normalizeThreadId(origin?.threadId) !== normalizeThreadId(params.deliveryContext?.threadId)
+  ) {
+    return undefined;
+  }
+  return originFrom;
+}
+
 /** Builds one stable transport address from authoritative channel route facts. */
 export function buildConversationIdentity(params: {
   channel?: string;
@@ -143,13 +172,22 @@ export function conversationIdentityFromSessionEntry(
   const channel = routeOwnsTarget
     ? deliveryContext?.channel
     : (normalizeText(entry.origin?.provider) ?? normalizeText(entry.channel));
+  // Outbound routes can use an alias for delivery while `origin.from` carries
+  // the canonical peer. Trust it only when both snapshots are fully paired.
+  const pairedOriginPeerId = routeOwnsTarget
+    ? resolvePairedOriginPeerId({
+        entry,
+        deliveryContext,
+        deliveryTarget,
+        kind,
+      })
+    : undefined;
   return buildConversationIdentity({
     channel,
     accountId: routeOwnsTarget ? deliveryContext?.accountId : entry.origin?.accountId,
     kind,
-    // One authoritative route snapshot owns both the opaque identity and egress target.
     // Native ids remain descriptive metadata and cannot redirect a stored conversation ref.
-    peerId: deliveryTarget,
+    peerId: pairedOriginPeerId ?? deliveryTarget,
     deliveryTarget,
     threadId: routeOwnsTarget ? deliveryContext?.threadId : entry.origin?.threadId,
     nativeChannelId: entry.origin?.nativeChannelId,

--- a/src/config/sessions/conversation-identity.ts
+++ b/src/config/sessions/conversation-identity.ts
@@ -174,11 +174,11 @@ export function conversationIdentityFromSessionEntry(
     : (normalizeText(entry.origin?.provider) ?? normalizeText(entry.channel));
   // Outbound routes can use an alias for delivery while `origin.from` carries
   // the canonical peer. Trust it only when both snapshots are fully paired.
-  const pairedOriginPeerId = routeOwnsTarget
+  const pairedOriginPeerId = routeTarget
     ? resolvePairedOriginPeerId({
         entry,
         deliveryContext,
-        deliveryTarget,
+        deliveryTarget: routeTarget,
         kind,
       })
     : undefined;

--- a/src/gateway/conversation-turn.test.ts
+++ b/src/gateway/conversation-turn.test.ts
@@ -138,7 +138,7 @@ function createDeps() {
       from: "reef:molty",
       to: conversation.target,
     })),
-    ensureOutboundSessionEntry: vi.fn(async () => undefined),
+    bindOutboundSessionEntry: vi.fn(async () => undefined),
     runMessageAction: vi.fn(async () => sentResult()) as never,
     operations,
     update,
@@ -193,7 +193,7 @@ describe("runGatewayConversationTurn", () => {
     expect(deps.resolveOutboundSessionRoute).toHaveBeenCalledWith(
       expect.objectContaining({ channel: "reef", target: "reef:molty" }),
     );
-    expect(deps.ensureOutboundSessionEntry).toHaveBeenCalledOnce();
+    expect(deps.bindOutboundSessionEntry).toHaveBeenCalledOnce();
     expect(deps.registerPendingConversationTurn).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: conversation.sessionId }),
     );
@@ -540,7 +540,7 @@ describe("runGatewayConversationTurn", () => {
       ),
     ).rejects.toBeInstanceOf(ConversationInputError);
     expect(deps.resolveOutboundSessionRoute).not.toHaveBeenCalled();
-    expect(deps.ensureOutboundSessionEntry).not.toHaveBeenCalled();
+    expect(deps.bindOutboundSessionEntry).not.toHaveBeenCalled();
     expect(deps.beginOperation).not.toHaveBeenCalled();
     expect(deps.registerPendingConversationTurn).not.toHaveBeenCalled();
     expect(deps.runMessageAction).not.toHaveBeenCalled();

--- a/src/gateway/conversation-turn.ts
+++ b/src/gateway/conversation-turn.ts
@@ -16,7 +16,7 @@ import {
   type ConversationDeliveryDeps,
 } from "../infra/outbound/conversation-delivery.js";
 import {
-  ensureOutboundSessionEntry,
+  bindOutboundSessionEntry,
   resolveOutboundSessionRoute,
 } from "../infra/outbound/outbound-session.js";
 import { registerPendingConversationTurn } from "../sessions/conversation-turns.js";
@@ -29,7 +29,7 @@ type ConversationTurnDeps = ConversationDeliveryDeps & {
   registerPendingConversationTurn: typeof registerPendingConversationTurn;
   resolveConversation: typeof resolveConversation;
   resolveOutboundChannelPlugin: typeof resolveOutboundChannelPlugin;
-  ensureOutboundSessionEntry: typeof ensureOutboundSessionEntry;
+  bindOutboundSessionEntry: typeof bindOutboundSessionEntry;
   resolveOutboundSessionRoute: typeof resolveOutboundSessionRoute;
 };
 
@@ -49,7 +49,7 @@ const defaultDeps: ConversationTurnDeps = {
   registerPendingConversationTurn,
   resolveConversation,
   resolveOutboundChannelPlugin,
-  ensureOutboundSessionEntry,
+  bindOutboundSessionEntry,
   resolveOutboundSessionRoute,
 };
 
@@ -198,7 +198,7 @@ async function ensureConversationContextBinding(params: {
       `Conversation ${params.conversation.conversationRef} no longer resolves to a channel route`,
     );
   }
-  await params.deps.ensureOutboundSessionEntry({
+  await params.deps.bindOutboundSessionEntry({
     cfg: params.config,
     channel,
     accountId: params.conversation.accountId,
@@ -206,7 +206,7 @@ async function ensureConversationContextBinding(params: {
   });
   const bound = params.deps.resolveConversation(params.scope, params.conversation.conversationRef);
   if (!bound || !hasConversationSessionBinding(bound)) {
-    throw new ConversationInputError(
+    throw new Error(
       `Conversation ${params.conversation.conversationRef} could not create its local context binding`,
     );
   }

--- a/src/infra/outbound/outbound-session.integration.test.ts
+++ b/src/infra/outbound/outbound-session.integration.test.ts
@@ -24,7 +24,7 @@ describe("outbound session persistence", () => {
     closeOpenClawAgentDatabasesForTest();
   });
 
-  it("binds a discovered peer after replacing a shared-main delivery route", async () => {
+  it("binds a discovered canonical peer through a different delivery alias", async () => {
     const sessionKey = "agent:main:main";
     await upsertSessionEntry(
       { agentId: "main", sessionKey, storePath },
@@ -41,7 +41,7 @@ describe("outbound session persistence", () => {
       accountId: "default",
       kind: "direct",
       peerId: "reef:peer-agent",
-      deliveryTarget: "reef:peer-agent",
+      deliveryTarget: "@molty",
       nativeDirectUserId: "peer-agent",
     });
     expect(identity).toBeDefined();
@@ -60,7 +60,7 @@ describe("outbound session persistence", () => {
         peer: { kind: "direct", id: "peer-agent" },
         chatType: "direct",
         from: "reef:peer-agent",
-        to: "reef:peer-agent",
+        to: "@molty",
       },
     });
 
@@ -70,7 +70,7 @@ describe("outbound session persistence", () => {
       sessionId: "shared-main-session",
       sessionKey,
       role: "participant",
-      target: "reef:peer-agent",
+      target: "@molty",
     });
   });
 

--- a/src/infra/outbound/outbound-session.integration.test.ts
+++ b/src/infra/outbound/outbound-session.integration.test.ts
@@ -73,4 +73,44 @@ describe("outbound session persistence", () => {
       target: "reef:peer-agent",
     });
   });
+
+  it("creates the session row when a discovered peer has no local entry", async () => {
+    const sessionKey = "agent:main:reef:direct:peer-agent";
+    const identity = buildConversationIdentity({
+      channel: "reef",
+      accountId: "default",
+      kind: "direct",
+      peerId: "reef:peer-agent",
+      deliveryTarget: "reef:peer-agent",
+      nativeDirectUserId: "peer-agent",
+    });
+    expect(identity).toBeDefined();
+    registerConversationAddresses({ agentId: "main", storePath }, [identity!], 200);
+    expect(
+      resolveConversation({ agentId: "main", storePath }, identity!.conversationRef),
+    ).not.toMatchObject({ sessionId: expect.any(String) });
+
+    await bindOutboundSessionEntry({
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      channel: "reef",
+      accountId: "default",
+      route: {
+        sessionKey,
+        baseSessionKey: sessionKey,
+        peer: { kind: "direct", id: "peer-agent" },
+        chatType: "direct",
+        from: "reef:peer-agent",
+        to: "reef:peer-agent",
+      },
+    });
+
+    expect(
+      resolveConversation({ agentId: "main", storePath }, identity!.conversationRef),
+    ).toMatchObject({
+      sessionId: expect.any(String),
+      sessionKey,
+      role: "primary",
+      target: "reef:peer-agent",
+    });
+  });
 });

--- a/src/infra/outbound/outbound-session.integration.test.ts
+++ b/src/infra/outbound/outbound-session.integration.test.ts
@@ -1,0 +1,76 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { buildConversationIdentity } from "../../config/sessions/conversation-identity.js";
+import {
+  registerConversationAddresses,
+  resolveConversation,
+} from "../../config/sessions/conversation-registry.js";
+import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { bindOutboundSessionEntry } from "./outbound-session.js";
+
+describe("outbound session persistence", () => {
+  let storePath: string;
+
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  beforeEach(() => {
+    storePath = path.join(tempDirs.make("openclaw-outbound-session-"), "sessions.json");
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("binds a discovered peer after replacing a shared-main delivery route", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      {
+        sessionId: "shared-main-session",
+        updatedAt: 100,
+        chatType: "direct",
+        deliveryContext: { channel: "discord", accountId: "default", to: "user:operator" },
+        origin: { provider: "discord", accountId: "default", from: "discord:operator" },
+      },
+    );
+    const identity = buildConversationIdentity({
+      channel: "reef",
+      accountId: "default",
+      kind: "direct",
+      peerId: "reef:peer-agent",
+      deliveryTarget: "reef:peer-agent",
+      nativeDirectUserId: "peer-agent",
+    });
+    expect(identity).toBeDefined();
+    registerConversationAddresses({ agentId: "main", storePath }, [identity!], 200);
+    expect(
+      resolveConversation({ agentId: "main", storePath }, identity!.conversationRef),
+    ).not.toMatchObject({ sessionId: expect.any(String) });
+
+    await bindOutboundSessionEntry({
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      channel: "reef",
+      accountId: "default",
+      route: {
+        sessionKey,
+        baseSessionKey: sessionKey,
+        peer: { kind: "direct", id: "peer-agent" },
+        chatType: "direct",
+        from: "reef:peer-agent",
+        to: "reef:peer-agent",
+      },
+    });
+
+    expect(
+      resolveConversation({ agentId: "main", storePath }, identity!.conversationRef),
+    ).toMatchObject({
+      sessionId: "shared-main-session",
+      sessionKey,
+      role: "participant",
+      target: "reef:peer-agent",
+    });
+  });
+});

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -605,6 +605,7 @@ describe("ensureOutboundSessionEntry", () => {
       NativeDirectUserId: "peer-agent",
       OriginatingTo: "reef:peer-agent",
     });
+    expect(metadata.createIfMissing).toBe(true);
   });
 
   it("keeps ordinary outbound sends best-effort when route persistence fails", async () => {

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -1,10 +1,14 @@
 // Covers outbound session-route resolution through plugin hooks and fallback
-// target parsing, plus best-effort session metadata persistence.
+// target parsing, plus best-effort session route persistence.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
-import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
+import {
+  bindOutboundSessionEntry,
+  ensureOutboundSessionEntry,
+  resolveOutboundSessionRoute,
+} from "./outbound-session.js";
 import { setMinimalOutboundSessionPluginRegistryForTests } from "./outbound-session.test-helpers.js";
 
 type InboundMetadataParams = {
@@ -13,7 +17,10 @@ type InboundMetadataParams = {
 };
 
 const mocks = vi.hoisted(() => ({
-  recordInboundSessionMeta: vi.fn(async (_params: InboundMetadataParams) => ({ ok: true })),
+  updateSessionLastRoute: vi.fn(async (_params: InboundMetadataParams) => ({
+    sessionId: "session-1",
+    updatedAt: 1,
+  })),
   resolveStorePath: vi.fn(
     (_store: unknown, params?: { agentId?: string }) => `/stores/${params?.agentId ?? "main"}.json`,
   ),
@@ -35,13 +42,13 @@ function firstMockArg(
 }
 
 vi.mock("../../config/sessions/inbound.runtime.js", () => ({
-  recordInboundSessionMeta: mocks.recordInboundSessionMeta,
   resolveStorePath: mocks.resolveStorePath,
+  updateSessionLastRoute: mocks.updateSessionLastRoute,
 }));
 
 describe("resolveOutboundSessionRoute", () => {
   beforeEach(() => {
-    mocks.recordInboundSessionMeta.mockClear();
+    mocks.updateSessionLastRoute.mockClear();
     mocks.resolveStorePath.mockClear();
     setMinimalOutboundSessionPluginRegistryForTests();
   });
@@ -544,7 +551,7 @@ describe("resolveOutboundSessionRoute", () => {
 
 describe("ensureOutboundSessionEntry", () => {
   beforeEach(() => {
-    mocks.recordInboundSessionMeta.mockClear();
+    mocks.updateSessionLastRoute.mockClear();
     mocks.resolveStorePath.mockClear();
   });
 
@@ -569,8 +576,8 @@ describe("ensureOutboundSessionEntry", () => {
     expect(mocks.resolveStorePath).toHaveBeenCalledWith("/stores/{agentId}.json", {
       agentId: "main",
     });
-    expect(mocks.recordInboundSessionMeta).toHaveBeenCalledOnce();
-    const metadata = firstMockArg(mocks.recordInboundSessionMeta, "recordInboundSessionMeta");
+    expect(mocks.updateSessionLastRoute).toHaveBeenCalledOnce();
+    const metadata = firstMockArg(mocks.updateSessionLastRoute, "updateSessionLastRoute");
     expect(metadata.storePath).toBe("/stores/main.json");
     expect(metadata.sessionKey).toBe("agent:main:workspace:channel:c1");
     expect(metadata.ctx).toMatchObject({
@@ -593,10 +600,48 @@ describe("ensureOutboundSessionEntry", () => {
       },
     });
 
-    const metadata = firstMockArg(mocks.recordInboundSessionMeta, "recordInboundSessionMeta");
+    const metadata = firstMockArg(mocks.updateSessionLastRoute, "updateSessionLastRoute");
     expect(metadata.ctx).toMatchObject({
       NativeDirectUserId: "peer-agent",
       OriginatingTo: "reef:peer-agent",
     });
+  });
+
+  it("keeps ordinary outbound sends best-effort when route persistence fails", async () => {
+    mocks.updateSessionLastRoute.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await expect(
+      ensureOutboundSessionEntry({
+        cfg: {} as OpenClawConfig,
+        channel: "reef",
+        route: {
+          sessionKey: "agent:main:main",
+          baseSessionKey: "agent:main:main",
+          peer: { kind: "direct", id: "peer-agent" },
+          chatType: "direct",
+          from: "reef:peer-agent",
+          to: "reef:peer-agent",
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("surfaces route persistence failures when a conversation requires binding", async () => {
+    mocks.updateSessionLastRoute.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await expect(
+      bindOutboundSessionEntry({
+        cfg: {} as OpenClawConfig,
+        channel: "reef",
+        route: {
+          sessionKey: "agent:main:main",
+          baseSessionKey: "agent:main:main",
+          peer: { kind: "direct", id: "peer-agent" },
+          chatType: "direct",
+          from: "reef:peer-agent",
+          to: "reef:peer-agent",
+        },
+      }),
+    ).rejects.toThrow("storage unavailable");
   });
 });

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -257,6 +257,9 @@ async function persistOutboundSessionEntry(
   return await updateSessionLastRoute({
     storePath,
     sessionKey: params.route.sessionKey,
+    // Creation is part of this helper's contract: directory-discovered peers
+    // may not have a local session row until their first outbound turn.
+    createIfMissing: true,
     channel: params.channel,
     to: params.route.to,
     accountId: params.accountId ?? undefined,

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -7,10 +7,8 @@ import type { ChatType } from "../../channels/chat-type.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
-import {
-  recordInboundSessionMeta,
-  resolveStorePath,
-} from "../../config/sessions/inbound.runtime.js";
+import { resolveStorePath, updateSessionLastRoute } from "../../config/sessions/inbound.runtime.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RoutePeer } from "../../routing/resolve-route.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
@@ -227,13 +225,16 @@ export async function resolveOutboundSessionRoute(
   return resolveFallbackSession(nextParams);
 }
 
-/** Persists best-effort session metadata for an outbound-only route. */
-export async function ensureOutboundSessionEntry(params: {
+type OutboundSessionEntryParams = {
   cfg: OpenClawConfig;
   channel: ChannelId;
   accountId?: string | null;
   route: OutboundSessionRoute;
-}): Promise<void> {
+};
+
+async function persistOutboundSessionEntry(
+  params: OutboundSessionEntryParams,
+): Promise<SessionEntry | null> {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: resolveAgentIdFromSessionKey(params.route.sessionKey),
   });
@@ -251,13 +252,34 @@ export async function ensureOutboundSessionEntry(params: {
     NativeDirectUserId: params.route.peer.kind === "direct" ? params.route.peer.id : undefined,
     NativeChannelId: params.route.peer.kind === "direct" ? undefined : params.route.peer.id,
   };
+  // Shared-main context may still point at another channel. Commit route and
+  // origin together so its conversation identity binds the exact destination.
+  return await updateSessionLastRoute({
+    storePath,
+    sessionKey: params.route.sessionKey,
+    channel: params.channel,
+    to: params.route.to,
+    accountId: params.accountId ?? undefined,
+    threadId: params.route.threadId,
+    ctx,
+  });
+}
+
+/** Persists best-effort session metadata for an outbound-only route. */
+export async function ensureOutboundSessionEntry(
+  params: OutboundSessionEntryParams,
+): Promise<void> {
   try {
-    await recordInboundSessionMeta({
-      storePath,
-      sessionKey: params.route.sessionKey,
-      ctx,
-    });
+    await persistOutboundSessionEntry(params);
   } catch {
     // Do not block outbound sends on session meta writes.
+  }
+}
+
+/** Persists the route required to bind an exact conversation address to local context. */
+export async function bindOutboundSessionEntry(params: OutboundSessionEntryParams): Promise<void> {
+  const entry = await persistOutboundSessionEntry(params);
+  if (!entry) {
+    throw new Error(`Failed to bind outbound session ${params.route.sessionKey}`);
   }
 }


### PR DESCRIPTION
Closes #110018

## What Problem This Solves

Fixes an issue where users starting a turn through a Reef conversation discovered from the directory would see the turn fail before delivery when the shared-main session still carried another channel's delivery route.

## Why This Change Was Made

The outbound session owner now persists delivery route and origin metadata together. Correlated conversation turns use a strict binding path so storage failures surface before delivery, while ordinary outbound message mirroring remains best-effort.

No config, database schema, or schema-version changes are included.

## User Impact

Agents can start a normal correlated turn with a discovered Reef peer even when their shared-main session was previously routed through Discord or another channel. Binding failures are reported as transport availability failures instead of being silently swallowed.

## Evidence

- Live pre-fix repro: Reef discovery returned a valid conversation reference, but `conversations_turn` failed with `could not create its local context binding` before Molty received anything.
- Real SQLite-backed regression covers a shared-main session initially routed through Discord, binds the discovered Reef identity, and resolves the same conversation reference to the existing session.
- `pnpm test src/infra/outbound/outbound-session.test.ts src/infra/outbound/outbound-session.integration.test.ts src/gateway/conversation-turn.test.ts` — 50 tests passed on Blacksmith Testbox `tbx_01kxr5mpm99ym7d8jygxg4g6wp`.
- `pnpm check:changed` — passed on the same rebased head and Testbox lease.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
