### PR TITLE
fix(ci): preserve private plugins in Docker E2E

### DIFF
--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -91,13 +91,15 @@ FROM bare AS functional
 COPY --from=openclaw_package --chown=appuser:appuser openclaw-current.tgz /tmp/openclaw-current.tgz
 COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules
 # Extract the package over the prebuilt dependency tree (bundled deps ship in
-# the tarball), then run its packaged postinstall exactly as `npm install -g`
-# would. The /app/node_modules/openclaw self-link preserves package
-# self-reference imports such as openclaw/plugin-sdk/*; create it after
-# postinstall so its prune walks cannot cycle through the link.
+# the tarball), then run its packaged postinstall. Functional E2E lanes exercise
+# private bundled plugins too, so skip the production migration's intentionally
+# curated persisted registry in this test image. The /app/node_modules/openclaw
+# self-link preserves package self-reference imports such as
+# openclaw/plugin-sdk/*; create it after postinstall so its prune walks cannot
+# cycle through the link.
 RUN tar -xzf /tmp/openclaw-current.tgz -C /app --strip-components=1 \
  && chmod +x /app/openclaw.mjs \
- && node /app/scripts/postinstall-bundled-plugins.mjs \
+ && OPENCLAW_DISABLE_PLUGIN_REGISTRY_MIGRATION=1 node /app/scripts/postinstall-bundled-plugins.mjs \
  && ln -sfn /app /app/node_modules/openclaw \
  && mkdir -p "$HOME/.local/bin" \
  && ln -sf /app/openclaw.mjs "$HOME/.local/bin/openclaw" \

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3695,6 +3695,14 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     );
   });
 
+  it("keeps private bundled plugins discoverable in the functional Docker E2E image", () => {
+    const dockerfile = readFileSync("scripts/e2e/Dockerfile", "utf8");
+
+    expect(dockerfile).toContain(
+      "OPENCLAW_DISABLE_PLUGIN_REGISTRY_MIGRATION=1 node /app/scripts/postinstall-bundled-plugins.mjs",
+    );
+  });
+
   it("keeps onboarding Docker E2E resource-guarded", () => {
     const runner = readFileSync(ONBOARD_DOCKER_E2E_PATH, "utf8");
 


### PR DESCRIPTION
## Summary

- keep private bundled plugins discoverable in the functional Docker E2E image
- preserve the rest of packaged postinstall behavior
- add a focused Dockerfile contract regression test

## Proof

- `pnpm exec vitest run test/scripts/docker-build-helper.test.ts --maxWorkers=1` (174 passed)
- `pnpm check:changed` via Blacksmith Testbox (green)
- autoreview clean
