### PR TITLE
fix(thread-ownership): bound forwarder JSON reads and cap mention cache

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -1,8 +1,36 @@
+import { once } from "node:events";
 // Thread Ownership tests cover index plugin behavior.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "./api.js";
-import register from "./index.js";
+import register, { OWNERSHIP_CONFLICT_MAX_BYTES, resetMentionedThreadsForTests } from "./index.js";
+
+function createOversizedConflictResponse(minBytes: number): Response {
+  const chunk = Buffer.alloc(16 * 1024, 0x78);
+  let sent = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent === 0) {
+        const prefix = Buffer.from('{"owner":"');
+        controller.enqueue(prefix);
+        sent += prefix.length;
+        return;
+      }
+      if (sent < minBytes) {
+        controller.enqueue(chunk);
+        sent += chunk.length;
+        return;
+      }
+      controller.enqueue(Buffer.from('"}'));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 409,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 describe("thread-ownership plugin", () => {
   const hooks: Record<string, Function> = {};
@@ -53,6 +81,7 @@ describe("thread-ownership plugin", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetMentionedThreadsForTests();
     for (const key of Object.keys(hooks)) {
       delete hooks[key];
     }
@@ -281,6 +310,86 @@ describe("thread-ownership plugin", () => {
       const warningMessage = requireFirstLogMessage(api.logger.warn, "ownership check warning log");
       expect(warningMessage).toContain("ownership check failed");
     });
+
+    it("fails open when a 409 conflict body exceeds the ownership JSON bound", async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        createOversizedConflictResponse(OWNERSHIP_CONFLICT_MAX_BYTES + 1),
+      );
+
+      const result = await sendSlackThreadMessage();
+
+      expect(result).toBeUndefined();
+      const warningMessage = requireFirstLogMessage(api.logger.warn, "ownership check warning log");
+      expect(warningMessage).toContain("ownership check failed");
+      expect(warningMessage).toMatch(/exceeds .* bytes/);
+      expect(api.logger.info).not.toHaveBeenCalled();
+    });
+
+    it("bounds live forwarder 409 bodies over loopback HTTP", async () => {
+      vi.unstubAllGlobals();
+      const handlers: Array<(req: IncomingMessage, res: ServerResponse) => void> = [];
+      const server = createServer((req, res) => {
+        const handler = handlers.shift();
+        if (!handler) {
+          res.writeHead(500);
+          res.end("unexpected");
+          return;
+        }
+        handler(req, res);
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP listen address");
+      }
+      process.env.SLACK_FORWARDER_URL = `http://127.0.0.1:${address.port}`;
+      for (const key of Object.keys(hooks)) {
+        delete hooks[key];
+      }
+      register.register(api as unknown as OpenClawPluginApi);
+
+      try {
+        handlers.push((_req, res) => {
+          const body = JSON.stringify({ owner: "other-agent" });
+          res.writeHead(409, {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+          });
+          res.end(body);
+        });
+        const cancelled = await sendSlackThreadMessage();
+        expect(cancelled).toEqual({ cancel: true });
+        expect(requireFirstLogMessage(api.logger.info, "loopback cancel log")).toContain(
+          "cancelled send",
+        );
+
+        api.logger.info.mockClear();
+        api.logger.warn.mockClear();
+        handlers.push((_req, res) => {
+          res.writeHead(409, { "Content-Type": "application/json" });
+          res.write('{"owner":"');
+          const chunk = Buffer.alloc(16 * 1024, 0x78);
+          let sent = 10;
+          while (sent <= OWNERSHIP_CONFLICT_MAX_BYTES) {
+            res.write(chunk);
+            sent += chunk.length;
+          }
+          res.end('"}');
+        });
+        const allowed = await sendSlackThreadMessage();
+        expect(allowed).toBeUndefined();
+        const warningMessage = requireFirstLogMessage(
+          api.logger.warn,
+          "loopback oversized warning log",
+        );
+        expect(warningMessage).toContain("ownership check failed");
+        expect(warningMessage).toMatch(/exceeds .* bytes/);
+      } finally {
+        server.close();
+        await once(server, "close");
+      }
+    });
   });
 
   describe("message_received @-mention tracking", () => {
@@ -504,6 +613,44 @@ describe("thread-ownership plugin", () => {
       );
 
       expect(globalThis.fetch).toHaveBeenCalled();
+    });
+
+    it("evicts oldest mention cache entries once the cache exceeds its cap", async () => {
+      await requireHook("message_received")(
+        {
+          content: "hey @TestBot help",
+          threadId: "1111.0001",
+          metadata: { channelId: "C000" },
+        },
+        { channelId: "slack", conversationId: "C000" },
+      );
+
+      for (let i = 1; i <= 1000; i += 1) {
+        await requireHook("message_received")(
+          {
+            content: "hey @TestBot help",
+            threadId: `2222.${i.toString().padStart(4, "0")}`,
+            metadata: { channelId: `C${i.toString().padStart(3, "0")}` },
+          },
+          { channelId: "slack", conversationId: `C${i.toString().padStart(3, "0")}` },
+        );
+      }
+
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      await requireHook("message_sending")(
+        {
+          content: "On it!",
+          replyToId: "1111.0001",
+          metadata: { channelId: "C000" },
+          to: "C000",
+        },
+        { channelId: "slack", conversationId: "C000" },
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,5 +1,7 @@
 // Thread Ownership plugin entrypoint registers its OpenClaw integration.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -19,9 +21,13 @@ type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[num
 type ThreadOwnershipMessageSendingResult = { cancel: true } | undefined;
 
 // In-memory set of {channel}:{thread} keys where this agent was @-mentioned.
-// Entries expire after 5 minutes.
+// Entries expire after 5 minutes. Cap bounds memory under bursty Slack churn;
+// eviction can re-enable ownership checks for the oldest mentioned threads.
 const mentionedThreads = new Map<string, number>();
 const MENTION_TTL_MS = 5 * 60 * 1000;
+const MENTIONED_THREADS_MAX_ENTRIES = 1000;
+// Forwarder 409 bodies are tiny owner objects; keep the parse cap explicit and tight.
+export const OWNERSHIP_CONFLICT_MAX_BYTES = 64 * 1024;
 
 function isThreadOwnershipConfig(value: unknown): value is ThreadOwnershipConfig {
   return value !== null && typeof value === "object";
@@ -49,6 +55,15 @@ function cleanExpiredMentions(): void {
       mentionedThreads.delete(key);
     }
   }
+}
+
+function trackMentionedThread(key: string): void {
+  cleanExpiredMentions();
+  if (mentionedThreads.has(key)) {
+    mentionedThreads.delete(key);
+  }
+  mentionedThreads.set(key, Date.now());
+  pruneMapToMaxSize(mentionedThreads, MENTIONED_THREADS_MAX_ENTRIES);
 }
 
 function containsAgentNameMention(text: string, agentName: string): boolean {
@@ -136,8 +151,7 @@ export default definePluginEntry({
         containsAgentNameMention(text, agent.name) ||
         (botUserId && text.includes(`<@${botUserId}>`));
       if (mentioned) {
-        cleanExpiredMentions();
-        mentionedThreads.set(`${channelId}:${threadTs}`, Date.now());
+        trackMentionedThread(`${channelId}:${threadTs}`);
       }
     });
 
@@ -189,7 +203,11 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            const body = (await resp.json()) as { owner?: string };
+            const body = await readProviderJsonResponse<{ owner?: string }>(
+              resp,
+              "thread-ownership.ownership-conflict",
+              { maxBytes: OWNERSHIP_CONFLICT_MAX_BYTES },
+            );
             api.logger.info?.(
               `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
             );
@@ -208,3 +226,7 @@ export default definePluginEntry({
     });
   },
 });
+
+export function resetMentionedThreadsForTests(): void {
+  mentionedThreads.clear();
+}


### PR DESCRIPTION
## What Problem This Solves

The `thread-ownership` plugin's Slack ownership check calls an internal forwarder
(`{forwarderUrl}/api/v1/ownership/{channelId}/{threadTs}`) and, on a `409`
response, previously parsed the body with unbounded `await resp.json()`. A
misconfigured or hostile forwarder can return an arbitrarily large body and force
the Node process to buffer it before parse — an easy OOM vector.

Separately, the in-memory `mentionedThreads` cache only expired entries by a
5-minute TTL, with no entry-count cap. Busy multi-channel Slack workspaces could
grow that map without bound between TTL sweeps.

## Why This Change Was Made

- Parse conflict bodies with `readProviderJsonResponse` and an **explicit**
  `OWNERSHIP_CONFLICT_MAX_BYTES` (64 KiB). The helper default is 16 MiB; this
  endpoint only returns a tiny `{ owner }` object, so the tighter cap is
  intentional.
- Cap `mentionedThreads` at 1,000 entries via `pruneMapToMaxSize` (oldest-inserted
  eviction). Under extreme five-minute churn, eviction can re-enable the
  ownership check for the oldest mentioned threads (documented delivery tradeoff).

## User Impact

Normal forwarder responses are unchanged: small `409 {"owner":"..."}` still
cancels the send. Oversized conflict bodies fail open (allow send) after a
bounded read error, matching existing network-error fail-open. Mention-cache
eviction may rarely resume ownership enforcement for the oldest threads after
>1,000 distinct mentions within the TTL window.

## Evidence

### Real behavior proof

#### Behavior or issue addressed

Bounded 409 JSON parsing on the production `message_sending` ownership path;
oversized bodies fail open; normal conflict still cancels; mention cache evicts
at 1,000 entries.

#### Canonical reachability path

`message_sending` hook → `fetchWithSsrFGuard(forwarderUrl/api/v1/ownership/...)`
→ `readProviderJsonResponse(..., { maxBytes: OWNERSHIP_CONFLICT_MAX_BYTES })`
→ `{ cancel: true }` or catch fail-open.

#### Real environment tested

Local trusted checkout; Vitest with mocked fetch plus a real `node:http`
loopback forwarder (no Slack workspace credentials).

#### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/thread-ownership/index.test.ts --reporter=verbose
```

#### Evidence after fix

```text
✓ cancels when thread owned by another agent 6ms
✓ fails open on network error 0ms
✓ fails open when a 409 conflict body exceeds the ownership JSON bound 1ms
✓ bounds live forwarder 409 bodies over loopback HTTP 238ms
✓ evicts oldest mention cache entries once the cache exceeds its cap 22ms
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

The loopback case starts a real HTTP server as `SLACK_FORWARDER_URL`, then:
1) returns a small `409 {"owner":"other-agent"}` → send cancelled;
2) streams a body larger than 64 KiB → ownership check fails with `exceeds … bytes`
   and the send is allowed (fail-open).

#### Observed result after fix

Normal conflict cancellation preserved; oversized 409 bodies are bounded and
fail open; mention cache eviction proven at the 1,000-entry cap.

#### What was not tested

Live Slack workspace / production forwarder credentials; multi-agent A/B channel
traffic under real load.

#### Fix classification

bugfix — unbounded forwarder JSON read + unbounded mention cache

## AI Assistance

AI-assisted. Author reviewed the production caller path and the focused proof output.
