### PR TITLE
fix(signal): preserve newlines in debounced messages

### DIFF
--- a/docs/start/onboarding-redesign.md
+++ b/docs/start/onboarding-redesign.md
@@ -255,11 +255,16 @@ restart` from the real environment and verify the plist. Product follow-up:
 - **Agent landing needs exact-head hosted CI.** The heavy `CI` workflow may
   not queue on pushes under org load; the maintainer fallback is a
   release-gate dispatch on the PR branch:
-  `gh workflow run ci.yml --ref <branch> -f target_ref=<head-sha>
--f release_gate=true -f pull_request_number=<pr>` (the run must be on the
+
+  ```bash
+  gh workflow run ci.yml --ref <branch> -f target_ref=<head-sha> -f release_gate=true -f pull_request_number=<pr>
+  ```
+
+  The run must be on the
   branch ref so `head_sha` matches, and the title becomes
   `CI release gate <sha>`, which `scripts/verify-pr-hosted-gates.mjs`
-  accepts). Then `scripts/pr` prepare/merge as usual.
+  accepts. Then `scripts/pr` prepare/merge as usual.
+
 - **Gates that CI enforces beyond focused tests**: docs map
   (`pnpm docs:map:gen` after adding any docs page), oxlint (`no-map-spread`,
   `max-lines` — split files, never suppress), `check:test-types`, knip

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -336,7 +336,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     ).resolves.toEqual({ author: "+15550002222", body: "edited hello" });
   });
 
-  it("preserves the last debounced message body for native reply quote metadata", async () => {
+  it("joins debounced message bodies with newlines and preserves the last for replies", async () => {
     vi.useFakeTimers();
     const deliverRepliesMock = vi.fn().mockResolvedValue(undefined);
     dispatchInboundMessageMock.mockImplementationOnce(async (params: any) => {
@@ -386,7 +386,8 @@ describe("signal createSignalEventHandler inbound context", () => {
         expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
       });
       const context = requireCapturedContext();
-      expect(context.BodyForAgent).toBe("first debounced message\\nsecond debounced message");
+      expect(context.BodyForAgent).toBe("first debounced message\nsecond debounced message");
+      expect(context.CommandBody).toBe("first debounced message\nsecond debounced message");
       expect(context.ReplyToId).toBe("1700000000002");
       expect(context.ReplyThreading).toEqual({ implicitCurrentMessage: "allow" });
       expect(deliverRepliesMock.mock.calls[0]?.[0]).toMatchObject({
@@ -2070,8 +2071,8 @@ describe("signal createSignalEventHandler inbound context", () => {
 
       const context = requireCapturedContext();
       expect(context.BodyForAgent).toContain("[signal attachment unavailable]");
-      expect(context.RawBody).toBe("first request\\nsecond request");
-      expect(context.CommandBody).toBe("first request\\nsecond request");
+      expect(context.RawBody).toBe("first request\nsecond request");
+      expect(context.CommandBody).toBe("first request\nsecond request");
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -731,11 +731,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const combinedText = entries
       .map((entry) => entry.bodyText)
       .filter(Boolean)
-      .join("\\n");
+      .join("\n");
     const combinedCommandBody = entries
       .map((entry) => entry.commandBody)
       .filter(Boolean)
-      .join("\\n");
+      .join("\n");
     if (!combinedText.trim()) {
       await settle();
       return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where multiple Signal messages received inside the inbound debounce window reached the agent with visible literal `\n` text instead of line breaks.

## Why This Change Was Made

Signal now joins both the agent-facing body and command body with real newline characters, matching sibling channel debounce behavior. The nearby verbose-log preview escape remains unchanged because logs intentionally keep the preview on one line.

The existing maintainer release-gate example is also rendered as a fenced shell command, with its generated title in inline code, so the docs gate accepts it.

AI-assisted: yes.

## User Impact

Debounced Signal messages now reach the agent as distinct lines, preserving message boundaries without visible escape characters.

Release-note context: Signal debounce batches preserve message boundaries with real line breaks.

## Evidence

- Before fix: focused Signal inbound-context proof reproduced the bug with 2 failures and 45 passes; received values contained literal `\n` text.
- After fix: the focused Signal file passed all 47 tests.
- Rebased final-tree focused proof passed Signal 47/47.
- A patch-superset remote changed gate passed selected formatting, typecheck, lint, plugin-boundary, import-cycle, state-guard, and test lanes.
- Docs formatting and markdownlint passed all 722 files.
- Exact-head hosted release gate [29617325982](https://github.com/openclaw/openclaw/actions/runs/29617325982) completed all 136 jobs with zero failures.
- Fresh final-branch autoreview: clean, no actionable findings, confidence 0.96.
- `git diff --check`: passed.
- Live Signal send/receive was not exercised because no linked Signal account was available in this task.
