### PR TITLE
fix(config): add enabled field to compaction schema

### DIFF
--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -396,6 +396,18 @@ describe("agent defaults schema", () => {
     expect(result.compaction?.midTurnPrecheck?.enabled).toBe(true);
   });
 
+  it("accepts compaction.enabled and allows disabling auto-compaction", () => {
+    const enabled = AgentDefaultsSchema.parse({
+      compaction: { enabled: true },
+    })!;
+    expect(enabled.compaction?.enabled).toBe(true);
+
+    const disabled = AgentDefaultsSchema.parse({
+      compaction: { enabled: false },
+    })!;
+    expect(disabled.compaction?.enabled).toBe(false);
+  });
+
   it("accepts focused contextLimits on defaults and agent entries", () => {
     const defaults = AgentDefaultsSchema.parse({
       contextLimits: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -159,6 +159,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
+        enabled: z.boolean().optional(),
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         provider: z.string().optional(),
         thinkingLevel: AgentThinkingLevelSchema.optional(),


### PR DESCRIPTION
## What Problem This Solves

The `compaction` config block in `openclaw.json` is accepted by the runtime but rejected by schema validation because the `enabled` field is missing from the Zod schema definition in `AgentDefaultsSchema`.

## Why This Change Was Made

One-line addition of `enabled: z.boolean().optional()` to the compaction schema object, matching the existing runtime behavior where compaction defaults to enabled.

## Evidence

```
$ npx vitest run src/config/zod-schema.agent-defaults.test.ts --no-coverage

 RUN  v4.1.9 /home/0668001435/.openclaw/browser/openclaw

 Test Files  1 passed (1)
      Tests  45 passed (45)
   Start at  17:13:11
   Duration  6.49s (transform 4.54s, setup 114ms, import 5.97s, tests 81ms, environment 0ms)
```

New test covers `compaction.enabled` (both `true` and `false`) accepted by `AgentDefaultsSchema.parse()`.

## Merge Risk

Low — adding an optional boolean field to schema, no runtime behavior change.
