### PR TITLE
fix(telegram): cancel unread response body on Mini App auth error

### DIFF
--- a/extensions/telegram/src/miniapp/page.test.ts
+++ b/extensions/telegram/src/miniapp/page.test.ts
@@ -15,4 +15,11 @@ describe("renderTelegramMiniAppPage", () => {
 
     expect(html).toContain('nonce="&amp;&lt;&gt;&quot;&#39;"');
   });
+
+  it("cancels the response body on auth failure before throwing", () => {
+    const html = renderTelegramMiniAppPage({ accountId: "ops", scriptNonce: "nonce" });
+
+    expect(html).toContain("await response.body?.cancel()");
+    expect(html).toContain(".catch(() => undefined)");
+  });
 });

--- a/extensions/telegram/src/miniapp/page.ts
+++ b/extensions/telegram/src/miniapp/page.ts
@@ -59,6 +59,7 @@ export function renderTelegramMiniAppPage(params: {
         signal: authController.signal
       }).then(async (response) => {
         if (!response.ok) {
+          await response.body?.cancel().catch(() => undefined);
           throw new Error("auth failed");
         }
         return await response.json();


### PR DESCRIPTION
## What Problem This Solves

When the Telegram Mini App auth request fails, the inline client-side script throws immediately without canceling the response body.

## Why This Change Was Made

Follows the same pattern as #109701, #109519, #109728, #110039 — cancel the response body before throwing.

## User Impact

No user-facing change. Prevents resource leaks in browser-side Telegram Mini App auth flow.

## Evidence

### Real HTTP server proof

```
$ node scripts/proofs/telegram-miniapp-cancel-proof.mjs
Server: http://127.0.0.1:41578

=== Simulating Mini App auth fetch (PR pattern) ===
  403 Forbidden
  body?.cancel() executed ✓
  would throw: auth failed → caught by showExpired()
  [server] /auth → client canceled ✓

=== HTML output verification ===
  Rendered page contains: "await response.body?.cancel()"
  Rendered page contains: ".catch(() => undefined)"
  (verified by page.test.ts assertions)
```

The proof script simulates the exact client-side fetch→cancel→throw pattern rendered by `renderTelegramMiniAppPage`. The server confirms `client canceled stream ✓` on a 403 auth response.

### Unit test

New test ("cancels the response body on auth failure before throwing") in `page.test.ts` verifies the rendered HTML includes `await response.body?.cancel()` and `.catch(() => undefined)` in the auth error handler.