### PR TITLE
test(ui): cover plan-snapshot replay on reconnect end to end

### DIFF
--- a/qa/scenarios/ui/control-ui-plan-replay-reconnect.yaml
+++ b/qa/scenarios/ui/control-ui-plan-replay-reconnect.yaml
@@ -1,0 +1,30 @@
+title: Control UI plan checklist replay on reconnect
+
+scenario:
+  id: control-ui-plan-replay-reconnect
+  surface: control-ui
+  coverage:
+    primary:
+      - ui.control
+  objective: >-
+    Prove a client that connects or refreshes mid-run renders the active plan
+    checklist from the replayed chat.history/chat.startup inFlightRun snapshot,
+    then keeps the normal live-update and terminal-clear lifecycle.
+  successCriteria:
+    - The checklist renders from the replayed snapshot alone, before any live plan event.
+    - A newer live plan event replaces the seeded snapshot in place.
+    - The checklist clears when the run reaches a terminal outcome.
+    - A mid-run page reload restores the checklist from the snapshot.
+  docsRefs:
+    - docs/web/control-ui.md
+  codeRefs:
+    - ui/src/e2e/plan-replay-reconnect.e2e.test.ts
+    - ui/src/pages/chat/chat-history.ts
+    - src/gateway/chat-abort.ts
+  execution:
+    kind: playwright
+    path: ui/src/e2e/plan-replay-reconnect.e2e.test.ts
+    summary: >-
+      Playwright coverage for plan-snapshot replay on connect, reload, live
+      replacement, and terminal clearing (follow-up to the live-verified
+      reconnect gap fixed in PR 109966).

--- a/ui/src/e2e/plan-replay-reconnect.e2e.test.ts
+++ b/ui/src/e2e/plan-replay-reconnect.e2e.test.ts
@@ -58,7 +58,7 @@ describeControlUiE2e("Control UI plan snapshot replay", () => {
   });
 
   afterEach(async () => {
-    for (const context of [...openBrowserContexts]) {
+    for (const context of openBrowserContexts) {
       await closeBrowserContext(context);
     }
   });

--- a/ui/src/e2e/plan-replay-reconnect.e2e.test.ts
+++ b/ui/src/e2e/plan-replay-reconnect.e2e.test.ts
@@ -1,0 +1,143 @@
+// Control UI tests cover plan-snapshot replay on connect/reconnect.
+import { chromium, expect, type Browser, type BrowserContext, type Page } from "playwright/test";
+import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let server: ControlUiE2eServer;
+let browser: Browser;
+const openBrowserContexts = new Set<BrowserContext>();
+
+const REPLAY_RUN_ID = "run-plan-replay";
+// Mirrors the gateway's chat.history/chat.startup inFlightRun recovery payload.
+const replayScenario = {
+  inFlightRun: {
+    runId: REPLAY_RUN_ID,
+    text: "",
+    plan: {
+      explanation: "Restore the checklist after reconnect",
+      steps: [
+        { step: "Inspect the primes script", status: "completed" },
+        { step: "Add a docstring", status: "in_progress" },
+        { step: "Verify the output", status: "pending" },
+      ],
+    },
+  },
+  sessionInfo: { activeRunIds: [REPLAY_RUN_ID], hasActiveRun: true, key: "main" },
+};
+
+async function newPage(): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1280 },
+  });
+  openBrowserContexts.add(context);
+  return { context, page: await context.newPage() };
+}
+
+async function closeBrowserContext(context: BrowserContext): Promise<void> {
+  openBrowserContexts.delete(context);
+  await context.close();
+}
+
+describeControlUiE2e("Control UI plan snapshot replay", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterEach(async () => {
+    for (const context of [...openBrowserContexts]) {
+      await closeBrowserContext(context);
+    }
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("seeds the plan checklist from a replayed in-flight snapshot on load", async () => {
+    const { context, page } = await newPage();
+    await installMockGateway(page, replayScenario);
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      // The checklist must render from the replayed snapshot alone, before any
+      // live plan event arrives — this is the reconnect gap the replay closes.
+      const checklist = page.locator(".plan-checklist").first();
+      await checklist.waitFor({ state: "visible", timeout: 10_000 });
+      await checklist.getByText("Add a docstring").first().waitFor({ timeout: 10_000 });
+      await page.getByText("1/3").first().waitFor({ timeout: 10_000 });
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
+  it("replaces the seeded snapshot with a newer live plan event and clears with the run", async () => {
+    const { context, page } = await newPage();
+    const gateway = await installMockGateway(page, replayScenario);
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.locator(".plan-checklist").first().waitFor({ state: "visible", timeout: 10_000 });
+      // Bar + in-thread card render for an active run; the live event must
+      // replace both in place, not mount additional checklists.
+      const seededChecklistCount = await page.locator(".plan-checklist").count();
+
+      await gateway.emitGatewayEvent("agent", {
+        data: {
+          phase: "update",
+          steps: [
+            { step: "Inspect the primes script", status: "completed" },
+            { step: "Add a docstring", status: "completed" },
+            { step: "Verify the output", status: "in_progress" },
+          ],
+        },
+        runId: REPLAY_RUN_ID,
+        seq: 1,
+        sessionKey: "main",
+        stream: "plan",
+        ts: Date.now(),
+      });
+      await page.getByText("2/3").first().waitFor({ timeout: 10_000 });
+      await expect(page.getByText("1/3")).toHaveCount(0);
+      await expect(page.locator(".plan-checklist")).toHaveCount(seededChecklistCount);
+
+      // Terminal run outcome clears the checklist through the existing lifecycle.
+      await gateway.emitChatFinal({ runId: REPLAY_RUN_ID, text: "All steps complete." });
+      await page.locator(".plan-checklist").first().waitFor({ state: "detached", timeout: 10_000 });
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
+  it("restores the checklist from the snapshot after a mid-run page reload", async () => {
+    const { context, page } = await newPage();
+    await installMockGateway(page, replayScenario);
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.locator(".plan-checklist").first().waitFor({ state: "visible", timeout: 10_000 });
+
+      // Mock routes are page-scoped, so reinstall before reload to keep serving
+      // the same snapshot — the refresh-mid-run case from the live QA repro.
+      await installMockGateway(page, replayScenario);
+      await page.reload();
+      const checklist = page.locator(".plan-checklist").first();
+      await checklist.waitFor({ state: "visible", timeout: 10_000 });
+      await checklist.getByText("Add a docstring").first().waitFor({ timeout: 10_000 });
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -63,6 +63,10 @@ export type ControlUiMockGatewayScenario = {
   historyMessages?: unknown[];
   /** Static payloads, parameter-matched cases, or call-ordered sequences. */
   methodResponses?: Record<string, unknown>;
+  /** Replayed in-flight run snapshot served by chat.history and chat.startup. */
+  inFlightRun?: { runId: string; text?: string; plan?: unknown } | null;
+  /** Session run state served alongside history (hasActiveRun/activeRunIds). */
+  sessionInfo?: Record<string, unknown> | null;
   models?: Array<{
     id: string;
     name: string;
@@ -253,7 +257,9 @@ function normalizeScenario(
     featureMethods: scenario.featureMethods ?? ["chat.metadata", "chat.startup"],
     historyMessages: scenario.historyMessages ?? [],
     methodResponses: scenario.methodResponses ?? {},
+    inFlightRun: scenario.inFlightRun ?? null,
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+    sessionInfo: scenario.sessionInfo ?? null,
     sessionKey,
     sessionGroups: scenario.sessionGroups ?? [],
     terminalEnabled: scenario.terminalEnabled ?? false,
@@ -778,6 +784,8 @@ function installControlUiMockGateway(input: {
           messages: scenario.historyMessages,
           sessionId: "control-ui-e2e-session",
           thinkingLevel: null,
+          ...(scenario.inFlightRun ? { inFlightRun: scenario.inFlightRun } : {}),
+          ...(scenario.sessionInfo ? { sessionInfo: scenario.sessionInfo } : {}),
         };
       case "chat.startup":
         return {
@@ -800,6 +808,8 @@ function installControlUiMockGateway(input: {
           },
           sessionId: "control-ui-e2e-session",
           thinkingLevel: null,
+          ...(scenario.inFlightRun ? { inFlightRun: scenario.inFlightRun } : {}),
+          ...(scenario.sessionInfo ? { sessionInfo: scenario.sessionInfo } : {}),
         };
       case "chat.metadata":
         return {


### PR DESCRIPTION
## What Problem This Solves

Plan-snapshot replay to reconnecting clients (#109966) shipped with unit coverage per layer, but nothing proves the full browser-visible contract end to end: a client that connects or refreshes mid-run must render the checklist from the replayed `inFlightRun` snapshot alone, keep live updates working, and clear on the terminal outcome. This was the stated follow-up in that PR's review artifacts.

## Why This Change Was Made

Extends the existing Control UI Playwright harness rather than building new scaffolding: the mock gateway scenario can now serve an `inFlightRun` snapshot plus session run state through both `chat.history` and `chat.startup` (mirroring the real gateway payload), and a focused e2e suite drives a real Chromium client through the four contract behaviors:

- checklist renders from the replayed snapshot alone, before any live plan event;
- a newer live `stream:"plan"` event replaces the seeded checklist **in place** (asserted strictly: old counter gone, checklist count unchanged — a duplicate-mount regression fails);
- the terminal run outcome clears it through the existing lifecycle;
- a mid-run page reload restores it from the snapshot (the original live-verified gap).

Registered as QA scenario `control-ui-plan-replay-reconnect` (`execution.kind: playwright`), following the `control-ui-chat-flow-playwright` precedent.

## User Impact

None at runtime — test and QA-pack coverage only. The reconnect contract from #109966 is now guarded end to end in a real browser.

## Evidence

- `node scripts/run-vitest.mjs ui/src/e2e/plan-replay-reconnect.e2e.test.ts` — 3 passed (real Chromium via the ui-e2e config).
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts` — 41 passed (validates the new scenario YAML against the pack schema and coverage taxonomy).
- Full `node scripts/run-tsgo.mjs -b tsconfig.projects.json` — 0 errors.
- Structured autoreview (Codex gpt-5.6-sol): converged clean; one accepted finding (replacement assertion too weak to catch duplicate mounts) fixed with strict counts.
- Note: `ui/src/e2e/chat-flow.e2e.test.ts` has 3 pre-existing local failures on this Mac (identical with and without this diff, verified via stash); CI truth is Linux.
