### PR TITLE
fix(qa-lab): cancel unread response body on non-OK HTTP responses

### DIFF
--- a/extensions/qa-lab/web/src/http.test.ts
+++ b/extensions/qa-lab/web/src/http.test.ts
@@ -76,4 +76,36 @@ describe("QA Lab dashboard HTTP", () => {
 
     await expect(request).rejects.toMatchObject({ name: "TimeoutError" });
   });
+
+  it("cancels the response body on a non-OK getJson response before throwing", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(body, { status: 503, statusText: "Service Unavailable" })),
+    );
+
+    await expect(getJson("/api/error")).rejects.toThrow("503 Service Unavailable");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the response body on a non-OK getJsonNoStore response before throwing", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(body, { status: 500, statusText: "Internal Server Error" }),
+        ),
+    );
+
+    await expect(getJsonNoStore("/api/snapshot-error")).rejects.toThrow(
+      "500 Internal Server Error",
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });

--- a/extensions/qa-lab/web/src/http.ts
+++ b/extensions/qa-lab/web/src/http.ts
@@ -7,6 +7,7 @@ function createRequestSignal(): AbortSignal {
 export async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(path, { signal: createRequestSignal() });
   if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
     throw new Error(`${response.status} ${response.statusText}`);
   }
   return (await response.json()) as T;
@@ -18,6 +19,7 @@ export async function getJsonNoStore<T>(path: string): Promise<T> {
     signal: createRequestSignal(),
   });
   if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
     throw new Error(`${response.status} ${response.statusText}`);
   }
   return (await response.json()) as T;


### PR DESCRIPTION
## What Problem This Solves

When `getJson` and `getJsonNoStore` receive a non-OK response from the qa-lab dashboard API, they throw immediately without canceling the response body. The unconsumed stream holds the connection open until garbage collection.

Note: `postJson` already reads the error body via `.json().catch()` so it does not need this fix.

## Why This Change Was Made

Follows the same pattern as #109701 (MSTeams), #109519 (Google Chat), #109728 (APNs relay), and #110039 (Telegram media harness) — cancel the response body before throwing so that upstream streams are drained.

## User Impact

No user-facing change. Prevents resource leaks from unconsumed response bodies when the qa-lab dashboard API returns non-OK status codes.

## Evidence

### Real HTTP server proof

```
$ node scripts/proofs/qa-lab-http-cancel-proof.mjs
Server: http://127.0.0.1:37943

=== BEFORE: getJson (no body.cancel) ===
  503 Service Unavailable — body UNCONSUMED, throw immediately
  [server] /api/bootstrap → stream completed (no cancel)

=== AFTER: getJson (body?.cancel before throw) ===
  503 Service Unavailable
  body?.cancel() executed ✓
  [server] /api/bootstrap → client canceled ✓

=== AFTER: getJsonNoStore (body?.cancel before throw) ===
  503 Service Unavailable
  body?.cancel() executed ✓
  [server] /api/snapshot → client canceled ✓

=== Error message preserved ===
  Thrown: 503 Service Unavailable
```

The proof script starts a real HTTP server returning 503, then exercises the exact cancel-before-throw pattern for both `getJson` and `getJsonNoStore`. The server confirms `client canceled stream ✓` for both paths.

### Unit tests

Two new tests in `http.test.ts`:
- `getJson`: 503 response → `body.cancel()` called once, error contains "503 Service Unavailable"
- `getJsonNoStore`: 500 response → `body.cancel()` called once, error contains "500 Internal Server Error"

Tests use `ReadableStream({ cancel })` spy pattern matching #109701.