### PR TITLE
test(extensions): align lifecycle mocks

### DIFF
--- a/extensions/discord/src/test-support/component-runtime.ts
+++ b/extensions/discord/src/test-support/component-runtime.ts
@@ -54,6 +54,55 @@ const resolvePluginConversationBindingApprovalMock: AsyncUnknownMock =
 const buildPluginBindingResolvedTextMock: UnknownMock =
   runtimeMocks.buildPluginBindingResolvedTextMock;
 
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  const runMockedTurn = async (plan: Parameters<typeof actual.dispatchChannelInboundTurn>[0]) => {
+    const { cfg, route, delivery, ...prepared } = plan;
+    return await actual.runPreparedInboundReply({
+      ...prepared,
+      routeSessionKey: route.sessionKey,
+      storePath: String(resolveStorePathMock(cfg.session?.store, { agentId: route.agentId })),
+      recordInboundSession: async (...args: unknown[]) => {
+        await recordInboundSessionMock(...args);
+      },
+      runDispatch: async () =>
+        await dispatchReplyMock({
+          ctx: plan.ctxPayload,
+          cfg,
+          dispatcherOptions: {
+            ...plan.dispatcherOptions,
+            deliver: delivery.deliver,
+            onError: delivery.onError,
+            responsePrefixContextProvider: vi.fn(() => ({})),
+          },
+          toolsAllow: plan.toolsAllow,
+          replyOptions: {
+            ...plan.replyOptions,
+            onModelSelected: vi.fn(),
+          },
+          replyResolver: plan.replyResolver,
+        }),
+    });
+  };
+  return {
+    ...actual,
+    runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) => {
+      const input = await params.adapter.ingest(params.raw);
+      if (!input) {
+        return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
+      }
+      const resolved = await params.adapter.resolveTurn(
+        input,
+        { kind: "interaction", canStartAgentTurn: true },
+        {},
+      );
+      return await runMockedTurn(
+        resolved as Parameters<typeof actual.dispatchChannelInboundTurn>[0],
+      );
+    },
+  };
+});
+
 async function readChannelIngressStoreAllowFromForDmPolicy(params: {
   provider: string;
   accountId: string;

--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -54,12 +54,15 @@ type WebAutoReplyMonitorHarness = {
   run: Promise<unknown>;
 };
 type MockSessionSocket = {
+  end: ReturnType<typeof vi.fn>;
   ev: {
     on: ReturnType<typeof vi.fn>;
     off: ReturnType<typeof vi.fn>;
   };
   ws: EventEmitter & {
     close: ReturnType<typeof vi.fn>;
+    readonly isClosed: boolean;
+    readonly isClosing: boolean;
   };
   user: { id: string };
 };
@@ -80,9 +83,21 @@ vi.mock("./session.js", async () => {
   return {
     ...actual,
     createWaSocket: vi.fn(async () => {
+      let closed = false;
       const ws = new EventEmitter() as MockSessionSocket["ws"];
-      ws.close = vi.fn();
+      Object.defineProperties(ws, {
+        isClosed: { get: () => closed },
+        isClosing: { get: () => false },
+      });
+      ws.close = vi.fn(() => {
+        closed = true;
+        ws.emit("close");
+      });
       const socket: MockSessionSocket = {
+        end: vi.fn(() => {
+          closed = true;
+          ws.emit("close");
+        }),
         ev: {
           on: vi.fn(),
           off: vi.fn(),


### PR DESCRIPTION
## Summary

- route Discord component tests through the canonical prepared inbound lifecycle while retaining mocked delivery
- model WhatsApp socket shutdown state in the shared auto-reply harness

## Proof

- focused extension tests: 37 passed
- changed-lane check: passed, including extension production/test types and lint
- autoreview: no accepted actionable findings
