### PR TITLE
fix: guarded fetch falls back to IPv6 when IPv4 is unreachable

### DIFF
--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -51,7 +51,7 @@ describe("ssrf pinning", () => {
     );
   });
 
-  it("keeps automatic pinned lookups on IPv4 when both address families are available", async () => {
+  it("keeps single-address lookups on IPv4 while exposing both families to Happy Eyeballs", async () => {
     const lookup = createPinnedLookup({
       hostname: "api.anthropic.com",
       addresses: ["160.79.104.10", "2607:6bc0::10"],
@@ -89,7 +89,10 @@ describe("ssrf pinning", () => {
         }
       });
     });
-    expect(all).toEqual([{ address: "160.79.104.10", family: 4 }]);
+    expect(all).toEqual([
+      { address: "160.79.104.10", family: 4 },
+      { address: "2607:6bc0::10", family: 6 },
+    ]);
 
     await expect(lookupWithOptions({ family: 6 })).resolves.toEqual({
       address: "2607:6bc0::10",

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -524,10 +524,14 @@ export function createPinnedLookup(params: {
         : {};
     const requestedFamily =
       typeof options === "number" ? options : typeof opts.family === "number" ? opts.family : 0;
+    // Single-address lookups stay IPv4-only when possible, while Happy Eyeballs
+    // receives every validated family so it can fall back when IPv4 is unreachable.
     const candidates =
       requestedFamily === 4 || requestedFamily === 6
         ? records.filter((entry) => entry.family === requestedFamily)
-        : automaticRecords;
+        : opts.all
+          ? records
+          : automaticRecords;
     const usable = candidates.length > 0 ? candidates : automaticRecords;
     if (opts.all) {
       cb(null, usable as LookupAddress[]);


### PR DESCRIPTION
Closes #87763

## What Problem This Solves

Fixes an issue where guarded provider requests on dual-stack hosts can fail when IPv4 is unreachable even though IPv6 is available.

## Why This Change Was Made

Single-address pinned lookups remain IPv4-only when IPv4 records exist, preserving the behavior introduced for #80078. All-record lookups used by Node/Undici Happy Eyeballs now receive the complete SSRF-validated, IPv4-first pinned record set, so IPv6 remains available as a fallback. Explicit-family and hostname-fallback behavior are unchanged.

## User Impact

Users on networks where a provider's IPv4 route is unavailable but IPv6 works can complete guarded provider requests without disabling DNS pinning or weakening resolved-address checks.

## Evidence

- Updated `src/infra/net/ssrf.pinning.test.ts` proves:
  - repeated single-address lookups stay on IPv4;
  - `{ all: true }` returns IPv4 and IPv6 in IPv4-first order;
  - explicit family 6 still returns IPv6.
- `git diff --check` passes.
- A source-aware Codex review found no actionable regression.
- [Secretless fork CI](https://github.com/an2in/openclaw/actions/runs/29602936046) completed successfully at exact head `fdea545196ae73695d1fc6fe54c1252af8c4374b`: 125 jobs passed and 6 scope-inapplicable jobs skipped. The network/security test shard, build artifacts, lint, production types, and `openclaw/ci-gate` all passed.

### Exact-head dual-stack runtime proof

The following redacted `NODE_DEBUG=net` excerpts came from disposable Node 24 containers on an Ubuntu 24.04.4 VM. Both containers checked out exact head `fdea545196ae73695d1fc6fe54c1252af8c4374b` and invoked `fetchWithSsrFGuard` from that checkout. No API key or authorization header was supplied; the containers received only `PROOF_SHA` and `NODE_DEBUG` as environment variables.

IPv4 unreachable, IPv6 succeeds (`https://openrouter.ai/api/v1/models`, host networking):

```text
SCENARIO=ipv4-unreachable_ipv6-success
PROOF_SHA=fdea545196ae73695d1fc6fe54c1252af8c4374b
NODE=v24.18.0
DNS_IPV4_COUNT=2
DNS_IPV6_COUNT=2
PINNED_FAMILY_ORDER=4,4,6,6
FORCED_IPV4=error:ETIMEDOUT
FORCED_IPV6=status:200
NET: connect/multiple: attempting to connect to <IPv4>:443 (addressType: 4)
NET: connect/multiple: connection to <IPv4>:443 timed out
NET: connect/multiple: attempting to connect to <IPv6>:443 (addressType: 6)
NET: connect/multiple: connection attempt to <IPv6>:443 completed with status 0
GUARDED_FETCH_STATUS=200
GUARDED_FETCH_OK=true
ELAPSED_MS=584
```

IPv6 unreachable, IPv4 succeeds (`https://www.google.com/generate_204`, IPv4-only Docker bridge):

```text
SCENARIO=ipv6-unreachable_ipv4-success
PROOF_SHA=fdea545196ae73695d1fc6fe54c1252af8c4374b
NODE=v24.18.0
DNS_IPV4_COUNT=1
DNS_IPV6_COUNT=1
PINNED_FAMILY_ORDER=4,6
FORCED_IPV4=status:204
FORCED_IPV6=error:ENETUNREACH
NET: connect/multiple: attempting to connect to <IPv4>:443 (addressType: 4)
NET: connect/multiple: connection attempt to <IPv4>:443 completed with status 0
GUARDED_FETCH_STATUS=204
GUARDED_FETCH_OK=true
ELAPSED_MS=334
```

The original shipped-version observation is consistent with the exact-head proof: on Ubuntu 24.04.4 LTS with Node v24.15.0 and OpenClaw 2026.5.26, direct IPv6 worked while guarded IPv4 timed out; retaining the validated IPv6 candidate restored the provider request.

AI-assisted: Codex helped diagnose, implement, and review this change. I reviewed the code and understand the behavior. The original diagnostic transcript is not attached because it contained credentials; the exact-head proof above was rerun without credentials and is sanitized.
