### PR TITLE
fix: dead-export gate rejects internal script helper

### DIFF
--- a/scripts/copy-bundled-plugin-metadata.d.mts
+++ b/scripts/copy-bundled-plugin-metadata.d.mts
@@ -1,5 +1,3 @@
-export function rewritePackageExtensions(entries: unknown): string[] | undefined;
-
 export function copyBundledPluginMetadata(params?: {
   repoRoot?: string;
   cwd?: string;

--- a/scripts/copy-bundled-plugin-metadata.mjs
+++ b/scripts/copy-bundled-plugin-metadata.mjs
@@ -31,11 +31,7 @@ function shouldCopyBundledPluginMetadata(id, env, buildablePluginDirs) {
   return env.OPENCLAW_BUILD_PRIVATE_QA === "1";
 }
 
-/**
- * Rewrites package extension entries for bundled metadata output.
- * @internal Directly tested script implementation detail.
- */
-export function rewritePackageExtensions(entries) {
+function rewritePackageExtensions(entries) {
   if (!Array.isArray(entries)) {
     return undefined;
   }

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -2,10 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  copyBundledPluginMetadata,
-  rewritePackageExtensions,
-} from "../../scripts/copy-bundled-plugin-metadata.mjs";
+import { copyBundledPluginMetadata } from "../../scripts/copy-bundled-plugin-metadata.mjs";
 import { cleanupTempDirs, makeTempRepoRoot, writeJsonFile } from "../../test/helpers/temp-repo.js";
 
 const tempDirs: string[] = [];
@@ -84,15 +81,6 @@ function createTlonSkillPlugin(repoRoot: string, skillPath = "node_modules/@tlon
 
 afterEach(() => {
   cleanupTempDirs(tempDirs);
-});
-
-describe("rewritePackageExtensions", () => {
-  it("rewrites TypeScript extension entries to built JS paths", () => {
-    expect(rewritePackageExtensions(["./index.ts", "./nested/entry.mts"])).toEqual([
-      "./index.js",
-      "./nested/entry.js",
-    ]);
-  });
 });
 
 describe("copyBundledPluginMetadata", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the hard-zero script dead-export gate fails on current `main` because a script implementation helper is exported only for a direct unit test.

## Why This Change Was Made

Keeps `rewritePackageExtensions` private to the bundled-plugin metadata copier and tests the behavior through the exported copier seam. Removes the stale declaration and redundant direct helper test.

## User Impact

No user-visible behavior change. Maintainer dead-export validation returns to zero.

## Evidence

- Exact head: `3df49a68b0feb237a80045dfb135f52af13c74f4`
- Rebase proof: `git range-diff` reports the reviewed patch is identical
- AWS Crabbox: [run_e4fcc555d979](https://crabbox.openclaw.ai/portal/runs/run_e4fcc555d979)
- `pnpm test src/plugins/copy-bundled-plugin-metadata.test.ts`: 13/13 passed
- `node scripts/check-deadcode-exports.mjs`: production, full-tree, and script scans all passed with 0 entries
- Targeted `oxfmt --check`: passed locally with the pinned repository binary
- Autoreview: clean on the exact head, no accepted/actionable findings (0.96)

AI-assisted; implementation and proof reviewed by the submitting maintainer.
