### PR TITLE
fix(feeds): accept standard DSSE envelopes

### DIFF
--- a/src/plugins/official-external-plugin-catalog-envelope.test.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.test.ts
@@ -57,13 +57,11 @@ function signedEnvelope(params: {
   const payload = payloadBytes.toString(params.encoding ?? "base64url");
   const input = signingInput(payloadType, payloadBytes);
   return {
-    schemaVersion: 1,
     payloadType,
     payload,
     signatures: params.keys.map((key) => ({
-      keyId: key.keyId,
-      algorithm: "ed25519",
-      signature: crypto.sign(null, input, key.privateKey).toString("base64url"),
+      keyid: key.keyId,
+      sig: crypto.sign(null, input, key.privateKey).toString("base64url"),
     })),
   };
 }
@@ -167,7 +165,7 @@ describe("official external plugin catalog signed envelopes", () => {
           ...envelope,
           signatures: Array.from({ length: 17 }, (_, index) => ({
             ...signature,
-            keyId: `key-${index}`,
+            keyid: `key-${index}`,
           })),
         },
         { trustedKeys },
@@ -198,10 +196,77 @@ describe("official external plugin catalog signed envelopes", () => {
   });
 
   it("rejects malformed envelopes before verification", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
     expect(
       verifyOfficialExternalPluginCatalogSignedEnvelope(
-        { schemaVersion: 1, payloadType: PAYLOAD_TYPE, payload: "", signatures: [] },
+        { payloadType: PAYLOAD_TYPE, payload: "", signatures: [] },
         { trustedKeys: [] },
+      ),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        { ...envelope, signatures: [{ sig: signature.sig }] },
+        { trustedKeys: [{ keyId: key.keyId, publicKey: exportPublicKey(key) }] },
+      ),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+  });
+
+  it("ignores unrecognized DSSE envelope and signature fields", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        {
+          ...envelope,
+          futureEnvelopeField: true,
+          signatures: [{ ...signature, futureSignatureField: true }],
+        },
+        { trustedKeys: [{ keyId: key.keyId, publicKey: exportPublicKey(key) }] },
+      ),
+    ).toMatchObject({ ok: true, signedBy: key.keyId });
+  });
+
+  it("accepts the beta legacy field names without allowing mixed formats", () => {
+    const key = createSigningKey("catalog-root");
+    const envelope = signedEnvelope({ keys: [key] });
+    const signature = envelope.signatures[0];
+    expect(signature).toBeDefined();
+    if (!signature) {
+      throw new Error("expected a generated signature");
+    }
+    const legacySignature = {
+      keyId: signature.keyid,
+      algorithm: "ed25519",
+      signature: signature.sig,
+    };
+    const trustedKeys = [{ keyId: key.keyId, publicKey: exportPublicKey(key) }];
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        {
+          ...envelope,
+          schemaVersion: 1,
+          signatures: [legacySignature],
+        },
+        { trustedKeys },
+      ),
+    ).toMatchObject({ ok: true, signedBy: key.keyId });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(
+        { ...envelope, schemaVersion: 1, signatures: [signature, legacySignature] },
+        { trustedKeys },
       ),
     ).toMatchObject({ ok: false, error: "invalid-envelope" });
   });

--- a/src/plugins/official-external-plugin-catalog-envelope.test.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.test.ts
@@ -238,7 +238,7 @@ describe("official external plugin catalog signed envelopes", () => {
     ).toMatchObject({ ok: true, signedBy: key.keyId });
   });
 
-  it("accepts the beta legacy field names without allowing mixed formats", () => {
+  it("accepts beta legacy field names only for persisted snapshots", () => {
     const key = createSigningKey("catalog-root");
     const envelope = signedEnvelope({ keys: [key] });
     const signature = envelope.signatures[0];
@@ -253,21 +253,34 @@ describe("official external plugin catalog signed envelopes", () => {
     };
     const trustedKeys = [{ keyId: key.keyId, publicKey: exportPublicKey(key) }];
 
+    const legacyEnvelope = {
+      ...envelope,
+      schemaVersion: 1,
+      signatures: [legacySignature],
+    };
+
     expect(
-      verifyOfficialExternalPluginCatalogSignedEnvelope(
-        {
-          ...envelope,
-          schemaVersion: 1,
-          signatures: [legacySignature],
-        },
-        { trustedKeys },
-      ),
+      verifyOfficialExternalPluginCatalogSignedEnvelope(legacyEnvelope, { trustedKeys }),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(legacyEnvelope, {
+        trustedKeys,
+        allowLegacyBetaEnvelope: true,
+      }),
     ).toMatchObject({ ok: true, signedBy: key.keyId });
+    const mixedEnvelope = {
+      ...envelope,
+      schemaVersion: 1,
+      signatures: [signature, legacySignature],
+    };
     expect(
-      verifyOfficialExternalPluginCatalogSignedEnvelope(
-        { ...envelope, schemaVersion: 1, signatures: [signature, legacySignature] },
-        { trustedKeys },
-      ),
+      verifyOfficialExternalPluginCatalogSignedEnvelope(mixedEnvelope, { trustedKeys }),
+    ).toMatchObject({ ok: false, error: "invalid-envelope" });
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(mixedEnvelope, {
+        trustedKeys,
+        allowLegacyBetaEnvelope: true,
+      }),
     ).toMatchObject({ ok: false, error: "invalid-envelope" });
   });
 });

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -13,6 +13,10 @@ const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE =
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES = 16;
 
 type OfficialExternalPluginCatalogEnvelopeSignature = {
+  keyid?: string;
+  sig?: string;
+};
+type LegacyOfficialExternalPluginCatalogEnvelopeSignature = {
   keyId?: string;
   algorithm?: string;
   signature?: string;
@@ -87,7 +91,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   const trustedSignatureKeyIds: string[] = [];
   const trustedSignaturePublicKeys = new Set<string>();
   for (const envelopeSignature of envelope.signatures) {
-    const keyId = envelopeSignature.keyId;
+    const keyId = envelopeSignature.keyid;
     const trustedKey = params.trustedKeys.find((candidate) => candidate.keyId === keyId);
     if (!trustedKey || trustedSignatureKeyIds.includes(trustedKey.keyId)) {
       continue;
@@ -100,7 +104,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
       verifyEd25519SignatureBytes({
         publicKey: trustedKey.publicKey,
         payload: signingInput,
-        signatureBase64Url: envelopeSignature.signature,
+        signatureBase64Url: envelopeSignature.sig,
       })
     ) {
       trustedSignatureKeyIds.push(trustedKey.keyId);
@@ -134,7 +138,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     };
   }
   const hasKnownKey = envelope.signatures.some((signature) =>
-    params.trustedKeys.some((key) => key.keyId === signature.keyId),
+    params.trustedKeys.some((key) => key.keyId === signature.keyid),
   );
   return hasKnownKey
     ? {
@@ -157,7 +161,7 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   payload: string;
   signatures: readonly Required<OfficialExternalPluginCatalogEnvelopeSignature>[];
 } | null {
-  if (!isRecord(raw) || raw.schemaVersion !== 1) {
+  if (!isRecord(raw)) {
     return null;
   }
   const payloadType = raw.payloadType;
@@ -172,15 +176,38 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   if (signatures.length > OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_SIGNATURES) {
     return null;
   }
-  const parsedSignatures = signatures.filter(
+  // Hosted Feed v1 requires keyid even though generic DSSE makes it optional:
+  // trust thresholds and rotation are resolved against configured key ids.
+  const standardSignatures = signatures.filter(
     (signature): signature is Required<OfficialExternalPluginCatalogEnvelopeSignature> =>
       isRecord(signature) &&
-      typeof signature.keyId === "string" &&
-      signature.keyId.trim().length > 0 &&
-      signature.algorithm === "ed25519" &&
-      typeof signature.signature === "string" &&
-      signature.signature.trim().length > 0,
+      typeof signature.keyid === "string" &&
+      signature.keyid.trim().length > 0 &&
+      typeof signature.sig === "string" &&
+      signature.sig.trim().length > 0,
   );
+  // Beta releases briefly accepted this pre-DSSE field shape. Keep it as an
+  // all-or-nothing read path while every producer moves to the standard shape.
+  const legacySignatures =
+    raw.schemaVersion === 1
+      ? signatures
+          .filter(
+            (
+              signature,
+            ): signature is Required<LegacyOfficialExternalPluginCatalogEnvelopeSignature> =>
+              isRecord(signature) &&
+              typeof signature.keyId === "string" &&
+              signature.keyId.trim().length > 0 &&
+              signature.algorithm === "ed25519" &&
+              typeof signature.signature === "string" &&
+              signature.signature.trim().length > 0,
+          )
+          .map((signature) => ({ keyid: signature.keyId, sig: signature.signature }))
+      : [];
+  if (standardSignatures.length > 0 && legacySignatures.length > 0) {
+    return null;
+  }
+  const parsedSignatures = standardSignatures.length > 0 ? standardSignatures : legacySignatures;
   if (parsedSignatures.length === 0) {
     return null;
   }
@@ -189,10 +216,10 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   }
   const keyIds = new Set<string>();
   for (const signature of parsedSignatures) {
-    if (keyIds.has(signature.keyId)) {
+    if (keyIds.has(signature.keyid)) {
       return null;
     }
-    keyIds.add(signature.keyId);
+    keyIds.add(signature.keyid);
   }
   return {
     payloadType,

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -58,9 +58,12 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   params: {
     trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
     threshold?: number;
+    allowLegacyBetaEnvelope?: boolean;
   },
 ): OfficialExternalPluginCatalogEnvelopeVerificationResult {
-  const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw);
+  const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw, {
+    allowLegacyBetaEnvelope: params.allowLegacyBetaEnvelope === true,
+  });
   if (!envelope) {
     return {
       ok: false,
@@ -156,7 +159,10 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
       };
 }
 
-function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
+function parseOfficialExternalPluginCatalogSignedEnvelope(
+  raw: unknown,
+  params: { allowLegacyBetaEnvelope: boolean },
+): {
   payloadType: string;
   payload: string;
   signatures: readonly Required<OfficialExternalPluginCatalogEnvelopeSignature>[];
@@ -186,8 +192,8 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
       typeof signature.sig === "string" &&
       signature.sig.trim().length > 0,
   );
-  // Beta releases briefly accepted this pre-DSSE field shape. Keep it as an
-  // all-or-nothing read path while every producer moves to the standard shape.
+  // Beta releases briefly persisted this pre-DSSE field shape. It remains an
+  // all-or-nothing snapshot read path only; live publishers must use DSSE.
   const legacySignatures =
     raw.schemaVersion === 1
       ? signatures
@@ -207,7 +213,12 @@ function parseOfficialExternalPluginCatalogSignedEnvelope(raw: unknown): {
   if (standardSignatures.length > 0 && legacySignatures.length > 0) {
     return null;
   }
-  const parsedSignatures = standardSignatures.length > 0 ? standardSignatures : legacySignatures;
+  const parsedSignatures =
+    standardSignatures.length > 0
+      ? standardSignatures
+      : params.allowLegacyBetaEnvelope
+        ? legacySignatures
+        : [];
   if (parsedSignatures.length === 0) {
     return null;
   }

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -121,14 +121,12 @@ function signedHostedCatalogFeed(params: {
   ]);
   return {
     body: JSON.stringify({
-      schemaVersion: 1,
       payloadType: HOSTED_CATALOG_PAYLOAD_TYPE,
       payload: payloadBytes.toString("base64url"),
       signatures: [
         {
-          keyId: "acme-root",
-          algorithm: "ed25519",
-          signature: crypto
+          keyid: "acme-root",
+          sig: crypto
             .sign(null, signingInput, crypto.createPrivateKey(keys.privateKeyPem))
             .toString("base64url"),
         },

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -136,6 +136,24 @@ function signedHostedCatalogFeed(params: {
   };
 }
 
+function toLegacyBetaSignedEnvelope(body: string): string {
+  const envelope = JSON.parse(body) as {
+    payloadType: string;
+    payload: string;
+    signatures: Array<{ keyid: string; sig: string }>;
+  };
+  return JSON.stringify({
+    payloadType: envelope.payloadType,
+    payload: envelope.payload,
+    schemaVersion: 1,
+    signatures: envelope.signatures.map((signature) => ({
+      keyId: signature.keyid,
+      algorithm: "ed25519",
+      signature: signature.sig,
+    })),
+  });
+}
+
 function signedCatalogConfig(publicKeyPem: string): HostedCatalogConfig {
   return {
     feeds: {
@@ -827,6 +845,38 @@ describe("official external plugin catalog", () => {
     if (rejectedSnapshot.source === "bundled-fallback") {
       expect(rejectedSnapshot.error).toContain("signed envelope is malformed");
     }
+  });
+
+  it("accepts beta envelopes only from persisted snapshots", async () => {
+    const signed = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/legacy-snapshot" }),
+    });
+    const legacyBody = toLegacyBetaSignedEnvelope(signed.body);
+    const catalogConfig = signedCatalogConfig(signed.publicKeyPem);
+
+    const live = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      fetchImpl: vi.fn(async () => new Response(legacyBody, { status: 200 })),
+      snapshotStore: null,
+    });
+
+    expect(live.source).toBe("bundled-fallback");
+    if (live.source === "bundled-fallback") {
+      expect(live.error).toContain("signed envelope is malformed");
+    }
+
+    const offline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      offline: true,
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore([
+        signedHostedCatalogSnapshot({ body: legacyBody }),
+      ]),
+    });
+
+    expect(offline.source).toBe("hosted-snapshot");
+    expect(offline.entries.map((entry) => entry.name)).toEqual(["@openclaw/legacy-snapshot"]);
   });
 
   it.each([

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -672,6 +672,7 @@ async function parseHostedCatalogFeedBody(params: {
   body: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
   verifiedAt: string;
+  allowLegacyBetaEnvelope?: boolean;
 }): Promise<{
   feed: OfficialExternalPluginCatalogFeed;
   trust?: HostedOfficialExternalPluginCatalogTrustState;
@@ -684,6 +685,7 @@ async function parseHostedCatalogFeedBody(params: {
     const verification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
       trustedKeys: params.verification.keys,
       threshold,
+      ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
     });
     if (!verification.ok) {
       const invalidTimestampSequence =
@@ -768,6 +770,7 @@ async function loadHostedCatalogSnapshotResult(params: {
     body: params.snapshot.body,
     verification: params.verification,
     verifiedAt: params.snapshot.trust?.verifiedAt ?? params.snapshot.savedAt,
+    allowLegacyBetaEnvelope: true,
   });
   return {
     source: "hosted-snapshot",
@@ -1057,6 +1060,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
           body: currentSnapshot.body,
           verification: source.verification,
           verifiedAt: currentSnapshot.trust.verifiedAt,
+          allowLegacyBetaEnvelope: true,
         }).catch((err: unknown) => {
           if (err instanceof HostedCatalogFeedTimestampError) {
             return { feed: { sequence: err.sequence } };


### PR DESCRIPTION
## Summary

- accept the standard DSSE JSON envelope fields: `payloadType`, `payload`, and `signatures[].keyid` / `sig`
- ignore unrecognized envelope and signature fields as required by DSSE
- preserve the pre-standard envelope accepted by the 2026.7.2 beta tags only when reading persisted snapshots; live feeds must use standard DSSE
- reject mixed standard/legacy signature sets and continue requiring Hosted Feed key ids for configured trust thresholds and rotation
- update signed hosted-catalog fixtures to emit only the standard representation

## Context

ClawHub's signer now emits standard DSSE envelopes. OpenClaw main still expected the earlier custom `schemaVersion` / `keyId` / `algorithm` / `signature` shape, so the producer and consumer would not interoperate.

Hosted Feed v1 intentionally requires `keyid` even though generic DSSE makes it optional, because configured trust keys, distinct-key thresholds, and rotation diagnostics are key-id based.

## Validation

- focused envelope tests: 10 passed
- signed hosted-feed integration paths: 3 passed
- scoped `oxlint`, `oxfmt --check`, and `git diff --check`
- Codex review accepted beta-format transition compatibility; the keyless-signature comment was rejected as outside the Hosted Feed trust profile
- current-head focused suites on Node 24.15.0: 10 envelope tests and 46 catalog tests passed
- repository-wide typecheck is deferred to fresh-install CI; this worktree uses a borrowed dependency tree whose stale test typings produce unrelated errors
## Real behavior proof

Behavior or issue addressed:
Prove producer-to-consumer interoperability for the standard DSSE representation, rather than only exercising OpenClaw-authored fixtures.

Real environment tested:
Windows source checkouts at ClawHub #3005 head `b20bda13bba` and OpenClaw #110037 head `f8a928eb792b8abc66dc4f7a5dc85055f614013f`, using Node 24.15.0. An ephemeral Ed25519 key was generated in memory. ClawHub's production `signCatalogFeedPayload` signed a schema-v1 catalog payload; those exact body bytes were returned to OpenClaw's production `loadConfiguredHostedOfficialExternalPluginCatalogEntries` path with the matching public key.

Exact command run after this patch:

```powershell
& "$env:LOCALAPPDATA\pnpm\store\v11\links\@\node\24.15.0\...\node.exe" scripts\run-vitest.mjs src\plugins\dsse-interoperability.proof.test.ts --run --reporter=verbose
```

Evidence after fix:

```text
INTEROPERABILITY_PROOF {"producer":"ClawHub signCatalogFeedPayload","envelopeFields":["payload","payloadType","signatures"],"signatureFields":["keyid","sig"],"payloadType":"openclaw.official-external-plugin-catalog-feed.v1","expectedPayloadType":"openclaw.official-external-plugin-catalog-feed.v1","keyId":"clawhub-proof-2026-q3","consumer":"OpenClaw loadConfiguredHostedOfficialExternalPluginCatalogEntries","source":"hosted","feedId":"clawhub-official","sequence":42,"signedBy":"clawhub-proof-2026-q3","entries":0}
Test Files 1 passed (1)
Tests 1 passed (1)
```



Current-head proof refresh (2026-07-23):

```text
INTEROPERABILITY_PROOF {"producer":"ClawHub signCatalogFeedPayload DSSE contract","clawHubHead":"f76d8a3f31209087d781dc8b7e2323847288972a","openClawHead":"f8a928eb792b8abc66dc4f7a5dc85055f614013f","envelopeFields":["payload","payloadType","signatures"],"signatureFields":["keyid","sig"],"payloadType":"openclaw.official-external-plugin-catalog-feed.v1","expectedPayloadType":"openclaw.official-external-plugin-catalog-feed.v1","keyId":"clawhub-proof-2026-q3","consumer":"OpenClaw loadConfiguredHostedOfficialExternalPluginCatalogEntries","source":"hosted","feedId":"openclaw-official-external-plugins","sequence":42,"signedBy":"clawhub-proof-2026-q3","entries":0}
Test Files 1 passed (1)
Tests 1 passed (1)
[test] passed 1 Vitest shard
```

Observed result after fix:
The actual ClawHub signer emitted only the standard DSSE envelope/signature fields. OpenClaw accepted the exact representation under configured trust and returned the authenticated catalog as `hosted`, preserving feed id, sequence, and signing key id.

What was not tested:
A provisioned production ClawHub private key or deployed endpoint was not used. The proof-only cross-repo harness and ephemeral private key were deleted after the run. Production key provisioning remains owned by ClawHub #3005.

Maintainer-approved compatibility policy:
- Maintainer decision: approve a temporary snapshot-only compatibility exception for persisted snapshots produced by the 2026.7.2 beta implementation.
- Live feed responses must use standard DSSE.
- Persisted snapshots produced by the 2026.7.2 beta implementation may use the legacy signed-envelope shape.
- Mixed legacy/standard signatures are rejected for both live feeds and snapshots.
- Feeds maintainers will remove the legacy snapshot reader after validating that the supported population has migrated off the beta format.
- The legacy shape is not a publisher contract.

