### PR TITLE
fix(imessage): keep fast progress out of chat

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -188,6 +188,10 @@ describe("iMessage monitor last-route updates", () => {
       };
       params.replyOptions?.onTypingController?.(typingController);
       await params.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params.replyOptions?.onToolResult?.({
+        text: "💨Fast: auto-off(75s>=60s)",
+        channelData: { openclawProgressKind: "fast-mode-auto" },
+      });
       typingController.markRunComplete();
       typingController.markDispatchIdle();
       return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
@@ -275,6 +279,10 @@ describe("iMessage monitor last-route updates", () => {
       expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
       expect(params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
       expect(params.replyOptions?.onToolStart).toBeUndefined();
+      await params.replyOptions?.onToolResult?.({
+        text: "💨Fast: auto-off(75s>=60s)",
+        channelData: { openclawProgressKind: "fast-mode-auto" },
+      });
       return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
     });
 

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -188,7 +188,9 @@ describe("iMessage monitor last-route updates", () => {
       };
       params.replyOptions?.onTypingController?.(typingController);
       await params.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params.replyOptions?.onToolResult?.({
+      const onToolResult = params.replyOptions?.onToolResult;
+      expect(onToolResult).toBeTypeOf("function");
+      await onToolResult?.({
         text: "💨Fast: auto-off(75s>=60s)",
         channelData: { openclawProgressKind: "fast-mode-auto" },
       });
@@ -279,7 +281,9 @@ describe("iMessage monitor last-route updates", () => {
       expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
       expect(params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
       expect(params.replyOptions?.onToolStart).toBeUndefined();
-      await params.replyOptions?.onToolResult?.({
+      const onToolResult = params.replyOptions?.onToolResult;
+      expect(onToolResult).toBeTypeOf("function");
+      await onToolResult?.({
         text: "💨Fast: auto-off(75s>=60s)",
         channelData: { openclawProgressKind: "fast-mode-auto" },
       });
@@ -348,6 +352,7 @@ describe("iMessage monitor last-route updates", () => {
       expect.objectContaining({ typing: true }),
       expect.anything(),
     );
+    expect(client.request).not.toHaveBeenCalledWith("send", expect.anything(), expect.anything());
   });
 
   it("starts direct typing before dispatching the inbound turn", async () => {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1423,6 +1423,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             directTypingController = typing;
             typingReplyOptions.onTypingController?.(typing);
           },
+          // Keep the channel-owned progress lane present even when private-API
+          // typing is unavailable. Fast-mode notices are then consumed here
+          // instead of falling back to a durable iMessage bubble.
+          onToolResult: async () => {
+            await directTypingController?.startTypingLoop();
+          },
           ...(supportsTyping
             ? {
                 onToolStart: async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iMessage users would receive transient fast-mode status notices, such as `💨Fast: auto-off(...)`, as permanent chat bubbles when the agent crossed the automatic fast-mode threshold.

## Why This Change Was Made

iMessage already uses a channel-owned native typing lane for tool progress, but it did not register the tool-result callback that consumes fast-mode notices through that lane. This adds the missing callback at the iMessage boundary, preserving the shared fallback behavior for channels that intentionally deliver these notices.

## User Impact

iMessage conversations no longer retain standalone fast-mode auto-on or auto-off status bubbles. Native typing remains the progress surface when the installed bridge supports it, and normal assistant replies are unchanged.

## Maintainer Policy Decision

Automatic fast-mode notices are internal, transient progress rather than durable user-facing conversation content. Other channels also keep these notices on channel-owned transient progress surfaces when those surfaces are active. For iMessage, the native typing bubble is the appropriate status surface. When native typing is unavailable, showing no transient status is preferable to permanently writing an internal fast-mode lifecycle notice into chat history.

This iMessage-specific behavior is intentional and accepted for landing. Channels that deliberately expose a durable fallback continue to use the shared delivery behavior unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor.last-route.test.ts` (34 tests passed)
- Regression coverage requires the iMessage `onToolResult` callback in both typing-capable and typing-unavailable paths.
- The typing-unavailable regression verifies the fast-mode progress callback does not issue an iMessage `send` request.
- Deterministic PR-build cutoff proof: `fastAutoOnSeconds=1`, first model response after `2231ms`, one successful real `read` tool boundary, final `proof-ok`.
- Focused monitor-path rerun: both typing-capable and typing-unavailable cutoff cases passed (2 passed, 32 skipped).
- Redacted proof bundle: https://github.com/openclaw/openclaw/pull/110052#issuecomment-5004858517
- Inspectable redacted Messages capture: https://github.com/openclaw/openclaw/pull/110052#issuecomment-5013290570
- On-device post-run bridge check: v2 ready, advanced features, typing indicators, and read receipts all true; exactly one prod gateway and one prod `imsg rpc`.
- Fresh repo-native autoreview: no accepted or actionable findings.
- Local ClawSweeper committed-range review: no blocking findings, patch correct with 0.96 confidence.
- Rebased onto current `origin/main`; the reviewed patch ID remained unchanged and the focused suite passed again.

## ClawSweeper Status

ClawSweeper accepted the exact-head bridge-backed screenshot as sufficient real behavior proof, rated proof and patch `🐚 platinum hermit`, and marked the PR ready for maintainer review with no remaining contributor-facing blocker. The maintainer policy decision above is accepted.

Latest durable review: https://github.com/openclaw/openclaw/pull/110052#issuecomment-5004501875

AI-assisted: yes. I reviewed the implementation and validation results.

### Live bridge-backed inbound proof

Exact PR head tested: `e26d91c5ecf1f664c6c5b19a92dc1c3c444f95b0`. The exact PR build handled the inbound iMessage through Homebrew `imsg` `0.13.1`, bridge v2, with advanced features enabled.

Inbound message:

```text
Run the exec tool once with sleep 65; printf ready. After it returns, reply exactly proof-ok.
```

Redacted delivery evidence:

```text
2026-07-18 12:16:08 inbound message length=94
2026-07-18 12:18:09 Codex app-server turn released after terminal dynamic tool result
2026-07-18 12:18:09 outbound assistant message proof-ok
```

The Messages transcript showed the normal `proof-ok` reply and no `Fast: auto-off(...)` or `Fast: auto-on` bubble between the inbound prompt and final reply. Production was restored afterward on gateway `18789` with exactly one Homebrew `imsg rpc`.

The duplicate visible `proof-ok` was caused by the proof handoff: production replayed the shared inbound row after restoration. It was not a second fast-progress emission.
