### PR TITLE
fix(heartbeat): task prompts reach the model

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../../../auto-reply/heartbeat.js";
 import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { ToolResultPromptProjectionState } from "../session-prompt-state.js";
@@ -252,5 +253,25 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     );
     expect(fixture.report.currentTurn?.kind).toBe("room_event");
     expect(fixture.report.currentTurn?.runtimeContextChars).toBeGreaterThan(0);
+  });
+
+  it("uses heartbeat task text at the model and hook boundary", () => {
+    const heartbeatTask = "Read HEARTBEAT.md and handle any due tasks.";
+    const fixture = createInput({
+      prompt: createPrompt({
+        effectivePrompt: heartbeatTask,
+        promptBeforePromptBuildHooks: heartbeatTask,
+        effectiveTranscriptPrompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+        transcriptPromptForRuntimeSplit: HEARTBEAT_TRANSCRIPT_PROMPT,
+        promptForRuntimeContextSplit: heartbeatTask,
+        promptForModelBeforeRuntimeContextSplit: heartbeatTask,
+        promptForRuntimeContextBeforeAnnotation: heartbeatTask,
+      }),
+    });
+
+    const result = prepareEmbeddedAttemptPromptContext(fixture.input);
+
+    expect(result.promptForSession).toBe(HEARTBEAT_TRANSCRIPT_PROMPT);
+    expect(result.promptForModel).toBe(heartbeatTask);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -272,7 +272,7 @@ export function shouldWarnOnOrphanedUserRepair(
   return trigger === "user" || trigger === "manual";
 }
 
-const QUEUED_USER_MESSAGE_MARKER =
+export const QUEUED_USER_MESSAGE_MARKER =
   "[Queued user message from a previous active turn; preserved as context only. " +
   "Continue with the active prompt below.]";
 const MAX_STRUCTURED_MEDIA_REF_CHARS = 300;

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -2,6 +2,7 @@
 // user-visible prompt while preserving model-only hook additions.
 import { describe, expect, it } from "vitest";
 import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../../../auto-reply/heartbeat.js";
+import { QUEUED_USER_MESSAGE_MARKER } from "./attempt.prompt-helpers.js";
 import {
   buildCurrentInboundPrompt,
   buildRuntimeContextCustomMessage,
@@ -94,6 +95,20 @@ describe("runtime context prompt submission", () => {
     ).toEqual({
       prompt: HEARTBEAT_TRANSCRIPT_PROMPT,
       modelPrompt: `${prependContext}\n\n${heartbeatTask}`,
+    });
+  });
+
+  it("keeps queued heartbeat task text model-visible while persisting the poll marker", () => {
+    const heartbeatTask = "Read HEARTBEAT.md and handle any due tasks.";
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: `${QUEUED_USER_MESSAGE_MARKER}\n${heartbeatTask}\n\n${HEARTBEAT_TRANSCRIPT_PROMPT}`,
+        transcriptPrompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+      }),
+    ).toEqual({
+      prompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+      modelPrompt: heartbeatTask,
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -1,6 +1,7 @@
 // Runtime-context prompt tests keep hidden OpenClaw context separate from the
 // user-visible prompt while preserving model-only hook additions.
 import { describe, expect, it } from "vitest";
+import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../../../auto-reply/heartbeat.js";
 import {
   buildCurrentInboundPrompt,
   buildRuntimeContextCustomMessage,
@@ -33,6 +34,53 @@ describe("runtime context prompt submission", () => {
         transcriptPrompt: "visible ask",
       }),
     ).toEqual({ prompt: "visible ask" });
+  });
+
+  it("keeps heartbeat task text model-visible while persisting the transcript marker", () => {
+    const heartbeatTask = "Read HEARTBEAT.md and handle any due tasks.";
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: heartbeatTask,
+        transcriptPrompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+      }),
+    ).toEqual({
+      prompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+      modelPrompt: heartbeatTask,
+    });
+  });
+
+  it("preserves heartbeat task text when prompt-build hooks add model context", () => {
+    const heartbeatTask = "Read HEARTBEAT.md and handle any due tasks.";
+    const prependContext = "Hook-provided policy context";
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: heartbeatTask,
+        transcriptPrompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+        modelPrompt: `${prependContext}\n\n${heartbeatTask}`,
+        ...withModelPromptBuildContext({
+          promptBeforeHooks: heartbeatTask,
+          transcriptPrompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+          prependContext,
+        }),
+      }),
+    ).toEqual({
+      prompt: HEARTBEAT_TRANSCRIPT_PROMPT,
+      modelPrompt: `${prependContext}\n\n${heartbeatTask}`,
+    });
+  });
+
+  it("keeps source context separate when the transcript prompt is embedded", () => {
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: "System event\n\nvisible ask",
+        transcriptPrompt: "visible ask",
+      }),
+    ).toEqual({
+      prompt: "visible ask",
+      runtimeContext: "System event",
+    });
   });
 
   it("moves hidden runtime context out of the visible prompt", () => {

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -50,6 +50,32 @@ describe("runtime context prompt submission", () => {
     });
   });
 
+  it("keeps bare reset context model-visible while persisting the reset marker", () => {
+    const resetContext = "Startup context\n\nA new session was started via /reset.";
+
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: resetContext,
+        transcriptPrompt: "[OpenClaw session reset]",
+      }),
+    ).toEqual({
+      prompt: "[OpenClaw session reset]",
+      modelPrompt: resetContext,
+    });
+  });
+
+  it("keeps the room-event instruction model-visible while persisting the chat line", () => {
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: "[OpenClaw room event]",
+        transcriptPrompt: "#35676 Kesava: No thanks",
+      }),
+    ).toEqual({
+      prompt: "#35676 Kesava: No thanks",
+      modelPrompt: "[OpenClaw room event]",
+    });
+  });
+
   it("preserves heartbeat task text when prompt-build hooks add model context", () => {
     const heartbeatTask = "Read HEARTBEAT.md and handle any due tasks.";
     const prependContext = "Hook-provided policy context";

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -151,7 +151,16 @@ export function resolveRuntimeContextPromptParts(params: {
           .text,
       }
     : undefined;
-  const modelPromptText = modelPrompt?.text ?? transcriptPrompt ?? extracted.text;
+  const transcriptPromptParts = transcriptPrompt?.trim()
+    ? splitLastPromptOccurrence(extracted.text, transcriptPrompt)
+    : undefined;
+  // Non-empty transcript substitutions are persistence-only; the effective
+  // prompt must still reach the model when no hook supplied an explicit copy.
+  const modelPromptText =
+    modelPrompt?.text ??
+    (transcriptPrompt?.trim() && !transcriptPromptParts
+      ? extracted.text
+      : (transcriptPrompt ?? extracted.text));
   const prompt = transcriptPrompt ?? extracted.text;
   if (!prompt.trim() && params.emptyTranscriptMode === "model-prompt") {
     return {
@@ -173,13 +182,8 @@ export function resolveRuntimeContextPromptParts(params: {
     : undefined;
   const fallbackPromptParts = !modelPromptBuildContext
     ? modelPrompt
-      ? (splitLastPromptOccurrence(extracted.text, modelPrompt.text) ??
-        (transcriptPrompt
-          ? splitLastPromptOccurrence(extracted.text, transcriptPrompt)
-          : undefined))
-      : transcriptPrompt
-        ? splitLastPromptOccurrence(extracted.text, transcriptPrompt)
-        : undefined
+      ? (splitLastPromptOccurrence(extracted.text, modelPrompt.text) ?? transcriptPromptParts)
+      : transcriptPromptParts
     : undefined;
   // Source context sits inside the active prompt; provenance sits outside all
   // prompt transforms. Preserve that nesting order when hiding both.

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -10,6 +10,7 @@ import {
   OPENCLAW_RUNTIME_CONTEXT_NOTICE,
   OPENCLAW_RUNTIME_EVENT_HEADER,
 } from "../../internal-runtime-context.js";
+import { QUEUED_USER_MESSAGE_MARKER } from "./attempt.prompt-helpers.js";
 import type { CurrentInboundPromptContext } from "./params.js";
 
 const OPENCLAW_RUNTIME_EVENT_USER_PROMPT = "Continue the OpenClaw runtime event.";
@@ -42,6 +43,8 @@ type ModelPromptBuildContext = {
   appendContext: string;
 };
 
+type PromptParts = { before: string; after: string };
+
 /** Combines inbound context and the current prompt using the channel-provided joiner. */
 export function buildCurrentInboundPrompt(params: {
   context: CurrentInboundPromptContext | undefined;
@@ -62,10 +65,7 @@ export function buildCurrentInboundPrompt(params: {
   return [prefix, params.prompt].join(params.context?.promptJoiner ?? "\n\n");
 }
 
-function splitLastPromptOccurrence(
-  text: string,
-  prompt: string,
-): { before: string; after: string } | null {
+function splitLastPromptOccurrence(text: string, prompt: string): PromptParts | null {
   const index = text.lastIndexOf(prompt);
   if (index === -1) {
     return null;
@@ -74,6 +74,37 @@ function splitLastPromptOccurrence(
     before: text.slice(0, index),
     after: text.slice(index + prompt.length),
   };
+}
+
+function resolveQueuedUserTranscriptSubstitution(params: {
+  text: string;
+  transcriptPrompt?: string;
+}): { prompt: string; parts: PromptParts } | undefined {
+  const transcriptPrompt = params.transcriptPrompt?.trim();
+  if (!transcriptPrompt) {
+    return undefined;
+  }
+  const transcriptParts = splitLastPromptOccurrence(params.text, transcriptPrompt);
+  if (!transcriptParts) {
+    return undefined;
+  }
+  const beforeTranscript = transcriptParts.before.trimEnd();
+  const markerStart = beforeTranscript.lastIndexOf(QUEUED_USER_MESSAGE_MARKER);
+  if (markerStart === -1 || beforeTranscript.slice(0, markerStart).trim()) {
+    return undefined;
+  }
+  const queuedPrompt = beforeTranscript
+    .slice(markerStart + QUEUED_USER_MESSAGE_MARKER.length)
+    .trim();
+  if (!queuedPrompt) {
+    return undefined;
+  }
+  const queuedBlock = `${QUEUED_USER_MESSAGE_MARKER}\n${queuedPrompt}\n\n${transcriptPrompt}`;
+  const parts = splitLastPromptOccurrence(params.text, queuedBlock);
+  if (!parts) {
+    return undefined;
+  }
+  return { prompt: queuedPrompt, parts };
 }
 
 function replacePromptOccurrenceWithinHookBounds(params: {
@@ -154,10 +185,15 @@ export function resolveRuntimeContextPromptParts(params: {
   const transcriptPromptParts = transcriptPrompt?.trim()
     ? splitLastPromptOccurrence(extracted.text, transcriptPrompt)
     : undefined;
+  const queuedUserTranscriptSubstitution = resolveQueuedUserTranscriptSubstitution({
+    text: extracted.text,
+    transcriptPrompt,
+  });
   // Non-empty transcript substitutions are persistence-only; the effective
   // prompt must still reach the model when no hook supplied an explicit copy.
   const modelPromptText =
     modelPrompt?.text ??
+    queuedUserTranscriptSubstitution?.prompt ??
     (transcriptPrompt?.trim() && !transcriptPromptParts
       ? extracted.text
       : (transcriptPrompt ?? extracted.text));
@@ -183,7 +219,7 @@ export function resolveRuntimeContextPromptParts(params: {
   const fallbackPromptParts = !modelPromptBuildContext
     ? modelPrompt
       ? (splitLastPromptOccurrence(extracted.text, modelPrompt.text) ?? transcriptPromptParts)
-      : transcriptPromptParts
+      : (queuedUserTranscriptSubstitution?.parts ?? transcriptPromptParts)
     : undefined;
   // Source context sits inside the active prompt; provenance sits outside all
   // prompt transforms. Preserve that nesting order when hiding both.

--- a/src/infra/heartbeat-runner.natural-prompt.test.ts
+++ b/src/infra/heartbeat-runner.natural-prompt.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  runHeartbeatOnce,
+  setHeartbeatsEnabled,
+  startHeartbeatRunner,
+  type HeartbeatRunResult,
+  type HeartbeatRunner,
+} from "./heartbeat-runner.js";
+import { readSessionStoreForTest } from "./heartbeat-runner.test-utils.js";
+
+const cleanupDirs: string[] = [];
+const runners: HeartbeatRunner[] = [];
+
+afterEach(async () => {
+  for (const runner of runners.splice(0)) {
+    runner.stop();
+  }
+  await Promise.all(cleanupDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  setHeartbeatsEnabled(true);
+});
+
+describe("natural heartbeat scheduled prompt", () => {
+  it("uses the due HEARTBEAT.md task as the model-facing prompt", async () => {
+    const fixtureDir = await mkdtemp(path.join(tmpdir(), "openclaw-natural-heartbeat-"));
+    cleanupDirs.push(fixtureDir);
+    const workspaceDir = path.join(fixtureDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    await writeFile(
+      path.join(workspaceDir, "HEARTBEAT.md"),
+      [
+        "tasks:",
+        "  - name: natural-heartbeat-proof",
+        "    interval: 1ms",
+        "    prompt: Verify queued heartbeat tasks reach the model request",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          heartbeat: {
+            every: "50ms",
+            target: "none",
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+      session: { store: path.join(fixtureDir, "sessions.sqlite") },
+    } satisfies OpenClawConfig;
+
+    setHeartbeatsEnabled(true);
+    const observedContexts: MsgContext[] = [];
+    const runResults: HeartbeatRunResult[] = [];
+    const runner = startHeartbeatRunner({
+      cfg: config,
+      readCurrentConfig: () => config,
+      runOnce: async (opts) => {
+        const result = await runHeartbeatOnce({
+          ...opts,
+          deps: {
+            ...opts.deps,
+            getQueueSize: () => 0,
+            getReplyFromConfig: async (ctx) => {
+              observedContexts.push(ctx);
+              return { text: "HEARTBEAT_OK" };
+            },
+          },
+        });
+        runResults.push(result);
+        return result;
+      },
+      stableSchedulerSeed: "natural-heartbeat-prompt",
+    });
+    runners.push(runner);
+
+    await vi.waitFor(
+      () => {
+        expect(
+          observedContexts.length,
+          `heartbeat results: ${JSON.stringify(runResults)}`,
+        ).toBeGreaterThan(0);
+      },
+      { timeout: 2_000, interval: 20 },
+    );
+
+    expect(observedContexts[0]?.Body).toContain("Run the following periodic tasks");
+    expect(observedContexts[0]?.Body).toContain(
+      "natural-heartbeat-proof: Verify queued heartbeat tasks reach the model request",
+    );
+    expect(observedContexts[0]?.Body).not.toContain("[OpenClaw heartbeat poll]");
+
+    const sessionStore = readSessionStoreForTest<{
+      heartbeatTaskState?: Record<string, number>;
+    }>(path.join(fixtureDir, "sessions.sqlite"));
+    expect(
+      Object.values(sessionStore).some(
+        (entry) => entry.heartbeatTaskState?.["natural-heartbeat-proof"],
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/infra/heartbeat-runner.natural-prompt.test.ts
+++ b/src/infra/heartbeat-runner.natural-prompt.test.ts
@@ -8,10 +8,10 @@ import {
   runHeartbeatOnce,
   setHeartbeatsEnabled,
   startHeartbeatRunner,
-  type HeartbeatRunResult,
   type HeartbeatRunner,
 } from "./heartbeat-runner.js";
 import { readSessionStoreForTest } from "./heartbeat-runner.test-utils.js";
+import type { HeartbeatRunResult } from "./heartbeat-wake.js";
 
 const cleanupDirs: string[] = [];
 const runners: HeartbeatRunner[] = [];


### PR DESCRIPTION
Closes #110025

## What Problem This Solves

Fixes an issue where due heartbeat task text could be hidden behind the persisted `[OpenClaw heartbeat poll]` transcript marker before the model turn, while heartbeat task bookkeeping still advanced as if the task had run.

## Why This Change Was Made

The transcript marker is still the durable session text for heartbeat polls, but runtime-only substitutions now remain persistence-only when they would otherwise hide real model-facing work. The follow-up also handles the scheduled repair shape where a queued heartbeat task is merged before the persisted poll marker; that queued task now becomes the model prompt instead of hidden context-only text.

## User Impact

Heartbeat tasks can reach the model and execute as scheduled without exposing their full generated prompt in the persisted transcript. Existing runtime-event handling, source-context separation, and transcript hygiene remain unchanged.

## Evidence

Earlier isolated gateway/provider proof used a loopback OpenAI-compatible provider with this due heartbeat task:

```md
tasks:
  - name: probe
    interval: 5m
    prompt: "Include the word TASKPROBE in your response."
```

That proof showed the persisted transcript kept only `[OpenClaw heartbeat poll]`, the provider request contained the due task context, the provider returned `TASKPROBE observed`, and `heartbeatTaskState.probe` advanced.

Reviewer follow-up found the natural scheduled path could still merge the queued task into a preserved-context block before the transcript marker. This branch now adds final-head coverage for that exact shape:

```console
[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]
Read HEARTBEAT.md and handle any due tasks.

[OpenClaw heartbeat poll]
```

The regression verifies the persisted prompt remains `[OpenClaw heartbeat poll]` while the model prompt is `Read HEARTBEAT.md and handle any due tasks.`.

Final-head natural scheduled heartbeat coverage was also added. It starts the real heartbeat scheduler with a due `HEARTBEAT.md` task, lets the interval wake fire naturally, captures the context passed to reply resolution, verifies the due task is model-facing, verifies the poll marker is not model-facing, and verifies `heartbeatTaskState` is persisted through the SQLite session accessor.

Focused validation completed on the rebased branch:

```console
node scripts/run-vitest.mjs src/infra/heartbeat-runner.natural-prompt.test.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts src/infra/heartbeat-runner.tool-response.test.ts
# 3 shards passed; 71 tests passed

node node_modules/.bin/oxfmt --check src/infra/heartbeat-runner.natural-prompt.test.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
# passed

node node_modules/.bin/oxlint src/infra/heartbeat-runner.natural-prompt.test.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
# passed

git diff --check origin/main...HEAD
# passed
```

Regression coverage verifies the no-hook heartbeat path, scheduled queued-heartbeat repair path, natural scheduled heartbeat task path, prompt-build hook context, the model/hook prompt boundary, empty runtime-only events, and source context surrounding an embedded transcript prompt. Other distinct non-empty transcript substitutions are covered as well: bare resets keep startup context model-visible while persisting the reset marker, and room events keep the room-event instruction model-visible while persisting the chat line.

## Real behavior proof

- Behavior or issue addressed: due structured heartbeat task text was replaced or demoted by the transcript marker before provider submission while task bookkeeping still advanced.
- Real environment tested: macOS, Node 24.16, isolated OpenClaw gateway/provider proof from the earlier patch, plus final-head natural scheduled heartbeat regression through the real scheduler, heartbeat runner, prompt construction, and SQLite session persistence.
- Exact steps or command run after this patch: the final-head validation commands are listed above.
- Evidence after fix: copied output above shows the final-head natural scheduled regression and focused validation passing; the earlier loopback provider proof showed the task text reaching the provider request while the transcript persisted only the heartbeat poll marker.
- Observed result after fix: due heartbeat task text remains model-visible, the heartbeat poll marker remains transcript-only, and heartbeat task state advances after the run.
- What was not tested: no external live channel/provider delivery was exercised for this follow-up.
- Proof limitations or environment constraints: channel delivery was disabled because this issue concerns model submission and transcript persistence. A full natural scheduled gateway/provider rerun in the local test harness timed out before producing a provider request, so this PR does not claim fresh external-provider proof for the final follow-up commit.
- Before evidence: issue #110025 and the reviewer harness capture show the due task absent or demoted from the model-active prompt while only the marker was sent as the active user turn.

Disclosure: AI was used to understand the codebase and review the fix.
