### PR TITLE
fix: reload config after watcher recovery

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -464,7 +464,7 @@ describe("buildGatewayReloadPlan", () => {
 });
 
 type WatcherHandler = () => void;
-type WatcherEvent = "add" | "change" | "unlink" | "error";
+type WatcherEvent = "add" | "change" | "unlink" | "ready" | "error";
 
 function createWatcherMock(effectiveUsePolling?: boolean) {
   const handlers = new Map<WatcherEvent, WatcherHandler[]>();
@@ -734,6 +734,32 @@ describe("startGatewayConfigReloader", () => {
     resetGatewayWorkAdmission();
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("reconciles the config after recreating a failed watcher", async () => {
+    const initialConfig = {
+      gateway: { reload: { debounceMs: 0 }, port: 18_789 },
+    } satisfies OpenClawConfig;
+    const updatedConfig = {
+      gateway: { reload: { debounceMs: 0 }, port: 19_001 },
+    } satisfies OpenClawConfig;
+    const readSnapshot = vi.fn(async () => makeSnapshot({ config: updatedConfig }));
+    const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    const replacementWatcher = createWatcherMock();
+    vi.mocked(chokidar.watch).mockReturnValueOnce(replacementWatcher as unknown as never);
+
+    harness.watcher.emit("error");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(readSnapshot).not.toHaveBeenCalled();
+
+    replacementWatcher.emit("ready");
+    await vi.runAllTimersAsync();
+
+    expect(readSnapshot).toHaveBeenCalledOnce();
+    const [, nextConfig] = getOnlyRestartCall(harness);
+    expect(nextConfig).toEqual(updatedConfig);
+    await harness.reloader.stop();
   });
 
   it.each([

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -903,7 +903,7 @@ export function startGatewayConfigReloader(opts: {
   let degradedToPolling = false;
   let watcherUsesPolling = false;
 
-  const createWatcher = () => {
+  const createWatcher = (createOpts?: { reconcileAfterReady?: boolean }) => {
     if (stopped) {
       return;
     }
@@ -916,6 +916,9 @@ export function startGatewayConfigReloader(opts: {
     next.on("add", scheduleExternalRefresh);
     next.on("change", scheduleExternalRefresh);
     next.on("unlink", scheduleExternalRefresh);
+    if (createOpts?.reconcileAfterReady) {
+      next.on("ready", scheduleExternalRefresh);
+    }
     next.on("error", (err) => {
       handleWatcherError(next, err);
     });
@@ -945,7 +948,7 @@ export function startGatewayConfigReloader(opts: {
         );
         watcherRecreateTimer = setTimeout(() => {
           watcherRecreateTimer = null;
-          createWatcher();
+          createWatcher({ reconcileAfterReady: true });
         }, WATCHER_RECREATE_BACKOFF_MS[0] ?? 500);
         return;
       }
@@ -966,7 +969,7 @@ export function startGatewayConfigReloader(opts: {
     );
     watcherRecreateTimer = setTimeout(() => {
       watcherRecreateTimer = null;
-      createWatcher();
+      createWatcher({ reconcileAfterReady: true });
     }, backoff);
   };
 


### PR DESCRIPTION
Closes #103729

## What Problem This Solves

Fixes an issue where users could make an external `openclaw.json` edit while the gateway config watcher was recovering from an error and the running gateway would keep using the stale pre-edit config indefinitely.

AI-assisted PR: yes. I used Hermes/Codex assistance and verified the change locally.

## Why This Change Was Made

Replacement watchers still use `ignoreInitial: true`, but recovery-created watchers now schedule the existing config reload path once after chokidar reports `ready`. This preserves startup behavior while reconciling edits that landed during the watcher-down recovery window.

## User Impact

Gateway config hot reload is more reliable after transient watcher failures such as native watch resource exhaustion. Users no longer need to make a second unrelated config edit to force the gateway to notice the missed change.

## Evidence

- `pnpm test src/gateway/config-reload.test.ts` — passed, 134 tests.
- `git diff --check` — passed.
- `pnpm check:changed -- src/gateway/config-reload.ts src/gateway/config-reload.test.ts` could not complete in this local environment because the repo's check wrapper delegated to crabbox and the crabbox binary failed its basic sanity check. Retried the local child mode, but this environment does not have `corepack`, so that lane stopped before running its checks. The focused gateway test above was run successfully.
