### PR TITLE
fix(telegram): cancel unread response body on media fetch error

### DIFF
--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -43,6 +43,7 @@ async function defaultReadRemoteMediaBuffer(
   }
   const response = await params.fetchImpl(params.url, { redirect: "manual" });
   if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
     throw new Error(
       `Failed to fetch media from ${params.url}: HTTP ${response.status} ${response.statusText}`,
     );

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -3,7 +3,11 @@ import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { readRemoteMediaBufferSpy, telegramBotDepsForTest } from "./bot.media.e2e-harness.js";
+import {
+  readRemoteMediaBufferSpy,
+  resetReadRemoteMediaBufferMock,
+  telegramBotDepsForTest,
+} from "./bot.media.e2e-harness.js";
 import {
   TELEGRAM_TEST_TIMINGS,
   cacheStickerSpy,
@@ -269,6 +273,24 @@ describe("telegram local Bot API media", () => {
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it("cancels response body on non-ok status before throwing", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    const response = new Response(body, { status: 404, statusText: "Not Found" });
+    const fetchImpl = vi.fn().mockResolvedValue(response);
+
+    resetReadRemoteMediaBufferMock();
+
+    await expect(
+      readRemoteMediaBufferSpy({
+        url: "https://example.com/file.jpg",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow("Failed to fetch media from https://example.com/file.jpg");
+
+    expect(cancel).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

When `defaultReadRemoteMediaBuffer` in the Telegram e2e harness receives a non-OK response (e.g. 404, 503), it throws immediately without canceling the response body. The unconsumed stream holds a connection open until garbage collection.

## Why This Change Was Made

Follows the same pattern as #109519 (Google Chat), #109508 (docs search), #109677 (Chutes), #109701 (MSTeams consent upload), and #109728 (APNs relay) — cancel the response body before throwing so that upstream streams are drained and connections released.

## User Impact

No user-facing change. This is test harness infrastructure used by the Telegram bot media e2e tests. Prevents resource leaks from unconsumed response bodies.

## Evidence

### Real HTTP server proof

```
$ node scripts/proofs/telegram-media-cancel-proof.mjs
Server: http://127.0.0.1:34072

=== BEFORE (no body.cancel — throw immediately) ===
  Response: 503 Service Unavailable

=== AFTER (body?.cancel().catch(() => undefined) before throw) ===
  Response: 503 Service Unavailable
  body?.cancel() executed ✓
  [server] /new → client canceled stream ✓

=== Error message preserved after cancel ===
  Thrown: Failed to fetch media from http://127.0.0.1:34072/error: HTTP 503 Service Unavailable
```

The proof script starts a real HTTP server returning 503 with a slow stream, then exercises the exact cancel-before-throw pattern from this PR. The server confirms the client canceled the stream (`client canceled stream ✓`), demonstrating that `body?.cancel()` reaches the server and releases the connection. The error message is preserved after cancel.

### Unit test

New test ("cancels response body on non-ok status before throwing") in `bot.media.stickers-and-fragments.e2e.test.ts` verifies:
- A real `Response` with status 404 is returned by the fetch mock
- `response.body.cancel()` is called exactly once before the error is thrown
- Uses `ReadableStream({ cancel })` spy pattern as in #109701