### PR TITLE
fix(browser): stop orphaned Chrome when browser was auto-launched by agent

### DIFF
--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -166,7 +166,7 @@ function createChromeLaunchStderrDiagnostics(maxBytes: number) {
   };
 }
 
-function processExists(pid: number): boolean {
+export function processExists(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) {
     return false;
   }
@@ -474,7 +474,10 @@ function isPortInUseError(err: unknown): boolean {
   );
 }
 
-function readCurrentHostSingletonPid(userDataDir: string, hostname = os.hostname()): number | null {
+export function readCurrentHostSingletonPid(
+  userDataDir: string,
+  hostname = os.hostname(),
+): number | null {
   const lock = readSingletonLockTarget(userDataDir);
   if (!lock || lock.hostname !== hostname || !processExists(lock.pid)) {
     return null;
@@ -569,7 +572,7 @@ async function terminateChromeForRetry(proc: ChildProcess, userDataDir: string):
   return true;
 }
 
-async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
+export async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (!processExists(pid)) {

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -19,6 +19,8 @@ import {
   isChromeReachable,
   launchOpenClawChrome,
   ManagedChromeCleanupError,
+  readCurrentHostSingletonPid,
+  resolveOpenClawUserDataDir,
   stopOpenClawChrome,
 } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
@@ -465,6 +467,14 @@ export function createProfileAvailability({
           (await isReachable(PROFILE_ATTACH_RETRY_TIMEOUT_MS, { signal }))
         ) {
           resetManagedLaunchFailure(runtime);
+          // The port is reachable but we have no tracked process handle.
+          // Discover the Chrome PID so `browser stop` can terminate it.
+          // See issue #109678.
+          const userDataDir = resolveOpenClawUserDataDir(profile.name);
+          const pid = readCurrentHostSingletonPid(userDataDir);
+          if (pid) {
+            runtime.untrackedPid = pid;
+          }
           return;
         }
       }
@@ -508,6 +518,16 @@ export function createProfileAvailability({
     // Port is reachable - check if we own it.
     if (await isReachable(undefined, { signal })) {
       resetManagedLaunchFailure(runtime);
+      // The port is reachable but we may not have a tracked process handle.
+      // Discover the Chrome PID so `browser stop` can terminate it.
+      // See issue #109678.
+      if (!attachOnly && !remoteCdp && profile.cdpIsLoopback && !runtime.running) {
+        const userDataDir = resolveOpenClawUserDataDir(profile.name);
+        const pid = readCurrentHostSingletonPid(userDataDir);
+        if (pid) {
+          runtime.untrackedPid = pid;
+        }
+      }
       return;
     }
 

--- a/extensions/browser/src/browser/server-context.chrome-test-harness.ts
+++ b/extensions/browser/src/browser/server-context.chrome-test-harness.ts
@@ -39,6 +39,9 @@ vi.mock("./chrome.js", () => ({
   launchOpenClawChrome: vi.fn(async () => {
     throw new Error("unexpected launch");
   }),
+  processExists: vi.fn(() => false),
+  readCurrentHostSingletonPid: vi.fn(() => null),
   resolveOpenClawUserDataDir: vi.fn(() => chromeUserDataDir.dir),
   stopOpenClawChrome: vi.fn(async () => {}),
+  waitForPidExit: vi.fn(async () => true),
 }));

--- a/extensions/browser/src/browser/server-context.lifecycle.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.ts
@@ -6,9 +6,10 @@
  * transition can still abort and drain all previously admitted work.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { CHROME_STOP_TIMEOUT_MS } from "./cdp-timeouts.js";
 import { getChromeMcpModule } from "./chrome-mcp.runtime.js";
+import { processExists, stopOpenClawChrome, waitForPidExit } from "./chrome.js";
 import type { RunningChrome } from "./chrome.js";
-import { stopOpenClawChrome } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { BrowserProfileUnavailableError } from "./errors.js";
 import type { ExtensionRelayHandle } from "./extension-relay/relay-server.js";
@@ -407,6 +408,26 @@ async function cleanupProfileResources(params: {
       stopped = true;
     } catch (err) {
       firstError ??= toLifecycleError(err, "Managed browser cleanup failed.");
+    }
+  }
+
+  // Clean up an untracked Chrome PID discovered by `ensureBrowserAvailableOnce`
+  // when the browser was already running on the CDP port but not launched by
+  // the current gateway session. See issue #109678.
+  if (runtime.untrackedPid) {
+    const pid = runtime.untrackedPid;
+    runtime.untrackedPid = null;
+    try {
+      if (processExists(pid)) {
+        process.kill(pid, "SIGTERM");
+        const exited = await waitForPidExit(pid, CHROME_STOP_TIMEOUT_MS);
+        if (!exited) {
+          process.kill(pid, "SIGKILL");
+        }
+        stopped = true;
+      }
+    } catch (err) {
+      firstError ??= toLifecycleError(err, "Untracked browser cleanup failed.");
     }
   }
 

--- a/extensions/browser/src/browser/server-context.types.ts
+++ b/extensions/browser/src/browser/server-context.types.ts
@@ -20,6 +20,14 @@ export type BrowserTabTargetOptions = BrowserOperationOptions & {
 export type ProfileRuntimeState = {
   profile: ResolvedBrowserProfile;
   running: RunningChrome | null;
+  /**
+   * PID of a managed Chrome that was discovered already running on the
+   * profile's CDP port but was not launched by the current gateway session.
+   * Set when `ensureBrowserAvailableOnce` finds the port reachable without
+   * a tracked process handle. Cleared by `cleanupProfileResources` so
+   * `browser stop` can terminate the orphaned Chrome.
+   */
+  untrackedPid?: number | null;
   /** @deprecated Lifecycle starts are owned by the profile actor. */
   ensureBrowserAvailable?: { key: string; promise: Promise<void> } | null;
   managedLaunchFailure?: {


### PR DESCRIPTION
Closes #109678

## What Problem This Solves

Fixes an issue where `openclaw browser stop` fails to terminate a managed Chrome instance that was auto-launched by an agent's browser tool. The CLI prints `running: true`, `browser status` keeps reporting `running: true`, and the Chrome process survives repeated stop attempts — while instances started via `openclaw browser start` stop normally.

## Why This Change Was Made

When `ensureBrowserAvailableOnce` in `extensions/browser/src/browser/server-context.availability.ts` detects an already-running Chrome on a managed loopback profile's CDP port (from a previous session or agent auto-launch), it takes one of two "already reachable" shortcut paths (lines 462–469 and 508–512) that return success **without registering the Chrome process handle** in `actor.handles` or setting `runtime.running`. The stop logic in `cleanupProfileResources` (`server-context.lifecycle.ts:399–411`) iterates `actor.handles` and `runtime.running` — if neither contains the running Chrome, `stopOpenClawChrome` is never called and the process survives indefinitely.

The fix discovers the orphaned Chrome's PID and stores it so `cleanupProfileResources` can kill it:

1. **`server-context.types.ts`** — Added `untrackedPid?: number | null` to `ProfileRuntimeState` to store a discovered-but-unregistered Chrome PID
2. **`server-context.availability.ts`** — Both "already reachable" paths now call `readCurrentHostSingletonPid(userDataDir)` to discover the Chrome PID via the singleton lock and store it as `runtime.untrackedPid`
3. **`server-context.lifecycle.ts`** — `cleanupProfileResources` now checks for `untrackedPid` and kills it via `process.kill(pid, "SIGTERM")` → `process.kill(pid, "SIGKILL")`, reusing the existing `processExists` and `waitForPidExit` helpers (same pattern used by `terminateOwnedStaleChromeProcess` for stale Chrome recovery)
4. **`chrome.ts`** — Exported `readCurrentHostSingletonPid`, `processExists`, and `waitForPidExit` (previously internal functions)
5. **`server-context.chrome-test-harness.ts`** — Added the new exports to the shared Chrome mock

The kill path mirrors `terminateOwnedStaleChromeProcess` (chrome.ts:585–623): SIGTERM first, wait for exit within `CHROME_STOP_TIMEOUT_MS`, then SIGKILL if needed. No new process management code — only reuse of existing helpers.

## User Impact

Operators can now stop an agent-launched managed Chrome with `openclaw browser stop`, just as they can for CLI-launched instances. The orphaned Chrome process holding CDP port 18800 will be terminated instead of surviving indefinitely.

## Evidence

- **Issue #109678** provides a 2/2 reproduction on v2026.7.1 showing `browser stop` failing on agent-launched Chrome while succeeding on CLI-launched Chrome.
- **ClawSweeper review** confirmed the bug is source-reproducible with `clawsweeper:queueable-fix` and `clawsweeper:source-repro` labels.
- **Root cause verified**: the two "already reachable" paths at `server-context.availability.ts:462–469` and `508–512` return without calling `registerProfileHandle()` or setting `runtime.running`.
- **Existing helpers reused**: `readCurrentHostSingletonPid` reads the Chrome singleton lock to discover the PID; `processExists` and `waitForPidExit` are the same helpers used in `terminateOwnedStaleChromeProcess` (chrome.ts:585–623) for stale Chrome recovery.

### Test output

```
RUN  v4.1.10

 ✓  extension-browser  server-lifecycle.test.ts (2 tests) 242ms
 ✓  extension-browser  server-context.ensure-browser-available.waits-for-cdp-ready.test.ts (22 tests) 71ms
 ✓  extension-browser  chrome.test.ts (35 tests) 335ms
 ✓  extension-browser  runtime-lifecycle.shutdown-race.test.ts (1 test) 13ms

 Test Files  4 passed (4)
      Tests  60 passed (60)
```

The Chrome test harness mock was updated to include the newly exported functions (`readCurrentHostSingletonPid`, `processExists`, `waitForPidExit`) so all existing tests continue to pass.