### PR TITLE
fix(infra): use bigint stats when comparing session store identity

### DIFF
--- a/src/infra/state-migrations.session-store.ts
+++ b/src/infra/state-migrations.session-store.ts
@@ -1213,7 +1213,11 @@ function resolveSessionStorePathRelationship(
     return "same";
   }
   try {
-    return sameFileIdentity(fs.statSync(left), fs.statSync(right)) ? "same" : "different";
+    // bigint stats: filesystems like bcachefs use inode numbers above 2^53,
+    // which collide when coerced to JS numbers and make distinct stores look aliased.
+    return sameFileIdentity(fs.statSync(left, { bigint: true }), fs.statSync(right, { bigint: true }))
+      ? "same"
+      : "different";
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== "ENOENT" && code !== "ENOTDIR") {


### PR DESCRIPTION
Fixes #110123

## Problem

On filesystems with inode numbers above 2^53 (e.g. bcachefs), `resolveSessionStorePathRelationship()` compares file identity using non-bigint `fs.statSync()`. JS number rounding makes distinct files report identical inodes (at ~8.6e17 adjacent doubles are 128 apart), so different agents' session stores are classified as the same file reachable via different paths. Startup migrations defer with "aliased store" warnings, and on 2026.7.1 — where these migrations are fatal — the gateway refuses to start. `doctor --fix` cannot resolve it because no actual filesystem aliases exist.

## Change

Pass `{ bigint: true }` to both `statSync` calls. `FileIdentityStat` is already typed `number | bigint` and `sameStatValue()` already coerces mixed comparisons, so no changes needed in `@openclaw/fs-safe`.

## Verification

- Reproduced on a bcachefs root (see issue for real stat output showing 3-way inode collisions across agent stores).
- Applied this exact change to an installed 2026.7.1 dist on the affected machine: all `Deferred session key migration in aliased store` failures disappeared and the gateway started cleanly; without it, startup crash-loops.
- Other `sameFileIdentity` call sites compare pre/post-open stats of the same path, where rounding is consistent — unaffected.

A unit test would need `fs.statSync` mocking through the exported migration entry points since the helper is module-private; happy to add one if you point me at the preferred harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)