### PR TITLE
test: tolerate slow cross-OS process startup

### DIFF
--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -1576,7 +1576,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         logPath,
         timeoutMs: 500,
       });
-      await waitForFile(childPidPath, 2_000);
+      await waitForFile(childPidPath, 10_000);
       const childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
 
       await expect(command).rejects.toThrow(/Command timed out:/u);
@@ -1639,7 +1639,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       );
       runnerPid = runner.pid;
 
-      await waitForFile(childPidPath, 2_000);
+      await waitForFile(childPidPath, 10_000);
       childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
       runner.kill("SIGTERM");
       const result = await waitForExit(runner, 5_000);
@@ -1706,7 +1706,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       );
       runnerPid = runner.pid;
 
-      await waitForFile(childPidPath, 2_000);
+      await waitForFile(childPidPath, 10_000);
       childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
       const signaledAt = Date.now();
       runner.kill("SIGTERM");


### PR DESCRIPTION
Related: #110081

## What Problem This Solves

Fixes an issue where the cross-OS release process tests could fail on a busy CI runner before their child process had started, even though the signal-forwarding behavior under test was correct.

## Why This Change Was Made

The three child-process startup polls now allow 10 seconds instead of 2 seconds. Signal forwarding, cleanup, exit-status, and prompt-exit assertions remain unchanged and retain their tighter behavior deadlines.

No production, config, UI, protocol, or capability surface changes.

## User Impact

No user-visible product change. CI no longer treats slow test-process startup as a signal-forwarding regression.

## Evidence

- Exact repeated CI failures: `checks-node-compact-small-7` timed out waiting for the same two child PID files on two attempts while 1,247 sibling tests passed: https://github.com/openclaw/openclaw/actions/runs/29599345146
- `for i in 1 2 3; do node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts || exit $?; done` — 108/108 passed on all three runs.
- `node scripts/check-changed.mjs -- test/scripts/openclaw-cross-os-release-checks.test.ts` — hosted changed gate passed, exit 0, 2m39s: https://github.com/openclaw/openclaw/actions/runs/29601162859
- Fresh autoreview: no accepted/actionable findings.

AI-assisted: yes. Maintainer diagnosis and proof completed.
