### PR TITLE
fix(memory-host): accept repeated content lengths

### DIFF
--- a/packages/memory-host-sdk/src/host/response-snippet.test.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.test.ts
@@ -108,4 +108,98 @@ describe("readMemoryHostResponseTextSnippet", () => {
       readResponseJsonWithLimit(new Response(body), { errorPrefix: "remote memory" }),
     ).rejects.toThrow(/not valid for encoding/);
   });
+  it("accepts repeated identical JSON content-length values before reading", async () => {
+    let readStarted = false;
+    let done = false;
+    const response = {
+      headers: new Headers({ "content-length": "11, 11" }),
+      body: {
+        getReader() {
+          return {
+            async read() {
+              readStarted = true;
+              if (done) {
+                return { done: true, value: undefined };
+              }
+              done = true;
+              return { done: false, value: new TextEncoder().encode('{"ok":true}') };
+            },
+            async cancel() {},
+            releaseLock() {},
+          };
+        },
+      },
+    } as unknown as Response;
+
+    await expect(
+      readResponseJsonWithLimit(response, {
+        errorPrefix: "remote memory",
+        maxBytes: 11,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(readStarted).toBe(true);
+  });
+
+  it("rejects oversized repeated JSON content-length values before reading", async () => {
+    let readStarted = false;
+    let canceled = false;
+    const response = {
+      headers: new Headers({ "content-length": "12, 12" }),
+      body: {
+        async cancel() {
+          canceled = true;
+        },
+        getReader() {
+          return {
+            async read() {
+              readStarted = true;
+              return new Promise<ReadableStreamReadResult<Uint8Array>>(() => {});
+            },
+            async cancel() {
+              canceled = true;
+            },
+            releaseLock() {},
+          };
+        },
+      },
+    } as unknown as Response;
+
+    await expect(
+      readResponseJsonWithLimit(response, {
+        errorPrefix: "remote memory",
+        maxBytes: 11,
+      }),
+    ).rejects.toThrow("remote memory: response body too large: 12 bytes (limit: 11 bytes)");
+    expect(readStarted).toBe(false);
+    expect(canceled).toBe(true);
+  });
+
+  it.each(["11, 12", "011, 11", "11,", "1e1"])(
+    "rejects invalid JSON content-length %j before reading",
+    async (contentLength) => {
+      let readStarted = false;
+      const response = {
+        headers: new Headers({ "content-length": contentLength }),
+        body: {
+          getReader() {
+            return {
+              async read() {
+                readStarted = true;
+                return { done: false, value: new TextEncoder().encode('{"ok":true}') };
+              },
+              async cancel() {},
+              releaseLock() {},
+            };
+          },
+        },
+      } as unknown as Response;
+
+      await expect(
+        readResponseJsonWithLimit(response, {
+          errorPrefix: "remote memory",
+        }),
+      ).rejects.toThrow(`remote memory: invalid content-length header: ${contentLength}`);
+      expect(readStarted).toBe(false);
+    },
+  );
 });

--- a/packages/memory-host-sdk/src/host/response-snippet.test.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.test.ts
@@ -108,6 +108,7 @@ describe("readMemoryHostResponseTextSnippet", () => {
       readResponseJsonWithLimit(new Response(body), { errorPrefix: "remote memory" }),
     ).rejects.toThrow(/not valid for encoding/);
   });
+
   it("accepts repeated identical JSON content-length values before reading", async () => {
     let readStarted = false;
     let done = false;

--- a/packages/memory-host-sdk/src/host/response-snippet.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.ts
@@ -216,18 +216,21 @@ async function cancelResponseBody(res: Response): Promise<void> {
 }
 
 function parseContentLength(raw: string | null, errorPrefix: string): number | undefined {
-  const trimmed = raw?.trim();
-  if (!trimmed) {
+  if (raw === null) {
     return undefined;
   }
-  if (!/^\d+$/.test(trimmed)) {
+  const values = raw.split(",").map((value) => value.replace(/^[\t ]+|[\t ]+$/g, ""));
+  const value = values[0] ?? "";
+  // Repeated lengths affect framing, so their trimmed decimal bytes must match.
+  // Numeric comparison would wrongly accept ambiguous values such as "05, 5".
+  if (!/^\d+$/.test(value) || values.some((candidate) => candidate !== value)) {
     throw new Error(`${errorPrefix}: invalid content-length header: ${raw}`);
   }
-  const value = Number(trimmed);
-  if (!Number.isSafeInteger(value)) {
+  const size = Number(value);
+  if (!Number.isSafeInteger(size)) {
     throw new Error(`${errorPrefix}: invalid content-length header: ${raw}`);
   }
-  return value;
+  return size;
 }
 
 function responseTooLarge(errorPrefix: string, size: number, maxBytes: number): Error {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where memory host HTTP JSON responses with repeated equivalent `Content-Length` values were treated as invalid instead of using the declared size to reject oversized bodies before reading.

## Why This Change Was Made

The memory host response reader now accepts comma-combined lengths only when every trimmed decimal value resolves to the same safe size, while rejecting conflicting, ambiguous, malformed, or unsafe values. This keeps the parsing local to the memory host response boundary.

## User Impact

Memory host calls can handle valid repeated `Content-Length` headers from intermediaries and still fail early on oversized responses without reading or buffering the body.

## Evidence

- Current head: `76d1982191895d230b719dedd42cdef6b264e34e`.
- Runtime proof: `node --import tsx --input-type=module` exercised the production `readResponseJsonWithLimit` response reader on the current head.

```text
11, 11 => ok={"ok":true} {"readStarted":true,"canceled":false}
011, 11 => error=remote memory: invalid content-length header: 011, 11 {"readStarted":false,"canceled":false}
12, 12 => error=remote memory: response body too large: 12 bytes (limit: 11 bytes) {"readStarted":false,"canceled":true}
11, 12 => error=remote memory: invalid content-length header: 11, 12 {"readStarted":false,"canceled":false}
11, => error=remote memory: invalid content-length header: 11, {"readStarted":false,"canceled":false}
1e1 => error=remote memory: invalid content-length header: 1e1 {"readStarted":false,"canceled":false}
```

- Focused test: `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/response-snippet.test.ts` passed, 12 tests.
- Diff hygiene: `git diff --check` passed.
- Proof boundary: deterministic local response/stream doubles exercised the production reader; no external memory service was used.
