### PR TITLE
fix(lmstudio): set supportsTools only for native tool-trained models

### DIFF
--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -185,6 +185,30 @@ describe("lmstudio-models", () => {
     });
   });
 
+  it("preserves configured catalog supportsTools through normalization", () => {
+    expect(
+      normalizeLmstudioConfiguredCatalogEntry({
+        id: "native-tools",
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      })?.compat,
+    ).toEqual({ supportsTools: true, supportsUsageInStreaming: true });
+
+    // Explicit false remains a valid configured opt-out (unlike discovery mapping).
+    expect(
+      normalizeLmstudioConfiguredCatalogEntry({
+        id: "tools-disabled",
+        compat: { supportsTools: false },
+      })?.compat,
+    ).toEqual({ supportsTools: false });
+
+    expect(
+      normalizeLmstudioConfiguredCatalogEntry({
+        id: "tools-unknown",
+        compat: { supportsUsageInStreaming: true },
+      })?.compat,
+    ).toEqual({ supportsUsageInStreaming: true });
+  });
+
   it("drops malformed configured catalog token metadata", () => {
     expect(
       normalizeLmstudioConfiguredCatalogEntry({

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -228,7 +228,7 @@ describe("lmstudio-models", () => {
     });
   });
 
-  it("maps trained_for_tool_use into explicit catalog supportsTools", () => {
+  it("maps trained_for_tool_use true into supportsTools without disabling false", () => {
     expect(
       mapLmstudioWireEntry({
         type: "llm",
@@ -237,13 +237,15 @@ describe("lmstudio-models", () => {
       })?.compat,
     ).toEqual({ supportsTools: true });
 
+    // LM Studio still provides default tool-use mode when untrained; leave
+    // compat unset so OpenClaw keeps tools enabled (supportsTools !== false).
     expect(
       mapLmstudioWireEntry({
         type: "llm",
         key: "tools-untrained",
         capabilities: { trained_for_tool_use: false },
       })?.compat,
-    ).toEqual({ supportsTools: false });
+    ).toBeUndefined();
 
     expect(
       mapLmstudioWireEntry({

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -228,6 +228,32 @@ describe("lmstudio-models", () => {
     });
   });
 
+  it("maps trained_for_tool_use into explicit catalog supportsTools", () => {
+    expect(
+      mapLmstudioWireEntry({
+        type: "llm",
+        key: "tools-trained",
+        capabilities: { trained_for_tool_use: true },
+      })?.compat,
+    ).toEqual({ supportsTools: true });
+
+    expect(
+      mapLmstudioWireEntry({
+        type: "llm",
+        key: "tools-untrained",
+        capabilities: { trained_for_tool_use: false },
+      })?.compat,
+    ).toEqual({ supportsTools: false });
+
+    expect(
+      mapLmstudioWireEntry({
+        type: "llm",
+        key: "tools-unknown",
+        capabilities: { vision: true },
+      })?.compat,
+    ).toBeUndefined();
+  });
+
   it("resolves reasoning capability for supported and unsupported options", () => {
     expect(resolveLmstudioReasoningCapability({ capabilities: undefined })).toBe(false);
     expect(
@@ -365,6 +391,7 @@ describe("lmstudio-models", () => {
       input: ["text", "image"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       compat: {
+        supportsTools: true,
         supportsUsageInStreaming: true,
         supportsReasoningEffort: true,
         supportedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],

--- a/extensions/lmstudio/src/models.ts
+++ b/extensions/lmstudio/src/models.ts
@@ -350,6 +350,12 @@ function normalizeLmstudioConfiguredCompat(value: unknown): ModelDefinitionConfi
   const supportedReasoningEfforts = normalizeReasoningOptions(record.supportedReasoningEfforts);
   const reasoningEffortMap = normalizeConfiguredReasoningEffortMap(record.reasoningEffortMap);
   const compat: NonNullable<ModelDefinitionConfig["compat"]> = {};
+  // Keep configured/native tool capability through setup → augmentModelCatalog.
+  // Dynamic discovery already spreads supportsTools; dropping it here makes the
+  // two catalog paths disagree for the same LM Studio model metadata.
+  if (typeof record.supportsTools === "boolean") {
+    compat.supportsTools = record.supportsTools;
+  }
   if (typeof record.supportsUsageInStreaming === "boolean") {
     compat.supportsUsageInStreaming = record.supportsUsageInStreaming;
   }

--- a/extensions/lmstudio/src/models.ts
+++ b/extensions/lmstudio/src/models.ts
@@ -184,17 +184,17 @@ export function resolveLmstudioReasoningCompat(
 }
 
 /**
- * Maps LM Studio `trained_for_tool_use` into catalog `compat.supportsTools`.
- * Boolean true/false are authoritative. Omitted metadata stays unset so core
- * keeps the permissive default (`supportsTools !== false`); otherwise models
- * that report false still advertise tools.
+ * Maps LM Studio native tool training into catalog `compat.supportsTools`.
+ * Only `trained_for_tool_use: true` becomes an explicit opt-in. False and
+ * omitted stay unset so core keeps the permissive default
+ * (`supportsTools !== false`): LM Studio still offers default tool-use mode
+ * for untrained models, and OpenClaw must not disable tools on that signal.
  */
 function resolveLmstudioToolsCompat(
   entry: Pick<LmstudioModelWire, "capabilities">,
 ): Pick<NonNullable<ModelDefinitionConfig["compat"]>, "supportsTools"> | undefined {
-  const trained = entry.capabilities?.trained_for_tool_use;
-  if (trained === true || trained === false) {
-    return { supportsTools: trained };
+  if (entry.capabilities?.trained_for_tool_use === true) {
+    return { supportsTools: true };
   }
   return undefined;
 }

--- a/extensions/lmstudio/src/models.ts
+++ b/extensions/lmstudio/src/models.ts
@@ -184,6 +184,33 @@ export function resolveLmstudioReasoningCompat(
 }
 
 /**
+ * Maps LM Studio `trained_for_tool_use` into catalog `compat.supportsTools`.
+ * Boolean true/false are authoritative. Omitted metadata stays unset so core
+ * keeps the permissive default (`supportsTools !== false`); otherwise models
+ * that report false still advertise tools.
+ */
+function resolveLmstudioToolsCompat(
+  entry: Pick<LmstudioModelWire, "capabilities">,
+): Pick<NonNullable<ModelDefinitionConfig["compat"]>, "supportsTools"> | undefined {
+  const trained = entry.capabilities?.trained_for_tool_use;
+  if (trained === true || trained === false) {
+    return { supportsTools: trained };
+  }
+  return undefined;
+}
+
+function resolveLmstudioModelCompat(
+  entry: Pick<LmstudioModelWire, "capabilities">,
+): ModelDefinitionConfig["compat"] | undefined {
+  const reasoningCompat = resolveLmstudioReasoningCompat(entry);
+  const toolsCompat = resolveLmstudioToolsCompat(entry);
+  if (!reasoningCompat && !toolsCompat) {
+    return undefined;
+  }
+  return { ...reasoningCompat, ...toolsCompat };
+}
+
+/**
  * Resolves LM Studio reasoning support from capabilities payloads.
  * Defaults to false when the server omits reasoning metadata.
  */
@@ -537,7 +564,7 @@ export function mapLmstudioWireEntry(entry: LmstudioModelWire): LmstudioModelBas
     reasoning: resolveLmstudioReasoningCapability(entry),
     input: entry.capabilities?.vision ? ["text", "image"] : ["text"],
     cost: SELF_HOSTED_DEFAULT_COST,
-    compat: resolveLmstudioReasoningCompat(entry),
+    compat: resolveLmstudioModelCompat(entry),
     contextWindow,
     contextTokens,
     maxTokens: Math.max(1, Math.min(contextWindow, SELF_HOSTED_DEFAULT_MAX_TOKENS)),


### PR DESCRIPTION
## What Problem This Solves

LM Studio discovery already reads `capabilities.trained_for_tool_use`, but catalog `compat` never set `supportsTools`. Native-trained models therefore relied only on core’s permissive default, with no explicit catalog signal when LM Studio reports native tool training. Configured/setup catalog normalization also dropped any `supportsTools` value, so dynamic discovery and configured augmentation disagreed.

## Why This Change Was Made

1. Map only `trained_for_tool_use: true` → `compat.supportsTools: true`. False/omitted stay unset so OpenClaw keeps the permissive default (`supportsTools !== false`) and LM Studio’s default tool-use mode remains available.
2. Preserve boolean `supportsTools` in `normalizeLmstudioConfiguredCompat` so setup/persisted models keep the signal through `augmentModelCatalog` (same path as dynamic discovery).

AI-assisted: yes. I inspected the wire mapper, configured-catalog normalizer, `augmentModelCatalog`, and `supportsModelTools` before the change.

## User Impact

Native tool-trained LM Studio models get an explicit `supportsTools: true` on both dynamic discovery and configured catalog paths. Untrained/omitted models keep tools enabled. Explicit configured `supportsTools: false` remains a valid operator opt-out.

## Evidence

**Configured catalog path (production helpers):** macOS `darwin 21.6.0 x64`, Node `v22.19.0`. `normalizeLmstudioConfiguredCatalogEntry` + the same compat spread used by `augmentModelCatalog`:

```json
{
  "normalizedCompat": { "supportsTools": true },
  "augmentedCompat": { "supportsTools": true, "supportsUsageInStreaming": true },
  "toolsAllowedByRuntime": true
}
```

**Dynamic discovery path:** localhost HTTP speaking LM Studio `/api/v1/models` wire → production `discoverLmstudioModels` (desktop LM Studio was not listening on `:1234`): native-trained gains `supportsTools: true`; false/omitted stay unset and keep tools.

| Layer | Proof | Result |
| --- | --- | --- |
| L1 | true-only discovery mapping + configured normalizer preserves `supportsTools` | pass |
| L2 | configured augment-style spread keeps `supportsTools: true` | pass |
| Gate | focused vitest on mapping + configured preserve | 2 passed |

```text
pnpm exec vitest run extensions/lmstudio/src/models.test.ts -t "preserves configured catalog supportsTools|trained_for_tool_use|maps trained"
→ 2 passed
```

Head: `0b61ae8ed07285da66363a6e72996bf828b4c9d7`

```text
extensions/lmstudio/src/models.ts       +34 -1
extensions/lmstudio/src/models.test.ts  +53 -0
```

Note: a desktop LM Studio instance was not available in this environment for contributor-side live proof; configured + dynamic production-path harnesses above cover both catalog owners.
