### PR TITLE
fix(scripts): honor repeated response content lengths

### DIFF
--- a/scripts/lib/bounded-response.mjs
+++ b/scripts/lib/bounded-response.mjs
@@ -29,10 +29,19 @@ function cancelReaderSoon(reader) {
 
 function parseContentLengthHeader(headers) {
   const raw = headers.get("content-length");
-  if (!raw || !/^\d+$/u.test(raw)) {
+  if (!raw) {
     return undefined;
   }
-  const parsed = Number(raw);
+  // This is post-framing early rejection, not framing validation.
+  const values = raw.split(",").map((value) => value.trim());
+  if (values.some((value) => !/^\d+$/u.test(value))) {
+    return undefined;
+  }
+  const canonical = values.map((value) => value.replace(/^0+(?=\d)/u, ""));
+  if (canonical.some((value) => value !== canonical[0])) {
+    return undefined;
+  }
+  const parsed = Number(canonical[0]);
   return Number.isSafeInteger(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }
 

--- a/test/scripts/bounded-response.test.ts
+++ b/test/scripts/bounded-response.test.ts
@@ -93,17 +93,33 @@ describe("scripts bounded response reader", () => {
     });
   });
 
-  it("streams responses with non-decimal content-length values", async () => {
+  it.each([
+    { label: "identical", second: "17", combined: "17, 17", readsBody: false },
+    { label: "equivalent", second: "017", combined: "17, 017", readsBody: false },
+    { label: "conflicting", second: "12", combined: "17, 12", readsBody: true },
+    { label: "malformed", second: "1e3", combined: "17, 1e3", readsBody: true },
+    { label: "empty", second: "", combined: "17, ", readsBody: true },
+  ])("handles $label repeated content-length values", async ({ second, combined, readsBody }) => {
+    const headers = new Headers();
+    headers.append("content-length", "17");
+    headers.append("content-length", second);
+    expect(headers.get("content-length")).toBe(combined);
+
     let readStarted = false;
     let canceled = false;
     const response = {
-      headers: new Headers({ "content-length": "1e3" }),
+      headers,
       body: {
+        async cancel() {
+          canceled = true;
+        },
         getReader() {
           return {
             async read() {
               readStarted = true;
-              return { done: false, value: new Uint8Array(17) };
+              return readsBody
+                ? { done: false, value: new Uint8Array(17) }
+                : new Promise<ReadableStreamReadResult<Uint8Array>>(() => {});
             },
             async cancel() {
               canceled = true;
@@ -114,10 +130,10 @@ describe("scripts bounded response reader", () => {
       },
     } as unknown as Response;
 
-    await expect(readBoundedResponseText(response, "probe", 16)).rejects.toMatchObject({
-      message: "probe response body exceeded 16 bytes",
-    });
-    expect(readStarted).toBe(true);
+    await expect(readBoundedResponseText(response, "probe", 16)).rejects.toThrow(
+      "probe response body exceeded 16 bytes",
+    );
+    expect(readStarted).toBe(readsBody);
     expect(canceled).toBe(true);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw script helpers could begin reading a known-oversized response when Fetch exposed repeated equivalent `Content-Length` declarations as one comma-combined field.

## Why This Change Was Made

The canonical bounded-response helper now trims comma-separated tokens, accepts only digit-only members, canonicalizes leading zeros, and uses the value for early rejection only when every canonical member agrees. Absent, empty, malformed, or conflicting declarations remain unknown and continue through the existing bounded streaming path.

This is post-framing early rejection, not HTTP framing validation. The retired TypeScript helper remains deleted.

## User Impact

Automation and local tooling reject known-oversized responses before reading their bodies when intermediaries repeat the same decimal length, including zero-padded equivalents. Conflicting or malformed metadata cannot weaken the streaming byte limit.

## Evidence

- Exact head: `e614894c9a9f004a4e6e9ece46a67468b7bb5b62`.
- Isolated Blacksmith Testbox: `tbx_01kzr0p57pds1c590cr7x1w53m`.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31475569174
- Node `v24.19.0`: `test/scripts/bounded-response.test.ts` passed 11/11 focused Vitest cases.
- Bun `1.3.14` loopback sent duplicate wire headers and observed `content-length=17, 017`.
- `node --check scripts/lib/bounded-response.mjs` passed.
- Targeted `pnpm format:check` passed for both changed files.
- `git diff --check origin/main...HEAD` passed.
- Production LOC: `+11/-2` (net `+9`), justified by stricter post-framing early rejection while preserving the existing streaming owner boundary.
- Tests: `+23/-7`.
- No changelog: narrow script-helper repair; release context is recorded here.

Punchcard-Session: clear-valley-meadow-4p
