### PR TITLE
fix(mac): open the receiving agent's conversation from Quick Chat under global scope

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
+++ b/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
@@ -19,11 +19,15 @@ enum AppNavigationActions {
         }
     }
 
-    static func openChat() {
+    static func openChat(sessionKey: String? = nil, agentID: String? = nil) {
         NSApp.activate(ignoringOtherApps: true)
         Task { @MainActor in
-            let sessionKey = await WebChatManager.shared.preferredSessionKey()
-            WebChatManager.shared.show(sessionKey: sessionKey)
+            let resolvedSessionKey = if let sessionKey {
+                sessionKey
+            } else {
+                await WebChatManager.shared.preferredSessionKey()
+            }
+            WebChatManager.shared.show(sessionKey: resolvedSessionKey, agentID: agentID)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -34,6 +34,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     typealias MonitorClearer = (inout Any?) -> Void
     typealias HotkeyRegistrar = (@escaping () -> Void) -> Void
     typealias HotkeyRemover = () -> Void
+    typealias ChatOpener = @MainActor (_ sessionKey: String?, _ agentID: String?) -> Void
 
     static let shared = QuickChatController()
 
@@ -48,6 +49,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     @ObservationIgnored private let monitorClearer: MonitorClearer
     @ObservationIgnored private let hotkeyRegistrar: HotkeyRegistrar
     @ObservationIgnored private let hotkeyRemover: HotkeyRemover
+    @ObservationIgnored private let chatOpener: ChatOpener
     @ObservationIgnored private let allowsHotkeyRegistrationInTests: Bool
     @ObservationIgnored private var panel: QuickChatPanel?
     @ObservationIgnored private var hostingView: NSHostingView<QuickChatView>?
@@ -82,6 +84,9 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         hotkeyRemover: @escaping HotkeyRemover = {
             KeyboardShortcuts.removeHandler(for: .toggleQuickChat)
         },
+        chatOpener: @escaping ChatOpener = { sessionKey, agentID in
+            AppNavigationActions.openChat(sessionKey: sessionKey, agentID: agentID)
+        },
         allowsHotkeyRegistrationInTests: Bool = false)
     {
         self.enableUI = enableUI
@@ -92,6 +97,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         self.monitorClearer = monitorClearer
         self.hotkeyRegistrar = hotkeyRegistrar
         self.hotkeyRemover = hotkeyRemover
+        self.chatOpener = chatOpener
         self.allowsHotkeyRegistrationInTests = allowsHotkeyRegistrationInTests
         super.init()
     }
@@ -262,21 +268,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
             model: self.model,
             onDismiss: { [weak self] in self?.dismiss() },
             onSendAccepted: { [weak self] openChat in
-                guard let self else { return }
-                // Command-Return must open the session that actually received the send;
-                // the accepted route is immutable, unlike live model routing state.
-                let route = self.model.lastAcceptedRoute
-                self.dismiss()
-                guard openChat else { return }
-                if let route, !route.sessionKey.isEmpty {
-                    // Accepted tradeoff: in global scope the window opens the shared "global"
-                    // session without the agent discriminator; threading route.agentID through
-                    // the WebChat window contract is a follow-up if that config needs it.
-                    NSApp.activate(ignoringOtherApps: true)
-                    WebChatManager.shared.show(sessionKey: route.sessionKey)
-                } else {
-                    AppNavigationActions.openChat()
-                }
+                self?.handleSendAccepted(openChat: openChat)
             },
             onShowAgentPicker: { [weak self] in
                 self?.showAgentPicker()
@@ -291,6 +283,19 @@ final class QuickChatController: NSObject, NSWindowDelegate {
                 self?.textView = textView
                 self?.focusEditor()
             })
+    }
+
+    private func handleSendAccepted(openChat: Bool) {
+        // Command-Return must open the immutable route that accepted the send,
+        // not live model routing state that may already have changed.
+        let route = self.model.lastAcceptedRoute
+        self.dismiss()
+        guard openChat else { return }
+        if let route, !route.sessionKey.isEmpty {
+            self.chatOpener(route.sessionKey, route.agentID)
+        } else {
+            self.chatOpener(nil, nil)
+        }
     }
 
     private func updateContentHeight(_ height: CGFloat) {
@@ -432,6 +437,10 @@ final class QuickChatController: NSObject, NSWindowDelegate {
 
     var hotkeyRegisteredForTesting: Bool {
         self.hotkeyRegistered
+    }
+
+    func handleSendAcceptedForTesting(openChat: Bool) {
+        self.handleSendAccepted(openChat: openChat)
     }
     #endif
 }

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -17,58 +17,89 @@ enum WebChatPresentation {
     case panel(anchorProvider: () -> NSRect?)
 }
 
+struct WebChatRoute: Equatable, Sendable {
+    let sessionKey: String
+    let agentID: String?
+
+    init(sessionKey: String, agentID: String?) {
+        self.sessionKey = sessionKey
+        self.agentID = Self.normalizedAgentID(agentID)
+    }
+
+    func replacingSessionKey(_ sessionKey: String) -> Self {
+        Self(sessionKey: sessionKey, agentID: self.agentID)
+    }
+
+    static func normalizedAgentID(_ agentID: String?) -> String? {
+        let normalized = agentID?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized?.isEmpty == false ? normalized : nil
+    }
+}
+
 @MainActor
 final class WebChatManager {
     static let shared = WebChatManager()
 
     private var windowController: WebChatSwiftUIWindowController?
-    private var windowSessionKey: String?
+    private var windowRoute: WebChatRoute?
     private var panelController: WebChatSwiftUIWindowController?
-    private var panelSessionKey: String?
-    private var currentChatSessionKey: String?
+    private var panelRoute: WebChatRoute?
+    private var currentChatRoute: WebChatRoute?
     private var cachedPreferredSessionKey: String?
 
     var onPanelVisibilityChanged: ((Bool) -> Void)?
 
     var activeSessionKey: String? {
-        self.currentChatSessionKey ?? self.panelSessionKey ?? self.windowSessionKey
+        self.currentChatRoute?.sessionKey ?? self.panelRoute?.sessionKey ?? self.windowRoute?.sessionKey
     }
 
-    func show(sessionKey: String) {
+    func show(sessionKey: String, agentID: String? = nil) {
+        let route = WebChatRoute(sessionKey: sessionKey, agentID: agentID)
         self.closePanel()
         if let controller = self.windowController {
             // The window shell switches sessions in place (sidebar, /new);
-            // windowSessionKey tracks those switches, so a window already on
-            // the requested session must not be torn down and re-bootstrapped.
-            if self.windowSessionKey == sessionKey {
+            // full route identity tracks those switches and the global owner.
+            if Self.shouldReuseController(currentRoute: self.windowRoute, requestedRoute: route) {
                 controller.show()
                 return
             }
 
             controller.close()
             self.windowController = nil
-            self.windowSessionKey = nil
+            self.windowRoute = nil
         }
-        let controller = WebChatSwiftUIWindowController(sessionKey: sessionKey, presentation: .window)
+        let controller = WebChatSwiftUIWindowController(
+            sessionKey: route.sessionKey,
+            agentID: route.agentID,
+            presentation: .window)
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)
         }
-        controller.onSessionKeyChanged = { [weak self] key in
-            self?.windowSessionKey = key
-            self?.currentChatSessionKey = key
+        controller.onSessionKeyChanged = { [weak self, weak controller] key in
+            guard let self, let controller, self.windowController === controller else { return }
+            // Retaining the agent is safe: this surface has no in-window agent switcher,
+            // and the controller pins explicit agents against gateway-default changes.
+            let updatedRoute = (self.windowRoute ?? route).replacingSessionKey(key)
+            self.windowRoute = updatedRoute
+            self.currentChatRoute = updatedRoute
         }
         self.windowController = controller
-        self.windowSessionKey = sessionKey
-        self.currentChatSessionKey = sessionKey
+        self.windowRoute = route
+        self.currentChatRoute = route
         controller.show()
     }
 
-    func togglePanel(sessionKey: String, anchorProvider: @escaping () -> NSRect?) {
+    func togglePanel(
+        sessionKey: String,
+        agentID: String? = nil,
+        anchorProvider: @escaping () -> NSRect?)
+    {
+        let route = WebChatRoute(sessionKey: sessionKey, agentID: agentID)
         if let controller = self.panelController {
-            if self.panelSessionKey != sessionKey {
+            if !Self.shouldReuseController(currentRoute: self.panelRoute, requestedRoute: route) {
                 controller.close()
                 self.panelController = nil
-                self.panelSessionKey = nil
+                self.panelRoute = nil
             } else {
                 if controller.isVisible {
                     controller.close()
@@ -80,7 +111,8 @@ final class WebChatManager {
         }
 
         let controller = WebChatSwiftUIWindowController(
-            sessionKey: sessionKey,
+            sessionKey: route.sessionKey,
+            agentID: route.agentID,
             presentation: .panel(anchorProvider: anchorProvider))
         controller.onClosed = { [weak self] in
             self?.panelHidden()
@@ -88,20 +120,24 @@ final class WebChatManager {
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)
         }
-        controller.onSessionKeyChanged = { [weak self] key in
-            self?.panelSessionKey = key
-            self?.currentChatSessionKey = key
+        controller.onSessionKeyChanged = { [weak self, weak controller] key in
+            guard let self, let controller, self.panelController === controller else { return }
+            let updatedRoute = (self.panelRoute ?? route).replacingSessionKey(key)
+            self.panelRoute = updatedRoute
+            self.currentChatRoute = updatedRoute
         }
         self.panelController = controller
-        self.panelSessionKey = sessionKey
-        self.currentChatSessionKey = sessionKey
+        self.panelRoute = route
+        self.currentChatRoute = route
         controller.presentAnchored(anchorProvider: anchorProvider)
     }
 
     func recordActiveSessionKey(_ sessionKey: String) {
         let trimmed = sessionKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        self.currentChatSessionKey = trimmed
+        let route = self.currentChatRoute ?? self.panelRoute ?? self.windowRoute
+        self.currentChatRoute = route?.replacingSessionKey(trimmed)
+            ?? WebChatRoute(sessionKey: trimmed, agentID: nil)
     }
 
     func closePanel() {
@@ -118,11 +154,11 @@ final class WebChatManager {
     func resetTunnels() {
         self.windowController?.close()
         self.windowController = nil
-        self.windowSessionKey = nil
+        self.windowRoute = nil
         self.panelController?.close()
         self.panelController = nil
-        self.panelSessionKey = nil
-        self.currentChatSessionKey = nil
+        self.panelRoute = nil
+        self.currentChatRoute = nil
         self.cachedPreferredSessionKey = nil
     }
 
@@ -133,5 +169,12 @@ final class WebChatManager {
     private func panelHidden() {
         self.onPanelVisibilityChanged?(false)
         // Keep panel controller cached so reopening doesn't re-bootstrap.
+    }
+
+    static func shouldReuseController(
+        currentRoute: WebChatRoute?,
+        requestedRoute: WebChatRoute) -> Bool
+    {
+        currentRoute == requestedRoute
     }
 }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -737,6 +737,7 @@ private final class WebChatSessionKeyRelay {
 final class WebChatSwiftUIWindowController {
     private let presentation: WebChatPresentation
     private let sessionKey: String
+    private let initialActiveAgentID: String?
     private let contentController: NSViewController
     private let sessionKeyRelay: WebChatSessionKeyRelay
     private let speech: OpenClawChatSpeechController
@@ -749,21 +750,44 @@ final class WebChatSwiftUIWindowController {
     /// composer picker, /new) so the owner can track what this surface shows.
     var onSessionKeyChanged: ((String) -> Void)?
 
-    convenience init(sessionKey: String, presentation: WebChatPresentation) {
+    convenience init(
+        sessionKey: String,
+        agentID: String? = nil,
+        presentation: WebChatPresentation)
+    {
         // Connection-mode changes tear chat windows down via resetTunnels(),
         // so binding the cache identity at construction stays correct. One
         // store instance backs both the transcript cache and the offline
         // command outbox.
         let context = MacChatTranscriptCache.makeContext()
-        let store = context?.store
+        self.init(
+            sessionKey: sessionKey,
+            agentID: agentID,
+            presentation: presentation,
+            cachedRoutingIdentity: context?.routingIdentity,
+            store: context?.store)
+    }
+
+    convenience init(
+        sessionKey: String,
+        agentID: String?,
+        presentation: WebChatPresentation,
+        cachedRoutingIdentity: OpenClawChatSessionRoutingIdentity?,
+        store: OpenClawChatSQLiteTranscriptCache?)
+    {
+        let explicitAgentID = WebChatRoute.normalizedAgentID(agentID)
+        let effectiveAgentID = Self.effectiveAgentID(
+            explicitAgentID: explicitAgentID,
+            cachedDefaultAgentID: cachedRoutingIdentity?.defaultAgentID)
         self.init(
             sessionKey: sessionKey,
             presentation: presentation,
             transport: MacGatewayChatTransport(
                 outboxGatewayID: store?.gatewayID,
-                defaultGlobalAgentID: context?.routingIdentity?.defaultAgentID),
-            initialActiveAgentID: context?.routingIdentity?.defaultAgentID,
-            initialSessionRoutingContract: context?.routingIdentity?.contract,
+                defaultGlobalAgentID: effectiveAgentID),
+            initialActiveAgentID: effectiveAgentID,
+            explicitAgentID: explicitAgentID,
+            initialSessionRoutingContract: cachedRoutingIdentity?.contract,
             transcriptCache: store,
             outbox: store)
     }
@@ -773,12 +797,15 @@ final class WebChatSwiftUIWindowController {
         presentation: WebChatPresentation,
         transport: any OpenClawChatTransport,
         initialActiveAgentID: String? = nil,
+        explicitAgentID: String? = nil,
         initialSessionRoutingContract: String? = nil,
         transcriptCache: (any OpenClawChatTranscriptCache)? = nil,
         outbox: (any OpenClawChatCommandOutbox)? = nil)
     {
         self.sessionKey = sessionKey
         self.presentation = presentation
+        let initialActiveAgentID = WebChatRoute.normalizedAgentID(initialActiveAgentID)
+        self.initialActiveAgentID = initialActiveAgentID
         let voiceNoteRecorder = OpenClawVoiceNoteRecorder()
         voiceNoteRecorder.setCaptureAdmissionHandler {
             !AppStateStore.shared.talkEnabled
@@ -808,6 +835,7 @@ final class WebChatSwiftUIWindowController {
             onThinkingLevelChanged: { level in
                 UserDefaults.standard.set(level, forKey: webChatThinkingLevelDefaultsKey)
             })
+        let explicitAgentID = WebChatRoute.normalizedAgentID(explicitAgentID)
         Task { @MainActor [weak vm] in
             let pushes = await GatewayConnection.shared.subscribe()
             for await push in pushes {
@@ -821,8 +849,13 @@ final class WebChatSwiftUIWindowController {
                     nil
                 }
                 if let routingIdentity {
+                    // An explicit navigation agent owns this window; gateway
+                    // default refreshes only supply the fallback route.
+                    let effectiveAgentID = Self.effectiveAgentID(
+                        explicitAgentID: explicitAgentID,
+                        cachedDefaultAgentID: routingIdentity.defaultAgentID)
                     (transport as? MacGatewayChatTransport)?
-                        .updateDefaultGlobalAgentID(routingIdentity.defaultAgentID)
+                        .updateDefaultGlobalAgentID(effectiveAgentID)
                     if let store = transcriptCache as? OpenClawChatSQLiteTranscriptCache,
                        store.gatewayID == MacChatTranscriptCache.currentGatewayID(),
                        let persistedIdentity = OpenClawChatSessionRoutingIdentity(
@@ -831,7 +864,7 @@ final class WebChatSwiftUIWindowController {
                         await store.storeSessionRoutingIdentity(persistedIdentity)
                     }
                     vm.syncDeliveryIdentity(
-                        activeAgentId: routingIdentity.defaultAgentID,
+                        activeAgentId: effectiveAgentID,
                         sessionRoutingContract: routingIdentity.contract)
                 }
             }
@@ -967,6 +1000,14 @@ final class WebChatSwiftUIWindowController {
         return stored
     }
 
+    static func effectiveAgentID(
+        explicitAgentID: String?,
+        cachedDefaultAgentID: String?) -> String?
+    {
+        WebChatRoute.normalizedAgentID(explicitAgentID)
+            ?? WebChatRoute.normalizedAgentID(cachedDefaultAgentID)
+    }
+
     private static func makeWindow(
         for presentation: WebChatPresentation,
         contentViewController: NSViewController) -> NSWindow
@@ -1095,6 +1136,10 @@ final class WebChatSwiftUIWindowController {
         return self.contentController.children
             .compactMap { $0 as? NSHostingController<MacChatSurface> }
             .first?.rootView._testCapabilities
+    }
+
+    var _testActiveAgentID: String? {
+        self.initialActiveAgentID
     }
     #endif
 }

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
@@ -6,6 +6,44 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct QuickChatControllerTests {
+    @Test func `accepted global route opens chat with its agent`() async {
+        var openedRoute: QuickChatRoutingTarget?
+        let model = QuickChatModel(
+            sessionKeyProvider: { "main" },
+            agentsProvider: {
+                AgentsListResult(
+                    defaultid: "main",
+                    mainkey: "main",
+                    scope: AnyCodable("global"),
+                    agents: [
+                        AgentSummary(id: "main", name: "Main"),
+                        AgentSummary(id: "work", name: "Work"),
+                    ])
+            },
+            agentIdentityProvider: { _ in .placeholder },
+            sendProvider: { _, _, _, _, _ in "ok" },
+            permissionStatusProvider: { _ in [:] },
+            permissionGrantProvider: { _ in [:] },
+            connectionGateProvider: { .available })
+        let controller = QuickChatController(
+            enableUI: false,
+            model: model,
+            monitoringEnabled: false,
+            chatOpener: { sessionKey, agentID in
+                guard let sessionKey else { return }
+                openedRoute = QuickChatRoutingTarget(sessionKey: sessionKey, agentID: agentID)
+            })
+        let presentationID = model.beginPresentation()
+        await model.refreshForPresentation(id: presentationID)
+        model.selectAgent("work")
+        model.text = "hello"
+
+        #expect(await model.send())
+        controller.handleSendAcceptedForTesting(openChat: true)
+        #expect(openedRoute == QuickChatRoutingTarget(sessionKey: "global", agentID: "work"))
+        controller.stop()
+    }
+
     @Test func `controller lifecycle cleans monitor tokens without UI`() {
         let snapshots = QuickChatController.exerciseForTesting()
 

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatManagerTests.swift
@@ -4,6 +4,24 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct WebChatManagerTests {
+    @Test func `controller reuse requires the full normalized route`() {
+        let work = WebChatRoute(sessionKey: "global", agentID: " Work ")
+        let sameWork = WebChatRoute(sessionKey: "global", agentID: "work")
+        let main = WebChatRoute(sessionKey: "global", agentID: "main")
+
+        #expect(work == sameWork)
+        #expect(WebChatManager.shouldReuseController(currentRoute: work, requestedRoute: sameWork))
+        #expect(!WebChatManager.shouldReuseController(currentRoute: work, requestedRoute: main))
+        #expect(!WebChatManager.shouldReuseController(
+            currentRoute: work,
+            requestedRoute: WebChatRoute(sessionKey: "main", agentID: "work")))
+    }
+
+    @Test func `blank agent route normalizes to nil`() {
+        #expect(WebChatRoute(sessionKey: "global", agentID: "  ") ==
+            WebChatRoute(sessionKey: "global", agentID: nil))
+    }
+
     @Test func `preferred session key is non empty`() async {
         let key = await WebChatManager.shared.preferredSessionKey()
         #expect(!key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -88,6 +88,30 @@ struct WebChatSwiftUISmokeTests {
         controller.close()
     }
 
+    @Test func `controller explicit agent wins and nil falls back to cached default`() throws {
+        let cachedIdentity = try #require(OpenClawChatSessionRoutingIdentity(
+            scope: "global",
+            mainSessionKey: "main",
+            defaultAgentID: "main"))
+        let explicit = WebChatSwiftUIWindowController(
+            sessionKey: "global",
+            agentID: " Work ",
+            presentation: .window,
+            cachedRoutingIdentity: cachedIdentity,
+            store: nil)
+        let fallback = WebChatSwiftUIWindowController(
+            sessionKey: "global",
+            agentID: nil,
+            presentation: .window,
+            cachedRoutingIdentity: cachedIdentity,
+            store: nil)
+
+        #expect(explicit._testActiveAgentID == "work")
+        #expect(fallback._testActiveAgentID == "main")
+        explicit.close()
+        fallback.close()
+    }
+
     @Test func `max and Ultra thinking preferences survive reopen`() throws {
         let suiteName = "WebChatSwiftUISmokeTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -22,6 +22,8 @@ Press Option-Space (⌥Space) or choose **Quick Chat** from the menu bar menu to
 
 Quick Chat shows the targeted agent (avatar or emoji, with the agent's name as the placeholder), sends to that agent's main session, and leaves replies in the full chat window. With more than one agent configured, click the avatar to switch agents from a native menu. Press Return to send, Command-Return to send and open full chat, Shift-Return for a newline, or Escape to dismiss. Clicking outside the bar also dismisses it. When relevant macOS permissions are missing, an attached strip offers **Grant** and **Not now** actions.
 
+Command-Return opens the conversation of the agent that received the send, including when session scope is global.
+
 The camera button starts a window screenshot: every visible window gets a labeled overlay, and clicking one captures it and sends it (with any typed text as the caption) to the selected agent. The first use asks for macOS Screen Recording access. Escape or clicking empty space cancels.
 
 Disable the feature entirely with **Settings → General → Quick Chat**; the same section hosts the shortcut recorder.


### PR DESCRIPTION
## What Problem This Solves

Closes the known limitation shipped in #109952: after Quick Chat sends to a non-default agent under **global** session scope, Command-Return opened the unqualified `global` WebChat — the default agent's conversation — because the WebChat window contract had no agent discriminator (`chat.send` permits a separate `agentId` only for global routing, and each agent owns its own `global` store).

## Why This Change Was Made

Minimal threading through existing seams — the shared chat UI already supports per-agent global routing (`MacGatewayChatTransport(defaultGlobalAgentID:)`, `initialActiveAgentID:`); only the macOS plumbing dropped it:

- `WebChatRoute` (session key + normalized agent id) replaces string tracking in `WebChatManager`; window/panel reuse compares the full route, and session-key callbacks retain the explicit agent while guarding against stale controllers (fixing a latent stale-callback clobber in the process).
- `WebChatSwiftUIWindowController` gains an optional `agentID`; an explicit selection feeds the existing transport/view-model seams and is pinned against gateway-default refreshes (`explicitAgentID ?? latestDefaultAgentID`).
- `AppNavigationActions.openChat(sessionKey:agentID:)` is route-aware with unchanged no-arg behavior; Quick Chat's Command-Return now opens the accepted route's conversation — global scope included — and the v2 tradeoff comment is retired.

## User Impact

Command-Return after a Quick Chat send always lands in the conversation that received the message, for any agent and any session scope. All existing entry points behave exactly as before (nil agent = today's default resolution; canonical `agent:<id>:…` keys ignore ambient agents by existing resolver rules).

Release-note context: `fix(mac): Quick Chat Command-Return opens the receiving agent's conversation under global session scope`.

## Evidence

- Design follows a validated code recon of the shared-UI seams (462 lines, file:line-cited); no protocol, server, or shared-kit changes.
- Structured autoreview (Codex gpt-5.6-sol, xhigh): build-time pass clean; my independent pass raised one finding — manager routes going stale if the window switched agents internally — rejected with source proof: `activeAgentId` mutates only from routing-snapshot updates (ChatViewModel.swift:534), this surface has no in-window agent switcher, and explicit routes are pinned by the controller precedence; the invariant is now documented at the callback site.
- Tests: route-identity reuse (same key/different agent → fresh controller), explicit-vs-default precedence, Quick Chat navigation seam passing both route components; suites follow the established patterns.
- Local gates: release build pass, lint 0, format 0, `git diff --check` clean; `swift test` runs on the macos-swift CI lane (author machine blocked by pre-existing Xcode-beta errors in untouched files).
