### PR TITLE
fix(active-memory): honor abortSignal during recall cleanup retry delays

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -846,6 +846,74 @@ describe("active-memory plugin", () => {
     );
   });
 
+  it("runs a subsequent recall normally after an aborted cleanup leaves the session entry", async () => {
+    testing.setMinimumTimeoutMsForTests(1);
+    testing.setSetupGraceTimeoutMsForTests(0);
+    // Let the timeout path wait for the subagent so the cleanup retry schedule
+    // (or the aborted shortcut) fully settles before the assertions run.
+    testing.setTimeoutPartialDataGraceMsForTests(500);
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 20,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    // Transient failure only for the aborted recall's first cleanup attempt;
+    // the subsequent recall's cleanup falls back to the default store behavior.
+    hoisted.cleanupSessionLifecycleArtifacts.mockRejectedValueOnce(
+      new Error("session store is busy"),
+    );
+
+    const startedAt = Date.now();
+    await requireHook("before_prompt_build")(
+      { prompt: "what wings should i order? abort then recall again", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    // The 20ms watchdog aborts the recall while cleanup waits out the first
+    // 50ms retry backoff, so the remaining retries never run and the aborted
+    // recall's session entry is left behind in the store.
+    expect(hoisted.cleanupSessionLifecycleArtifacts).toHaveBeenCalledTimes(1);
+    expect(Date.now() - startedAt).toBeLessThan(300);
+    const abortedSessionKey = requireNonEmptyString(
+      lastRuntimeEmbeddedRunParams().sessionKey,
+      "expected aborted runtime session key",
+    );
+    expect(hoisted.sessionStore[abortedSessionKey]).toBeDefined();
+
+    // The next recall against the same store must proceed normally: no lock
+    // error from the leftover entry, no hang, and its own cleanup succeeds.
+    api.pluginConfig = {
+      agents: ["main"],
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const result = await requireHook("before_prompt_build")(
+      { prompt: "what wings should i order? subsequent recall", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    expectPrependContextContains(result, "lemon pepper wings");
+    expect(hoisted.cleanupSessionLifecycleArtifacts).toHaveBeenCalledTimes(2);
+    const subsequentSessionKey = requireNonEmptyString(
+      lastRuntimeEmbeddedRunParams().sessionKey,
+      "expected subsequent runtime session key",
+    );
+    expect(subsequentSessionKey).not.toBe(abortedSessionKey);
+    expect(hoisted.sessionStore[subsequentSessionKey]).toBeUndefined();
+    expect(api.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed to clean up recall session"),
+    );
+  });
+
   it("registers a session-scoped active-memory toggle command", async () => {
     const command = registeredCommands["active-memory"];
     const sessionKey = "agent:main:active-memory-toggle";

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -810,6 +810,42 @@ describe("active-memory plugin", () => {
     );
   });
 
+  it("stops recall session cleanup retries when the recall aborts mid-backoff", async () => {
+    testing.setMinimumTimeoutMsForTests(1);
+    testing.setSetupGraceTimeoutMsForTests(0);
+    // Let the timeout path wait for the subagent so the cleanup retry schedule
+    // (or the aborted shortcut) fully settles before the assertions run.
+    testing.setTimeoutPartialDataGraceMsForTests(500);
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 20,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    hoisted.cleanupSessionLifecycleArtifacts.mockRejectedValue(
+      new Error("session store remains busy"),
+    );
+
+    const startedAt = Date.now();
+    await requireHook("before_prompt_build")(
+      { prompt: "what wings should i order? abort cleanup retry", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    // The 20ms watchdog aborts the recall while cleanup waits out the first
+    // 50ms retry backoff; cleanup must honor the abort instead of running the
+    // full [0, 50, 250]ms schedule to exhaustion.
+    expect(hoisted.cleanupSessionLifecycleArtifacts).toHaveBeenCalledTimes(1);
+    expect(Date.now() - startedAt).toBeLessThan(300);
+    expect(api.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed to clean up recall session"),
+    );
+  });
+
   it("registers a session-scoped active-memory toggle command", async () => {
     const command = registeredCommands["active-memory"];
     const sessionKey = "agent:main:active-memory-toggle";

--- a/extensions/active-memory/recall-run.ts
+++ b/extensions/active-memory/recall-run.ts
@@ -106,13 +106,24 @@ async function cleanupActiveMemoryRecallSession(params: {
   sessionId: string;
   sessionKey: string;
   storePath: string;
+  abortSignal?: AbortSignal;
 }): Promise<void> {
   const sessionKeySegmentPrefix =
     parseAgentSessionKey(params.sessionKey)?.rest ?? params.sessionKey;
   let lastError: unknown;
   for (const delayMs of ACTIVE_MEMORY_CLEANUP_RETRY_DELAYS_MS) {
     if (delayMs > 0) {
-      await sleep(delayMs);
+      try {
+        await sleep(delayMs, undefined, { signal: params.abortSignal });
+      } catch (error) {
+        // A cancelled recall must not wait out the remaining backoff schedule.
+        // Return without throwing so the finally-chain caller keeps the main
+        // outcome instead of a late cleanup AbortError.
+        if (params.abortSignal?.aborted) {
+          return;
+        }
+        throw error;
+      }
     }
     try {
       const result = await cleanupSessionLifecycleArtifacts({
@@ -408,6 +419,7 @@ async function runRecallSubagent(params: {
           sessionId: subagentSessionId,
           sessionKey: subagentSessionKey,
           storePath,
+          abortSignal: params.abortSignal,
         }).catch((error: unknown) => {
           const message = toSingleLineLogValue(
             error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## What Problem This Solves

`cleanupActiveMemoryRecallSession` in `extensions/active-memory/recall-run.ts` retries session-artifact cleanup on a `[0, 50, 250]ms` schedule using bare `node:timers/promises` sleeps. The outer `runRecallSubagent` already accepts `params.abortSignal` (wired to the real controller in `recall.ts`) and honors it everywhere else, but the cleanup retry loop never received it — a cancelled recall still waited out the remaining backoff schedule inside the `finally` chain, and a late `AbortError` risked masking the main outcome.

Honest scope note: the absolute latency at stake is ~300ms. The value here is contract consistency — every other stage of the recall already honors the same signal, and cancellation during cleanup now returns promptly without being misreported as a cleanup failure.

## Why This Change Was Made

`node:timers/promises` `setTimeout` natively supports `{ signal }`, so the cleanup params simply thread `abortSignal` through and pass it to the sleep. An abort rejection returns early instead of throwing: the call site's `.catch` logs "failed to clean up recall session" and rethrows, and a cancelled cleanup is not a failure — letting the AbortError propagate there would both misreport it and risk masking the main-flow outcome in the `finally` chain. Non-abort errors (including the initial attempt at `delayMs: 0`, which always runs) keep the exact previous behavior.

## Changes

- Add optional `abortSignal` to the cleanup params; pass it to the backoff sleep via the native `{ signal }` option (zero new dependencies).
- Return early on abort; rethrow anything else unchanged. Pass `params.abortSignal` at the recall call site.
- Regression test: cleanup mock always rejects, the recall's own 20ms watchdog aborts during the first 50ms backoff; asserts exactly one cleanup attempt, sub-300ms wall clock, and no spurious cleanup-failure warning.
- Subsequent-recall regression test: after an aborted cleanup leaves the recall session entry behind, the next recall against the same store proceeds normally — resolves with the recall result, no lock error, its own cleanup succeeds, no cleanup-failure warning.

## User Impact

Cancelling or timing out a recall now tears down promptly instead of lingering through the remaining cleanup backoff, and cancellation is no longer logged as a cleanup failure.

## Evidence

Exact head: `533489c05cca5630ce7aa2b35ec244ee8532b7fc`.

**Outside-runner behavior proof** — the production `runRecallSubagent` is driven directly (no test runner) via `node --import tsx` against a real on-disk SQLite agent session store under a temp `OPENCLAW_STATE_DIR`. A real transient fault is injected for the aborted recall's first cleanup attempt (the database path is swapped to a directory, so the production SQLite open fails); an ESM loader seam counts `cleanupSessionLifecycleArtifacts` attempts while delegating every call to the real production implementation. Disk readback opens the real database after each recall.

After fix — the timed-out recall keeps its main outcome and returns at 251ms with the remaining retries cut; the leftover session entry is visible on disk; the subsequent recall on the same store resolves in 25ms, returns the recall result, cleans its own entry, and logs no warning:

```text
$ TSX_TSCONFIG_PATH=tsconfig.proof.json node --import tsx /tmp/recall-abort-proof.mts; echo "EXIT=$?"
[proof] real session store: /tmp/openclaw-recall-abort-proof-rmOt4J/state/agents/main/sessions/sessions.json
[proof] real sqlite database: /tmp/openclaw-recall-abort-proof-rmOt4J/state/agents/main/agent/openclaw-agent.sqlite
[proof] embedded recall run sessionId=active-memory-mrpmngc7-7232d1f8 at +176ms
[proof] cleanup attempt #1 at +179ms
[proof] injected real fault: .../openclaw-agent.sqlite is now a directory (SQLite open must fail)
[proof] abort fired at +249ms (simulates timed-out recall)
[proof] recall#1 settled=resolved elapsed=251ms attempts=1 reply="- lemon pepper wings\n- blue cheese" error=""
[proof] disk readback after recall#1: session_entries keys=["agent:main:main:active-memory:bbef4024fbe3"]
[proof] check ok: aborted recall left its session entry behind (cleanup was cut short)
[proof] embedded recall run sessionId=active-memory-mrpmngj8-a2af8f44 at +271ms
[proof] cleanup attempt #2 at +272ms
[proof] recall#2 settled=resolved elapsed=25ms attempts_total=2 reply="- lemon pepper wings\n- blue cheese" error=""
[proof] disk readback after recall#2: session_entries keys=["agent:main:main:active-memory:bbef4024fbe3"]
[proof] check ok: subsequent recall resolved (no lock/store error)
[proof] check ok: subsequent recall returned the expected recall result
[proof] check ok: subsequent recall completed promptly (25ms < 1000ms)
[proof] check ok: subsequent recall logged no new cleanup warning
[proof] check ok: subsequent recall cleaned its own entry; only the aborted recall's leftover remains
[proof] check ok: after-fix: timed-out recall keeps its main outcome
[proof] check ok: after-fix: abort cut the remaining cleanup retries (attempts=1)
[proof] check ok: after-fix: timed-out recall returned promptly (251ms < 400ms)
[proof] check ok: after-fix: no late cleanup failure warning
[proof] OK
EXIT=0
```

Before fix (same script with `extensions/active-memory/recall-run.ts` from `upstream/main`, restored immediately after): the abort at +222ms is ignored — cleanup attempts #2 and #3 still run on the full backoff schedule, the recall waits 536ms, and the late cleanup failure overrides the recall outcome entirely (rejection + "failed to clean up recall session" warning). The subsequent recall still proceeds normally, confirming the comparison isolates the abort handling.

```text
[proof] cleanup attempt #1 at +169ms
[proof] injected real fault: .../openclaw-agent.sqlite is now a directory (SQLite open must fail)
[proof] abort fired at +222ms (simulates timed-out recall)
[proof] cleanup attempt #2 at +272ms
[proof] cleanup attempt #3 at +530ms
[proof] logger.warn: active-memory: failed to clean up recall session agent:main:main:active-memory:03a0e36a59af: unable to open database file
[proof] recall#1 settled=rejected elapsed=536ms attempts=3 reply="" error="unable to open database file"
[proof] check ok: before-fix: exhausted cleanup retries override the recall outcome
[proof] check ok: before-fix: abort did not interrupt the backoff schedule (attempts=3)
[proof] check ok: before-fix: recall waited out the full backoff (536ms >= 290ms)
[proof] check ok: before-fix: late cleanup failure warning emitted
[proof] OK (expect=before)
```

Regression tests (Node 24):

```text
node scripts/run-vitest.mjs run extensions/active-memory/index.test.ts
Test Files  1 passed (1)
Tests  176 passed (176)
```

This includes the new subsequent-recall regression: the aborted recall's leftover session entry does not block or corrupt the next recall on the same store. Against the pre-change implementation the abort regression fails deterministically: cleanup runs the full 3-attempt schedule (≥300ms) and the cleanup-failure warning fires despite the abort. Must-not-fire paths are covered by the existing "retries transient cleanup failures" (2 attempts, success, no warning) and "retries exhausted" (3 attempts + warning) tests, which still pass unchanged.

`oxlint` clean on both changed files; `tsgo` extensions project reports no errors in active-memory files.

## Intentionally out of scope

- If the abort lands during a post-failure backoff, the session artifact may remain on disk without a warning — the accepted cost of cancellation; the common path is covered by the unconditional first attempt. The new regression and the outside-runner proof both demonstrate the next recall against that store proceeds normally (no lock error, no hang, own cleanup succeeds).
- No change to the retry schedule, attempt counts, or cleanup failure reporting for real errors.
