### PR TITLE
fix(swift): keep node routes valid in connected callbacks

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -351,8 +351,9 @@ public actor GatewayChannelActor {
         self.activeConnectAttemptID = attemptID
         self.task = connectTask
         connectTask.resume()
+        let connectHello: HelloOk
         do {
-            try await AsyncTimeout.withTimeout(
+            connectHello = try await AsyncTimeout.withTimeout(
                 seconds: self.connectTimeoutSeconds,
                 onTimeout: {
                     NSError(
@@ -395,6 +396,13 @@ public actor GatewayChannelActor {
         self.listen(connectionGeneration: connectionGeneration)
         self.startTickWatchdog(connectionGeneration: connectionGeneration)
         self.startKeepalive(connectionGeneration: connectionGeneration)
+        // Snapshot callbacks may resolve a route through currentConnectionGeneration().
+        // Publish only after the physical socket is admitted and its receive loop is armed.
+        Task { [weak self] in
+            await self?.deliverPushIfCurrent(
+                .snapshot(connectHello),
+                connectionGeneration: connectionGeneration)
+        }
     }
 
     private func startKeepalive(connectionGeneration: UInt64) {
@@ -425,7 +433,7 @@ public actor GatewayChannelActor {
     private func sendConnect(
         task: WebSocketTaskBox,
         attemptID: UUID,
-        connectionGeneration: UInt64) async throws
+        connectionGeneration: UInt64) async throws -> HelloOk
     {
         defer { self.testConnectAttemptFinishedHandler?(attemptID) }
         try self.ensureCurrentConnectAttempt(attemptID, task: task)
@@ -536,20 +544,21 @@ public actor GatewayChannelActor {
                 attemptID: attemptID)
             try self.ensureCurrentConnectAttempt(attemptID, task: task)
             try self.requireCurrentConnection(connectionGeneration)
-            let issuedRoles = try await self.handleConnectResponse(
+            let outcome = try await self.handleConnectResponse(
                 response,
                 identity: identity,
                 role: role,
                 deviceAuthGatewayID: deviceAuthGatewayID,
                 deviceIdentityProfile: deviceIdentityProfile,
                 connectionGeneration: connectionGeneration)
-            self.issuedDeviceAuthRoles.formUnion(issuedRoles)
-            if issuedRoles.contains(role) {
+            self.issuedDeviceAuthRoles.formUnion(outcome.issuedRoles)
+            if outcome.issuedRoles.contains(role) {
                 // Only a token persisted from this endpoint may unlock stored auth for its role.
                 self.connectOptions?.allowStoredDeviceAuth = true
             }
             self.pendingDeviceTokenRetry = false
             self.deviceTokenRetryBudgetUsed = false
+            return outcome.hello
         } catch {
             try self.ensureCurrentConnectAttempt(attemptID, task: task)
             try self.requireCurrentConnection(connectionGeneration)
@@ -880,7 +889,7 @@ extension GatewayChannelActor {
         role: String,
         deviceAuthGatewayID: String?,
         deviceIdentityProfile: GatewayDeviceIdentityProfile,
-        connectionGeneration: UInt64) async throws -> Set<String>
+        connectionGeneration: UInt64) async throws -> (issuedRoles: Set<String>, hello: HelloOk)
     {
         if res.ok == false {
             let error = res.error
@@ -988,12 +997,7 @@ extension GatewayChannelActor {
         {
             await self.connectSnapshotAdmissionHandler?(ok, connectionGeneration)
         }
-        Task { [weak self] in
-            await self?.deliverPushIfCurrent(
-                .snapshot(ok),
-                connectionGeneration: connectionGeneration)
-        }
-        return issuedRoles
+        return (issuedRoles, ok)
     }
 
     private func deliverPushIfCurrent(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -3556,6 +3556,9 @@ struct GatewayNodeSessionTests {
             })
 
         let route = try #require(await gateway.currentRoute())
+        try await waitUntil("main session key captured", timeoutSeconds: 2) {
+            await capturedMainSessionKey.get() == "agent:main:main"
+        }
         #expect(await capturedMainSessionKey.get() == "agent:main:main")
         #expect(await gateway.waitForCurrentMainSessionKey(ifCurrentRoute: route) == "agent:main:main")
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a node connected callback could briefly observe no current route when asynchronous hello-snapshot delivery won a scheduler race. This made `main session key follows the current node snapshot route` flaky in the macOS Swift CI job and could cause route-bound callback work to return early.

Observed on #110107 in [CI run 29601070036, job 87953146209](https://github.com/openclaw/openclaw/actions/runs/29601070036/job/87953146209), where the assertion failed after 0.754 seconds.

## Why This Change Was Made

The channel now retains the decoded hello snapshot through the connect handshake and publishes the general snapshot callback only after the physical socket is marked connected and its receive loop is armed. The dedicated fast snapshot-admission hook remains unchanged. The regression test also waits for its callback capture with a bounded confirmation instead of relying on immediate scheduler timing.

## User Impact

No intended UI change. Node connected callbacks now consistently see a valid current route and its snapshot-derived main-session key; macOS CI no longer depends on task scheduling order at connection setup.

## Evidence

- Exact focused test: 20/20 bounded local repetitions passed under Xcode 27.
- `GatewayNodeSessionTests`: 66/66 tests passed.
- SwiftFormat: both touched files clean.
- SwiftLint: touched production file clean. The shared test file is outside the CI SwiftLint include set and still has its pre-existing file/type-length findings.
- `git diff --check`: clean.
- Autoreview: clean, no accepted/actionable findings.
