### PR TITLE
fix(slack): stabilize tool-result reaction tests

### DIFF
--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -21,6 +21,38 @@ type SlackProviderMonitor = (params: {
 }) => Promise<unknown>;
 type SlackStartupAuthClientFactory = typeof import("./client.js").createSlackStartupAuthClient;
 
+const SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY = "openclawIngressLifecycle";
+
+type SlackRunOnceOptions = {
+  botToken?: string;
+  appToken?: string;
+  awaitDispatch?: boolean;
+};
+
+function withSlackDispatchLifecycle(args: unknown): Record<string, unknown> {
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    throw new Error("Slack event arguments must be an object");
+  }
+  const eventArgs = args as Record<string, unknown>;
+  const existingContext =
+    eventArgs.context && typeof eventArgs.context === "object" && !Array.isArray(eventArgs.context)
+      ? (eventArgs.context as Record<string, unknown>)
+      : {};
+  return {
+    ...eventArgs,
+    context: {
+      ...existingContext,
+      [SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY]: {
+        admission: "exclusive",
+        abortSignal: new AbortController().signal,
+        onAdopted: vi.fn(),
+        onDeferred: vi.fn(),
+        onAbandoned: vi.fn(),
+      },
+    },
+  };
+}
+
 type SlackTestState = {
   config: Record<string, unknown>;
   appStartMock: Mock<(...args: unknown[]) => Promise<unknown>>;
@@ -201,18 +233,24 @@ async function runSlackEventOnce(
   monitorSlackProvider: SlackProviderMonitor,
   name: string,
   args: unknown,
-  opts?: { botToken?: string; appToken?: string },
+  opts?: SlackRunOnceOptions,
 ) {
   const { controller, run } = startSlackMonitor(monitorSlackProvider, opts);
   const handler = await getSlackHandlerOrThrow(name);
-  await handler(args);
-  await stopSlackMonitor({ controller, run });
+  // Normal Bolt handlers return after queue admission. Terminal-state tests use the
+  // durable-ingress lifecycle so this helper can await the actual dispatch boundary.
+  const handlerArgs = opts?.awaitDispatch ? withSlackDispatchLifecycle(args) : args;
+  try {
+    await handler(handlerArgs);
+  } finally {
+    await stopSlackMonitor({ controller, run });
+  }
 }
 
 export async function runSlackMessageOnce(
   monitorSlackProvider: SlackProviderMonitor,
   args: unknown,
-  opts?: { botToken?: string; appToken?: string },
+  opts?: SlackRunOnceOptions,
 ) {
   await runSlackEventOnce(monitorSlackProvider, "message", args, opts);
 }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -157,20 +157,27 @@ function ensureSlackTestRuntime(): {
         },
       },
       reactions: {
-        add: (...args: unknown[]) => {
-          slackTestState.reactionAddMock(...args);
-          return slackTestState.reactMock(...args);
-        },
-        remove: (...args: unknown[]) => {
-          slackTestState.reactionRemoveMock(...args);
-          return slackTestState.reactMock(...args);
-        },
+        add: () => undefined,
+        remove: () => undefined,
       },
     };
   }
+  const client = globalState["__slackClient"];
+  // The non-isolated Slack lane keeps this global client across file-level module resets.
+  // Rebind delegates so reaction assertions always target the current file's hoisted mocks.
+  client.reactions = {
+    add: (...args: unknown[]) => {
+      slackTestState.reactionAddMock(...args);
+      return slackTestState.reactMock(...args);
+    },
+    remove: (...args: unknown[]) => {
+      slackTestState.reactionRemoveMock(...args);
+      return slackTestState.reactMock(...args);
+    },
+  };
   return {
     handlers: globalState["__slackHandlers"],
-    client: globalState["__slackClient"],
+    client,
   };
 }
 

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -282,15 +282,18 @@ describe("monitorSlackProvider tool results", () => {
     });
   }
 
-  async function runMentionGatedChannelMessageAndFlush() {
-    await runSlackMessageOnce(monitorSlackProvider, {
-      event: makeSlackMessageEvent({
-        text: "<@bot-user> hello",
-        ts: "456",
-        channel_type: "channel",
-      }),
-    });
-    await flush();
+  async function runMentionGatedChannelMessage() {
+    await runSlackMessageOnce(
+      monitorSlackProvider,
+      {
+        event: makeSlackMessageEvent({
+          text: "<@bot-user> hello",
+          ts: "456",
+          channel_type: "channel",
+        }),
+      },
+      { awaitDispatch: true },
+    );
   }
 
   function expectReactionFlow(expected: {
@@ -640,13 +643,17 @@ describe("monitorSlackProvider tool results", () => {
       channel: { name: "general", is_channel: true },
     });
 
-    await runSlackMessageOnce(monitorSlackProvider, {
-      event: makeSlackMessageEvent({
-        text: "<@bot-user> hello",
-        ts: "456",
-        channel_type: "channel",
-      }),
-    });
+    await runSlackMessageOnce(
+      monitorSlackProvider,
+      {
+        event: makeSlackMessageEvent({
+          text: "<@bot-user> hello",
+          ts: "456",
+          channel_type: "channel",
+        }),
+      },
+      { awaitDispatch: true },
+    );
 
     expect(reactMock).toHaveBeenCalledWith({
       channel: "C1",
@@ -659,7 +666,7 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue(undefined);
     setMentionGatedAckConfig(false);
     mockGeneralChannelInfo();
-    await runMentionGatedChannelMessageAndFlush();
+    await runMentionGatedChannelMessage();
 
     expect(sendMock).not.toHaveBeenCalled();
     expect(reactMock).toHaveBeenCalledTimes(1);
@@ -674,7 +681,7 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue(undefined);
     setMentionGatedAckConfig(true);
     mockGeneralChannelInfo();
-    await runMentionGatedChannelMessageAndFlush();
+    await runMentionGatedChannelMessage();
 
     expect(sendMock).not.toHaveBeenCalled();
     expect(reactMock).toHaveBeenCalledTimes(1);
@@ -707,7 +714,7 @@ describe("monitorSlackProvider tool results", () => {
     };
     mockGeneralChannelInfo();
 
-    await runMentionGatedChannelMessageAndFlush();
+    await runMentionGatedChannelMessage();
 
     expect(replyMock).toHaveBeenCalledTimes(1);
     expect(sendMock).not.toHaveBeenCalled();
@@ -722,7 +729,7 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockRejectedValue(new Error("boom"));
     setMentionGatedAckConfig(true);
     mockGeneralChannelInfo();
-    await runMentionGatedChannelMessageAndFlush();
+    await expect(runMentionGatedChannelMessage()).rejects.toThrow("boom");
 
     expect(sendMock).not.toHaveBeenCalled();
     expectReactionFlow({


### PR DESCRIPTION
Related: #109910

## What Problem This Solves

Resolves a problem where five Slack reaction assertions in the tool-result suite intermittently observed zero reaction calls during the full Slack test lane, despite the underlying turn reaching the reply resolver. The failures reproduced on clean `main` in 2 of 3 full-suite runs.

## Why This Change Was Made

The Slack lane runs non-isolated in one worker. Its global mock client survives file-level module resets, but the reaction delegates remained closed over whichever test file first created that client. Suite ordering therefore routed reaction calls into stale mocks. The helper now rebinds those delegates to the active file's hoisted mocks, and terminal reaction tests opt into the existing durable-ingress lifecycle so assertions await dispatch completion instead of timer turns.

No production runtime behavior changes. AI-assisted; implementation and failure mechanism reviewed directly.

## User Impact

No user-visible change. Slack CI now reports reaction behavior deterministically, including silent turns and dispatch failures.

## Evidence

- Baseline: unchanged `main` passed once, then failed all five named reaction tests on the second full Slack run (1,881 passed / 5 failed).
- Focused: `node scripts/run-vitest.mjs extensions/slack/src/monitor.tool-result.test.ts` — 29/29 passed.
- Current exact head `f91e1e89d079433b05c8107297a0a6a54a2959bd`; Slack patch is byte-identical to pre-refresh proof head `71e9b192ad936829fd30a2a971bb78160c0bd174` (SHA-256 `9125c5666d9c1e50ad2e089dd9010f4302ca54b5ca0725633265508510503af5`), where three consecutive runs of `node scripts/run-vitest.mjs extensions/slack` passed:
  - 119 files / 1,886 tests passed in 33.50s.
  - 119 files / 1,886 tests passed in 31.56s.
  - 119 files / 1,886 tests passed in 30.15s.
- `node scripts/check-changed.mjs` — passed extension/test typechecks, lint, format, API/boundary, database-first, sidecar, and import-cycle gates.
- `autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.


