### PR TITLE
fix(plugin-sdk): attached send results report the configured channel

### DIFF
--- a/src/plugin-sdk/channel-send-result.test.ts
+++ b/src/plugin-sdk/channel-send-result.test.ts
@@ -36,6 +36,24 @@ describe("attachChannelToResult(s)", () => {
       { channel: "signal", messageId: "m2", timestamp: 2 },
     ]);
   });
+
+  it("keeps the explicitly attached channel authoritative", () => {
+    const providerResult = {
+      channel: "stale-provider-channel",
+      messageId: "m1",
+    };
+
+    expect(attachChannelToResult("configured-channel", providerResult)).toEqual({
+      channel: "configured-channel",
+      messageId: "m1",
+    });
+    expect(attachChannelToResults("configured-channel", [providerResult])).toEqual([
+      {
+        channel: "configured-channel",
+        messageId: "m1",
+      },
+    ]);
+  });
 });
 
 describe("buildChannelSendResult", () => {

--- a/src/plugin-sdk/channel-send-result.ts
+++ b/src/plugin-sdk/channel-send-result.ts
@@ -27,10 +27,13 @@ export function attachChannelToResult<T extends object>(
   /** Delivery-shaped result without channel metadata. */
   result: T,
 ) {
-  return {
+  const attached = {
     channel,
     ...result,
   };
+  // Keep the existing inferred return shape while making the explicit owner authoritative.
+  attached.channel = channel;
+  return attached;
 }
 
 /** Attaches the channel id to each outbound send result in order. */

--- a/src/plugin-sdk/channel-send-result.ts
+++ b/src/plugin-sdk/channel-send-result.ts
@@ -27,13 +27,10 @@ export function attachChannelToResult<T extends object>(
   /** Delivery-shaped result without channel metadata. */
   result: T,
 ) {
-  const attached = {
-    channel,
+  return {
     ...result,
+    channel,
   };
-  // Keep the existing inferred return shape while making the explicit owner authoritative.
-  attached.channel = channel;
-  return attached;
 }
 
 /** Attaches the channel id to each outbound send result in order. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel plugins could report the wrong channel on an otherwise successful send when the provider result happened to include its own stale `channel` field.

## Why This Change Was Made

The plugin SDK's explicitly attached channel is the routing owner, so it must remain authoritative over incidental provider metadata. The helper now returns the provider payload first and stamps the explicit channel last, making ownership clear without a post-construction mutation.

## User Impact

Delivery results and callbacks now consistently identify the configured channel, including for providers that return a conflicting `channel` property. Other provider result fields and the public SDK surface remain unchanged.

## Evidence

- Regression test: red before the fix (`stale-provider-channel` won), green after the fix; 6 focused tests pass across single and batch attachment paths.
- Maintainer Blacksmith Testbox run: `src/plugin-sdk/channel-send-result.test.ts`, 6/6 passed: https://github.com/openclaw/openclaw/actions/runs/29638563271
- Fresh maintainer autoreview found no actionable findings (confidence 0.98).
- Live third-party proof: an OpenClaw NIP-04 send was accepted by the public Nostr relay at `wss://relay.nostr.net`, then re-observed and decrypted using randomly generated temporary keys.
  - Before: the provider round trip succeeded, but the returned channel was the stale provider value `nostr` instead of configured `nostr-live-proof`.
  - After: the provider round trip succeeded and the result retained configured `nostr-live-proof`.
- Plugin SDK surface and API baseline checks pass with no public API drift.
