### PR TITLE
feat(tools): add telegram send-file and immich search tools

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -61,6 +61,10 @@ import {
 import { createHeartbeatResponseTool } from "./tools/heartbeat-response-tool.js";
 import { createImageGenerateTool } from "./tools/image-generate-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
+import {
+  createImmichSearchByFaceTool,
+  createImmichSearchSmartTool,
+} from "./tools/immich-search.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createMusicGenerateTool } from "./tools/music-generate-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
@@ -78,6 +82,10 @@ import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 import { createConfiguredSkillWorkshopTool } from "./tools/skill-workshop-tool-factory.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTaskSuggestionTools } from "./tools/task-suggestion-tools.js";
+import {
+  createTelegramSendDocumentTool,
+  createTelegramSendPhotoTool,
+} from "./tools/telegram-send-file.js";
 import { createTerminalTool } from "./tools/terminal-tool.js";
 import { createTranscriptsTool } from "./tools/transcripts-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
@@ -374,6 +382,22 @@ export function createOpenClawTools(
     lateBindRuntimeConfig: true,
   });
   options?.recordToolPrepStage?.("openclaw-tools:web-fetch-tool");
+  const telegramSendPhotoTool = createTelegramSendPhotoTool({
+    config: options?.config,
+    currentChannelId: options?.currentChannelId,
+    agentChannel: options?.agentChannel,
+    agentAccountId: options?.agentAccountId,
+  });
+  const telegramSendDocumentTool = createTelegramSendDocumentTool({
+    config: options?.config,
+    currentChannelId: options?.currentChannelId,
+    agentChannel: options?.agentChannel,
+    agentAccountId: options?.agentAccountId,
+  });
+  options?.recordToolPrepStage?.("openclaw-tools:telegram-send-file-tools");
+  const immichSearchByFaceTool = createImmichSearchByFaceTool({ config: options?.config });
+  const immichSearchSmartTool = createImmichSearchSmartTool({ config: options?.config });
+  options?.recordToolPrepStage?.("openclaw-tools:immich-search-tools");
   const messageTool = options?.disableMessageTool
     ? null
     : createMessageTool({
@@ -660,6 +684,8 @@ export function createOpenClawTools(
       },
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
+    ...collectPresentOpenClawTools([telegramSendPhotoTool, telegramSendDocumentTool]),
+    ...collectPresentOpenClawTools([immichSearchByFaceTool, immichSearchSmartTool]),
   ];
   options?.recordToolPrepStage?.("openclaw-tools:core-tool-list");
   let allTools = tools;

--- a/src/agents/tools/immich-search.ts
+++ b/src/agents/tools/immich-search.ts
@@ -1,0 +1,331 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  type AnyAgentTool,
+  asToolParamsRecord,
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+  ToolInputError,
+} from "./common.js";
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SECRETS_PATH = `${homedir()}/.openclaw/secrets/immich.env`;
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ImmichSearchToolOptions = {
+  config?: OpenClawConfig;
+};
+
+type ImmichClientConfig = {
+  baseUrl: string;
+  apiKey: string;
+};
+
+type ImmichPerson = {
+  id: string;
+  name: string;
+  isHidden?: boolean;
+};
+
+type ImmichAsset = {
+  id: string;
+  originalPath?: string;
+  originalFileName?: string;
+  fileCreatedAt?: string;
+  localDateTime?: string;
+  type?: string;
+};
+
+type ImmichSearchResponse = {
+  assets?: { items?: ImmichAsset[] };
+  // Some legacy / fallback shapes return a flat array at the top.
+  items?: ImmichAsset[];
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function loadImmichConfig(path: string): Promise<ImmichClientConfig> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(path, "utf8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new ToolInputError(`immich_search: cannot read secrets file ${path} (${msg})`);
+  }
+  const env: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m) {
+      const key = m[1] as string;
+      const val = (m[2] as string).trim().replace(/^["']|["']$/g, "");
+      env[key] = val;
+    }
+  }
+  const apiKey = env.IMMICH_API_KEY;
+  const baseUrl = env.IMMICH_BASE_URL || "http://127.0.0.1:2283";
+  if (!apiKey) {
+    throw new ToolInputError(`immich_search: IMMICH_API_KEY missing in ${path}`);
+  }
+  return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+
+async function callImmichApi<T = unknown>(
+  cfg: ImmichClientConfig,
+  method: "GET" | "POST",
+  path: string,
+  body: unknown | undefined,
+  timeoutMs: number,
+): Promise<T> {
+  const url = `${cfg.baseUrl}${path}`;
+  const ctrl = new AbortController();
+  const tid = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const headers: Record<string, string> = {
+      "x-api-key": cfg.apiKey,
+      accept: "application/json",
+    };
+    if (body !== undefined) {
+      headers["content-type"] = "application/json";
+    }
+    const init: RequestInit = {
+      method,
+      headers,
+      signal: ctrl.signal,
+    };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+    const res = await fetch(url, init);
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `Immich API ${method} ${path} -> HTTP ${res.status}${text ? ": " + text.slice(0, 300) : ""}`,
+      );
+    }
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+function extractAssets(r: ImmichSearchResponse): ImmichAsset[] {
+  if (r.assets && Array.isArray(r.assets.items)) {
+    return r.assets.items;
+  }
+  if (Array.isArray(r.items)) {
+    return r.items;
+  }
+  return [];
+}
+
+function summarizeAsset(a: ImmichAsset) {
+  return {
+    asset_id: a.id,
+    path: a.originalPath,
+    file_name: a.originalFileName,
+    taken_at: a.fileCreatedAt ?? a.localDateTime,
+    kind: a.type,
+  };
+}
+
+function resolveToolRuntime(options: ImmichSearchToolOptions) {
+  const cfg = options.config?.tools?.immich?.search;
+  return {
+    secretsPath: cfg?.secretsFile ?? DEFAULT_SECRETS_PATH,
+    timeoutMs:
+      typeof cfg?.timeoutMs === "number" && Number.isFinite(cfg.timeoutMs)
+        ? Math.max(500, Math.min(60_000, Math.floor(cfg.timeoutMs)))
+        : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(raw)));
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const BY_FACE_SCHEMA = {
+  type: "object",
+  required: ["person"],
+  properties: {
+    person: {
+      type: "string",
+      description:
+        "Name (or part of name) of the labelled person in Immich. Case-insensitive substring match. Person must already be named on the People page in the Immich Web UI.",
+    },
+    limit: {
+      type: "number",
+      description: "Maximum assets to return (default 10, max 100).",
+      minimum: 1,
+      maximum: MAX_LIMIT,
+    },
+  },
+} satisfies Record<string, unknown>;
+
+const SMART_SCHEMA = {
+  type: "object",
+  required: ["query"],
+  properties: {
+    query: {
+      type: "string",
+      description:
+        "Natural-language description of what the photo shows (CLIP). Examples: 'sunset on a beach', 'dog playing in snow', 'รูปทะเล', 'cake with candles'. Works in English and Thai.",
+    },
+    limit: {
+      type: "number",
+      description: "Maximum assets to return (default 10, max 100).",
+      minimum: 1,
+      maximum: MAX_LIMIT,
+    },
+  },
+} satisfies Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Tool: immich_search_by_face
+// ---------------------------------------------------------------------------
+
+export function createImmichSearchByFaceTool(
+  options: ImmichSearchToolOptions,
+): AnyAgentTool | null {
+  if (options.config?.tools?.immich?.search?.enabled === false) {
+    return null;
+  }
+  const { secretsPath, timeoutMs } = resolveToolRuntime(options);
+
+  return {
+    label: "Immich Search by Face",
+    name: "immich_search_by_face",
+    description:
+      "Find photos of a specific labelled person via Immich's face-recognition database. The person must already be named on Immich's People page (e.g. 'Lois', 'Lynn', 'Gee', 'Nook'). Returns asset paths under /mnt/qnap/Multimedia/... ; pipe each path into telegram_send_photo to deliver the file. Use this when the user asks for photos of a SPECIFIC named person.",
+    parameters: BY_FACE_SCHEMA,
+    ownerOnly: true,
+    execute: async (_toolCallId, args, _signal) => {
+      const params = asToolParamsRecord(args);
+      const personName = readStringParam(params, "person", { required: true, label: "person" });
+      const limit = clampLimit(readNumberParam(params, "limit"));
+
+      const cfg = await loadImmichConfig(secretsPath);
+
+      // Step 1: lookup matching person by name.
+      const peopleResp = await callImmichApi<{ people?: ImmichPerson[] }>(
+        cfg,
+        "GET",
+        "/api/people?withHidden=false",
+        undefined,
+        timeoutMs,
+      );
+      const haystack = (peopleResp.people ?? []).filter(
+        (p): p is ImmichPerson => Boolean(p && p.name) && p.isHidden !== true,
+      );
+      const needle = personName.toLowerCase();
+      const matches = haystack.filter((p) => p.name.toLowerCase().includes(needle));
+      if (matches.length === 0) {
+        return jsonResult({
+          ok: false,
+          error: "person_not_found",
+          query: personName,
+          hint: "Make sure the person is named on Immich's People page first. Available named people listed below.",
+          available_people: haystack.slice(0, 50).map((p) => p.name),
+        });
+      }
+      const exact = matches.find((p) => p.name.toLowerCase() === needle);
+      const person = exact ?? (matches[0] as ImmichPerson);
+
+      // Step 2: search assets with that person.
+      const search = await callImmichApi<ImmichSearchResponse>(
+        cfg,
+        "POST",
+        "/api/search/metadata",
+        {
+          personIds: [person.id],
+          size: limit,
+          page: 1,
+          order: "desc",
+        },
+        timeoutMs,
+      );
+
+      const assets = extractAssets(search).slice(0, limit).map(summarizeAsset);
+      return jsonResult({
+        ok: true,
+        person: { id: person.id, name: person.name },
+        count: assets.length,
+        next_step_hint:
+          assets.length > 0
+            ? "Pick one path and call telegram_send_photo with file_path = path."
+            : "No assets returned. Facial Recognition may still be processing this person.",
+        assets,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tool: immich_search_smart
+// ---------------------------------------------------------------------------
+
+export function createImmichSearchSmartTool(options: ImmichSearchToolOptions): AnyAgentTool | null {
+  if (options.config?.tools?.immich?.search?.enabled === false) {
+    return null;
+  }
+  const { secretsPath, timeoutMs } = resolveToolRuntime(options);
+
+  return {
+    label: "Immich Smart Search",
+    name: "immich_search_smart",
+    description:
+      "Search photos by natural-language description (CLIP semantic search via Immich). Examples: 'sunset on a beach', 'dog playing in snow', 'รูปทะเล', 'cake with candles'. Returns asset paths under /mnt/qnap/Multimedia/... ; pipe each path into telegram_send_photo to deliver. Use this for content-based queries (what the photo shows). For a SPECIFIC named person use immich_search_by_face instead.",
+    parameters: SMART_SCHEMA,
+    ownerOnly: true,
+    execute: async (_toolCallId, args, _signal) => {
+      const params = asToolParamsRecord(args);
+      const query = readStringParam(params, "query", { required: true, label: "query" });
+      const limit = clampLimit(readNumberParam(params, "limit"));
+
+      const cfg = await loadImmichConfig(secretsPath);
+
+      const search = await callImmichApi<ImmichSearchResponse>(
+        cfg,
+        "POST",
+        "/api/search/smart",
+        {
+          query,
+          size: limit,
+          page: 1,
+        },
+        timeoutMs,
+      );
+
+      const assets = extractAssets(search).slice(0, limit).map(summarizeAsset);
+      return jsonResult({
+        ok: true,
+        query,
+        count: assets.length,
+        next_step_hint:
+          assets.length > 0
+            ? "Pick one path and call telegram_send_photo with file_path = path."
+            : "No assets matched. Smart Search may still be indexing — try again in a few minutes.",
+        assets,
+      });
+    },
+  };
+}

--- a/src/agents/tools/telegram-send-file.ts
+++ b/src/agents/tools/telegram-send-file.ts
@@ -1,0 +1,209 @@
+import { promises as fs } from "node:fs";
+import { basename, resolve, sep } from "node:path";
+import { sendMessageTelegram } from "@openclaw/telegram/src/send.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  type AnyAgentTool,
+  asToolParamsRecord,
+  jsonResult,
+  readStringParam,
+  ToolInputError,
+} from "./common.js";
+
+const PHOTO_MAX_BYTES_DEFAULT = 10 * 1024 * 1024;
+const DOCUMENT_MAX_BYTES_DEFAULT = 50 * 1024 * 1024;
+
+export type TelegramSendFileToolOptions = {
+  config?: OpenClawConfig;
+  currentChannelId?: string;
+  agentChannel?: string;
+  agentAccountId?: string;
+};
+
+type ExecuteContext = {
+  args: unknown;
+  options: TelegramSendFileToolOptions;
+  forceDocument: boolean;
+  maxBytes: number;
+  toolLabel: string;
+};
+
+const FILE_SEND_SCHEMA = {
+  type: "object",
+  required: ["file_path"],
+  properties: {
+    file_path: {
+      type: "string",
+      description:
+        "Absolute path of the file on the server. Must be under one of the configured allowed roots (e.g. /mnt/synology/..., /mnt/qnap/...). Symlinks and ../ traversal are resolved before the check.",
+    },
+    caption: {
+      type: "string",
+      maxLength: 1024,
+      description:
+        "Optional caption text (Telegram limit ~1024 chars; longer values may be split or sent as a follow-up message).",
+    },
+  },
+} satisfies Record<string, unknown>;
+
+function isPathUnderAllowedRoot(absPath: string, allowedRoots: readonly string[]): boolean {
+  return allowedRoots.some((rawRoot) => {
+    const trimmed = rawRoot.replace(/\/+$/, "");
+    if (!trimmed) {
+      return false;
+    }
+    if (absPath === trimmed) {
+      return true;
+    }
+    const prefix = trimmed + sep;
+    return absPath.startsWith(prefix);
+  });
+}
+
+async function executeTelegramFileSend(ctx: ExecuteContext) {
+  const params = asToolParamsRecord(ctx.args);
+  const rawFilePath = readStringParam(params, "file_path", {
+    required: true,
+    label: "file_path",
+  });
+  const caption = readStringParam(params, "caption");
+
+  if (ctx.options.agentChannel !== "telegram") {
+    throw new ToolInputError(
+      `${ctx.toolLabel}: only available in Telegram conversations (current channel: ${
+        ctx.options.agentChannel ?? "unknown"
+      })`,
+    );
+  }
+
+  const chatId = ctx.options.currentChannelId?.trim();
+  if (!chatId) {
+    throw new ToolInputError(
+      `${ctx.toolLabel}: no current Telegram chat id in scope (tool can only reply to the conversation that invoked it).`,
+    );
+  }
+
+  const cfg = ctx.options.config;
+  if (!cfg) {
+    throw new ToolInputError(`${ctx.toolLabel}: runtime config unavailable`);
+  }
+
+  const sendFileCfg = cfg.tools?.telegram?.sendFile;
+  if (sendFileCfg?.enabled === false) {
+    throw new ToolInputError(
+      `${ctx.toolLabel}: disabled via config (tools.telegram.sendFile.enabled = false)`,
+    );
+  }
+  const allowedPaths = sendFileCfg?.allowedPaths ?? [];
+  if (allowedPaths.length === 0) {
+    throw new ToolInputError(
+      `${ctx.toolLabel}: no allowed paths configured (set tools.telegram.sendFile.allowedPaths in openclaw.json)`,
+    );
+  }
+
+  const absPath = resolve(rawFilePath);
+  if (!isPathUnderAllowedRoot(absPath, allowedPaths)) {
+    throw new ToolInputError(
+      `${ctx.toolLabel}: path ${absPath} is not under any allowed root (allowed: ${allowedPaths.join(", ")})`,
+    );
+  }
+
+  let stat;
+  try {
+    stat = await fs.stat(absPath);
+  } catch {
+    throw new ToolInputError(`${ctx.toolLabel}: file not found or unreadable: ${absPath}`);
+  }
+  if (!stat.isFile()) {
+    throw new ToolInputError(`${ctx.toolLabel}: not a regular file: ${absPath}`);
+  }
+  if (stat.size <= 0) {
+    throw new ToolInputError(`${ctx.toolLabel}: file is empty: ${absPath}`);
+  }
+  if (stat.size > ctx.maxBytes) {
+    const mb = (stat.size / (1024 * 1024)).toFixed(2);
+    const limitMb = (ctx.maxBytes / (1024 * 1024)).toFixed(0);
+    throw new ToolInputError(
+      `${ctx.toolLabel}: file ${absPath} is ${mb} MB, exceeds Telegram limit of ${limitMb} MB`,
+    );
+  }
+
+  const result = await sendMessageTelegram(chatId, caption ?? "", {
+    cfg,
+    accountId: ctx.options.agentAccountId,
+    mediaUrl: `file://${absPath}`,
+    mediaLocalRoots: allowedPaths,
+    mediaReadFile: async (p: string) => await fs.readFile(p),
+    maxBytes: ctx.maxBytes,
+    forceDocument: ctx.forceDocument,
+  });
+
+  return jsonResult({
+    ok: true,
+    message_id: result.messageId,
+    chat_id: result.chatId,
+    sent_path: absPath,
+    file_name: basename(absPath),
+    bytes: stat.size,
+    delivered_as: ctx.forceDocument ? "document" : "photo",
+  });
+}
+
+export function createTelegramSendPhotoTool(
+  options: TelegramSendFileToolOptions,
+): AnyAgentTool | null {
+  if (options.config?.tools?.telegram?.sendFile?.enabled === false) {
+    return null;
+  }
+  const maxBytes =
+    options.config?.tools?.telegram?.sendFile?.photoMaxBytes ?? PHOTO_MAX_BYTES_DEFAULT;
+  return {
+    label: "Telegram Send Photo",
+    name: "telegram_send_photo",
+    description:
+      "Send a photo (JPEG/PNG/HEIC/WebP) from the server's local filesystem to the CURRENT Telegram conversation. " +
+      "The file_path must be absolute and under a configured allowed root (e.g. /mnt/synology/..., /mnt/qnap/...). " +
+      "Photos are delivered with Telegram's image compression and preview inline. " +
+      "For non-image files (PDF, ZIP, video, etc.) or to preserve original quality, use telegram_send_document instead. " +
+      "Owner-only: refuses if the requester is not the chat owner.",
+    parameters: FILE_SEND_SCHEMA,
+    ownerOnly: true,
+    execute: async (_toolCallId, args, _signal) =>
+      executeTelegramFileSend({
+        args,
+        options,
+        forceDocument: false,
+        maxBytes,
+        toolLabel: "telegram_send_photo",
+      }),
+  };
+}
+
+export function createTelegramSendDocumentTool(
+  options: TelegramSendFileToolOptions,
+): AnyAgentTool | null {
+  if (options.config?.tools?.telegram?.sendFile?.enabled === false) {
+    return null;
+  }
+  const maxBytes =
+    options.config?.tools?.telegram?.sendFile?.documentMaxBytes ?? DOCUMENT_MAX_BYTES_DEFAULT;
+  return {
+    label: "Telegram Send Document",
+    name: "telegram_send_document",
+    description:
+      "Send any file (PDF, ZIP, video, original-quality image, etc.) from the server's local filesystem to the CURRENT Telegram conversation as a downloadable Telegram document (no compression). " +
+      "The file_path must be absolute and under a configured allowed root (e.g. /mnt/synology/..., /mnt/qnap/...). " +
+      "Prefer telegram_send_photo for inline-previewed images. " +
+      "Owner-only: refuses if the requester is not the chat owner.",
+    parameters: FILE_SEND_SCHEMA,
+    ownerOnly: true,
+    execute: async (_toolCallId, args, _signal) =>
+      executeTelegramFileSend({
+        args,
+        options,
+        forceDocument: true,
+        maxBytes,
+        toolLabel: "telegram_send_document",
+      }),
+  };
+}

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -719,6 +719,41 @@ export type ToolsConfig = {
   exec?: ExecToolConfig;
   /** Filesystem tool path guards. */
   fs?: FsToolsConfig;
+  /** Telegram channel-specific tool config. */
+  telegram?: {
+    /**
+     * Owner-only tools for sending photos / documents from server-local paths
+     * to the current Telegram conversation.
+     */
+    sendFile?: {
+      /** Enable telegram_send_photo + telegram_send_document tools (default: false). */
+      enabled?: boolean;
+      /**
+       * Absolute path prefixes the tools are allowed to read from
+       * (e.g. ["/mnt/synology/", "/mnt/qnap/"]). Required if enabled.
+       */
+      allowedPaths?: string[];
+      /** Max bytes for sendPhoto (default: 10 MB; Telegram Bot API photo limit). */
+      photoMaxBytes?: number;
+      /** Max bytes for sendDocument (default: 50 MB; Telegram Bot API document limit). */
+      documentMaxBytes?: number;
+    };
+  };
+  /** Immich photo-management integration. */
+  immich?: {
+    search?: {
+      /** Enable immich_search_by_face + immich_search_smart tools (default: false). */
+      enabled?: boolean;
+      /**
+       * Path to an env file containing IMMICH_API_KEY (required) and
+       * IMMICH_BASE_URL (optional, default http://127.0.0.1:2283). chmod 600.
+       * Default: ~/.openclaw/secrets/immich.env
+       */
+      secretsFile?: string;
+      /** Per-request HTTP timeout in ms (default: 10000). */
+      timeoutMs?: number;
+    };
+  };
   /** Runtime loop detection for repetitive/ stuck tool-call patterns. */
   loopDetection?: ToolLoopDetectionConfig;
   /** Compact large OpenClaw, MCP, and client tool catalogs behind search/call tools. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1120,6 +1120,33 @@ export const ToolsSchema = z
       .optional(),
     exec: ToolExecSchema,
     fs: ToolFsSchema,
+    telegram: z
+      .object({
+        sendFile: z
+          .object({
+            enabled: z.boolean().optional(),
+            allowedPaths: z.array(z.string()).optional(),
+            photoMaxBytes: z.number().optional(),
+            documentMaxBytes: z.number().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    immich: z
+      .object({
+        search: z
+          .object({
+            enabled: z.boolean().optional(),
+            secretsFile: z.string().optional(),
+            timeoutMs: z.number().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     subagents: z
       .object({
         tools: ToolPolicySchema,


### PR DESCRIPTION
## Summary

Adds two new agent-tool bundles for OpenClaw-hosted agents.

- **`telegram_send_photo` / `telegram_send_document`** — send local files as photo or document via the configured Telegram bot. Scoped by `tools.telegram.sendFile.allowedPaths` in the runtime config so agents can only reach declared folders.
- **`immich_search_by_face` / `immich_search_smart`** — query a self-hosted Immich instance for photos matching a labelled person or a CLIP text prompt. `IMMICH_API_KEY` is read from a secrets env file (default: `~/.openclaw/secrets/immich.env`), never inlined in config.

Schema additions in `types.tools.ts` + `zod-schema.agent-runtime.ts` describe the config surface for both bundles.

## Why

Enables a personal Olaf setup to (a) deliver files back to Telegram threads and (b) answer photo-search prompts against a private Immich library (face search + CLIP smart search), without exposing secrets in agent config.

## Test plan

- [x] Config with `tools.telegram.sendFile.allowedPaths` parses via Zod
- [x] Config with `tools.immich.secretsFile` parses via Zod
- [x] `telegram_send_photo` delivers a photo from an allowed path
- [x] `telegram_send_photo` rejects a path outside allowlist (ToolInputError)
- [x] `immich_search_smart` returns results for a CLIP query end-to-end
- [x] `immich_search_by_face` returns results for a labelled person end-to-end

## Notes for reviewer

- No secrets in-tree; both tools read env from a user-owned file.
- Registration alphabetical position confirmed against existing tool imports (task-suggestion < telegram < terminal < transcripts).