### PR TITLE
feat(omniroute): add bundled OmniRoute provider plugin

### DIFF
--- a/extensions/omniroute/index.test.ts
+++ b/extensions/omniroute/index.test.ts
@@ -1,0 +1,158 @@
+// OmniRoute tests cover index plugin behavior.
+import { readFileSync } from "node:fs";
+import {
+  registerProviderPlugin,
+  registerSingleProviderPlugin,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  expectUnifiedModelCatalogProviderRegistration,
+} from "openclaw/plugin-sdk/provider-test-contracts";
+import { describe, expect, it } from "vitest";
+
+import omniroutePlugin from "./index.js";
+import { buildOmniRouteProvider } from "./provider-catalog.js";
+import {
+  applyOmniRouteConfig,
+  applyOmniRouteProviderConfig,
+} from "./onboard.js";
+import {
+  OMNIROUTE_API_KEY_ENV_VAR,
+  OMNIROUTE_DEFAULT_BASE_URL,
+  OMNIROUTE_DEFAULT_MODEL_ID,
+  OMNIROUTE_DEFAULT_MODEL_REF,
+  OMNIROUTE_LABEL,
+  OMNIROUTE_PROVIDER_ID,
+} from "./models.js";
+
+type OmniRouteManifest = {
+  providerAuthChoices?: Array<{
+    provider?: string;
+    method?: string;
+    choiceId?: string;
+    choiceLabel?: string;
+    choiceHint?: string;
+    groupId?: string;
+    groupLabel?: string;
+    groupHint?: string;
+  }>;
+};
+
+function readManifest(): OmniRouteManifest {
+  return JSON.parse(readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"));
+}
+
+describe("omniroute provider plugin", () => {
+  it("registers the OmniRoute provider with correct id", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: omniroutePlugin,
+      id: OMNIROUTE_PROVIDER_ID,
+      name: "OmniRoute Provider",
+    });
+
+    expect(providers.map((p) => p.id)).toEqual([OMNIROUTE_PROVIDER_ID]);
+    expect(providers[0].id).toBe("omniroute");
+  });
+
+  it("registers a single provider plugin with API-key auth method", async () => {
+    const provider = await registerSingleProviderPlugin(omniroutePlugin);
+
+    expect(provider.id).toBe(OMNIROUTE_PROVIDER_ID);
+    expect(provider.label).toBe(OMNIROUTE_LABEL);
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.auth[0]).toMatchObject({
+      id: "api-key",
+      label: "OmniRoute API key",
+    });
+  });
+
+  it("exposes auth choice metadata matching the manifest", async () => {
+    const provider = await registerSingleProviderPlugin(omniroutePlugin);
+    const manifestChoices = readManifest().providerAuthChoices?.map((choice) => ({
+      provider: choice.provider,
+      method: choice.method,
+      choiceId: choice.choiceId,
+      choiceLabel: choice.choiceLabel,
+      choiceHint: choice.choiceHint,
+      groupId: choice.groupId,
+      groupLabel: choice.groupLabel,
+      groupHint: choice.groupHint,
+    }));
+
+    const runtimeChoices = provider.auth.map((method) => ({
+      provider: provider.id,
+      method: method.id,
+      choiceId: method.wizard?.choiceId,
+      choiceLabel: method.wizard?.choiceLabel,
+      choiceHint: method.wizard?.choiceHint,
+      groupId: method.wizard?.groupId,
+      groupLabel: method.wizard?.groupLabel,
+      groupHint: method.wizard?.groupHint,
+    }));
+
+    expect(runtimeChoices).toEqual(manifestChoices);
+  });
+
+  it("builds a provider catalog with correct baseUrl, api, and models", () => {
+    const catalog = buildOmniRouteProvider();
+
+    expect(catalog.baseUrl).toBe(OMNIROUTE_DEFAULT_BASE_URL);
+    expect(catalog.api).toBe("openai-completions");
+    expect(catalog.models).toHaveLength(1);
+    expect(catalog.models![0]).toMatchObject({
+      id: OMNIROUTE_DEFAULT_MODEL_ID,
+      name: "Auto (OmniRoute)",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 128_000,
+      maxTokens: 16_384,
+    });
+  });
+
+  it("exposes the default model ref constant", () => {
+    expect(OMNIROUTE_DEFAULT_MODEL_REF).toBe("omniroute/auto");
+  });
+
+  it("applies OmniRoute provider config correctly", () => {
+    const config = applyOmniRouteProviderConfig({} as never);
+
+    expect(config).toBeDefined();
+  });
+
+  it("applies full OmniRoute config including default model", () => {
+    const config = applyOmniRouteConfig({} as never);
+
+    expect(config).toBeDefined();
+  });
+
+  it("registers through the unified model catalog provider path", async () => {
+    const modelCatalogProvider = expectUnifiedModelCatalogProviderRegistration({
+      plugin: omniroutePlugin,
+      pluginId: OMNIROUTE_PROVIDER_ID,
+      pluginName: "OmniRoute Provider",
+      provider: OMNIROUTE_PROVIDER_ID,
+      kind: "text",
+    });
+
+    expect(modelCatalogProvider.liveCatalog).toBeTypeOf("function");
+  });
+
+  it("exposes env vars for auth", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: omniroutePlugin,
+      id: OMNIROUTE_PROVIDER_ID,
+      name: "OmniRoute Provider",
+    });
+
+    expect(providers[0].envVars).toContain(OMNIROUTE_API_KEY_ENV_VAR);
+  });
+
+  it("has a valid manifest with correct provider id", () => {
+    const manifest = readManifest();
+
+    expect(manifest).toMatchObject({
+      id: "omniroute",
+      providers: ["omniroute"],
+      enabledByDefault: true,
+    });
+  });
+});

--- a/extensions/omniroute/index.ts
+++ b/extensions/omniroute/index.ts
@@ -1,0 +1,66 @@
+// OmniRoute plugin entrypoint registers its OpenClaw integration.
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { applyOmniRouteConfig } from "./onboard.js";
+import {
+  OMNIROUTE_API_KEY_ENV_VAR,
+  OMNIROUTE_DEFAULT_MODEL_REF,
+  OMNIROUTE_LABEL,
+  OMNIROUTE_PROVIDER_ID,
+} from "./models.js";
+import { buildOmniRouteProvider } from "./provider-catalog.js";
+
+export default defineSingleProviderPluginEntry({
+  id: OMNIROUTE_PROVIDER_ID,
+  name: "OmniRoute Provider",
+  description: "Bundled OmniRoute provider plugin",
+  provider: {
+    label: OMNIROUTE_LABEL,
+    docsPath: "/providers/omniroute",
+    envVars: [OMNIROUTE_API_KEY_ENV_VAR],
+    auth: [
+      {
+        methodId: "api-key",
+        label: "OmniRoute API key",
+        hint: "OpenAI-compatible OmniRoute gateway",
+        optionKey: "omnirouteApiKey",
+        flagName: "--omniroute-api-key",
+        envVar: OMNIROUTE_API_KEY_ENV_VAR,
+        promptMessage: "Enter OmniRoute API key",
+        defaultModel: OMNIROUTE_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyOmniRouteConfig(cfg),
+        noteTitle: "OmniRoute",
+        noteMessage: [
+          "OmniRoute exposes an OpenAI-compatible /v1/chat/completions endpoint.",
+          "By default this plugin targets http://localhost:20128/v1 and lets OmniRoute route downstream providers.",
+        ].join("\n"),
+        wizard: {
+          choiceId: "omniroute-api-key",
+          choiceLabel: "OmniRoute API key",
+          choiceHint: "OpenAI-compatible OmniRoute gateway",
+          groupId: OMNIROUTE_PROVIDER_ID,
+          groupLabel: OMNIROUTE_LABEL,
+          groupHint: "OpenAI-compatible OmniRoute gateway",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildOmniRouteProvider,
+      buildStaticProvider: buildOmniRouteProvider,
+      allowExplicitBaseUrl: true,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: OMNIROUTE_PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    ...buildProviderToolCompatFamilyHooks("openai"),
+    isModernModelRef: () => true,
+  },
+});

--- a/extensions/omniroute/models.ts
+++ b/extensions/omniroute/models.ts
@@ -1,0 +1,24 @@
+// OmniRoute model metadata for the thin OpenAI-compatible provider wrapper.
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const OMNIROUTE_PROVIDER_ID = "omniroute";
+export const OMNIROUTE_LABEL = "OmniRoute";
+export const OMNIROUTE_API_KEY_ENV_VAR = "OMNIROUTE_API_KEY";
+export const OMNIROUTE_DEFAULT_BASE_URL = "http://localhost:20128/v1";
+export const OMNIROUTE_DEFAULT_MODEL_ID = "auto";
+export const OMNIROUTE_DEFAULT_MODEL_REF = `${OMNIROUTE_PROVIDER_ID}/${OMNIROUTE_DEFAULT_MODEL_ID}`;
+
+export function buildOmniRouteDefaultModel(): ModelDefinitionConfig {
+  return {
+    id: OMNIROUTE_DEFAULT_MODEL_ID,
+    name: "Auto (OmniRoute)",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    compat: {
+      supportsUsageInStreaming: true,
+    },
+  };
+}

--- a/extensions/omniroute/onboard.ts
+++ b/extensions/omniroute/onboard.ts
@@ -1,0 +1,27 @@
+// OmniRoute setup helpers for API-key onboarding.
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalogPreset,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildOmniRouteDefaultModel,
+  OMNIROUTE_DEFAULT_BASE_URL,
+  OMNIROUTE_DEFAULT_MODEL_REF,
+  OMNIROUTE_PROVIDER_ID,
+} from "./models.js";
+
+export function applyOmniRouteProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = applyProviderConfigWithModelCatalogPreset(cfg, {
+    providerId: OMNIROUTE_PROVIDER_ID,
+    api: "openai-completions",
+    baseUrl: OMNIROUTE_DEFAULT_BASE_URL,
+    catalogModels: [buildOmniRouteDefaultModel()],
+    aliases: [{ modelRef: OMNIROUTE_DEFAULT_MODEL_REF, alias: "OmniRoute" }],
+  });
+  return next;
+}
+
+export function applyOmniRouteConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(applyOmniRouteProviderConfig(cfg), OMNIROUTE_DEFAULT_MODEL_REF);
+}

--- a/extensions/omniroute/openclaw.plugin.json
+++ b/extensions/omniroute/openclaw.plugin.json
@@ -1,0 +1,81 @@
+{
+  "id": "omniroute",
+  "name": "OmniRoute",
+  "description": "OpenClaw OmniRoute text inference provider plugin.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["omniroute"],
+  "providerRequest": {
+    "providers": {
+      "omniroute": {
+        "family": "openai-compatible",
+        "openAICompletions": {
+          "supportsStreamingUsage": true
+        }
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "omniroute",
+        "authMethods": ["api-key"],
+        "envVars": ["OMNIROUTE_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "omniroute",
+      "method": "api-key",
+      "choiceId": "omniroute-api-key",
+      "appGuidedSecret": true,
+      "choiceLabel": "OmniRoute API key",
+      "choiceHint": "OpenAI-compatible OmniRoute gateway",
+      "groupId": "omniroute",
+      "groupLabel": "OmniRoute",
+      "groupHint": "OpenAI-compatible OmniRoute gateway",
+      "optionKey": "omnirouteApiKey",
+      "cliFlag": "--omniroute-api-key",
+      "cliOption": "--omniroute-api-key <key>",
+      "cliDescription": "OmniRoute API key"
+    }
+  ],
+  "modelCatalog": {
+    "providers": {
+      "omniroute": {
+        "baseUrl": "http://localhost:20128/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "auto",
+            "name": "Auto (OmniRoute)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "omniroute": "static"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/omniroute/package.json
+++ b/extensions/omniroute/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/omniroute-provider",
+  "version": "2026.7.2",
+  "private": true,
+  "description": "OpenClaw OmniRoute provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/omniroute/provider-catalog.ts
+++ b/extensions/omniroute/provider-catalog.ts
@@ -1,0 +1,14 @@
+// OmniRoute provider catalog for the bundled OpenAI-compatible proxy plugin.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildOmniRouteDefaultModel,
+  OMNIROUTE_DEFAULT_BASE_URL,
+} from "./models.js";
+
+export function buildOmniRouteProvider(): ModelProviderConfig {
+  return {
+    baseUrl: OMNIROUTE_DEFAULT_BASE_URL,
+    api: "openai-completions",
+    models: [buildOmniRouteDefaultModel()],
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1383,6 +1383,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/omniroute:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/onepassword:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## Add bundled OmniRoute provider plugin

### Problem
OpenClaw has no built-in support for OmniRoute as a model provider. Users who self-host OmniRoute as an AI gateway must configure it as a generic OpenAI-compatible endpoint, losing provider-level auth, onboarding, and catalog features.

### Solution
Adds a new bundled provider plugin at `extensions/omniroute/` that registers OmniRoute as a first-class text inference provider.

### What it does
- Registers `omniroute` as a text inference provider via `api.registerProvider()`
- Auth via `OMNIROUTE_API_KEY` environment variable
- Configurable base URL via `models.providers.omniroute.baseUrl` (default `http://localhost:20128/v1`)
- OpenAI-compatible chat/completions transport with streaming support
- Static model catalog with a single `auto` model — OmniRoute handles downstream routing
- Uses `openai-compatible` replay family
- Discovery via `package.json` `openclaw.extensions` field — no core registry changes needed

### Files added
- `extensions/omniroute/index.ts` — Plugin entry using `defineSingleProviderPluginEntry`
- `extensions/omniroute/models.ts` — Constants (provider id, env var, base URL, default model)
- `extensions/omniroute/onboard.ts` — Config appliers for API-key onboarding
- `extensions/omniroute/provider-catalog.ts` — Provider catalog builder
- `extensions/omniroute/openclaw.plugin.json` — Full manifest with auth, model catalog, setup
- `extensions/omniroute/package.json` — Package metadata with `openclaw.extensions` for discovery
- `extensions/omniroute/index.test.ts` — 10 tests

### Files changed
- `pnpm-lock.yaml` — Auto-updated for new workspace package

### Design
Follows the same bundled provider plugin pattern as OpenRouter, fal, MiniMax, and Google extensions. Thin proxy wrapper — OpenClaw talks to OmniRoute, OmniRoute handles downstream provider routing and model selection.

### Out of scope (future PRs)
- Music generation
- Image/video/audio/media providers
- Model discovery/catalog sophistication
- Multi-provider granularity inside OmniRoute

### Evidence
```
# Tests
$ pnpm test -- extensions/omniroute/
 PASS  extensions/omniroute/index.test.ts
  ✓ registers the OmniRoute provider with correct id
  ✓ registers a single provider plugin with API-key auth method
  ✓ exposes auth choice metadata matching the manifest
  ✓ builds a provider catalog with correct baseUrl, api, and models
  ✓ exposes the default model ref constant
  ✓ applies OmniRoute provider config correctly
  ✓ applies full OmniRoute config including default model
  ✓ registers through the unified model catalog provider path
  ✓ exposes env vars for auth
  ✓ has a valid manifest with correct provider id

# Build
$ pnpm build
[build-all] phase timings: total 2m 7.8s
```

### AI-assisted disclosure
This PR was implemented with AI assistance. The author reviewed and verified all changes.
