### PR TITLE
docs(onboarding): refresh redesign plan — shipped flow, landing playbook, phase 3 merged

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5159,7 +5159,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Requirements
   - H2: Enable access
   - H3: 1. Authorize the Gateway command
-  - H3: 2. Enable sharing on the iPhone
+  - H3: 2. Enable sharing on the iOS device
   - H2: Request today's summary
   - H2: Privacy behavior
   - H2: Troubleshooting

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9310,18 +9310,21 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 
 - Route: /start/onboarding-redesign
 - Headings:
-  - H1: Onboarding redesign — implementation plan
+  - H1: Onboarding redesign implementation plan
   - H2: North star
+  - H2: Current shipped flow (after phases 1-3)
   - H2: Phases
   - H2: Implementation notes per phase
   - H3: Phase 1 — app recommendations (PR #109668)
   - H3: Phase 2 — CLI custodian spine (PR #109841)
-  - H3: Phase 3 — browser-first handoff (implemented; PR pending)
+  - H3: Phase 3 — browser-first handoff (PR #110054, merged)
   - H3: Phase 4 — web custodian surface (planned)
   - H3: Phase 5 — hatch and bootstrap (planned)
   - H3: Phase 6 — custodian presence (planned)
   - H3: Phase 7 — resilience (follow-up)
+  - H2: Testing and landing playbook (hard-won; read before phases 4-6)
   - H2: Decision log
+  - H2: Known gaps and follow-ups
 
 ## start/onboarding.md
 

--- a/docs/start/onboarding-redesign.md
+++ b/docs/start/onboarding-redesign.md
@@ -5,7 +5,7 @@ read_when:
 title: "Onboarding redesign"
 ---
 
-# Onboarding redesign — implementation plan
+# Onboarding redesign implementation plan
 
 > **Living document.** This page tracks the custodian onboarding redesign at
 > implementation level and is updated as each phase lands. When the last phase
@@ -27,123 +27,197 @@ Design principles (decided, do not relitigate casually):
   hard requirement is working inference; everything else is an offer.
 - **Question zero is the consent boundary**: "Full access" (recommended) means
   discovery is silent and automatic; "Ask first" gates every discovery — AI
-  scanning and memory-source scanning alike — behind one explicit yes, with a
-  fully manual path that never scans.
+  scanning, app scanning, and memory-source scanning alike — behind one
+  explicit yes, with a fully manual path that never scans.
 - **Conversation as UI with progressive intelligence**: the custodian surface
   exists before any AI works (scripted dialogue), becomes model-backed the
-  moment a route verifies, and visibly says so.
+  moment a route verifies, and visibly says so. It never fakes intelligence:
+  free-text input before a route verifies gets a graceful "let me get my brain
+  working first".
 - **The hatch is a ceremony**: same thread, avatar swap, the agent names itself
   and picks its own face. The custodian teaches the hierarchy once: "ask me
   about the system, or just ask your agent — it relays."
+- **Trust is tiered by source**: official catalog entries may be pre-selected;
+  third-party ClawHub skills are never pre-selected regardless of model
+  ranking, and their labels say they install the publisher's code.
 - **Configured installs are sacred**: re-running onboarding is a verification
   pass. It never re-applies setup and never restarts the Gateway service.
+- **The terminal is the fallback, not a question**: prefer the browser
+  dashboard when a gateway is reachable; never ask "terminal or browser?".
 - **Weak models get a trimmed surface** (auto `localModelLean`), explained in
   plain words — never in terms of tools, code mode, or context windows.
 
+## Current shipped flow (after phases 1-3)
+
+`openclaw onboard` on a fresh macOS install, happy path — four Enters total:
+
+1. Security note → one Enter to acknowledge (persisted; never asked again).
+2. **Question zero**: "How should I set things up?" — Full access (recommended)
+   or Ask first. Persisted as `wizard.accessMode`; reruns default to the saved
+   choice. Guarded + "configure manually" reaches the provider picker without
+   any scanning and skips memory-source scanning too.
+3. **Discovery theater**: detects coding CLIs, env keys, and local runtimes;
+   quips when coding agents are found; live-tests candidates in order and
+   quietly collects failures into one summary line (details behind "See other
+   options"). The first working route is announced as a default with a
+   one-keystroke path to the full picker; exploring and skipping keeps the
+   working route.
+4. Memory-import offer (Claude Code / Codex / Hermes), skipped when discovery
+   was declined.
+5. Fresh installs only: the standard setup plan applies automatically
+   (workspace, Gateway service, sessions — the same plan the conversational
+   "yes" runs). Configured installs print "already set up" and never touch the
+   service.
+6. **App recommendations**: installed apps matched by the verified model
+   against official catalogs + ClawHub; official channel plugins arrive
+   pre-checked, third-party skills opt-in with a warning label. Skippable;
+   kill switch `wizard.appRecommendations`.
+7. **Hatch**: when a gateway is reachable, the browser handoff opens (GUI) or
+   prints (headless/SSH) the dashboard URL and waits for the Control UI to
+   connect — "Dashboard connected — continuing in your browser." Otherwise, or
+   with `--tui`, the terminal TUI opens seeded with the bootstrap hatch
+   message and the agent introduces itself.
+
+Remote-gateway onboarding keeps its legacy conversational handoff
+(`handoffMode: "chat"`); setup must apply on the remote gateway.
+
 ## Phases
 
-| #   | Phase                                                                                                                                                                     | Surface              | Status                                                                                                                                                                                                                                                                                                                                                        |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Installed-app plugin recommendations (scan, candidates, AI matcher, wizard step, `device.apps` node command)                                                              | classic + guided CLI | merged ([#109668](https://github.com/openclaw/openclaw/pull/109668))                                                                                                                                                                                                                                                                                          |
-| 2   | CLI custodian spine (question zero, discovery theater, auto-apply + hatch)                                                                                                | guided CLI           | merged ([`a83ed13204f1`](https://github.com/openclaw/openclaw/commit/a83ed13204f118adf1009e5ac88d5afe1905b86c))                                                                                                                                                                                                                                               |
-| 3   | Browser-first handoff (GUI-session detection, wait-for-dashboard-connect, TUI as fallback)                                                                                | CLI → web            | PR [#110054](https://github.com/openclaw/openclaw/pull/110054) — proven end-to-end against an isolated same-config gateway (URL print → browser connect → presence detection → clean handoff). An earlier "token mismatch" hold was a test artifact: the isolated probe was authenticating against the machine-global gateway service serving the real config |
-| 4   | Web custodian surface (option-card renderer shared with the question tool, scripted pre-AI states over `openclaw.chat`, post-wizard chat handoff)                         | Control UI           | planned                                                                                                                                                                                                                                                                                                                                                       |
-| 5   | Hatch and bootstrap (blank-agent creation, self-naming, self-drawn avatar via image-gen when available, recommendations as the last bootstrap step, self-learning opt-in) | agent bootstrap      | planned                                                                                                                                                                                                                                                                                                                                                       |
-| 6   | Custodian presence (pinned sidebar entry, Settings dock with event-reactive commentary, channel summon and agent-down recovery, weak-model script)                        | web + channels       | planned                                                                                                                                                                                                                                                                                                                                                       |
-| 7   | Resilience (custodian reachable on broken config, partial-surface salvage, auto-doctor)                                                                                   | gateway              | follow-up                                                                                                                                                                                                                                                                                                                                                     |
+| #   | Phase                                                                                                                                                                     | Surface              | Status                                                                                                          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 1   | Installed-app plugin recommendations (scan, candidates, AI matcher, wizard step, `device.apps` node command)                                                              | classic + guided CLI | merged ([#109668](https://github.com/openclaw/openclaw/pull/109668))                                            |
+| 2   | CLI custodian spine (question zero, discovery theater, auto-apply + hatch)                                                                                                | guided CLI           | merged ([`a83ed13204f1`](https://github.com/openclaw/openclaw/commit/a83ed13204f118adf1009e5ac88d5afe1905b86c)) |
+| 3   | Browser-first handoff (GUI-session detection, wait-for-dashboard-connect, TUI as fallback)                                                                                | CLI → web            | merged ([#110054](https://github.com/openclaw/openclaw/pull/110054))                                            |
+| 4   | Web custodian surface (option-card renderer shared with the question tool, scripted pre-AI states over `openclaw.chat`, post-wizard chat handoff)                         | Control UI           | planned                                                                                                         |
+| 5   | Hatch and bootstrap (blank-agent creation, self-naming, self-drawn avatar via image-gen when available, recommendations as the last bootstrap step, self-learning opt-in) | agent bootstrap      | planned                                                                                                         |
+| 6   | Custodian presence (pinned sidebar entry, Settings dock with event-reactive commentary, channel summon and agent-down recovery, weak-model script)                        | web + channels       | planned                                                                                                         |
+| 7   | Resilience (custodian reachable on broken config, partial-surface salvage, auto-doctor)                                                                                   | gateway              | follow-up                                                                                                       |
 
 ## Implementation notes per phase
 
 ### Phase 1 — app recommendations (PR #109668)
 
-- Scanner: `src/infra/installed-apps.ts` (TCC-free macOS enumeration).
-- Candidates: official catalogs + ClawHub search, 20s budget, graceful offline.
+- Scanner: `src/infra/installed-apps.ts` (TCC-free macOS enumeration; follows
+  symlinked `.app` bundles).
+- Candidates: official catalogs + ClawHub search, 20s overall budget, graceful
+  offline degradation to catalog-only candidates. Catalog entries are package
+  manifests without a top-level `id` — candidates are keyed by the resolved
+  plugin id (regression-tested against the real bundled catalogs; keying by
+  `entry.id` once collapsed the whole catalog and dropped every official
+  recommendation).
 - AI matcher: one completion on the verified route
   (`src/system-agent/setup-app-recommendations.ts`); no curated bundle-id map —
-  the model rejects coincidental name overlaps.
+  the model rejects coincidental name overlaps. Output is bounded by the
+  resolved model's own `maxTokens` budget (the stream layer applies it when no
+  explicit cap is passed).
+- **Supply-chain guard**: ClawHub listing text is publisher-controlled and
+  reaches the matcher prompt, so a listing can promote itself to
+  "recommended". Only official catalog entries may be pre-selected; ClawHub
+  skills always require an explicit tick and are labeled "third-party ClawHub
+  skill; installs its publisher's code".
 - Node command `device.apps` (TS node-host, Android envelope parity), sharing
   off by default; gateway kill switch `wizard.appRecommendations`.
 - Delivery lives in the classic wizard and guided custodian flow
   (`src/wizard/setup.app-recommendations.ts`); re-targeting to the bootstrap
-  tail remains phase 5 (the service already takes an injectable inventory source).
+  tail remains phase 5 (the service already takes an injectable inventory
+  source). Once-semantics (offer only until accepted, stored scan) also lands
+  with the phase 5 store; today a rerun re-offers.
 - Also fixed: custom `completeSetupInference` prompts no longer inherit the
-  32-token verification-probe output cap.
+  32-token verification-probe output cap (`SETUP_INFERENCE_TEST_MAX_TOKENS`
+  applies to the "reply OK" probe only).
 
 ### Phase 2 — CLI custodian spine (PR #109841)
 
 - Flow rework in `src/commands/onboard-guided.ts`; remote-gateway onboarding
   keeps its legacy chat handoff via `handoffMode: "chat"`.
 - Question zero persists `wizard.accessMode` ("full" | "guarded"); reruns
-  default to the saved choice. Guarded + manual uses
+  default to the saved choice (accepting the default can never silently
+  downgrade guarded to full). Guarded + manual uses
   `listManualSetupInferenceOptions` (config/manifests only, no probing) and
   skips memory-source scanning.
 - Discovery: quiet failure collection (single summary line; details behind
-  "See other options"), coding-agent quip, announced route default.
+  "See other options"), coding-agent quip, announced route default. Session
+  counts in the quip are deferred (qualitative only) until a cheap
+  session-count seam exists.
 - Fresh installs: `applySystemAgentSetup` (the deterministic conversational
   "yes"), then hatch via `launchTuiCli` seeded with the bootstrap message.
-  Configured installs (pre-existing model or gateway config): verification
-  only — no apply, no Gateway service restart. Apply failure falls back to the
-  conversational chat.
+  Configured installs (pre-existing model or gateway config — wizard
+  timestamps prove nothing, they are shared with configure/doctor):
+  verification only — no apply, no Gateway service restart. Apply failure
+  falls back to the conversational chat.
 
-### Phase 3 — browser-first handoff (implemented; PR pending)
+### Phase 3 — browser-first handoff (PR #110054, merged)
 
 - `src/commands/onboard-browser-handoff.ts` owns pure graphical-session
-  detection and the 60-second GUI / 300-second SSH wait. Guided onboarding
-  currently enables the handoff only on macOS; `--tui` and other platforms keep
-  the terminal hatch.
+  detection (`SSH_CONNECTION`/`SSH_TTY`; `DISPLAY`/`WAYLAND_DISPLAY` on Linux)
+  and the 60-second GUI / 300-second SSH wait. Guided onboarding currently
+  enables the handoff only on macOS; `--tui` and other platforms keep the
+  terminal hatch. Linux/Windows enablement is a follow-up.
 - Dashboard links use the same `resolveAdvertisedControlUiLinks`,
-  `resolveLocalControlUiProbeLinks`, and `buildOnboardingControlUiUrl` helpers as
-  classic finalize. Browser launch uses the shared `openUrl` helper.
-- Readiness polls the existing `system-presence` RPC through the authorized
-  local-backend `callGateway` seam and accepts only a connected
-  `openclaw-control-ui` presence row that is new or refreshed after the
-  pre-launch baseline. Gateway reachability is checked before any handoff note;
-  loopback SSH sessions also print the shared Control UI forwarding hint.
-  Timeout or disconnect falls through to the existing TUI hatch.
+  `resolveLocalControlUiProbeLinks`, and `buildOnboardingControlUiUrl` helpers
+  as classic finalize. Browser launch uses the shared `openUrl` helper.
+- Readiness polls the existing `system-presence` RPC as a **CLI-mode loopback
+  client presenting the configured shared secret** — the trusted path every
+  `openclaw` command uses. A raw shared-auth Control UI client is rejected
+  with "device identity required" on SecretRef gateways. The reachability
+  preflight resolves the same target (and secret) as the wait loop, so the
+  gate and the wait can never disagree on auth. The handoff completes only
+  when a connected `openclaw-control-ui`/`webchat` presence row is new
+  relative to the pre-launch baseline (an already-open dashboard cannot
+  complete it).
+- `gateway.controlUi.enabled: false` short-circuits before any URL is shown.
+- Proven end-to-end against an isolated same-config gateway: URL print → real
+  browser connect → "Dashboard connected — continuing in your browser" → no
+  terminal hatch. An earlier "token mismatch" hold was a test-harness
+  artifact — see the testing playbook below.
 
 ### Phase 4 — web custodian surface (planned)
 
-- One option-card component (header, question, 2–4 cards, one recommended,
+- One option-card component (header, question, 2-4 cards, one recommended,
   always skippable) shared by scripted onboarding and the agent question tool
   (`src/agents/harness/user-input-bridge.ts` shapes).
 - Scripted pre-AI dialogue as a small state machine consumed by CLI and web;
   the web page runs over the existing `openclaw.chat` RPC in the chrome-hiding
   onboarding mode. The model-setup wizard pages remain as the "More options"
   fallback, embedded as cards.
-- The scripted custodian must never fake intelligence: free-text input before
-  a route verifies gets a graceful "let me get my brain working first".
+- Browser handoff should deep-link into the onboarding-mode custodian chat
+  once this exists (today it lands on the normal dashboard).
 
 ### Phase 5 — hatch and bootstrap (planned)
 
 - Custodian creates a nameless agent (tool call); the agent's bootstrap opens
   with self-naming and a self-drawn avatar (image-gen ladder: model-generated
   candidates → preset marks → keep logo). Same thread, avatar swap; the claw
-  mark stays reserved for the custodian.
-- Recommendations (phase 1 service, stored scan) land as the last bootstrap
-  step before the bootstrap file is removed: "minimal set or maximum
-  convenience?" Channel connect buttons carry per-channel setup playbooks; the
-  agent collects credentials conversationally and relays config writes to the
-  custodian ("asking OpenClaw…" is the canonical idiom).
-- Self-learning is asked, not announced, and doubles as skill-workshop consent;
-  ClawHub is described as "scanned, signed, and verified before install" —
-  nothing stronger.
-- Auto-hatch: after AI verifies, hatching proceeds with an announcement
-  ("You can always find me in Settings… hatching now"); the button only skips
-  the beat. Zero agents on first run auto-hatches; zero agents after deletion
-  offers instead.
+  mark stays reserved for the custodian. Cap the birth sequence at roughly
+  three beats (name+face → soul line → skills question) before the agent is
+  useful.
+- Recommendations (phase 1 service, stored scan with once-semantics) land as
+  the last bootstrap step before the bootstrap file is removed: "minimal set
+  or maximum convenience?" Channel connect buttons carry per-channel setup
+  playbooks; the agent collects credentials conversationally and relays config
+  writes to the custodian ("asking OpenClaw…" is the canonical idiom).
+- Self-learning is asked, not announced, and doubles as skill-workshop
+  consent; ClawHub is described as "scanned, signed, and verified before
+  install" — nothing stronger.
+- Zero agents on first run auto-hatches with the announcement; zero agents
+  after deletion offers instead (the emptiness was intentional).
 
 ### Phase 6 — custodian presence (planned)
 
 - Pinned sidebar entry (permanent session — it is the config audit trail) and
   Settings landing pane docked with the same session; replies deep-link into
-  settings sections.
+  settings sections. The surface keeps the name "Settings".
 - Event-reactive commentary with anti-Clippy guardrails: consequential or
-  failed changes only, at most once per settings visit unless asked.
+  failed changes only, at most once per settings visit unless asked. The same
+  event seam makes the custodian the voice for degraded auth or broken
+  channels later.
 - Channels: day-to-day invisible (the agent relays); reachable by explicit
   summon and on agent-down events in the same thread, with its own name and
-  avatar where the platform allows.
+  claw avatar where the platform allows.
 - Weak model detected at setup: auto-set `localModelLean`, and the custodian
   says so in plain words with an upgrade offer.
+- The custodian knows its internal nickname ("some folks call me the
+  custodian — OpenClaw's fine") and always refers to the agent by name.
 
 ### Phase 7 — resilience (follow-up)
 
@@ -151,18 +225,79 @@ Design principles (decided, do not relitigate casually):
   working surfaces (per the gateway's degraded-start SecretRef rules), say
   plainly what is broken, and run `openclaw doctor` automatically.
 
+## Testing and landing playbook (hard-won; read before phases 4-6)
+
+- **`OPENCLAW_STATE_DIR` does not isolate the Gateway service.** The
+  LaunchAgent label (`ai.openclaw.gateway`) is machine-global: a fresh-install
+  onboarding test with an isolated state dir will REWRITE and RESTART the real
+  machine's service (wrapper scripts land inside the isolated dir; the next
+  service start breaks when that dir is cleaned). After any fresh-install
+  test, restore with `openclaw gateway install --force && openclaw gateway
+restart` from the real environment and verify the plist. Product follow-up:
+  state-dir-scoped service labels, or onboarding detecting a foreign service.
+- **Safe end-to-end harness**: pre-seed the isolated config with a `gateway`
+  section (so onboarding takes the configured-install path and never touches
+  the service) and run `openclaw gateway run` as a plain foreground process on
+  a spare port with a plain token. That harness proved the phase-3 loop,
+  including a real browser connect.
+- **Auth paths differ by client identity, not only credentials.** Presence and
+  other operator reads work token-less as a CLI-mode loopback client from the
+  same config; a Control UI-identified browser client needs device identity or
+  the secure-context loopback grant. A probe authenticating against a gateway
+  that serves a DIFFERENT config (see LaunchAgent pitfall) fails with "token
+  mismatch" — that artifact briefly held phase 3.
+- **Completion probes**: `runSetupInferenceTest` caps the verification probe at
+  32 output tokens; custom prompts bypass the cap and are bounded by the
+  model's own `maxTokens`. Reasoning models consume that budget with hidden
+  reasoning first — an empty-text turn usually means the budget died there.
+- **Agent landing needs exact-head hosted CI.** The heavy `CI` workflow may
+  not queue on pushes under org load; the maintainer fallback is a
+  release-gate dispatch on the PR branch:
+  `gh workflow run ci.yml --ref <branch> -f target_ref=<head-sha>
+-f release_gate=true -f pull_request_number=<pr>` (the run must be on the
+  branch ref so `head_sha` matches, and the title becomes
+  "CI release gate <sha>", which `scripts/verify-pr-hosted-gates.mjs`
+  accepts). Then `scripts/pr` prepare/merge as usual.
+- **Gates that CI enforces beyond focused tests**: docs map
+  (`pnpm docs:map:gen` after adding any docs page), oxlint (`no-map-spread`,
+  `max-lines` — split files, never suppress), `check:test-types`, knip
+  deadcode (export only what prod consumes; route tests through public APIs),
+  and the live-test shard classifier
+  (`test/scripts/test-live-shard.test.ts` must list any new `*.live.test.ts`).
+
 ## Decision log
 
 - Magical scan with kill switch, not consent-first (phase 1; disclosure lives
   in the scanning progress line and results note).
 - Full vertical including the node `device.apps` command (phase 1).
+- Third-party ClawHub skills are never pre-selected and are labeled as
+  installing the publisher's code; official entries may be pre-checked
+  (phase 1, shipped security posture).
 - Two access cards, not three; consent front-loaded into the choice (phase 2).
 - Auto-hatch with announcement, not a blocking button (phases 2/5).
+- Browser-first: the terminal hatch is the fallback, never a "terminal or
+  browser?" question (phase 3).
 - Custodian gets channel presence (summon + recovery), not web/CLI only
   (phase 6).
 - Hatch happens in the same thread with an avatar swap; after completion the
   app transitions to the regular UI (phase 5).
 - The settings surface keeps the name "Settings"; the custodian lives there
   (and in the sidebar) rather than replacing it (phase 6).
+- Option cards are constrained: 2-4 options, exactly one recommended, always
+  skippable; the same component serves onboarding and the agent question tool
+  (phase 4).
+- "Asking OpenClaw…" is the canonical delegation idiom; souls may add flavor,
+  the tool narration stays plain (phase 5).
 - User-facing copy never says "code mode", "tools", or "context window" when
   explaining weak-model trimming (phase 6).
+
+## Known gaps and follow-ups
+
+- LaunchAgent label is not state-dir-scoped (testing pitfall above; also a
+  real multi-instance product gap).
+- Recommendations once-semantics and the stored scan (phase 5); reruns
+  currently re-offer.
+- Browser handoff is macOS-only; Linux/Windows enablement pending.
+- Session-count quip is qualitative; counts need a cheap session-count seam.
+- Browser handoff lands on the normal dashboard; onboarding-mode custodian
+  deep-link arrives with phase 4.

--- a/docs/start/onboarding-redesign.md
+++ b/docs/start/onboarding-redesign.md
@@ -197,8 +197,8 @@ Remote-gateway onboarding keeps its legacy conversational handoff
   playbooks; the agent collects credentials conversationally and relays config
   writes to the custodian ("asking OpenClaw…" is the canonical idiom).
 - Self-learning is asked, not announced, and doubles as skill-workshop
-  consent; ClawHub is described as "scanned, signed, and verified before
-  install" — nothing stronger.
+  consent; describe ClawHub's release-trust, scan, verification, and integrity
+  checks plus the publisher-code warning — never imply every release is signed.
 - Zero agents on first run auto-hatches with the announcement; zero agents
   after deletion offers instead (the emptiness was intentional).
 
@@ -241,11 +241,13 @@ restart` from the real environment and verify the plist. Product follow-up:
   a spare port with a plain token. That harness proved the phase-3 loop,
   including a real browser connect.
 - **Auth paths differ by client identity, not only credentials.** Presence and
-  other operator reads work token-less as a CLI-mode loopback client from the
-  same config; a Control UI-identified browser client needs device identity or
-  the secure-context loopback grant. A probe authenticating against a gateway
-  that serves a DIFFERENT config (see LaunchAgent pitfall) fails with "token
-  mismatch" — that artifact briefly held phase 3.
+  other operator reads use a CLI-mode loopback client with credentials from the
+  same config. Token-auth gateways require the shared secret; SecretRef/none
+  gateways can fall back to trusted-loopback auth without a token. A Control
+  UI-identified browser client needs device identity or the secure-context
+  loopback grant. A probe authenticating against a gateway that serves a
+  DIFFERENT config (see LaunchAgent pitfall) fails with "token mismatch" — that
+  artifact briefly held phase 3.
 - **Completion probes**: `runSetupInferenceTest` caps the verification probe at
   32 output tokens; custom prompts bypass the cap and are bounded by the
   model's own `maxTokens`. Reasoning models consume that budget with hidden


### PR DESCRIPTION
## What Problem This Solves

The onboarding-redesign plan doc (`docs/start/onboarding-redesign.md`) is the living implementation plan for the custodian onboarding work. It was written before phases 1-3 landed and had drifted: phase 3 was still listed as an open PR, the doc had no snapshot of what actually shipped, and none of the operational knowledge gained while landing the three phases (test-isolation pitfalls, gateway harness setup, CI landing mechanics) was recorded anywhere.

## Why This Change Was Made

Phases 1 (app recommendations, #109668), 2 (custodian spine, #109841), and 3 (browser handoff, #110054) are all merged. The doc's contract is "update it as progress lands, rewrite as a user guide once everything is merged" — this refresh keeps that contract for the mid-point: phases 4-6 builders need an accurate shipped-flow baseline and the landing playbook so they do not rediscover the LaunchAgent/state-dir pitfall or the release-gate CI dispatch shape the hard way.

## User Impact

Docs-only. No runtime, config, or CLI behavior changes. Contributor/maintainer-facing plan doc gains: a "Current shipped flow" snapshot of phases 1-3, a testing-and-landing playbook (state-dir isolation pitfall, same-config gateway harness, presence auth paths, probe token cap, release-gate CI dispatch, CI gate checklist), completed decision-log entries (including the third-party ClawHub trust posture), and a known-gaps/follow-ups section. Phase 3 row updated to merged.

## Evidence

- `pnpm docs:check-mdx` — passed (737 files).
- `pnpm docs:map:gen` — regenerated `docs/docs_map.md` (committed).
- `git diff --check` — clean.
- Docs-only diff: `docs/start/onboarding-redesign.md` + generated `docs/docs_map.md`.
