### PR TITLE
fix(plugins): bound plugin manifest metadata file reads

### DIFF
--- a/src/plugins/manifest-metadata-scan.test.ts
+++ b/src/plugins/manifest-metadata-scan.test.ts
@@ -126,4 +126,50 @@ describe("listOpenClawPluginManifestMetadata", () => {
       origin: "global",
     });
   });
+
+  it("skips oversized plugin manifests to prevent OOM during metadata scan", () => {
+    const root = createTempRoot();
+    const home = path.join(root, "home");
+
+    const goodPluginDir = path.join(home, ".openclaw", "extensions", "good-plugin");
+    writeJson(path.join(goodPluginDir, "openclaw.plugin.json"), { id: "good-plugin" });
+
+    const oversizedDir = path.join(home, ".openclaw", "extensions", "big-plugin");
+    const oversizedPath = path.join(oversizedDir, "openclaw.plugin.json");
+    fs.mkdirSync(oversizedDir, { recursive: true });
+    fs.writeFileSync(oversizedPath, "x".repeat(256 * 1024 + 1), "utf8");
+
+    const records = listOpenClawPluginManifestMetadata({
+      OPENCLAW_HOME: home,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "empty-bundled"),
+    });
+
+    // "good-plugin" is present; "big-plugin" is skipped due to oversized manifest.
+    expect(records.find((record) => record.manifest.id === "good-plugin")).toBeTruthy();
+    expect(records.find((record) => record.manifest.id === "big-plugin")).toBeUndefined();
+  });
+
+  it("accepts plugin manifests at the exact byte limit", () => {
+    const root = createTempRoot();
+    const home = path.join(root, "home");
+
+    const exactDir = path.join(home, ".openclaw", "extensions", "exact-plugin");
+    fs.mkdirSync(exactDir, { recursive: true });
+
+    // Write a compact JSON manifest padded to exactly the byte limit.
+    const exactPath = path.join(exactDir, "openclaw.plugin.json");
+    const exactManifest = { id: "exact-plugin", pad: "" };
+    const compactJson = JSON.stringify(exactManifest);
+    const requiredPadding = 256 * 1024 - Buffer.byteLength(compactJson, "utf8");
+    exactManifest.pad = "x".repeat(requiredPadding);
+    fs.writeFileSync(exactPath, JSON.stringify(exactManifest), "utf8");
+    expect(Buffer.byteLength(fs.readFileSync(exactPath), "utf8")).toBe(256 * 1024);
+
+    const records = listOpenClawPluginManifestMetadata({
+      OPENCLAW_HOME: home,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "empty-bundled"),
+    });
+
+    expect(records.find((record) => record.manifest.id === "exact-plugin")).toBeTruthy();
+  });
 });

--- a/src/plugins/manifest-metadata-scan.test.ts
+++ b/src/plugins/manifest-metadata-scan.test.ts
@@ -137,7 +137,12 @@ describe("listOpenClawPluginManifestMetadata", () => {
     const oversizedDir = path.join(home, ".openclaw", "extensions", "big-plugin");
     const oversizedPath = path.join(oversizedDir, "openclaw.plugin.json");
     fs.mkdirSync(oversizedDir, { recursive: true });
-    fs.writeFileSync(oversizedPath, "x".repeat(256 * 1024 + 1), "utf8");
+    fs.writeFileSync(
+      oversizedPath,
+      JSON.stringify({ id: "big-plugin", pad: "x".repeat(256 * 1024) }),
+      "utf8",
+    );
+    expect(fs.statSync(oversizedPath).size).toBeGreaterThan(256 * 1024);
 
     const records = listOpenClawPluginManifestMetadata({
       OPENCLAW_HOME: home,

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -71,7 +71,7 @@ function readJsonObject(filePath: string): Record<string, unknown> | undefined {
     const parsed = parseJsonWithJson5Fallback(buffer.toString("utf-8"));
     return isRecord(parsed) ? parsed : undefined;
   } catch (err) {
-    if (err instanceof RangeError) {
+    if (err instanceof Error && err.message.includes("exceeds")) {
       log.warn(
         `Ignoring oversized plugin manifest at ${filePath}: file exceeds the ${PLUGIN_MANIFEST_METADATA_MAX_BYTES}-byte limit`,
       );

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -6,9 +6,17 @@ import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/nor
 import { resolveStateDir } from "../config/paths.js";
 import { resolveHomeRelativePath } from "../infra/home-dir.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { readPersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+
+// Plugin manifest files are small metadata descriptors. Bound reads to prevent
+// a corrupted or hostile manifest from exhausting memory during metadata scan.
+const PLUGIN_MANIFEST_METADATA_MAX_BYTES = 256 * 1024;
+
+const log = createSubsystemLogger("plugins/manifest-metadata-scan");
 
 type PluginManifestMetadataRecord = {
   pluginDir: string;
@@ -56,9 +64,18 @@ function listChildPluginDirs(
 
 function readJsonObject(filePath: string): Record<string, unknown> | undefined {
   try {
-    const parsed = parseJsonWithJson5Fallback(fs.readFileSync(filePath, "utf8"));
+    const { buffer } = readRegularFileSync({
+      filePath,
+      maxBytes: PLUGIN_MANIFEST_METADATA_MAX_BYTES,
+    });
+    const parsed = parseJsonWithJson5Fallback(buffer.toString("utf-8"));
     return isRecord(parsed) ? parsed : undefined;
-  } catch {
+  } catch (err) {
+    if (err instanceof RangeError) {
+      log.warn(
+        `Ignoring oversized plugin manifest at ${filePath}: file exceeds the ${PLUGIN_MANIFEST_METADATA_MAX_BYTES}-byte limit`,
+      );
+    }
     return undefined;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Plugin manifest metadata scan reads `openclaw.plugin.json` files from installed, bundled, and global plugin directories through unbounded `fs.readFileSync`. A corrupted or hostile manifest file could therefore exhaust memory during metadata enumeration.

## Why This Change Was Made

Plugin manifest files are small metadata descriptors like workspace hook manifests. The shared bounded `readRegularFileSync` helper with the same 256 KiB maximum used by the full plugin manifest loader now enforces the cap during metadata scanning as well. An oversized manifest is logged and skipped; scanning continues for remaining plugins.

## User Impact

Oversized plugin manifests are warned about and skipped. Metadata scan continues for other plugins.

## Maintainer Changes

- Added `PLUGIN_MANIFEST_METADATA_MAX_BYTES = 256 * 1024` constant, matching the existing limit in the full plugin manifest loader (`src/plugins/manifest.ts` `MAX_PLUGIN_MANIFEST_BYTES`).
- Replaced unbounded `fs.readFileSync` with `readRegularFileSync` bounded reader.
- Handles oversized files via `readRegularFileSync` error (plain `Error` with "exceeds" message): logs a subsystem warning and returns `undefined` so the oversized plugin is skipped.
- Added two bounding coverage tests: oversized manifest skipped, exact-limit manifest accepted.

## Evidence

### Real behavior proof: bounded manifest read via listOpenClawPluginManifestMetadata

The bounded reader correctly handles all three cases — normal, oversized, and exact-limit manifests — against the **real** discovered plugin tree including source checkout, bundled, and global plugin paths. The run uses a fresh OPENCLAW_HOME with no SQLite state DB, so `readPersistedInstalledPluginIndexSync` returns null (bypasses the SQLite WAL-safety check entirely).

**Subsystem warning output (stderr):**

```
[WARN] [plugins/manifest-metadata-scan] Ignoring oversized plugin manifest at /tmp/.../big-plugin/openclaw.plugin.json: file exceeds the 262144-byte limit
```

**Scan results:**

```
── Test data ──
Good manifest size:    51 bytes
Oversized manifest:    262145 bytes (> 256 KiB)
Exact manifest size:   262144 bytes (== 256 KiB)

── Scan results ──
Total plugins discovered:  150
good-plugin found:          true
big-plugin (oversized):     false (expected: false — skipped)
exact-plugin (256 KiB):     true (expected: true — accepted)

── Verification ──
  ✅ Oversized manifest skipped
  ✅ Valid plugin still discovered
  ✅ Exact-limit manifest accepted
  ✅ Subsystem warning emitted

ALL CHECKS PASSED
```

The 150 discovered plugins include all bundled extensions and the test good-plugin, confirming that manifest discovery continues normally after the oversized entry is skipped.