### PR TITLE
fix: OpenAI OAuth works behind fake-IP proxies

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -7,10 +7,21 @@ const ssrfMocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: ssrfMocks.fetchWithSsrFGuard,
-}));
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: ssrfMocks.fetchWithSsrFGuard,
+  };
+});
 
+import {
+  resolvePinnedHostnameWithPolicy,
+  type LookupFn,
+  type SsrFPolicy,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   createOpenAIAuthorizationFlow,
   resolveOpenAICallbackHost,
@@ -63,6 +74,36 @@ function mockTokenResponseText(body: string, status = 200): void {
     }),
     release: vi.fn(async () => undefined),
   });
+}
+
+function mockFakeIpTokenResponse(params: { address: string; family: 4 | 6 }): void {
+  ssrfMocks.fetchWithSsrFGuard.mockImplementationOnce(
+    async ({ policy }: { policy?: SsrFPolicy }) => {
+      const lookupFn = vi.fn(async () => [params]) as unknown as LookupFn;
+      const pinned = await resolvePinnedHostnameWithPolicy("auth.openai.com", {
+        lookupFn,
+        policy,
+      });
+
+      expect(pinned.addresses).toEqual([params.address]);
+      await expect(
+        resolvePinnedHostnameWithPolicy("redirect.example.com", { lookupFn, policy }),
+      ).rejects.toThrow("Blocked hostname (not in allowlist)");
+      expect(lookupFn).toHaveBeenCalledOnce();
+
+      return {
+        response: new Response(
+          JSON.stringify({
+            access_token: "test-access-token",
+            refresh_token: "test-refresh-token",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        release: vi.fn(async () => undefined),
+      };
+    },
+  );
 }
 
 afterEach(() => {
@@ -229,6 +270,40 @@ describe("OpenAI Codex OAuth flow", () => {
       message: "OpenAI Codex token exchange timed out after 5ms",
     });
   });
+
+  it.each([
+    { operation: "authorization-code exchange", address: "198.18.0.42", family: 4 as const },
+    { operation: "refresh-token exchange", address: "fc00::42", family: 6 as const },
+  ])(
+    "allows fake-IP DNS for the OpenAI OAuth $operation",
+    async ({ operation, address, family }) => {
+      mockFakeIpTokenResponse({ address, family });
+
+      const result =
+        operation === "authorization-code exchange"
+          ? await exchangeOpenAIAuthorizationCode(
+              "code",
+              "verifier",
+              resolveOpenAIRedirectUri("localhost"),
+            )
+          : await refreshOpenAIAccessToken("old-refresh-token");
+
+      expect(result).toMatchObject({
+        type: "success",
+        access: "test-access-token",
+        refresh: "test-refresh-token",
+      });
+      expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          policy: {
+            allowRfc2544BenchmarkRange: true,
+            allowIpv6UniqueLocalRange: true,
+            hostnameAllowlist: ["auth.openai.com"],
+          },
+        }),
+      );
+    },
+  );
 
   it("cancels token exchange requests with the caller signal", async () => {
     const controller = new AbortController();

--- a/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
@@ -3,11 +3,16 @@ import {
   resolveOAuthTokenLifetimeMs,
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { throwIfOAuthLoginAborted } from "./openai-chatgpt-oauth-abort.runtime.js";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const OAUTH_TOKEN_SSRF_POLICY = {
+  allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
+  hostnameAllowlist: ["auth.openai.com"],
+} satisfies SsrFPolicy;
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 const OAUTH_TOKEN_RESPONSE_BODY_LIMIT_BYTES = 1 * 1024 * 1024;
 
@@ -61,6 +66,9 @@ async function postTokenForm(
   throwIfOAuthLoginAborted(options.signal);
   const { response, release } = await fetchWithSsrFGuard({
     url: TOKEN_URL,
+    // Fake-IP proxies map public hosts into these ranges. The exact-host allowlist
+    // keeps redirects and every other hostname fail-closed.
+    policy: OAUTH_TOKEN_SSRF_POLICY,
     init: {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },


### PR DESCRIPTION
Related: #89491

*AI-assisted (approved by Peter)*

## What Problem This Solves

Fixes an issue where users behind Clash, Surge, sing-box, or similar fake-IP proxy DNS would have OpenAI OAuth token exchange and refresh rejected when `auth.openai.com` resolved into the RFC 2544 benchmark range or IPv6 unique-local range.

## Why This Change Was Made

The fixed OpenAI token endpoint now uses the same narrow fake-IP SSRF policy as OpenAI Realtime: only `198.18.0.0/15` and `fc00::/7` are exempted, and only for the exact `auth.openai.com` hostname. Redirects and all other hostnames remain rejected. No config, environment variable, SDK export, or broad private-network permission is added.

The shared token POST helper applies this policy to both authorization-code and refresh-token exchange. Contributor credit is preserved for @abnershang, whose original #89491 patch identified the proxy-DNS failure mode.

## User Impact

OpenAI OAuth sign-in and token refresh can complete behind supported fake-IP proxies without weakening the guard for other OAuth destinations.

## Evidence

- Resolver-backed regression covers `auth.openai.com` resolving to `198.18.0.42` during authorization-code exchange and `fc00::42` during refresh-token exchange; the same policy rejects `redirect.example.com` before DNS lookup.
- `node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts` — 15 tests passed.
- `node scripts/check-changed.mjs -- extensions/openai/openai-chatgpt-oauth-token.runtime.ts extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts` — all extension checks, typechecks, lint, boundaries, and import-cycle gates passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29598129277
- `curl -sS --max-time 20 -o /dev/null -w '%{http_code} %{url_effective}\n' https://auth.openai.com/oauth/token` — live endpoint reachable; returned expected method rejection `405` for a credential-free GET.
- Fresh autoreview: clean, no accepted/actionable findings.
