### PR TITLE
fix(reef): restore inbox recovery after gateway restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Reef inbox recovery:** open the live socket before ordered backlog catch-up, persist the last successfully processed relay cursor, and surface retry failures so restarts do not replay retained receipts or remain silently disconnected. (#110070)
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Reef inbox recovery:** open the live socket before ordered backlog catch-up, persist the last successfully processed relay cursor, and surface retry failures so restarts do not replay retained receipts or remain silently disconnected. (#110070)
 - **Gateway control-plane rate limiting:** use per-method buckets with a 30-per-minute budget so interactive admin writes remain responsive while retaining runaway-loop protection.
 - **External supervisor restart health:** accept device-identity policy closes only when the replacement gateway lock and listener PID agree, preventing OCM-managed restarts from timing out after a successful handoff. Thanks @shakkernerd.
 - **ACPX cleanup process inspection:** bound host process-table reads so stalled `ps` calls cannot hang gateway startup or session cleanup while retaining fail-closed ownership checks. Thanks @Alix-007.

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -30,7 +30,7 @@ import {
 import { isRephrasedReefResend } from "./rejection-resend.js";
 import { getActiveReef, getOptionalReefRuntime, getReefRuntime, setActiveReef } from "./runtime.js";
 import { reefSetupAdapter, reefSetupWizard } from "./setup.js";
-import { assertReefIdentityBinding, loadKeys, openStores } from "./state.js";
+import { assertReefIdentityBinding, loadKeys, openStores, ReefInboxCursorStore } from "./state.js";
 import {
   ReefInboxConnection,
   ReefTransportClient,
@@ -219,16 +219,18 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
       }
       const runtime = getReefRuntime();
       const keys = await loadKeys(runtime);
-      assertReefIdentityBinding(runtime, {
+      const identityBinding = {
         handle: ctx.account.config.handle!,
         relayUrl: parseReefRelayUrl(ctx.account.config.relayUrl),
-      });
+      };
+      assertReefIdentityBinding(runtime, identityBinding);
       const transport = new ReefTransportClient(
         ctx.account.config.relayUrl,
         ctx.account.config.handle!,
         keys,
       );
       const stores = openStores(runtime, keys);
+      const inboxCursor = new ReefInboxCursorStore(runtime, identityBinding);
       const reviews = stores.reviews;
       const pairing = createChannelPairingController({
         core: runtime,
@@ -419,20 +421,37 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               ctx.log?.error?.(`reef rejection notice processing failed: ${String(error)}`),
           }),
         createReefWebSocket,
-        (state) => {
-          if (ctx.abortSignal.aborted) {
-            return;
-          }
-          ctx.setStatus(
-            state === "connected"
-              ? {
-                  accountId: "default",
-                  running: true,
-                  connected: true,
-                  lastConnectedAt: Date.now(),
-                }
-              : { accountId: "default", running: true, connected: false },
-          );
+        {
+          initialCursor: inboxCursor.load(),
+          persistCursor: (cursor) => inboxCursor.advance(cursor),
+          onState: (state) => {
+            if (ctx.abortSignal.aborted) {
+              return;
+            }
+            ctx.setStatus(
+              state === "connected"
+                ? {
+                    accountId: "default",
+                    running: true,
+                    connected: true,
+                    lastConnectedAt: Date.now(),
+                    lastError: null,
+                  }
+                : { accountId: "default", running: true, connected: false },
+            );
+          },
+          onError: (error) => {
+            if (ctx.abortSignal.aborted) {
+              return;
+            }
+            ctx.log?.error?.(`reef inbox connection failed: ${error.message}`);
+            ctx.setStatus({
+              accountId: "default",
+              running: true,
+              connected: false,
+              lastError: error.message,
+            });
+          },
         },
       );
       const reconciliationLoop = async () => {

--- a/extensions/reef/src/state.test.ts
+++ b/extensions/reef/src/state.test.ts
@@ -29,6 +29,7 @@ import {
   openStores,
   finalizeReefIdentityBinding,
   REEF_DELIVERED_NAMESPACE,
+  ReefInboxCursorStore,
   REEF_REPLAY_TTL_MS,
   REEF_REVIEWS_NAMESPACE,
   releaseReefIdentityReservation,
@@ -71,6 +72,23 @@ describe("Reef SQLite state", () => {
     vi.useRealTimers();
     resetPluginStateStoreForTests();
     fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("persists a monotonic inbox cursor for the bound Reef identity", () => {
+    const binding = { handle: "molty", relayUrl: "https://reefwire.ai" };
+    const store = new ReefInboxCursorStore(createRuntime(stateDir), binding);
+
+    expect(store.load()).toBe(0);
+    store.advance(12);
+    store.advance(7);
+
+    expect(new ReefInboxCursorStore(createRuntime(stateDir), binding).load()).toBe(12);
+    expect(() =>
+      new ReefInboxCursorStore(createRuntime(stateDir), {
+        handle: "clawd",
+        relayUrl: "https://reefwire.ai",
+      }).load(),
+    ).toThrow("different identity");
   });
 
   it("does not let an expired audit writer replace a committed successor link", async () => {

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -45,9 +45,9 @@ export const REEF_REVIEWS_MAX_ENTRIES = 2_000;
 export const REEF_DELIVERED_NAMESPACE = "delivered";
 export const REEF_DELIVERED_MAX_ENTRIES = 5_000;
 export const REEF_DELIVERED_TTL_MS = REEF_REPLAY_TTL_MS;
-export const REEF_INBOX_CURSOR_NAMESPACE = "inbox-cursor";
-export const REEF_INBOX_CURSOR_KEY = "current";
-export const REEF_INBOX_CURSOR_MAX_ENTRIES = 1;
+const REEF_INBOX_CURSOR_NAMESPACE = "inbox-cursor";
+const REEF_INBOX_CURSOR_KEY = "current";
+const REEF_INBOX_CURSOR_MAX_ENTRIES = 1;
 
 export type ReefReplayRecord = {
   peer: string;

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -22,7 +22,7 @@ import {
   type SignedReceipt,
 } from "../protocol/index.js";
 import { openReefAuditStore } from "./audit-state.js";
-import { loadReefIdentityBinding } from "./registration-state.js";
+import { loadReefIdentityBinding, type ReefIdentityBinding } from "./registration-state.js";
 import type { ReefKeys } from "./types.js";
 
 export * from "./audit-state.js";
@@ -45,6 +45,9 @@ export const REEF_REVIEWS_MAX_ENTRIES = 2_000;
 export const REEF_DELIVERED_NAMESPACE = "delivered";
 export const REEF_DELIVERED_MAX_ENTRIES = 5_000;
 export const REEF_DELIVERED_TTL_MS = REEF_REPLAY_TTL_MS;
+export const REEF_INBOX_CURSOR_NAMESPACE = "inbox-cursor";
+export const REEF_INBOX_CURSOR_KEY = "current";
+export const REEF_INBOX_CURSOR_MAX_ENTRIES = 1;
 
 export type ReefReplayRecord = {
   peer: string;
@@ -502,6 +505,79 @@ export class ReefDeliveredStore {
     if (!this.#store.registerIfAbsent(id, { id }) && this.#store.lookup(id)?.id !== id) {
       throw new Error("Failed persisting Reef delivered marker");
     }
+  }
+}
+
+type ReefInboxCursorRecord = ReefIdentityBinding & { cursor: number };
+
+function parseReefInboxCursorRecord(value: unknown): ReefInboxCursorRecord | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Partial<ReefInboxCursorRecord>;
+  return typeof record.handle === "string" &&
+    record.handle.length > 0 &&
+    typeof record.relayUrl === "string" &&
+    record.relayUrl.length > 0 &&
+    Number.isSafeInteger(record.cursor) &&
+    (record.cursor ?? -1) >= 0
+    ? { handle: record.handle, relayUrl: record.relayUrl, cursor: record.cursor! }
+    : undefined;
+}
+
+/** Durable relay progress for the single Reef identity bound to this state DB. */
+export class ReefInboxCursorStore {
+  readonly #store: PluginStateSyncKeyedStore<ReefInboxCursorRecord>;
+
+  constructor(
+    runtime: PluginRuntime,
+    readonly binding: ReefIdentityBinding,
+  ) {
+    this.#store = runtime.state.openSyncKeyedStore<ReefInboxCursorRecord>({
+      namespace: REEF_INBOX_CURSOR_NAMESPACE,
+      maxEntries: REEF_INBOX_CURSOR_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+    });
+  }
+
+  load(): number {
+    const value = this.#store.lookup(REEF_INBOX_CURSOR_KEY);
+    if (value === undefined) {
+      return 0;
+    }
+    return this.#requireBoundRecord(value).cursor;
+  }
+
+  advance(cursor: number): void {
+    if (!Number.isSafeInteger(cursor) || cursor < 0) {
+      throw new Error("invalid Reef inbox cursor");
+    }
+    const update = this.#store.update;
+    if (!update) {
+      throw new Error("Reef inbox cursor requires atomic plugin-state updates");
+    }
+    update(REEF_INBOX_CURSOR_KEY, (current) => {
+      if (current === undefined) {
+        return { ...this.binding, cursor };
+      }
+      const existing = this.#requireBoundRecord(current);
+      return cursor > existing.cursor ? { ...existing, cursor } : existing;
+    });
+    const persisted = this.#store.lookup(REEF_INBOX_CURSOR_KEY);
+    if (!persisted || this.#requireBoundRecord(persisted).cursor < cursor) {
+      throw new Error("failed persisting Reef inbox cursor");
+    }
+  }
+
+  #requireBoundRecord(value: unknown): ReefInboxCursorRecord {
+    const record = parseReefInboxCursorRecord(value);
+    if (!record) {
+      throw new Error("invalid Reef inbox cursor state");
+    }
+    if (record.handle !== this.binding.handle || record.relayUrl !== this.binding.relayUrl) {
+      throw new Error("Reef inbox cursor belongs to a different identity");
+    }
+    return record;
   }
 }
 

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -2,7 +2,7 @@ import { createPublicKey, verify as verifySignature } from "node:crypto";
 import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import WebSocket, { WebSocketServer } from "ws";
 import { canonicalBytes, fromBase64url, sha256Hex } from "../protocol/index.js";
 import {
@@ -29,6 +29,10 @@ const keys: ReefKeys = {
   replayKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
   keyEpoch: 1,
 };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function verifyRelaySignature(
   signature: string,
@@ -643,6 +647,48 @@ describe("ReefInboxConnection recovery", () => {
 
     expect(states).toEqual(["connected", "disconnected"]);
     expect(errors).toEqual(["reef inbox socket closed unexpectedly code=1008 reason=policy"]);
+  });
+
+  it("resets reconnect backoff after a socket completes catch-up", async () => {
+    vi.useFakeTimers();
+    const sockets: ControlledSocket[] = [];
+    const persisted: number[] = [];
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [], cursor: 1 }),
+      () => ts,
+    );
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => {
+        const socket = new ControlledSocket();
+        sockets.push(socket);
+        return socket as unknown as WebSocketLike;
+      },
+      { persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    const running = inbox.start(abort.signal);
+    sockets[0]!.emit("close");
+    await vi.advanceTimersByTimeAsync(250);
+    expect(sockets).toHaveLength(2);
+
+    sockets[1]!.emit("open");
+    await vi.waitFor(() => expect(persisted).toEqual([1]));
+    await Promise.resolve();
+    sockets[1]!.emit("close");
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(sockets).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sockets).toHaveLength(3);
+
+    abort.abort();
+    await running;
   });
 
   it("waits for an in-flight handler before completing channel abort", async () => {

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -10,8 +10,9 @@ import {
   ReefRelayError,
   ReefTransportClient,
   createReefWebSocket,
+  type WebSocketLike,
 } from "./transport.js";
-import type { ReefKeys, RelayFriend } from "./types.js";
+import type { InboxEntry, ReefKeys, RelayFriend } from "./types.js";
 
 const ts = 1_752_300_000;
 const signing = {
@@ -330,6 +331,443 @@ describe("ReefTransportClient response body bounds", () => {
 
 const INBOX_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
 
+class ControlledSocket {
+  private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
+  private closed = false;
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.emit("close");
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function receiptEntry(seq: number): InboxEntry {
+  return {
+    seq,
+    peer: "bob",
+    id: `01ARZ3NDEKTSV4RRFFQ69G5F${String(seq).padStart(2, "0")}`,
+    kind: "receipt",
+    receipt: { id: `receipt-${seq}` } as never,
+    ts,
+  };
+}
+
+function parseRequestUrl(input: URL | RequestInfo): URL {
+  if (input instanceof URL) {
+    return input;
+  }
+  return new URL(typeof input === "string" ? input : input.url);
+}
+
+describe("ReefInboxConnection recovery", () => {
+  it("starts REST catch-up at the durable cursor and advances only processed entries", async () => {
+    const requestedAfter: number[] = [];
+    const persisted: number[] = [];
+    const processed: number[] = [];
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async (input) => {
+        const after = Number(parseRequestUrl(input).searchParams.get("after"));
+        requestedAfter.push(after);
+        return after === 7
+          ? Response.json({ entries: [receiptEntry(8)], cursor: 8 })
+          : Response.json({ entries: [], cursor: after });
+      },
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(
+      client,
+      async (entries) => {
+        processed.push(...entries.map((entry) => entry.seq));
+      },
+      () => {
+        throw new Error("socket should not open during direct drain");
+      },
+      { initialCursor: 7, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    await inbox.drain();
+
+    expect(requestedAfter).toEqual([7, 8]);
+    expect(processed).toEqual([8]);
+    expect(persisted).toEqual([8]);
+  });
+
+  it("does not advance past an entry that failed processing", async () => {
+    const persisted: number[] = [];
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [receiptEntry(8), receiptEntry(9)], cursor: 9 }),
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(
+      client,
+      async ([entry]) => {
+        if (entry?.seq === 9) {
+          throw new Error("entry failed");
+        }
+      },
+      () => {
+        throw new Error("socket should not open during direct drain");
+      },
+      { initialCursor: 7, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    await expect(inbox.drain()).rejects.toThrow("entry failed");
+    expect(persisted).toEqual([8]);
+  });
+
+  it("rejects an inconsistent REST page before dispatch or persistence", async () => {
+    const processed: number[] = [];
+    const persisted: number[] = [];
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [receiptEntry(9)], cursor: 8 }),
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(
+      client,
+      async (entries) => {
+        processed.push(...entries.map((entry) => entry.seq));
+      },
+      () => new ControlledSocket() as unknown as WebSocketLike,
+      { initialCursor: 7, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    await expect(inbox.drain()).rejects.toThrow(
+      "Reef relay inbox cursor does not match its entries",
+    );
+    expect(processed).toEqual([]);
+    expect(persisted).toEqual([]);
+  });
+
+  it("persists cursor-only progress when retained entries have expired", async () => {
+    const requestedAfter: number[] = [];
+    const persisted: number[] = [];
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async (input) => {
+        requestedAfter.push(Number(parseRequestUrl(input).searchParams.get("after")));
+        return Response.json({ entries: [], cursor: 12 });
+      },
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => new ControlledSocket() as unknown as WebSocketLike,
+      {
+        initialCursor: 7,
+        persistCursor: (cursor) => persisted.push(cursor),
+      },
+    );
+
+    await inbox.drain();
+
+    expect(requestedAfter).toEqual([7]);
+    expect(persisted).toEqual([12]);
+  });
+
+  it("reports connected before a slow REST catch-up completes", async () => {
+    const socket = new ControlledSocket();
+    const states: string[] = [];
+    let releasePull!: () => void;
+    const pullGate = new Promise<void>((resolve) => {
+      releasePull = resolve;
+    });
+    let pullStarted = false;
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => {
+        pullStarted = true;
+        await pullGate;
+        return Response.json({ entries: [], cursor: 0 });
+      },
+      () => ts,
+    );
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => socket as unknown as WebSocketLike,
+      { onState: (state) => states.push(state) },
+    );
+
+    const running = inbox.start(abort.signal);
+    socket.emit("open");
+    await vi.waitFor(() => expect(pullStarted).toBe(true));
+    expect(states).toEqual(["connected"]);
+
+    releasePull();
+    abort.abort();
+    await running;
+    expect(states).toEqual(["connected", "disconnected"]);
+  });
+
+  it("serializes socket frames behind catch-up and skips pull/socket duplicates", async () => {
+    const socket = new ControlledSocket();
+    const processed: number[] = [];
+    const persisted: number[] = [];
+    let releaseFirstPull!: () => void;
+    const firstPullGate = new Promise<void>((resolve) => {
+      releaseFirstPull = resolve;
+    });
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async (input) => {
+        const after = Number(parseRequestUrl(input).searchParams.get("after"));
+        if (after === 0) {
+          await firstPullGate;
+          return Response.json({ entries: [receiptEntry(1), receiptEntry(2)], cursor: 2 });
+        }
+        return Response.json({ entries: [], cursor: after });
+      },
+      () => ts,
+    );
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async (entries) => {
+        processed.push(...entries.map((entry) => entry.seq));
+      },
+      () => socket as unknown as WebSocketLike,
+      { persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    const running = inbox.start(abort.signal);
+    socket.emit("open");
+    socket.emit("message", { data: JSON.stringify({ type: "entry", entry: receiptEntry(2) }) });
+    socket.emit("message", { data: JSON.stringify({ type: "entry", entry: receiptEntry(3) }) });
+    releaseFirstPull();
+    await vi.waitFor(() => expect(processed).toEqual([1, 2, 3]));
+
+    expect(persisted).toEqual([1, 2, 3]);
+    abort.abort();
+    await running;
+  });
+
+  it("reports a socket close immediately while catch-up is still pending", async () => {
+    const socket = new ControlledSocket();
+    const states: string[] = [];
+    let releasePull!: () => void;
+    const pullGate = new Promise<void>((resolve) => {
+      releasePull = resolve;
+    });
+    let pullStarted = false;
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => {
+        pullStarted = true;
+        await pullGate;
+        return Response.json({ entries: [], cursor: 0 });
+      },
+      () => ts,
+    );
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => socket as unknown as WebSocketLike,
+      { onState: (state) => states.push(state) },
+    );
+
+    const running = inbox.start(abort.signal);
+    socket.emit("open");
+    await vi.waitFor(() => expect(pullStarted).toBe(true));
+    socket.emit("close");
+    await vi.waitFor(() => expect(states).toEqual(["connected", "disconnected"]));
+
+    abort.abort();
+    releasePull();
+    await running;
+  });
+
+  it("reports unexpected socket close details before retrying", async () => {
+    const socket = new ControlledSocket();
+    const states: string[] = [];
+    const errors: string[] = [];
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [], cursor: 0 }),
+      () => ts,
+    );
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => socket as unknown as WebSocketLike,
+      {
+        onState: (state) => states.push(state),
+        onError: (error) => {
+          errors.push(error.message);
+          abort.abort();
+        },
+      },
+    );
+
+    const running = inbox.start(abort.signal);
+    socket.emit("open");
+    socket.emit("close", { code: 1008, reason: "policy" });
+    await running;
+
+    expect(states).toEqual(["connected", "disconnected"]);
+    expect(errors).toEqual(["reef inbox socket closed unexpectedly code=1008 reason=policy"]);
+  });
+
+  it("waits for an in-flight handler before completing channel abort", async () => {
+    const socket = new ControlledSocket();
+    const persisted: number[] = [];
+    let releaseHandler!: () => void;
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    let handlerStarted = false;
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => Response.json({ entries: [receiptEntry(1)], cursor: 1 }),
+      () => ts,
+    );
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {
+        handlerStarted = true;
+        await handlerGate;
+      },
+      () => socket as unknown as WebSocketLike,
+      { persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    let finished = false;
+    const running = inbox.start(abort.signal).then(() => {
+      finished = true;
+    });
+    socket.emit("open");
+    await vi.waitFor(() => expect(handlerStarted).toBe(true));
+    abort.abort();
+    await Promise.resolve();
+    expect(finished).toBe(false);
+
+    releaseHandler();
+    await running;
+    expect(persisted).toEqual([1]);
+  });
+
+  it("bounds live frames during catch-up and reconnects through REST on overflow", async () => {
+    const socket = new ControlledSocket();
+    const errors: string[] = [];
+    let releasePull!: () => void;
+    const pullGate = new Promise<void>((resolve) => {
+      releasePull = resolve;
+    });
+    let pullStarted = false;
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => {
+        pullStarted = true;
+        await pullGate;
+        return Response.json({ entries: [], cursor: 0 });
+      },
+      () => ts,
+    );
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => socket as unknown as WebSocketLike,
+      {
+        onError: (error) => {
+          errors.push(error.message);
+          abort.abort();
+        },
+      },
+    );
+
+    const running = inbox.start(abort.signal);
+    socket.emit("open");
+    await vi.waitFor(() => expect(pullStarted).toBe(true));
+    for (let seq = 1; seq <= 257; seq += 1) {
+      socket.emit("message", {
+        data: JSON.stringify({ type: "entry", entry: receiptEntry(seq) }),
+      });
+    }
+    releasePull();
+    await running;
+
+    expect(errors).toEqual(["Reef inbox live buffer overflow; reconnecting for REST recovery"]);
+  });
+
+  it("surfaces catch-up failures to channel diagnostics", async () => {
+    const socket = new ControlledSocket();
+    const states: string[] = [];
+    const errors: string[] = [];
+    const abort = new AbortController();
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      async () => {
+        throw new Error("relay catch-up failed");
+      },
+      () => ts,
+    );
+    const inbox = new ReefInboxConnection(
+      client,
+      async () => {},
+      () => socket as unknown as WebSocketLike,
+      {
+        onState: (state) => states.push(state),
+        onError: (error) => {
+          errors.push(error.message);
+          abort.abort();
+        },
+      },
+    );
+
+    const running = inbox.start(abort.signal);
+    socket.emit("open");
+    await running;
+
+    expect(states).toEqual(["connected", "disconnected"]);
+    expect(errors).toEqual(["relay catch-up failed"]);
+  });
+});
+
 function inboxFrameAtSize(bytes: number): string {
   const prefix =
     '{"type":"entry","entry":{"seq":1,"peer":"bob","id":"01ARZ3NDEKTSV4RRFFQ69G5FAV","kind":"receipt","receipt":{"pad":"';
@@ -366,11 +804,13 @@ async function deliverInboxFrame(frame: string): Promise<{
       abort.abort();
     },
     createReefWebSocket,
-    (state) => {
-      states.push(state);
-      if (state === "disconnected") {
-        abort.abort();
-      }
+    {
+      onState: (state) => {
+        states.push(state);
+        if (state === "disconnected") {
+          abort.abort();
+        }
+      },
     },
   );
 

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -292,8 +292,11 @@ export class ReefInboxConnection {
       try {
         // Establish the live feed first. live() buffers frames behind the REST
         // catch-up, so a slow backlog cannot make a healthy socket look offline.
-        await this.live(signal);
-        delay = 250;
+        await this.live(signal, () => {
+          // A socket that completed catch-up is healthy. Future disconnects
+          // start from the short delay instead of inheriting old failures.
+          delay = 250;
+        });
       } catch (error) {
         this.options.onError?.(asError(error));
         await abortableSleep(delay, signal);
@@ -375,7 +378,7 @@ export class ReefInboxConnection {
     return scheduled;
   }
 
-  private live(signal?: AbortSignal): Promise<void> {
+  private live(signal?: AbortSignal, onReady?: () => void): Promise<void> {
     return new Promise((resolve, reject) => {
       const socket = this.webSocketFactory(this.client.websocketUrl());
       const workAbort = new AbortController();
@@ -456,6 +459,7 @@ export class ReefInboxConnection {
           if (catchUpPending) {
             catchUpPending = false;
             await this.drain(workAbort.signal);
+            onReady?.();
           }
           while (bufferedEntries.length > 0) {
             if (disconnected) {

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -227,7 +227,7 @@ export interface WebSocketLike {
   close(): void;
 }
 
-export interface ReefInboxConnectionOptions {
+interface ReefInboxConnectionOptions {
   initialCursor?: number;
   persistCursor?: (cursor: number) => void;
   onState?: (state: "connected" | "disconnected") => void;

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -300,7 +300,6 @@ export class ReefInboxConnection {
       } catch (error) {
         this.options.onError?.(asError(error));
         await abortableSleep(delay, signal);
-        // oxlint-disable-next-line no-useless-assignment -- Read by the next iteration's backoff sleep.
         delay = Math.min(delay * 2, 30_000);
       }
     }

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -14,6 +14,10 @@ const REEF_RELAY_ERROR_JSON_MAX_BYTES = 64 * 1024;
 // Relay envelopes are capped at 48 KiB. Leave room for inbox metadata while
 // rejecting oversized or compressed frames before ws materializes the message.
 const REEF_RELAY_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
+// A reconnect recovers dropped frames from REST, so keep only a bounded live
+// window while catch-up or entry dispatch is busy. At the payload cap this
+// limits retained frame data to roughly 16 MiB per connection.
+const REEF_INBOX_LIVE_BUFFER_MAX_ENTRIES = 256;
 // Stalled TCP peers that never complete the HTTP upgrade would otherwise hang
 // forever — ws defaults to no handshakeTimeout. Match sibling channel WS budgets.
 const REEF_WS_HANDSHAKE_MS = 30_000;
@@ -114,8 +118,8 @@ export class ReefTransportClient {
   acknowledge(peer: string, id: string, receipt: SignedReceipt): Promise<{ result: string }> {
     return this.signed("POST", `/v1/mail/${encodeURIComponent(peer)}/ack`, { id, receipt });
   }
-  pull(after: number): Promise<{ entries: InboxEntry[]; cursor: number }> {
-    return this.signed("GET", `/v1/mail?after=${after}`);
+  pull(after: number, signal?: AbortSignal): Promise<{ entries: InboxEntry[]; cursor: number }> {
+    return this.signed("GET", `/v1/mail?after=${after}`, undefined, signal);
   }
 
   websocketUrl(): string {
@@ -129,14 +133,20 @@ export class ReefTransportClient {
     return url.toString();
   }
 
-  async signed<T>(method: string, path: string, body?: unknown): Promise<T> {
+  async signed<T>(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
     const bytes = body === undefined ? new Uint8Array() : utf8(JSON.stringify(body));
     const auth = this.auth(path, bytes, method);
-    return await this.request(method, path, bytes, {
-      "x-reef-handle": this.handle,
-      "x-reef-ts": String(auth.ts),
-      "x-reef-sig": auth.signature,
-    });
+    return await this.request(
+      method,
+      path,
+      bytes,
+      {
+        "x-reef-handle": this.handle,
+        "x-reef-ts": String(auth.ts),
+        "x-reef-sig": auth.signature,
+      },
+      signal,
+    );
   }
 
   private auth(path: string, bytes: Uint8Array, method: string): { ts: number; signature: string } {
@@ -169,11 +179,13 @@ export class ReefTransportClient {
     path: string,
     bytes: Uint8Array,
     headers: Record<string, string>,
+    signal?: AbortSignal,
   ): Promise<T> {
     const response = await this.fetcher(new URL(path, this.relayUrl), {
       method,
       headers: { ...headers, ...(bytes.length ? { "content-type": "application/json" } : {}) },
       ...(bytes.length ? { body: bytes as BodyInit } : {}),
+      ...(signal ? { signal } : {}),
     });
     if (!response.ok) {
       let message = `relay HTTP ${response.status}`;
@@ -203,8 +215,23 @@ export class ReefTransportClient {
 
 export interface WebSocketLike {
   addEventListener(type: "message", listener: (event: { data: unknown }) => void): void;
-  addEventListener(type: "open" | "close" | "error", listener: () => void): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(
+    type: "close",
+    listener: (event: { code?: number; reason?: string }) => void,
+  ): void;
+  addEventListener(
+    type: "error",
+    listener: (event: { error?: unknown; message?: string }) => void,
+  ): void;
   close(): void;
+}
+
+export interface ReefInboxConnectionOptions {
+  initialCursor?: number;
+  persistCursor?: (cursor: number) => void;
+  onState?: (state: "connected" | "disconnected") => void;
+  onError?: (error: Error) => void;
 }
 
 export function createReefWebSocket(
@@ -234,26 +261,41 @@ export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> 
 }
 
 export class ReefInboxConnection {
-  private cursor = 0;
+  private cursor: number;
+  // Entry dispatch remains serial across socket replacements. A closed socket
+  // can be replaced immediately while its in-flight pull finishes, without a
+  // second connection concurrently delivering the same durable cursor range.
+  private processing = Promise.resolve();
   private stopped = false;
   constructor(
     readonly client: ReefTransportClient,
     readonly onEntries: (entries: InboxEntry[]) => Promise<void>,
     readonly webSocketFactory: (url: string) => WebSocketLike,
-    readonly onState?: (state: "connected" | "disconnected") => void,
-  ) {}
+    readonly options: ReefInboxConnectionOptions = {},
+  ) {
+    const initialCursor = options.initialCursor ?? 0;
+    if (!Number.isSafeInteger(initialCursor) || initialCursor < 0) {
+      throw new Error("invalid Reef inbox cursor");
+    }
+    this.cursor = initialCursor;
+  }
 
   async start(signal?: AbortSignal): Promise<void> {
     let delay = 250;
     for (;;) {
       if (this.stopped || signal?.aborted) {
+        // An error callback may abort after live() already detached its listener.
+        // Do not return control until every older socket's serial work is quiescent.
+        await this.processing;
         return;
       }
       try {
-        await this.drain();
+        // Establish the live feed first. live() buffers frames behind the REST
+        // catch-up, so a slow backlog cannot make a healthy socket look offline.
         await this.live(signal);
         delay = 250;
-      } catch {
+      } catch (error) {
+        this.options.onError?.(asError(error));
         await abortableSleep(delay, signal);
         // oxlint-disable-next-line no-useless-assignment -- Read by the next iteration's backoff sleep.
         delay = Math.min(delay * 2, 30_000);
@@ -265,51 +307,189 @@ export class ReefInboxConnection {
     this.stopped = true;
   }
 
-  async drain(): Promise<void> {
+  async drain(signal?: AbortSignal): Promise<void> {
     while (true) {
-      const page = await this.client.pull(this.cursor);
-      if (page.entries.length) {
-        await this.onEntries(page.entries);
+      signal?.throwIfAborted();
+      const page = await this.client.pull(this.cursor, signal);
+      signal?.throwIfAborted();
+      if (!Number.isSafeInteger(page.cursor) || page.cursor < this.cursor) {
+        throw new Error("invalid Reef relay inbox cursor");
       }
       const previous = this.cursor;
-      this.cursor = page.cursor;
+      await this.processEntries(page.entries, page.cursor, signal);
       if (!page.entries.length || this.cursor === previous) {
         return;
       }
     }
   }
 
+  private async processEntries(
+    entries: readonly InboxEntry[],
+    cursor?: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    let highestSequence = 0;
+    for (const entry of entries) {
+      if (!Number.isSafeInteger(entry.seq) || entry.seq < 1) {
+        throw new Error("invalid Reef relay inbox sequence");
+      }
+      highestSequence = Math.max(highestSequence, entry.seq);
+    }
+    // Validate the complete REST page before dispatch. Delivery and cursor
+    // persistence are irreversible, so a contradictory page must have no side effects.
+    if (cursor !== undefined && entries.length > 0 && cursor !== highestSequence) {
+      throw new Error("Reef relay inbox cursor does not match its entries");
+    }
+    const fresh = entries.toSorted((left, right) => left.seq - right.seq);
+    if (fresh.length === 0) {
+      if (cursor !== undefined) {
+        this.advanceCursor(cursor);
+      }
+      return;
+    }
+    for (const entry of fresh) {
+      if (entry.seq <= this.cursor) {
+        continue;
+      }
+      signal?.throwIfAborted();
+      await this.onEntries([entry]);
+      // A completed handler has consumed the entry even if shutdown arrived
+      // while it ran. Persist it before the next abort check to avoid replay.
+      this.advanceCursor(entry.seq);
+    }
+  }
+
+  private advanceCursor(cursor: number): void {
+    if (cursor <= this.cursor) {
+      return;
+    }
+    this.options.persistCursor?.(cursor);
+    this.cursor = cursor;
+  }
+
+  private serialize(task: () => Promise<void>): Promise<void> {
+    const scheduled = this.processing.then(task);
+    // Keep the shared serial tail usable after a socket-local failure. The
+    // caller still observes scheduled's rejection and tears down that socket.
+    this.processing = scheduled.catch(() => {});
+    return scheduled;
+  }
+
   private live(signal?: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
       const socket = this.webSocketFactory(this.client.websocketUrl());
+      const workAbort = new AbortController();
       // Emit each state transition at most once per socket and never after this
       // invocation settles, so late events from an abandoned socket cannot
       // overwrite the lifecycle state of its replacement (or of a stopped channel).
-      let settled = false;
-      const settle = (error?: Error) => {
-        if (settled) {
+      let finished = false;
+      let disconnected = false;
+      let aborting = false;
+      let opened = false;
+      let catchUpPending = false;
+      let pumpScheduled = false;
+      const bufferedEntries: InboxEntry[] = [];
+      const abortListener = () => {
+        if (finished) {
           return;
         }
-        settled = true;
-        this.onState?.("disconnected");
+        aborting = true;
+        markDisconnected();
+        socket.close();
+        // Older socket work can still own the shared serial tail. Waiting here
+        // prevents a replacement channel from dispatching the same cursor range.
+        void this.processing.then(
+          () => finish(),
+          () => finish(),
+        );
+      };
+      const finish = (error?: Error) => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        signal?.removeEventListener("abort", abortListener);
         if (error) {
           reject(error);
         } else {
           resolve();
         }
       };
-      signal?.addEventListener(
-        "abort",
-        () => {
-          socket.close();
-          settle();
-        },
-        { once: true },
-      );
-      socket.addEventListener("open", () => {
-        if (!settled) {
-          this.onState?.("connected");
+      const markDisconnected = () => {
+        if (disconnected) {
+          return;
         }
+        disconnected = true;
+        bufferedEntries.length = 0;
+        workAbort.abort();
+        this.options.onState?.("disconnected");
+      };
+      const disconnect = (error?: Error) => {
+        if (finished) {
+          return;
+        }
+        markDisconnected();
+        // An abort waits for the class-wide serial tail. A close event emitted
+        // synchronously by socket.close() must not finish this invocation early.
+        if (aborting) {
+          return;
+        }
+        finish(error);
+        if (error) {
+          socket.close();
+        }
+      };
+      const pump = () => {
+        if (
+          disconnected ||
+          !opened ||
+          pumpScheduled ||
+          (!catchUpPending && bufferedEntries.length === 0)
+        ) {
+          return;
+        }
+        pumpScheduled = true;
+        const scheduled = this.serialize(async () => {
+          if (disconnected) {
+            return;
+          }
+          if (catchUpPending) {
+            catchUpPending = false;
+            await this.drain(workAbort.signal);
+          }
+          while (bufferedEntries.length > 0) {
+            if (disconnected) {
+              return;
+            }
+            const entry = bufferedEntries.shift();
+            if (!entry) {
+              return;
+            }
+            await this.processEntries([entry], undefined, workAbort.signal);
+          }
+        });
+        void scheduled.then(
+          () => {
+            pumpScheduled = false;
+            pump();
+          },
+          (error: unknown) => {
+            pumpScheduled = false;
+            if (!disconnected) {
+              disconnect(asError(error));
+            }
+          },
+        );
+      };
+      signal?.addEventListener("abort", abortListener, { once: true });
+      socket.addEventListener("open", () => {
+        if (disconnected) {
+          return;
+        }
+        opened = true;
+        catchUpPending = true;
+        this.options.onState?.("connected");
+        pump();
       });
       socket.addEventListener("message", (event) => {
         try {
@@ -317,16 +497,42 @@ export class ReefInboxConnection {
           if (frame.type !== "entry" || !frame.entry) {
             return;
           }
-          this.cursor = Math.max(this.cursor, frame.entry.seq);
-          void this.onEntries([frame.entry]).catch((error: unknown) =>
-            settle(error instanceof Error ? error : new Error(String(error))),
-          );
+          if (bufferedEntries.length >= REEF_INBOX_LIVE_BUFFER_MAX_ENTRIES) {
+            disconnect(
+              new Error("Reef inbox live buffer overflow; reconnecting for REST recovery"),
+            );
+            return;
+          }
+          bufferedEntries.push(frame.entry);
+          pump();
         } catch (error) {
-          settle(error instanceof Error ? error : new Error(String(error)));
+          disconnect(asError(error));
         }
       });
-      socket.addEventListener("close", () => settle());
-      socket.addEventListener("error", () => settle(new Error("reef inbox socket error")));
+      // Socket state is independent of a slow REST pull or entry handler. Mark
+      // it disconnected now; the shared serial tail preserves ordered recovery.
+      socket.addEventListener("close", (event) => {
+        if (aborting || finished) {
+          return;
+        }
+        disconnect(reefInboxCloseError(event));
+      });
+      socket.addEventListener("error", (event) =>
+        disconnect(new Error(event.message?.trim() || "reef inbox socket error")),
+      );
+      if (signal?.aborted) {
+        abortListener();
+      }
     });
   }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function reefInboxCloseError(event: { code?: number; reason?: string }): Error {
+  const code = Number.isInteger(event.code) ? ` code=${event.code}` : "";
+  const reason = event.reason?.trim() ? ` reason=${event.reason.trim()}` : "";
+  return new Error(`reef inbox socket closed unexpectedly${code}${reason}`);
 }


### PR DESCRIPTION
Fixes #110070

## What Problem This Solves

Fixes an issue where Reef users could remain disconnected after a gateway restart while the inbox replayed the retained relay backlog before establishing its live socket. Restarting always began recovery at cursor zero, failures were hidden, and outbound conversations could reach the wrong recovery state or never resume.

## Why This Change Was Made

The Reef plugin now opens the live socket first, serializes a bounded live-frame buffer behind REST catch-up, and persists an identity-bound inbox cursor in the existing plugin-state store only after successful entry handling. It validates relay pages before irreversible delivery, cancels or drains in-flight work during shutdown, and reports catch-up, overflow, and unexpected-close failures through channel status. This does not add or change any SQLite schema or schema version.

## User Impact

Reef channels recover once from their durable cursor, stay visibly connected during catch-up, avoid unbounded buffering and duplicate delivery across reconnects, and expose actionable errors instead of silently remaining offline.

## Evidence

- Testbox `tbx_01kxredhcsc13bh1f3cryxkw5d`: `pnpm test extensions/reef/src/transport.test.ts extensions/reef/src/state.test.ts extensions/reef/src/channel.test.ts` — 45/45 passed.
- Same Testbox: `pnpm check:changed` — formatting, production/test tsgo, lint, plugin boundaries, DB-first guard, sidecar guard, and import-cycle checks passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Live diagnosis before the fix: both authenticated Reef sockets could open, while restart catch-up replayed retained inbox entries from cursor zero and left channel status disconnected without a surfaced error.
- Transcript attachment omitted because the supporting live-host diagnostics contain private operational context; the public reproduction and design are captured in #110070.
