### PR TITLE
improve: speed up async lifecycle test suites

### DIFF
--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -36,6 +36,10 @@ import {
   sendGatewayCronFailureAlert,
 } from "./server-cron-notifications.js";
 
+function waitForFast(assertion: () => void | Promise<void>) {
+  return vi.waitFor(assertion, { interval: 1 });
+}
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object") {
     throw new Error(`expected ${label}`);
@@ -120,7 +124,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
           resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
         });
 
-        await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
+        await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
         expect(getActiveGatewayRootWorkCount()).toBe(2);
       });
     } finally {
@@ -129,7 +133,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
     expect(getActiveGatewayRootWorkCount()).toBe(1);
     deferred.resolve();
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("keeps webhook delivery cold when its token owner is unavailable", async () => {
@@ -157,7 +161,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
     });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           jobId: job.id,
@@ -167,7 +171,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       ),
     );
     expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("independently admits immediate failure alerts", async () => {
@@ -188,7 +192,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       mode: "announce",
     });
 
-    await vi.waitFor(() => expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledOnce());
     expect(getActiveGatewayRootWorkCount()).toBe(1);
     deferred.resolve();
     await delivery;
@@ -216,7 +220,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(0);
 
     expect(suspensionAdmission?.release()).toBe(true);
-    await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
   });
 
   it("independently admits failure destination webhook delivery", async () => {
@@ -242,10 +246,10 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
     });
 
-    await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
     expect(getActiveGatewayRootWorkCount()).toBe(1);
     deferred.resolve();
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("independently admits failure destination announce delivery", async () => {
@@ -269,10 +273,10 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
     });
 
-    await vi.waitFor(() => expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1));
     expect(getActiveGatewayRootWorkCount()).toBe(1);
     deferred.resolve();
-    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("redacts invalid completion webhook targets in warnings", () => {
@@ -477,7 +481,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
     });
 
-    await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
     const body = webhookRequestBody();
     expect(body.summary).toContain("[redacted-url]");
     expect(body.summary).toContain("[redacted-code]");
@@ -559,7 +563,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
     });
 
-    await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1));
     const body = webhookRequestBody();
     expect(body).toMatchObject({
       action: "finished",

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -13,6 +13,13 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 
 type BuildAuthHealthSummary = typeof import("../../agents/auth-health.js").buildAuthHealthSummary;
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 const emptyUsageSummary = (): UsageSummary => ({ updatedAt: 0, providers: [] });
 
 const mocks = vi.hoisted(() => ({
@@ -720,7 +727,7 @@ describe("models.authStatus", () => {
     });
 
     const inFlightStatus = handler(createOptions());
-    await vi.waitFor(() => expect(mocks.loadProviderUsageSummary).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(mocks.loadProviderUsageSummary).toHaveBeenCalledOnce());
     await logoutHandler(createLogoutOptions({ provider: "openrouter" }));
     releaseUsage?.();
     await inFlightStatus;

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -67,6 +67,13 @@ import { createTerminalLaunchPolicy } from "./terminal/launch.js";
 type ReloadHandlerParams = Parameters<typeof createGatewayReloadHandlersImpl>[0];
 type ManagedReloaderParams = Parameters<typeof startManagedGatewayConfigReloaderImpl>[0];
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 const restartTesting = {
   resetSigusr1State() {
     resetGatewayRestartStateForInProcessRestart();
@@ -936,8 +943,8 @@ describe("gateway hot reload model state", () => {
     expect(cron.stop).toHaveBeenCalledTimes(1);
     expect(stopExitWatchers).toHaveBeenCalledTimes(1);
     expect(newCron.start).toHaveBeenCalledTimes(1);
-    await vi.waitFor(() => expect(newReconcileExitWatchers).toHaveBeenCalledTimes(1));
-    await vi.waitFor(() => expect(order.at(-1)).toBe("hook"));
+    await waitForFast(() => expect(newReconcileExitWatchers).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(order.at(-1)).toBe("hook"));
     expect(order).toEqual([
       "build-new",
       "invalidate-old",
@@ -975,7 +982,7 @@ describe("gateway hot reload model state", () => {
       await applyHotReload(createCronRestartPlan(), nextConfig);
     });
 
-    await vi.waitFor(() => expect(cronReconciliation.complete).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(cronReconciliation.complete).toHaveBeenCalledTimes(1));
     expect(cronReconciliation.arm).toHaveBeenCalledWith({
       reason: "reload",
       config: nextConfig,
@@ -1085,7 +1092,7 @@ describe("gateway hot reload model state", () => {
       ).resolves.toBeUndefined();
 
       expect(setState).toHaveBeenCalledOnce();
-      await vi.waitFor(() => expect(signalSpy).toHaveBeenCalledOnce());
+      await waitForFast(() => expect(signalSpy).toHaveBeenCalledOnce());
       expect(logReload.warn).toHaveBeenCalledWith(
         "cron reload failed after config commit: cron start failed; restarting gateway",
       );
@@ -1129,10 +1136,10 @@ describe("gateway hot reload model state", () => {
 
     await withGatewayRestartSignal(async (signalSpy) => {
       await applyHotReload(createCronRestartPlan(), { cron: { enabled: true } });
-      await vi.waitFor(() => expect(firstCronState.cron.start).toHaveBeenCalledOnce());
+      await waitForFast(() => expect(firstCronState.cron.start).toHaveBeenCalledOnce());
       await applyHotReload(createCronRestartPlan(), { cron: { enabled: true } });
       rejectFirstStart?.(new Error("superseded start failed"));
-      await vi.waitFor(() =>
+      await waitForFast(() =>
         expect(logCron.error).toHaveBeenCalledWith(
           "failed to start: Error: superseded start failed",
         ),
@@ -4071,11 +4078,10 @@ describe("gateway Gmail hot reload handlers", () => {
       const deferredPlan = buildGatewayReloadPlan(
         diffConfigPaths(harness.initialConfig, harness.deferredConfig),
       );
-      await vi.waitFor(() =>
-        expect(harness.requestRecoveryRestart.mock.calls).toEqual([
-          [`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined],
-        ]),
-      );
+      await vi.advanceTimersByTimeAsync(500);
+      expect(harness.requestRecoveryRestart.mock.calls).toEqual([
+        [`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined],
+      ]);
     } finally {
       hoisted.activeTaskBlockers.length = 0;
       await harness.reloader.stop();
@@ -4172,9 +4178,9 @@ describe("gateway Gmail hot reload handlers", () => {
         harness.writeConfig(acceptedConfig, `accepted-after-${_kind}`, 3);
         await vi.advanceTimersByTimeAsync(0);
         await acceptedPromotion;
-        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(500);
 
-        await vi.waitFor(() => expect(harness.requestRecoveryRestart).toHaveBeenCalledOnce());
+        expect(harness.requestRecoveryRestart).toHaveBeenCalledOnce();
       } finally {
         hoisted.activeTaskBlockers.length = 0;
         await harness.reloader.stop();
@@ -4321,11 +4327,10 @@ describe("gateway Gmail hot reload handlers", () => {
         reason: "restart-check",
         activate: false,
       });
-      await vi.waitFor(() =>
-        expect(harness.requestRecoveryRestart.mock.calls).toEqual([
-          [`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined],
-        ]),
-      );
+      await vi.advanceTimersByTimeAsync(500);
+      expect(harness.requestRecoveryRestart.mock.calls).toEqual([
+        [`config reload: ${deferredPlan.restartReasons.join(", ")}`, undefined],
+      ]);
     } finally {
       releaseEmissionPreflight();
       hoisted.activeTaskBlockers.length = 0;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -69,7 +69,13 @@ vi.mock("../agents/main-session-restart-recovery.js", async (importOriginal) => 
 });
 
 installGatewayTestHooks({ scope: "suite" });
-const FAST_WAIT_OPTS = { timeout: 2_000, interval: 5 } as const;
+const FAST_WAIT_OPTS = { timeout: 2_000, interval: 1 } as const;
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
 type GatewayHarness = Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 type GatewaySocket = Awaited<ReturnType<GatewayHarness["openWs"]>>;
 let harness: GatewayHarness;
@@ -1419,7 +1425,7 @@ describe("gateway server chat", () => {
         });
 
       const first = Promise.resolve(callSend("first"));
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
 
@@ -1460,7 +1466,7 @@ describe("gateway server chat", () => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
       expect(context.addChatRun).toHaveBeenCalledTimes(1);
       dispatchRelease.resolve();
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
     } finally {
@@ -1563,7 +1569,7 @@ describe("gateway server chat", () => {
           context,
         }),
       );
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
         expect(context.chatAbortControllers.has("idem-attachment-abort")).toBe(true);
       }, FAST_WAIT_OPTS);
@@ -1734,7 +1740,7 @@ describe("gateway server chat", () => {
           context,
         }),
       );
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.dedupe.has(pendingChatSendDedupeKey(runId))).toBe(true);
       }, FAST_WAIT_OPTS);
       expect(context.dedupe.get(collidingFinalKey)).toBe(collidingFinalEntry);
@@ -1866,7 +1872,7 @@ describe("gateway server chat", () => {
           context,
         }),
       );
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.dedupe.has(pendingChatSendDedupeKey(runId))).toBe(true);
       }, FAST_WAIT_OPTS);
 
@@ -1977,7 +1983,7 @@ describe("gateway server chat", () => {
           context,
         }),
       );
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.dedupe.has(pendingChatSendDedupeKey(runId))).toBe(true);
       }, FAST_WAIT_OPTS);
 
@@ -2055,7 +2061,7 @@ describe("gateway server chat", () => {
           context,
         }),
       );
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.dedupe.has(pendingChatSendDedupeKey(runId))).toBe(true);
       }, FAST_WAIT_OPTS);
 
@@ -2137,7 +2143,7 @@ describe("gateway server chat", () => {
           context,
         }),
       );
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.dedupe.has(pendingKey)).toBe(true);
       }, FAST_WAIT_OPTS);
       const original = context.dedupe.get(pendingKey);
@@ -2201,7 +2207,7 @@ describe("gateway server chat", () => {
           context,
         }),
       );
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.dedupe.has(terminalPendingKey)).toBe(true);
       }, FAST_WAIT_OPTS);
       const terminalResult = {
@@ -2370,14 +2376,14 @@ describe("gateway server chat", () => {
         });
 
         expect(responses[0]?.ok).toBe(true);
-        await vi.waitFor(() => expect(captured).toBeDefined(), FAST_WAIT_OPTS);
+        await waitForFast(() => expect(captured).toBeDefined(), FAST_WAIT_OPTS);
         expect(captured?.replyOptions?.images).toBeUndefined();
         expect(captured?.ctx?.MediaPath).toEqual(expect.any(String));
         expect(captured?.ctx?.MediaPaths).toEqual([expect.any(String)]);
         expect(captured?.ctx?.MediaType).toBe("image/png");
         expect(captured?.ctx?.MediaTypes).toEqual(["image/png"]);
         expect(captured?.ctx?.MediaStaged).toBe(true);
-        await vi.waitFor(() => expect(context.removeChatRun).toHaveBeenCalledTimes(1));
+        await waitForFast(() => expect(context.removeChatRun).toHaveBeenCalledTimes(1));
       } finally {
         dispatchInboundMessageMock.mockReset();
         testState.agentConfig = undefined;
@@ -2458,7 +2464,7 @@ describe("gateway server chat", () => {
       )?.replyOptions;
       expect(dispatchOptions?.suppressNextUserMessagePersistence).toBe(true);
       dispatchRelease.resolve(undefined);
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.removeChatRun).toHaveBeenCalledTimes(1),
         FAST_WAIT_OPTS,
       );
@@ -2535,7 +2541,7 @@ describe("gateway server chat", () => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
 
       dispatchRelease.resolve(undefined);
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.removeChatRun).toHaveBeenCalledTimes(1),
         FAST_WAIT_OPTS,
       );
@@ -2588,7 +2594,7 @@ describe("gateway server chat", () => {
         message: "persist, then stop",
         respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
       });
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.chatAbortControllers.get(runId)).toBeDefined(),
         FAST_WAIT_OPTS,
       );
@@ -2669,7 +2675,7 @@ describe("gateway server chat", () => {
         },
       ]);
       if (retryable) {
-        await vi.waitFor(
+        await waitForFast(
           () => expect(retryContext.removeChatRun).toHaveBeenCalledTimes(1),
           FAST_WAIT_OPTS,
         );
@@ -2887,7 +2893,7 @@ describe("gateway server chat", () => {
         respond: ((ok, payload, _error, meta) =>
           responses.push({ ok, payload, meta })) as RespondFn,
       });
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.dedupe.has(pendingChatSendDedupeKey(idempotencyKey))).toBe(true),
         FAST_WAIT_OPTS,
       );
@@ -3096,7 +3102,7 @@ describe("gateway server chat", () => {
           payload: expect.objectContaining({ runId, status: "started" }),
         },
       ]);
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.removeChatRun).toHaveBeenCalledTimes(1),
         FAST_WAIT_OPTS,
       );
@@ -3143,7 +3149,7 @@ describe("gateway server chat", () => {
           payload: expect.objectContaining({ runId, status: "started" }),
         },
       ]);
-      await vi.waitFor(
+      await waitForFast(
         () => expect(retryContext.removeChatRun).toHaveBeenCalledTimes(1),
         FAST_WAIT_OPTS,
       );
@@ -3275,7 +3281,7 @@ describe("gateway server chat", () => {
           payload: expect.objectContaining({ runId, status: "started" }),
         },
       ]);
-      await vi.waitFor(
+      await waitForFast(
         () => expect(retryContext.removeChatRun).toHaveBeenCalledTimes(1),
         FAST_WAIT_OPTS,
       );
@@ -3348,7 +3354,7 @@ describe("gateway server chat", () => {
         status: "done",
       });
       expect(ackSnapshot.entry?.restartRecoveryDeliveryRunId).toBeUndefined();
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.removeChatRun).toHaveBeenCalledTimes(1),
         FAST_WAIT_OPTS,
       );
@@ -3452,7 +3458,7 @@ describe("gateway server chat", () => {
         });
 
       const first = Promise.resolve(callSend("first", "idem-active-a"));
-      await vi.waitFor(
+      await waitForFast(
         () => {
           expect(responses).toEqual([
             {
@@ -3475,7 +3481,7 @@ describe("gateway server chat", () => {
 
       const duplicate = Promise.resolve(callSend("duplicate", "idem-active-b"));
 
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(responses).toEqual([
           {
             id: "first",
@@ -3512,7 +3518,7 @@ describe("gateway server chat", () => {
         callSend("system-context", "idem-active-c", "proposal=support-file-sampler-b"),
       );
 
-      await vi.waitFor(
+      await waitForFast(
         () => {
           expect(responses).toEqual([
             {
@@ -3564,7 +3570,7 @@ describe("gateway server chat", () => {
       const withDifferentThinking = Promise.resolve(
         callSend("different-thinking", "idem-active-d", undefined, "high"),
       );
-      await vi.waitFor(
+      await waitForFast(
         () => {
           expect(responses.at(-1)).toEqual({
             id: "different-thinking",
@@ -3587,7 +3593,7 @@ describe("gateway server chat", () => {
 
       dispatchRelease.resolve();
       await Promise.all([first, duplicate, withSystemContext, withDifferentThinking]);
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(4);
       }, FAST_WAIT_OPTS);
     } finally {
@@ -3632,7 +3638,7 @@ describe("gateway server chat", () => {
       };
 
       const first = Promise.resolve(callSend("first", "idem-new-session-a"));
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(responses[0]).toEqual({
           id: "first",
           ok: true,
@@ -3656,7 +3662,7 @@ describe("gateway server chat", () => {
       invalidateSessionStoreCache(storePath);
 
       const duplicate = Promise.resolve(callSend("duplicate", "idem-new-session-b"));
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(responses.at(-1)).toEqual({
           id: "duplicate",
           ok: true,
@@ -3668,7 +3674,7 @@ describe("gateway server chat", () => {
 
       dispatchRelease.resolve();
       await Promise.all([first, duplicate]);
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(2);
       }, FAST_WAIT_OPTS);
     } finally {
@@ -3787,7 +3793,7 @@ describe("gateway server chat", () => {
         RawBody: "/reset examples",
       });
       expect(dispatchContext).not.toHaveProperty("CommandSource");
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
     } finally {
@@ -3880,12 +3886,12 @@ describe("gateway server chat", () => {
         });
 
       await callSend("first", "first message", "idem-sequential-a");
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
 
       await callSend("second", "second message", "idem-sequential-b");
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(2);
       }, FAST_WAIT_OPTS);
 
@@ -4025,14 +4031,14 @@ describe("gateway server chat", () => {
         context,
       });
 
-      await vi.waitFor(() => expect(turnAdoptionLifecycle).toBeDefined(), FAST_WAIT_OPTS);
+      await waitForFast(() => expect(turnAdoptionLifecycle).toBeDefined(), FAST_WAIT_OPTS);
       expect(turnAdoptionLifecycle?.ownerKey).toBe("connection:conn-tui");
       expect(broadcast).not.toHaveBeenCalledWith(
         "chat",
         expect.objectContaining({ runId: "idem-queued-followup", state: "final" }),
       );
       dispatchRelease.resolve();
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(broadcast).toHaveBeenCalledWith(
           "chat",
           expect.objectContaining({
@@ -4098,7 +4104,7 @@ describe("gateway server chat", () => {
 
       turnAdoptionLifecycle?.onSettled?.();
       expect(context.chatQueuedTurns.has("idem-queued-followup")).toBe(false);
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.removeChatRun).toHaveBeenCalledTimes(1),
         FAST_WAIT_OPTS,
       );
@@ -4144,7 +4150,7 @@ describe("gateway server chat", () => {
         context,
       });
 
-      await vi.waitFor(
+      await waitForFast(
         () => expect(context.removeChatRun).toHaveBeenCalledTimes(2),
         FAST_WAIT_OPTS,
       );
@@ -4274,7 +4280,7 @@ describe("gateway server chat", () => {
           error: undefined,
         },
       ]);
-      await vi.waitFor(
+      await waitForFast(
         () => {
           const phases = broadcastToConnIds.mock.calls
             .filter(([event]) => event === "chat.send_timing")
@@ -4431,7 +4437,7 @@ describe("gateway server chat", () => {
           error: undefined,
         },
       ]);
-      await vi.waitFor(
+      await waitForFast(
         () => {
           expect(broadcastToConnIds).toHaveBeenCalledWith(
             "chat.send_timing",
@@ -5116,7 +5122,7 @@ describe("gateway server chat", () => {
         });
         expect(sendRes.ok).toBe(true);
 
-        await vi.waitFor(() => {
+        await waitForFast(() => {
           expect(spy.mock.calls.length).toBeGreaterThan(0);
         }, FAST_WAIT_OPTS);
 
@@ -5166,10 +5172,10 @@ describe("gateway server chat", () => {
             },
           });
 
-          await vi.waitFor(() => {
+          await waitForFast(() => {
             expect(spy.mock.calls.length).toBeGreaterThan(0);
           }, FAST_WAIT_OPTS);
-          await vi.waitFor(async () => {
+          await waitForFast(async () => {
             const events = await readTimelineEvents(timelinePath);
             const ackReady = events.find(
               (event) =>
@@ -5308,7 +5314,7 @@ describe("gateway server chat", () => {
         });
         expect(sendRes.ok).toBe(true);
 
-        await vi.waitFor(() => {
+        await waitForFast(() => {
           expect(spy.mock.calls.length).toBeGreaterThan(0);
         }, FAST_WAIT_OPTS);
 
@@ -5350,7 +5356,7 @@ describe("gateway server chat", () => {
         });
         expect(sendRes.ok).toBe(true);
 
-        await vi.waitFor(() => {
+        await waitForFast(() => {
           expect(spy.mock.calls.length).toBeGreaterThan(0);
         }, FAST_WAIT_OPTS);
 
@@ -6659,7 +6665,7 @@ describe("gateway server chat", () => {
 
       const sendRes = await sendResP;
       expect(sendRes.ok).toBe(true);
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(spy.mock.calls.length).toBeGreaterThan(0);
       }, FAST_WAIT_OPTS);
 
@@ -6677,7 +6683,7 @@ describe("gateway server chat", () => {
       });
       expect(abortRes.ok).toBe(true);
       expect(abortRes.payload?.aborted).toBe(true);
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(aborted).toBe(true);
       }, FAST_WAIT_OPTS);
 
@@ -6691,7 +6697,7 @@ describe("gateway server chat", () => {
       });
       expect(completeRes.ok).toBe(true);
 
-      await vi.waitFor(async () => {
+      await waitForFast(async () => {
         const again = await rpcReq<{ status?: string }>(ws, "chat.send", {
           sessionKey: "main",
           message: "hello",

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -38,6 +38,13 @@ import { installConnectedControlUiServerSuite } from "./test-with-server.js";
 installGatewayTestHooks({ scope: "suite" });
 const CHAT_RESPONSE_TIMEOUT_MS = 10_000;
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 let ws: WebSocket;
 let port: number;
 
@@ -278,11 +285,11 @@ describe("gateway server chat", () => {
 
       expect(res.ok).toBe(true);
       expect(res.payload?.status).toBe("started");
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(subordinateAdmissionClosed).toBe(false);
       });
       await finalPromise;
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(getActiveGatewayRootWorkCount()).toBe(0);
       });
     });
@@ -664,7 +671,7 @@ describe("gateway server chat", () => {
       expect(agentAllowedRes.ok).toBe(true);
       expect(agentAllowedRes.payload?.status).toBe("accepted");
       expect(agentAllowedRes.payload?.runId).toBe("idem-2");
-      await vi.waitFor(() => expect(agentCommand).toHaveBeenCalled());
+      await waitForFast(() => expect(agentCommand).toHaveBeenCalled());
 
       testState.sessionStorePath = undefined;
       testState.sessionConfig = undefined;
@@ -858,19 +865,19 @@ describe("gateway server chat", () => {
             idempotencyKey: "idem-dispatch-error-1",
           });
           expect(res.ok).toBe(true);
-          await vi.waitFor(() => {
+          await waitForFast(() => {
             expect(dispatchStarted).toBe(true);
           });
           markGatewayRestartDraining();
           rejectDispatch.resolve();
           await errorPromise;
-          await vi.waitFor(() => {
+          await waitForFast(() => {
             expect(persistenceEntered).toBe(true);
           });
           expect(getActiveGatewayRootWorkCount()).toBe(1);
           releasePersistence.resolve();
           const changed = await sessionChangedPromise;
-          await vi.waitFor(() => {
+          await waitForFast(() => {
             expect(getActiveGatewayRootWorkCount()).toBe(0);
           });
           return changed;
@@ -1636,7 +1643,7 @@ describe("gateway server chat", () => {
       });
 
       expect(res.ok).toBe(true);
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(dispatchInboundMessageMock).toHaveBeenCalled();
       });
       const sideResult = await sideResultPromise;
@@ -1717,7 +1724,7 @@ describe("gateway server chat", () => {
       });
 
       expect(res.ok).toBe(true);
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(dispatchInboundMessageMock).toHaveBeenCalled();
       });
       const sideResult = await sideResultPromise;
@@ -1781,7 +1788,7 @@ describe("gateway server chat", () => {
           await finalPromise;
 
           let assistantMessage: Record<string, unknown> | undefined;
-          await vi.waitFor(
+          await waitForFast(
             async () => {
               const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
                 sessionKey: "main",

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -37,21 +37,30 @@ const { createSessionStoreDir, createSelectedGlobalSessionStore, openClient } =
   setupGatewaySessionsTestHarness();
 const execFileAsync = promisify(execFile);
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 async function initializeGitWorkspace(root: string): Promise<string> {
   const workspace = path.join(root, "workspace");
   await fs.mkdir(workspace, { recursive: true });
   await execFileAsync("git", ["-C", workspace, "init", "-b", "main"]);
-  await execFileAsync("git", ["-C", workspace, "config", "user.name", "OpenClaw Test"]);
-  await execFileAsync("git", [
-    "-C",
-    workspace,
-    "config",
-    "user.email",
-    "openclaw-test@example.invalid",
-  ]);
   await fs.writeFile(path.join(workspace, "README.md"), "base\n");
   await execFileAsync("git", ["-C", workspace, "add", "README.md"]);
-  await execFileAsync("git", ["-C", workspace, "commit", "-m", "initial"]);
+  await execFileAsync("git", [
+    "-c",
+    "user.name=OpenClaw Test",
+    "-c",
+    "user.email=openclaw-test@example.invalid",
+    "-C",
+    workspace,
+    "commit",
+    "-m",
+    "initial",
+  ]);
   return await fs.realpath(workspace);
 }
 
@@ -125,7 +134,7 @@ test("sessions.create provisions and reuses a session worktree for later runs", 
       idempotencyKey: "session-worktree-cwd",
     });
     expect(run.ok, JSON.stringify(run)).toBe(true);
-    await vi.waitFor(() => expect(agentCommand).toHaveBeenCalled());
+    await waitForFast(() => expect(agentCommand).toHaveBeenCalled());
     expect(agentCommand.mock.calls.at(-1)?.[0]).toMatchObject({
       cwd: worktree?.path,
       workspaceDir: worktree?.path,
@@ -154,7 +163,17 @@ test("sessions.create honors worktree name/base ref and persists worktree info",
   await execFileAsync("git", ["-C", workspace, "checkout", "-b", "base-branch"]);
   await fs.writeFile(path.join(workspace, "base.txt"), "base\n");
   await execFileAsync("git", ["-C", workspace, "add", "base.txt"]);
-  await execFileAsync("git", ["-C", workspace, "commit", "-m", "base branch commit"]);
+  await execFileAsync("git", [
+    "-c",
+    "user.name=OpenClaw Test",
+    "-c",
+    "user.email=openclaw-test@example.invalid",
+    "-C",
+    workspace,
+    "commit",
+    "-m",
+    "base branch commit",
+  ]);
   const { stdout: baseCommitRaw } = await execFileAsync("git", [
     "-C",
     workspace,

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -85,6 +85,10 @@ const NODE_PAIR_REMOVE_PARAMS = {
   nodeId: "device-1",
 } as const satisfies Record<string, unknown>;
 
+function waitForFast(assertion: () => void | Promise<void>) {
+  return vi.waitFor(assertion, { interval: 1 });
+}
+
 function createLogger() {
   return {
     debug: vi.fn(),
@@ -348,14 +352,14 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     harness.sendRequest("revoke-1", "device.token.revoke", DEVICE_TOKEN_MUTATION_PARAMS);
     harness.sendRequest("queued-1", "status.summary");
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
       expect(releaseMutation).toBeTypeOf("function");
     });
 
     releaseMutation?.();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(close).toHaveBeenCalledWith(4001, "client invalidated: device-token-revoked");
     });
     expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
@@ -390,14 +394,14 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     harness.sendRequest("remove-node-1", "node.pair.remove", NODE_PAIR_REMOVE_PARAMS);
     harness.sendRequest("queued-1", "status.summary");
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
       expect(releaseMutation).toBeTypeOf("function");
     });
 
     releaseMutation?.();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(close).toHaveBeenCalledWith(4001, "client invalidated: device-pair-removed");
     });
     expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
@@ -438,13 +442,13 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     harness.sendRequest("revoke-1", "device.token.revoke", DEVICE_TOKEN_MUTATION_PARAMS);
     harness.sendRequest("queued-1", "status.summary");
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
       expect(releaseFirstMutation).toBeTypeOf("function");
     });
 
     releaseFirstMutation?.();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(handleGatewayRequest).toHaveBeenCalledTimes(2);
       expect(releaseSecondMutation).toBeTypeOf("function");
     });
@@ -454,7 +458,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     expect(handleGatewayRequest).toHaveBeenCalledTimes(2);
 
     releaseSecondMutation?.();
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(close).toHaveBeenCalledWith(4001, "client invalidated: device-token-revoked");
     });
     expect(handleGatewayRequest).toHaveBeenCalledTimes(2);
@@ -492,7 +496,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         caps: [],
       });
 
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(harness.socketSend).toHaveBeenCalled();
       });
     } finally {
@@ -519,7 +523,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: false });
     });
     resolveRefresh?.();
@@ -557,7 +561,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         auth: { token: "wrong-token" },
       });
 
-      await vi.waitFor(() => {
+      await waitForFast(() => {
         expect(close).toHaveBeenCalledWith(1008, expect.stringContaining("unauthorized"));
       });
     } finally {
@@ -637,7 +641,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       auth: { token: "test-token" },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(close).toHaveBeenCalledWith(1008, expect.stringContaining("retry later"));
     });
 
@@ -684,7 +688,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(harness.socketSend).toHaveBeenCalled();
     });
     expect(harness.advanceHandshakePhase.mock.calls.map(([phase]) => phase)).toEqual([
@@ -721,7 +725,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       caps: [],
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(harness.socketSend).toHaveBeenCalled();
     });
     const connectedClient = harness.client as {
@@ -759,7 +763,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(harness.socketSend).toHaveBeenCalled();
     });
     const connectedClient = harness.client as {
@@ -803,7 +807,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(harness.socketSend).toHaveBeenCalled();
     });
     const connectedClient = harness.client as {
@@ -842,7 +846,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(harness.socketSend).toHaveBeenCalled();
     });
     const connectedClient = harness.client as {
@@ -896,7 +900,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(close).toHaveBeenCalledWith(
         1008,
         "agent runtime identity token is only accepted from local backend gateway clients",
@@ -934,7 +938,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       },
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(close).toHaveBeenCalledWith(1008, "invalid agent runtime identity token");
     });
     expect(harness.client).toBeNull();

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -19,6 +19,13 @@ import type {
   WorkerWorkspaceReconciliationJournalAdapter,
 } from "./workspace-reconcile.js";
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 type WorkerSshProcessExit = Awaited<WorkerSshProcess["exited"]>;
 
 const HOST_KEY = [["ssh", "ed25519"].join("-"), "AAAA"].join(" ");
@@ -192,7 +199,7 @@ async function git(root: string, ...args: string[]): Promise<string> {
 const resolveIdentity = async () => ({ kind: "path", path: "/keys/worker" }) as const;
 
 async function waitForStarts(starts: unknown[], count: number) {
-  await vi.waitFor(() => expect(starts).toHaveLength(count));
+  await waitForFast(() => expect(starts).toHaveLength(count));
 }
 
 describe("worker tunnel manager", () => {
@@ -812,7 +819,7 @@ describe("worker tunnel manager", () => {
       resolveIdentity,
     });
     const rejectedReplacement = expect(replacement).rejects.toThrow("stopped before connecting");
-    await vi.waitFor(() => expect(fake.starts[0]?.process.stopCount).toBe(1));
+    await waitForFast(() => expect(fake.starts[0]?.process.stopCount).toBe(1));
 
     const stopping = manager.stop("worker:replacement");
     releaseStop.resolve();

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -34,6 +34,13 @@ import {
   resolveExistingUsageSessionFile,
 } from "./session-cost-usage.js";
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 function clearGatewayModelPricingState(): void {
   replaceGatewayModelPricingCache(new Map(), 0);
   clearGatewayModelPricingFailures();
@@ -280,7 +287,7 @@ describe("session cost usage", () => {
         agentId: "main",
         sessions: [{ sessionId, sessionFile }],
       });
-      await vi.waitFor(
+      await waitForFast(
         async () => {
           const bulk = await loadSessionCostSummariesFromCache({
             agentId: "main",
@@ -716,7 +723,7 @@ describe("session cost usage", () => {
       const session = { sessionId: "sess-batch-range", sessionFile };
       await loadSessionCostSummariesFromCache({ sessions: [session], agentId: "main" });
       const rangeEndMs = Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1;
-      await vi.waitFor(
+      await waitForFast(
         async () => {
           const ranged = await loadSessionCostSummariesFromCache({
             sessions: [session],
@@ -813,7 +820,7 @@ describe("session cost usage", () => {
     await withStateDir(root, async () => {
       const session = { sessionId: "sess-v8-upgrade", sessionFile };
       await loadSessionCostSummariesFromCache({ sessions: [session], agentId: "main" });
-      await vi.waitFor(async () => {
+      await waitForFast(async () => {
         const current = await loadSessionCostSummariesFromCache({
           sessions: [session],
           agentId: "main",
@@ -849,7 +856,7 @@ describe("session cost usage", () => {
         startMs: Date.UTC(2026, 1, 5),
         endMs: rangeEndMs,
       });
-      await vi.waitFor(async () => {
+      await waitForFast(async () => {
         const rebuilt = await loadSessionCostSummariesFromCache({
           sessions: [session],
           agentId: "main",
@@ -867,7 +874,7 @@ describe("session cost usage", () => {
         "utf-8",
       );
       await loadSessionCostSummariesFromCache({ sessions: [session], agentId: "main" });
-      await vi.waitFor(async () => {
+      await waitForFast(async () => {
         const appended = await loadSessionCostSummariesFromCache({
           sessions: [session],
           agentId: "main",
@@ -1480,7 +1487,7 @@ describe("session cost usage", () => {
       });
 
       expect(summary.totals.totalTokens).toBe(30);
-      await vi.waitFor(
+      await waitForFast(
         async () => {
           const refreshed = await loadCostUsageSummaryFromCache({
             startMs: Date.UTC(2026, 1, 5),
@@ -1532,7 +1539,7 @@ describe("session cost usage", () => {
         sessions,
         agentId: "main",
       });
-      await vi.waitFor(
+      await waitForFast(
         async () => {
           const cached = await loadSessionCostSummariesFromCache({
             sessions,

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -29,6 +29,7 @@ const { forceKillChildProcessTreeMock, spawnMock } = vi.hoisted(() => ({
   forceKillChildProcessTreeMock: vi.fn(),
   spawnMock: vi.fn(),
 }));
+const FAST_WAIT_OPTS = { interval: 1 } as const;
 
 function createSpawnMock(params?: { pid?: number }) {
   const child = Object.assign(new EventEmitter(), {
@@ -408,7 +409,7 @@ describe("managed service update handoff", () => {
       argv1: "/opt/openclaw/openclaw.mjs",
       meta: {},
     });
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
 
     const pending = Symbol("pending");
     await expect(
@@ -442,7 +443,7 @@ describe("managed service update handoff", () => {
       argv1: "/opt/openclaw/openclaw.mjs",
       meta: { sessionKey: "agent:test:webchat:dm:user-123" },
     });
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     const handoffDir = path.dirname(args[0] ?? "");
     tempDirs.add(handoffDir);
@@ -476,7 +477,7 @@ describe("managed service update handoff", () => {
       env: { PATH: binDir, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
       meta: {},
     });
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     const handoffDir = path.dirname(args.at(-2) ?? "");
     tempDirs.add(handoffDir);
@@ -509,7 +510,7 @@ describe("managed service update handoff", () => {
       meta: {},
     });
     const rejection = resultPromise.catch((err: unknown) => err);
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     const handoffDir = path.dirname(args[0] ?? "");
     tempDirs.add(handoffDir);

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -83,6 +83,13 @@ import {
   setTaskRegistryDeliveryRuntimeForTests,
 } from "./task-runtime.test-helpers.js";
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 const DEFAULT_TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
 const LOST_TASK_RETENTION_MS = 24 * 60 * 60_000;
 
@@ -296,7 +303,7 @@ function createAcpSessionStoreEntry(params: {
 }
 
 async function waitForAssertion(assertion: () => void, timeoutMs = 2_000, stepMs = 5) {
-  await vi.waitFor(assertion, { timeout: timeoutMs, interval: stepMs });
+  await waitForFast(assertion, { timeout: timeoutMs, interval: stepMs });
 }
 
 async function flushAsyncWork(times = 4) {
@@ -479,7 +486,7 @@ async function flushHeartbeatWakeRequests(): Promise<void> {
     reason: HEARTBEAT_FLUSH_REASON,
     coalesceMs: 0,
   });
-  await vi.waitFor(() => {
+  await waitForFast(() => {
     expect(heartbeatWakeRequests.some((request) => request.reason === HEARTBEAT_FLUSH_REASON)).toBe(
       true,
     );
@@ -2706,10 +2713,10 @@ describe("task-registry", () => {
         terminalSummary: "Waiting for parent review.",
       });
 
-      await vi.waitFor(() => expect(hoisted.sendMessageMock).toHaveBeenCalledOnce());
+      await waitForFast(() => expect(hoisted.sendMessageMock).toHaveBeenCalledOnce());
       expect(getActiveGatewayRootWorkCount()).toBe(1);
       releaseSend();
-      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       expectRecordFields(requireTaskByRunId("run-held-delivery"), {
         deliveryStatus: "delivered",
       });
@@ -3574,10 +3581,10 @@ describe("task-registry", () => {
 
       startTaskRegistryMaintenance();
       await vi.advanceTimersByTimeAsync(5_000);
-      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
 
       releaseInspection([]);
-      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       stopTaskRegistryMaintenance();
     });
   });

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -43,6 +43,13 @@ import {
 } from "./worker-rpc-clients.js";
 import { runWorkerDescriptor } from "./worker.runtime.js";
 
+function waitForFast<T>(
+  callback: () => T | Promise<T>,
+  options: { timeout?: number; interval?: number } = {},
+) {
+  return vi.waitFor(callback, { interval: 1, ...options });
+}
+
 const SESSION_ID = "worker-session";
 const RUN_ID = "worker-run";
 const OWNER_EPOCH = 4;
@@ -909,7 +916,7 @@ describe("worker runtime", () => {
     const { gateway, launch } = await setup({ inferencePlans: ["hold"] });
     const controller = new AbortController();
     const result = runWorkerDescriptor(launch, { signal: controller.signal });
-    await vi.waitFor(() => expect(gateway.inferenceRequests).toHaveLength(1));
+    await waitForFast(() => expect(gateway.inferenceRequests).toHaveLength(1));
 
     controller.abort(new Error("operator stopped worker"));
 
@@ -928,7 +935,7 @@ describe("worker runtime", () => {
     });
     const controller = new AbortController();
     const result = runWorkerDescriptor(launch, { signal: controller.signal });
-    await vi.waitFor(() => expect(gateway.inferenceRequests).toHaveLength(1));
+    await waitForFast(() => expect(gateway.inferenceRequests).toHaveLength(1));
 
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
@@ -1057,7 +1064,7 @@ describe("worker runtime", () => {
       reason: "owner-epoch-mismatch",
     });
     expect(gateway.inferenceRequests).toHaveLength(2);
-    await vi.waitFor(
+    await waitForFast(
       () => {
         expect(
           listRunningSessions().filter((session) => session.scopeKey === `worker:${SESSION_ID}`),
@@ -1199,7 +1206,7 @@ describe("worker reconnect clients", () => {
     });
     try {
       await connection.start();
-      await vi.waitFor(() => expect(gateway.connectionCount).toBeGreaterThanOrEqual(2));
+      await waitForFast(() => expect(gateway.connectionCount).toBeGreaterThanOrEqual(2));
     } finally {
       await connection.stop();
     }
@@ -1291,7 +1298,7 @@ describe("worker reconnect clients", () => {
           timestamp: 1,
         },
       ]);
-      await vi.waitFor(() => expect(gateway.transcriptRequests).toHaveLength(1));
+      await waitForFast(() => expect(gateway.transcriptRequests).toHaveLength(1));
 
       await connection.stop();
       await expect(commit).rejects.toBeInstanceOf(WorkerConnectionStoppedError);


### PR DESCRIPTION
## What Problem This Solves

Large async test suites spend avoidable wall time waiting for Vitest's default polling cadence and spawning extra Git configuration subprocesses. The slow feedback compounds across local validation and CI.

## Why This Change Was Made

This test-only change applies 1 ms polling to twelve bounded async test surfaces, replaces fake-timer polling with deterministic clock advancement, and passes Git commit identity inline instead of configuring each temporary repository. Test coverage and production behavior stay unchanged. No CI workflow or configuration files change.

AI-assisted: yes. I reviewed the complete diff and ran the repository autoreview workflow.

## User Impact

Developers and CI get faster test feedback. There is no runtime or user-visible product behavior change.

## Evidence

- Same-box warm A/B: `task-registry.test.ts` 13.78 s -> 1.85 s; `server-reload-handlers.test.ts` 2.17 s -> 0.12 s.
- Same-box warm A/B for the additional round: `message-handler.post-connect-health.test.ts` test body 947 ms -> 79 ms.
- Same-box warm A/B for round 12: `server-cron-notifications.test.ts` test body 333 ms -> 43 ms.
- Focused proof: all 605 tests passed across the 12 changed files; four Vitest shards completed in 58.28 s on Blacksmith Testbox `tbx_01kxrw97hgdc79s7a1sgecj12b`.
- `pnpm check:changed`: exit 0, including max-lines, formatting, core-test typecheck, and all core lint shards; Blacksmith Testbox `tbx_01kxrsce4se4pp55qxmykv0jq1`.
- Round-12 path-scoped `pnpm check:changed`: exit 0, including formatting, max-lines, core-test typecheck, and targeted lint; Blacksmith Testbox `tbx_01kxrw97hgdc79s7a1sgecj12b`.
- Branch autoreview: clean, no accepted/actionable findings.
