### PR TITLE
fix(telegram): keep streamed drafts visible after run failures

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -70,6 +70,35 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     );
   });
 
+  it("finalizes a streamed answer draft with the final error payload", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "partial answer" });
+        await dispatcherOptions.deliver(
+          { text: "Something went wrong after partial output", isError: true },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "partial answer");
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith(
+      "partial answer\n\nSomething went wrong after partial output",
+    );
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("returns retryable when spooled replay suppresses fallback after non-silent delivery skip", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       dispatcherOptions.onSkip?.({ text: "final answer" }, { kind: "final", reason: "empty" });

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -275,9 +275,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     buttons: TelegramInlineButtons | undefined,
     promptContextSequence: TelegramPromptContextProjectionSequence,
     followedByDurablePayload = false,
+    allowErrorPayload = false,
   ): Promise<LaneDeliveryResult | undefined> => {
     const stream = lane.stream;
-    if (!stream || text.length === 0 || payload.isError) {
+    if (!stream || text.length === 0 || (payload.isError && !allowErrorPayload)) {
       return undefined;
     }
     rotateFinalizedStream(lane);
@@ -390,17 +391,40 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     const isDurableFinal = infoKind === "final";
     const finalizePreview = requestedFinalizePreview ?? isDurableFinal;
     const durable = requestedDurable ?? isDurableFinal;
+    const streamedErrorDraftText =
+      isDurableFinal &&
+      payload.isError === true &&
+      laneName === "answer" &&
+      lane.stream &&
+      lane.hasStreamedMessage &&
+      !lane.finalized &&
+      !reply.hasMedia &&
+      text.trim()
+        ? (() => {
+            const existing = (
+              lane.lastPartialText ||
+              lane.stream?.lastDeliveredText?.() ||
+              ""
+            ).trimEnd();
+            const notice = text.trim();
+            return existing && !existing.endsWith(notice)
+              ? `${existing}\n\n${notice}`
+              : existing || notice;
+          })()
+        : undefined;
     const streamed =
       allowStream && !reply.hasMedia
         ? await streamText(
             laneName,
             lane,
-            text,
+            streamedErrorDraftText ?? text,
             payload,
             isDurableFinal,
             finalizePreview,
             buttons,
             promptContextSequence,
+            false,
+            streamedErrorDraftText !== undefined,
           )
         : undefined;
     if (streamed) {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1024,6 +1024,41 @@ describe("runReplyAgent heartbeat followup guard", () => {
       persistSpy.mockRestore();
     }
   });
+
+  it("returns a failure payload instead of rethrowing after block streaming reached the user", async () => {
+    const accounting = await import("./session-run-accounting.js");
+    const persistSpy = vi
+      .spyOn(accounting, "persistRunSessionUsage")
+      .mockRejectedValueOnce(new Error("persist exploded"));
+    const onBlockReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onBlockReply?.({ text: "partial answer" });
+      return {
+        payloads: [{ text: "final answer" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    try {
+      const { run } = createMinimalRun({
+        blockStreamingEnabled: true,
+        opts: { onBlockReply },
+      });
+      const result = await run();
+      const payload = Array.isArray(result) ? result[0] : result;
+
+      expect(onBlockReply).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "partial answer" }),
+        expect.any(Object),
+      );
+      expect(payload).toMatchObject({
+        text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+        isError: true,
+      });
+    } finally {
+      persistSpy.mockRestore();
+    }
+  });
 });
 
 describe("runReplyAgent pending final delivery capture", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -93,6 +93,7 @@ import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
 import {
   buildEmptyInteractiveReplyPayload,
   buildKnownAgentRunFailureReplyPayload,
+  buildTerminalAgentRunFailureReplyPayload,
 } from "./agent-runner-failure-reply.js";
 import {
   createShouldEmitToolOutput,
@@ -3009,6 +3010,26 @@ export async function runReplyAgent(params: {
     if (knownFailurePayload) {
       replyOperation.fail("run_failed", error);
       return returnWithQueuedFollowupDrain(knownFailurePayload);
+    }
+    if (blockReplyPipeline) {
+      try {
+        await blockReplyPipeline.flush({ force: true });
+      } catch (flushError) {
+        logVerbose(
+          `failed to flush streamed reply blocks before surfacing run failure: ${String(
+            flushError,
+          )}`,
+        );
+      }
+    }
+    if (!isHeartbeat && blockReplyPipeline?.didStream() && !blockReplyPipeline.isAborted()) {
+      replyOperation.fail("run_failed", error);
+      return returnWithQueuedFollowupDrain(
+        buildTerminalAgentRunFailureReplyPayload({
+          sessionCtx,
+          cfg,
+        }),
+      );
     }
     replyOperation.fail("run_failed", error);
     // Keep the followup queue moving even when an unexpected exception escapes


### PR DESCRIPTION
Closes #108586

## What Problem This Solves

Fixes an issue where users reading a Telegram streamed answer could lose the already-visible draft when an unexpected reply-run failure happened after partial output. The turn could clear that draft and leave only a generic failure message, so the partial answer disappeared.

## Why This Change Was Made

The reply runner now force-flushes block-streamed output and, when visible output already reached the user, returns the existing terminal failure payload instead of rethrowing into channel fallback handling. Telegram delivery now finalizes a non-finalized streamed answer draft by appending that final failure notice to the same preview message; no-partial and heartbeat paths keep their existing retry/fallback behavior.

## User Impact

Telegram users keep the partial answer they were already reading, with a clear failure notice appended in place. Turns that fail before any visible partial output still use the existing retry and generic failure handling.

## Evidence

- Targeted reply-runner e2e: 117 passed.
- Targeted Telegram draft-failure test: 19 passed.
- Adjacent Telegram progress/error rendering test: 25 passed.
- Combined post-format run: 117 + 44 passed.

## Real behavior proof

**Behavior addressed:** A Telegram streamed answer draft that already has visible text receives the final failure notice in the same preview message instead of being cleared or followed by a second durable send.
**Environment tested:** Node v24.16.0 on Linux, source checkout at commit c9f99755.
**Steps run after the patch:** Called the actual `createLaneTextDeliverer` production function from source via `node --import tsx --no-warnings` with a non-finalized streamed answer lane and a final error payload.
**Evidence after fix:**

```text
{
  "resultKind": "preview-finalized",
  "previewText": "partial answer\n\nSomething went wrong after partial output",
  "laneFinalized": true,
  "clearCalls": 0,
  "sendPayloadCalls": 0,
  "calls": [
    [
      "update",
      "partial answer\n\nSomething went wrong after partial output"
    ],
    [
      "stopDraftLane"
    ],
    [
      "stream.stop"
    ],
    [
      "markDelivered"
    ],
    [
      "prompt.accept",
      {
        "messageId": 2001,
        "text": "partial answer\n\nSomething went wrong after partial output"
      }
    ],
    [
      "prompt.finish"
    ]
  ]
}
```

**Observed result:** The production function returned `preview-finalized`, appended the failure notice to the original preview text, set `laneFinalized` to true, and reported zero clear/send calls.
**Not tested:** A live Telegram account session with real network delivery was not exercised.
