### PR TITLE
fix(telegram): require decimal watermark message ids

### DIFF
--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -637,10 +637,7 @@ describe("buildTelegramMessageContext prompt context", () => {
       timestampMs,
     });
 
-    const persistedWatermark = readAmbientTranscriptWatermark(
-      getSessionEntry({ storePath, sessionKey }),
-      key,
-    );
+    const persistedWatermark = readAmbientTranscriptWatermark({ storePath, sessionKey, key });
     expect(persistedWatermark).toMatchObject({ messageId: "1e3", timestampMs });
 
     const ctx = await buildTelegramMessageContextForTest({

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -613,4 +613,79 @@ describe("buildTelegramMessageContext prompt context", () => {
       }),
     ]);
   });
+
+  it("fails closed for malformed persisted watermark ids at the group-history boundary", async () => {
+    const storePath = createTempSessionStorePath();
+    const sessionKey = "agent:main:telegram:group:-1001234567890";
+    const key = resolveAmbientTranscriptWatermarkKey({
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "-1001234567890",
+    });
+    const timestampMs = 1_700_000_000_000;
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: { sessionId: "session-current", updatedAt: timestampMs },
+    });
+    await updateAmbientTranscriptWatermark({
+      storePath,
+      sessionKey,
+      key,
+      messageId: "1e3",
+      timestampMs,
+    });
+
+    const persistedWatermark = readAmbientTranscriptWatermark(
+      getSessionEntry({ storePath, sessionKey }),
+      key,
+    );
+    expect(persistedWatermark).toMatchObject({ messageId: "1e3", timestampMs });
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1003,
+        date: (timestampMs + 2000) / 1000,
+        chat: { id: -1001234567890, type: "supergroup", title: "Forum" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "@bot current",
+        entities: [{ type: "mention", offset: 0, length: 4 }],
+      },
+      historyLimit: 10,
+      groupHistories: new Map([
+        [
+          "-1001234567890",
+          [
+            {
+              messageId: "1001",
+              sender: "Sam",
+              timestamp: timestampMs,
+              body: "same-timestamp candidate",
+            },
+            {
+              messageId: "1002",
+              sender: "Lee",
+              timestamp: timestampMs + 1000,
+              body: "later group message",
+            },
+          ],
+        ],
+      ]),
+      sessionRuntime: {
+        readAmbientTranscriptWatermark,
+        resolveAmbientTranscriptWatermarkKey,
+        resolveStorePath: () => storePath,
+      },
+    });
+
+    expect(ctx?.ctxPayload.ChannelStructuredContext).toEqual([
+      expect.objectContaining({
+        type: "chat_window",
+        payload: expect.objectContaining({
+          messages: [expect.objectContaining({ message_id: "1002", body: "later group message" })],
+        }),
+      }),
+    ]);
+  });
 });

--- a/extensions/telegram/src/group-history-window.ts
+++ b/extensions/telegram/src/group-history-window.ts
@@ -51,11 +51,12 @@ function telegramHistoryEntryKey(entry: HistoryEntry): string | undefined {
 }
 
 function numericMessageId(value: string | undefined): number | undefined {
-  if (!value?.trim()) {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^(?:0|[1-9]\d*)$/.test(trimmed)) {
     return undefined;
   }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 export function isTelegramHistoryEntryAfterAmbientWatermark(

--- a/extensions/telegram/src/group-history-window.ts
+++ b/extensions/telegram/src/group-history-window.ts
@@ -51,11 +51,10 @@ function telegramHistoryEntryKey(entry: HistoryEntry): string | undefined {
 }
 
 function numericMessageId(value: string | undefined): number | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed || !/^(?:0|[1-9]\d*)$/.test(trimmed)) {
+  if (!value || !/^[1-9]\d*$/.test(value)) {
     return undefined;
   }
-  const parsed = Number(trimmed);
+  const parsed = Number(value);
   return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -773,6 +773,24 @@ describe("telegram message cache", () => {
     ).toBe(false);
     expect(
       isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: " 1000 ", timestamp: timestampMs },
+        watermark,
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "1000", timestamp: timestampMs },
+        { messageId: " 999 ", timestampMs },
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "1", timestamp: timestampMs },
+        { messageId: "0", timestampMs },
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
         { messageId: "0x10", timestamp: timestampMs },
         { messageId: "15", timestampMs },
       ),

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -1,5 +1,6 @@
 import type { Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
+import { isTelegramHistoryEntryAfterAmbientWatermark } from "./group-history-window.js";
 import {
   resolveTelegramMessageCachePersistentScopeKey,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
@@ -746,5 +747,41 @@ describe("telegram message cache", () => {
     const recent = await recentBefore(cache, "9007199254740992");
 
     expect(recent).toEqual([]);
+  });
+
+  it("does not treat non-decimal message ids as newer than ambient watermarks", () => {
+    const timestampMs = Date.parse("2026-05-10T12:40:00.000Z");
+    const watermark = { messageId: "999", timestampMs };
+
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "1000", timestamp: timestampMs },
+        watermark,
+      ),
+    ).toBe(true);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "999", timestamp: timestampMs },
+        watermark,
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "1e3", timestamp: timestampMs },
+        watermark,
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "0x10", timestamp: timestampMs },
+        { messageId: "15", timestampMs },
+      ),
+    ).toBe(false);
+    expect(
+      isTelegramHistoryEntryAfterAmbientWatermark(
+        { messageId: "9007199254740992", timestamp: timestampMs },
+        watermark,
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram group history watermarks could treat non-decimal JavaScript numeric forms such as `1e3` or `0x10` as newer message ids when timestamps matched.

## Why This Change Was Made

Telegram watermark message-id ordering now only uses safe canonical positive decimal integer strings. Non-decimal, whitespace-padded, zero, ambiguous, or unsafe values no longer participate in numeric ordering, so same-timestamp watermark boundaries stay conservative.

## User Impact

Telegram group context avoids pulling transcript-owned messages back into ambient history when a malformed or non-canonical message id is present at the watermark boundary.

## Evidence

- Current head: `bb7b427eb5ca92223b89efcc419ae3bf6a171cfe`.
- Runtime Telegram group-history proof: a temporary Vitest proof harness imported `buildTelegramMessageContextForTest` and drove the real `buildTelegramMessageContext()` path with redacted synthetic supergroup history plus ambient transcript watermarks. The runtime `ChannelStructuredContext` transcript was:

  ```text
  telegram-group-history-runtime-proof canonical-control ids=["1000"]
  telegram-group-history-runtime-proof padded-watermark ids=[]
  telegram-group-history-runtime-proof zero-watermark ids=[]
  Test Files  1 passed (1)
  Tests  1 passed (1)
  ```

  This proves the canonical positive decimal same-timestamp control (`1000` after watermark `999`) enters group history context, while malformed equal-timestamp watermark boundaries (` 999 ` and `0`) keep same-timestamp entries out conservatively.
- Focused regression proof: `OPENCLAW_FS_SAFE_NATIVE_MODE=off node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts` directly exercised `isTelegramHistoryEntryAfterAmbientWatermark` at equal timestamps; `1000` sorts after `999`, while `999`, `1e3`, `0x10`, `9007199254740992`, ` 1000 `, watermark ` 999 `, and watermark `0` do not cross the same-timestamp watermark. Observed output: `Test Files 1 passed (1)` and `Tests 19 passed (19)`.
- Diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- GitHub checks: `openclaw/ci-gate` and `Real behavior proof` are successful for this head.
- Proof boundary: source-checkout Telegram message-context/group-history runtime path with redacted synthetic supergroup messages; no live Telegram Bot API send was needed because this change tightens local cached-history filtering before transport delivery.