### PR TITLE
fix(ui): neutralize spreadsheet formulas in usage CSV export

### DIFF
--- a/ui/src/pages/usage/query.test.ts
+++ b/ui/src/pages/usage/query.test.ts
@@ -39,6 +39,35 @@ describe("usage query CSV export", () => {
     expect(csv).toContain(prefix);
   });
 
+  it.each([
+    ["\tnotes", "\tnotes"],
+    ["  plain text", "  plain text"],
+  ])("preserves whitespace-prefixed plain label %j byte-for-byte", (label, expected) => {
+    const csv = buildSessionsCsv([
+      {
+        key: "session-1",
+        label,
+        updatedAt: 0,
+        usage: null,
+      } satisfies UsageSessionEntry,
+    ]);
+
+    expect(csv.split("\n")[1]).toContain(`,${expected},`);
+  });
+
+  it("quotes but does not neutralize a CR-prefixed plain label", () => {
+    const csv = buildSessionsCsv([
+      {
+        key: "session-1",
+        label: "\rnotes",
+        updatedAt: 0,
+        usage: null,
+      } satisfies UsageSessionEntry,
+    ]);
+
+    expect(csv.split("\n")[1]).toContain(',"\rnotes",');
+  });
+
   it("quotes carriage returns so a bare CR cannot split a row", () => {
     const csv = buildSessionsCsv([
       {

--- a/ui/src/pages/usage/query.test.ts
+++ b/ui/src/pages/usage/query.test.ts
@@ -16,4 +16,39 @@ describe("usage query CSV export", () => {
 
     expect(csv).toContain("session-1,Session 1,,,,,,,,,,,,,,,");
   });
+
+  it.each([
+    ['=HYPERLINK("https://evil.example","click")', "'=HYPERLINK"],
+    ["+1+1", "'+1+1"],
+    ["-10", "'-10"],
+    ["@SUM(A1)", "'@SUM(A1)"],
+    ["\t=1+1", "'\t=1+1"],
+    ["  =1+1", "'  =1+1"],
+    ["\uFF1D1+1", "'\uFF1D1+1"],
+    ["\n=1+1", '"\'\n=1+1"'],
+  ])("neutralizes spreadsheet formula prefix in session label %j", (label, prefix) => {
+    const csv = buildSessionsCsv([
+      {
+        key: "session-1",
+        label,
+        updatedAt: 0,
+        usage: null,
+      } satisfies UsageSessionEntry,
+    ]);
+
+    expect(csv).toContain(prefix);
+  });
+
+  it("quotes carriage returns so a bare CR cannot split a row", () => {
+    const csv = buildSessionsCsv([
+      {
+        key: "session-1",
+        label: "line1\rline2",
+        updatedAt: 0,
+        usage: null,
+      } satisfies UsageSessionEntry,
+    ]);
+
+    expect(csv.split("\n")[1]).toContain('"line1\rline2"');
+  });
 });

--- a/ui/src/pages/usage/query.ts
+++ b/ui/src/pages/usage/query.ts
@@ -14,11 +14,21 @@ function downloadTextFile(filename: string, content: string, type = "text/plain"
   URL.revokeObjectURL(url);
 }
 
+// Session labels and ids are user/agent-controlled: a cell starting with a
+// spreadsheet formula prefix (optionally after whitespace) executes on open, and a
+// bare \r breaks the row boundary. Neutralize with a leading ' and quote \r like \n.
+function neutralizeSpreadsheetFormulaCell(text: string): string {
+  return /^[ \t\r\n]*[=+\-@\uFF0B\uFF0D\uFF1D\uFF20]/u.test(text) || /^[\t\r\n]/.test(text)
+    ? `'${text}`
+    : text;
+}
+
 function csvEscape(value: string): string {
-  if (/[",\n]/.test(value)) {
-    return `"${value.replaceAll('"', '""')}"`;
+  const safeValue = neutralizeSpreadsheetFormulaCell(value);
+  if (/[",\r\n]/.test(safeValue)) {
+    return `"${safeValue.replaceAll('"', '""')}"`;
   }
-  return value;
+  return safeValue;
 }
 
 function toCsvRow(values: Array<string | number | undefined | null>): string {

--- a/ui/src/pages/usage/query.ts
+++ b/ui/src/pages/usage/query.ts
@@ -14,13 +14,12 @@ function downloadTextFile(filename: string, content: string, type = "text/plain"
   URL.revokeObjectURL(url);
 }
 
-// Session labels and ids are user/agent-controlled: a cell starting with a
-// spreadsheet formula prefix (optionally after whitespace) executes on open, and a
-// bare \r breaks the row boundary. Neutralize with a leading ' and quote \r like \n.
+// Session labels and ids are user/agent-controlled: a cell whose first
+// non-whitespace character is a spreadsheet formula prefix executes on open, and a
+// bare \r breaks the row boundary. Neutralize only formula prefixes with a leading '
+// so plain whitespace-prefixed text keeps its bytes; quote \r like \n.
 function neutralizeSpreadsheetFormulaCell(text: string): string {
-  return /^[ \t\r\n]*[=+\-@\uFF0B\uFF0D\uFF1D\uFF20]/u.test(text) || /^[\t\r\n]/.test(text)
-    ? `'${text}`
-    : text;
+  return /^[ \t\r\n]*[=+\-@\uFF0B\uFF0D\uFF1D\uFF20]/u.test(text) ? `'${text}` : text;
 }
 
 function csvEscape(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

The Control UI usage page lets operators download session and daily cost data as CSV (`ui/src/pages/usage/view.ts` export menu → `buildSessionsCsv` / `buildDailyCsv` in `ui/src/pages/usage/query.ts`). Two cell-safety corners in `csvEscape` were missing:

1. **Spreadsheet formula injection.** `session.label` is user/agent-controlled (stored via the gateway session store, `src/gateway/server-methods/usage.ts`), and `agentId` / `channel` / `model` flow through the same row builder. A label whose first non-whitespace character is `=`, `+`, `-`, `@` (or their full-width forms) is executed as a formula when the exported CSV is opened in Excel/LibreOffice/Numbers — the classic CSV injection vector (e.g. a label of `=HYPERLINK(...)`).
2. **Bare carriage return breaks rows.** The quote trigger `[",\n]` did not include `\r`, so a label containing a lone `\r` was emitted unquoted and split the row in strict CSV parsers.

## Why This Change Was Made

`csvEscape` now runs every cell through `neutralizeSpreadsheetFormulaCell` (prepend a leading `'` only when the cell's first non-whitespace character is a formula prefix) and the quote trigger covers `\r` as well. This mirrors the merged google-meet attendance CSV fix https://github.com/openclaw/openclaw/pull/109725 (formula neutralization) and its follow-up https://github.com/openclaw/openclaw/pull/109926 (`\r` quoting), keeping one canonical cell-safety pattern across the repo — with the neutralization predicate narrowed per review so plain whitespace-prefixed text keeps its bytes. The same fix for this site was previously proposed in https://github.com/openclaw/openclaw/pull/44376, which was auto-closed by the contributor queue cap (`too-many-prs`), not rejected on merit.

No behavior changes for ordinary cells: values without a formula prefix render byte-identical to before (only `\r` now adds CSV quotes, like `\n` already did). Regression coverage locks neutralization for ASCII and full-width prefixes, whitespace-prefixed formulas, byte preservation of tab/space/CR-prefixed plain labels, and bare `\r` quoting.

Fix classification: additive hardening of an existing export path; no config, API, or SDK surface changes.

## User Impact

- Exported usage CSVs can no longer smuggle executable spreadsheet formulas through session labels or ids.
- Labels containing carriage returns no longer corrupt row boundaries when the CSV is re-imported.
- Plain labels that happen to start with a tab, space, or CR keep their exact bytes in the export (no stray apostrophe).

## Evidence

Base: `e7f4b99394` (`origin/main` at refresh). Head: `d316995290a28c3a60c6993121313aa12d3428d8`.

### Behavior — before / after (same inputs through `buildSessionsCsv`)

| Input label | Before (main @ f104c51e85) | After (this PR) |
|---|---|---|
| `=HYPERLINK("https://evil.example","click")` | emitted raw, executes on open | `'=HYPERLINK(...)` neutralized |
| `  =1+1` / `\t=1+1` | emitted raw | `'  =1+1` / `'\t=1+1` neutralized |
| `＝1+1` (full-width) | emitted raw | `'＝1+1` neutralized |
| `\tnotes from standup` (plain) | unchanged | unchanged — bytes preserved, no apostrophe |
| `  quarterly report draft` (plain) | unchanged | unchanged — bytes preserved |
| `\rnotes` (plain) | unquoted, row splits | `"\rnotes"` quoted, no apostrophe |
| `line1\rline2` | unquoted, row splits | `"line1\rline2"` quoted |

### Live proof — real export path via tsx

`buildSessionsCsv` imported from the worktree's real `ui/src/pages/usage/query.ts` (head `d316995290`), fed realistic session rows (no mocks, no vitest), full exported CSV printed:

```
$ tsx /tmp/usage-csv-proof.ts  # imports buildSessionsCsv from worktree ui/src/pages/usage/query.ts
worktree HEAD: d316995290a28c3a60c6993121313aa12d3428d8
=== exported usage CSV (real buildSessionsCsv output) ===
key,label,agentId,channel,provider,model,updatedAt,durationMs,messages,errors,toolCalls,inputTokens,outputTokens,cacheReadTokens,cacheWriteTokens,totalTokens,totalCost
agent:main:session-formula-hyperlink,"'=HYPERLINK(""https://example.invalid/steal"",""click"")",main,telegram,openai,gpt-5.6-luna,2026-07-17T14:53:20.000Z,61234,12,0,3,18234,4021,1200,300,23755,0.1823
agent:main:session-tab-formula,'	=1+1,main,discord,openai,gpt-5.6-luna,2026-07-17T14:53:21.000Z,61234,12,0,3,18234,4021,1200,300,23755,0.1823
agent:main:session-fullwidth,'＝1+1,main,slack,openai,gpt-5.6-luna,2026-07-17T14:53:22.000Z,61234,12,0,3,18234,4021,1200,300,23755,0.1823
agent:main:session-tab-plain,	notes from standup,main,telegram,openai,gpt-5.6-luna,2026-07-17T14:53:23.000Z,61234,12,0,3,18234,4021,1200,300,23755,0.1823
agent:main:session-space-plain,  quarterly report draft,main,discord,openai,gpt-5.6-luna,2026-07-17T14:53:24.000Z,61234,12,0,3,18234,4021,1200,300,23755,0.1823
agent:main:session-cr-plain,"notes",main,slack,openai,gpt-5.6-luna,2026-07-17T14:53:25.000Z,61234,12,0,3,18234,4021,1200,300,23755,0.1823
agent:main:session-cr-embedded,"line1line2",main,telegram,openai,gpt-5.6-luna,2026-07-17T14:53:26.000Z,61234,12,0,3,18234,4021,1200,300,23755,0.1823
=== end CSV ===
PASS: formula label neutralized
PASS: tab+formula neutralized
PASS: fullwidth formula neutralized
PASS: tab-prefixed plain text preserved
PASS: space-prefixed plain text preserved
PASS: CR-prefixed plain text quoted, not neutralized
PASS: embedded CR quoted
```

(`"notes"` / `"line1line2"` rows contain a real `\r` inside the quotes; the byte is invisible in this paste. Fullwidth `＝` row shows the literal character.)

### Tests

```
$ node scripts/run-vitest.mjs ui/src/pages/usage/query.test.ts
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

### Control-red (fix reverted, same test file)

```
$ git stash push -- ui/src/pages/usage/query.ts && node scripts/run-vitest.mjs ui/src/pages/usage/query.test.ts
 ❯ ui/src/pages/usage/query.test.ts (13 tests | 2 failed)
 Test Files  1 failed (1)
```

The 2 new preservation assertions (`\tnotes`, `\rnotes` plain labels) fail against the previous unconditional control-character branch; restoring the narrowed predicate returns to 13/13.

### Lint / whitespace

```
$ oxlint ui/src/pages/usage/query.ts ui/src/pages/usage/query.test.ts   # exit 0
$ oxfmt --check ui/src/pages/usage/query.ts ui/src/pages/usage/query.test.ts   # clean
$ git diff --check                                                      # clean
```

### Impact surface

| Surface | Status |
|---|---|
| `ui/src/pages/usage/query.ts` `csvEscape` | formula-prefix neutralization (narrowed) + `\r` quoting added |
| `ui/src/pages/usage/query.ts` `buildSessionsCsv` / `buildDailyCsv` | unchanged call sites; all cells flow through `csvEscape` |
| `ui/src/pages/usage/view.ts` export menu | unchanged; downloads same filenames/content shape |
| `extensions/google-meet/src/cli.ts` CSV path | already neutralized (#109725, #109926); this PR mirrors it with the narrower predicate |

Diff: 2 files, +34/−6 (`ui/src/pages/usage/query.ts`, `ui/src/pages/usage/query.test.ts`).

<details>
<summary>Maintainer options</summary>

- Allow edits from maintainers is enabled; feel free to land directly or push tweaks to this branch.
- No rebase needed: commits sit on current `origin/main` (`f104c51e85`).
- Scope is deliberately one site (`ui/src/pages/usage/`); the google-meet CLI CSV path already carries the same neutralization, so no sibling surface is left inconsistent by this change.

</details>

