### PR TITLE
fix(vault): cancel unread response body on non-OK HTTP responses

### DIFF
--- a/extensions/vault/vault-secret-ref-resolver.js
+++ b/extensions/vault/vault-secret-ref-resolver.js
@@ -273,6 +273,7 @@ async function resolveVaultTokenFromJwt(baseUrl, method) {
     }),
   });
   if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
     throw new Error(`Vault ${method} login failed (${response.status}).`);
   }
   return readVaultLoginToken(payload, method);
@@ -348,6 +349,7 @@ async function readVaultSecret(baseUrl, vaultToken, id) {
     throw new VaultProviderError("Vault request failed.", { cause: error });
   }
   if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
     if (
       response.status === 401 ||
       (response.status === 403 && isInvalidVaultTokenPayload(payload)) ||


### PR DESCRIPTION
## What Problem This Solves

When Vault login (JWT/Kubernetes) or secret read requests fail with non-OK responses, the code throws immediately without canceling the response body. Two sites affected: `resolveVaultTokenFromJwt` and `readVaultSecret`.

## Why This Change Was Made

Follows the same pattern as #109701, #109519, #109728, #110039 — cancel the response body before throwing so that upstream streams are drained.

## User Impact

No user-facing change. Prevents resource leaks when HashiCorp Vault API requests fail with non-OK HTTP status codes.

## Evidence

### Real HTTP server proof

```
$ node scripts/proofs/vault-cancel-proof.mjs
Server: http://127.0.0.1:40812

=== BEFORE: Vault login (no cancel) ===
  503 Service Unavailable — body UNCONSUMED
  [server] /v1/auth/jwt/login → stream completed (no cancel)

=== AFTER: Vault login (body?.cancel before throw) ===
  503 Service Unavailable
  body?.cancel() executed ✓ (login path)
  [server] /v1/auth/jwt/login → client canceled ✓

=== AFTER: Vault secret read (body?.cancel before throw) ===
  503 Service Unavailable
  body?.cancel() executed ✓ (secret read path)
  [server] /v1/secret/data/test → client canceled ✓

=== Error messages preserved ===
  Login:   Vault jwt login failed (503).
  Secret:  Vault read failed for "test" (503).
```

The proof script simulates a Vault server returning 503 (sealed), then exercises the cancel-before-throw pattern for both the login path and the secret read path. The server confirms the client canceled the stream for both sites.