### PR TITLE
fix(config): bound gateway.port to TCP range (1..65535)

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -938,6 +938,41 @@ describe("gateway.remote.transport", () => {
   });
 });
 
+describe("gateway.port", () => {
+  it("accepts a port within the TCP range", () => {
+    const res = validateConfigObject({
+      gateway: {
+        port: 18789,
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects a port above the TCP range", () => {
+    const res = validateConfigObject({
+      gateway: {
+        port: 65536,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.port");
+    }
+  });
+
+  it("rejects a non-positive port", () => {
+    const res = validateConfigObject({
+      gateway: {
+        port: 0,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.port");
+    }
+  });
+});
+
 describe("gateway.tools config", () => {
   it("accepts gateway.tools allow and deny lists", () => {
     const res = validateConfigObject({

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1127,7 +1127,7 @@ export const OpenClawSchema = z
     talk: TalkSchema.optional(),
     gateway: z
       .strictObject({
-        port: z.number().int().positive().optional(),
+        port: z.number().int().min(1).max(65_535).optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
         bind: z
           .union([


### PR DESCRIPTION
Closes #109293

## Summary

The `gateway.port` schema used `z.number().int().positive().optional()`, which accepts any positive integer — including values outside the TCP port range such as `65536`. The runtime gateway parser already rejects those values, leaving config validation and runtime in disagreement.

This aligns `gateway.port` with the existing `gateway.remote.remotePort` pattern (`z.number().int().min(1).max(65_535).optional()`).

## Diff

- `src/config/zod-schema.ts` — schema: `.positive()` → `.min(1).max(65_535)` (1 line).
- `src/config/config-misc.test.ts` — adds a `gateway.port` describe block mirroring the existing `gateway.remote.remotePort` tests: accepts a port within range, rejects `65536`, rejects `0`.

## Verification

The bug is confirmed by the issue's reproduction (`validateConfigObjectRaw({ gateway: { port: 65536 } })` currently returns `ok: true`). With this change, the same input returns `ok: false` with issue path `gateway.port`. Valid ports (`1..65535`) continue to be accepted; `0` and negative values continue to be rejected.

Vitest is blocked on Node 18.19.1 in this environment (`node:util.styleText` requires Node 20.12+), so the test suite could not be run locally; verification was via direct zod-schema comparison against the project's installed zod@4.4.3, which reproduces the issue's exact failure mode on the OLD schema and confirms the NEW schema's behaviour on the test cases.

## Notes

- Matches the existing `gateway.remote.remotePort` style exactly (`65_535` with underscore).
- No other `port: z.number().int().positive()` sites in the schema apply to a TCP-bound runtime field — `LegacyCanvasHostSchema.port` (line 80) and `talk.port` (line 1130 was the only gateway.port match) are the only positive-int ports in the schema; only the latter is a TCP runtime port.