### PR TITLE
fix(ui): use clipboard fallback in setup wizards

### DIFF
--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -1,0 +1,64 @@
+/* @vitest-environment jsdom */
+
+import { nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../../i18n/index.ts";
+import { renderChannelWizard } from "./wizard-view.ts";
+
+describe("renderChannelWizard", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
+  afterEach(() => {
+    for (const container of document.body.querySelectorAll("div")) {
+      render(nothing, container);
+    }
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+    delete (document as unknown as { execCommand?: unknown }).execCommand;
+  });
+
+  it("copies setup text through the plain-HTTP clipboard fallback", async () => {
+    vi.stubGlobal("navigator", {});
+    const execCommand = vi.fn().mockReturnValue(true);
+    (document as unknown as { execCommand: typeof execCommand }).execCommand = execCommand;
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderChannelWizard({
+        wizard: {
+          phase: "step",
+          channel: null,
+          step: {
+            id: "copy-command",
+            type: "note",
+            message: "openclaw channels add",
+          },
+          stepIndex: 1,
+          busy: false,
+          validationError: null,
+        },
+        channelLabel: (channelId) => channelId,
+        multiselectValues: [],
+        onToggleMultiselect: vi.fn(),
+        onAnswer: vi.fn(),
+        onClose: vi.fn(),
+        whatsappQrDataUrl: null,
+        whatsappMessage: null,
+        whatsappConnected: null,
+        whatsappBusy: false,
+        onWhatsAppStart: vi.fn(),
+        onWhatsAppWait: vi.fn(),
+      }),
+      container,
+    );
+
+    const copy = container.querySelector<HTMLButtonElement>(".channels-wizard__links button");
+    expect(copy).not.toBeNull();
+    copy?.click();
+
+    await vi.waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -21,7 +21,11 @@ describe("renderChannelWizard", () => {
 
   it("copies setup text through the plain-HTTP clipboard fallback", async () => {
     vi.stubGlobal("navigator", {});
-    const execCommand = vi.fn().mockReturnValue(true);
+    let copiedText: string | undefined;
+    const execCommand = vi.fn().mockImplementation(() => {
+      copiedText = document.querySelector<HTMLTextAreaElement>("textarea")?.value;
+      return true;
+    });
     (document as unknown as { execCommand: typeof execCommand }).execCommand = execCommand;
     const container = document.createElement("div");
     document.body.append(container);
@@ -59,6 +63,7 @@ describe("renderChannelWizard", () => {
     copy?.click();
 
     await vi.waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+    expect(copiedText).toBe("openclaw channels add");
     expect(document.querySelector("textarea")).toBeNull();
   });
 });

--- a/ui/src/pages/channels/wizard-view.ts
+++ b/ui/src/pages/channels/wizard-view.ts
@@ -5,6 +5,7 @@ import "@awesome.me/webawesome/dist/components/radio-group/radio-group.js";
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../../i18n/index.ts";
 import "../../components/modal-dialog.ts";
+import { copyToClipboard } from "../../lib/clipboard.ts";
 import { channelDocsUrl, channelHubMeta, renderChannelArt } from "./hub-meta.ts";
 import type {
   ChannelWizardState,
@@ -48,11 +49,7 @@ function renderNoteStep(step: ChannelWizardStep, props: ChannelWizardViewProps) 
     ${message
       ? html`
           <div class="channels-wizard__links">
-            <button
-              type="button"
-              class="btn btn--sm"
-              @click=${() => void navigator.clipboard?.writeText(message)}
-            >
+            <button type="button" class="btn btn--sm" @click=${() => void copyToClipboard(message)}>
               ${t("channels.setup.copyText")}
             </button>
           </div>

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -139,6 +139,8 @@ describe("renderModelSetup", () => {
       render(nothing, container);
     }
     document.body.replaceChildren();
+    vi.unstubAllGlobals();
+    delete (document as unknown as { execCommand?: unknown }).execCommand;
   });
 
   it("renders candidate, unavailable, sign-in, and manual sections", () => {
@@ -334,6 +336,26 @@ describe("renderModelSetup", () => {
     expect(link?.rel).toBe("noreferrer");
     expect(text(container)).toContain("ABCD-EFGH");
     expect(text(container)).toContain("Expires in 10 minutes");
+  });
+
+  it("copies device codes through the plain-HTTP clipboard fallback", async () => {
+    vi.stubGlobal("navigator", {});
+    const execCommand = vi.fn().mockReturnValue(true);
+    (document as unknown as { execCommand: typeof execCommand }).execCommand = execCommand;
+    const container = wizardStep({
+      id: "device",
+      type: "note",
+      deviceCode: { code: "ABCD-EFGH" },
+    });
+
+    const copy = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent?.trim() === "Copy",
+    );
+    expect(copy).toBeDefined();
+    copy?.click();
+
+    await vi.waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+    expect(document.querySelector("textarea")).toBeNull();
   });
 
   it("renders sensitive text, select, and confirm steps", () => {

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -340,7 +340,11 @@ describe("renderModelSetup", () => {
 
   it("copies device codes through the plain-HTTP clipboard fallback", async () => {
     vi.stubGlobal("navigator", {});
-    const execCommand = vi.fn().mockReturnValue(true);
+    let copiedText: string | undefined;
+    const execCommand = vi.fn().mockImplementation(() => {
+      copiedText = document.querySelector<HTMLTextAreaElement>("textarea")?.value;
+      return true;
+    });
     (document as unknown as { execCommand: typeof execCommand }).execCommand = execCommand;
     const container = wizardStep({
       id: "device",
@@ -355,6 +359,7 @@ describe("renderModelSetup", () => {
     copy?.click();
 
     await vi.waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+    expect(copiedText).toBe("ABCD-EFGH");
     expect(document.querySelector("textarea")).toBeNull();
   });
 

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../../i18n/index.ts";
 import "../../components/modal-dialog.ts";
+import { copyToClipboard } from "../../lib/clipboard.ts";
 import type { ModelSetupWizardState } from "./state.ts";
 
 type WizardViewProps = {
@@ -25,7 +26,7 @@ function renderDeviceCode(step: Extract<ModelSetupWizardState, { phase: "step" }
       <button
         type="button"
         class="btn btn--sm"
-        @click=${() => void navigator.clipboard?.writeText(step.deviceCode!.code)}
+        @click=${() => void copyToClipboard(step.deviceCode!.code)}
       >
         ${t("modelSetup.wizard.copy")}
       </button>


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

The model and channel setup wizards call the async Clipboard API directly. On Control UI deployments served over plain HTTP, that API is unavailable, so their Copy buttons silently do nothing.

## Why This Change Was Made

Route both setup copy actions through the existing shared clipboard helper, which uses the async API when available and falls back to the legacy copy path otherwise. Add direct regression coverage for the model and channel wizard actions.

## User Impact

Copying device codes and channel setup instructions now works on plain-HTTP/LAN Control UI deployments as well as secure contexts. Labels and layout are unchanged.

## Evidence

- `node node_modules/vitest/vitest.mjs run --root ui --config vitest.config.ts src/lib/clipboard.test.ts src/pages/model-setup/view.test.ts src/pages/channels/wizard-view.test.ts --reporter=verbose` — 3 files passed, 25 tests passed; this covers the shared fallback plus model-setup and channel-wizard integration.
- Fresh exact-head browser proof at `807ecb4c66a01e0639a5d0c10a246e4a89d524b8` on an actual non-secure plain-HTTP Control UI origin: `window.isSecureContext === false`, `navigator.clipboard` was absent, clicking the real channel-wizard Copy button invoked `execCommand("copy")` exactly once with the exact setup text, and focus returned to the Copy button.
- [Inspectable browser transcript and artifact hashes](https://github.com/IWhatsskill/openclaw/blob/ec1164d12b137fca060bd2d31fc81d6415fb0f85/proof-assets/pr-110139/proof.md)
- Operator-attested plain-HTTP browser media for this exact-head run:

<img width="1440" height="900" alt="plain-http-copy" src="https://github.com/user-attachments/assets/19d80ae1-7a46-487a-93b3-cccca90156cd" />

**Plain-HTTP copy video**

[plain-http-copy.webm](https://github.com/user-attachments/assets/686185df-c88e-494c-8428-0b2f8df1699f)

- `pnpm tsgo:ui` — passed.
- `pnpm exec oxlint ui/src/pages/model-setup/wizard-view.ts ui/src/pages/channels/wizard-view.ts ui/src/pages/model-setup/view.test.ts ui/src/pages/channels/wizard-view.test.ts` — 0 warnings and 0 errors.
- `pnpm exec oxfmt --check ui/src/pages/model-setup/wizard-view.ts ui/src/pages/channels/wizard-view.ts ui/src/pages/model-setup/view.test.ts ui/src/pages/channels/wizard-view.test.ts` — passed.
- `git diff --check` — passed.
