### PR TITLE
fix(deadcode): remove duplicate knip audit config entries from rootEntries

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -87,10 +87,6 @@ const repositoryScriptEntries = [
 
 const rootEntries = [
   ...repositoryScriptEntries,
-  // Knip loads these audit configurations directly by command-line path.
-  "config/knip.config.ts!",
-  "config/knip.all-exports.config.ts!",
-  "config/knip.scripts-exports.config.ts!",
   "openclaw.mjs!",
   "src/index.ts!",
   "src/entry.ts!",


### PR DESCRIPTION
## What Problem This Solves

Fixes a code quality issue where `config/knip.config.ts` contained duplicated entries in the `rootEntries` array. Three audit configuration entry paths and their preceding comment appeared twice in the same list, adding unnecessary noise to the configuration file.

## Why This Change Was Made

The duplicate lines at positions 90–93 were introduced when two closely-timed commits—both adding the same knip audit configuration entries to `rootEntries`—were merged via rebase, producing an unintended duplicate. The deduplication at line 144–147 is retained, preserving the correct logical grouping alongside related non-standard entry points (Mintlify docs, native app assets). The change is purely cosmetic: Knip internally uses a `Set<string>` for resolved entry file paths, so no behavior was affected by the duplication.

## User Impact

No user-visible impact. The change eliminates redundant configuration lines, reducing maintenance noise for anyone reading or modifying the knip configuration.

## Evidence

- The duplicated lines were confirmed via `git blame` and diff inspection: commit `906c7332d20` added the entries at lines 90–93; commit `7e1d93d36d7` added the same entries a second time at lines 148–151 as part of a broader "enforce full-repository hard zero" change.
- After removal, `pnpm knip --config config/knip.config.ts` exits with code 0 and produces no errors or warnings.

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
