### PR TITLE
fix(transcripts): imported text can inject terminal escapes through transcripts show

### DIFF
--- a/src/agents/tools/transcripts-tool.test.ts
+++ b/src/agents/tools/transcripts-tool.test.ts
@@ -110,7 +110,7 @@ describe("transcripts tool", () => {
       startupSignal = request.abortSignal;
       emitAfterStart = async () => {
         await request.onUtterance({
-          text: "captured after the start action completed",
+          text: "captured after the start action completed\nsecond\tcolumn",
           final: true,
         });
       };
@@ -146,13 +146,19 @@ describe("transcripts tool", () => {
         path.join(stateDir, "transcripts", currentDateDir(), "ongoing-meeting", "transcript.jsonl"),
         "utf8",
       ),
-    ).resolves.toContain("captured after the start action completed");
+    ).resolves.toContain("captured after the start action completed\\nsecond\\tcolumn");
     await tool.execute(
       "call-2",
       { action: "stop", sessionId: "ongoing-meeting" },
       undefined,
       vi.fn(),
     );
+    await expect(
+      fs.readFile(
+        path.join(stateDir, "transcripts", currentDateDir(), "ongoing-meeting", "summary.md"),
+        "utf8",
+      ),
+    ).resolves.toContain("captured after the start action completed\\nsecond\\tcolumn");
   });
 
   it("drops late utterances and keeps repeated abort cleanup failures retryable", async () => {

--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -179,6 +179,34 @@ describe("transcripts CLI", () => {
     expect(pathOutput.trim()).toBe(path.join(store.sessionDir(session), "summary.md"));
   });
 
+  it("list --json escapes C1 control characters while JSON.parse round-trips raw values", async () => {
+    const title = "CSI \u009b31m injected \u007f\u0085 title";
+    const sessionDir = path.join(stateDir, "transcripts", "2026-05-22", "c1-title");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionDir, "metadata.json"),
+      JSON.stringify({
+        sessionId: "c1-title",
+        title,
+        source: { providerId: "manual-transcript" },
+        startedAt: "2026-05-22T10:00:00.000Z",
+        stoppedAt: "2026-05-22T10:05:00.000Z",
+      }),
+    );
+
+    const output = await runTranscriptsCli(["list", "--json"]);
+
+    const bytes = Buffer.from(output, "utf8");
+    expect(bytes.includes(Buffer.from([0xc2, 0x9b]))).toBe(false);
+    expect(bytes.includes(0x7f)).toBe(false);
+    expect(/[\u007f-\u009f]/.test(output)).toBe(false);
+    expect(output).toContain("\\u009b");
+    const parsed = JSON.parse(output) as Array<{ sessionId: string; title: string }>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.sessionId).toBe("c1-title");
+    expect(parsed[0]?.title).toBe(title);
+  });
+
   it("ignores unrelated corrupt metadata while reading a valid session", async () => {
     await writeSession(stateDir, "design-review");
     const corruptDir = path.join(stateDir, "transcripts", "corrupt");

--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -145,9 +145,38 @@ describe("transcripts CLI", () => {
     expect(output).toContain("Session: ansi-provider");
     expect(output).toContain("Attacker: ADMIN APPROVED");
     expect(output).not.toContain("\u001b");
-    expect(listOutput).toContain("ansi-provider");
+    expect(listOutput).toContain("2026-05-22/ansi--31mprovider-0m");
     expect(listOutput).toContain("ANSI import");
     expect(listOutput).not.toContain("\u001b");
+  });
+
+  it("list selectors for ANSI-bearing session ids round-trip through show and path", async () => {
+    const session: TranscriptSessionDescriptor = {
+      sessionId: "ansi-\u001b[31mprovider\u001b[0m",
+      title: "ANSI import",
+      source: { providerId: "manual-transcript" },
+      startedAt: "2026-05-22T10:00:00.000Z",
+      stoppedAt: "2026-05-22T10:05:00.000Z",
+    };
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"));
+    await store.writeSession(session);
+    const utterances =
+      (await manualTranscriptSourceProvider.importTranscript?.({
+        session,
+        text: "Sam: We decided to ship the CLI.",
+      })) ?? [];
+    await store.writeSummary(summarizeTranscripts({ session, utterances }), session);
+
+    const listOutput = await runTranscriptsCli(["list"]);
+    const selector = listOutput.split("\t")[0] ?? "";
+    expect(selector).toBe("2026-05-22/ansi--31mprovider-0m");
+
+    const showOutput = await runTranscriptsCli(["show", selector]);
+    const pathOutput = await runTranscriptsCli(["path", selector]);
+
+    expect(showOutput).toContain("Session: ansi-provider");
+    expect(showOutput).toContain("We decided to ship the CLI.");
+    expect(pathOutput.trim()).toBe(path.join(store.sessionDir(session), "summary.md"));
   });
 
   it("ignores unrelated corrupt metadata while reading a valid session", async () => {

--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -105,10 +105,23 @@ describe("transcripts CLI", () => {
     expect(output).toContain("Ship CLI");
   });
 
+  it("sanitizes summaries created before the upgrade at the show boundary", async () => {
+    const sessionDir = await writeSession(stateDir, "legacy-summary");
+    await fs.writeFile(
+      path.join(sessionDir, "summary.md"),
+      "# Legacy\n\n- first\tcolumn\n- \u001b[2J\u001b[31mADMIN APPROVED\u001b[0m\n",
+    );
+
+    const output = await runTranscriptsCli(["show", "legacy-summary"]);
+
+    expect(output).toContain("# Legacy\n\n- first\\tcolumn\n- ADMIN APPROVED\n");
+    expect(output).not.toContain("\u001b");
+  });
+
   it("show prints imported summaries without terminal control bytes", async () => {
     const session: TranscriptSessionDescriptor = {
-      sessionId: "ansi-import",
-      title: "ANSI import",
+      sessionId: "ansi-\u001b[31mprovider\u001b[0m",
+      title: "\u001b[31mANSI import\u001b[0m",
       source: { providerId: "manual-transcript" },
       startedAt: "2026-05-22T10:00:00.000Z",
       stoppedAt: "2026-05-22T10:05:00.000Z",
@@ -118,17 +131,23 @@ describe("transcripts CLI", () => {
     const utterances =
       (await manualTranscriptSourceProvider.importTranscript?.({
         session,
-        text: "Attacker: \u001b[2J\u001b[31mADMIN APPROVED\u001b[0m",
+        text: "\u001b[31mAttacker\u001b[0m: \u001b[2J\u001b[31mADMIN APPROVED\u001b[0m",
       })) ?? [];
     for (const utterance of utterances) {
       await store.appendUtteranceForSession(session, utterance);
     }
     await store.writeSummary(summarizeTranscripts({ session, utterances }), session);
 
-    const output = await runTranscriptsCli(["show", "ansi-import"]);
+    const output = await runTranscriptsCli(["show", session.sessionId]);
+    const listOutput = await runTranscriptsCli(["list"]);
 
+    expect(output).toContain("# ANSI import");
+    expect(output).toContain("Session: ansi-provider");
     expect(output).toContain("Attacker: ADMIN APPROVED");
     expect(output).not.toContain("\u001b");
+    expect(listOutput).toContain("ansi-provider");
+    expect(listOutput).toContain("ANSI import");
+    expect(listOutput).not.toContain("\u001b");
   });
 
   it("ignores unrelated corrupt metadata while reading a valid session", async () => {

--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -4,6 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { manualTranscriptSourceProvider } from "../../transcripts/manual-source.js";
+import type { TranscriptSessionDescriptor } from "../../transcripts/provider-types.js";
+import { TranscriptsStore } from "../../transcripts/store.js";
+import { summarizeTranscripts } from "../../transcripts/summary.js";
 import { registerTranscriptsCli } from "./register.transcripts.js";
 
 const originalStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -99,6 +103,32 @@ describe("transcripts CLI", () => {
 
     expect(output).toContain("# Design review");
     expect(output).toContain("Ship CLI");
+  });
+
+  it("show prints imported summaries without terminal control bytes", async () => {
+    const session: TranscriptSessionDescriptor = {
+      sessionId: "ansi-import",
+      title: "ANSI import",
+      source: { providerId: "manual-transcript" },
+      startedAt: "2026-05-22T10:00:00.000Z",
+      stoppedAt: "2026-05-22T10:05:00.000Z",
+    };
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"));
+    await store.writeSession(session);
+    const utterances =
+      (await manualTranscriptSourceProvider.importTranscript?.({
+        session,
+        text: "Attacker: \u001b[2J\u001b[31mADMIN APPROVED\u001b[0m",
+      })) ?? [];
+    for (const utterance of utterances) {
+      await store.appendUtteranceForSession(session, utterance);
+    }
+    await store.writeSummary(summarizeTranscripts({ session, utterances }), session);
+
+    const output = await runTranscriptsCli(["show", "ansi-import"]);
+
+    expect(output).toContain("Attacker: ADMIN APPROVED");
+    expect(output).not.toContain("\u001b");
   });
 
   it("ignores unrelated corrupt metadata while reading a valid session", async () => {

--- a/src/cli/program/register.transcripts.ts
+++ b/src/cli/program/register.transcripts.ts
@@ -73,7 +73,12 @@ function writeLine(value: string): void {
 }
 
 function writeJson(value: unknown): void {
-  writeLine(JSON.stringify(value, null, 2));
+  writeLine(
+    JSON.stringify(value, null, 2).replace(
+      /[\u007f-\u009f]/g,
+      (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`,
+    ),
+  );
 }
 
 function isNodeError(err: unknown, code: string): boolean {

--- a/src/cli/program/register.transcripts.ts
+++ b/src/cli/program/register.transcripts.ts
@@ -3,6 +3,7 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Command } from "commander";
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TranscriptSessionDescriptor } from "../../transcripts/provider-types.js";
@@ -211,10 +212,15 @@ async function listStoredSessions(): Promise<StoredTranscriptsSession[]> {
 }
 
 function formatSessionLine(entry: StoredTranscriptsSession): string {
-  const title = entry.session.title?.trim() || "Transcripts";
-  const started = entry.session.startedAt || "unknown";
-  const summary = entry.hasSummary ? entry.summaryPath : "no summary.md";
-  return `${formatSelector(entry)}\t${started}\t${title}\t${summary}`;
+  const title = sanitizeTerminalText(entry.session.title?.trim() || "Transcripts");
+  const started = sanitizeTerminalText(entry.session.startedAt || "unknown");
+  const summary = sanitizeTerminalText(entry.hasSummary ? entry.summaryPath : "no summary.md");
+  return `${sanitizeTerminalText(formatSelector(entry))}\t${started}\t${title}\t${summary}`;
+}
+
+function sanitizeMarkdownForTerminal(markdown: string): string {
+  // Preserve the artifact's document structure while making every rendered line terminal-safe.
+  return markdown.split("\n").map(sanitizeTerminalText).join("\n");
 }
 
 async function listCommand(options: TranscriptsCliOptions): Promise<void> {
@@ -261,7 +267,7 @@ async function showCommand(sessionId: string, options: TranscriptsCliOptions): P
   if (!session.hasSummary) {
     throw new Error(`summary.md not found for transcripts session: ${sessionId}`);
   }
-  process.stdout.write(await fs.readFile(session.summaryPath, "utf8"));
+  process.stdout.write(sanitizeMarkdownForTerminal(await fs.readFile(session.summaryPath, "utf8")));
 }
 
 async function pathCommand(selector: string, options: TranscriptsPathOptions): Promise<void> {

--- a/src/cli/program/register.transcripts.ts
+++ b/src/cli/program/register.transcripts.ts
@@ -57,7 +57,7 @@ function readDateFromSessionDir(sessionDirValue: string): string {
 }
 
 function formatSelector(entry: StoredTranscriptsSession): string {
-  return `${entry.date}/${entry.session.sessionId}`;
+  return `${entry.date}/${safeSegment(entry.session.sessionId)}`;
 }
 
 function parseQualifiedSelector(selector: string): { date: string; sessionId: string } | null {
@@ -157,7 +157,7 @@ function assertRequestedSession(
   entry: StoredTranscriptsSession,
   sessionId: string,
 ): StoredTranscriptsSession {
-  if (entry.session.sessionId !== sessionId) {
+  if (entry.session.sessionId !== sessionId && safeSegment(entry.session.sessionId) !== sessionId) {
     throw new Error(
       `transcripts metadata mismatch for ${sessionId}: found ${entry.session.sessionId}`,
     );
@@ -181,7 +181,10 @@ async function requireStoredSession(selector: string): Promise<StoredTranscripts
     return assertRequestedSession(session, selector);
   }
   const sessions = await listStoredSessions();
-  const matches = sessions.filter((entry) => entry.session.sessionId === selector);
+  const matches = sessions.filter(
+    (entry) =>
+      entry.session.sessionId === selector || safeSegment(entry.session.sessionId) === selector,
+  );
   if (matches.length === 1 && matches[0]) {
     return assertRequestedSession(matches[0], selector);
   }
@@ -215,11 +218,10 @@ function formatSessionLine(entry: StoredTranscriptsSession): string {
   const title = sanitizeTerminalText(entry.session.title?.trim() || "Transcripts");
   const started = sanitizeTerminalText(entry.session.startedAt || "unknown");
   const summary = sanitizeTerminalText(entry.hasSummary ? entry.summaryPath : "no summary.md");
-  return `${sanitizeTerminalText(formatSelector(entry))}\t${started}\t${title}\t${summary}`;
+  return `${formatSelector(entry)}\t${started}\t${title}\t${summary}`;
 }
 
 function sanitizeMarkdownForTerminal(markdown: string): string {
-  // Preserve the artifact's document structure while making every rendered line terminal-safe.
   return markdown.split("\n").map(sanitizeTerminalText).join("\n");
 }
 

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -16,6 +16,7 @@ vi.mock("node:fs", async (importOriginal) => {
 import { listOpenFileDescriptorsForPath } from "../../src/infra/open-file-descriptors.test-support.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { TranscriptsStore } from "./store.js";
+import { summarizeTranscripts } from "./summary.js";
 
 const tempRoots: string[] = [];
 
@@ -136,5 +137,36 @@ describe("TranscriptsStore.readUtterancesFromSessionDir", () => {
     await expect(
       store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 }),
     ).rejects.toThrow("read failed");
+  });
+});
+
+describe("TranscriptsStore.writeSummary", () => {
+  afterEach(() => {
+    cleanupTempDirs(tempRoots);
+  });
+
+  it("stores the summary in the existing session directory without a session descriptor", async () => {
+    const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+    const store = new TranscriptsStore(tmpDir);
+    const session = {
+      sessionId: "ansi-\u001b[31mprovider\u001b[0m",
+      title: "ANSI import",
+      source: { providerId: "manual-transcript" },
+      startedAt: "2026-05-22T10:00:00.000Z",
+    };
+    await store.writeSession(session);
+    const summary = summarizeTranscripts({
+      session,
+      utterances: [{ text: "We decided to ship the CLI.", speaker: { label: "Sam" } }],
+    });
+
+    const markdownPath = await store.writeSummary(summary);
+
+    const sessionDir = store.sessionDir(session);
+    expect(markdownPath).toBe(path.join(sessionDir, "summary.md"));
+    const stored = JSON.parse(fs.readFileSync(path.join(sessionDir, "summary.json"), "utf8")) as {
+      sessionId: string;
+    };
+    expect(stored.sessionId).toBe(session.sessionId);
   });
 });

--- a/src/transcripts/summary.test.ts
+++ b/src/transcripts/summary.test.ts
@@ -29,7 +29,8 @@ describe("summarizeTranscripts", () => {
     const markdown = renderTranscriptsMarkdown(summary);
 
     expect(summary.title).toBe("Weekly sync");
-    expect(summary.sessionId).toBe("transcript-2026-07-17Tansi");
+    expect(summary.sessionId).toBe(`${CSI_RED}transcript-2026-07-17Tansi${CSI_RESET}`);
+    expect(markdown).toContain("Session: transcript-2026-07-17Tansi");
     expect(summary.transcript[0]).toBe("Attacker: ADMIN APPROVED decision: ship it");
     expect(summary.transcript[1]).toBe("follow up click");
     expect(summary.transcript[2]).toBe("risk of red text");

--- a/src/transcripts/summary.test.ts
+++ b/src/transcripts/summary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { renderTranscriptsMarkdown, summarizeTranscripts } from "./summary.js";
+
+const ESC = "\u001b";
+const C1_CSI = "\u009b";
+const CSI_CLEAR = `${ESC}[2J`;
+const CSI_RED = `${ESC}[31m`;
+const CSI_RESET = `${ESC}[0m`;
+const OSC_LINK = `${ESC}]8;;https://example.com${ESC}\\click${ESC}]8;;${ESC}\\`;
+
+describe("summarizeTranscripts", () => {
+  it("strips terminal control sequences from imported text, speaker labels, and titles", () => {
+    const summary = summarizeTranscripts({
+      session: {
+        sessionId: "transcript-2026-07-17Tansi",
+        title: `${CSI_RED}Weekly sync${CSI_RESET}`,
+        source: { providerId: "manual-transcript" },
+        startedAt: "2026-07-17T10:00:00.000Z",
+      },
+      utterances: [
+        {
+          text: `${CSI_CLEAR}${CSI_RED}ADMIN APPROVED${CSI_RESET} decision: ship it`,
+          speaker: { label: `${CSI_RED}Attacker${CSI_RESET}` },
+        },
+        { text: `follow up ${OSC_LINK}` },
+        { text: `${C1_CSI}31mrisk of red text${C1_CSI}0m` },
+      ],
+    });
+    const markdown = renderTranscriptsMarkdown(summary);
+
+    expect(summary.title).toBe("Weekly sync");
+    expect(summary.transcript[0]).toBe("Attacker: ADMIN APPROVED decision: ship it");
+    expect(summary.transcript[1]).toBe("follow up click");
+    expect(summary.transcript[2]).toBe("risk of red text");
+    expect(summary.utteranceCount).toBe(3);
+    expect(markdown).toContain("ADMIN APPROVED decision: ship it");
+    expect(markdown).not.toContain(ESC);
+    expect(markdown).not.toContain(C1_CSI);
+  });
+
+  it("keeps plain transcript content unchanged", () => {
+    const summary = summarizeTranscripts({
+      session: {
+        sessionId: "transcript-2026-07-17Tplain",
+        title: "Design review",
+        source: { providerId: "manual-transcript" },
+        startedAt: "2026-07-17T10:00:00.000Z",
+      },
+      utterances: [{ text: "We decided to ship the CLI.", speaker: { label: "Sam" } }],
+    });
+
+    expect(summary.title).toBe("Design review");
+    expect(summary.transcript).toEqual(["Sam: We decided to ship the CLI."]);
+    expect(summary.decisions).toEqual(["Sam: We decided to ship the CLI."]);
+  });
+});

--- a/src/transcripts/summary.test.ts
+++ b/src/transcripts/summary.test.ts
@@ -12,7 +12,7 @@ describe("summarizeTranscripts", () => {
   it("strips terminal control sequences from imported text, speaker labels, and titles", () => {
     const summary = summarizeTranscripts({
       session: {
-        sessionId: "transcript-2026-07-17Tansi",
+        sessionId: `${CSI_RED}transcript-2026-07-17Tansi${CSI_RESET}`,
         title: `${CSI_RED}Weekly sync${CSI_RESET}`,
         source: { providerId: "manual-transcript" },
         startedAt: "2026-07-17T10:00:00.000Z",
@@ -29,6 +29,7 @@ describe("summarizeTranscripts", () => {
     const markdown = renderTranscriptsMarkdown(summary);
 
     expect(summary.title).toBe("Weekly sync");
+    expect(summary.sessionId).toBe("transcript-2026-07-17Tansi");
     expect(summary.transcript[0]).toBe("Attacker: ADMIN APPROVED decision: ship it");
     expect(summary.transcript[1]).toBe("follow up click");
     expect(summary.transcript[2]).toBe("risk of red text");
@@ -52,5 +53,20 @@ describe("summarizeTranscripts", () => {
     expect(summary.title).toBe("Design review");
     expect(summary.transcript).toEqual(["Sam: We decided to ship the CLI."]);
     expect(summary.decisions).toEqual(["Sam: We decided to ship the CLI."]);
+  });
+
+  it("renders live-provider line breaks and tabs visibly in single-line summary fields", () => {
+    const text = "first line\nsecond\tcolumn";
+    const summary = summarizeTranscripts({
+      session: {
+        sessionId: "live-captions",
+        source: { providerId: "live-caption", kind: "live-caption" },
+        startedAt: "2026-07-17T10:00:00.000Z",
+      },
+      utterances: [{ text, speaker: { label: "Sam\tHost" } }],
+    });
+
+    expect(summary.transcript).toEqual(["Sam\\tHost: first line\\nsecond\\tcolumn"]);
+    expect(text).toBe("first line\nsecond\tcolumn");
   });
 });

--- a/src/transcripts/summary.ts
+++ b/src/transcripts/summary.ts
@@ -78,7 +78,7 @@ export function summarizeTranscripts(params: {
   const utterances = params.utterances.map(sanitizeUtterance);
   const overview = firstSentences(utterances, 4) || "No transcript captured yet.";
   return {
-    sessionId: sanitizeTerminalText(params.session.sessionId),
+    sessionId: params.session.sessionId,
     title,
     generatedAt: new Date().toISOString(),
     overview,
@@ -100,7 +100,7 @@ export function renderTranscriptsMarkdown(summary: TranscriptsSummary): string {
     `# ${summary.title}`,
     "",
     `Generated: ${summary.generatedAt}`,
-    `Session: ${summary.sessionId}`,
+    `Session: ${sanitizeTerminalText(summary.sessionId)}`,
     "",
     "## Overview",
     summary.overview,

--- a/src/transcripts/summary.ts
+++ b/src/transcripts/summary.ts
@@ -1,5 +1,6 @@
 // Builds transcript summaries and normalized transcript metadata.
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import type { TranscriptSessionDescriptor, TranscriptUtterance } from "./provider-types.js";
 
 /**
@@ -41,6 +42,14 @@ function collectMatches(utterances: TranscriptUtterance[], pattern: RegExp): str
     .slice(0, 12);
 }
 
+function sanitizeUtterance(utterance: TranscriptUtterance): TranscriptUtterance {
+  const sanitized: TranscriptUtterance = { ...utterance, text: sanitizeForLog(utterance.text) };
+  if (utterance.speaker) {
+    sanitized.speaker = { ...utterance.speaker, label: sanitizeForLog(utterance.speaker.label) };
+  }
+  return sanitized;
+}
+
 function formatSpeakerLine(utterance: TranscriptUtterance): string {
   const text = utterance.text.trim();
   if (!text) {
@@ -59,17 +68,18 @@ export function summarizeTranscripts(params: {
   session: TranscriptSessionDescriptor;
   utterances: TranscriptUtterance[];
 }): TranscriptsSummary {
-  const title = params.session.title?.trim() || "Transcripts";
-  const overview = firstSentences(params.utterances, 4) || "No transcript captured yet.";
+  const title = sanitizeForLog(params.session.title ?? "").trim() || "Transcripts";
+  const utterances = params.utterances.map(sanitizeUtterance);
+  const overview = firstSentences(utterances, 4) || "No transcript captured yet.";
   return {
     sessionId: params.session.sessionId,
     title,
     generatedAt: new Date().toISOString(),
     overview,
-    transcript: formatTranscript(params.utterances),
-    decisions: collectMatches(params.utterances, DECISION_PATTERNS),
-    actionItems: collectMatches(params.utterances, ACTION_PATTERNS),
-    risks: collectMatches(params.utterances, RISK_PATTERNS),
+    transcript: formatTranscript(utterances),
+    decisions: collectMatches(utterances, DECISION_PATTERNS),
+    actionItems: collectMatches(utterances, ACTION_PATTERNS),
+    risks: collectMatches(utterances, RISK_PATTERNS),
     utteranceCount: params.utterances.length,
   };
 }

--- a/src/transcripts/summary.ts
+++ b/src/transcripts/summary.ts
@@ -1,6 +1,6 @@
 // Builds transcript summaries and normalized transcript metadata.
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import type { TranscriptSessionDescriptor, TranscriptUtterance } from "./provider-types.js";
 
 /**
@@ -43,9 +43,15 @@ function collectMatches(utterances: TranscriptUtterance[], pattern: RegExp): str
 }
 
 function sanitizeUtterance(utterance: TranscriptUtterance): TranscriptUtterance {
-  const sanitized: TranscriptUtterance = { ...utterance, text: sanitizeForLog(utterance.text) };
+  const sanitized: TranscriptUtterance = {
+    ...utterance,
+    text: sanitizeTerminalText(utterance.text),
+  };
   if (utterance.speaker) {
-    sanitized.speaker = { ...utterance.speaker, label: sanitizeForLog(utterance.speaker.label) };
+    sanitized.speaker = {
+      ...utterance.speaker,
+      label: sanitizeTerminalText(utterance.speaker.label),
+    };
   }
   return sanitized;
 }
@@ -68,11 +74,11 @@ export function summarizeTranscripts(params: {
   session: TranscriptSessionDescriptor;
   utterances: TranscriptUtterance[];
 }): TranscriptsSummary {
-  const title = sanitizeForLog(params.session.title ?? "").trim() || "Transcripts";
+  const title = sanitizeTerminalText(params.session.title ?? "").trim() || "Transcripts";
   const utterances = params.utterances.map(sanitizeUtterance);
   const overview = firstSentences(utterances, 4) || "No transcript captured yet.";
   return {
-    sessionId: params.session.sessionId,
+    sessionId: sanitizeTerminalText(params.session.sessionId),
     title,
     generatedAt: new Date().toISOString(),
     overview,


### PR DESCRIPTION
Closes #102392

## What Problem This Solves

Fixes an issue where operators viewing a stored transcript summary with `openclaw transcripts show` would have raw terminal control sequences replayed into their terminal when the imported transcript text contained escape bytes. A transcript line such as `ESC[2J ESC[31mADMIN APPROVED ESC[0m` could clear the screen, spoof colored status text, or emit other terminal controls the moment the summary was displayed, because the escape bytes were persisted verbatim into `summary.md` and written directly to stdout. `transcripts list` had the same sink: session titles and externally supplied session IDs were formatted into list lines unsanitized.

## Why This Change Was Made

Sanitization is applied at presentation boundaries only; canonical identity is never rewritten. `summarizeTranscripts` sanitizes the derived summary content (utterance text, speaker labels, session title) with the existing terminal-core `sanitizeTerminalText` helper, `renderTranscriptsMarkdown` sanitizes the session ID it renders into the `Session:` line, `transcripts show` sanitizes stored markdown line by line at the stdout boundary so summaries persisted before this change are also protected, and `transcripts list` sanitizes the metadata columns it prints.

`TranscriptsSummary.sessionId` keeps the raw provider-supplied session ID. `TranscriptsStore.writeSummary` uses that field to locate the existing metadata and transcript directory when the optional session descriptor is not passed, so a lossy rewrite would misplace regenerated summary artifacts under a different directory. Identity stays raw; only rendering sanitizes.

The selector printed by `transcripts list` is now the directory-backed form `YYYY-MM-DD/<safe-segment>`, the same conservative segment the store uses on disk. It is terminal-safe by construction (no control bytes can survive `safeSegment`), and `show` and `path` resolve that exact printed value in addition to the raw session ID, so the documented copy-the-selector workflow keeps working for externally supplied IDs that carry escape bytes. For ordinary session IDs the printed selector is byte-identical to before.

The raw capture in `transcript.jsonl` and the stored `metadata.json`/`summary.json` are intentionally left untouched for fidelity; they are JSON-encoded on disk, so control bytes are escaped, and the CLI JSON output paths escape them via `JSON.stringify` as well.

## User Impact

Operators can view summaries of imported or captured transcripts and list stored sessions without untrusted transcript content executing terminal control sequences in their terminal. Selectors printed by `transcripts list` can always be copied back into `transcripts show` and `transcripts path`, including for session IDs containing escape bytes. Summary artifacts regenerated without a session descriptor keep landing in the original session directory. Plain transcript content and plain session IDs render exactly as before.

## Evidence

Live before/after on the real transcripts pipeline: a hostile transcript is imported through the real manual transcript provider, persisted through the real `TranscriptsStore` (summary written without the optional session descriptor), then driven through the real `transcripts list`, `show`, and `path` commands, on identical inputs. Only `src/transcripts/summary.ts` and `src/cli/program/register.transcripts.ts` are switched between pristine `main` (4a675228af) and this patch (head 7ee6df2a21). Escape bytes are shown in `cat -v` form (`^[` is the raw ESC byte); the selector passed to `show` and `path` is copied programmatically from the first column of `list` output.

```
=== BEFORE (pristine main 4a675228af) ===
--- seed: real import -> TranscriptsStore -> writeSummary (no session descriptor) ---
{"summaryWrittenTo":".../transcripts/2026-07-16/ansi--31mprovider-0m/summary.md","summaryInOriginalDir":true}
--- openclaw transcripts list ---
2026-07-16/ansi-^[[31mprovider^[[0m	2026-07-16T10:00:00.000Z	^[[31mQ3 Board sync^[[0m	.../summary.md
--- openclaw transcripts show <selector copied from list> ---
# ^[[31mQ3 Board sync^[[0m
...
Session: ansi-^[[31mprovider^[[0m
## Overview
^[[2J^[[31mADMIN APPROVED^[[0m decision: ship it
...
rawEscapeByteLinesInList=1 rawEscapeByteLinesInShow=6

=== AFTER (this patch, identical inputs, head 7ee6df2a21) ===
--- seed: real import -> TranscriptsStore -> writeSummary (no session descriptor) ---
{"summaryWrittenTo":".../transcripts/2026-07-16/ansi--31mprovider-0m/summary.md","summaryInOriginalDir":true}
--- openclaw transcripts list ---
2026-07-16/ansi--31mprovider-0m	2026-07-16T10:00:00.000Z	Q3 Board sync	.../summary.md
--- copied selector from list: 2026-07-16/ansi--31mprovider-0m ---
--- openclaw transcripts show <selector> ---
# Q3 Board sync
...
Session: ansi-provider
## Overview
ADMIN APPROVED decision: ship it
...
--- openclaw transcripts path <selector> ---
.../transcripts/2026-07-16/ansi--31mprovider-0m/summary.md
rawEscapeByteLinesInList=0 rawEscapeByteLinesInShow=0
```

Before the patch, `list` and `show` replay the raw ESC bytes (screen clear `^[[2J` plus color spoofing) into the terminal. After the patch, no escape byte reaches the terminal, the summary written without a descriptor still lands in the original session directory with its raw `sessionId` preserved in `summary.json`, and the selector printed by `list` resolves through both `show` and `path`.

Regression coverage: `src/transcripts/summary.test.ts` proves CSI, OSC 8, and C1 CSI sequences are stripped from rendered content while `summary.sessionId` keeps the raw provider ID and the rendered `Session:` line is sanitized; `src/transcripts/store.test.ts` proves `writeSummary` without a session descriptor stores the summary in the existing session directory for an ANSI-bearing session ID; `src/cli/program/register.transcripts.test.ts` drives import through the manual provider and store, asserts `show` and `list` output carry no ESC bytes, covers legacy summaries at the `show` boundary, and round-trips the printed `list` selector through `show` and `path`.

Local gates on the changed files: `node scripts/run-vitest.mjs src/transcripts/summary.test.ts src/transcripts/store.test.ts src/cli/program/register.transcripts.test.ts src/agents/tools/transcripts-tool.test.ts` (35 passed on the rebased head), `oxlint` and `oxfmt --check` clean on the changed files, `git diff --check` clean.

Not tested: live capture providers emitting escape bytes through `onUtterance` (the same summary build path covers them); no full build was run.
