### PR TITLE
fix: keep broken SSH sandbox refs agent-scoped

### DIFF
--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -23,6 +23,7 @@ import { resolveSandboxDockerUser } from "./docker-user.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
 import { updateRegistry } from "./registry.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
+import { assertSshSandboxSecretOwnerAvailable } from "./secret-owner.js";
 import { resolveSandboxWorkspaceLayoutPaths } from "./shared.js";
 import type { SandboxContext, SandboxWorkspaceInfo } from "./types.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
@@ -155,6 +156,15 @@ function resolveSandboxSession(params: {
   }
 
   const cfg = resolveSandboxConfigForAgent(params.config, runtime.agentId);
+  if (cfg.backend === "ssh") {
+    // Never let an unresolved inline SSH credential silently fall through to
+    // ambient host SSH identities for this agent.
+    assertSshSandboxSecretOwnerAvailable({
+      config: params.config,
+      scope: cfg.scope,
+      agentId: runtime.agentId,
+    });
+  }
   return { rawSessionKey, runtime, cfg };
 }
 

--- a/src/agents/sandbox/secret-owner.test.ts
+++ b/src/agents/sandbox/secret-owner.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
+import { resolveSandboxContext } from "./context.js";
+
+afterEach(() => {
+  setActiveDegradedSecretOwners([]);
+});
+
+describe("sandbox SSH secret owner", () => {
+  it("rejects an unmaterialized inherited ref without active degraded-owner state", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            backend: "ssh",
+            ssh: {
+              target: "sandbox@example.com:22",
+              identityData: {
+                source: "env",
+                provider: "default",
+                id: "UNMATERIALIZED_SANDBOX_IDENTITY",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    await expect(
+      resolveSandboxContext({
+        config,
+        agentId: "unlisted",
+        sessionKey: "agent:unlisted:main",
+      }),
+    ).rejects.toMatchObject({
+      code: "SECRET_SURFACE_UNAVAILABLE",
+      ownerKind: "capability",
+      ownerId: "agent-sandbox:unlisted",
+      paths: ["agents.defaults.sandbox.ssh.identityData"],
+    });
+  });
+});

--- a/src/agents/sandbox/secret-owner.ts
+++ b/src/agents/sandbox/secret-owner.ts
@@ -1,0 +1,66 @@
+/** Guards SSH sandbox use against unresolved runtime SecretRefs. */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { coerceSecretRef } from "../../config/types.secrets.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import { secretRefKey } from "../../secrets/ref-contract.js";
+import { SecretSurfaceUnavailableError } from "../../secrets/runtime-degraded-state.js";
+import {
+  assertRuntimeSandboxSecretOwnerAvailable,
+  runtimeSandboxSecretOwnerId,
+} from "../../secrets/runtime-sandbox-secret-owner.js";
+import { resolveAgentConfig } from "../agent-scope-config.js";
+import type { SandboxScope } from "./types.js";
+
+const SSH_SECRET_KEYS = ["identityData", "certificateData", "knownHostsData"] as const;
+
+/** Rejects cold or unmaterialized SSH credentials before any host SSH fallback is possible. */
+export function assertSshSandboxSecretOwnerAvailable(params: {
+  config?: OpenClawConfig;
+  scope: SandboxScope;
+  agentId?: string;
+}): void {
+  if (params.agentId) {
+    assertRuntimeSandboxSecretOwnerAvailable(params.agentId);
+  }
+  if (!params.config) {
+    return;
+  }
+
+  const defaultsSsh = params.config.agents?.defaults?.sandbox?.ssh;
+  const agentSsh =
+    params.agentId && params.scope !== "shared"
+      ? resolveAgentConfig(params.config, params.agentId)?.sandbox?.ssh
+      : undefined;
+  const normalizedAgentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
+  const agentIndex = normalizedAgentId
+    ? params.config.agents?.list?.findIndex(
+        (entry) => normalizeAgentId(entry?.id) === normalizedAgentId,
+      )
+    : undefined;
+  const unresolved: Array<{ path: string; refKey: string }> = [];
+  for (const key of SSH_SECRET_KEYS) {
+    const usesAgentValue = Boolean(agentSsh && Object.hasOwn(agentSsh, key));
+    const value = usesAgentValue ? agentSsh?.[key] : defaultsSsh?.[key];
+    const ref = coerceSecretRef(value, params.config.secrets?.defaults);
+    if (!ref) {
+      continue;
+    }
+    unresolved.push({
+      path:
+        usesAgentValue && agentIndex !== undefined && agentIndex >= 0
+          ? `agents.list.${agentIndex}.sandbox.ssh.${key}`
+          : `agents.defaults.sandbox.ssh.${key}`,
+      refKey: secretRefKey(ref),
+    });
+  }
+  if (unresolved.length > 0) {
+    throw new SecretSurfaceUnavailableError({
+      ownerKind: "capability",
+      ownerId: runtimeSandboxSecretOwnerId(params.agentId ?? "shared"),
+      state: "unavailable",
+      paths: unresolved.map((entry) => entry.path),
+      refKeys: unresolved.map((entry) => entry.refKey),
+      reason: "configured SSH secret reference was not materialized",
+    });
+  }
+}

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { captureFullEnv } from "../../test-utils/env.js";
 import type { SandboxConfig } from "./types.js";
 
@@ -156,6 +157,7 @@ describe("ssh sandbox backend", () => {
   beforeEach(() => {
     envSnapshot = captureFullEnv();
     vi.clearAllMocks();
+    setActiveDegradedSecretOwners([]);
     sshMocks.createSshSandboxSessionFromSettings.mockResolvedValue(createSession());
     sshMocks.disposeSshSandboxSession.mockResolvedValue(undefined);
     sshMocks.runSshSandboxCommand.mockResolvedValue({
@@ -175,6 +177,7 @@ describe("ssh sandbox backend", () => {
   });
 
   afterEach(async () => {
+    setActiveDegradedSecretOwners([]);
     envSnapshot.restore();
     for (const dir of tempDirs.splice(0)) {
       await fs.rm(dir, { recursive: true, force: true });
@@ -211,6 +214,142 @@ describe("ssh sandbox backend", () => {
     expect(sessionSettings.workspaceRoot).toBe("/remote/openclaw");
     const commandParams = requireSshRunCommandParams();
     expect(commandParams.remoteCommand).toContain("/remote/openclaw/openclaw-ssh-agent-worker");
+  });
+
+  it("uses the derived registry agent for both validation and SSH settings", async () => {
+    const config = createConfig();
+    config.agents!.defaults!.sandbox!.ssh!.identityData = {
+      source: "env",
+      provider: "default",
+      id: "UNMATERIALIZED_DEFAULT_IDENTITY",
+    };
+    config.agents!.list = [
+      {
+        id: "worker",
+        sandbox: {
+          ssh: {
+            identityData: "MATERIALIZED WORKER IDENTITY",
+          },
+        },
+      },
+    ];
+
+    await sshSandboxBackendManager.describeRuntime({
+      entry: {
+        containerName: "openclaw-ssh-worker-abcd1234",
+        backendId: "ssh",
+        runtimeLabel: "openclaw-ssh-worker-abcd1234",
+        sessionKey: "agent:worker",
+        createdAtMs: 1,
+        lastUsedAtMs: 1,
+        image: "peter@example.com:2222",
+        configLabelKind: "Target",
+      },
+      config,
+    });
+
+    expect(
+      requireMockRecordArg(sshMocks.createSshSandboxSessionFromSettings, 0, "ssh session settings")
+        .identityData,
+    ).toBe("MATERIALIZED WORKER IDENTITY");
+  });
+
+  it("rejects a cold agent owner before opening an SSH management session", async () => {
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "agent-sandbox:worker",
+        state: "unavailable",
+        paths: ["agents.defaults.sandbox.ssh.identityData"],
+        refKeys: ["env:default:MISSING_SSH_IDENTITY"],
+        reason: "secret reference was not found",
+      },
+    ]);
+
+    await expect(
+      sshSandboxBackendManager.describeRuntime({
+        entry: {
+          containerName: "openclaw-ssh-worker-abcd1234",
+          backendId: "ssh",
+          runtimeLabel: "openclaw-ssh-worker-abcd1234",
+          sessionKey: "agent:worker",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+          image: "peter@example.com:2222",
+          configLabelKind: "Target",
+        },
+        config: createConfig(),
+        agentId: "worker",
+      }),
+    ).rejects.toMatchObject({
+      code: "SECRET_SURFACE_UNAVAILABLE",
+      ownerKind: "capability",
+      ownerId: "agent-sandbox:worker",
+    });
+    expect(sshMocks.createSshSandboxSessionFromSettings).not.toHaveBeenCalled();
+  });
+
+  it("rejects unmaterialized shared SSH refs even when no active owner inherited them", async () => {
+    const config = createConfig();
+    config.agents!.defaults!.sandbox!.mode = "off";
+    config.agents!.defaults!.sandbox!.scope = "shared";
+    config.agents!.defaults!.sandbox!.ssh!.identityData = {
+      source: "env",
+      provider: "default",
+      id: "MISSING_SHARED_SSH_IDENTITY",
+    };
+
+    await expect(
+      sshSandboxBackendManager.removeRuntime({
+        entry: {
+          containerName: "openclaw-ssh-shared-abcd1234",
+          backendId: "ssh",
+          runtimeLabel: "openclaw-ssh-shared-abcd1234",
+          sessionKey: "shared",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+          image: "peter@example.com:2222",
+          configLabelKind: "Target",
+        },
+        config,
+      }),
+    ).rejects.toMatchObject({
+      code: "SECRET_SURFACE_UNAVAILABLE",
+      ownerKind: "capability",
+      ownerId: "agent-sandbox:shared",
+    });
+    expect(sshMocks.createSshSandboxSessionFromSettings).not.toHaveBeenCalled();
+  });
+
+  it("does not block shared SSH management for an unrelated cold agent override", async () => {
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "capability",
+        ownerId: "agent-sandbox:cold",
+        state: "unavailable",
+        paths: ["agents.list.0.sandbox.ssh.identityData"],
+        refKeys: ["env:default:MISSING_AGENT_SSH_IDENTITY"],
+        reason: "secret reference was not found",
+      },
+    ]);
+    const config = createConfig();
+    config.agents!.defaults!.sandbox!.scope = "shared";
+
+    await sshSandboxBackendManager.removeRuntime({
+      entry: {
+        containerName: "openclaw-ssh-shared-abcd1234",
+        backendId: "ssh",
+        runtimeLabel: "openclaw-ssh-shared-abcd1234",
+        sessionKey: "shared",
+        createdAtMs: 1,
+        lastUsedAtMs: 1,
+        image: "peter@example.com:2222",
+        configLabelKind: "Target",
+      },
+      config,
+    });
+
+    expect(sshMocks.createSshSandboxSessionFromSettings).toHaveBeenCalledTimes(1);
   });
 
   it("removes runtimes by deleting the remote scope root", async () => {

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -21,6 +21,8 @@ import {
   type RemoteShellSandboxHandle,
 } from "./remote-fs-bridge.js";
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
+import { assertSshSandboxSecretOwnerAvailable } from "./secret-owner.js";
+import { resolveSandboxAgentId } from "./shared.js";
 import {
   buildRemoteCommand,
   buildRemoteWorkdirValidationCommand,
@@ -49,7 +51,8 @@ type ResolvedSshRuntimePaths = {
 /** SSH backend lifecycle hooks for probing and removing remote sandbox copies. */
 export const sshSandboxBackendManager: SandboxBackendManager = {
   async describeRuntime({ entry, config, agentId }) {
-    const cfg = resolveSandboxConfigForAgent(config, agentId);
+    const effectiveAgentId = agentId ?? resolveSandboxAgentId(entry.sessionKey);
+    const cfg = resolveSandboxConfigForAgent(config, effectiveAgentId);
     if (cfg.backend !== "ssh" || !cfg.ssh.target) {
       return {
         running: false,
@@ -57,6 +60,11 @@ export const sshSandboxBackendManager: SandboxBackendManager = {
         configLabelMatch: false,
       };
     }
+    assertSshSandboxSecretOwnerAvailable({
+      config,
+      scope: cfg.scope,
+      agentId: effectiveAgentId,
+    });
     const runtimePaths = resolveSshRuntimePaths(cfg.ssh.workspaceRoot, entry.sessionKey);
     const session = await createSshSandboxSessionFromSettings({
       ...cfg.ssh,
@@ -83,10 +91,16 @@ export const sshSandboxBackendManager: SandboxBackendManager = {
     }
   },
   async removeRuntime({ entry, config, agentId }) {
-    const cfg = resolveSandboxConfigForAgent(config, agentId);
+    const effectiveAgentId = agentId ?? resolveSandboxAgentId(entry.sessionKey);
+    const cfg = resolveSandboxConfigForAgent(config, effectiveAgentId);
     if (cfg.backend !== "ssh" || !cfg.ssh.target) {
       return;
     }
+    assertSshSandboxSecretOwnerAvailable({
+      config,
+      scope: cfg.scope,
+      agentId: effectiveAgentId,
+    });
     const runtimePaths = resolveSshRuntimePaths(cfg.ssh.workspaceRoot, entry.sessionKey);
     const session = await createSshSandboxSessionFromSettings({
       ...cfg.ssh,

--- a/src/gateway/server-startup-secret-owner-isolation.test.ts
+++ b/src/gateway/server-startup-secret-owner-isolation.test.ts
@@ -5,6 +5,7 @@ import { getRuntimeAuthProfileStoreSnapshot } from "../agents/auth-profiles/runt
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { resolveSandboxContext } from "../agents/sandbox/context.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAuthProfileSecretOwnerId } from "../secrets/runtime-auth-profile-owner.js";
 import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime.js";
@@ -186,6 +187,60 @@ describe("Gateway startup SecretRef owner isolation", () => {
           state: "unavailable",
         },
       ]);
+    });
+  });
+
+  it("reaches /readyz with one cold agent sandbox and rejects that runtime", async () => {
+    await withEnvAsync({ MISSING_SANDBOX_IDENTITY: undefined }, async () => {
+      await writeConfig({
+        ...baseConfig(),
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+              backend: "ssh",
+              ssh: {
+                target: "sandbox@example.com:22",
+                identityData: {
+                  source: "env",
+                  provider: "default",
+                  id: "MISSING_SANDBOX_IDENTITY",
+                },
+              },
+            },
+          },
+          list: [{ id: "cold" }],
+        },
+      });
+
+      const port = await getFreePort();
+      server = await startGatewayServer(port, { auth: { mode: "none" } });
+      const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+
+      expect(ready.status).toBe(200);
+      const active = getActiveSecretsRuntimeSnapshot();
+      expect(active?.degradedOwners).toMatchObject([
+        {
+          ownerKind: "capability",
+          ownerId: "agent-sandbox:cold",
+          state: "unavailable",
+          paths: ["agents.defaults.sandbox.ssh.identityData"],
+        },
+      ]);
+      if (!active) {
+        throw new Error("Expected active secrets runtime snapshot");
+      }
+      await expect(
+        resolveSandboxContext({
+          config: active.config,
+          agentId: "cold",
+          sessionKey: "agent:cold:main",
+        }),
+      ).rejects.toMatchObject({
+        code: "SECRET_SURFACE_UNAVAILABLE",
+        ownerKind: "capability",
+        ownerId: "agent-sandbox:cold",
+      });
     });
   });
 

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -8,6 +8,7 @@ import {
 } from "../media-understanding/entry-capabilities.js";
 import { buildMediaUnderstandingCapabilityRegistry } from "../media-understanding/provider-capability-registry.js";
 import { collectAgentMemorySearchAssignments } from "./runtime-config-collectors-memory.js";
+import { collectAgentSandboxAssignments } from "./runtime-config-collectors-sandbox.js";
 import { collectTtsApiKeyAssignments } from "./runtime-config-collectors-tts.js";
 import { evaluateGatewayAuthSurfaceStates } from "./runtime-gateway-auth-surfaces.js";
 import {
@@ -556,92 +557,6 @@ function collectCronAssignments(params: {
   });
 }
 
-function collectSandboxSshAssignments(params: {
-  config: OpenClawConfig;
-  defaults: SecretDefaults | undefined;
-  context: ResolverContext;
-}): void {
-  const agents = isRecord(params.config.agents) ? params.config.agents : undefined;
-  if (!agents) {
-    return;
-  }
-  const defaultsAgent = isRecord(agents.defaults) ? agents.defaults : undefined;
-  const defaultsSandbox = isRecord(defaultsAgent?.sandbox) ? defaultsAgent.sandbox : undefined;
-  const defaultsSsh = isRecord(defaultsSandbox?.ssh)
-    ? (defaultsSandbox.ssh as Record<string, unknown>)
-    : undefined;
-  const defaultsBackend =
-    typeof defaultsSandbox?.backend === "string" ? defaultsSandbox.backend : undefined;
-  const defaultsMode = typeof defaultsSandbox?.mode === "string" ? defaultsSandbox.mode : undefined;
-
-  const inheritedDefaultsUsage = {
-    identityData: false,
-    certificateData: false,
-    knownHostsData: false,
-  };
-
-  const list = Array.isArray(agents.list) ? agents.list : [];
-  list.forEach((rawAgent, index) => {
-    const agentRecord = isRecord(rawAgent) ? (rawAgent as Record<string, unknown>) : null;
-    if (!agentRecord || agentRecord.enabled === false) {
-      return;
-    }
-    const sandbox = isRecord(agentRecord.sandbox) ? agentRecord.sandbox : undefined;
-    const ssh = isRecord(sandbox?.ssh) ? sandbox.ssh : undefined;
-    const effectiveBackend =
-      (typeof sandbox?.backend === "string" ? sandbox.backend : undefined) ??
-      defaultsBackend ??
-      "docker";
-    const effectiveMode =
-      (typeof sandbox?.mode === "string" ? sandbox.mode : undefined) ?? defaultsMode ?? "off";
-    const active =
-      normalizeOptionalLowercaseString(effectiveBackend) === "ssh" && effectiveMode !== "off";
-    for (const key of ["identityData", "certificateData", "knownHostsData"] as const) {
-      if (ssh && Object.hasOwn(ssh, key)) {
-        collectSecretInputAssignment({
-          value: ssh[key],
-          path: `agents.list.${index}.sandbox.ssh.${key}`,
-          expected: "string",
-          defaults: params.defaults,
-          context: params.context,
-          active,
-          inactiveReason: "sandbox SSH backend is not active for this agent.",
-          apply: (value) => {
-            ssh[key] = value;
-          },
-        });
-      } else if (active) {
-        // Defaults are active when at least one enabled SSH agent inherits this material.
-        inheritedDefaultsUsage[key] = true;
-      }
-    }
-  });
-
-  if (!defaultsSsh) {
-    return;
-  }
-
-  const defaultsActive =
-    (normalizeOptionalLowercaseString(defaultsBackend) === "ssh" && defaultsMode !== "off") ||
-    inheritedDefaultsUsage.identityData ||
-    inheritedDefaultsUsage.certificateData ||
-    inheritedDefaultsUsage.knownHostsData;
-  for (const key of ["identityData", "certificateData", "knownHostsData"] as const) {
-    collectSecretInputAssignment({
-      value: defaultsSsh[key],
-      path: `agents.defaults.sandbox.ssh.${key}`,
-      expected: "string",
-      defaults: params.defaults,
-      context: params.context,
-      active: defaultsActive || inheritedDefaultsUsage[key],
-      inactiveReason: "sandbox SSH backend is not active.",
-      apply: (value) => {
-        defaultsSsh[key] = value;
-      },
-    });
-  }
-}
-
 /** Collects SecretRef assignments from core non-plugin config surfaces. */
 export function collectCoreConfigAssignments(params: {
   config: OpenClawConfig;
@@ -669,7 +584,7 @@ export function collectCoreConfigAssignments(params: {
   collectAgentMemorySearchAssignments(params);
   collectTalkAssignments(params);
   collectGatewayAssignments(params);
-  collectSandboxSshAssignments(params);
+  collectAgentSandboxAssignments(params);
   collectMessagesTtsAssignments(params);
   collectAgentTtsAssignments(params);
   collectCronAssignments(params);

--- a/src/secrets/runtime-config-collectors-sandbox.ts
+++ b/src/secrets/runtime-config-collectors-sandbox.ts
@@ -64,6 +64,7 @@ export function collectAgentSandboxAssignments(params: {
   const defaultsAgent = isRecord(agents.defaults) ? agents.defaults : undefined;
   const defaultsSandbox = isRecord(defaultsAgent?.sandbox) ? defaultsAgent.sandbox : undefined;
   const defaultsSsh = isRecord(defaultsSandbox?.ssh) ? defaultsSandbox.ssh : undefined;
+  const defaultsBackend = normalizeOptionalLowercaseString(defaultsSandbox?.backend) ?? "docker";
   const rawList = Array.isArray(agents.list) ? agents.list : [];
   const configuredAgents: Array<{ entry: Record<string, unknown>; index: number }> = [];
   rawList.forEach((entry, index) => {
@@ -169,13 +170,16 @@ export function collectAgentSandboxAssignments(params: {
     if (!Object.hasOwn(defaultsSsh, key) || activeDefaultKeys.has(key)) {
       continue;
     }
+    // Unlisted agents and stale registry entries still resolve through defaults,
+    // even when every current list entry overrides this credential.
+    const active = defaultsBackend === "ssh";
     collectAssignment({
       target: defaultsSsh,
       key,
       path: `agents.defaults.sandbox.ssh.${key}`,
       defaults: params.defaults,
       context: params.context,
-      active: false,
+      active,
       inactiveReason: "no enabled agent uses the sandbox SSH material.",
       owner: sandboxSecretOwner(DEFAULT_AGENT_ID),
     });

--- a/src/secrets/runtime-config-collectors-sandbox.ts
+++ b/src/secrets/runtime-config-collectors-sandbox.ts
@@ -50,7 +50,7 @@ function collectAssignment(params: {
   });
 }
 
-/** Collects SSH material once for every enabled agent that can use it. */
+/** Collects SSH material once for every agent whose current backend can manage it. */
 export function collectAgentSandboxAssignments(params: {
   config: OpenClawConfig;
   defaults: SecretDefaults | undefined;
@@ -94,10 +94,6 @@ export function collectAgentSandboxAssignments(params: {
       normalizeOptionalLowercaseString(sandbox?.backend) ??
       normalizeOptionalLowercaseString(defaultsSandbox?.backend) ??
       "docker";
-    const mode =
-      (typeof sandbox?.mode === "string" ? sandbox.mode : undefined) ??
-      (typeof defaultsSandbox?.mode === "string" ? defaultsSandbox.mode : undefined) ??
-      "off";
     const scope = resolveSandboxScope({
       scope:
         typeof sandbox?.scope === "string"
@@ -112,7 +108,10 @@ export function collectAgentSandboxAssignments(params: {
             ? defaultsSandbox.perSession
             : undefined,
     });
-    const active = rawAgent?.enabled !== false && backend === "ssh" && mode !== "off";
+    // Existing registry entries remain inspectable/removable after an agent or its
+    // sandbox is disabled, so SSH lifecycle credentials stay materialized while
+    // SSH remains the configured backend.
+    const active = backend === "ssh";
     const owner = sandboxSecretOwner(agentId);
 
     for (const key of SANDBOX_SSH_SECRET_KEYS) {
@@ -126,7 +125,7 @@ export function collectAgentSandboxAssignments(params: {
             defaults: params.defaults,
             context: params.context,
             active,
-            inactiveReason: "sandbox SSH backend is not active for this agent.",
+            inactiveReason: "sandbox SSH backend is not configured for this agent.",
             owner,
           });
           continue;
@@ -157,7 +156,7 @@ export function collectAgentSandboxAssignments(params: {
         defaults: params.defaults,
         context: params.context,
         active: true,
-        inactiveReason: "sandbox SSH backend is not active for this agent.",
+        inactiveReason: "sandbox SSH backend is not configured for this agent.",
         owner,
       });
     }

--- a/src/secrets/runtime-config-collectors-sandbox.ts
+++ b/src/secrets/runtime-config-collectors-sandbox.ts
@@ -1,0 +1,184 @@
+/** Collects agent-scoped sandbox SSH SecretRefs during runtime preparation. */
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { resolveSandboxScope } from "../agents/sandbox/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { runtimeSandboxSecretOwnerId } from "./runtime-sandbox-secret-owner.js";
+import {
+  collectRuntimeSecretInputAssignment,
+  type ResolverContext,
+  type SecretAssignmentOwner,
+  type SecretDefaults,
+} from "./runtime-shared.js";
+import { isRecord } from "./shared.js";
+
+const SANDBOX_SSH_SECRET_KEYS = ["identityData", "certificateData", "knownHostsData"] as const;
+
+type SandboxSshSecretKey = (typeof SANDBOX_SSH_SECRET_KEYS)[number];
+
+function sandboxSecretOwner(agentId: string): SecretAssignmentOwner {
+  return {
+    ownerKind: "capability",
+    ownerId: runtimeSandboxSecretOwnerId(agentId),
+    requiredForGateway: false,
+    disposition: "isolate",
+  };
+}
+
+function collectAssignment(params: {
+  target: Record<string, unknown>;
+  key: SandboxSshSecretKey;
+  path: string;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+  active: boolean;
+  inactiveReason: string;
+  owner: SecretAssignmentOwner;
+}): void {
+  collectRuntimeSecretInputAssignment({
+    value: params.target[params.key],
+    path: params.path,
+    expected: "string",
+    defaults: params.defaults,
+    context: params.context,
+    active: params.active,
+    inactiveReason: params.inactiveReason,
+    owner: params.owner,
+    apply: (value) => {
+      params.target[params.key] = value;
+    },
+  });
+}
+
+/** Collects SSH material once for every enabled agent that can use it. */
+export function collectAgentSandboxAssignments(params: {
+  config: OpenClawConfig;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+}): void {
+  const rawAgents: unknown = params.config.agents;
+  const agents = isRecord(rawAgents) ? rawAgents : undefined;
+  if (!agents) {
+    return;
+  }
+  const defaultsAgent = isRecord(agents.defaults) ? agents.defaults : undefined;
+  const defaultsSandbox = isRecord(defaultsAgent?.sandbox) ? defaultsAgent.sandbox : undefined;
+  const defaultsSsh = isRecord(defaultsSandbox?.ssh) ? defaultsSandbox.ssh : undefined;
+  const rawList = Array.isArray(agents.list) ? agents.list : [];
+  const configuredAgents: Array<{ entry: Record<string, unknown>; index: number }> = [];
+  rawList.forEach((entry, index) => {
+    if (isRecord(entry)) {
+      configuredAgents.push({ entry, index });
+    }
+  });
+  const candidates: Array<{
+    entry: Record<string, unknown> | undefined;
+    index: number | undefined;
+  }> = configuredAgents.length > 0 ? configuredAgents : [{ entry: undefined, index: undefined }];
+  const activeDefaultKeys = new Set<SandboxSshSecretKey>();
+  const seenAgentIds = new Set<string>();
+
+  for (const candidate of candidates) {
+    const rawAgent = candidate.entry;
+    const agentId = normalizeAgentId(
+      typeof rawAgent?.id === "string" ? rawAgent.id : DEFAULT_AGENT_ID,
+    );
+    if (seenAgentIds.has(agentId)) {
+      continue;
+    }
+    seenAgentIds.add(agentId);
+
+    const sandbox = isRecord(rawAgent?.sandbox) ? rawAgent.sandbox : undefined;
+    const ssh = isRecord(sandbox?.ssh) ? sandbox.ssh : undefined;
+    const backend =
+      normalizeOptionalLowercaseString(sandbox?.backend) ??
+      normalizeOptionalLowercaseString(defaultsSandbox?.backend) ??
+      "docker";
+    const mode =
+      (typeof sandbox?.mode === "string" ? sandbox.mode : undefined) ??
+      (typeof defaultsSandbox?.mode === "string" ? defaultsSandbox.mode : undefined) ??
+      "off";
+    const scope = resolveSandboxScope({
+      scope:
+        typeof sandbox?.scope === "string"
+          ? (sandbox.scope as "agent" | "session" | "shared")
+          : typeof defaultsSandbox?.scope === "string"
+            ? (defaultsSandbox.scope as "agent" | "session" | "shared")
+            : undefined,
+      perSession:
+        typeof sandbox?.perSession === "boolean"
+          ? sandbox.perSession
+          : typeof defaultsSandbox?.perSession === "boolean"
+            ? defaultsSandbox.perSession
+            : undefined,
+    });
+    const active = rawAgent?.enabled !== false && backend === "ssh" && mode !== "off";
+    const owner = sandboxSecretOwner(agentId);
+
+    for (const key of SANDBOX_SSH_SECRET_KEYS) {
+      const hasAgentOverride = Boolean(ssh && Object.hasOwn(ssh, key));
+      if (hasAgentOverride && ssh) {
+        if (scope !== "shared") {
+          collectAssignment({
+            target: ssh,
+            key,
+            path: `agents.list.${candidate.index}.sandbox.ssh.${key}`,
+            defaults: params.defaults,
+            context: params.context,
+            active,
+            inactiveReason: "sandbox SSH backend is not active for this agent.",
+            owner,
+          });
+          continue;
+        }
+        collectAssignment({
+          target: ssh,
+          key,
+          path: `agents.list.${candidate.index}.sandbox.ssh.${key}`,
+          defaults: params.defaults,
+          context: params.context,
+          active: false,
+          inactiveReason: "shared sandbox scope ignores agent SSH overrides.",
+          owner,
+        });
+      }
+
+      if (!defaultsSsh || !Object.hasOwn(defaultsSsh, key)) {
+        continue;
+      }
+      if (!active) {
+        continue;
+      }
+      activeDefaultKeys.add(key);
+      collectAssignment({
+        target: defaultsSsh,
+        key,
+        path: `agents.defaults.sandbox.ssh.${key}`,
+        defaults: params.defaults,
+        context: params.context,
+        active: true,
+        inactiveReason: "sandbox SSH backend is not active for this agent.",
+        owner,
+      });
+    }
+  }
+
+  if (!defaultsSsh) {
+    return;
+  }
+  for (const key of SANDBOX_SSH_SECRET_KEYS) {
+    if (!Object.hasOwn(defaultsSsh, key) || activeDefaultKeys.has(key)) {
+      continue;
+    }
+    collectAssignment({
+      target: defaultsSsh,
+      key,
+      path: `agents.defaults.sandbox.ssh.${key}`,
+      defaults: params.defaults,
+      context: params.context,
+      active: false,
+      inactiveReason: "no enabled agent uses the sandbox SSH material.",
+      owner: sandboxSecretOwner(DEFAULT_AGENT_ID),
+    });
+  }
+}

--- a/src/secrets/runtime-sandbox-secret-owner.ts
+++ b/src/secrets/runtime-sandbox-secret-owner.ts
@@ -1,0 +1,12 @@
+import { normalizeAgentId } from "../routing/session-key.js";
+import { assertSecretOwnerAvailable } from "./runtime-degraded-state.js";
+
+/** Runtime owner for one agent's SSH sandbox credentials. */
+export function runtimeSandboxSecretOwnerId(agentId: string): string {
+  return `agent-sandbox:${normalizeAgentId(agentId)}`;
+}
+
+/** Rejects one agent's SSH sandbox when its runtime credentials are cold. */
+export function assertRuntimeSandboxSecretOwnerAvailable(agentId: string): void {
+  assertSecretOwnerAvailable("capability", runtimeSandboxSecretOwnerId(agentId));
+}

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -225,6 +225,44 @@ describe("secrets runtime snapshot", () => {
     expect(ssh?.knownHostsData).toBe("example.com ssh-ed25519 AAAATEST");
   });
 
+  it("keeps SSH lifecycle secrets materialized after the agent sandbox is disabled", async () => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "off",
+              backend: "ssh",
+              ssh: { target: "peter@example.com:22" },
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              enabled: false,
+              sandbox: {
+                ssh: {
+                  identityData: {
+                    source: "env",
+                    provider: "default",
+                    id: "DISABLED_WORKER_SSH_IDENTITY",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+      env: { DISABLED_WORKER_SSH_IDENTITY: "DISABLED WORKER PRIVATE KEY" },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+
+    expect(snapshot.config.agents?.list?.[0]?.sandbox?.ssh?.identityData).toBe(
+      "DISABLED WORKER PRIVATE KEY",
+    );
+  });
+
   it("isolates only the agent whose inherited sandbox SSH SecretRef is unavailable", async () => {
     const missingRef = {
       source: "env",

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -225,6 +225,66 @@ describe("secrets runtime snapshot", () => {
     expect(ssh?.knownHostsData).toBe("example.com ssh-ed25519 AAAATEST");
   });
 
+  it("isolates only the agent whose inherited sandbox SSH SecretRef is unavailable", async () => {
+    const missingRef = {
+      source: "env",
+      provider: "default",
+      id: "MISSING_COLD_SSH_IDENTITY",
+    } as const;
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+              backend: "ssh",
+              ssh: {
+                target: "sandbox@example.com:22",
+                identityData: missingRef,
+              },
+            },
+          },
+          list: [
+            { id: "cold" },
+            {
+              id: "healthy",
+              sandbox: {
+                ssh: {
+                  identityData: {
+                    source: "env",
+                    provider: "default",
+                    id: "HEALTHY_SSH_IDENTITY",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+      env: { HEALTHY_SSH_IDENTITY: "HEALTHY PRIVATE KEY" },
+      includeAuthStoreRefs: false,
+      allowUnavailableSecretOwners: true,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+
+    expect(snapshot.config.agents?.defaults?.sandbox?.ssh?.identityData).toEqual(missingRef);
+    expect(snapshot.config.agents?.list?.[1]?.sandbox?.ssh?.identityData).toBe(
+      "HEALTHY PRIVATE KEY",
+    );
+    expect(snapshot.degradedOwners).toMatchObject([
+      {
+        ownerKind: "capability",
+        ownerId: "agent-sandbox:cold",
+        state: "unavailable",
+        paths: ["agents.defaults.sandbox.ssh.identityData"],
+      },
+    ]);
+    expectWarning(snapshot, {
+      code: "SECRETS_OWNER_UNAVAILABLE",
+      path: "agents.defaults.sandbox.ssh.identityData",
+    });
+  });
+
   it("treats sandbox ssh secret refs as inactive when ssh backend is not selected", async () => {
     const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -263,6 +263,56 @@ describe("secrets runtime snapshot", () => {
     );
   });
 
+  it("keeps default SSH lifecycle secrets materialized when every listed agent overrides them", async () => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "off",
+              backend: "ssh",
+              ssh: {
+                target: "peter@example.com:22",
+                identityData: {
+                  source: "env",
+                  provider: "default",
+                  id: "DEFAULT_SSH_IDENTITY",
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              sandbox: {
+                ssh: {
+                  identityData: {
+                    source: "env",
+                    provider: "default",
+                    id: "WORKER_SSH_IDENTITY",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+      env: {
+        DEFAULT_SSH_IDENTITY: "DEFAULT PRIVATE KEY",
+        WORKER_SSH_IDENTITY: "WORKER PRIVATE KEY",
+      },
+      includeAuthStoreRefs: false,
+      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+    });
+
+    expect(snapshot.config.agents?.defaults?.sandbox?.ssh?.identityData).toBe(
+      "DEFAULT PRIVATE KEY",
+    );
+    expect(snapshot.config.agents?.list?.[0]?.sandbox?.ssh?.identityData).toBe(
+      "WORKER PRIVATE KEY",
+    );
+  });
+
   it("isolates only the agent whose inherited sandbox SSH SecretRef is unavailable", async () => {
     const missingRef = {
       source: "env",


### PR DESCRIPTION
Related: #101265

## What Problem This Solves

Fixes an issue where users with one broken SSH sandbox SecretRef could lose Gateway startup or unrelated agent sandboxing, while an unresolved direct SSH identity could fall through to ambient filesystem or agent configuration.

## Why This Change Was Made

Sandbox secret collection now assigns exact normalized agent owners, duplicates inherited defaults only for relevant agents, and ignores unrelated per-agent overrides in shared scope. Sandbox resolution and SSH manager paths validate the effective agent owner plus the selected raw SSH refs before filesystem or network access, returning the existing typed unavailable error for only that agent. SSH lifecycle credentials remain materialized while SSH is configured, so disabling an agent or sandbox does not strand inspection or removal of an existing remote runtime.

No config, environment, UI, protocol, or capability surface is added.

## User Impact

The Gateway continues starting when one agent has a broken SSH sandbox secret. That agent's sandbox stays cold, while healthy agents remain available. Broken direct SSH secret refs cannot silently fall through to another profile or ambient identity. Existing SSH runtimes remain manageable after sandbox deactivation.

## Evidence

- `node scripts/run-vitest.mjs src/secrets/runtime.test.ts src/agents/sandbox/secret-owner.test.ts src/agents/sandbox/ssh-backend.test.ts src/gateway/server-startup-secret-owner-isolation.test.ts` — 48/48 tests passed across 4 shards after the lifecycle repair.
- `node scripts/check-changed.mjs -- src/agents/sandbox/context.ts src/agents/sandbox/secret-owner.test.ts src/agents/sandbox/secret-owner.ts src/agents/sandbox/ssh-backend.test.ts src/agents/sandbox/ssh-backend.ts src/gateway/server-startup-secret-owner-isolation.test.ts src/secrets/runtime-config-collectors-core.ts src/secrets/runtime-config-collectors-sandbox.ts src/secrets/runtime-sandbox-secret-owner.ts src/secrets/runtime.test.ts` — hosted changed gate passed, exit 0, 19m04s before the final two-file lifecycle repair: https://github.com/openclaw/openclaw/actions/runs/29594877204
- Exact-head PR CI is the final full gate.
- Fresh autoreview after the lifecycle repair: no accepted/actionable findings.

AI-assisted: yes. Maintainer deep review and focused regression proof completed.
