### PR TITLE
fix(clickclack): resolve SecretRef tokens at runtime

### DIFF
--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -6,9 +6,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   listClickClackAccountIds,
   resolveClickClackAccount,
+  resolveClickClackRuntimeAccount,
   resolveDefaultClickClackAccountId,
 } from "./accounts.js";
 import type { CoreConfig } from "./types.js";
+
+function writeExecResolver(filePath: string, values: Record<string, string>) {
+  fs.writeFileSync(
+    filePath,
+    `#!/bin/sh\nprintf '%s\\n' '${JSON.stringify({ protocolVersion: 1, values })}'\n`,
+    "utf8",
+  );
+  fs.chmodSync(filePath, 0o700);
+}
 
 describe("ClickClack account resolution", () => {
   afterEach(() => {
@@ -124,6 +134,86 @@ describe("ClickClack account resolution", () => {
       timeoutSeconds: undefined,
       toolsAllow: undefined,
       workspace: "wsp_1",
+    });
+  });
+
+  it("treats configured exec SecretRefs as configured without exposing tokens in inspect snapshots", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          token: { source: "exec", provider: "example_exec", id: "CLICKCLACK_SERVICE_TOKEN" },
+        },
+      },
+      secrets: {
+        providers: {
+          example_exec: {
+            source: "exec",
+            command: "/not-run-during-inspection",
+            jsonOnly: true,
+            allowInsecurePath: true,
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    const account = resolveClickClackAccount({ cfg });
+
+    expect(account.configured).toBe(true);
+    expect(account.token).toBe("");
+  });
+
+  it("resolves file and exec SecretRefs for runtime account tokens", async () => {
+    await withTempDir("clickclack-secretref-", async (tempDir) => {
+      const secretFile = path.join(tempDir, "clickclack-token");
+      fs.writeFileSync(secretFile, "  file-token-placeholder  \n", "utf8");
+      fs.chmodSync(secretFile, 0o600);
+      const execResolver = path.join(tempDir, "resolve-clickclack-token");
+      writeExecResolver(execResolver, {
+        CLICKCLACK_SERVICE_TOKEN: "  exec-token-placeholder  ",
+      });
+      const cfg = {
+        channels: {
+          clickclack: {
+            enabled: true,
+            baseUrl: "https://app.clickclack.chat",
+            workspace: "wsp_1",
+            accounts: {
+              file: {
+                token: { source: "file", provider: "clickclack_file", id: "value" },
+              },
+              exec: {
+                token: {
+                  source: "exec",
+                  provider: "clickclack_exec",
+                  id: "CLICKCLACK_SERVICE_TOKEN",
+                },
+              },
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            clickclack_file: { source: "file", path: secretFile, mode: "singleValue" },
+            clickclack_exec: { source: "exec", command: execResolver, jsonOnly: true },
+          },
+        },
+      } satisfies CoreConfig;
+
+      await expect(
+        resolveClickClackRuntimeAccount({ cfg, accountId: "file" }),
+      ).resolves.toMatchObject({
+        configured: true,
+        token: "file-token-placeholder",
+      });
+      await expect(
+        resolveClickClackRuntimeAccount({ cfg, accountId: "exec" }),
+      ).resolves.toMatchObject({
+        configured: true,
+        token: "exec-token-placeholder",
+      });
     });
   });
 

--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -12,12 +12,12 @@ import {
 import type { CoreConfig } from "./types.js";
 
 function writeExecResolver(filePath: string, values: Record<string, string>) {
+  const payload = JSON.stringify({ protocolVersion: 1, values });
   fs.writeFileSync(
     filePath,
-    `#!/bin/sh\nprintf '%s\\n' '${JSON.stringify({ protocolVersion: 1, values })}'\n`,
+    `let input = "";\nprocess.stdin.setEncoding("utf8");\nprocess.stdin.on("data", (chunk) => {\n  input += chunk;\n});\nprocess.stdin.on("end", () => {\n  process.stdout.write(${JSON.stringify(`${payload}\n`)});\n});\n`,
     "utf8",
   );
-  fs.chmodSync(filePath, 0o700);
 }
 
 describe("ClickClack account resolution", () => {
@@ -151,7 +151,8 @@ describe("ClickClack account resolution", () => {
         providers: {
           example_exec: {
             source: "exec",
-            command: "/not-run-during-inspection",
+            command: process.execPath,
+            args: ["not-run-during-inspection"],
             jsonOnly: true,
             allowInsecurePath: true,
           },
@@ -170,7 +171,7 @@ describe("ClickClack account resolution", () => {
       const secretFile = path.join(tempDir, "clickclack-token");
       fs.writeFileSync(secretFile, "  file-token-placeholder  \n", "utf8");
       fs.chmodSync(secretFile, 0o600);
-      const execResolver = path.join(tempDir, "resolve-clickclack-token");
+      const execResolver = path.join(tempDir, "resolve-clickclack-token.cjs");
       writeExecResolver(execResolver, {
         CLICKCLACK_SERVICE_TOKEN: "  exec-token-placeholder  ",
       });
@@ -197,7 +198,13 @@ describe("ClickClack account resolution", () => {
         secrets: {
           providers: {
             clickclack_file: { source: "file", path: secretFile, mode: "singleValue" },
-            clickclack_exec: { source: "exec", command: execResolver, jsonOnly: true },
+            clickclack_exec: {
+              source: "exec",
+              command: process.execPath,
+              args: [execResolver],
+              jsonOnly: true,
+              allowInsecurePath: true,
+            },
           },
         },
       } satisfies CoreConfig;

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -17,6 +17,7 @@ import {
   normalizeResolvedSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClickClackAccountConfig, CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
@@ -74,6 +75,33 @@ export function resolveClickClackAccountConfig(
   return merged;
 }
 
+function clickClackTokenPath(accountId: string): string {
+  return accountId === DEFAULT_ACCOUNT_ID
+    ? "channels.clickclack.token"
+    : `channels.clickclack.accounts.${accountId}.token`;
+}
+
+function clickClackTokenFilePath(accountId: string): string {
+  return accountId === DEFAULT_ACCOUNT_ID
+    ? "channels.clickclack.tokenFile"
+    : `channels.clickclack.accounts.${accountId}.tokenFile`;
+}
+
+function readClickClackTokenFile(tokenFile: string, accountId: string): string {
+  return (
+    tryReadSecretFileSync(tokenFile, clickClackTokenFilePath(accountId), {
+      rejectSymlink: true,
+    }) ?? ""
+  );
+}
+
+function defaultEnvToken(params: { accountId: string; env?: NodeJS.ProcessEnv }): string {
+  if (params.accountId !== DEFAULT_ACCOUNT_ID) {
+    return "";
+  }
+  return normalizeSecretInputString((params.env ?? process.env).CLICKCLACK_BOT_TOKEN) ?? "";
+}
+
 function resolveClickClackToken(params: {
   cfg: CoreConfig;
   value: unknown;
@@ -83,28 +111,17 @@ function resolveClickClackToken(params: {
 }): string {
   const tokenFile = params.tokenFile?.trim();
   if (tokenFile) {
-    return (
-      tryReadSecretFileSync(
-        tokenFile,
-        params.accountId === DEFAULT_ACCOUNT_ID
-          ? "channels.clickclack.tokenFile"
-          : `channels.clickclack.accounts.${params.accountId}.tokenFile`,
-        { rejectSymlink: true },
-      ) ?? ""
-    );
+    return readClickClackTokenFile(tokenFile, params.accountId);
   }
   const resolved = resolveSecretInputString({
     value: params.value,
-    path:
-      params.accountId === DEFAULT_ACCOUNT_ID
-        ? "channels.clickclack.token"
-        : `channels.clickclack.accounts.${params.accountId}.token`,
+    path: clickClackTokenPath(params.accountId),
     defaults: params.cfg.secrets?.defaults,
     mode: "inspect",
   });
   if (resolved.status !== "available") {
     if (resolved.status === "missing" && params.accountId === DEFAULT_ACCOUNT_ID) {
-      return normalizeSecretInputString((params.env ?? process.env).CLICKCLACK_BOT_TOKEN) ?? "";
+      return defaultEnvToken(params);
     }
     if (resolved.status === "configured_unavailable" && resolved.ref.source === "env") {
       const providerConfig = params.cfg.secrets?.providers?.[resolved.ref.provider];
@@ -134,8 +151,57 @@ function resolveClickClackToken(params: {
   return (
     normalizeResolvedSecretInputString({
       value: resolved.value,
-      path: "channels.clickclack.token",
+      path: clickClackTokenPath(params.accountId),
     }) ?? ""
+  );
+}
+
+async function resolveClickClackRuntimeToken(params: {
+  cfg: CoreConfig;
+  value: unknown;
+  tokenFile?: string;
+  accountId: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<string> {
+  const tokenFile = params.tokenFile?.trim();
+  if (tokenFile) {
+    return readClickClackTokenFile(tokenFile, params.accountId);
+  }
+
+  const path = clickClackTokenPath(params.accountId);
+  const inspected = resolveSecretInputString({
+    value: params.value,
+    path,
+    defaults: params.cfg.secrets?.defaults,
+    mode: "inspect",
+  });
+  const resolved = await resolveConfiguredSecretInputString({
+    config: params.cfg,
+    env: params.env ?? process.env,
+    value: params.value,
+    path,
+  });
+  if (resolved.value) {
+    return resolved.value;
+  }
+  if (inspected.status === "missing") {
+    return defaultEnvToken(params);
+  }
+  return "";
+}
+
+function hasConfiguredClickClackToken(params: {
+  token: string;
+  value: unknown;
+  tokenFile?: string;
+  accountId: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  return Boolean(
+    params.token ||
+    params.tokenFile?.trim() ||
+    hasConfiguredAccountValue(params.value) ||
+    defaultEnvToken(params),
   );
 }
 
@@ -161,10 +227,17 @@ export function resolveClickClackAccount(params: {
     env: params.env,
   });
   const workspace = merged.workspace?.trim() ?? "";
+  const hasToken = hasConfiguredClickClackToken({
+    token,
+    value: merged.token,
+    tokenFile: merged.tokenFile,
+    accountId,
+    env: params.env,
+  });
   return {
     accountId,
     enabled,
-    configured: Boolean(baseUrl && token && workspace),
+    configured: Boolean(baseUrl && hasToken && workspace),
     name: normalizeOptionalString(merged.name),
     baseUrl,
     token,
@@ -193,6 +266,30 @@ export function resolveClickClackAccount(params: {
       ...merged,
       allowFrom: merged.allowFrom ?? ["*"],
     },
+  };
+}
+
+/**
+ * Builds the runtime account snapshot with SecretRefs materialized for gateway
+ * startup and outbound delivery.
+ */
+export async function resolveClickClackRuntimeAccount(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ResolvedClickClackAccount> {
+  const account = resolveClickClackAccount(params);
+  const token = await resolveClickClackRuntimeToken({
+    cfg: params.cfg,
+    value: account.config.token,
+    tokenFile: account.config.tokenFile,
+    accountId: account.accountId,
+    env: params.env,
+  });
+  return {
+    ...account,
+    token,
+    configured: Boolean(account.baseUrl && token && account.workspace),
   };
 }
 

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -127,12 +127,12 @@ function emitMessageEvent(
 }
 
 function writeExecResolver(filePath: string, values: Record<string, string>) {
+  const payload = JSON.stringify({ protocolVersion: 1, values });
   fs.writeFileSync(
     filePath,
-    `#!/bin/sh\nprintf '%s\\n' '${JSON.stringify({ protocolVersion: 1, values })}'\n`,
+    `let input = "";\nprocess.stdin.setEncoding("utf8");\nprocess.stdin.on("data", (chunk) => {\n  input += chunk;\n});\nprocess.stdin.on("end", () => {\n  process.stdout.write(${JSON.stringify(`${payload}\n`)});\n});\n`,
     "utf8",
   );
-  fs.chmodSync(filePath, 0o700);
 }
 
 describe("ClickClack gateway", () => {
@@ -219,7 +219,7 @@ describe("ClickClack gateway", () => {
 
   it("resolves exec SecretRef tokens before gateway startup", async () => {
     await withTempDir("clickclack-gateway-secretref-", async (tempDir) => {
-      const execResolver = path.join(tempDir, "resolve-clickclack-token");
+      const execResolver = path.join(tempDir, "resolve-clickclack-token.cjs");
       writeExecResolver(execResolver, {
         CLICKCLACK_SERVICE_TOKEN: "  exec-token-placeholder  ",
       });
@@ -243,7 +243,13 @@ describe("ClickClack gateway", () => {
           },
           secrets: {
             providers: {
-              clickclack_exec: { source: "exec", command: execResolver, jsonOnly: true },
+              clickclack_exec: {
+                source: "exec",
+                command: process.execPath,
+                args: [execResolver],
+                jsonOnly: true,
+                allowInsecurePath: true,
+              },
             },
           },
         } as ChannelGatewayContext<ResolvedClickClackAccount>["cfg"],

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -1,6 +1,9 @@
 // Clickclack tests cover gateway plugin behavior.
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedClickClackAccount } from "./types.js";
 
@@ -64,22 +67,25 @@ function createGatewayContext(
   abortSignal: AbortSignal,
   options: {
     commandMenu?: boolean;
+    cfg?: ChannelGatewayContext<ResolvedClickClackAccount>["cfg"];
   } = {},
 ): ChannelGatewayContext<ResolvedClickClackAccount> {
   const setStatus = vi.fn();
   const log = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
   return {
-    cfg: {
-      channels: {
-        clickclack: {
-          baseUrl: "https://clickclack.example",
-          token: "test-token",
-          workspace: "main",
-          reconnectMs: 1,
-          ...(options.commandMenu === undefined ? {} : { commandMenu: options.commandMenu }),
+    cfg:
+      options.cfg ??
+      ({
+        channels: {
+          clickclack: {
+            baseUrl: "https://clickclack.example",
+            token: "test-token",
+            workspace: "main",
+            reconnectMs: 1,
+            ...(options.commandMenu === undefined ? {} : { commandMenu: options.commandMenu }),
+          },
         },
-      },
-    } as ChannelGatewayContext<ResolvedClickClackAccount>["cfg"],
+      } as ChannelGatewayContext<ResolvedClickClackAccount>["cfg"]),
     accountId: "default",
     account: {} as ResolvedClickClackAccount,
     runtime: {} as ChannelGatewayContext<ResolvedClickClackAccount>["runtime"],
@@ -118,6 +124,15 @@ function emitMessageEvent(
       JSON.stringify({ ...event, seq: index + 1, payload: { ...event.payload, ...payload } }),
     ),
   );
+}
+
+function writeExecResolver(filePath: string, values: Record<string, string>) {
+  fs.writeFileSync(
+    filePath,
+    `#!/bin/sh\nprintf '%s\\n' '${JSON.stringify({ protocolVersion: 1, values })}'\n`,
+    "utf8",
+  );
+  fs.chmodSync(filePath, 0o700);
 }
 
 describe("ClickClack gateway", () => {
@@ -200,6 +215,51 @@ describe("ClickClack gateway", () => {
 
     abort.abort();
     await run;
+  });
+
+  it("resolves exec SecretRef tokens before gateway startup", async () => {
+    await withTempDir("clickclack-gateway-secretref-", async (tempDir) => {
+      const execResolver = path.join(tempDir, "resolve-clickclack-token");
+      writeExecResolver(execResolver, {
+        CLICKCLACK_SERVICE_TOKEN: "  exec-token-placeholder  ",
+      });
+      const socket = new FakeSocket();
+      mocks.client.websocket.mockReturnValue(socket);
+      const abort = new AbortController();
+      const ctx = createGatewayContext(abort.signal, {
+        cfg: {
+          channels: {
+            clickclack: {
+              baseUrl: "https://clickclack.example",
+              token: {
+                source: "exec",
+                provider: "clickclack_exec",
+                id: "CLICKCLACK_SERVICE_TOKEN",
+              },
+              workspace: "main",
+              reconnectMs: 1,
+              commandMenu: false,
+            },
+          },
+          secrets: {
+            providers: {
+              clickclack_exec: { source: "exec", command: execResolver, jsonOnly: true },
+            },
+          },
+        } as ChannelGatewayContext<ResolvedClickClackAccount>["cfg"],
+      });
+      const run = startClickClackGatewayAccount(ctx);
+
+      await waitForGatewayState(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+      expect(mocks.createClickClackClient).toHaveBeenCalledWith({
+        baseUrl: "https://clickclack.example",
+        token: "exec-token-placeholder",
+      });
+
+      abort.abort();
+      await run;
+    });
   });
 
   it.each([

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -7,7 +7,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import type { RawData } from "ws";
 import { resolveClickClackInboundAccess } from "./access.js";
-import { resolveClickClackAccount } from "./accounts.js";
+import { resolveClickClackRuntimeAccount } from "./accounts.js";
 import { syncClickClackCommandMenu } from "./command-menu.js";
 import { createClickClackClient, normalizeClickClackCorrelationId } from "./http-client.js";
 import { handleClickClackInbound } from "./inbound.js";
@@ -170,7 +170,7 @@ async function drainEventBacklog(params: {
 export async function startClickClackGatewayAccount(
   ctx: ChannelGatewayContext<ResolvedClickClackAccount>,
 ) {
-  const configuredAccount = resolveClickClackAccount({
+  const configuredAccount = await resolveClickClackRuntimeAccount({
     cfg: ctx.cfg,
     accountId: ctx.account.accountId,
   });

--- a/extensions/clickclack/src/outbound.test.ts
+++ b/extensions/clickclack/src/outbound.test.ts
@@ -24,15 +24,18 @@ const message = vi.hoisted(() =>
 );
 const createClientOptions = vi.hoisted(() => vi.fn());
 const loadOutboundMediaFromUrl = vi.hoisted(() => vi.fn());
+const resolveClickClackRuntimeAccount = vi.hoisted(() =>
+  vi.fn(async () => ({
+    baseUrl: "https://clickclack.example",
+    token: "test-token-placeholder",
+    workspace: "wsp_1",
+  })),
+);
 
 vi.mock("openclaw/plugin-sdk/outbound-media", () => ({ loadOutboundMediaFromUrl }));
 
 vi.mock("./accounts.js", () => ({
-  resolveClickClackAccount: () => ({
-    baseUrl: "https://clickclack.example",
-    token: "test-token-placeholder",
-    workspace: "wsp_1",
-  }),
+  resolveClickClackRuntimeAccount,
 }));
 
 vi.mock("./http-client.js", () => ({
@@ -71,6 +74,7 @@ describe("sendClickClackText routing", () => {
     attachUpload.mockClear();
     message.mockClear();
     createClientOptions.mockClear();
+    resolveClickClackRuntimeAccount.mockClear();
     loadOutboundMediaFromUrl.mockReset();
   });
 
@@ -114,6 +118,31 @@ describe("sendClickClackText routing", () => {
       baseUrl: "https://clickclack.example",
       token: "test-token-placeholder",
       correlationId: "fakeco.case_1",
+    });
+  });
+
+  it("uses the runtime account token for outbound ClickClack HTTP calls", async () => {
+    resolveClickClackRuntimeAccount.mockResolvedValueOnce({
+      baseUrl: "https://clickclack.example",
+      token: "runtime-secretref-token",
+      workspace: "wsp_1",
+    });
+
+    await sendClickClackText({
+      cfg,
+      accountId: "service",
+      to: "channel:general",
+      text: "hi",
+    });
+
+    expect(resolveClickClackRuntimeAccount).toHaveBeenCalledWith({
+      cfg,
+      accountId: "service",
+    });
+    expect(createClientOptions).toHaveBeenCalledWith({
+      baseUrl: "https://clickclack.example",
+      token: "runtime-secretref-token",
+      correlationId: undefined,
     });
   });
 
@@ -212,6 +241,7 @@ describe("sendClickClackMedia", () => {
     attachUpload.mockReset().mockResolvedValue(undefined);
     message.mockReset().mockResolvedValue({ id: "msg_out", attachments: [] });
     createClientOptions.mockClear();
+    resolveClickClackRuntimeAccount.mockClear();
     loadOutboundMediaFromUrl.mockReset().mockResolvedValue({
       buffer: Buffer.from("const proof = true;"),
       contentType: "text/typescript",
@@ -479,6 +509,7 @@ describe("reconcileClickClackUnknownSend", () => {
     attachUpload.mockReset().mockResolvedValue(undefined);
     message.mockReset().mockResolvedValue({ id: "msg_out", attachments: [] });
     createClientOptions.mockClear();
+    resolveClickClackRuntimeAccount.mockClear();
     loadOutboundMediaFromUrl.mockClear();
   });
 

--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -13,7 +13,7 @@ import {
   type OutboundMediaLoadOptions,
 } from "openclaw/plugin-sdk/outbound-media";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
-import { resolveClickClackAccount } from "./accounts.js";
+import { resolveClickClackRuntimeAccount } from "./accounts.js";
 import { createClickClackClient, type ClickClackClient } from "./http-client.js";
 import { resolveChannelId, resolveWorkspaceId } from "./resolve.js";
 import { parseClickClackTarget } from "./target.js";
@@ -136,12 +136,15 @@ async function attachUploadRetrySafe(params: {
   }
 }
 
-function createOutboundContext(params: {
+async function createOutboundContext(params: {
   cfg: CoreConfig;
   accountId?: string | null;
   correlationId?: string;
 }) {
-  const account = resolveClickClackAccount({ cfg: params.cfg, accountId: params.accountId });
+  const account = await resolveClickClackRuntimeAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
   const client = createClickClackClient({
     baseUrl: account.baseUrl,
     token: account.token,
@@ -178,7 +181,7 @@ export async function sendClickClackText(params: {
   if (!text) {
     return undefined;
   }
-  const { account, client } = createOutboundContext(params);
+  const { account, client } = await createOutboundContext(params);
   const workspaceId = await resolveWorkspaceId(client, account.workspace);
   const dispatch = createDispatchOnce(params.onPlatformSendDispatch);
   const message = await createTargetMessage({
@@ -229,7 +232,7 @@ export async function sendClickClackMedia(params: {
         mediaLocalRoots: params.mediaLocalRoots,
         mediaReadFile: params.mediaReadFile,
       });
-  const { account, client } = createOutboundContext(params);
+  const { account, client } = await createOutboundContext(params);
   const workspaceId = await resolveWorkspaceId(client, account.workspace);
   const persistedUpload = nonces.upload
     ? await client.findUploadByNonce({ workspaceId, nonce: nonces.upload })
@@ -303,7 +306,7 @@ export async function reconcileClickClackUnknownSend(
     };
   }
   const mediaUrls = collectReconciliationMediaUrls(ctx);
-  const { account, client } = createOutboundContext({
+  const { account, client } = await createOutboundContext({
     cfg: ctx.cfg as CoreConfig,
     accountId: ctx.accountId,
   });


### PR DESCRIPTION
Closes #98428

## What Problem This Solves

Fixes an issue where users configuring ClickClack with a SecretRef-backed token could pass `openclaw secrets audit --allow-exec`, but gateway startup and outbound delivery treated non-`env` SecretRefs as unavailable and reported the channel account as not configured.

## Why This Change Was Made

ClickClack now keeps a non-secret inspect snapshot for setup/status while resolving runtime token reads through the shared SecretRef runtime resolver. Gateway startup and outbound delivery use the runtime account snapshot, so `env`, `file`, and `exec` SecretRefs materialize before ClickClack HTTP/WebSocket clients are created.

This does not add new config fields or change ClickClack target routing; it aligns the existing token schema, secret contract, and runtime behavior.

## User Impact

Users can configure `channels.clickclack.token` or `channels.clickclack.accounts.*.token` with managed SecretRefs directly. Resolvable SecretRefs count as configured for status/setup surfaces without exposing token values, and runtime paths receive the resolved token for startup and message delivery.

## Evidence

Targeted ClickClack regression tests on latest head:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs extensions/clickclack/src/accounts.test.ts extensions/clickclack/src/gateway.test.ts extensions/clickclack/src/outbound.test.ts

Test Files  3 passed (3)
Tests  59 passed (59)
```

ClickClack plugin suite on latest head:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs extensions/clickclack

Test Files  15 passed (15)
Tests  150 passed (150)
```

Shared SecretRef contract tests from the issue review:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/run-vitest.mjs src/secrets/runtime-config-collectors-channels.test.ts src/secrets/target-registry.test.ts src/secrets/target-registry.docs.test.ts

Test Files  3 passed (3)
Tests  11 passed (11)
```

Type and formatting checks:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH pnpm tsgo:extensions
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH pnpm tsgo:test:extensions
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH pnpm format extensions/clickclack/src/accounts.ts extensions/clickclack/src/accounts.test.ts extensions/clickclack/src/gateway.ts extensions/clickclack/src/gateway.test.ts extensions/clickclack/src/outbound.ts extensions/clickclack/src/outbound.test.ts
git diff --check
```

Attempted local changed-code gate:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node scripts/check-changed.mjs -- extensions/clickclack/src/accounts.ts extensions/clickclack/src/accounts.test.ts extensions/clickclack/src/gateway.ts extensions/clickclack/src/gateway.test.ts extensions/clickclack/src/outbound.ts extensions/clickclack/src/outbound.test.ts
```

The local gate delegated to Blacksmith/Testbox but could not start because the local `crabbox` binary failed its basic sanity check:

```text
[crabbox] selected binary failed basic --version/--help sanity checks
```

Hosted PR CI later ran the changed-code gate successfully on this PR.

## Real behavior proof

**Behavior addressed:** ClickClack runtime token reads now resolve configured SecretRefs before gateway/outbound clients are created, while inspect snapshots can treat configured SecretRefs as configured without exposing token values.

**Environment tested:** Linux source checkout, Node 24.16.0, patched `extensions/clickclack/src/accounts.ts` imported directly through `node --import tsx`, with a real local `exec` SecretRef provider invoked through `process.execPath`.

**Steps run after the patch:** Called the actual patched `resolveClickClackAccount` and `resolveClickClackRuntimeAccount` production functions from source against a ClickClack config whose token is an `exec` SecretRef.

**Evidence after fix:** Command and output from the patched source path:

```text
PATH=/home/0668001394/.config/nvm/versions/node/v24.16.0/bin:$PATH node --import tsx --no-warnings --input-type=module <<'NODE_PROOF'
import fs from 'node:fs';
import os from 'node:os';
import path from 'node:path';
import {
  resolveClickClackAccount,
  resolveClickClackRuntimeAccount,
} from './extensions/clickclack/src/accounts.ts';

const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clickclack-proof-'));
const resolver = path.join(tempDir, 'resolve-clickclack-token.cjs');
const payload = JSON.stringify({
  protocolVersion: 1,
  values: { CLICKCLACK_SERVICE_TOKEN: '  exec-token-from-proof  ' },
});
fs.writeFileSync(
  resolver,
  `let input = "";\nprocess.stdin.setEncoding("utf8");\nprocess.stdin.on("data", (chunk) => {\n  input += chunk;\n});\nprocess.stdin.on("end", () => {\n  process.stdout.write(${JSON.stringify(`${payload}\n`)});\n});\n`,
  'utf8',
);

const cfg = {
  channels: {
    clickclack: {
      enabled: true,
      baseUrl: 'https://clickclack.example',
      workspace: 'main',
      token: {
        source: 'exec',
        provider: 'clickclack_exec',
        id: 'CLICKCLACK_SERVICE_TOKEN',
      },
    },
  },
  secrets: {
    providers: {
      clickclack_exec: {
        source: 'exec',
        command: process.execPath,
        args: [resolver],
        jsonOnly: true,
        allowInsecurePath: true,
      },
    },
  },
};

const inspectAccount = resolveClickClackAccount({ cfg });
const runtimeAccount = await resolveClickClackRuntimeAccount({ cfg });
console.log(JSON.stringify({
  inspect: {
    configured: inspectAccount.configured,
    tokenLength: inspectAccount.token.length,
  },
  runtime: {
    configured: runtimeAccount.configured,
    token: runtimeAccount.token,
    workspace: runtimeAccount.workspace,
  },
}, null, 2));

fs.rmSync(tempDir, { recursive: true, force: true });
NODE_PROOF
```

Output:

```text
{
  "inspect": {
    "configured": true,
    "tokenLength": 0
  },
  "runtime": {
    "configured": true,
    "token": "exec-token-from-proof",
    "workspace": "main"
  }
}
```

**Observed result after the fix:** The inspect account reports configured without exposing the token, and the runtime account resolves the `exec` SecretRef into the trimmed ClickClack token used by gateway/outbound paths.

**Not tested:** A live ClickClack server connection was not run; network behavior is covered by the existing ClickClack plugin tests and the production-path SecretRef materialization proof above.
