### PR TITLE
fix: Android Japanese localization fails generated-resource check

### DIFF
--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -1050,7 +1050,7 @@
     <string name="native_b78426f40a794c5d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未ペアリング"</string>
     <string name="native_b7b190b4be0b2385" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayがこのスマートフォンを認識しました"</string>
     <string name="native_b7b89bf0fd930a9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"設定済みのモデルはありません"</string>
-    <string name="native_b7e3e4aa4257b9a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無効にする"</string>
+    <string name="native_b7e3e4aa4257b9a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無効化"</string>
     <string name="native_b8352b44a588721c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"アプリの言語"</string>
     <string name="native_b8380b8a2317b9fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayをペアリング中"</string>
     <string name="native_b860c709e9ba7e6f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存済みの認証情報が無効です"</string>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Android localization consistency check fails because the committed Japanese resources no longer match the repository's generated output.

The failure was observed on main in [CI run 29607109226](https://github.com/openclaw/openclaw/actions/runs/29607109226), job [`checks-node-core-tooling-2`](https://github.com/openclaw/openclaw/actions/runs/29607109226/job/87973356771).

## Why This Change Was Made

Regenerates the Japanese Android resource through the existing `android-app-i18n` owner path. The generated stable translation for the affected source string is restored; no generator policy changes.

## User Impact

Android Japanese localization remains aligned with the canonical generated resource set, and the deterministic main CI failure is removed.

## Evidence

- Before: `test/scripts/android-app-i18n.test.ts` failed with `Android generated localization drift: apps/android/app/src/main/res/values-ja/strings.xml`.
- After: `node scripts/run-vitest.mjs test/scripts/android-app-i18n.test.ts` — 19 passed.
- `node --import tsx scripts/android-app-i18n.ts check` — passed.
- `git diff --check` — passed.
- Autoreview — clean, patch correctness 0.98.
