### PR TITLE
fix(nostr): pairing replies retain DM context

### DIFF
--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -12,8 +12,10 @@ const mockState = vi.hoisted(() => ({
     onclose?: (reason: string[]) => void;
   } | null,
   subscribeMany: vi.fn(),
+  publish: vi.fn((_relays: string[], _event: unknown) => [Promise.resolve("ok")]),
   close: vi.fn(),
   subscriptionClose: vi.fn(),
+  finalizeEvent: vi.fn((event: unknown) => event),
   verifyEvent: vi.fn(() => true),
   decrypt: vi.fn(() => "plaintext"),
   publishProfile: vi.fn(async () => ({
@@ -42,7 +44,9 @@ vi.mock("nostr-tools", () => {
       };
     }
 
-    publish = vi.fn(async () => {});
+    publish(relays: string[], event: unknown) {
+      return mockState.publish(relays, event);
+    }
 
     close(relays: string[]) {
       mockState.close(relays);
@@ -51,7 +55,7 @@ vi.mock("nostr-tools", () => {
 
   return {
     SimplePool: MockSimplePool,
-    finalizeEvent: vi.fn((event: unknown) => event),
+    finalizeEvent: mockState.finalizeEvent,
     getPublicKey: vi.fn(() => BOT_PUBKEY),
     verifyEvent: mockState.verifyEvent,
     nip19: {
@@ -101,8 +105,11 @@ describe("startNostrBus inbound guards", () => {
   beforeEach(() => {
     mockState.handlers = null;
     mockState.subscribeMany.mockClear();
+    mockState.publish.mockReset();
+    mockState.publish.mockReturnValue([Promise.resolve("ok")]);
     mockState.close.mockClear();
     mockState.subscriptionClose.mockReset();
+    mockState.finalizeEvent.mockClear();
     mockState.verifyEvent.mockClear();
     mockState.verifyEvent.mockReturnValue(true);
     mockState.decrypt.mockClear();
@@ -190,6 +197,42 @@ describe("startNostrBus inbound guards", () => {
     expect(mockState.decrypt).not.toHaveBeenCalled();
     expect(onMessage).not.toHaveBeenCalled();
     expect(bus.getMetrics().eventsReceived).toBe(1);
+
+    bus.close();
+  });
+
+  it("links authorization replies to the inbound NIP-04 event", async () => {
+    const inboundEventId = "c".repeat(64);
+    const senderPubkey = "a".repeat(64);
+    const authorizeSender = vi.fn(async ({ reply }: { reply: (text: string) => Promise<void> }) => {
+      await reply("pairing reply");
+      return "pairing" as const;
+    });
+    const key = TEST_HEX_PRIVATE_KEY;
+    const bus = await startNostrBus({
+      privateKey: key,
+      relays: ["wss://relay.example"],
+      onMessage: vi.fn(async () => {}),
+      authorizeSender,
+      onMetric: () => {},
+    });
+
+    await emitEvent(
+      createEvent({
+        id: inboundEventId,
+        pubkey: senderPubkey,
+      }),
+    );
+
+    expect(mockState.finalizeEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: [
+          ["p", senderPubkey],
+          ["e", inboundEventId],
+        ],
+      }),
+      expect.any(Uint8Array),
+    );
 
     bus.close();
   });

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -514,6 +514,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
           circuitBreakers,
           healthTracker,
           onError,
+          event.id,
         );
       };
 
@@ -742,13 +743,19 @@ async function sendEncryptedDm(
   circuitBreakers: Map<string, CircuitBreaker>,
   healthTracker: RelayHealthTracker,
   onError?: (error: Error, context: string) => void,
+  replyToEventId?: string,
 ): Promise<void> {
   const ciphertext = encrypt(sk, toPubkey, text);
+  // NIP-04 uses an e tag to keep a reply attached to its verified inbound event.
+  const tags = [["p", toPubkey]];
+  if (replyToEventId) {
+    tags.push(["e", replyToEventId]);
+  }
   const reply = finalizeEvent(
     {
       kind: 4,
       content: ciphertext,
-      tags: [["p", toPubkey]],
+      tags,
       created_at: Math.floor(Date.now() / 1000),
     },
     sk,


### PR DESCRIPTION
Related: #58236

## What Problem This Solves

Fixes an issue where Nostr users receiving a pairing reply would see it as an unrelated direct message because the reply event did not reference the inbound NIP-04 event.

## Why This Change Was Made

The verified inbound event id is now carried through the existing reply closure and emitted as the NIP-04 `e` reply tag. Proactive sends still emit only the recipient `p` tag, so this does not change ordinary outbound message shape.

## User Impact

Nostr clients can associate OpenClaw pairing and conversation replies with the direct message that triggered them instead of displaying those replies without conversation context.

## Evidence

- Official protocol contract: NIP-04 permits an `e` tag identifying the previous message or explicit reply target: https://github.com/nostr-protocol/nips/blob/master/04.md
- Test-first regression proof on latest main:
  - RED: `node scripts/run-vitest.mjs extensions/nostr/src/nostr-bus.inbound.test.ts` failed because the reply had only the recipient `p` tag.
  - GREEN: the same focused file passed, 18/18 tests.
- Nostr extension lane: `node scripts/test-extension.mjs nostr` passed, 14 files / 212 tests.
- Changed-surface checks: local trusted-source fallback passed formatting, production and test typechecks, lint, plugin boundaries, API baseline, import cycles, and repository guards. Blacksmith delegation was unavailable because the local Crabbox binary failed its health check.
- Build: `node scripts/run-node.mjs --version` completed successfully on Node 24.15.0.
- Live public-relay proof with temporary random keys and the real OpenClaw plugin install/gateway path (`openclaw plugins install --link`, then `openclaw gateway run`) through `wss://relay.nostr.net`:
  - BEFORE: the relay stored the inbound event and a decryptable pairing reply, but `replyTagPresent=false`.
  - AFTER: the relay stored the inbound event and a decryptable pairing reply with `replyTagPresent=true` and an `e` tag exactly matching the inbound event id.
  - Both runs reported `coClawPathObserved=false`.
- Structured autoreview created the review bundle but the Codex Responses WebSocket returned HTTP 403, so no model finding was produced; the final two-file diff was manually reviewed against the caller, proactive-send sibling, tests, NIP-04 contract, and `nostr-tools@2.23.9` publish types.
