### PR TITLE
test(mcp): tolerate delayed assistant channel events

### DIFF
--- a/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
@@ -248,7 +248,35 @@ async function main() {
     ]).then(([result]) => result)) as {
       structuredContent?: { event?: Record<string, unknown> };
     };
-    const assistantEvent = waited.structuredContent?.event;
+    let assistantEvent = waited.structuredContent?.event;
+    if (!assistantEvent) {
+      let pollCursor = 0;
+      assistantEvent = await waitFor(
+        "delayed MCP assistant event",
+        async () => {
+          const polledValue = await callTool<{
+            structuredContent?: {
+              events?: Array<Record<string, unknown>>;
+              next_cursor?: number;
+            };
+          }>({
+            name: "events_poll",
+            arguments: {
+              session_key: "agent:main:main",
+              after_cursor: pollCursor,
+              limit: 200,
+            },
+          });
+          const found = findEventByText(
+            polledValue.structuredContent?.events,
+            "assistant live event",
+          );
+          pollCursor = polledValue.structuredContent?.next_cursor ?? pollCursor;
+          return found;
+        },
+        60_000,
+      );
+    }
     assert(assistantEvent, "expected events_wait result");
     assert(assistantEvent.type === "message", "expected message event");
     assert(assistantEvent.role === "assistant", "expected assistant event role");


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the packaged MCP channel smoke timed out when an assistant transcript event arrived after the initial `events_wait` window.

## Why This Change Was Made

The smoke keeps `events_wait` as the primary assertion, then performs bounded cursor-aware polling for the exact delayed event. Cursor advancement prevents rereading the same bounded page.

## User Impact

No user-visible behavior change. Plugin prerelease validation now tolerates delayed SQLite transcript delivery without weakening event identity assertions.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29592376403
- Focused MCP unit test: 10 passed
- Changed-scope Testbox: https://github.com/openclaw/openclaw/actions/runs/29595145092
- Autoreview: clean
