### PR TITLE
fix(config): reject gateway.port values above TCP port range

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2921,6 +2921,77 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
   });
 });
 
+describe("gateway.port out-of-range repair migrate", () => {
+  it("replaces gateway.port above TCP max with the default port", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 65_536 },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Replaced out-of-range gateway.port (65536) with default 18789. Valid TCP ports are 1–65535.",
+    ]);
+    expect(res.config?.gateway?.port).toBe(18789);
+  });
+
+  it("replaces gateway.port zero with the default port", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 0 },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Replaced out-of-range gateway.port (0) with default 18789. Valid TCP ports are 1–65535.",
+    ]);
+    expect(res.config?.gateway?.port).toBe(18789);
+  });
+
+  it("replaces negative gateway.port with the default port", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: -1 },
+    });
+
+    expect(res.changes.length).toBe(1);
+    expect(res.config?.gateway?.port).toBe(18789);
+  });
+
+  it("preserves valid gateway.port values", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 65_535 },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("preserves valid minimum gateway.port (1)", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 1 },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("preserves other gateway keys when replacing the port", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { port: 65_536, bind: "loopback" },
+    });
+
+    expect(res.config?.gateway).toEqual({ port: 18789, bind: "loopback" });
+    expect(res.changes.length).toBe(1);
+  });
+
+  it("is idempotent - second migration on repaired config produces no changes", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { port: 65_536 },
+    });
+    expect(first.changes.length).toBe(1);
+    expect(first.config?.gateway?.port).toBe(18789);
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
+  });
+});
+
 describe("legacy model compat migrate", () => {
   it("upgrades the retired xAI quality image slug without pinning active aliases", () => {
     const raw = {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -14,6 +14,14 @@ import {
 } from "../../../config/legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "../../../config/paths.js";
 
+const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "port"],
+  message:
+    'gateway.port is outside the valid TCP range (1–65535) and will be replaced with the default. Run "openclaw doctor --fix".',
+  match: (value) =>
+    typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 65_535,
+};
+
 const GATEWAY_BIND_RULE: LegacyConfigRule = {
   path: ["gateway", "bind"],
   message:
@@ -152,6 +160,30 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       gateway.bind = mapped;
       raw.gateway = gateway;
       changes.push(`Normalized gateway.bind "${escapeControlForLog(bindRaw)}" → "${mapped}".`);
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "gateway.port-oob-repair",
+    describe:
+      "Replace out-of-range gateway.port with the default to avoid post-schema-tightening startup failures",
+    legacyRules: [GATEWAY_PORT_OOB_RULE],
+    apply: (raw, changes) => {
+      const gateway = getRecord(raw.gateway);
+      if (!gateway || !Object.hasOwn(gateway, "port")) {
+        return;
+      }
+      const port = gateway.port;
+      // Replace the invalid value with the default port rather than deleting it
+      // so the gateway still binds to a known, working port after upgrade.
+      if (typeof port === "number" && Number.isInteger(port) && port >= 1 && port <= 65_535) {
+        return;
+      }
+      gateway.port = DEFAULT_GATEWAY_PORT;
+      raw.gateway = gateway;
+      changes.push(
+        `Replaced out-of-range gateway.port (${String(port)}) with default ${DEFAULT_GATEWAY_PORT}. ` +
+          "Valid TCP ports are 1–65535.",
+      );
     },
   }),
 ];

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -207,4 +207,30 @@ describe("config validation SecretRef policy guards", () => {
       expect(schemaIssue.message).not.toContain("webhookToken");
     }
   });
+
+  it("rejects gateway.port values outside the 1–65535 TCP range", () => {
+    // port 0 - not a valid TCP port
+    const zero = validateConfigObjectRaw({ gateway: { port: 0 } });
+    expect(zero.ok).toBe(false);
+    if (!zero.ok) {
+      const issue = requireIssue(zero.issues, "gateway.port");
+      expect(issue.message).toContain("expected number to be >=1");
+    }
+
+    // port 65536 - above TCP max
+    const above = validateConfigObjectRaw({ gateway: { port: 65_536 } });
+    expect(above.ok).toBe(false);
+    if (!above.ok) {
+      const issue = requireIssue(above.issues, "gateway.port");
+      expect(issue.message).toContain("expected number to be <=65535");
+    }
+
+    // port 65535 - valid TCP max
+    const validMax = validateConfigObjectRaw({ gateway: { port: 65_535 } });
+    expect(validMax.ok).toBe(true);
+
+    // port 1 - valid TCP min
+    const validMin = validateConfigObjectRaw({ gateway: { port: 1 } });
+    expect(validMin.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.gateway.test.ts
+++ b/src/config/zod-schema.gateway.test.ts
@@ -4,10 +4,10 @@ import { GatewayConfigSchema } from "./zod-schema.gateway.js";
 describe("GatewayConfigSchema port validation", () => {
   it("accepts a valid gateway port (1–65535)", () => {
     const result = GatewayConfigSchema.safeParse({ port: 8080 });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.port).toBe(8080);
+    if (!result.success) {
+      throw new Error("expected valid port 8080");
     }
+    expect(result.data.port).toBe(8080);
   });
 
   it("accepts port 1 (minimum valid TCP port)", () => {

--- a/src/config/zod-schema.gateway.test.ts
+++ b/src/config/zod-schema.gateway.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { GatewayConfigSchema } from "./zod-schema.gateway.js";
+
+describe("GatewayConfigSchema port validation", () => {
+  it("accepts a valid gateway port (1–65535)", () => {
+    const result = GatewayConfigSchema.safeParse({ port: 8080 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.port).toBe(8080);
+    }
+  });
+
+  it("accepts port 1 (minimum valid TCP port)", () => {
+    const result = GatewayConfigSchema.safeParse({ port: 1 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts port 65535 (maximum valid TCP port)", () => {
+    const result = GatewayConfigSchema.safeParse({ port: 65535 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects port 0 (below TCP range)", () => {
+    const result = GatewayConfigSchema.safeParse({ port: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects port 65536 (above TCP range)", () => {
+    const result = GatewayConfigSchema.safeParse({ port: 65536 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative port values", () => {
+    const result = GatewayConfigSchema.safeParse({ port: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer port values", () => {
+    const result = GatewayConfigSchema.safeParse({ port: 8080.5 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.gateway.test.ts
+++ b/src/config/zod-schema.gateway.test.ts
@@ -4,10 +4,11 @@ import { GatewayConfigSchema } from "./zod-schema.gateway.js";
 describe("GatewayConfigSchema port validation", () => {
   it("accepts a valid gateway port (1–65535)", () => {
     const result = GatewayConfigSchema.safeParse({ port: 8080 });
-    if (!result.success) {
-      throw new Error("expected valid port 8080");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // GatewayConfigSchema is optional at the top level, so data may be undefined.
+      expect(result.data?.port).toBe(8080);
     }
-    expect(result.data.port).toBe(8080);
   });
 
   it("accepts port 1 (minimum valid TCP port)", () => {

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -13,7 +13,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 export const GatewayConfigSchema = z
   .strictObject({
-    port: z.number().int().positive().optional(),
+    port: z.number().int().min(1).max(65_535).optional(),
     mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
     bind: z
       .union([


### PR DESCRIPTION
Closes #109293

## What Problem This Solves

Fixes an issue where `gateway.port` values outside the valid TCP range (1–65535) passed config validation. Invalid values like `0` or `65536` were silently ignored at runtime by `resolveGatewayPort`, creating a confusing gap between validation and actual behavior. After this PR, invalid ports are rejected at config-load time, and a Doctor migration automatically repairs existing configs with out-of-range values.

## Why This Change Was Made

The Zod schema for `gateway.port` used `z.number().int().positive().optional()` which only checked for a positive integer, missing the TCP upper bound. The sibling field `gateway.remote.remotePort` already had the correct constraint: `z.number().int().min(1).max(65_535).optional()`.

This change aligns `gateway.port` validation with `gateway.remote.remotePort` and adds a Doctor migration that replaces out-of-range values with the default port (18789) rather than deleting the key — so the gateway still binds to a known working port after upgrade.

## User Impact

- **Fresh configs**: invalid port values are rejected at config-load time with a descriptive error.
- **Existing configs**: `openclaw doctor --fix` automatically replaces out-of-range `gateway.port` values with the default (18789) and logs a change message. The gateway then uses the default port, which matches the previous runtime fallback behavior.
- **Upgrade safety**: validated by Doctor migration + raw validation integration tests.

## Evidence

### 1. Schema validation — BEFORE vs AFTER

**BEFORE** (current main) — `gateway.port: 65536` passed validation with `ok: true`

**AFTER** — `gateway.port: 65536` is rejected:

```sh
$ node --import tsx -e "
import { validateConfigObjectRaw } from ./src/config/validation.ts;
console.log(JSON.stringify(validateConfigObjectRaw({gateway:{port:65536}}), null, 2));"
{
  "ok": false,
  "issues": [{
    "path": "gateway.port",
    "message": "Too big: expected number to be <=65535 (maximum: 65535)"
  }]
}
```

`gateway.port: 0` — rejected:
```
"Too small: expected number to be >=1 (minimum: 1)"
```

`gateway.port: 65535` and `gateway.port: 1` — accepted.

### 2. Doctor migration — upgrade path proof

**port 65536** — replaced with default 18789:
```
changes: ["Replaced out-of-range gateway.port (65536) with default 18789. Valid TCP ports are 1–65535."]
next: {"gateway":{"port":18789}}
```

**port 0** — replaced with default 18789:
```
changes: ["Replaced out-of-range gateway.port (0) with default 18789. Valid TCP ports are 1–65535."]
next: {"gateway":{"port":18789}}
```

**port 65535 (valid)** — no migration triggered, no changes.

**port 65536 + bind:loopback** — port replaced, bind preserved:
```
changes: ["Replaced out-of-range gateway.port (65536) with default 18789..."]
next: {"gateway":{"port":18789,"bind":"loopback"}}
```

**Idempotency** — second migration on repaired config produces no changes.

### 3. Test results

- `node scripts/run-vitest.mjs src/config/zod-schema.gateway.test.ts` — 7 schema boundary tests passed
- `node scripts/run-vitest.mjs src/config/validation.policy.test.ts` — 8 policy tests passed (1 new)
- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts` — 158 tests passed (7 new)
- `git diff --check` passed