### PR TITLE
fix(signal): merged messages show real line breaks

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -336,7 +336,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     ).resolves.toEqual({ author: "+15550002222", body: "edited hello" });
   });
 
-  it("preserves the last debounced message body for native reply quote metadata", async () => {
+  it("joins debounced message bodies with newlines and preserves the last native reply body", async () => {
     vi.useFakeTimers();
     const deliverRepliesMock = vi.fn().mockResolvedValue(undefined);
     dispatchInboundMessageMock.mockImplementationOnce(async (params: any) => {
@@ -386,7 +386,7 @@ describe("signal createSignalEventHandler inbound context", () => {
         expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
       });
       const context = requireCapturedContext();
-      expect(context.BodyForAgent).toBe("first debounced message\\nsecond debounced message");
+      expect(context.BodyForAgent).toBe("first debounced message\nsecond debounced message");
       expect(context.ReplyToId).toBe("1700000000002");
       expect(context.ReplyThreading).toEqual({ implicitCurrentMessage: "allow" });
       expect(deliverRepliesMock.mock.calls[0]?.[0]).toMatchObject({
@@ -2070,8 +2070,8 @@ describe("signal createSignalEventHandler inbound context", () => {
 
       const context = requireCapturedContext();
       expect(context.BodyForAgent).toContain("[signal attachment unavailable]");
-      expect(context.RawBody).toBe("first request\\nsecond request");
-      expect(context.CommandBody).toBe("first request\\nsecond request");
+      expect(context.RawBody).toBe("first request\nsecond request");
+      expect(context.CommandBody).toBe("first request\nsecond request");
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -731,11 +731,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const combinedText = entries
       .map((entry) => entry.bodyText)
       .filter(Boolean)
-      .join("\\n");
+      .join("\n");
     const combinedCommandBody = entries
       .map((entry) => entry.commandBody)
       .filter(Boolean)
-      .join("\\n");
+      .join("\n");
     if (!combinedText.trim()) {
       await settle();
       return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending multiple Signal messages inside the inbound debounce window would have those messages reach the agent with visible literal `\n` text between them instead of line breaks.

## Why This Change Was Made

The Signal batch merge now separates both agent-facing message bodies and command bodies with real newline characters. Native reply metadata still uses the final message body, and the intentionally escaped verbose-log preview remains unchanged.

This is AI-assisted. The full downstream prompt path, sibling WhatsApp merge behavior, regression provenance, focused tests, and changed gates were reviewed before submission.

## User Impact

Debounced Signal messages now appear to the agent as ordinary multiline input, matching what the sender intended. Text-command parsing sees the same newline-separated batch.

## Evidence

- Before fix: the focused Signal test failed 2 assertions, showing received literal `\n` separators in `BodyForAgent`, `RawBody`, and `CommandBody`; 45 neighboring assertions passed.
- After fix: `corepack pnpm test extensions/signal/src/monitor/event-handler.inbound-context.test.ts` passed all 47 tests on Blacksmith Testbox.
- `corepack pnpm check:changed` passed extension production/test typechecks, formatting, lint, boundary checks, and guards on the same Testbox.
- Autoreview: clean, no accepted/actionable findings, 0.99 confidence.
- Testbox: https://github.com/openclaw/openclaw/actions/runs/29597134967

Provenance: #971 introduced Signal debounced batching with an intended newline separator; the literal escape survived later moves and refactors.
