### PR TITLE
fix(telegram): duplicate inbound messages after a transient update-offset persistence failure

### DIFF
--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -24,6 +24,10 @@ import {
 } from "./network-errors.js";
 import { acquireTelegramPollingLease } from "./polling-lease.js";
 import { makeProxyFetch } from "./proxy.js";
+import {
+  createTelegramUpdateOffsetPersistence,
+  normalizeTelegramUpdateId,
+} from "./update-offset-persistence.js";
 import type {
   TelegramOffsetRotationReason,
   TelegramUpdateOffsetRotationInfo,
@@ -49,16 +53,6 @@ function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
       retryInterval: "exponential",
     },
   };
-}
-
-function normalizePersistedUpdateId(value: number | null): number | null {
-  if (value === null) {
-    return null;
-  }
-  if (!Number.isSafeInteger(value) || value < 0) {
-    return null;
-  }
-  return value;
 }
 
 const TELEGRAM_OFFSET_ROTATION_LABELS: Record<TelegramOffsetRotationReason, string> = {
@@ -235,33 +229,32 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           }
         },
       });
-      let lastUpdateId = normalizePersistedUpdateId(persistedOffsetRaw);
+      const lastUpdateId = normalizeTelegramUpdateId(persistedOffsetRaw);
       if (persistedOffsetRaw !== null && lastUpdateId === null) {
         log(
           `[telegram] Ignoring invalid persisted update offset (${String(persistedOffsetRaw)}); starting without offset confirmation.`,
         );
       }
 
-      const persistUpdateId = async (updateId: number) => {
-        const normalizedUpdateId = normalizePersistedUpdateId(updateId);
-        if (normalizedUpdateId === null) {
-          log(`[telegram] Ignoring invalid update_id value: ${String(updateId)}`);
-          return;
-        }
-        if (lastUpdateId !== null && normalizedUpdateId <= lastUpdateId) {
-          return;
-        }
-        lastUpdateId = normalizedUpdateId;
-        try {
+      const offsetPersistence = createTelegramUpdateOffsetPersistence({
+        initialUpdateId: lastUpdateId,
+        writeUpdateId: async (updateId) => {
           await writeTelegramUpdateOffset({
             accountId: account.accountId,
-            updateId: normalizedUpdateId,
+            updateId,
             botToken: token,
           });
-        } catch (err) {
-          logError(`telegram: failed to persist update offset: ${String(err)}`);
-        }
-      };
+        },
+        onInvalidUpdateId: (updateId) => {
+          log(`[telegram] Ignoring invalid update_id value: ${String(updateId)}`);
+        },
+        onRetry: ({ attempt, delayMs, error, updateId }) => {
+          logError(
+            `telegram: failed to persist update offset ${updateId}; retry ${attempt} in ${delayMs}ms: ${formatErrorMessage(error)}`,
+          );
+        },
+        abortSignal: opts.abortSignal,
+      });
 
       // Preserve sticky IPv4 fallback state across clean/conflict restarts.
       // Dirty polling cycles rebuild transport inside TelegramPollingSession.
@@ -280,8 +273,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         botInfo: opts.botInfo,
         abortSignal: opts.abortSignal,
         runnerOptions: createTelegramRunnerOptions(cfg),
-        getLastUpdateId: () => lastUpdateId,
-        persistUpdateId,
+        getAcceptedUpdateId: offsetPersistence.getAcceptedUpdateId,
+        getCommittedUpdateId: offsetPersistence.getCommittedUpdateId,
+        persistUpdateId: offsetPersistence.persistUpdateId,
         log,
         telegramTransport,
         createTelegramTransport: createTelegramTransportForPolling,
@@ -293,7 +287,11 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           network: account.config.network,
         },
       });
-      await pollingSession.runUntilAbort();
+      try {
+        await pollingSession.runUntilAbort();
+      } finally {
+        await offsetPersistence.stop();
+      }
     } finally {
       pollingLease.release();
     }

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -32,6 +32,7 @@ import {
   resetTelegramReplyFenceForTest as resetTelegramReplyFenceForTests,
 } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
+import { createTelegramUpdateOffsetPersistence } from "./update-offset-persistence.js";
 const resolveSpooledUpdateRetryDelayMs = (
   update: { attempts?: number; lastAttemptAt?: number; lastError?: string; receivedAt: number },
   now?: number,
@@ -490,7 +491,8 @@ function createPollingSession(params: {
   log?: (message: string) => void;
   telegramTransport?: ReturnType<typeof makeTelegramTransport>;
   createTelegramTransport?: () => ReturnType<typeof makeTelegramTransport>;
-  getLastUpdateId?: () => number | null;
+  getAcceptedUpdateId?: () => number | null;
+  getCommittedUpdateId?: () => number | null;
   persistUpdateId?: ConstructorParameters<typeof TelegramPollingSession>[0]["persistUpdateId"];
   stallThresholdMs?: number;
   setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
@@ -505,7 +507,8 @@ function createPollingSession(params: {
     proxyFetch: undefined,
     abortSignal: params.abortSignal,
     runnerOptions: {},
-    getLastUpdateId: params.getLastUpdateId ?? (() => null),
+    getAcceptedUpdateId: params.getAcceptedUpdateId ?? params.getCommittedUpdateId ?? (() => null),
+    getCommittedUpdateId: params.getCommittedUpdateId ?? (() => null),
     persistUpdateId: params.persistUpdateId ?? (async () => undefined),
     log: params.log ?? (() => undefined),
     telegramTransport: params.telegramTransport,
@@ -803,7 +806,7 @@ function startIsolatedIngressSession(params: {
   handleUpdate: (update: { update_id?: number }) => Promise<void>;
   createWorker?: IsolatedIngressOptions["createWorker"];
   drainIntervalMs?: number;
-  getLastUpdateId?: () => number | null;
+  getCommittedUpdateId?: () => number | null;
   init?: AsyncVoidFn;
   log?: (message: string) => void;
   persistUpdateId?: ConstructorParameters<typeof TelegramPollingSession>[0]["persistUpdateId"];
@@ -822,7 +825,7 @@ function startIsolatedIngressSession(params: {
   createTelegramBotMock.mockReturnValueOnce(bot);
   const session = createPollingSession({
     abortSignal: params.abort.signal,
-    getLastUpdateId: params.getLastUpdateId,
+    getCommittedUpdateId: params.getCommittedUpdateId,
     log: params.log,
     persistUpdateId: params.persistUpdateId,
     stallThresholdMs: params.stallThresholdMs,
@@ -925,7 +928,8 @@ describe("TelegramPollingSession", () => {
       proxyFetch: undefined,
       abortSignal: abort.signal,
       runnerOptions: {},
-      getLastUpdateId: () => null,
+      getAcceptedUpdateId: () => null,
+      getCommittedUpdateId: () => null,
       persistUpdateId: async () => undefined,
       log: () => undefined,
       telegramTransport: undefined,
@@ -1047,7 +1051,8 @@ describe("TelegramPollingSession", () => {
       proxyFetch: undefined,
       abortSignal: abort.signal,
       runnerOptions: {},
-      getLastUpdateId: () => 41,
+      getAcceptedUpdateId: () => 41,
+      getCommittedUpdateId: () => 41,
       persistUpdateId: async () => undefined,
       log: () => undefined,
       telegramTransport: undefined,
@@ -1058,6 +1063,130 @@ describe("TelegramPollingSession", () => {
     // Offset confirmation was removed because it could self-conflict with the runner.
     // OpenClaw middleware still skips duplicates using the persisted update offset.
     expect(bot.api.getUpdates).not.toHaveBeenCalled();
+  });
+
+  it("keeps legacy polling offset progress after a malformed update ID", async () => {
+    const abort = new AbortController();
+    const bot = makeBot();
+    const writes: number[] = [];
+    const onInvalidUpdateId = vi.fn();
+    const offsetPersistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId: async (updateId) => {
+        writes.push(updateId);
+      },
+      onInvalidUpdateId,
+      onRetry: vi.fn(),
+    });
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    mockLongRunningPollingCycle(vi.fn(async () => undefined));
+
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      getAcceptedUpdateId: offsetPersistence.getAcceptedUpdateId,
+      getCommittedUpdateId: offsetPersistence.getCommittedUpdateId,
+      persistUpdateId: offsetPersistence.persistUpdateId,
+    });
+    const runPromise = session.runUntilAbort();
+    try {
+      await waitForTelegramTestState(() => expect(createTelegramBotMock).toHaveBeenCalledOnce());
+
+      const updateOffset = mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset;
+      if (!updateOffset || typeof updateOffset !== "object" || !("onUpdateId" in updateOffset)) {
+        throw new Error("Expected legacy polling update-offset callback");
+      }
+      const onUpdateId = updateOffset.onUpdateId;
+      if (typeof onUpdateId !== "function") {
+        throw new Error("Expected legacy polling update-offset callback");
+      }
+
+      onUpdateId(Number.NaN);
+      onUpdateId(101);
+      await waitForTelegramTestState(() => expect(writes).toEqual([101]));
+
+      expect(onInvalidUpdateId).toHaveBeenCalledWith(Number.NaN);
+      expect(offsetPersistence.getCommittedUpdateId()).toBe(101);
+    } finally {
+      abort.abort();
+      await runPromise;
+      await offsetPersistence.stop();
+    }
+  });
+
+  it("seeds a restarted classic polling cycle from accepted progress", async () => {
+    const abort = new AbortController();
+    let releaseWrite: (() => void) | undefined;
+    const write = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let restartFirstCycle: (() => void) | undefined;
+    const restartSignal = new Promise<void>((resolve) => {
+      restartFirstCycle = resolve;
+    });
+    const offsetPersistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId: async () => await write,
+      onInvalidUpdateId: vi.fn(),
+      onRetry: vi.fn(),
+    });
+    createTelegramBotMock.mockReturnValueOnce(makeBot()).mockReturnValueOnce(makeBot());
+    runMock
+      .mockReturnValueOnce({
+        task: async () => {
+          await restartSignal;
+          throw new Error("restart classic polling");
+        },
+        stop: vi.fn(async () => undefined),
+        isRunning: () => false,
+      })
+      .mockReturnValueOnce({
+        task: async () => {
+          abort.abort();
+        },
+        stop: vi.fn(async () => undefined),
+        isRunning: () => false,
+      });
+
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      getAcceptedUpdateId: offsetPersistence.getAcceptedUpdateId,
+      getCommittedUpdateId: offsetPersistence.getCommittedUpdateId,
+      persistUpdateId: offsetPersistence.persistUpdateId,
+    });
+    const runPromise = session.runUntilAbort();
+    try {
+      await waitForTelegramTestState(() => expect(createTelegramBotMock).toHaveBeenCalledOnce());
+      const firstOffset = mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset;
+      if (!firstOffset || typeof firstOffset !== "object" || !("onUpdateId" in firstOffset)) {
+        throw new Error("Expected classic polling update-offset callback");
+      }
+      const onUpdateId = firstOffset.onUpdateId;
+      if (typeof onUpdateId !== "function") {
+        throw new Error("Expected classic polling update-offset callback");
+      }
+      onUpdateId(101);
+
+      expect(offsetPersistence.getAcceptedUpdateId()).toBe(101);
+      expect(offsetPersistence.getCommittedUpdateId()).toBe(100);
+      restartFirstCycle?.();
+      await runPromise;
+
+      const restartedOffset = mockObjectArg(
+        createTelegramBotMock,
+        "createTelegramBot",
+        1,
+      ).updateOffset;
+      expect(restartedOffset).toMatchObject({
+        lastUpdateId: 101,
+        persistenceFloorUpdateId: 100,
+      });
+    } finally {
+      releaseWrite?.();
+      restartFirstCycle?.();
+      abort.abort();
+      await runPromise;
+      await offsetPersistence.stop();
+    }
   });
 
   it("initializes the main-thread bot before draining isolated ingress spool", async () => {
@@ -1254,7 +1383,7 @@ describe("TelegramPollingSession", () => {
         handleUpdate: vi.fn(async () => undefined),
         createWorker: worker.createWorker,
         drainIntervalMs: 60_000,
-        getLastUpdateId: () => 40,
+        getCommittedUpdateId: () => 40,
         persistUpdateId,
       });
       try {
@@ -1316,6 +1445,141 @@ describe("TelegramPollingSession", () => {
       } finally {
         abort.abort();
         await runPromise;
+      }
+    });
+  });
+
+  it("keeps isolated intake moving while the durable offset catches up", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      let releaseOffsetWrite: (() => void) | undefined;
+      const offsetWrite = new Promise<void>((resolve) => {
+        releaseOffsetWrite = resolve;
+      });
+      const handleUpdate = vi.fn(async () => undefined);
+      const worker = createListeningIngressWorker();
+      const { runPromise } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: worker.createWorker,
+        persistUpdateId: vi.fn(async () => await offsetWrite),
+      });
+      try {
+        await waitForTelegramTestState(() => expect(worker.hasListener()).toBe(true));
+        worker.emit({
+          type: "update",
+          requestId: "offset-catching-up",
+          update: { update_id: 44, message: { text: "hello" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(worker.ackSpooledUpdate).toHaveBeenCalledWith("offset-catching-up", {
+            ok: true,
+            updateId: 44,
+          }),
+        );
+        await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledOnce());
+      } finally {
+        releaseOffsetWrite?.();
+        abort.abort();
+        await runPromise;
+      }
+    });
+  });
+
+  it("recovers offset persistence and suppresses restart replay", async () => {
+    await withTempSpool(async (tempDir) => {
+      let durableUpdateId = 40;
+      const writeUpdateId = vi
+        .fn(async (updateId: number) => {
+          durableUpdateId = updateId;
+        })
+        .mockRejectedValueOnce(new Error("offset store unavailable"));
+      const firstOffsetPersistence = createTelegramUpdateOffsetPersistence({
+        initialUpdateId: durableUpdateId,
+        writeUpdateId,
+        onInvalidUpdateId: vi.fn(),
+        onRetry: vi.fn(),
+      });
+      const handleUpdate = vi.fn(async () => undefined);
+      const firstAbort = new AbortController();
+      const firstWorker = createListeningIngressWorker();
+      const firstSession = startIsolatedIngressSession({
+        abort: firstAbort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: firstWorker.createWorker,
+        getCommittedUpdateId: firstOffsetPersistence.getCommittedUpdateId,
+        persistUpdateId: firstOffsetPersistence.persistUpdateId,
+      });
+      try {
+        await waitForTelegramTestState(() => expect(firstWorker.hasListener()).toBe(true));
+        firstWorker.emit({
+          type: "update",
+          requestId: "first-delivery",
+          update: { update_id: 42, message: { text: "hello" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(firstWorker.ackSpooledUpdate).toHaveBeenCalledWith("first-delivery", {
+            ok: true,
+            updateId: 42,
+          }),
+        );
+        await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledOnce());
+        await waitForTelegramTestState(() =>
+          expect(firstOffsetPersistence.getCommittedUpdateId()).toBe(42),
+        );
+        await waitForTelegramTestState(async () =>
+          expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+        );
+      } finally {
+        firstAbort.abort();
+        await firstSession.runPromise;
+        await firstOffsetPersistence.stop();
+      }
+
+      expect(writeUpdateId).toHaveBeenCalledTimes(2);
+      expect(durableUpdateId).toBe(42);
+
+      const restartWriteUpdateId = vi.fn(async () => undefined);
+      const restartedOffsetPersistence = createTelegramUpdateOffsetPersistence({
+        initialUpdateId: durableUpdateId,
+        writeUpdateId: restartWriteUpdateId,
+        onInvalidUpdateId: vi.fn(),
+        onRetry: vi.fn(),
+      });
+      const restartAbort = new AbortController();
+      const restartWorker = createListeningIngressWorker();
+      const restartedSession = startIsolatedIngressSession({
+        abort: restartAbort,
+        spoolDir: tempDir,
+        handleUpdate,
+        createWorker: restartWorker.createWorker,
+        getCommittedUpdateId: restartedOffsetPersistence.getCommittedUpdateId,
+        persistUpdateId: restartedOffsetPersistence.persistUpdateId,
+      });
+      try {
+        await waitForTelegramTestState(() => expect(restartWorker.hasListener()).toBe(true));
+        restartWorker.emit({
+          type: "update",
+          requestId: "restart-replay",
+          update: { update_id: 42, message: { text: "hello" } },
+          queued: 1,
+        });
+        await waitForTelegramTestState(() =>
+          expect(restartWorker.ackSpooledUpdate).toHaveBeenCalledWith("restart-replay", {
+            ok: true,
+            updateId: 42,
+          }),
+        );
+        expect(handleUpdate).toHaveBeenCalledOnce();
+        expect(restartWriteUpdateId).not.toHaveBeenCalled();
+      } finally {
+        restartAbort.abort();
+        await restartedSession.runPromise;
+        await restartedOffsetPersistence.stop();
       }
     });
   });
@@ -1498,7 +1762,7 @@ describe("TelegramPollingSession", () => {
         abort,
         spoolDir: tempDir,
         handleUpdate,
-        getLastUpdateId: () => 42,
+        getCommittedUpdateId: () => 42,
       });
       try {
         await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
@@ -4070,7 +4334,8 @@ describe("TelegramPollingSession", () => {
         proxyFetch: undefined,
         abortSignal: abort.signal,
         runnerOptions: {},
-        getLastUpdateId: () => null,
+        getAcceptedUpdateId: () => null,
+        getCommittedUpdateId: () => null,
         persistUpdateId: async () => undefined,
         log: () => undefined,
         telegramTransport: transport1,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -93,8 +93,9 @@ type TelegramPollingSessionOpts = {
   botInfo?: Parameters<typeof createTelegramBot>[0]["botInfo"];
   abortSignal?: AbortSignal;
   runnerOptions: RunOptions<unknown>;
-  getLastUpdateId: () => number | null;
-  persistUpdateId: (updateId: number) => Promise<void>;
+  getAcceptedUpdateId: () => number | null;
+  getCommittedUpdateId: () => number | null;
+  persistUpdateId: (updateId: number) => void | Promise<void>;
   log: (line: string) => void;
   /** Pre-resolved Telegram transport to reuse across bot instances */
   telegramTransport?: TelegramTransport;
@@ -292,11 +293,13 @@ export class TelegramPollingSession {
       ? this.opts.abortSignal
       : cycleAbortSignal;
     const telegramTransport = this.#transportState.acquireForNextCycle();
-    const persistedLastUpdateId = this.opts.getLastUpdateId();
-    const lastUpdateId = this.opts.isolatedIngress?.enabled ? null : persistedLastUpdateId;
+    const committedUpdateId = this.opts.getCommittedUpdateId();
+    const lastUpdateId = this.opts.isolatedIngress?.enabled
+      ? null
+      : this.opts.getAcceptedUpdateId();
     const updateOffset = {
       lastUpdateId,
-      persistenceFloorUpdateId: persistedLastUpdateId,
+      persistenceFloorUpdateId: committedUpdateId,
       // In isolated mode the offset is persisted as soon as the update is
       // durably spooled (see #runIsolatedIngressCycle), so the bot's update
       // tracker does not need to persist it again after dispatch.
@@ -414,7 +417,7 @@ export class TelegramPollingSession {
     const worker = workerFactory({
       token: this.opts.token,
       accountId: this.opts.accountId,
-      initialUpdateId: this.opts.getLastUpdateId(),
+      initialUpdateId: this.opts.getCommittedUpdateId(),
       spoolDir,
       apiRoot: ingress.apiRoot,
       timeoutSeconds: ingress.timeoutSeconds,
@@ -526,7 +529,8 @@ export class TelegramPollingSession {
           `[telegram][diag] isolated polling worker update received updateId=${updateIdHint} queued=${message.queued}`,
         );
         // The worker waits for this request's ACK before emitting the next update.
-        // Keep spool, offset persistence, and ACK on that single ordered path.
+        // The committed spool enqueue is the ACK boundary; offset persistence is
+        // monotonic catch-up and must not stall intake during a state-store outage.
         void (async () => {
           let updateId: number;
           try {
@@ -547,16 +551,15 @@ export class TelegramPollingSession {
             return;
           }
 
-          try {
-            await this.opts.persistUpdateId(updateId);
-            this.opts.log(
-              `[telegram][diag] isolated polling offset persisted updateId=${updateId}`,
-            );
-          } catch (err: unknown) {
-            this.opts.log(
-              `[telegram] isolated polling offset persist failed updateId=${updateId}: ${formatErrorMessage(err)}`,
-            );
-          }
+          const offsetPersistence = this.opts.persistUpdateId(updateId);
+          void Promise.resolve(offsetPersistence).catch((err: unknown) => {
+            if (!this.opts.abortSignal?.aborted) {
+              this.opts.log(
+                `[telegram] isolated polling offset persist failed updateId=${updateId}: ${formatErrorMessage(err)}`,
+              );
+            }
+          });
+          this.opts.log(`[telegram][diag] isolated polling offset queued updateId=${updateId}`);
           ackSpooledUpdate(message.requestId, { ok: true, updateId });
           requestImmediateDrain();
         })();

--- a/extensions/telegram/src/update-offset-persistence.test.ts
+++ b/extensions/telegram/src/update-offset-persistence.test.ts
@@ -1,0 +1,202 @@
+// Telegram tests cover monotonic update-offset persistence and retry.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTelegramUpdateOffsetPersistence } from "./update-offset-persistence.js";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createTelegramUpdateOffsetPersistence", () => {
+  it("retries a failed write and coalesces the highest pending update", async () => {
+    vi.useFakeTimers();
+    const writes: number[] = [];
+    let failFirstWrite = true;
+    const onRetry = vi.fn();
+    const persistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId: async (updateId) => {
+        writes.push(updateId);
+        if (failFirstWrite) {
+          failFirstWrite = false;
+          throw new Error("offset store unavailable");
+        }
+      },
+      onInvalidUpdateId: vi.fn(),
+      onRetry,
+    });
+
+    persistence.persistUpdateId(101);
+    await flushMicrotasks();
+    persistence.persistUpdateId(103);
+    persistence.persistUpdateId(102);
+
+    expect(writes).toEqual([101]);
+    expect(persistence.getAcceptedUpdateId()).toBe(103);
+    expect(persistence.getCommittedUpdateId()).toBe(100);
+    expect(onRetry).toHaveBeenCalledWith(expect.objectContaining({ attempt: 1, updateId: 101 }));
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushMicrotasks();
+
+    expect(writes).toEqual([101, 103]);
+    expect(persistence.getCommittedUpdateId()).toBe(103);
+    await persistence.stop();
+  });
+
+  it("never regresses when a lower update arrives during a higher write", async () => {
+    const write = deferred();
+    const writes: number[] = [];
+    const persistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId: async (updateId) => {
+        writes.push(updateId);
+        await write.promise;
+      },
+      onInvalidUpdateId: vi.fn(),
+      onRetry: vi.fn(),
+    });
+
+    persistence.persistUpdateId(103);
+    persistence.persistUpdateId(102);
+    await flushMicrotasks();
+    write.resolve();
+    await flushMicrotasks();
+
+    expect(writes).toEqual([103]);
+    expect(persistence.getCommittedUpdateId()).toBe(103);
+    await persistence.stop();
+  });
+
+  it("restarts the drain when a higher update arrives during teardown", async () => {
+    const firstWrite = deferred();
+    const writes: number[] = [];
+    const persistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId: async (updateId) => {
+        writes.push(updateId);
+        if (updateId === 101) {
+          await firstWrite.promise;
+        }
+      },
+      onInvalidUpdateId: vi.fn(),
+      onRetry: vi.fn(),
+    });
+
+    persistence.persistUpdateId(101);
+    await flushMicrotasks();
+    firstWrite.resolve();
+    queueMicrotask(() => persistence.persistUpdateId(102));
+    await vi.waitFor(() => expect(writes).toEqual([101, 102]));
+
+    expect(persistence.getAcceptedUpdateId()).toBe(102);
+    expect(persistence.getCommittedUpdateId()).toBe(102);
+    await persistence.stop();
+  });
+
+  it("fences an in-flight write before stop resolves", async () => {
+    const write = deferred();
+    const persistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId: async () => await write.promise,
+      onInvalidUpdateId: vi.fn(),
+      onRetry: vi.fn(),
+    });
+
+    persistence.persistUpdateId(101);
+    await flushMicrotasks();
+    let stopped = false;
+    const stop = persistence.stop().then(() => {
+      stopped = true;
+    });
+    await flushMicrotasks();
+    expect(stopped).toBe(false);
+
+    write.resolve();
+    await stop;
+    expect(stopped).toBe(true);
+    expect(persistence.getCommittedUpdateId()).toBe(101);
+  });
+
+  it("cancels a scheduled retry when stopped", async () => {
+    vi.useFakeTimers();
+    const writeUpdateId = vi.fn(async () => {
+      throw new Error("offset store unavailable");
+    });
+    const persistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId,
+      onInvalidUpdateId: vi.fn(),
+      onRetry: vi.fn(),
+    });
+
+    persistence.persistUpdateId(101);
+    await flushMicrotasks();
+    await persistence.stop();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(writeUpdateId).toHaveBeenCalledTimes(1);
+    expect(persistence.getCommittedUpdateId()).toBe(100);
+  });
+
+  it("does not rearm a failed write after the supplied signal aborts", async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    const writeUpdateId = vi.fn(async () => {
+      throw new Error("offset store unavailable");
+    });
+    const persistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId,
+      onInvalidUpdateId: vi.fn(),
+      onRetry: vi.fn(),
+      abortSignal: abortController.signal,
+    });
+
+    persistence.persistUpdateId(101);
+    await flushMicrotasks();
+    abortController.abort();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(writeUpdateId).toHaveBeenCalledTimes(1);
+    expect(persistence.getCommittedUpdateId()).toBe(100);
+    await persistence.stop();
+  });
+
+  it("ignores a malformed update ID without blocking the next valid write", async () => {
+    const writes: number[] = [];
+    const onInvalidUpdateId = vi.fn();
+    const persistence = createTelegramUpdateOffsetPersistence({
+      initialUpdateId: 100,
+      writeUpdateId: async (updateId) => {
+        writes.push(updateId);
+      },
+      onInvalidUpdateId,
+      onRetry: vi.fn(),
+    });
+
+    persistence.persistUpdateId(Number.NaN);
+    persistence.persistUpdateId(101);
+    await flushMicrotasks();
+
+    expect(onInvalidUpdateId).toHaveBeenCalledWith(Number.NaN);
+    expect(writes).toEqual([101]);
+    expect(persistence.getAcceptedUpdateId()).toBe(101);
+    expect(persistence.getCommittedUpdateId()).toBe(101);
+    await persistence.stop();
+  });
+});

--- a/extensions/telegram/src/update-offset-persistence.ts
+++ b/extensions/telegram/src/update-offset-persistence.ts
@@ -1,0 +1,113 @@
+// Telegram plugin module owns monotonic update-offset persistence and retry.
+import {
+  computeBackoff,
+  sleepWithAbort,
+  type BackoffPolicy,
+} from "openclaw/plugin-sdk/runtime-env";
+
+const OFFSET_PERSIST_RETRY_POLICY: BackoffPolicy = {
+  initialMs: 250,
+  maxMs: 5_000,
+  factor: 2,
+  jitter: 0.1,
+};
+
+type TelegramUpdateOffsetPersistenceOptions = {
+  initialUpdateId: number | null;
+  writeUpdateId: (updateId: number) => Promise<void>;
+  onInvalidUpdateId: (updateId: number) => void;
+  onRetry: (retry: { attempt: number; delayMs: number; error: unknown; updateId: number }) => void;
+  abortSignal?: AbortSignal;
+};
+
+export function normalizeTelegramUpdateId(value: number | null): number | null {
+  if (value === null || !Number.isSafeInteger(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+export function createTelegramUpdateOffsetPersistence(
+  options: TelegramUpdateOffsetPersistenceOptions,
+) {
+  const stopController = new AbortController();
+  const retrySignal = options.abortSignal
+    ? AbortSignal.any([options.abortSignal, stopController.signal])
+    : stopController.signal;
+  let acceptedUpdateId = options.initialUpdateId;
+  let committedUpdateId = options.initialUpdateId;
+  let pendingUpdateId: number | null = null;
+  let activeDrain: Promise<void> | undefined;
+
+  const drain = async () => {
+    let attempt = 0;
+    while (pendingUpdateId !== null) {
+      if (retrySignal.aborted) {
+        return;
+      }
+      const updateId = pendingUpdateId;
+      try {
+        await options.writeUpdateId(updateId);
+        committedUpdateId = updateId;
+        if (pendingUpdateId === updateId) {
+          pendingUpdateId = null;
+        }
+        attempt = 0;
+      } catch (error) {
+        if (retrySignal.aborted) {
+          return;
+        }
+        attempt += 1;
+        const delayMs = computeBackoff(OFFSET_PERSIST_RETRY_POLICY, attempt);
+        options.onRetry({ attempt, delayMs, error, updateId });
+        await sleepWithAbort(delayMs, retrySignal, { ref: false });
+      }
+    }
+  };
+
+  const startDrain = () => {
+    if (activeDrain) {
+      return;
+    }
+    const run = drain()
+      .catch(() => undefined)
+      .finally(() => {
+        if (activeDrain === run) {
+          activeDrain = undefined;
+          if (pendingUpdateId !== null && !retrySignal.aborted) {
+            startDrain();
+          }
+        }
+      });
+    activeDrain = run;
+  };
+
+  const persistUpdateId = (updateId: number) => {
+    if (retrySignal.aborted) {
+      return;
+    }
+    const normalizedUpdateId = normalizeTelegramUpdateId(updateId);
+    if (normalizedUpdateId === null) {
+      options.onInvalidUpdateId(updateId);
+      return;
+    }
+    if (acceptedUpdateId !== null && normalizedUpdateId <= acceptedUpdateId) {
+      return;
+    }
+    acceptedUpdateId = normalizedUpdateId;
+    pendingUpdateId = normalizedUpdateId;
+    startDrain();
+  };
+
+  const stop = async () => {
+    stopController.abort(new Error("Telegram update-offset persistence stopped."));
+    await activeDrain?.catch(() => undefined);
+  };
+
+  return {
+    getAcceptedUpdateId: () => acceptedUpdateId,
+    getCommittedUpdateId: () => committedUpdateId,
+    persistUpdateId,
+    stop,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes #105191. A transient Telegram update-offset write failure used to advance the monitor's in-memory watermark anyway. The durable watermark stayed stale, so a later restart could replay already-handled updates and duplicate replies or side effects.

## Canonical fix

- Own offset persistence at the account monitor boundary, not the per-bot update tracker.
- Track two authoritative facts: accepted progress for same-process classic polling restarts, and committed progress for durable recovery plus isolated-worker startup.
- Advance the committed watermark only after the state-store write succeeds.
- Coalesce traffic behind one monotonic highest-pending target and retry with bounded, unref'ed backoff.
- Validate persisted and live update IDs through one non-negative safe-integer boundary, so malformed legacy input cannot poison later progress.
- Fence the one active write and cancel retry sleep before the polling lease is released.
- Keep isolated polling's existing durability contract: committed SQLite spool enqueue is the worker ACK boundary. Offset catch-up runs independently, so a plugin-state outage cannot stop all Telegram intake.
- Keep completed spool tombstones authoritative, so even a stale restart replay cannot dispatch the same update twice.

No config/default surfaces change. Production delta: +161/-47 (net +114) for the account-lifecycle owner and its accepted/committed boundaries. Tests: +476/-9 (net +467).

## Why this is the best fix

The previous tracker-local retry could not observe the production failure: `monitor.ts` swallowed the write error after optimistically advancing memory. It also created a second retry lifecycle under the bot. One monitor-owned writer now serves classic and default isolated polling with one accepted watermark, one committed watermark, one pending maximum, one active write, and one retry timer only during an outage.

Classic polling recreates its tracker from accepted progress so a runner restart during a storage outage cannot dispatch an already-handled update again. Durable recovery, persistence floors, and isolated-worker startup use only committed progress.

The older review move to delay the isolated worker ACK until secondary offset persistence is intentionally not applied. The current scoped Telegram contract makes committed durable spool enqueue the ACK boundary. Blocking that ACK on plugin-state recovery would stall the single polling worker even though the update is already durable; restart replay is handled by the completed queue tombstone.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/update-offset-persistence.test.ts extensions/telegram/src/monitor.test.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/bot-update-tracker.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/telegram-ingress-worker.runtime.test.ts` — 278 passed, including supplied-abort shutdown and teardown-handoff regressions.
- Drain teardown proof: resolve write 101, queue 102 in the ownership-handoff microtask, and verify 102 is written and committed.n- Classic failure-through-restart proof: accepted progress advances to 101 while committed progress remains 100; a recreated classic bot starts at 101 while its persistence floor stays 100.
- Malformed-input proof: the owner helper ignores `NaN` and commits the following valid ID; legacy polling wires that same callback and proves `NaN → 101` persists `101`.
- Injected isolated-boundary proof: first offset write rejects, retry commits 42, the same SQLite state restarts, update 42 is replayed, and the completed tombstone keeps total handler calls at exactly one.
- Telegram real-user E2E after the accepted/committed split via `telegram-e2e-userbot`: doctor passed; one mock-provider request; two recorded typing events; one recorded Telegram message at 2080 ms; exact reply `OPENCLAW_E2E_OK`; recording complete. Tokens and account/chat/message identifiers are omitted.
- [browser] build: node scripts/build-copilot-runtime.mjs
[canvas] build: node scripts/bundle-a2ui.mjs
A2UI bundle up to date; skipping.
[diffs] build: node ../../scripts/build-diffs-viewer-runtime.mjs curated
[diffs-language-pack] build: node ../../scripts/build-diffs-viewer-runtime.mjs full
[discord] build: node ../../scripts/build-discord-activity-sdk.mjs
[tsdown-build] invocation 1/1 finished in 0.4s
[tsdown-build] invocation 1/1 finished in 0.4s
[tsdown-build] invocation 1/9 finished in 3.2s
[tsdown-build] invocation 2/9 finished in 16.2s
[tsdown-build] invocation 3/9 finished in 19.9s
[tsdown-build] invocation 4/9 finished in 17.8s
[tsdown-build] invocation 5/9 finished in 21.6s
[tsdown-build] invocation 6/9 finished in 17.2s
[tsdown-build] invocation 7/9 finished in 17.5s
[tsdown-build] invocation 8/9 finished in 19.5s
[tsdown-build] invocation 9/9 finished in 19.6s
CLI bootstrap import guard passed.
[browser] copy: node scripts/copy-chrome-extension.mjs
[canvas] copy: node scripts/copy-a2ui.mjs
Public plugin SDK declaration graph: 3176319/5315536 bytes (5250000-byte ratchet + 65536-byte output variance).
OK: All 149 public plugin-sdk subpaths verified.
[copy-hook-metadata] Copied 5 hook metadata files.
vite v8.1.5 building client environment for production...
^[[2Ktransforming...✓ 3042 modules transformed.
rendering chunks...
computing gzip size...
../dist/control-ui/index.html                                                15.55 kB │ gzip:   4.26 kB
../dist/control-ui/assets/cron-jobs-pagination-CAMzNrG9.css                   0.28 kB │ gzip:   0.21 kB
../dist/control-ui/assets/agents-page-D3n-txaC.css                            0.35 kB │ gzip:   0.20 kB
../dist/control-ui/assets/logs-page-BDXqQVlM.css                              0.53 kB │ gzip:   0.23 kB
../dist/control-ui/assets/wizard-step-controls-BOnb7nf1.css                   1.21 kB │ gzip:   0.49 kB
../dist/control-ui/assets/profile-page-D9CIbLiC.css                           1.27 kB │ gzip:   0.49 kB
../dist/control-ui/assets/nodes-page-CTKLiBom.css                             1.39 kB │ gzip:   0.52 kB
../dist/control-ui/assets/connection-page-C_iOeqsC.css                        1.81 kB │ gzip:   0.61 kB
../dist/control-ui/assets/custodian-panel-DOKDi9wY.css                        1.89 kB │ gzip:   0.69 kB
../dist/control-ui/assets/hub-tabs-BKqcNjfb.css                               2.36 kB │ gzip:   0.76 kB
../dist/control-ui/assets/activity-page-DBeWdVd1.css                          3.29 kB │ gzip:   0.95 kB
../dist/control-ui/assets/model-providers-page-EG2fyZrI.css                   4.04 kB │ gzip:   0.98 kB
../dist/control-ui/assets/apps-page-DP6XGC9R.css                              4.43 kB │ gzip:   1.22 kB
../dist/control-ui/assets/memory-import-page-BZgOsZiU.css                     4.62 kB │ gzip:   1.24 kB
../dist/control-ui/assets/about-page-BM-UoCAZ.css                             4.75 kB │ gzip:   1.49 kB
../dist/control-ui/assets/skills-shared-BC20uDd8.css                          4.99 kB │ gzip:   1.32 kB
../dist/control-ui/assets/text-Dl6NQ8BW.css                                   5.39 kB │ gzip:   1.40 kB
../dist/control-ui/assets/logbook-view-BG9QHuAs.css                           5.72 kB │ gzip:   1.34 kB
../dist/control-ui/assets/channels-page-FDpMvElK.css                          6.91 kB │ gzip:   1.60 kB
../dist/control-ui/assets/model-setup-page-DZRsianv.css                       7.33 kB │ gzip:   1.76 kB
../dist/control-ui/assets/approval-page-registration-BbmQaaTT.css             8.01 kB │ gzip:   2.02 kB
../dist/control-ui/assets/new-session-page-B8zoE-wn.css                       9.70 kB │ gzip:   2.24 kB
../dist/control-ui/assets/plugins-e2jK4R5d.css                               10.49 kB │ gzip:   2.39 kB
../dist/control-ui/assets/cron-page-C25b8WLO.css                             15.75 kB │ gzip:   3.28 kB
../dist/control-ui/assets/memory-panel-CueRoiPa.css                          16.84 kB │ gzip:   3.48 kB
../dist/control-ui/assets/board-view-8aHzRCuq.css                            17.12 kB │ gzip:   3.55 kB
../dist/control-ui/assets/config-page-BnH5Oafo.css                           17.75 kB │ gzip:   3.86 kB
../dist/control-ui/assets/sessions-page-XBMixjXT.css                         17.97 kB │ gzip:   3.31 kB
../dist/control-ui/assets/lobster-pet-D3Co_fG9.css                           25.36 kB │ gzip:   5.33 kB
../dist/control-ui/assets/skill-workshop-page-D2DZi8u6.css                   28.75 kB │ gzip:   5.56 kB
../dist/control-ui/assets/workboard-page-CDuj4QH2.css                        30.88 kB │ gzip:   5.51 kB
../dist/control-ui/assets/usage-CWMnUCbt.css                                 33.30 kB │ gzip:   6.12 kB
../dist/control-ui/assets/custodian-surface-0Oz70KGr.css                    118.77 kB │ gzip:  19.03 kB
../dist/control-ui/assets/chat-model-controls-C4IV0Cfc.css                  201.81 kB │ gzip:  31.22 kB
../dist/control-ui/assets/control-ui-core-CMupHFtS.css                      263.52 kB │ gzip:  42.38 kB
../dist/control-ui/assets/text-CjvvY051.js                                    0.12 kB │ gzip:   0.13 kB │ map:     7.90 kB
../dist/control-ui/assets/__vite-browser-external-2447137e-D8N5sTJI.js        0.13 kB │ gzip:   0.15 kB │ map:     0.27 kB
../dist/control-ui/assets/index-OpdJtaQB.js                                   0.24 kB │ gzip:   0.20 kB │ map:    19.86 kB
../dist/control-ui/assets/preview-DzpTTA8I.js                                 0.25 kB │ gzip:   0.21 kB │ map:     0.36 kB
../dist/control-ui/assets/cron-status-CX5IwEkV.js                             0.26 kB │ gzip:   0.22 kB │ map:     1.07 kB
../dist/control-ui/assets/agent-select-registration-DKa8b8VE.js               0.29 kB │ gzip:   0.22 kB │ map:     0.41 kB
../dist/control-ui/assets/task-summary-Dd8rMIbb.js                            0.35 kB │ gzip:   0.27 kB │ map:     1.00 kB
../dist/control-ui/assets/route-view-MXEDwOBi.js                              0.38 kB │ gzip:   0.27 kB │ map:     0.60 kB
../dist/control-ui/assets/system-info-CCJ-99C3.js                             0.40 kB │ gzip:   0.30 kB │ map:     0.88 kB
../dist/control-ui/assets/diff-0FqzS32D.js                                    0.41 kB │ gzip:   0.32 kB │ map:     1.14 kB
../dist/control-ui/assets/platform-label-CpNCbwLC.js                          0.46 kB │ gzip:   0.34 kB │ map:     1.26 kB
../dist/control-ui/assets/workboard-board-glyph-D6fXMVf4.js                   0.48 kB │ gzip:   0.33 kB │ map:     0.99 kB
../dist/control-ui/assets/plugins-Bql88Lb9.js                                 0.48 kB │ gzip:   0.31 kB │ map:    16.44 kB
../dist/control-ui/assets/navigation-handoff-BUQY0wgp.js                      0.49 kB │ gzip:   0.34 kB │ map:     2.20 kB
../dist/control-ui/assets/model-auth-BW81fSVK.js                              0.51 kB │ gzip:   0.35 kB │ map:     2.43 kB
../dist/control-ui/assets/poll-controller-BnQs2EZr.js                         0.52 kB │ gzip:   0.32 kB │ map:     1.47 kB
../dist/control-ui/assets/settings-workspace-BbyrBOFl.js                      0.52 kB │ gzip:   0.33 kB │ map:     1.18 kB
../dist/control-ui/assets/child-session-data-CpX_1UL-.js                      0.56 kB │ gzip:   0.40 kB │ map:     1.84 kB
../dist/control-ui/assets/gateway-readiness-CgLa_3I7.js                       0.62 kB │ gzip:   0.41 kB │ map:     2.20 kB
../dist/control-ui/assets/lobster-pet-contract-CTr2AH0h.js                    0.65 kB │ gzip:   0.45 kB │ map:     5.71 kB
../dist/control-ui/assets/brainfuck-Ds2vRhs-.js                               0.71 kB │ gzip:   0.40 kB │ map:     2.30 kB
../dist/control-ui/assets/fast-mode-BTyJtA9f.js                               0.74 kB │ gzip:   0.45 kB │ map:     6.11 kB
../dist/control-ui/assets/properties-EB1YgqDp.js                              0.77 kB │ gzip:   0.43 kB │ map:     2.44 kB
../dist/control-ui/assets/models-D3RQvKVl.js                                  0.80 kB │ gzip:   0.45 kB │ map:     3.58 kB
../dist/control-ui/assets/builtin-dashboard-C9Jr_T_v.js                       0.80 kB │ gzip:   0.48 kB │ map:     3.14 kB
../dist/control-ui/assets/cron-jobs-pagination-CfTvx3hB.js                    0.83 kB │ gzip:   0.46 kB │ map:     1.86 kB
../dist/control-ui/assets/cmake-B-PIXJMN.js                                   0.88 kB │ gzip:   0.55 kB │ map:     3.16 kB
../dist/control-ui/assets/dock-panel-layout-BeKwwc_p.js                       0.90 kB │ gzip:   0.50 kB │ map:     3.81 kB
../dist/control-ui/assets/asciiarmor-DKmoBgzD.js                              0.90 kB │ gzip:   0.48 kB │ map:     2.63 kB
../dist/control-ui/assets/protobuf-CD5FpG0s.js                                0.91 kB │ gzip:   0.60 kB │ map:     2.40 kB
../dist/control-ui/assets/stream-auto-follow-controller-DZ9E9o4h.js           0.93 kB │ gzip:   0.48 kB │ map:     2.83 kB
../dist/control-ui/assets/http-CxzHkxGO.js                                    0.95 kB │ gzip:   0.50 kB │ map:     3.17 kB
../dist/control-ui/assets/paged-session-rows-C8hiLoFL.js                      0.96 kB │ gzip:   0.55 kB │ map:     3.90 kB
../dist/control-ui/assets/open-external-url-Dbg6sq07.js                       0.97 kB │ gzip:   0.57 kB │ map:     3.68 kB
../dist/control-ui/assets/solr-DSArHS0o.js                                    0.97 kB │ gzip:   0.54 kB │ map:     3.19 kB
../dist/control-ui/assets/identity-avatar-view-CSFRD7g8.js                    1.04 kB │ gzip:   0.64 kB │ map:     3.74 kB
../dist/control-ui/assets/troff-DXWVfN6z.js                                   1.06 kB │ gzip:   0.52 kB │ map:     3.15 kB
../dist/control-ui/assets/elapsed-time-8sDiyIDc.js                            1.08 kB │ gzip:   0.59 kB │ map:     2.28 kB
../dist/control-ui/assets/sessions-hub-header-CY3OD2xx.js                     1.10 kB │ gzip:   0.52 kB │ map:     2.56 kB
../dist/control-ui/assets/panel-refresh-status-DDfC7xJK.js                    1.12 kB │ gzip:   0.58 kB │ map:     2.73 kB
../dist/control-ui/assets/rolldown-runtime-DaJ6WEGw.js                        1.17 kB │ gzip:   0.66 kB
../dist/control-ui/assets/spreadsheet-BvaZfCIQ.js                             1.25 kB │ gzip:   0.62 kB │ map:     3.87 kB
../dist/control-ui/assets/toml-BohymRtS.js                                    1.29 kB │ gzip:   0.62 kB │ map:     3.82 kB
../dist/control-ui/assets/agent-scope-control-Du_bqvkI.js                     1.41 kB │ gzip:   0.78 kB │ map:     4.49 kB
../dist/control-ui/assets/tasks-3GA_eazJ.js                                   1.47 kB │ gzip:   0.70 kB │ map:     7.38 kB
../dist/control-ui/assets/mbox-CuTe5vaV.js                                    1.51 kB │ gzip:   0.75 kB │ map:     4.87 kB
../dist/control-ui/assets/session-goal-BCKLIdYx.js                            1.55 kB │ gzip:   0.69 kB │ map:     5.02 kB
../dist/control-ui/assets/load-CSBQt-ky.js                                    1.56 kB │ gzip:   0.84 kB │ map:     5.77 kB
../dist/control-ui/assets/web-push.runtime-Wr6csakk.js                        1.60 kB │ gzip:   0.82 kB │ map:     4.97 kB
../dist/control-ui/assets/canvas-surface-lease.runtime-CDo2H3XY.js            1.62 kB │ gzip:   0.89 kB │ map:     8.14 kB
../dist/control-ui/assets/critical-observer-notice.runtime-DCpO5vJQ.js        1.68 kB │ gzip:   0.88 kB │ map:     6.25 kB
../dist/control-ui/assets/board-view-placeholder-BrvM8nSW.js                  1.71 kB │ gzip:   0.80 kB │ map:     2.66 kB
../dist/control-ui/assets/rpm-DfNBtzxa.js                                     1.72 kB │ gzip:   0.91 kB │ map:     4.45 kB
../dist/control-ui/assets/sieve-CapJqCuR.js                                   1.72 kB │ gzip:   0.85 kB │ map:     5.88 kB
../dist/control-ui/assets/presenter-m5f_c1BY.js                               1.72 kB │ gzip:   0.85 kB │ map:     4.95 kB
../dist/control-ui/assets/toast-exhV-oro.js                                   1.75 kB │ gzip:   0.77 kB │ map:     3.43 kB
../dist/control-ui/assets/factor-C99TnTg9.js                                  1.79 kB │ gzip:   0.69 kB │ map:     4.43 kB
../dist/control-ui/assets/eiffel-wyRG_RdM.js                                  1.80 kB │ gzip:   0.99 kB │ map:     4.87 kB
../dist/control-ui/assets/bootstrap-location-CHLkQRmH.js                      1.82 kB │ gzip:   0.82 kB │ map:     6.78 kB
../dist/control-ui/assets/confirm-dialog-BIlp8zTl.js                          1.83 kB │ gzip:   0.76 kB │ map:     3.96 kB
../dist/control-ui/assets/approval-result-validators-B2fWxcKH.js              1.84 kB │ gzip:   0.81 kB │ map:    13.00 kB
../dist/control-ui/assets/z80-C7moI0Ck.js                                     1.86 kB │ gzip:   0.88 kB │ map:     4.69 kB
../dist/control-ui/assets/brand-icons-qCscRGgO.js                             1.89 kB │ gzip:   0.90 kB │ map:     2.29 kB
../dist/control-ui/assets/view-CQhYPk-v.js                                    1.93 kB │ gzip:   0.83 kB │ map:     3.82 kB
../dist/control-ui/assets/chunk.GWSUX3V5-CtwtgqtS.js                          1.94 kB │ gzip:   0.83 kB │ map:     3.68 kB
../dist/control-ui/assets/mumps-JK_q2E6I.js                                   1.95 kB │ gzip:   1.05 kB │ map:     6.33 kB
../dist/control-ui/assets/elm-CqrWEj-Z.js                                     1.98 kB │ gzip:   0.91 kB │ map:     7.40 kB
../dist/control-ui/assets/mathematica-Cm_AkQhg.js                             2.02 kB │ gzip:   0.91 kB │ map:     6.76 kB
../dist/control-ui/assets/catalog-target-CzoylLTZ.js                          2.02 kB │ gzip:   0.96 kB │ map:     5.54 kB
../dist/control-ui/assets/hub-tabs-DByyIl3h.js                                2.03 kB │ gzip:   0.97 kB │ map:     9.78 kB
../dist/control-ui/assets/dockerfile-VHW6_OSl.js                              2.04 kB │ gzip:   0.75 kB │ map:     6.36 kB
../dist/control-ui/assets/skills-shared-CVdcLqP4.js                           2.05 kB │ gzip:   0.90 kB │ map:    11.80 kB
../dist/control-ui/assets/turtle-DIfR7Oeq.js                                  2.06 kB │ gzip:   0.98 kB │ map:     6.76 kB
../dist/control-ui/assets/primitives-DBeclW_q.js                              2.08 kB │ gzip:   1.12 kB │ map:    12.30 kB
../dist/control-ui/assets/ebnf-CwcMVHEx.js                                    2.09 kB │ gzip:   0.89 kB │ map:     6.59 kB
../dist/control-ui/assets/mcp-app-security-BbDLI_QY.js                        2.10 kB │ gzip:   1.12 kB │ map:     8.48 kB
../dist/control-ui/assets/app-sidebar-session-section-header-tDO9yRTD.js      2.11 kB │ gzip:   0.96 kB │ map:     7.22 kB
../dist/control-ui/assets/smalltalk-JQOWDCeE.js                               2.12 kB │ gzip:   0.94 kB │ map:     6.54 kB
../dist/control-ui/assets/fcl-BLcJqLpb.js                                     2.14 kB │ gzip:   1.04 kB │ map:     6.53 kB
../dist/control-ui/assets/dist-BXmorxl3.js                                    2.15 kB │ gzip:   1.37 kB │ map:     5.13 kB
../dist/control-ui/assets/ntriples-QizMz05H.js                                2.18 kB │ gzip:   0.81 kB │ map:     7.64 kB
../dist/control-ui/assets/dtd-DdfIki4x.js                                     2.19 kB │ gzip:   0.95 kB │ map:     6.94 kB
../dist/control-ui/assets/octave-B4-05vr8.js                                  2.22 kB │ gzip:   1.17 kB │ map:     5.73 kB
../dist/control-ui/assets/src-CUM-UwnZ.js                                     2.24 kB │ gzip:   1.10 kB │ map:     8.72 kB
../dist/control-ui/assets/provider-icon-DNIEV6Si.js                           2.25 kB │ gzip:   1.15 kB │ map:     6.81 kB
../dist/control-ui/assets/yacas-CTJiMo2X.js                                   2.26 kB │ gzip:   1.18 kB │ map:     7.16 kB
../dist/control-ui/assets/device-auth-migration-CpVLZLYi.js                   2.33 kB │ gzip:   1.09 kB │ map:     7.79 kB
../dist/control-ui/assets/pascal-z1_3S7WH.js                                  2.36 kB │ gzip:   1.26 kB │ map:     5.65 kB
../dist/control-ui/assets/observer-digest-DN2cDq_M.js                         2.39 kB │ gzip:   0.94 kB │ map:    11.60 kB
../dist/control-ui/assets/swarm-roster-DGqa03Nn.js                            2.40 kB │ gzip:   1.08 kB │ map:     8.68 kB
../dist/control-ui/assets/apl-Cqe3HFhb.js                                     2.41 kB │ gzip:   1.32 kB │ map:     6.44 kB
../dist/control-ui/assets/simple-mode-D3-eS7uP.js                             2.42 kB │ gzip:   1.19 kB │ map:     7.79 kB
../dist/control-ui/assets/commonlisp-DyPLPFUp.js                              2.43 kB │ gzip:   1.19 kB │ map:     6.70 kB
../dist/control-ui/assets/tcl-LEFfAW0r.js                                     2.46 kB │ gzip:   1.31 kB │ map:     6.50 kB
../dist/control-ui/assets/shell-Dcd2KFa1.js                                   2.55 kB │ gzip:   1.29 kB │ map:     7.94 kB
../dist/control-ui/assets/webidl-BlwtLWsI.js                                  2.59 kB │ gzip:   1.36 kB │ map:     7.72 kB
../dist/control-ui/assets/pig-U9IM6Sse.js                                     2.63 kB │ gzip:   1.48 kB │ map:     6.60 kB
../dist/control-ui/assets/forth-BPUluTNE.js                                   2.65 kB │ gzip:   1.41 kB │ map:     6.18 kB
../dist/control-ui/assets/puppet-RdkJUsJI.js                                  2.65 kB │ gzip:   1.28 kB │ map:     9.01 kB
../dist/control-ui/assets/browser-annotation-BTbM2bds.js                      2.70 kB │ gzip:   1.28 kB │ map:    11.62 kB
../dist/control-ui/assets/dist-OEZVZsW-.js                                    2.75 kB │ gzip:   1.59 kB │ map:     5.07 kB
../dist/control-ui/assets/velocity-CdetbRT8.js                                2.81 kB │ gzip:   1.19 kB │ map:     8.42 kB
../dist/control-ui/assets/workboard-mini-D_AE4Igx.js                          2.87 kB │ gzip:   1.13 kB │ map:     5.68 kB
../dist/control-ui/assets/tiddlywiki-aQ3kpKB5.js                              2.89 kB │ gzip:   1.17 kB │ map:    11.09 kB
../dist/control-ui/assets/modelica-B5NLfSpl.js                                2.91 kB │ gzip:   1.37 kB │ map:     8.06 kB
../dist/control-ui/assets/gateway-page-controller-BhkZTblQ.js                 2.97 kB │ gzip:   0.99 kB │ map:     9.35 kB
../dist/control-ui/assets/oz-BOXn6tTI.js                                      3.00 kB │ gzip:   1.37 kB │ map:     9.47 kB
../dist/control-ui/assets/workboard-card-ByeTTTbd.js                          3.06 kB │ gzip:   1.12 kB │ map:     5.91 kB
../dist/control-ui/assets/r-DCEXht4A.js                                       3.12 kB │ gzip:   1.45 kB │ map:     9.99 kB
../dist/control-ui/assets/stex-_geSQI7Q.js                                    3.22 kB │ gzip:   1.26 kB │ map:    11.29 kB
../dist/control-ui/assets/approvals-DrDANSrm.js                               3.23 kB │ gzip:   1.43 kB │ map:    18.75 kB
../dist/control-ui/assets/lua-BgmTmyqG.js                                     3.24 kB │ gzip:   1.50 kB │ map:     7.76 kB
../dist/control-ui/assets/cypher-7B-pzmVj.js                                  3.31 kB │ gzip:   1.59 kB │ map:     8.52 kB
../dist/control-ui/assets/tiki-CFRPp0lZ.js                                    3.33 kB │ gzip:   1.35 kB │ map:    12.42 kB
../dist/control-ui/assets/grouping-B29zeYOR.js                                3.41 kB │ gzip:   1.44 kB │ map:    16.74 kB
../dist/control-ui/assets/vhdl-BZddcJrO.js                                    3.42 kB │ gzip:   1.59 kB │ map:     9.62 kB
../dist/control-ui/assets/sparql-DyxwoOhd.js                                  3.44 kB │ gzip:   1.68 kB │ map:     9.50 kB
../dist/control-ui/assets/dist-D91sftKr.js                                    3.51 kB │ gzip:   1.82 kB │ map:     6.97 kB
../dist/control-ui/assets/app-sidebar-session-types-CDJmGrVn.js               3.59 kB │ gzip:   1.61 kB │ map:    19.65 kB
../dist/control-ui/assets/mscgen-B32__qDo.js                                  3.61 kB │ gzip:   1.07 kB │ map:     9.69 kB
../dist/control-ui/assets/exec-approval-CCXYOcrT.js                           3.69 kB │ gzip:   1.58 kB │ map:    10.27 kB
../dist/control-ui/assets/data-BoToSfu7.js                                    3.70 kB │ gzip:   1.44 kB │ map:    13.81 kB
../dist/control-ui/assets/markdown-code-blocks-BCPx0RoX.js                    3.76 kB │ gzip:   1.85 kB │ map:    12.63 kB
../dist/control-ui/assets/app-sidebar-workboard.runtime-C5_VZRSD.js           3.78 kB │ gzip:   1.51 kB │ map:    10.60 kB
../dist/control-ui/assets/d-CHTIqqSE.js                                       3.79 kB │ gzip:   1.78 kB │ map:    10.87 kB
../dist/control-ui/assets/vb-r_8gcpmz.js                                      3.79 kB │ gzip:   1.93 kB │ map:    11.63 kB
../dist/control-ui/assets/q-DgUvnPlH.js                                       3.79 kB │ gzip:   1.77 kB │ map:     9.81 kB
../dist/control-ui/assets/swift-Bj43ctJA.js                                   3.89 kB │ gzip:   1.93 kB │ map:    10.80 kB
../dist/control-ui/assets/fortran-DZ1KI-Ge.js                                 3.97 kB │ gzip:   2.02 kB │ map:     9.72 kB
../dist/control-ui/assets/coffeescript-B7AjrdCL.js                            3.98 kB │ gzip:   1.78 kB │ map:    13.74 kB
../dist/control-ui/assets/asn1-B1dG7mN_.js                                    4.06 kB │ gzip:   2.04 kB │ map:    10.99 kB
../dist/control-ui/assets/control-ui-shared-CLYiY12x.js                       4.08 kB │ gzip:   1.92 kB │ map:    17.86 kB
../dist/control-ui/assets/session-icon-DSCTmGfc.js                            4.12 kB │ gzip:   1.94 kB │ map:    16.28 kB
../dist/control-ui/assets/dylan-Dgw7ONEs.js                                   4.15 kB │ gzip:   1.72 kB │ map:    13.98 kB
../dist/control-ui/assets/asterisk-Diryl_rN.js                                4.19 kB │ gzip:   1.83 kB │ map:     9.30 kB
../dist/control-ui/assets/livescript-B5wMXth4.js                              4.19 kB │ gzip:   1.72 kB │ map:     9.99 kB
../dist/control-ui/assets/ttcn-cfg-CX9fFXmr.js                                4.20 kB │ gzip:   1.83 kB │ map:    11.11 kB
../dist/control-ui/assets/groovy-BBIxTddG.js                                  4.21 kB │ gzip:   1.85 kB │ map:    12.76 kB
../dist/control-ui/assets/haskell-DcE2ND1L.js                                 4.28 kB │ gzip:   2.00 kB │ map:    12.06 kB
../dist/control-ui/assets/exec-approval-card-9qCdGl8q.js                      4.52 kB │ gzip:   1.69 kB │ map:    12.76 kB
../dist/control-ui/assets/thinking-B9hsR4LS.js                                4.52 kB │ gzip:   1.71 kB │ map:    25.43 kB
../dist/control-ui/assets/lobsterdex-page-vXP4m_a1.js                         4.63 kB │ gzip:   1.78 kB │ map:    10.66 kB
../dist/control-ui/assets/gas-BATavbhG.js                                     4.65 kB │ gzip:   1.36 kB │ map:    13.73 kB
../dist/control-ui/assets/mcp-servers-DYU1lpbg.js                             4.65 kB │ gzip:   1.86 kB │ map:    14.39 kB
../dist/control-ui/assets/heartbeat-display-CYjp9cV6.js                       4.71 kB │ gzip:   2.11 kB │ map:    22.44 kB
../dist/control-ui/assets/custodian-panel-CCh-GaUE.js                         4.80 kB │ gzip:   1.68 kB │ map:    12.01 kB
../dist/control-ui/assets/history-scan-page-controller-BZx8v13s.js            4.91 kB │ gzip:   1.68 kB │ map:    13.89 kB
../dist/control-ui/assets/mllike-CVdt0l5n.js                                  4.93 kB │ gzip:   1.67 kB │ map:    12.77 kB
../dist/control-ui/assets/ttcn-B2NyoKzY.js                                    4.96 kB │ gzip:   2.26 kB │ map:    13.42 kB
../dist/control-ui/assets/workboard-widget-BqONd2xz.js                        5.02 kB │ gzip:   1.85 kB │ map:    16.64 kB
../dist/control-ui/assets/dist-BoeatbPP.js                                    5.14 kB │ gzip:   2.48 kB │ map:    10.82 kB
../dist/control-ui/assets/icon-loader-BsYLW214.js                             5.15 kB │ gzip:   2.34 kB │ map:    16.76 kB
../dist/control-ui/assets/crystal-pcdW9EVx.js                                 5.15 kB │ gzip:   2.21 kB │ map:    17.83 kB
../dist/control-ui/assets/workboard-card-dashboard-BkCHGLZT.js                5.17 kB │ gzip:   1.80 kB │ map:     9.15 kB
../dist/control-ui/assets/ecl-S_h57pHg.js                                     5.21 kB │ gzip:   2.40 kB │ map:    12.01 kB
../dist/control-ui/assets/ruby-DwvmjIfo.js                                    5.22 kB │ gzip:   2.24 kB │ map:    16.15 kB
../dist/control-ui/assets/logbook-controller-D8dPiIy0.js                      5.23 kB │ gzip:   1.71 kB │ map:    20.40 kB
../dist/control-ui/assets/dock-layout-controller-BoyqOhTW.js                  5.36 kB │ gzip:   1.70 kB │ map:    11.97 kB
../dist/control-ui/assets/julia-CTBfmwdK.js                                   5.41 kB │ gzip:   2.29 kB │ map:    16.10 kB
../dist/control-ui/assets/session-pull-requests-C0defIHa.js                   5.42 kB │ gzip:   2.39 kB │ map:    25.34 kB
../dist/control-ui/assets/vbscript-Cl5kc1w-.js                                5.54 kB │ gzip:   2.64 kB │ map:    17.58 kB
../dist/control-ui/assets/usage-DkkFvzuC.js                                   5.80 kB │ gzip:   1.74 kB │ map:    55.63 kB
../dist/control-ui/assets/mirc-JpXmO_jl.js                                    6.02 kB │ gzip:   2.81 kB │ map:    11.47 kB
../dist/control-ui/assets/app-sidebar-nav-menus-DXCn202h.js                   6.15 kB │ gzip:   1.87 kB │ map:    15.66 kB
../dist/control-ui/assets/viewer-facepile-DwsnusLi.js                         6.21 kB │ gzip:   2.11 kB │ map:    15.38 kB
../dist/control-ui/assets/workboard-card-chip.runtime-B4LfPe8h.js             6.24 kB │ gzip:   2.18 kB │ map:    19.26 kB
../dist/control-ui/assets/xquery-BrJSccsj.js                                  6.33 kB │ gzip:   2.64 kB │ map:    21.04 kB
../dist/control-ui/assets/cobol-D4GdoaXN.js                                   6.35 kB │ gzip:   3.14 kB │ map:    11.94 kB
../dist/control-ui/assets/python-B3uVEBuh.js                                  6.39 kB │ gzip:   2.76 kB │ map:    21.46 kB
../dist/control-ui/assets/scheme-C0GrTVSB.js                                  6.48 kB │ gzip:   2.49 kB │ map:    15.91 kB
../dist/control-ui/assets/panel-tab-strip-TSZRTlvQ.js                         6.61 kB │ gzip:   2.01 kB │ map:     9.10 kB
../dist/control-ui/assets/agent-select-D1S9zqcU.js                            6.78 kB │ gzip:   2.35 kB │ map:    17.13 kB
../dist/control-ui/assets/pug-DCXOdrhr.js                                     6.78 kB │ gzip:   2.07 kB │ map:    20.02 kB
../dist/control-ui/assets/src-Xal_rlTa.js                                     6.82 kB │ gzip:   2.70 kB │ map:   508.01 kB
../dist/control-ui/assets/textile-BAErXuET.js                                 6.88 kB │ gzip:   2.52 kB │ map:    20.63 kB
../dist/control-ui/assets/nsis-Cnkegpqw.js                                    6.92 kB │ gzip:   3.07 kB │ map:     9.18 kB
../dist/control-ui/assets/web-awesome-popover-Cte1MlzI.js                     7.05 kB │ gzip:   2.48 kB │ map:    16.43 kB
../dist/control-ui/assets/about-page-uMlz0a_1.js                              7.40 kB │ gzip:   2.58 kB │ map:    23.97 kB
../dist/control-ui/assets/nginx-CqZhujYO.js                                   7.52 kB │ gzip:   2.82 kB │ map:    12.45 kB
../dist/control-ui/assets/labs-page-CCEqWfVW.js                               7.57 kB │ gzip:   2.59 kB │ map:    26.29 kB
../dist/control-ui/assets/wizard-step-controls-Bea15ziC.js                    7.70 kB │ gzip:   2.59 kB │ map:    21.39 kB
../dist/control-ui/assets/powershell-B0jU7bl-.js                              7.81 kB │ gzip:   3.37 kB │ map:    16.62 kB
../dist/control-ui/assets/haxe-Rhph2Qi7.js                                    7.97 kB │ gzip:   3.04 kB │ map:    27.67 kB
../dist/control-ui/assets/erlang-BTsFFbT3.js                                  7.98 kB │ gzip:   2.99 kB │ map:    27.09 kB
../dist/control-ui/assets/approvals-page-ptaHJCBM.js                          8.51 kB │ gzip:   2.53 kB │ map:    18.92 kB
../dist/control-ui/assets/verilog-FtI4kQcZ.js                                 8.56 kB │ gzip:   3.63 kB │ map:    30.05 kB
../dist/control-ui/assets/dist-DwHTbqE5.js                                    8.61 kB │ gzip:   3.73 kB │ map:   102.47 kB
../dist/control-ui/assets/debug-page-DbskwqZO.js                              8.68 kB │ gzip:   2.82 kB │ map:    21.69 kB
../dist/control-ui/assets/presentation-Q6mcRUnD.js                            9.14 kB │ gzip:   2.83 kB │ map:    20.97 kB
../dist/control-ui/assets/sas-Cszx7rgJ.js                                     9.44 kB │ gzip:   4.19 kB │ map:    18.03 kB
../dist/control-ui/assets/custodian-page-DfVkMOu3.js                          9.45 kB │ gzip:   2.72 kB │ map:    19.60 kB
../dist/control-ui/assets/clojure-CxJvrtAf.js                                 9.53 kB │ gzip:   4.14 kB │ map:    20.95 kB
../dist/control-ui/assets/session-organizer-operations.runtime-3Bw6njlp.js    9.60 kB │ gzip:   2.50 kB │ map:    32.32 kB
../dist/control-ui/assets/perl-CVLgjRxo.js                                    9.86 kB │ gzip:   3.59 kB │ map:    43.67 kB
../dist/control-ui/assets/worktrees-page-DHOaeY3a.js                          9.91 kB │ gzip:   2.94 kB │ map:    23.97 kB
../dist/control-ui/assets/idl-CF0Vc8u9.js                                     9.94 kB │ gzip:   4.51 kB │ map:    15.15 kB
../dist/control-ui/assets/apps-page-Bw2a6EPp.js                              10.02 kB │ gzip:   3.51 kB │ map:    26.53 kB
../dist/control-ui/assets/command-palette-C_fKcS6L.js                        10.05 kB │ gzip:   3.48 kB │ map:    26.84 kB
../dist/control-ui/assets/app-sidebar-session-catalog-render-De-S03yr.js     10.10 kB │ gzip:   3.24 kB │ map:    25.92 kB
../dist/control-ui/assets/gherkin-Dc3YANZC.js                                10.26 kB │ gzip:   5.19 kB │ map:    14.19 kB
../dist/control-ui/assets/proposals-hhOAZPPM.js                              10.51 kB │ gzip:   2.88 kB │ map:    36.27 kB
../dist/control-ui/assets/logbook-view-BSaJG8uo.js                           11.00 kB │ gzip:   2.95 kB │ map:    29.10 kB
../dist/control-ui/assets/app-sidebar-session-narration-DLl1rZWX.js          11.02 kB │ gzip:   3.51 kB │ map:    51.80 kB
../dist/control-ui/assets/outbox-store-qEg2kmXx.js                           11.04 kB │ gzip:   4.06 kB │ map:    48.01 kB
../dist/control-ui/assets/browser-D0_R_7S-.js                                11.33 kB │ gzip:   4.23 kB │ map:    37.77 kB
../dist/control-ui/assets/mutations-DtJoxZSu.js                              11.35 kB │ gzip:   3.85 kB │ map:    48.15 kB
../dist/control-ui/assets/normalization-CrEkxrkY.js                          11.45 kB │ gzip:   3.04 kB │ map:    39.36 kB
../dist/control-ui/assets/route-loader-DBqIILch.js                           11.76 kB │ gzip:   4.04 kB │ map:    54.40 kB
../dist/control-ui/assets/dist-OPazxlAg.js                                   11.81 kB │ gzip:   5.36 kB │ map:    31.37 kB
../dist/control-ui/assets/question-prompt-3q3HKJd4.js                        12.06 kB │ gzip:   4.05 kB │ map:    42.63 kB
../dist/control-ui/assets/logs-page-C07_lv5c.js                              12.52 kB │ gzip:   4.53 kB │ map:    54.72 kB
../dist/control-ui/assets/profile-page-DP-iZ4x4.js                           12.65 kB │ gzip:   3.92 kB │ map:    35.19 kB
../dist/control-ui/assets/connection-page-Cy9PyG-E.js                        12.65 kB │ gzip:   3.75 kB │ map:    36.07 kB
../dist/control-ui/assets/tasks-page-Bsq_hTYQ.js                             12.97 kB │ gzip:   4.01 kB │ map:    34.47 kB
../dist/control-ui/assets/plugin-page-Cvyf9Pcl.js                            13.04 kB │ gzip:   3.55 kB │ map:    31.52 kB
../dist/control-ui/assets/chat-sidebar-region.runtime-Bd_djImg.js            14.17 kB │ gzip:   4.48 kB │ map:    37.59 kB
../dist/control-ui/assets/activity-page-CA9VvKIk.js                          14.21 kB │ gzip:   4.79 kB │ map:    43.87 kB
../dist/control-ui/assets/dist-Dvwyf6lt.js                                   14.55 kB │ gzip:   5.94 kB │ map:    34.91 kB
../dist/control-ui/assets/chat-session-rail-CbcO09do.js                      14.82 kB │ gzip:   3.81 kB │ map:    31.41 kB
../dist/control-ui/assets/control-ui-foundation-OE0aAIzW.js                  15.70 kB │ gzip:   5.35 kB │ map:    45.69 kB
../dist/control-ui/assets/dist-sU9t95Qj.js                                   16.40 kB │ gzip:   7.58 kB │ map:    22.07 kB
../dist/control-ui/assets/web-awesome-tabs-Ct-trtla.js                       16.67 kB │ gzip:   4.30 kB │ map:    37.96 kB
../dist/control-ui/assets/approval-page-registration-S_mm1Yyb.js             16.93 kB │ gzip:   4.25 kB │ map:    48.02 kB
../dist/control-ui/assets/javascript-DpFoYDCe.js                             17.14 kB │ gzip:   5.84 kB │ map:    63.13 kB
../dist/control-ui/assets/provider-B-2TWrbV.js                               17.41 kB │ gzip:   5.14 kB │ map:    63.48 kB
../dist/control-ui/assets/session-menu-work-B-VoZ1n3.js                      19.70 kB │ gzip:   4.59 kB │ map:    42.38 kB
../dist/control-ui/assets/gateway-runtime-DWs8EJ0W.js                        19.85 kB │ gzip:   7.57 kB │ map:   107.41 kB
../dist/control-ui/assets/dist-DTcmrCa8.js                                   20.90 kB │ gzip:   9.50 kB │ map:    35.43 kB
../dist/control-ui/assets/dist-DHLSHayU.js                                   21.17 kB │ gzip:   9.83 kB │ map:    37.50 kB
../dist/control-ui/assets/chat-queue-BiGdEUMP.js                             21.47 kB │ gzip:   6.85 kB │ map:    92.40 kB
../dist/control-ui/assets/workboard-Cr1mJq1e.js                              21.85 kB │ gzip:   7.02 kB │ map:    90.47 kB
../dist/control-ui/assets/clike-C_ZbG_yJ.js                                  22.17 kB │ gzip:   7.82 kB │ map:    56.66 kB
../dist/control-ui/assets/cron-DskhyWhm.js                                   22.40 kB │ gzip:   6.59 kB │ map:    75.75 kB
../dist/control-ui/assets/dist-kDIle_NH.js                                   23.25 kB │ gzip:  10.62 kB │ map:    37.60 kB
../dist/control-ui/assets/stylus-BBpPyVxW.js                                 23.69 kB │ gzip:   8.75 kB │ map:    55.58 kB
../dist/control-ui/assets/css-Do3t3Blg.js                                    24.85 kB │ gzip:   8.37 kB │ map:    53.78 kB
../dist/control-ui/assets/lit-runtime-D5xZwgO1.js                            26.28 kB │ gzip:   9.94 kB │ map:    70.67 kB
../dist/control-ui/assets/dist-UucoU0df.js                                   26.59 kB │ gzip:   8.82 kB │ map:   106.56 kB
../dist/control-ui/assets/dist-DcGW9Xhz.js                                   26.95 kB │ gzip:  12.82 kB │ map:    45.12 kB
../dist/control-ui/assets/memory-import-page-BDxUg8cf.js                     27.97 kB │ gzip:   6.52 kB │ map:    72.11 kB
../dist/control-ui/assets/settings-ui-CbnNH7I9.js                            28.11 kB │ gzip:   7.10 kB │ map:    65.33 kB
../dist/control-ui/assets/dist-DmUe5QBR.js                                   28.65 kB │ gzip:  11.77 kB │ map:    71.71 kB
../dist/control-ui/assets/skills-page-Cjhz6Jqy.js                            29.68 kB │ gzip:   7.55 kB │ map:    66.42 kB
../dist/control-ui/assets/custodian-surface-HX-gw6li.js                      30.77 kB │ gzip:   8.76 kB │ map:   248.61 kB
../dist/control-ui/assets/dist-97SeI16I.js                                   30.99 kB │ gzip:  12.91 kB │ map:    43.80 kB
../dist/control-ui/assets/sidebar-menus-render-D8dnkz-W.js                   33.63 kB │ gzip:   7.24 kB │ map:    78.75 kB
../dist/control-ui/assets/tool-display-C7p2Zduy.js                           34.84 kB │ gzip:  11.21 kB │ map:   125.12 kB
../dist/control-ui/assets/message-extract-CpOm8z8m.js                        36.31 kB │ gzip:  12.38 kB │ map:   285.67 kB
../dist/control-ui/assets/web-awesome-select-Bcc_SPSC.js                     36.46 kB │ gzip:   9.09 kB │ map:    79.17 kB
../dist/control-ui/assets/sql-Bi4SE94B.js                                    36.96 kB │ gzip:  10.99 kB │ map:    54.83 kB
../dist/control-ui/assets/markdown-EsocTSrt.js                               38.80 kB │ gzip:  14.49 kB │ map:   145.54 kB
../dist/control-ui/assets/model-setup-page-D_dSLvW6.js                       39.08 kB │ gzip:   9.68 kB │ map:   110.64 kB
../dist/control-ui/assets/browser-panel-BXfc8k7l.js                          39.94 kB │ gzip:  10.87 kB │ map:   109.53 kB
../dist/control-ui/assets/split-drop-zone-BlbENAa7.js                        40.16 kB │ gzip:   9.97 kB │ map:   101.45 kB
../dist/control-ui/assets/plugins-page-BhQ6wAfz.js                           40.52 kB │ gzip:  11.05 kB │ map:   111.00 kB
../dist/control-ui/assets/dist--K5SXeob.js                                   40.87 kB │ gzip:  17.06 kB │ map:    45.74 kB
../dist/control-ui/assets/nodes-page-G-bGPT5R.js                             41.07 kB │ gzip:  11.47 kB │ map:   130.03 kB
../dist/control-ui/assets/model-providers-page-DZwOPE9p.js                   41.28 kB │ gzip:  10.75 kB │ map:   128.55 kB
../dist/control-ui/assets/dist-BGfuEDrH.js                                   44.13 kB │ gzip:  15.40 kB │ map:   168.80 kB
../dist/control-ui/assets/chat-model-controls-CYd3iflz.js                    44.72 kB │ gzip:  12.40 kB │ map:   139.60 kB
../dist/control-ui/assets/dist-_FwP8O4c.js                                   44.99 kB │ gzip:  19.55 kB │ map:    71.25 kB
../dist/control-ui/assets/dist-BZMufNlj.js                                   47.20 kB │ gzip:  13.54 kB │ map:    68.94 kB
../dist/control-ui/assets/memory-panel-C3Rcpg5J.js                           50.60 kB │ gzip:  12.89 kB │ map:   159.04 kB
../dist/control-ui/assets/terminal-panel-registration-DjSJg9cO.js            50.65 kB │ gzip:  14.14 kB │ map:   147.27 kB
../dist/control-ui/assets/file-editor-view-Dy7bVtXr.js                       51.14 kB │ gzip:  15.00 kB │ map:   182.82 kB
../dist/control-ui/assets/cron-page-BqshhW7L.js                              55.59 kB │ gzip:  14.51 kB │ map:   169.87 kB
../dist/control-ui/assets/workboard-page-CwiPHlcD.js                         56.61 kB │ gzip:  14.51 kB │ map:   150.57 kB
../dist/control-ui/assets/skill-workshop-page-WWCWSsUQ.js                    59.70 kB │ gzip:  15.14 kB │ map:   179.83 kB
../dist/control-ui/assets/board-view-C8spFEiv.js                             59.94 kB │ gzip:  16.19 kB │ map:   168.86 kB
../dist/control-ui/assets/config-form-BJGToPDo.js                            61.02 kB │ gzip:  17.58 kB │ map:   227.65 kB
../dist/control-ui/assets/control-ui-foundation-DkfOBVsU.js                  62.15 kB │ gzip:  20.18 kB │ map:   333.30 kB
../dist/control-ui/assets/channels-page-CCdGBnia.js                          64.48 kB │ gzip:  15.75 kB │ map:   184.18 kB
../dist/control-ui/assets/mcp-app-view-registration-CPR4uQXC.js              67.00 kB │ gzip:  18.96 kB │ map:   327.06 kB
../dist/control-ui/assets/reasoning-tags-E1GmCy_b.js                         67.83 kB │ gzip:  19.32 kB │ map:   420.10 kB
../dist/control-ui/assets/sessions-page-CQ1WuJwd.js                          70.06 kB │ gzip:  17.86 kB │ map:   212.60 kB
../dist/control-ui/assets/dist-DCZ4zBmi.js                                   70.99 kB │ gzip:  26.24 kB │ map:    78.85 kB
../dist/control-ui/assets/lobster-pet-BNeA-f58.js                            75.27 kB │ gzip:  22.73 kB │ map:   215.91 kB
../dist/control-ui/assets/realtime-talk-CX-IYhqu.js                          76.56 kB │ gzip:  20.19 kB │ map:   286.49 kB
../dist/control-ui/assets/new-session-page-DZPFOMO8.js                       77.83 kB │ gzip:  19.33 kB │ map:   254.29 kB
../dist/control-ui/assets/dist-B2vEF34B.js                                   84.92 kB │ gzip:  33.96 kB │ map:   115.26 kB
../dist/control-ui/assets/dist-D5okxHmf.js                                   98.12 kB │ gzip:  28.91 kB │ map:   112.22 kB
../dist/control-ui/assets/dist-CdFcPUGl.js                                  104.11 kB │ gzip:  34.92 kB │ map:   113.29 kB
../dist/control-ui/assets/usage-page-D9HZxROh.js                            106.38 kB │ gzip:  27.31 kB │ map:   309.04 kB
../dist/control-ui/assets/agents-page-C5co2rNs.js                           128.48 kB │ gzip:  33.89 kB │ map:   336.88 kB
../dist/control-ui/assets/value-Bh5d6NNx.js                                 134.97 kB │ gzip:  38.25 kB │ map: 1,092.16 kB
../dist/control-ui/assets/control-ui-core-DgzgGRDk.js                       138.13 kB │ gzip:  38.37 kB │ map:   346.50 kB
../dist/control-ui/assets/app-sidebar-DczMRQXG.js                           146.29 kB │ gzip:  36.48 kB │ map:   441.23 kB
../dist/control-ui/assets/config-page-B8NNyEQi.js                           146.54 kB │ gzip:  34.69 kB │ map:   426.29 kB
../dist/control-ui/assets/control-ui-core-D6Bx780P.js                       168.81 kB │ gzip:  52.24 kB │ map:   627.77 kB
../dist/control-ui/assets/zh-CN-uwhLJ33R.js                                 181.63 kB │ gzip:  68.07 kB │ map:     0.24 kB
../dist/control-ui/assets/zh-TW-BqMEPZ6c.js                                 185.40 kB │ gzip:  68.91 kB │ map:     0.24 kB
../dist/control-ui/assets/control-ui-core-DQIpko4c.js                       189.42 kB │ gzip:  64.05 kB │ map:   318.95 kB
../dist/control-ui/assets/id-DZmNPdYr.js                                    192.22 kB │ gzip:  64.18 kB │ map:     0.22 kB
../dist/control-ui/assets/nl-BFt8Ig3h.js                                    199.17 kB │ gzip:  67.78 kB │ map:     0.22 kB
../dist/control-ui/assets/control-ui-foundation-Dgui328h.js                 204.25 kB │ gzip:  53.65 kB │ map:   493.70 kB
../dist/control-ui/assets/control-ui-core-Lda35Y9t.js                       204.83 kB │ gzip:  63.58 kB │ map:   826.66 kB
../dist/control-ui/assets/markdown-runtime-BCCaEqDL.js                      205.30 kB │ gzip:  80.71 kB │ map:   832.49 kB
../dist/control-ui/assets/pt-BR-BLvp6Vjb.js                                 205.43 kB │ gzip:  68.48 kB │ map:     0.24 kB
../dist/control-ui/assets/it-BngFSwsM.js                                    206.23 kB │ gzip:  67.91 kB │ map:     0.22 kB
../dist/control-ui/assets/tr-C902dDZf.js                                    206.32 kB │ gzip:  69.04 kB │ map:     0.22 kB
../dist/control-ui/assets/pl-BTxGnDiX.js                                    206.95 kB │ gzip:  71.29 kB │ map:     0.22 kB
../dist/control-ui/assets/de-C3hcUxjk.js                                    208.94 kB │ gzip:  70.25 kB │ map:     0.22 kB
../dist/control-ui/assets/es-BMehG8hG.js                                    209.31 kB │ gzip:  69.15 kB │ map:     0.22 kB
../dist/control-ui/assets/ko-DXxrA0Zg.js                                    214.46 kB │ gzip:  70.16 kB │ map:     0.22 kB
../dist/control-ui/assets/fr-DMYIQR__.js                                    215.69 kB │ gzip:  70.36 kB │ map:     0.22 kB
../dist/control-ui/assets/config-runtime-bj88oeNR.js                        223.35 kB │ gzip:  58.86 kB │ map:   855.85 kB
../dist/control-ui/assets/vi-C75sz41D.js                                    228.15 kB │ gzip:  69.03 kB │ map:     0.22 kB
../dist/control-ui/assets/ja-JP-DHLsIve6.js                                 245.55 kB │ gzip:  73.92 kB │ map:     0.24 kB
../dist/control-ui/assets/chat-message-4dGQkwzj.js                          254.65 kB │ gzip:  74.86 kB │ map:   973.40 kB
../dist/control-ui/assets/ar-BVAOkqaQ.js                                    256.70 kB │ gzip:  74.12 kB │ map:     0.22 kB
../dist/control-ui/assets/fa-cFI3znVz.js                                    269.71 kB │ gzip:  73.79 kB │ map:     0.22 kB
../dist/control-ui/assets/dist-BcLEWlxS.js                                  274.96 kB │ gzip:  90.62 kB │ map: 1,232.74 kB
../dist/control-ui/assets/uk-Cy9kE7U4.js                                    294.62 kB │ gzip:  80.70 kB │ map:     0.22 kB
../dist/control-ui/assets/ru-D16v6VZM.js                                    300.85 kB │ gzip:  81.72 kB │ map:     0.22 kB
../dist/control-ui/assets/hi-gafjoj5s.js                                    351.89 kB │ gzip:  79.90 kB │ map:     0.22 kB
../dist/control-ui/assets/th-DqkCgDSd.js                                    359.41 kB │ gzip:  77.53 kB │ map:     0.22 kB
../dist/control-ui/assets/chat-page-CRaJEUo_.js                             540.59 kB │ gzip: 148.67 kB │ map: 1,803.34 kB
../dist/control-ui/assets/ghostty-web-IRe0fnQT.js                           636.95 kB │ gzip: 187.36 kB │ map:   756.32 kB

✓ built in 2.53s
verified 704 finalized Control UI sidecars
Control UI performance:
  startup JS: 12 requests, 307.7 KiB gzip, 285.9 KiB br (limits: 18 requests, 317.0 KiB gzip)
  startup JS gzip vs baseline: 315060 B (baseline 324587 B + tolerance 1024 B, ceiling 324608 B)
  startup CSS: 1 request, 41.0 KiB gzip, 35.2 KiB br (limits: 1 request, 45.0 KiB gzip)
  largest JS: assets/ghostty-web-IRe0fnQT.js, 179.8 KiB gzip (limit: 215.0 KiB)
  largest CSS: assets/control-ui-core-CMupHFtS.css, 41.0 KiB gzip (limit: 45.0 KiB)
  all JS: 318 requests, 3588.4 KiB gzip, 3269.2 KiB br
  all CSS: 34 requests, 152.0 KiB gzip, 136.9 KiB br
  hint: startup JS gzip is more than 4096 B below the 324587 B baseline; lower it with node scripts/check-control-ui-performance.mjs --update-baseline --reason "<reason>" on the accepted/committed split — passed. The final delta only re-arms pending work during drain teardown and is covered by the deterministic microtask regression.
- Formatting and `git diff --check` — passed.
- Targeted type-aware Oxlint — passed.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — passed.
- Autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable P0 finding; accepted/committed split correct at 0.98 confidence. TruffleHog clean.
- Remote changed-file gate could not start because the installed Crabbox binary failed its own `--version/--help` sanity check. Trusted-source local build, formatting, lint, both extension typecheck lanes, focused tests, and live Telegram proof passed instead.

Redacted failure → recovery → restart verdict:

```json
{
  "verdict": "pass",
  "offsetWrites": ["42:rejected", "42:committed"],
  "committedUpdateId": 42,
  "restartReplayUpdateId": 42,
  "handlerCalls": 1,
  "restartOffsetWrites": 0,
  "pendingIngressRows": 0
}
```

Co-authored-by: @YangManBOBO

