### PR TITLE
fix(line): await deferred ingress release on stop

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-16f7664192e83f3e689685ecc917fa0578db5686646d3e7277ba866f07e1002d  plugin-sdk-api-baseline.json
-f8c7d2a77b258f347bd6b741461990c57c4f70d85d91d05b2526829e2980df60  plugin-sdk-api-baseline.jsonl
+f08ff5ef3bead5b08631b72d347884808c262aab7d33c8ae085407ba55e44402  plugin-sdk-api-baseline.json
+d62e193e943766c515978531ef88463eba94094bd77eecef397cef391d841a67  plugin-sdk-api-baseline.jsonl

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -13,7 +13,11 @@ import {
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLineNodeWebhookHandler } from "./webhook-node.js";
-import { createLineWebhookSpool, LineWebhookTerminalDeliveryError } from "./webhook-spool.js";
+import {
+  createLineWebhookSpool,
+  LineWebhookTerminalDeliveryError,
+  type LineWebhookTurnAdoptionLifecycle,
+} from "./webhook-spool.js";
 
 type SpoolPayload = {
   version: number;
@@ -271,6 +275,46 @@ describe("LINE webhook spool", () => {
       } finally {
         await restarted.stop();
       }
+    });
+  });
+
+  it("waits for deferred claim settlement before disposing on stop", async () => {
+    await withQueue(async (queue) => {
+      let deferredLifecycle: LineWebhookTurnAdoptionLifecycle | undefined;
+      const deliver = vi.fn(async (_event, _destination, control) => {
+        deferredLifecycle = control.turnAdoptionLifecycle;
+        control.turnAdoptionLifecycle.onDeferred();
+      });
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+      });
+      const event = createEvent({ webhookEventId: "event-stop-deferred" });
+
+      spool.start();
+      await spool.accept(callback(event));
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+
+      let stopSettled = false;
+      const stopping = spool.stop().then(() => {
+        stopSettled = true;
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(stopSettled).toBe(false);
+      expect(await queue.listClaims()).toHaveLength(1);
+
+      if (!deferredLifecycle) {
+        throw new Error("LINE delivery did not expose its deferred lifecycle");
+      }
+      await deferredLifecycle.onAbandoned();
+      await stopping;
+      expect(stopSettled).toBe(true);
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listPending()).toHaveLength(1);
     });
   });
 

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -156,6 +156,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
   const shutdown = new AbortController();
   // Match the predecessor worker's per-spool cap across repeated drain pumps.
   const activeDeliveries = new Set<Promise<void>>();
+  const deferredClaims = new Map<string, Promise<void>>();
   const drain = createChannelIngressDrain<LineWebhookSpoolPayload>({
     queue,
     abortSignal: shutdown.signal,
@@ -184,8 +185,47 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
     onLog: (message) => options.runtime.error?.(danger(`line: ${message}`)),
     dispatchClaimedEvent: async (claimed, lifecycle) => {
       const event = parseClaimedEvent(claimed.payload, claimed.id);
+      const boundLifecycle = bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle;
+      let resolveDeferredClaim!: () => void;
+      const deferredClaim = new Promise<void>((resolve) => {
+        resolveDeferredClaim = resolve;
+      });
+      let deferredClaimSettled = false;
+      const settleDeferredClaim = () => {
+        if (deferredClaimSettled) {
+          return;
+        }
+        deferredClaimSettled = true;
+        // Delete only this dispatch's entry; a later retry may reuse the claim id.
+        if (deferredClaims.get(claimed.id) === deferredClaim) {
+          deferredClaims.delete(claimed.id);
+        }
+        resolveDeferredClaim();
+      };
       const delivery = options.deliver(event, claimed.payload.destination, {
-        turnAdoptionLifecycle: bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle,
+        turnAdoptionLifecycle: {
+          ...boundLifecycle,
+          onAdopted: async () => {
+            try {
+              await boundLifecycle.onAdopted();
+            } finally {
+              settleDeferredClaim();
+            }
+          },
+          onDeferred: () => {
+            if (!deferredClaimSettled) {
+              deferredClaims.set(claimed.id, deferredClaim);
+            }
+            boundLifecycle.onDeferred();
+          },
+          onAbandoned: async () => {
+            try {
+              await boundLifecycle.onAbandoned();
+            } finally {
+              settleDeferredClaim();
+            }
+          },
+        },
       });
       activeDeliveries.add(delivery);
       try {
@@ -285,6 +325,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       // Keep the claim owner live until every real delivery and core handler exits;
       // disposing earlier lets a replacement drain recover work still producing replies.
       await Promise.allSettled(activeDeliveries);
+      await Promise.allSettled(deferredClaims.values());
       await drain.waitForIdle();
       drain.dispose();
     },

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -278,7 +278,8 @@ export function createSlackMessageHandler(params: {
                   },
                   onAbandoned: () => {
                     releaseClaims();
-                    turnAdoptionLifecycle.onAbandoned();
+                    // Slack has no owner-local teardown gated on core claim release.
+                    void turnAdoptionLifecycle.onAbandoned();
                   },
                 }
               : turnAdoptionLifecycle;

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -431,7 +431,9 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               if (!adopted) {
                 void settle({ kind: "skipped" }, "terminal");
               }
-              drainLifecycle?.onAbandoned();
+              // Generic reply abandonment is synchronous; Telegram has no
+              // owner-local resource teardown gated on core claim release.
+              void drainLifecycle?.onAbandoned();
             },
           },
         });

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -16,7 +16,7 @@ type TelegramSpooledReplayLifecycle = {
   onDeferred: () => void;
   /** Clears pre-adoption stall while durable adoption finalization is held. */
   onAdoptionFinalizing?: () => void;
-  onAbandoned: () => void;
+  onAbandoned: () => void | Promise<void>;
 };
 
 type TelegramSpooledReplayFrame = {

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -53,7 +53,7 @@ export type TelegramIngressDrainLifecycle = {
   onAdopted: () => void | Promise<void>;
   onDeferred: () => void;
   onAdoptionFinalizing: () => void;
-  onAbandoned: () => void;
+  onAbandoned: () => void | Promise<void>;
 };
 
 type TelegramIngressDrainDispatch = (

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -146,13 +146,61 @@ describe("channel ingress drain", () => {
       expect(await queue.listPending()).toEqual([]);
 
       // Abandon releases for retry (attempts increment).
-      expectDefined(capturedLifecycles[0], "deferred lifecycle").onAbandoned();
+      await expectDefined(capturedLifecycles[0], "deferred lifecycle").onAbandoned();
       await drain.waitForIdle();
       await vi.waitFor(async () => {
         const pending = await queue.listPending();
         expect(pending).toHaveLength(1);
         expect(pending[0]?.attempts).toBeGreaterThanOrEqual(1);
       });
+      drain.dispose();
+    });
+  });
+
+  it("lets callers await an abandoned claim release", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<Payload>({
+        channelId: "test",
+        accountId: "a",
+        stateDir,
+      });
+      await queue.enqueue("evt-await-abandon", { text: "x" }, { laneKey: "l1" });
+
+      let finishRelease!: () => void;
+      const releaseGate = new Promise<void>((resolve) => {
+        finishRelease = resolve;
+      });
+      const release = vi.fn(async (...args: Parameters<typeof queue.release>) => {
+        await releaseGate;
+        return await queue.release(...args);
+      });
+      const capturedLifecycles: ChannelIngressDispatchLifecycle[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue: { ...queue, release },
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          capturedLifecycles.push(lifecycle);
+          return { kind: "deferred" };
+        },
+      });
+
+      await drain.drainOnce();
+      await vi.waitFor(() => expect(capturedLifecycles).toHaveLength(1));
+
+      let abandoned = false;
+      const abandonment = Promise.resolve(
+        expectDefined(capturedLifecycles[0], "deferred lifecycle").onAbandoned(),
+      ).then(() => {
+        abandoned = true;
+      });
+      await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+      expect(abandoned).toBe(false);
+      expect(await queue.listClaims()).toHaveLength(1);
+
+      finishRelease();
+      await abandonment;
+      expect(abandoned).toBe(true);
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listPending()).toHaveLength(1);
       drain.dispose();
     });
   });
@@ -172,7 +220,7 @@ describe("channel ingress drain", () => {
           const bound = bindIngressLifecycleToReplyOptions(lifecycle);
           bound.turnAdoptionLifecycle.onDeferred();
           // Never admitted — abandon path releases claim.
-          bound.turnAdoptionLifecycle.onAbandoned();
+          await bound.turnAdoptionLifecycle.onAbandoned();
           return { kind: "deferred" };
         },
       });
@@ -512,7 +560,7 @@ describe("channel ingress drain", () => {
     });
   });
 
-  it("bindIngressLifecycleToReplyOptions returns only turnAdoptionLifecycle", () => {
+  it("bindIngressLifecycleToReplyOptions returns only turnAdoptionLifecycle", async () => {
     const abort = new AbortController();
     const calls: string[] = [];
     const bound = bindIngressLifecycleToReplyOptions({
@@ -535,11 +583,11 @@ describe("channel ingress drain", () => {
     expect("onAdopted" in bound).toBe(false);
     expect(Object.keys(bound)).toEqual(["turnAdoptionLifecycle"]);
     bound.turnAdoptionLifecycle.onDeferred();
-    bound.turnAdoptionLifecycle.onAbandoned();
+    await bound.turnAdoptionLifecycle.onAbandoned();
     expect(calls).toEqual(["deferred", "abandoned"]);
     calls.length = 0;
     bound.turnAdoptionLifecycle.onDeferred();
-    void bound.turnAdoptionLifecycle.onAdopted();
+    await bound.turnAdoptionLifecycle.onAdopted();
     expect(calls).toEqual(["deferred", "adopted"]);
   });
 

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -79,7 +79,7 @@ type ChannelIngressDispatchLifecycle = {
    * Deferred turn finished without ever owning the reply lane.
    * Drain releases the claim for retry.
    */
-  onAbandoned: () => void;
+  onAbandoned: () => void | Promise<void>;
 };
 
 type ChannelIngressDrainDispatchResult =
@@ -170,7 +170,7 @@ export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDisp
     admission: "exclusive";
     onAdopted: () => void | Promise<void>;
     onDeferred: () => void;
-    onAbandoned: () => void;
+    onAbandoned: () => void | Promise<void>;
     abortSignal: AbortSignal;
   };
 } {
@@ -517,7 +517,7 @@ export function createChannelIngressDrain<
         // stall watchdog race and dead-letter an about-to-complete event.
         clearStallTimer(state);
       },
-      onAbandoned: () => {
+      onAbandoned: async () => {
         if (state.phase !== "deferred" && state.phase !== "dispatching") {
           return;
         }
@@ -525,7 +525,7 @@ export function createChannelIngressDrain<
           return;
         }
         clearStallTimer(state);
-        void state
+        await state
           .settleOnce(async () => {
             await releaseClaim(state.claim, "turn-abandoned");
           })


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping and replacing the LINE webhook spool could recover a still-deferred ingress claim before its asynchronous abandonment release finished, allowing the same durable event to be dispatched again during the shutdown race.

## Why This Change Was Made

The core ingress lifecycle now returns its existing abandonment settlement promise through `onAbandoned`, which is additive for callers that continue to ignore the return value. LINE tracks only claims that actually defer to the reply lane and waits for adoption or abandonment settlement before disposing the drain owner. Slack and Telegram keep their current fire-and-forget owner contracts explicitly; Telegram preserves the promise across its internal drain seam but does not add owner-local shutdown waiting.

Broadening the generic `TurnAdoptionLifecycle` was intentionally avoided: its completion API is synchronous. LINE's per-spool `deferredClaims` tracking is the bounded owner-side bridge that makes stop await the release without changing every reply-queue caller.

AI-assisted: Codex. I reviewed the owner boundary, lifecycle callers, sibling channel drains, and the generated Plugin SDK surface update.

## User Impact

LINE restarts and shutdowns now preserve single-owner durable webhook handling while queued followups are abandoned. Normal dispatch and adoption behavior is unchanged; shutdown may wait for the deferred claim settlement it previously raced.

## Evidence

- Focused core ingress-drain, LINE spool, and Telegram drain tests: 39 passed across three Vitest shards.
- Targeted `oxfmt` and type-aware `oxlint` across the original core/LINE files and all sibling-boundary files: passed.
- Plugin SDK API baseline regenerated and `generate-plugin-sdk-api-baseline.ts --check`: passed.
- `pnpm check:changed`: API baseline, plugin boundaries, package guards, and core/core-test/extension/extension-test tsgo lanes passed.
- Fresh full-chain `$autoreview --mode uncommitted`: clean; no accepted/actionable findings.
