### PR TITLE
fix: slow session node delays sidebar for a minute

### DIFF
--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -1407,6 +1407,45 @@ describe("Claude session catalog", () => {
     ]);
   });
 
+  it("bounds how long a hung paired-node catalog can delay the caller", async () => {
+    vi.useFakeTimers();
+    try {
+      const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(
+        async () => await new Promise<never>(() => {}),
+      );
+      const provider = captureCatalogProvider({
+        nodes: {
+          list: vi.fn().mockResolvedValue({
+            nodes: [
+              {
+                nodeId: "slow-node",
+                displayName: "Slow node",
+                connected: true,
+                commands: [CLAUDE_SESSIONS_LIST_COMMAND],
+              },
+            ],
+          }),
+          invoke,
+        },
+      } as unknown as PluginRuntime);
+      const pending = provider.list({ hostIds: ["node:slow-node"] });
+
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      await expect(pending).resolves.toEqual([
+        expect.objectContaining({
+          hostId: "node:slow-node",
+          connected: true,
+          sessions: [],
+          error: expect.objectContaining({ code: "NODE_INVOKE_FAILED" }),
+        }),
+      ]);
+      expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 30_000 }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("starts paired-node discovery while the local catalog is still reading", async () => {
     const home = await createHome();
     process.env.HOME = home;

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { withTimeout } from "openclaw/plugin-sdk/security-runtime";
 import type {
   SessionCatalogHost,
   SessionCatalogProvider,
@@ -66,6 +67,9 @@ const MAX_TRANSCRIPT_SCAN_BYTES = 64 * 1024 * 1024;
 const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
 
 const NODE_INVOKE_TIMEOUT_MS = 30_000;
+// Catalog refresh is fail-soft: one unhealthy machine must not hold the whole sidebar.
+// The node invoke keeps running so cold native discovery can warm the next poll.
+const NODE_CATALOG_LIST_RESPONSE_TIMEOUT_MS = 8_000;
 const CLAUDE_HISTORY_IMPORT_MAX_ITEMS = 200;
 const CLAUDE_HISTORY_IMPORT_MAX_BYTES = 512 * 1024;
 
@@ -1061,17 +1065,21 @@ async function listClaudeSessionCatalog(params: {
         });
       }
       try {
-        const raw = await params.runtime.nodes.invoke({
-          nodeId: node.nodeId,
-          command: CLAUDE_SESSIONS_LIST_COMMAND,
-          params: {
-            limit: query.limitPerHost,
-            ...(query.search ? { searchTerm: query.search } : {}),
-            ...(query.cursors?.[hostId] ? { cursor: query.cursors[hostId] } : {}),
-          },
-          timeoutMs: NODE_INVOKE_TIMEOUT_MS,
-          scopes: ["operator.write"],
-        });
+        const raw = await withTimeout(
+          params.runtime.nodes.invoke({
+            nodeId: node.nodeId,
+            command: CLAUDE_SESSIONS_LIST_COMMAND,
+            params: {
+              limit: query.limitPerHost,
+              ...(query.search ? { searchTerm: query.search } : {}),
+              ...(query.cursors?.[hostId] ? { cursor: query.cursors[hostId] } : {}),
+            },
+            timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+            scopes: ["operator.write"],
+          }),
+          NODE_CATALOG_LIST_RESPONSE_TIMEOUT_MS,
+          { message: "paired node Claude session catalog timed out" },
+        );
         return Object.assign(common, parseCatalogPage(unwrapNodePayload(raw)));
       } catch {
         return Object.assign(common, {

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { CodexThread } from "./app-server/protocol.js";
+import { withTimeout } from "./app-server/timeout.js";
 import { createCodexCliNodeConversationBindingData } from "./conversation-binding-data.js";
 import { CODEX_CLI_SESSION_RESUME_COMMAND } from "./node-cli-sessions.js";
 import {
@@ -43,6 +44,10 @@ const CODEX_NODE_CONTINUE_COMMANDS = [
   CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
   CODEX_CLI_SESSION_RESUME_COMMAND,
 ] as const;
+
+// Catalog refresh is fail-soft: one unhealthy machine must not hold the whole sidebar.
+// The node invoke keeps running so cold native discovery can warm the next poll.
+const NODE_CATALOG_LIST_RESPONSE_TIMEOUT_MS = 8_000;
 
 export type CatalogNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
 
@@ -96,17 +101,21 @@ export async function listPairedNode(params: {
     };
   }
   try {
-    const raw = await params.runtime.nodes.invoke({
-      nodeId: params.node.nodeId,
-      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
-      params: {
-        cursor: params.query.cursors?.[hostId],
-        limit: params.query.limitPerHost,
-        searchTerm: params.query.search,
-      },
-      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
-      scopes: ["operator.write"],
-    });
+    const raw = await withTimeout(
+      params.runtime.nodes.invoke({
+        nodeId: params.node.nodeId,
+        command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+        params: {
+          cursor: params.query.cursors?.[hostId],
+          limit: params.query.limitPerHost,
+          searchTerm: params.query.search,
+        },
+        timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+        scopes: ["operator.write"],
+      }),
+      NODE_CATALOG_LIST_RESPONSE_TIMEOUT_MS,
+      "paired node Codex session catalog timed out",
+    );
     const page = filterCatalogPageByTitle(
       parseCatalogPage(unwrapNodeInvokePayload(raw)),
       params.query.search,

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -17,6 +17,7 @@ import {
   type CodexAppServerBindingStore,
   type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.test-helpers.js";
+import { listPairedNode } from "./session-catalog-node-continue.js";
 import { catalogError } from "./session-catalog-parsing.js";
 import { CODEX_TERMINAL_RESUME_COMMAND } from "./session-catalog-terminal.js";
 import {
@@ -993,6 +994,38 @@ describe("Codex supervision catalog", () => {
       }),
     ]);
     expect(JSON.stringify(result)).not.toContain("private transcript");
+  });
+
+  it("bounds how long a hung paired-node catalog can delay the caller", async () => {
+    vi.useFakeTimers();
+    try {
+      const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(
+        async () => await new Promise<never>(() => {}),
+      );
+      const pending = listPairedNode({
+        runtime: { nodes: { invoke } } as unknown as PluginRuntime,
+        node: {
+          nodeId: "slow-node",
+          displayName: "Slow node",
+          connected: true,
+          commands: [CODEX_APP_SERVER_THREADS_LIST_COMMAND],
+        },
+        query: { limitPerHost: 40 },
+        adoptedSessions: new Map(),
+      });
+
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      await expect(pending).resolves.toMatchObject({
+        hostId: "node:slow-node",
+        connected: true,
+        sessions: [],
+        error: { code: "NODE_INVOKE_FAILED" },
+      });
+      expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 65_000 }));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("serves one bounded transcript page from the node host command", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the web UI could wait about a minute for Claude and Codex session catalogs when one connected computer was slow or unhealthy. The gateway aggregated every host with `Promise.all`, so the slowest node delayed all healthy results.

## Why This Change Was Made

Paired-node catalog reads now stop holding the caller after 8 seconds and return the existing per-host fail-soft error. The underlying 30/65-second node invocation continues in the background, so cold native discovery can warm the next 30-second sidebar poll without weakening transcript, continuation, or terminal operation timeouts.

This is deliberately scoped to passive session listing in the owning Claude and Codex plugins. It does not change protocol, config, persistence, or the canonical Codex app-server session source.

## User Impact

The session sidebar can show healthy computers promptly even when another connected computer is slow. A cold host may show as temporarily unavailable for one poll, then appear after its native catalog warms.

Release note: Session catalog loading no longer waits up to a minute for one slow paired computer.

AI-assisted: yes. I understand and reviewed the changed request, timeout, and retry behavior.

## Evidence

- Live fleet baseline, three connected Macs: combined catalog request took 60,441 ms because one Codex host hit its 60-second failure path.
- Read-only live benchmark of the new per-host deadline policy against the same gateway/node RPC fan-out: 8,003 ms (7.55x faster). The first cold pass returned 235 session rows from 6/8 catalog-host requests; the next poll returned 275 rows from 7/8 after a cold Codex host warmed. The persistently slow host remained isolated.
- `node scripts/run-vitest.mjs extensions/codex/src/session-catalog.test.ts extensions/anthropic/session-catalog.test.ts` — 112 tests passed.
- `check:changed` trusted-source local fallback — format, API baseline, plugin boundaries, extension/type-test typechecks, changed-file lint, database-first guard, sidecar guard, and import-cycle checks passed. Testbox could not start because the local sparse-sync preflight lacked its required free disk; no remote code ran.
- Autoreview found no runtime or security defect. A later zero-context diff review incorrectly flagged an existing balanced test closure; the normal unified diff, both Vitest suites, and extension-test typecheck confirm the file parses.
