### PR TITLE
fix(infra): bound gateway TLS file reads via secret-file helper

### DIFF
--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -110,6 +110,66 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.error).toBeUndefined();
   });
 
+  it("rejects oversized cert files before reading them", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "oversized-cert.pem");
+    const keyPath = path.join(dir, "oversized-key.pem");
+    await writeFile(certPath, "x".repeat(256 * 1024 + 1), "utf8");
+    await writeFile(keyPath, KEY_PEM, "utf8");
+
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath,
+      keyPath,
+      autoGenerate: false,
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(result.required).toBe(true);
+    expect(result.error).toContain("cert file exceeds");
+  });
+
+  it("rejects oversized key files before reading them", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "oversized-cert.pem");
+    const keyPath = path.join(dir, "oversized-key.pem");
+    await writeFile(certPath, CERT_PEM, "utf8");
+    await writeFile(keyPath, "x".repeat(256 * 1024 + 1), "utf8");
+
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath,
+      keyPath,
+      autoGenerate: false,
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(result.required).toBe(true);
+    expect(result.error).toContain("key file exceeds");
+  });
+
+  it("rejects oversized ca files before reading them", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "oversized-cert.pem");
+    const keyPath = path.join(dir, "oversized-key.pem");
+    const caPath = path.join(dir, "oversized-ca.pem");
+    await writeFile(certPath, CERT_PEM, "utf8");
+    await writeFile(keyPath, KEY_PEM, "utf8");
+    await writeFile(caPath, "x".repeat(256 * 1024 + 1), "utf8");
+
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath,
+      keyPath,
+      caPath,
+      autoGenerate: false,
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(result.required).toBe(true);
+    expect(result.error).toContain("ca file exceeds");
+  });
+
   it("fails closed when cert/key are missing and auto generation is disabled", async () => {
     const dir = await createTempDir();
     const certPath = path.join(dir, "missing-cert.pem");

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -110,11 +110,11 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.error).toBeUndefined();
   });
 
-  it("rejects oversized cert files before reading them", async () => {
+  it("rejects oversized cert files before loading TLS options", async () => {
     const dir = await createTempDir();
     const certPath = path.join(dir, "oversized-cert.pem");
-    const keyPath = path.join(dir, "oversized-key.pem");
-    await writeFile(certPath, "x".repeat(256 * 1024 + 1), "utf8");
+    const keyPath = path.join(dir, "ok-key.pem");
+    await writeFile(certPath, "x".repeat(64 * 1024 + 1), "utf8");
     await writeFile(keyPath, KEY_PEM, "utf8");
 
     const result = await loadGatewayTlsRuntime({
@@ -127,14 +127,15 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.enabled).toBe(false);
     expect(result.required).toBe(true);
     expect(result.error).toContain("cert file exceeds");
+    expect(result.error).toContain(String(64 * 1024));
   });
 
-  it("rejects oversized key files before reading them", async () => {
+  it("rejects oversized key files before loading TLS options", async () => {
     const dir = await createTempDir();
-    const certPath = path.join(dir, "oversized-cert.pem");
+    const certPath = path.join(dir, "ok-cert.pem");
     const keyPath = path.join(dir, "oversized-key.pem");
     await writeFile(certPath, CERT_PEM, "utf8");
-    await writeFile(keyPath, "x".repeat(256 * 1024 + 1), "utf8");
+    await writeFile(keyPath, "x".repeat(64 * 1024 + 1), "utf8");
 
     const result = await loadGatewayTlsRuntime({
       enabled: true,
@@ -146,12 +147,36 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.enabled).toBe(false);
     expect(result.required).toBe(true);
     expect(result.error).toContain("key file exceeds");
+    expect(result.error).toContain(String(64 * 1024));
   });
 
-  it("rejects oversized ca files before reading them", async () => {
+  it("allows a CA bundle larger than the cert/key limit but under the CA cap", async () => {
     const dir = await createTempDir();
-    const certPath = path.join(dir, "oversized-cert.pem");
-    const keyPath = path.join(dir, "oversized-key.pem");
+    const certPath = path.join(dir, "ok-cert.pem");
+    const keyPath = path.join(dir, "ok-key.pem");
+    const caPath = path.join(dir, "large-ca.pem");
+    await writeFile(certPath, CERT_PEM, "utf8");
+    await writeFile(keyPath, KEY_PEM, "utf8");
+    // Upgrade-safe: previously unbounded CA bundles between 64 KiB and 256 KiB must still load.
+    await writeFile(caPath, `${CERT_PEM}${"x".repeat(64 * 1024)}`, "utf8");
+
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath,
+      keyPath,
+      caPath,
+      autoGenerate: false,
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.tlsOptions?.ca).toContain("BEGIN CERTIFICATE");
+  });
+
+  it("rejects oversized ca files before loading TLS options", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "ok-cert.pem");
+    const keyPath = path.join(dir, "ok-key.pem");
     const caPath = path.join(dir, "oversized-ca.pem");
     await writeFile(certPath, CERT_PEM, "utf8");
     await writeFile(keyPath, KEY_PEM, "utf8");
@@ -168,7 +193,31 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.enabled).toBe(false);
     expect(result.required).toBe(true);
     expect(result.error).toContain("ca file exceeds");
+    expect(result.error).toContain(String(256 * 1024));
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects non-regular cert paths before loading",
+    async () => {
+      const dir = await createTempDir();
+      const certPath = path.join(dir, "fifo-cert.pem");
+      const keyPath = path.join(dir, "ok-key.pem");
+      await writeFile(keyPath, KEY_PEM, "utf8");
+      const { execFileSync } = await import("node:child_process");
+      execFileSync("mkfifo", [certPath]);
+
+      const result = await loadGatewayTlsRuntime({
+        enabled: true,
+        certPath,
+        keyPath,
+        autoGenerate: false,
+      });
+
+      expect(result.enabled).toBe(false);
+      expect(result.required).toBe(true);
+      expect(result.error).toMatch(/gateway tls: failed to load cert/);
+    },
+  );
 
   it("fails closed when cert/key are missing and auto generation is disabled", async () => {
     const dir = await createTempDir();

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -1,18 +1,41 @@
 // Gateway TLS runtime loads configured certificates or generates a local
 // self-signed pair, returning server-ready options plus client fingerprint.
 import { X509Certificate } from "node:crypto";
-import fs from "node:fs";
-import fsp from "node:fs/promises";
+import fs from "node:fs/promises";
 import path from "node:path";
 import tls from "node:tls";
 import type { GatewayTlsConfig } from "../../config/types.gateway.js";
 import { runExec } from "../../process/exec.js";
 import { CONFIG_DIR, ensureDir, resolveUserPath, shortenHomeInString } from "../../utils.js";
-import { pathExists } from "../fs-safe.js";
+import { FsSafeError, pathExists } from "../fs-safe.js";
 import { resolveSystemBin } from "../resolve-system-bin.js";
+import { readSecretFileSync } from "../secret-file.js";
 import { normalizeFingerprint } from "./fingerprint.js";
 
-const GATEWAY_TLS_FILE_MAX_BYTES = 256 * 1024;
+// Leaf cert/key PEMs are small; match MCP client TLS (#110016).
+const GATEWAY_TLS_CERT_KEY_MAX_BYTES = 64 * 1024;
+// CA path is a trust bundle and may hold multiple roots; match managed proxy CA (#110032).
+const GATEWAY_TLS_CA_FILE_MAX_BYTES = 256 * 1024;
+
+function readGatewayTlsFile(params: {
+  filePath: string;
+  label: "cert" | "key" | "ca";
+  maxBytes: number;
+}): string {
+  try {
+    return readSecretFileSync(params.filePath, `gateway tls ${params.label} file`, {
+      maxBytes: params.maxBytes,
+      rejectHardlinks: false,
+    });
+  } catch (err) {
+    if (err instanceof FsSafeError && err.code === "too-large") {
+      throw new Error(`gateway tls: ${params.label} file exceeds ${params.maxBytes} bytes`, {
+        cause: err,
+      });
+    }
+    throw err;
+  }
+}
 
 // Gateway TLS runtime carries loaded cert material plus the normalized SHA-256
 // fingerprint advertised to clients.
@@ -66,8 +89,8 @@ async function generateSelfSignedCert(params: {
     ],
     { logOutput: false },
   );
-  await fsp.chmod(params.keyPath, 0o600).catch(() => {});
-  await fsp.chmod(params.certPath, 0o600).catch(() => {});
+  await fs.chmod(params.keyPath, 0o600).catch(() => {});
+  await fs.chmod(params.certPath, 0o600).catch(() => {});
   params.log?.info?.(
     `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
   );
@@ -128,42 +151,25 @@ export async function loadGatewayTlsRuntime(
   }
 
   try {
-    const certStat = fs.statSync(certPath);
-    if (certStat.size > GATEWAY_TLS_FILE_MAX_BYTES) {
-      return {
-        enabled: false,
-        required: true,
-        certPath,
-        keyPath,
-        error: `gateway tls: cert file exceeds ${GATEWAY_TLS_FILE_MAX_BYTES} bytes`,
-      };
-    }
-    const keyStat = fs.statSync(keyPath);
-    if (keyStat.size > GATEWAY_TLS_FILE_MAX_BYTES) {
-      return {
-        enabled: false,
-        required: true,
-        certPath,
-        keyPath,
-        error: `gateway tls: key file exceeds ${GATEWAY_TLS_FILE_MAX_BYTES} bytes`,
-      };
-    }
-    if (caPath) {
-      const caStat = fs.statSync(caPath);
-      if (caStat.size > GATEWAY_TLS_FILE_MAX_BYTES) {
-        return {
-          enabled: false,
-          required: true,
-          certPath,
-          keyPath,
-          caPath,
-          error: `gateway tls: ca file exceeds ${GATEWAY_TLS_FILE_MAX_BYTES} bytes`,
-        };
-      }
-    }
-    const cert = await fsp.readFile(certPath, "utf8");
-    const key = await fsp.readFile(keyPath, "utf8");
-    const ca = caPath ? await fsp.readFile(caPath, "utf8") : undefined;
+    // Bound TLS material through the shared secret-file reader (pinned regular-file
+    // read + maxBytes) so pathname swaps / FIFOs cannot bypass a separate stat check.
+    const cert = readGatewayTlsFile({
+      filePath: certPath,
+      label: "cert",
+      maxBytes: GATEWAY_TLS_CERT_KEY_MAX_BYTES,
+    });
+    const key = readGatewayTlsFile({
+      filePath: keyPath,
+      label: "key",
+      maxBytes: GATEWAY_TLS_CERT_KEY_MAX_BYTES,
+    });
+    const ca = caPath
+      ? readGatewayTlsFile({
+          filePath: caPath,
+          label: "ca",
+          maxBytes: GATEWAY_TLS_CA_FILE_MAX_BYTES,
+        })
+      : undefined;
     const x509 = new X509Certificate(cert);
     const fingerprintSha256 = normalizeFingerprint(x509.fingerprint256 ?? "");
 
@@ -193,13 +199,17 @@ export async function loadGatewayTlsRuntime(
       },
     };
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     return {
       enabled: false,
       required: true,
       certPath,
       keyPath,
       caPath,
-      error: `gateway tls: failed to load cert (${String(err)})`,
+      // Preserve role-specific size errors from readGatewayTlsFile; wrap everything else.
+      error: message.startsWith("gateway tls:")
+        ? message
+        : `gateway tls: failed to load cert (${message})`,
     };
   }
 }

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -1,7 +1,8 @@
 // Gateway TLS runtime loads configured certificates or generates a local
 // self-signed pair, returning server-ready options plus client fingerprint.
 import { X509Certificate } from "node:crypto";
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import tls from "node:tls";
 import type { GatewayTlsConfig } from "../../config/types.gateway.js";
@@ -10,6 +11,8 @@ import { CONFIG_DIR, ensureDir, resolveUserPath, shortenHomeInString } from "../
 import { pathExists } from "../fs-safe.js";
 import { resolveSystemBin } from "../resolve-system-bin.js";
 import { normalizeFingerprint } from "./fingerprint.js";
+
+const GATEWAY_TLS_FILE_MAX_BYTES = 256 * 1024;
 
 // Gateway TLS runtime carries loaded cert material plus the normalized SHA-256
 // fingerprint advertised to clients.
@@ -63,8 +66,8 @@ async function generateSelfSignedCert(params: {
     ],
     { logOutput: false },
   );
-  await fs.chmod(params.keyPath, 0o600).catch(() => {});
-  await fs.chmod(params.certPath, 0o600).catch(() => {});
+  await fsp.chmod(params.keyPath, 0o600).catch(() => {});
+  await fsp.chmod(params.certPath, 0o600).catch(() => {});
   params.log?.info?.(
     `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
   );
@@ -125,9 +128,42 @@ export async function loadGatewayTlsRuntime(
   }
 
   try {
-    const cert = await fs.readFile(certPath, "utf8");
-    const key = await fs.readFile(keyPath, "utf8");
-    const ca = caPath ? await fs.readFile(caPath, "utf8") : undefined;
+    const certStat = fs.statSync(certPath);
+    if (certStat.size > GATEWAY_TLS_FILE_MAX_BYTES) {
+      return {
+        enabled: false,
+        required: true,
+        certPath,
+        keyPath,
+        error: `gateway tls: cert file exceeds ${GATEWAY_TLS_FILE_MAX_BYTES} bytes`,
+      };
+    }
+    const keyStat = fs.statSync(keyPath);
+    if (keyStat.size > GATEWAY_TLS_FILE_MAX_BYTES) {
+      return {
+        enabled: false,
+        required: true,
+        certPath,
+        keyPath,
+        error: `gateway tls: key file exceeds ${GATEWAY_TLS_FILE_MAX_BYTES} bytes`,
+      };
+    }
+    if (caPath) {
+      const caStat = fs.statSync(caPath);
+      if (caStat.size > GATEWAY_TLS_FILE_MAX_BYTES) {
+        return {
+          enabled: false,
+          required: true,
+          certPath,
+          keyPath,
+          caPath,
+          error: `gateway tls: ca file exceeds ${GATEWAY_TLS_FILE_MAX_BYTES} bytes`,
+        };
+      }
+    }
+    const cert = await fsp.readFile(certPath, "utf8");
+    const key = await fsp.readFile(keyPath, "utf8");
+    const ca = caPath ? await fsp.readFile(caPath, "utf8") : undefined;
     const x509 = new X509Certificate(cert);
     const fingerprintSha256 = normalizeFingerprint(x509.fingerprint256 ?? "");
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators enabling `gateway.tls` with `certPath` / `keyPath` / `caPath` could load arbitrarily large files into memory while preparing TLS options. A mistaken path could therefore allocate unbounded input before the gateway listener started.

## Why This Change Was Made

ClawSweeper re-review rejected the first approach (separate `stat` then `readFile`) because pathname swaps, FIFOs, and device-like inputs can bypass that check. This revision loads each TLS artifact through OpenClaw’s shared bounded secret-file reader (`readSecretFileSync`, `rejectHardlinks: false`), matching MCP client TLS (#110016) and managed proxy CA (#110032):

- cert / key: **64 KiB**
- CA bundle: **256 KiB** (upgrade-safe for multi-root trust bundles between those caps)

AI-assisted: yes. I inspected `loadGatewayTlsRuntime`, sibling MCP/proxy TLS bound-read PRs, `@openclaw/fs-safe` secret-file behavior, and the gateway TLS config contract before the change.

## User Impact

Normal gateway TLS cert/key/CA PEMs continue to load. Oversized cert/key/CA files fail closed with a clear role-specific size error before TLS options are built. Existing CA bundles up to 256 KiB remain accepted.

## Evidence

**Real-machine production-path proof (L3):** macOS `darwin 21.6.0 x64`, Node `v22.19.0`. Harness imported production `loadGatewayTlsRuntime`, auto-generated a real self-signed pair, started a real `tls.createServer` on localhost with the returned options, completed a TLS client connect, then proved oversized cert fail-closed and a >64 KiB / <256 KiB CA still loads.

```json
{
  "normal": {
    "enabled": true,
    "fingerprint": "820b014300c1485066f814f56b56a6a76fe0ba1629bfe269bee172bde25046bb",
    "listenerPort": 57956
  },
  "oversized": {
    "enabled": false,
    "error": "gateway tls: cert file exceeds 65536 bytes"
  },
  "largeCa": {
    "enabled": true,
    "caBytes": 66533
  }
}
```

| Layer | Result |
| --- | --- |
| L1 | `pnpm exec vitest run src/infra/tls/gateway.test.ts` → **12 passed** (normal load, oversized cert/key/ca, CA upgrade window, FIFO reject, missing/invalid paths) |
| L2 | Production loader uses `readSecretFileSync` with role caps; `FsSafeError` `too-large` → role-labelled error |
| L3 | Real TLS listener + oversized/CA cases above |
| Gate | `oxfmt` + `oxlint` on touched files — clean |

Head: `85b5ec9aded4e5a830473b9a4ba514f7c6de98b7`

```text
src/infra/tls/gateway.ts       role-specific bounded reads
src/infra/tls/gateway.test.ts  oversized + CA upgrade + non-regular coverage
```
