### PR TITLE
refactor(codex): keep projector no-op cases local

### DIFF
--- a/extensions/codex/src/app-server/event-projector-diagnostics.ts
+++ b/extensions/codex/src/app-server/event-projector-diagnostics.ts
@@ -8,25 +8,6 @@ import {
 } from "./notification-correlation.js";
 import type { CodexServerNotification, CodexThreadItem, JsonObject } from "./protocol.js";
 
-const KNOWN_NOOP_NOTIFICATION_METHODS = new Set([
-  "thread/compacted",
-  "turn/started",
-  "turn/diff/updated",
-  "item/reasoning/summaryPartAdded",
-  "item/commandExecution/terminalInteraction",
-  "item/fileChange/outputDelta",
-  "item/fileChange/patchUpdated",
-  "item/mcpToolCall/progress",
-  "model/rerouted",
-  "model/verification",
-  "turn/moderationMetadata",
-  "model/safetyBuffering/updated",
-]);
-
-export function isKnownNoopCodexNotificationMethod(method: string): boolean {
-  return KNOWN_NOOP_NOTIFICATION_METHODS.has(method);
-}
-
 export function redactCodexEventKind(method: string): string {
   return redactSensitiveText(sanitizeTerminalText(method));
 }

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -1,10 +1,16 @@
 import { normalizeUsage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { readNonNegativeInteger, readNumber } from "./event-projector-values.js";
-import type { JsonObject } from "./protocol.js";
+import { isJsonObject, type JsonObject } from "./protocol.js";
 
 function readTokenCount(record: JsonObject, key: string): number | undefined {
   const value = readNonNegativeInteger(record, key);
   return value !== undefined && Number.isSafeInteger(value) ? value : undefined;
+}
+
+export function readCodexThreadTokenUsage(params: JsonObject): ReturnType<typeof normalizeUsage> {
+  const tokenUsage = isJsonObject(params.tokenUsage) ? params.tokenUsage : undefined;
+  const last = tokenUsage && isJsonObject(tokenUsage.last) ? tokenUsage.last : undefined;
+  return last ? normalizeCodexThreadTokenUsage(last) : undefined;
 }
 
 export function normalizeCodexThreadTokenUsage(

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -6322,6 +6322,8 @@ describe("CodexAppServerEventProjector", () => {
     const params = await createParams();
     const onPartialReply = vi.fn();
     const projector = await createProjector({ ...params, onPartialReply });
+    await projector.handleNotification(forCurrentTurn("thread/compacted", {}));
+    expect(warn).not.toHaveBeenCalled();
     const rawEventKind = "item/futureStatus/updated\nforged";
     const collidingSanitizedEventKind = "item/futureStatus/updated\\nforged";
     const notification = forCurrentTurn(rawEventKind, {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -13,10 +13,7 @@ import {
   type MessagingToolSourceReplyPayload,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { CodexAssistantProjection } from "./event-projector-assistant.js";
-import {
-  CodexProjectionDiagnostics,
-  isKnownNoopCodexNotificationMethod,
-} from "./event-projector-diagnostics.js";
+import { CodexProjectionDiagnostics } from "./event-projector-diagnostics.js";
 import { CodexEventProjection } from "./event-projector-events.js";
 import {
   itemName,
@@ -32,6 +29,7 @@ import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript
 import {
   normalizeCodexResponseTokenUsage,
   normalizeCodexThreadTokenUsage,
+  readCodexThreadTokenUsage,
 } from "./event-projector-usage.js";
 import {
   readCodexErrorNotificationMessage,
@@ -269,7 +267,7 @@ export class CodexAppServerEventProjector {
         this.eventProjection.handleHook(notification.method, params);
         break;
       case "thread/tokenUsage/updated":
-        this.handleTokenUsage(params);
+        this.tokenUsage = readCodexThreadTokenUsage(params) ?? this.tokenUsage;
         break;
       case "turn/completed":
         await this.handleTurnCompleted(params);
@@ -288,10 +286,21 @@ export class CodexAppServerEventProjector {
         this.promptError = this.formatCodexErrorMessage(params) ?? "codex app-server error";
         this.promptErrorSource = "prompt";
         break;
+      case "thread/compacted":
+      case "turn/started":
+      case "turn/diff/updated":
+      case "item/reasoning/summaryPartAdded":
+      case "item/commandExecution/terminalInteraction":
+      case "item/fileChange/outputDelta":
+      case "item/fileChange/patchUpdated":
+      case "item/mcpToolCall/progress":
+      case "model/rerouted":
+      case "model/verification":
+      case "turn/moderationMetadata":
+      case "model/safetyBuffering/updated":
+        break;
       default:
-        if (!isKnownNoopCodexNotificationMethod(notification.method)) {
-          this.diagnostics.warnUnknownEvent(notification, params);
-        }
+        this.diagnostics.warnUnknownEvent(notification, params);
         break;
     }
   }
@@ -578,18 +587,6 @@ export class CodexAppServerEventProjector {
       stream: "codex_app_server.item",
       data: { phase: "completed", itemId, type: item?.type },
     });
-  }
-
-  private handleTokenUsage(params: JsonObject): void {
-    const tokenUsage = isJsonObject(params.tokenUsage) ? params.tokenUsage : undefined;
-    const last = tokenUsage && isJsonObject(tokenUsage.last) ? tokenUsage.last : undefined;
-    if (!last) {
-      return;
-    }
-    const usage = normalizeCodexThreadTokenUsage(last);
-    if (usage) {
-      this.tokenUsage = usage;
-    }
   }
 
   private handleRawResponseCompleted(params: JsonObject): void {


### PR DESCRIPTION
Related: #99287

## What Problem This Solves

Removes a one-use exported no-op notification table left by the Codex projector diagnostics repair. There is no user-visible behavior change.

## Why This Change Was Made

The projector now lists its intentionally non-projecting notification methods directly in the existing switch, so handled, no-op, and unknown methods share one decision surface. Thread token-usage payload parsing moves into the existing usage module, keeping the capped projector lean. The change is net 14 lines smaller.

## User Impact

None. Known no-op methods remain silent, unknown methods still warn and continue, and malformed thread-usage updates retain the prior usage snapshot.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts` — 168 passed after rebasing onto latest `origin/main`.
- Representative `thread/compacted` regression remains warning-free before the existing unknown-kind warning/continuation assertions.
- `./node_modules/.bin/oxfmt --check <four changed files>`, targeted `oxlint`, and `git diff --check` — passed.
- `node scripts/check-changed.mjs -- <four changed files>` — hosted extension/test typechecks, lint, boundaries, SDK baseline, and import-cycle checks passed: https://github.com/openclaw/openclaw/actions/runs/29616014010
- Exact-head PR CI and aggregate gate passed: https://github.com/openclaw/openclaw/actions/runs/29615953140
- Fresh mandatory autoreview — clean, no accepted/actionable findings.
