### PR TITLE
fix: keep media SecretRef failures model-scoped

### DIFF
--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -146,6 +146,49 @@ describe("Gateway startup SecretRef owner isolation", () => {
     });
   });
 
+  it("reaches /readyz with one cold media model", async () => {
+    await withEnvAsync({ MISSING_MEDIA_MODEL_VALUE: undefined }, async () => {
+      await writeConfig({
+        ...baseConfig(),
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              models: [
+                {
+                  provider: "openai",
+                  request: {
+                    auth: {
+                      mode: "authorization-bearer",
+                      token: {
+                        source: "env",
+                        provider: "default",
+                        id: "MISSING_MEDIA_MODEL_VALUE",
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const port = await getFreePort();
+      server = await startGatewayServer(port, { auth: { mode: "none" } });
+      const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+
+      expect(ready.status).toBe(200);
+      expect(getActiveSecretsRuntimeSnapshot()?.degradedOwners).toMatchObject([
+        {
+          ownerKind: "capability",
+          ownerId: "media-model:audio:0",
+          state: "unavailable",
+        },
+      ]);
+    });
+  });
+
   it("isolates TTS during a successful Gateway-auth SecretRef preflight", async () => {
     await withEnvAsync(
       {

--- a/src/media-understanding/resolve.test.ts
+++ b/src/media-understanding/resolve.test.ts
@@ -38,6 +38,10 @@ describe("resolveModelEntries", () => {
       providerRegistry,
     });
     expect(imageEntries).toHaveLength(1);
+    expect(imageEntries[0]).toMatchObject({
+      entry: { provider: "openai", model: "gpt-5.4" },
+      secretOwnerId: "media-model:shared:0",
+    });
 
     const audioEntries = resolveModelEntries({
       cfg,
@@ -65,6 +69,7 @@ describe("resolveModelEntries", () => {
       providerRegistry,
     });
     expect(imageEntries).toHaveLength(1);
+    expect(imageEntries[0]?.secretOwnerId).toBe("media-model:image:0");
   });
 
   it("skips shared CLI entries without capabilities", () => {

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -12,6 +12,7 @@ import type {
   MediaUnderstandingScopeConfig,
 } from "../config/types.tools.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { runtimeMediaModelSecretOwnerId } from "../secrets/runtime-media-secret-owner.js";
 import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_CHARS_BY_CAPABILITY,
@@ -21,6 +22,11 @@ import {
 import { resolveEffectiveMediaEntryCapabilities } from "./entry-capabilities.js";
 import { normalizeMediaUnderstandingChatType, resolveMediaUnderstandingScope } from "./scope.js";
 import type { MediaUnderstandingCapability } from "./types.js";
+
+export type ResolvedMediaModelEntry = {
+  entry: MediaUnderstandingModelConfig;
+  secretOwnerId?: string;
+};
 
 /** Default per-provider media-understanding runtime timeout in milliseconds. */
 const DEFAULT_MEDIA_RUNTIME_TIMEOUT_MS = 30_000;
@@ -110,12 +116,24 @@ export function resolveModelEntries(params: {
   capability: MediaUnderstandingCapability;
   config?: MediaUnderstandingConfig;
   providerRegistry: Map<string, { capabilities?: MediaUnderstandingCapability[] }>;
-}): MediaUnderstandingModelConfig[] {
+}): ResolvedMediaModelEntry[] {
   const { cfg, capability, config } = params;
   const sharedModels = cfg.tools?.media?.models ?? [];
   const entries = [
-    ...(config?.models ?? []).map((entry) => ({ entry, source: "capability" as const })),
-    ...sharedModels.map((entry) => ({ entry, source: "shared" as const })),
+    ...(config?.models ?? []).map((entry, index) => ({
+      entry,
+      source: "capability" as const,
+      secretOwnerId: runtimeMediaModelSecretOwnerId({
+        source: "capability",
+        capability,
+        index,
+      }),
+    })),
+    ...sharedModels.map((entry, index) => ({
+      entry,
+      source: "shared" as const,
+      secretOwnerId: runtimeMediaModelSecretOwnerId({ source: "shared", index }),
+    })),
   ];
   if (entries.length === 0) {
     return [];
@@ -141,7 +159,7 @@ export function resolveModelEntries(params: {
       }
       return caps.includes(capability);
     })
-    .map(({ entry }) => entry);
+    .map(({ entry, secretOwnerId }) => ({ entry, secretOwnerId }));
 }
 
 /** Resolves the bounded media-understanding task concurrency from config. */

--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -1,8 +1,17 @@
 // Runner entry guard tests cover malformed decision data formatting without
 // depending on provider execution.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
+import {
+  runtimeMediaModelSecretOwnerId,
+  runtimeMediaRequestSecretOwnerId,
+} from "../secrets/runtime-media-secret-owner.js";
 import { buildModelDecision, formatDecisionSummary, runProviderEntry } from "./runner.entries.js";
 import type { MediaUnderstandingDecision } from "./types.js";
+
+afterEach(() => {
+  setActiveDegradedSecretOwners([]);
+});
 
 describe("media-understanding formatDecisionSummary guards", () => {
   it("formats skipped summary when decision.attachments is undefined", () => {
@@ -120,4 +129,77 @@ describe("media-understanding missing provider errors", () => {
       );
     },
   );
+});
+
+describe("media-understanding SecretRef owner isolation", () => {
+  it("rejects only the configured media model whose owner is unavailable", async () => {
+    const entry = { provider: "openai" };
+    const cfg = { tools: { media: { audio: { models: [entry] } } } };
+    const ownerId = runtimeMediaModelSecretOwnerId({
+      source: "capability",
+      capability: "audio",
+      index: 0,
+    });
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId,
+        state: "unavailable",
+        paths: ["tools.media.audio.models.0.request.auth.token"],
+        refKeys: ["env:default:MISSING_MEDIA_VALUE"],
+        reason: "secret reference was not found",
+      },
+    ]);
+
+    type RunProviderEntryParams = Parameters<typeof runProviderEntry>[0];
+    await expect(
+      runProviderEntry({
+        capability: "audio",
+        entry,
+        cfg,
+        config: cfg.tools.media.audio,
+        secretOwnerId: ownerId,
+        ctx: {} as RunProviderEntryParams["ctx"],
+        attachmentIndex: 0,
+        cache: {} as RunProviderEntryParams["cache"],
+        providerRegistry: new Map(),
+      }),
+    ).rejects.toMatchObject({
+      code: "SECRET_SURFACE_UNAVAILABLE",
+      ownerKind: "capability",
+      ownerId,
+    });
+  });
+
+  it("keeps a model active when it overrides the unavailable request field", async () => {
+    const entry = {
+      provider: "unknown-provider",
+      request: { auth: { mode: "authorization-bearer" as const, token: "test-token" } },
+    };
+    const cfg = { tools: { media: { audio: { models: [entry] } } } };
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: runtimeMediaRequestSecretOwnerId("audio"),
+        state: "unavailable",
+        paths: ["tools.media.audio.request.auth.token"],
+        refKeys: ["env:default:MISSING_MEDIA_DEFAULT_VALUE"],
+        reason: "secret reference was not found",
+      },
+    ]);
+
+    type RunProviderEntryParams = Parameters<typeof runProviderEntry>[0];
+    await expect(
+      runProviderEntry({
+        capability: "audio",
+        entry,
+        cfg,
+        config: cfg.tools.media.audio,
+        ctx: {} as RunProviderEntryParams["ctx"],
+        attachmentIndex: 0,
+        cache: {} as RunProviderEntryParams["cache"],
+        providerRegistry: new Map(),
+      }),
+    ).rejects.toThrow("Media provider not available: unknown-provider");
+  });
 });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -46,6 +46,8 @@ import {
 import { resolveOfficialExternalPluginRepairHint } from "../plugins/official-external-plugin-repair-hints.js";
 import { runExec } from "../process/exec.js";
 import { providerOperationRetryConfig } from "../provider-runtime/operation-retry.js";
+import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js";
+import { assertRuntimeMediaRequestSecretOwnerAvailable } from "../secrets/runtime-media-secret-owner.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import {
@@ -792,6 +794,7 @@ export async function runProviderEntry(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   config?: MediaUnderstandingConfig;
+  secretOwnerId?: string;
 }): Promise<MediaUnderstandingOutput | null> {
   const { entry, capability, cfg } = params;
   const providerIdRaw = entry.provider?.trim();
@@ -800,6 +803,10 @@ export async function runProviderEntry(params: {
   }
   const providerId = normalizeMediaProviderId(providerIdRaw);
   const requestProviderId = normalizeMediaExecutionProviderId(providerIdRaw);
+  assertRuntimeMediaRequestSecretOwnerAvailable({ capability, entry });
+  if (params.secretOwnerId) {
+    assertSecretOwnerAvailable("capability", params.secretOwnerId);
+  }
   const { maxBytes, maxChars, timeoutMs, prompt, hasConfiguredPrompt } = resolveEntryRunOptions({
     capability,
     entry,

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -54,7 +54,11 @@ import {
   buildMediaUnderstandingRegistry,
   getMediaUnderstandingProvider,
 } from "./provider-registry.js";
-import { resolveModelEntries, resolveScopeDecision } from "./resolve.js";
+import {
+  resolveModelEntries,
+  resolveScopeDecision,
+  type ResolvedMediaModelEntry,
+} from "./resolve.js";
 import {
   buildModelDecision,
   formatDecisionSummary,
@@ -854,7 +858,7 @@ async function runAttachmentEntries(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   cache: MediaAttachmentCache;
-  entries: MediaUnderstandingModelConfig[];
+  entries: ResolvedMediaModelEntry[];
   config?: MediaUnderstandingConfig;
 }): Promise<{
   output: MediaUnderstandingOutput | null;
@@ -862,7 +866,8 @@ async function runAttachmentEntries(params: {
 }> {
   const { entries, capability } = params;
   const attempts: MediaUnderstandingModelDecision[] = [];
-  for (const entry of entries) {
+  for (const candidate of entries) {
+    const { entry } = candidate;
     const entryType = entry.type ?? (entry.command ? "cli" : "provider");
     try {
       const result =
@@ -887,6 +892,7 @@ async function runAttachmentEntries(params: {
               workspaceDir: params.workspaceDir,
               providerRegistry: params.providerRegistry,
               config: params.config,
+              secretOwnerId: candidate.secretOwnerId,
             });
       if (result) {
         const decision = buildModelDecision({ entry, entryType, outcome: "success" });
@@ -1042,17 +1048,19 @@ export async function runCapability(params: {
     config,
     providerRegistry: params.providerRegistry,
   });
-  let resolvedEntries = entries;
+  let resolvedEntries: ResolvedMediaModelEntry[] = entries;
   if (resolvedEntries.length === 0) {
-    resolvedEntries = await resolveAutoEntries({
-      cfg,
-      agentId: params.agentId,
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
-      providerRegistry: params.providerRegistry,
-      capability,
-      activeModel: params.activeModel,
-    });
+    resolvedEntries = (
+      await resolveAutoEntries({
+        cfg,
+        agentId: params.agentId,
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
+        providerRegistry: params.providerRegistry,
+        capability,
+        activeModel: params.activeModel,
+      })
+    ).map((entry) => ({ entry }));
   }
   if (resolvedEntries.length === 0) {
     return {

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -11,6 +11,10 @@ import { collectAgentMemorySearchAssignments } from "./runtime-config-collectors
 import { collectTtsApiKeyAssignments } from "./runtime-config-collectors-tts.js";
 import { evaluateGatewayAuthSurfaceStates } from "./runtime-gateway-auth-surfaces.js";
 import {
+  runtimeMediaModelSecretOwnerId,
+  runtimeMediaRequestSecretOwnerId,
+} from "./runtime-media-secret-owner.js";
+import {
   collectSecretInputAssignment,
   collectRuntimeSecretInputAssignment,
   type SecretAssignmentOwner,
@@ -384,6 +388,7 @@ function collectMediaRequestAssignments(params: {
   const collectModelAssignments = (
     models: unknown,
     pathPrefix: string,
+    resolveOwnerId: (index: number) => string,
     resolveActivity: (rawModel: Record<string, unknown>) => {
       active: boolean;
       inactiveReason: string;
@@ -404,34 +409,45 @@ function collectMediaRequestAssignments(params: {
         context: params.context,
         active,
         inactiveReason,
+        owner: {
+          ownerKind: "capability",
+          ownerId: resolveOwnerId(index),
+          requiredForGateway: false,
+          disposition: "isolate",
+        },
       });
     });
   };
 
-  collectModelAssignments(media.models, "tools.media.models", (rawModel) => {
-    const entry = rawModel as MediaUnderstandingModelConfig;
-    const configuredCapabilities = resolveConfiguredMediaEntryCapabilities(entry);
-    // Shared models are active only for enabled capabilities; when the config omits explicit
-    // capabilities, provider metadata is the contract for which media sections can use it.
-    const capabilities =
-      configuredCapabilities ??
-      resolveEffectiveMediaEntryCapabilities({
-        entry,
-        source: "shared",
-        providerRegistry: getProviderRegistry(),
-      });
-    if (!capabilities || capabilities.length === 0) {
+  collectModelAssignments(
+    media.models,
+    "tools.media.models",
+    (index) => runtimeMediaModelSecretOwnerId({ source: "shared", index }),
+    (rawModel) => {
+      const entry = rawModel as MediaUnderstandingModelConfig;
+      const configuredCapabilities = resolveConfiguredMediaEntryCapabilities(entry);
+      // Shared models are active only for enabled capabilities; when the config omits explicit
+      // capabilities, provider metadata is the contract for which media sections can use it.
+      const capabilities =
+        configuredCapabilities ??
+        resolveEffectiveMediaEntryCapabilities({
+          entry,
+          source: "shared",
+          providerRegistry: getProviderRegistry(),
+        });
+      if (!capabilities || capabilities.length === 0) {
+        return {
+          active: false,
+          inactiveReason:
+            "shared media model does not declare capabilities and none could be inferred from its provider.",
+        };
+      }
       return {
-        active: false,
-        inactiveReason:
-          "shared media model does not declare capabilities and none could be inferred from its provider.",
+        active: capabilities.some((capability) => isCapabilityEnabled(capability)),
+        inactiveReason: `all configured media capabilities for this shared model are disabled: ${capabilities.join(", ")}.`,
       };
-    }
-    return {
-      active: capabilities.some((capability) => isCapabilityEnabled(capability)),
-      inactiveReason: `all configured media capabilities for this shared model are disabled: ${capabilities.join(", ")}.`,
-    };
-  });
+    },
+  );
 
   for (const capability of capabilityKeys) {
     const section = isRecord(media[capability]) ? media[capability] : undefined;
@@ -445,20 +461,31 @@ function collectMediaRequestAssignments(params: {
         context: params.context,
         active,
         inactiveReason,
+        owner: {
+          ownerKind: "capability",
+          ownerId: runtimeMediaRequestSecretOwnerId(capability),
+          requiredForGateway: false,
+          disposition: "isolate",
+        },
       });
     }
-    collectModelAssignments(section?.models, `tools.media.${capability}.models`, (rawModel) => ({
-      active:
-        active &&
-        (() => {
-          const entry = rawModel as MediaUnderstandingModelConfig;
-          const configuredCapabilities = resolveConfiguredMediaEntryCapabilities(entry);
-          return configuredCapabilities ? configuredCapabilities.includes(capability) : true;
-        })(),
-      inactiveReason: active
-        ? `${capability} media model is filtered out by its configured capabilities.`
-        : inactiveReason,
-    }));
+    collectModelAssignments(
+      section?.models,
+      `tools.media.${capability}.models`,
+      (index) => runtimeMediaModelSecretOwnerId({ source: "capability", capability, index }),
+      (rawModel) => ({
+        active:
+          active &&
+          (() => {
+            const entry = rawModel as MediaUnderstandingModelConfig;
+            const configuredCapabilities = resolveConfiguredMediaEntryCapabilities(entry);
+            return configuredCapabilities ? configuredCapabilities.includes(capability) : true;
+          })(),
+        inactiveReason: active
+          ? `${capability} media model is filtered out by its configured capabilities.`
+          : inactiveReason,
+      }),
+    );
   }
 }
 

--- a/src/secrets/runtime-media-secret-owner.ts
+++ b/src/secrets/runtime-media-secret-owner.ts
@@ -1,0 +1,62 @@
+import type {
+  MediaUnderstandingCapability,
+  MediaUnderstandingModelConfig,
+} from "../config/types.tools.js";
+import {
+  findActiveDegradedSecretOwner,
+  SecretSurfaceUnavailableError,
+} from "./runtime-degraded-state.js";
+
+/** Runtime owner for one configured media-understanding model entry. */
+export function runtimeMediaModelSecretOwnerId(
+  params: {
+    index: number;
+  } & ({ source: "shared" } | { source: "capability"; capability: MediaUnderstandingCapability }),
+): string {
+  return params.source === "shared"
+    ? `media-model:shared:${params.index}`
+    : `media-model:${params.capability}:${params.index}`;
+}
+
+/** Runtime owner for request defaults inherited by one media capability. */
+export function runtimeMediaRequestSecretOwnerId(capability: MediaUnderstandingCapability): string {
+  return `media-model:${capability}:request`;
+}
+
+function modelRequestOverridesPath(entry: MediaUnderstandingModelConfig, path: string): boolean {
+  const request = entry.request;
+  const requestPath = path.split(".request.")[1];
+  if (!request || !requestPath) {
+    return false;
+  }
+  if (requestPath.startsWith("auth.")) {
+    return request.auth !== undefined;
+  }
+  if (requestPath.startsWith("tls.")) {
+    return request.tls !== undefined;
+  }
+  if (requestPath.startsWith("proxy.")) {
+    return request.proxy !== undefined;
+  }
+  const headerName = requestPath.startsWith("headers.")
+    ? requestPath.slice("headers.".length).toLowerCase()
+    : undefined;
+  return Boolean(
+    headerName &&
+    Object.keys(request.headers ?? {}).some((key) => key.toLowerCase() === headerName),
+  );
+}
+
+/** Rejects a cold capability request only when the model still inherits its failed field. */
+export function assertRuntimeMediaRequestSecretOwnerAvailable(params: {
+  capability: MediaUnderstandingCapability;
+  entry: MediaUnderstandingModelConfig;
+}): void {
+  const owner = findActiveDegradedSecretOwner(
+    "capability",
+    runtimeMediaRequestSecretOwnerId(params.capability),
+  );
+  if (owner && owner.paths.some((path) => !modelRequestOverridesPath(params.entry, path))) {
+    throw new SecretSurfaceUnavailableError(owner);
+  }
+}

--- a/src/secrets/runtime-provider-and-media-surfaces.test.ts
+++ b/src/secrets/runtime-provider-and-media-surfaces.test.ts
@@ -508,6 +508,49 @@ describe("secrets runtime provider and media surfaces", () => {
     );
   });
 
+  it("isolates a broken media request ref to its exact model owner", async () => {
+    const missingRef = envTokenRef("MISSING_MEDIA_MODEL_VALUE");
+    const healthyRef = envTokenRef("HEALTHY_MEDIA_MODEL_VALUE");
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: {
+          media: {
+            models: [
+              {
+                provider: "openai",
+                capabilities: ["audio"],
+                request: { auth: { mode: "authorization-bearer", token: missingRef } },
+              },
+              {
+                provider: "deepgram",
+                capabilities: ["audio"],
+                request: { auth: { mode: "authorization-bearer", token: healthyRef } },
+              },
+            ],
+            audio: { enabled: true },
+          },
+        },
+      }),
+      env: { HEALTHY_MEDIA_MODEL_VALUE: "test-token" },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+      allowUnavailableSecretOwners: true,
+    });
+
+    expect(snapshot.config.tools?.media?.models?.[1]?.request?.auth).toEqual({
+      mode: "authorization-bearer",
+      token: "test-token",
+    });
+    expect(snapshot.degradedOwners).toMatchObject([
+      {
+        ownerKind: "capability",
+        ownerId: "media-model:shared:0",
+        state: "unavailable",
+        paths: ["tools.media.models.0.request.auth.token"],
+      },
+    ]);
+  });
+
   it("treats defaults memorySearch ref as inactive when all enabled agents disable memorySearch", async () => {
     const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({


### PR DESCRIPTION
Related: #101265

## What Problem This Solves

Fixes an issue where one broken SecretRef in a configured media-understanding model could prevent the Gateway from starting and disable unrelated media models.

## Why This Change Was Made

Each configured media model now has a stable runtime owner. Startup degrades only the broken model, request-time dispatch returns typed unavailability for that exact model, and healthy sibling models remain usable. Request-level defaults are checked only when the selected model actually inherits them.

## User Impact

Operators can start the Gateway with one unavailable media-model secret. Only that exact model is cold; other image, audio, and video candidates continue working.

## Evidence

- Focused proof: `node scripts/run-vitest.mjs src/secrets/runtime-provider-and-media-surfaces.test.ts src/media-understanding/runner.entries.guards.test.ts src/media-understanding/resolve.test.ts src/gateway/server-startup-secret-owner-isolation.test.ts` — 39 tests passed.
- Full changed-surface gate: `node scripts/check-changed.mjs -- src/gateway/server-startup-secret-owner-isolation.test.ts src/media-understanding/resolve.test.ts src/media-understanding/resolve.ts src/media-understanding/runner.entries.guards.test.ts src/media-understanding/runner.entries.ts src/media-understanding/runner.ts src/secrets/runtime-config-collectors-core.ts src/secrets/runtime-media-secret-owner.ts src/secrets/runtime-provider-and-media-surfaces.test.ts` — passed on Blacksmith Testbox.
- Hosted gate: https://github.com/openclaw/openclaw/actions/runs/29586348266
- Autoreview: clean after replacing object-identity owner inference with stable candidate metadata and narrowing request-owner checks to inherited fields.

AI-assisted implementation; maintainer reviewed and verified.
