### PR TITLE
fix(ai): signed thinking replays across providers permanently bricks Claude 5 sessions

### DIFF
--- a/packages/ai/src/providers/anthropic-model-contract.test.ts
+++ b/packages/ai/src/providers/anthropic-model-contract.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelBoundThinkingReplayMode } from "./anthropic-model-contract.js";
+
+const SONNET5 = "claude-sonnet-5";
+
+function ref(provider: string, modelId: string = SONNET5) {
+  return { provider, api: "anthropic-messages", modelId };
+}
+
+describe("resolveModelBoundThinkingReplayMode", () => {
+  it("preserves model-bound thinking on the exact same provider route", () => {
+    expect(
+      resolveModelBoundThinkingReplayMode({
+        source: ref("anthropic"),
+        target: ref("anthropic"),
+      }),
+    ).toBe("preserve");
+  });
+
+  // Regression: the same-model branch compared only api+identity, so signed
+  // thinking issued by one platform was replayed through a different
+  // provider serving the same Claude identity. Foreign platforms reject the
+  // signature on every turn, permanently bricking the persisted session.
+  it.each([
+    ["anthropic", "amazon-bedrock-mantle"],
+    ["anthropic", "anthropic-vertex"],
+    ["anthropic-vertex", "anthropic"],
+    ["anthropic", "github-copilot"],
+  ])("drops model-bound thinking when switching providers %s -> %s", (source, target) => {
+    expect(
+      resolveModelBoundThinkingReplayMode({
+        source: ref(source),
+        target: ref(target),
+      }),
+    ).toBe("drop");
+  });
+
+  it("drops model-bound thinking across different Claude 5 identities", () => {
+    expect(
+      resolveModelBoundThinkingReplayMode({
+        source: ref("anthropic", "claude-sonnet-5"),
+        target: ref("anthropic", "claude-fable-5"),
+      }),
+    ).toBe("drop");
+  });
+
+  it("preserves cloud-id variants of one identity on the same provider", () => {
+    expect(
+      resolveModelBoundThinkingReplayMode({
+        source: ref("amazon-bedrock-mantle", "us.anthropic.claude-sonnet-5-20260929-v1:0"),
+        target: ref("amazon-bedrock-mantle", "claude-sonnet-5-20260929-v1:0"),
+      }),
+    ).toBe("preserve");
+  });
+
+  it("preserves same-route replay when only the response model proves the identity", () => {
+    // Deployment aliases may hide the identity on the persisted side; the
+    // same provider+api+modelId route is still the issuing platform.
+    expect(
+      resolveModelBoundThinkingReplayMode({
+        source: { provider: "anthropic", api: "anthropic-messages", modelId: "my-alias" },
+        target: {
+          provider: "anthropic",
+          api: "anthropic-messages",
+          modelId: "my-alias",
+          responseModelId: SONNET5,
+        },
+      }),
+    ).toBe("preserve");
+  });
+
+  it("stays default for non-Claude-5 identities", () => {
+    expect(
+      resolveModelBoundThinkingReplayMode({
+        source: ref("anthropic", "claude-opus-4-8"),
+        target: ref("amazon-bedrock-mantle", "claude-opus-4-8"),
+      }),
+    ).toBe("default");
+  });
+});

--- a/packages/ai/src/providers/anthropic-model-contract.ts
+++ b/packages/ai/src/providers/anthropic-model-contract.ts
@@ -183,6 +183,14 @@ export function resolveModelBoundThinkingReplayMode(params: {
   if (!sourceIdentity && !hasConcreteResponseModel(params.source) && targetIdentity && sameRoute) {
     return "preserve";
   }
-  const sameModel = sourceApi === targetApi && sourceIdentity === targetIdentity;
+  // Signed/redacted thinking is cryptographically bound to the issuing
+  // platform, not just the model identity. Preserving across providers
+  // replays an `anthropic` signature through Bedrock/Vertex/proxy routes
+  // (or vice versa), which fails signature validation on every turn and
+  // permanently bricks the persisted session.
+  const sameProvider =
+    normalizeLowercaseStringOrEmpty(params.source.provider) ===
+    normalizeLowercaseStringOrEmpty(params.target.provider);
+  const sameModel = sameProvider && sourceApi === targetApi && sourceIdentity === targetIdentity;
   return sameModel ? "preserve" : "drop";
 }

--- a/packages/ai/src/providers/transform-messages.test.ts
+++ b/packages/ai/src/providers/transform-messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Message, Model } from "../types.js";
+import type { AssistantMessage, Message, Model } from "../types.js";
 import { transformMessages } from "./transform-messages.js";
 
 const model: Model<"openai-completions"> = {
@@ -14,6 +14,48 @@ const model: Model<"openai-completions"> = {
   contextWindow: 128_000,
   maxTokens: 4_096,
 };
+
+function sonnet5Model(provider: string): Model<"anthropic-messages"> {
+  return {
+    id: "claude-sonnet-5",
+    name: "Claude Sonnet 5",
+    api: "anthropic-messages",
+    provider,
+    baseUrl: "https://example.invalid/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  };
+}
+
+function signedThinkingAssistantMessage(provider: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "thinking",
+        thinking: "internal reasoning",
+        thinkingSignature: "sig-bound-to-issuer",
+      },
+      { type: "text", text: "final answer" },
+    ],
+    api: "anthropic-messages",
+    provider,
+    model: "claude-sonnet-5",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 2,
+  } as AssistantMessage;
+}
 
 describe("transformMessages", () => {
   it("normalizes null or missing content before provider transforms", () => {
@@ -49,5 +91,33 @@ describe("transformMessages", () => {
 
     expect(transformed).toHaveLength(3);
     expect(transformed.map((message) => message.content)).toEqual([[], [], []]);
+  });
+
+  it("keeps signed thinking when replaying to the same provider route", () => {
+    const [transformed] = transformMessages(
+      [signedThinkingAssistantMessage("anthropic")],
+      sonnet5Model("anthropic"),
+    );
+
+    expect(transformed?.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "internal reasoning",
+        thinkingSignature: "sig-bound-to-issuer",
+      },
+      { type: "text", text: "final answer" },
+    ]);
+  });
+
+  // Regression: signed thinking from one platform was preserved verbatim when
+  // the session switched to a different provider serving the same Claude
+  // identity; the foreign platform rejects the signature on every turn.
+  it("drops signed thinking when replaying to a different provider", () => {
+    const [transformed] = transformMessages(
+      [signedThinkingAssistantMessage("anthropic")],
+      sonnet5Model("amazon-bedrock-mantle"),
+    );
+
+    expect(transformed?.content).toEqual([{ type: "text", text: "final answer" }]);
   });
 });


### PR DESCRIPTION
Closes #110079
See also: #109881 (same defect family, Bedrock-converter focus), #109972 (Bedrock partial-signature fix in progress)

## What Problem This Solves

Fixes an issue where switching a Claude 5 session (Sonnet 5, Fable 5, Mythos 5) between two providers that both serve the same model over `anthropic-messages` — for example `anthropic` → `amazon-bedrock-mantle`, `anthropic` → `anthropic-vertex`, or back — permanently bricks the session. Signed thinking blocks issued by the first platform are replayed verbatim to the second platform, whose signature validation rejects them on **every** subsequent turn, and self-healing has two escape hatches that keep the session stuck.

This is the upstream shared gate — the cross-provider generalization of #109881. That issue covers Bedrock's converter replaying partial signatures within Bedrock; this issue is the provider-agnostic same-model check (`resolveModelBoundThinkingReplayMode`) that gates whether signatures are preserved at all. The same-model branch compared only api + identity, not provider, so the very block that contains cryptographically foreign signatures survived and reached a different platform.

## Why This Change Was Made

`resolveModelBoundThinkingReplayMode`'s same-model branch now requires source and target provider to be equal (normalized lowercase) in addition to api+identity. This mirrors the Google transport's same-route rule (`extensions/google/transport-stream.ts:625-627` — "Never replay signatures from foreign providers"). The change affects only the "preserve" / "drop" classification for model-bound thinking — no other replay path, no request shaping, no config.

The original code already compared provider in the `sameRoute` branch (used for a narrower pattern: unknown-persisted-model becomes known-on-target). That branch is unchanged: it continues to compare provider+api+modelId, which is correct for the operational-route check it serves.

## User Impact

Cross-provider Claude 5 sessions (including model-failover configs, `/model` switches, or auth-profile rotation across Anthropic/Bedrock-Mantle/Vertex/Copilot) no longer permanently brick. Signing from the old provider is dropped before the first request to the new one, just as it is for the Google transport and for different-identity switches. Same-provider replays (e.g. `anthropic` → `anthropic`) keep signed thinking exactly as before.

## Evidence

### Real pipeline proof (production `transformMessages` + `resolveModelBoundThinkingReplayMode`)

Feeding the production pipeline a Sonnet 5 assistant message from `provider: "anthropic"` with a signed thinking block, building the replay content for three target providers. Before (current `main`): '''

```
proof anthropic              [{"type":"thinking","thinking":"internal reasoning","thinkingSignature":"sig-issued-by-anthropic"},{"type":"text","text":"final answer"}]
proof amazon-bedrock-mantle  [{"type":"thinking","thinking":"internal reasoning","thinkingSignature":"sig-issued-by-anthropic"},{"type":"text","text":"final answer"}]
proof anthropic-vertex       [{"type":"thinking","thinking":"internal reasoning","thinkingSignature":"sig-issued-by-anthropic"},{"type":"text","text":"final answer"}]
```

The `anthropic`-issued signature is sent verbatim to Bedrock Mantle and Vertex. The running session is permanently bricked on the first turn after the switch.

After (this patch): foreign-provider blocks and signatures are dropped, same-provider blocks keep their signatures:

```
proof anthropic              [{"type":"thinking","thinking":"internal reasoning","thinkingSignature":"sig-issued-by-anthropic"},{"type":"text","text":"final answer"}]
proof amazon-bedrock-mantle  [{"type":"text","text":"final answer"}]
proof anthropic-vertex       [{"type":"text","text":"final answer"}]
```

### Regression coverage

- `anthropic-model-contract.test.ts` (new, 9 tests): same-provider preserves; 4 cross-provider pairs drop; different identity drops; cloud-id variant of same identity on same provider preserves; response-model identity resolves on same route.
- All 4 cross-provider vectors fail against unfixed `main` (the same-model branch returns `"preserve"`); the 5 semantic-unchanged vectors pass in both states.
- `transform-messages.test.ts` (2 new tests): same-provider keeps signed thinking in wire content; cross-provider drops it to plain text.
- `node scripts/run-vitest.mjs packages/ai` → 514 passed (no regressions).
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/thinking.test.ts src/agents/transcript-policy.test.ts` → passed.
- Scoped `oxlint`, `oxfmt`, and `git diff --check` pass on the three changed files.

### Sibling-surface context

The Google transport (`extensions/google/transport-stream.ts:625-627`) already enforces a same-route guard for thought-signature replay with the explicit comment "Never replay signatures from foreign providers." The #109881-linked Bedrock fix (#109972) handles partial-signature stripping within the Bedrock converter. This change closes the remaining hole: the shared model-contract gate that lets signatures cross providers before any converter sees them.

AI-assisted.