### PR TITLE
fix(apns): reject oversized private key files before JWT signing

### DIFF
--- a/src/infra/push-apns.auth.test.ts
+++ b/src/infra/push-apns.auth.test.ts
@@ -109,8 +109,62 @@ describe("push APNs auth and helper coverage", () => {
       expect(missingKey.error).toContain(
         `failed reading OPENCLAW_APNS_PRIVATE_KEY_PATH (${missingPath})`,
       );
+      expect(missingKey.error).toContain("file is missing or empty");
     }
   });
+
+  it("rejects oversized APNs private key files", async () => {
+    const { DEFAULT_SECRET_FILE_MAX_BYTES } = await import("./secret-file.js");
+    const dir = await makeTempDir();
+    const keyPath = path.join(dir, "oversized-key.p8");
+    await fs.writeFile(keyPath, "x".repeat(DEFAULT_SECRET_FILE_MAX_BYTES + 1), "utf8");
+
+    const resolved = await resolveApnsAuthConfigFromEnv({
+      OPENCLAW_APNS_TEAM_ID: "TEAM123",
+      OPENCLAW_APNS_KEY_ID: "KEY123",
+      OPENCLAW_APNS_PRIVATE_KEY_PATH: keyPath,
+    } as NodeJS.ProcessEnv);
+
+    expect(resolved.ok).toBe(false);
+    if (!resolved.ok) {
+      expect(resolved.error).toContain(
+        `failed reading OPENCLAW_APNS_PRIVATE_KEY_PATH (${keyPath})`,
+      );
+      expect(resolved.error).toContain("APNs private key file is too large");
+    }
+  });
+
+  it.runIf(process.platform !== "win32").each(["symlink", "hardlink"] as const)(
+    "preserves %s APNs private key files",
+    async (linkType) => {
+      const dir = await makeTempDir();
+      const targetPath = path.join(dir, "apns-key-target.p8");
+      const keyPath = path.join(dir, "apns-key.p8");
+      await fs.writeFile(
+        targetPath,
+        "-----BEGIN PRIVATE KEY-----\\nline-g\\nline-h\\n-----END PRIVATE KEY-----\n",
+        "utf8",
+      );
+      if (linkType === "symlink") {
+        await fs.symlink(targetPath, keyPath);
+      } else {
+        await fs.link(targetPath, keyPath);
+      }
+
+      const resolved = await resolveApnsAuthConfigFromEnv({
+        OPENCLAW_APNS_TEAM_ID: "TEAM123",
+        OPENCLAW_APNS_KEY_ID: "KEY123",
+        OPENCLAW_APNS_PRIVATE_KEY_PATH: keyPath,
+      } as NodeJS.ProcessEnv);
+
+      expect(resolved.ok).toBe(true);
+      if (resolved.ok) {
+        expect(resolved.value.privateKey).toBe(
+          "-----BEGIN PRIVATE KEY-----\nline-g\nline-h\n-----END PRIVATE KEY-----",
+        );
+      }
+    },
+  );
 
   it("clears only direct registrations without an environment override mismatch", () => {
     expect(

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -1,6 +1,6 @@
 // Manages APNs registration state and direct/relay push sending.
 import { createHash, createPrivateKey, sign as signJwt } from "node:crypto";
-import fs from "node:fs/promises";
+import { FsSafeError } from "@openclaw/fs-safe/errors";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -37,6 +37,7 @@ import {
   resolveApnsRelayConfigFromEnv,
   sendApnsRelayPush,
 } from "./push-apns.relay.js";
+import { tryReadSecretFileSync } from "./secret-file.js";
 
 export {
   clearApnsRegistrationIfCurrent,
@@ -226,17 +227,31 @@ export async function resolveApnsAuthConfigFromEnv(
     };
   }
   try {
-    const privateKey = normalizePrivateKey(await fs.readFile(keyPath, "utf8"));
+    // Bound credential reads like other secret files so a mistaken huge path cannot
+    // allocate unbounded memory into the APNs JWT signer. Symlink/hardlink layouts
+    // stay allowed for operator secret managers.
+    const fileValue = tryReadSecretFileSync(keyPath, "APNs private key", {
+      rejectHardlinks: false,
+    });
+    if (!fileValue) {
+      return {
+        ok: false,
+        error: `failed reading OPENCLAW_APNS_PRIVATE_KEY_PATH (${keyPath}): file is missing or empty`,
+      };
+    }
     return {
       ok: true,
       value: {
         teamId,
         keyId,
-        privateKey,
+        privateKey: normalizePrivateKey(fileValue),
       },
     };
   } catch (err) {
-    const message = formatErrorMessage(err);
+    const message =
+      err instanceof FsSafeError && err.code === "too-large"
+        ? "APNs private key file is too large"
+        : formatErrorMessage(err);
     return {
       ok: false,
       error: `failed reading OPENCLAW_APNS_PRIVATE_KEY_PATH (${keyPath}): ${message}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators configuring direct APNs auth with `OPENCLAW_APNS_PRIVATE_KEY_PATH` could load an arbitrarily large private-key file into memory before JWT signing. A mistaken or hostile path could therefore allocate unbounded input on every APNs auth resolve.

Related sibling hardening: #108321 / #108596 (bounded secret-file credential reads).

## Why This Change Was Made

APNs private-key path reads now use OpenClaw's existing pinned secret-file helper and its default credential size limit. Oversized files fail closed with a clear path-labelled error; missing/empty files keep an explicit failure; symlink and hardlink layouts stay allowed for operator secret managers (same contract as the 1Password token-file fix).

AI-assisted: yes. I inspected the production APNs auth resolver, auth tests, sibling secret-file / 1Password bounded-read pattern, and `@openclaw/fs-safe` secret-file defaults before the change.

## User Impact

Operators can continue using normal APNs `.p8` key files, including symlink or hardlink layouts, while oversized credential files are rejected before their contents reach the APNs JWT signer.

## Evidence

**Real-machine production-path proof (L3):** `Linux 4.19.112 x64`, Node `v24.13.1`. The harness directly imported production `resolveApnsAuthConfigFromEnv` from `src/infra/push-apns.ts` and resolved real on-disk files (no mocked reader).

### Before (`main` `90ab572582b`)

Oversized file (16385 bytes = `DEFAULT_SECRET_FILE_MAX_BYTES + 1`) was read in full:

```json
[
  { "scenario": "normal file", "ok": true, "fileBytes": 118, "privateKeyBytes": 118 },
  { "scenario": "oversized file (16385B)", "ok": true, "fileBytes": 16385, "privateKeyBytes": 16385 },
  { "scenario": "symlink to normal file", "ok": true, "fileBytes": 118, "privateKeyBytes": 118 },
  { "scenario": "hardlink to normal file", "ok": true, "fileBytes": 118, "privateKeyBytes": 118 },
  { "scenario": "missing file", "ok": false, "error": "ENOENT: no such file or directory" }
]
```

**Result: 4 ok, 1 failed (missing). Oversized file silently accepted.**

### After (PR tip `21f1a13f084`)

Oversized file fails closed before any private-key material is returned:

```json
[
  { "scenario": "normal file", "ok": true, "fileBytes": 118, "privateKeyBytes": 118 },
  { "scenario": "oversized file (16385B)", "ok": false, "error": "APNs private key file is too large" },
  { "scenario": "symlink to normal file", "ok": true, "fileBytes": 118, "privateKeyBytes": 118 },
  { "scenario": "hardlink to normal file", "ok": true, "fileBytes": 118, "privateKeyBytes": 118 },
  { "scenario": "missing file", "ok": false, "error": "file is missing or empty" }
]
```

**Result: 3 ok, 2 failed (oversized rejected with clear error, missing gives clearer message).**

### Terminal transcript

```
$ git checkout 90ab572582b  # main before fix
$ npx tsx ./proof-harness.ts
Normal key file: /tmp/apns-proof-xxx/normal.p8 (118 bytes)
Oversized file: /tmp/apns-proof-xxx/oversized.p8 (16385 bytes)
Symlink: /tmp/apns-proof-xxx/linked.p8 -> /tmp/apns-proof-xxx/normal.p8
Hardlink: /tmp/apns-proof-xxx/hardlinked.p8 -> /tmp/apns-proof-xxx/normal.p8
Missing file: /tmp/apns-proof-xxx/nonexistent.p8
Summary: 4 ok, 1 failed

$ git checkout 21f1a13f084  # PR tip after fix
$ npx tsx ./proof-harness.ts
Normal key file: /tmp/apns-proof-yyy/normal.p8 (118 bytes)
Oversized file: /tmp/apns-proof-yyy/oversized.p8 (16385 bytes)
Symlink: /tmp/apns-proof-yyy/linked.p8 -> /tmp/apns-proof-yyy/normal.p8
Hardlink: /tmp/apns-proof-yyy/hardlinked.p8 -> /tmp/apns-proof-yyy/normal.p8
Missing file: /tmp/apns-proof-yyy/nonexistent.p8
Summary: 3 ok, 2 failed
  FAIL: oversized file -> APNs private key file is too large
  FAIL: missing file -> file is missing or empty
```

### Coverage

| Layer | Result |
| --- | --- |
| L1 unit | `pnpm exec vitest run src/infra/push-apns.auth.test.ts` → **9 passed** (inline key, path key, missing/empty, oversized, symlink, hardlink, registration helpers) |
| L2 path | Production `resolveApnsAuthConfigFromEnv` calls `tryReadSecretFileSync(..., { rejectHardlinks: false })`; `FsSafeError` `too-large` → `APNs private key file is too large` |
| L3 live | Before/after real filesystem resolve above: oversized path accepted → rejected; symlink/hardlink paths still accepted |
| Lint/format | `pnpm exec oxfmt` + `pnpm exec oxlint` on touched files — clean |
| Scope | 2 files / +73 −4 vs `main` `90ab572582b`; tip `21f1a13f084` |

```text
src/infra/push-apns.ts            +19 -4
src/infra/push-apns.auth.test.ts  +54 -0
```